### PR TITLE
Format time interval for log message

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -40,7 +40,7 @@ class MiqTask < ApplicationRecord
   def self.update_status_for_timed_out_active_tasks
     MiqTask.active.timed_out.no_associated_job.find_each do |task|
       task.update_status(STATE_FINISHED, STATUS_ERROR,
-                         "Task [#{task.id}] timed out - not active for more than #{::Settings.task.active_task_timeout}")
+                         "Task [#{task.id}] timed out - not active for more than #{::Settings.task.active_task_timeout.to_i_with_method} seconds")
     end
   end
 

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -402,6 +402,7 @@ describe MiqTask do
           MiqTask.update_status_for_timed_out_active_tasks
           miq_task.reload
           expect(miq_task.status).to eq MiqTask::STATUS_ERROR
+          expect(miq_task.message).to include("not active for more than 3600 seconds")
         end
 
         it "does not update status if task not timed out" do


### PR DESCRIPTION
**ISSUE**: Time interval (when task got expired) recorded to log exactly as present in settings.yaml. Example: ```10.minutes``` but should be ```10 minutes```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1457979

@miq-bot add-label bug, core

\cc @gtanzillo 