### PR TITLE
Make user filter as restriction in RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -361,7 +361,7 @@ module Rbac
     #
     # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
     #            d_union_b_and_m  = d_filtered_ids UNION b_intersection_m
-    #            filter           = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
+    #            filter           = d_union_b_and_m INTERSECTION tenant_filter_ids INTERSECTION u_filtered_ids
     #
     # a nil as input for any field means it DOES NOT apply the operation(INTERSECTION, UNION)
     # a nil as output means there is not filter
@@ -375,13 +375,13 @@ module Rbac
     # @return [Array<Integer>] target ids for filter
 
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)
-      intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
+      intersection = ->(operand1, operand2, operand3 = nil) { [operand1, operand2, operand3].compact.reduce(&:&) }
       union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
 
       b_intersection_m                 = intersection.call(b_filtered_ids, m_filtered_ids)
       d_union_b_intersection_m = union.call(d_filtered_ids, b_intersection_m)
 
-      intersection.call(d_union_b_intersection_m, tenant_filter_ids)
+      intersection.call(d_union_b_intersection_m, tenant_filter_ids, u_filtered_ids)
     end
 
     # @param parent_class [Class] Class of parent (e.g. Host)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -359,9 +359,9 @@ module Rbac
     end
 
     #
-    # Algorithm: b_intersection_m        = (b_filtered_ids INTERSECTION m_filtered_ids)
-    #            u_union_d_union_b_and_m = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
-    #            filter                  = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
+    # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
+    #            d_union_b_and_m  = d_filtered_ids UNION b_intersection_m
+    #            filter           = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
     #
     # a nil as input for any field means it DOES NOT apply the operation(INTERSECTION, UNION)
     # a nil as output means there is not filter
@@ -376,12 +376,12 @@ module Rbac
 
     def combine_filtered_ids(u_filtered_ids, b_filtered_ids, m_filtered_ids, d_filtered_ids, tenant_filter_ids)
       intersection = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:&) }
-      union        = ->(operand1, operand2, operand3 = nil) { [operand1, operand2, operand3].compact.reduce(&:|) }
+      union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
 
       b_intersection_m                 = intersection.call(b_filtered_ids, m_filtered_ids)
-      u_union_d_union_b_intersection_m = union.call(u_filtered_ids, d_filtered_ids, b_intersection_m)
+      d_union_b_intersection_m = union.call(d_filtered_ids, b_intersection_m)
 
-      intersection.call(u_union_d_union_b_intersection_m, tenant_filter_ids)
+      intersection.call(d_union_b_intersection_m, tenant_filter_ids)
     end
 
     # @param parent_class [Class] Class of parent (e.g. Host)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -378,7 +378,7 @@ module Rbac
       intersection = ->(operand1, operand2, operand3 = nil) { [operand1, operand2, operand3].compact.reduce(&:&) }
       union        = ->(operand1, operand2) { [operand1, operand2].compact.reduce(&:|) }
 
-      b_intersection_m                 = intersection.call(b_filtered_ids, m_filtered_ids)
+      b_intersection_m         = intersection.call(b_filtered_ids, m_filtered_ids)
       d_union_b_intersection_m = union.call(d_filtered_ids, b_intersection_m)
 
       intersection.call(d_union_b_intersection_m, tenant_filter_ids, u_filtered_ids)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1,9 +1,9 @@
 describe Rbac::Filterer do
   describe '.combine_filtered_ids' do
     # Algorithm (from Rbac::Filterer.combine_filtered_ids):
-    # b_intersection_m        = (belongsto_filtered_ids INTERSECTION managed_filtered_ids)
-    # u_union_d_union_b_and_m = user_filtered_ids UNION descendant_filtered_ids UNION belongsto_filtered_ids
-    # filter                  = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
+    # Algorithm: b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
+    #            d_union_b_and_m  = d_filtered_ids UNION b_intersection_m
+    #            filter           = d_union_b_and_m INTERSECTION tenant_filter_ids INTERSECTION u_filtered_ids
 
     def combine_filtered_ids(user_filtered_ids, belongsto_filtered_ids, managed_filtered_ids, descendant_filtered_ids, tenant_filter_ids)
       Rbac::Filterer.new.send(:combine_filtered_ids, user_filtered_ids, belongsto_filtered_ids, managed_filtered_ids, descendant_filtered_ids, tenant_filter_ids)
@@ -38,15 +38,15 @@ describe Rbac::Filterer do
     end
 
     it 'user filter, belongs to and managed filters(self service user, Host & Cluster filter and tags)' do
-      expect(combine_filtered_ids([1], [2, 3], [3, 4], nil, nil)).to match_array([1, 3])
+      expect(combine_filtered_ids([1], [2, 3], [3, 4], nil, nil)).to be_empty
     end
 
     it 'user filter, belongs to, managed filters and descendants filter(self service user, Host & Cluster filter and tags)' do
-      expect(combine_filtered_ids([1], [2, 3], [3, 4], [5, 6], nil)).to match_array([1, 3, 5, 6])
+      expect(combine_filtered_ids([1, 5, 6], [2, 3], [3, 4], [5, 6], nil)).to match_array([5, 6])
     end
 
     it 'user filter, belongs to managed filters, descendants filter and tenant filter(self service user, Host & Cluster filter and tags)' do
-      expect(combine_filtered_ids([1], [2, 3], [3, 4], [5, 6], [1, 6])).to match_array([1, 6])
+      expect(combine_filtered_ids([1, 6], [2, 3], [3, 4], [5, 6], [1, 6])).to match_array([6])
     end
 
     it 'belongs to managed filters, descendants filter and tenant filter(self service user, Host & Cluster filter and tags)' do


### PR DESCRIPTION
WIP: this PR is based on https://github.com/ManageIQ/manageiq/pull/15346, 
last 4 commits are related to this PR

## Some facts 📝 
we have method `combine_filtered_ids` in RBAC  and there is combination logic of different filter ids:

`u_filtered_ids` - this ids of resource are based set ownership of resource and option in user role
called  "Only User or Group Owned" and "Only User Owned"

`b_filtered_ids` - belongs to filter ids are from filter called `Host & Cluster` (tab in group)
`m_filtered_ids`  - managed filter ids are form tag filer (tab in group)
`d_filtered_ids` - these are based on any descendant relation. (example: https://github.com/ManageIQ/manageiq/pull/15271 https://github.com/ManageIQ/manageiq-ui-classic/pull/1474 )
we want to filter CloudNetwork instances according to the relation of extmanagement system
`tenant_filter_ids` - this additional tenant filter for rbac through association, it used for classes like a `MetricRollup, Metric `where want to do rbac thru his polymorphic resource

## Algorithm before
this filtered ids are combined by algorithm:
```ruby
b_intersection_m        = (b_filtered_ids INTERSECTION m_filtered_ids)
u_union_d_union_b_and_m = u_filtered_ids UNION d_filtered_ids UNION b_intersection_m
filter                  = u_union_d_union_b_and_m INTERSECTION tenant_filter_ids
```
As you can see user filter (u_filtered_ids) is not doing restriction of descedant filter and of belongs/managed filter.

## Algorithm after

So we have to restrict whole result according to user filter (u_filtered_ids) :


```ruby
b_intersection_m = (b_filtered_ids INTERSECTION m_filtered_ids)
d_union_b_and_m  = d_filtered_ids UNION b_intersection_m
filter           = d_union_b_and_m INTERSECTION tenant_filter_ids INTERSECTION u_filtered_ids
 ```

## Real case
User has enabled filtering acccording tag `tag1` and also he self service user(option Only User or Group Owned)
also three vms:
vm1 - no tag, group ownership set to User's group
vm2- tagged by `tag1`, ownership is not set
vm3 -tagged by `tag1`,group ownership set to User's group

## result before
vm1, vm2 and vm3
## result after
vm3 (only) - because only this vm has tag1 and ownership set to vm2



## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1451266
https://bugzilla.redhat.com/show_bug.cgi?id=1450839


@miq-bot assign @gtanzillo 
@miq-bot add_label rbac, bug

