### PR TITLE
[WIP] Add some performance stats to generate report tool

### DIFF
--- a/tools/generate_report.rb
+++ b/tools/generate_report.rb
@@ -26,7 +26,19 @@ end
 puts "Generating report... #{report.name}"
 
 report.queue_generate_table(:userid => USER_ID)
-report._async_generate_table(MiqTask.last.id, REPORT_PARAMS)
+def report_run
+  if defined?(ManageIQPerformance)
+    ManageIQPerformance.profile('generate_report') do
+      yield
+    end
+  else
+    yield
+  end
+end
+
+report_run do
+  report._async_generate_table(MiqTask.last.id, REPORT_PARAMS)
+end
 
 default_url_options[:host] = "localhost"
 default_url_options[:port] = 3000

--- a/tools/generate_report.rb
+++ b/tools/generate_report.rb
@@ -31,6 +31,10 @@ def report_run
     ManageIQPerformance.profile('generate_report') do
       total_report_time = Benchmark.measure { yield }
       puts "Total report time: #{total_report_time.utime} (user)  #{total_report_time.stime} (system)  #{total_report_time.real} (real)  #{total_report_time.total} (total)"
+      puts "Total time in SQL: #{Thread.current[:miq_perf_sql_query_data][:queries].inject(0){ |s,r| s + r[:elapsed_time] }.round(2)} ms"
+      puts "Total count queries #{Thread.current[:miq_perf_sql_query_data][:total_queries]}"
+      slowest_query = Thread.current[:miq_perf_sql_query_data][:queries].max_by{ |x| x[:elapsed_time] }
+      puts "Slowest SQL query took #{slowest_query[:elapsed_time]} ms: \n" + slowest_query[:sql]
     end
   else
     yield

--- a/tools/generate_report.rb
+++ b/tools/generate_report.rb
@@ -29,7 +29,8 @@ report.queue_generate_table(:userid => USER_ID)
 def report_run
   if defined?(ManageIQPerformance)
     ManageIQPerformance.profile('generate_report') do
-      yield
+      total_report_time = Benchmark.measure { yield }
+      puts "Total report time: #{total_report_time.utime} (user)  #{total_report_time.stime} (system)  #{total_report_time.real} (real)  #{total_report_time.total} (total)"
     end
   else
     yield


### PR DESCRIPTION
Adding some performance stats what I am using locally to generate reports with usage of [manageiq-performance](https://github.com/ManageIQ/manageiq-performance) gem

Output:

```ruby
 ./tools/generate_report.rb 'Chargeback Cliente A'

Generating report... Chargeback Cliente A
Total report time: 19.12 (user)  3.1199999999999997 (system)  29.213407000061125 (real)  22.240000000000002 (total)
Total time in SQL: 1475.4 ms
Total count queries 2387
Slowest SQL query took 200.8 ms:
UPDATE "miq_report_results" SET "last_run_on" = $1, "last_accessed_on" = $2, "report" = $3 WHERE "miq_report_results"."id" = $4
```

@miq-bot add_label developer
cc @NickLaMuro 
@miq-bot assign @gtanzillo 