### PR TITLE
Put back region_description method that was accidentally extracted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ manageiq_plugin "manageiq-providers-vmware"
 manageiq_plugin "manageiq-ui-classic"
 
 # Unmodified gems
-gem "activerecord-id_regions",        "~>0.1.0"
+gem "activerecord-id_regions",        "~>0.2.0"
 gem "activerecord-session_store",     "~>1.0.0"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.2.1",       :require => false

--- a/lib/extensions/ar_region.rb
+++ b/lib/extensions/ar_region.rb
@@ -9,7 +9,7 @@ module ArRegion
     def inherited(other)
       if other == other.base_class
         other.class_eval do
-          virtual_column :region_number,      :type => :integer
+          virtual_column :region_number,      :type => :integer # This method is defined in ActiveRecord::IdRegions
           virtual_column :region_description, :type => :string
         end
       end
@@ -19,5 +19,9 @@ module ArRegion
 
   def miq_region
     self.class.id_to_miq_region[region_number] || (self.class.id_to_miq_region[region_number] = MiqRegion.where(:region => region_number).first)
+  end
+
+  def region_description
+    miq_region.description if miq_region
   end
 end

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -23,4 +23,17 @@ describe ArRegion do
       end.to match_query_limit_of(2)
     end
   end
+
+  context "#region_description" do
+    it "when the region exists" do
+      MiqRegion.seed
+      vm = FactoryGirl.create(:vm)
+      expect(vm.region_description).to eq(MiqRegion.first.description)
+    end
+
+    it "when the region does not exist" do
+      vm = FactoryGirl.create(:vm)
+      expect(vm.region_description).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
~~Depends on https://github.com/ManageIQ/activerecord-id_regions/pull/3 and subsequent gem release~~ EDIT: Now merged and released as 0.2.0

I accidentally moved this method to ActiveRecord::IdRegions, but it could never work there standalone because it depends on the miq_region method defined in ManageIQ.  This PR puts it back.

@jrafanie Please review.