### PR TITLE
Decouple from CompressedIds mixin

### DIFF
--- a/app/controllers/api/automate_domains_controller.rb
+++ b/app/controllers/api/automate_domains_controller.rb
@@ -34,7 +34,7 @@ module Api
     end
 
     def resource_search(id, type, klass)
-      if cid?(id)
+      if ApplicationRecord.compressed_id?(id)
         super
       else
         begin

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -18,7 +18,6 @@ module Api
     include_concern 'Results'
     include_concern 'Generic'
     include_concern 'Authentication'
-    include CompressedIds
     include ActionController::HttpAuthentication::Basic::ControllerMethods
     extend ErrorHandler::ClassMethods
 

--- a/app/controllers/api/base_controller/parser.rb
+++ b/app/controllers/api/base_controller/parser.rb
@@ -76,7 +76,7 @@ module Api
         collection, c_id    = path_array[cidx..cidx + 1]
         subcollection, s_id = path_array[cidx + 2..cidx + 3]
 
-        subcollection ? [subcollection.to_sym, from_cid(s_id)] : [collection.to_sym, from_cid(c_id)]
+        subcollection ? [subcollection.to_sym, ApplicationRecord.uncompress_id(s_id)] : [collection.to_sym, ApplicationRecord.uncompress_id(c_id)]
       end
 
       def parse_id(resource, collection)
@@ -88,14 +88,14 @@ module Api
           href_id
         when resource["id"].kind_of?(Integer)
           resource["id"]
-        when cid?(resource["id"])
-          from_cid(resource["id"])
+        when ApplicationRecord.compressed_id?(resource["id"])
+          ApplicationRecord.uncompress_id(resource["id"])
         end
       end
 
       def href_id(href, collection)
-        if href.present? && href.match(%r{^.*/#{collection}/(#{BaseController::CID_OR_ID_MATCHER})$})
-          from_cid(Regexp.last_match(1))
+        if href.present? && href.match(%r{^.*/#{collection}/(#{ApplicationRecord::CID_OR_ID_MATCHER})$})
+          ApplicationRecord.uncompress_id(Regexp.last_match(1))
         end
       end
 

--- a/app/controllers/api/base_controller/parser/request_adapter.rb
+++ b/app/controllers/api/base_controller/parser/request_adapter.rb
@@ -2,8 +2,6 @@ module Api
   class BaseController
     module Parser
       class RequestAdapter
-        include CompressedIds
-
         def initialize(req, params)
           @request = req
           @params = params
@@ -68,7 +66,7 @@ module Api
 
         def c_id
           id = @params[:c_id] || c_path_parts[1]
-          cid?(id) ? from_cid(id) : id
+          ApplicationRecord.compressed_id?(id) ? ApplicationRecord.uncompress_id(id) : id
         end
 
         def subcollection
@@ -77,7 +75,7 @@ module Api
 
         def s_id
           id = @params[:s_id] || c_path_parts[3]
-          cid?(id) ? from_cid(id) : id
+          ApplicationRecord.compressed_id?(id) ? ApplicationRecord.uncompress_id(id) : id
         end
 
         def subcollection?

--- a/app/controllers/api/subcollections/policies.rb
+++ b/app/controllers/api/subcollections/policies.rb
@@ -43,7 +43,11 @@ module Api
         return klass.find_by(:guid => guid) if guid.present?
 
         href = data["href"]
-        href =~ %r{^.*/#{collection}/#{BaseController::CID_OR_ID_MATCHER}$} ? klass.find(from_cid(href.split('/').last)) : {}
+        if href =~ %r{^.*/#{collection}/#{ApplicationRecord::CID_OR_ID_MATCHER}$}
+          klass.find(ApplicationRecord.uncompress_id(href.split('/').last))
+        else
+          {}
+        end
       end
 
       def policy_subcollection_action(ctype, policy)

--- a/app/controllers/api/subcollections/tags.rb
+++ b/app/controllers/api/subcollections/tags.rb
@@ -102,9 +102,9 @@ module Api
 
       def parse_tag_from_href(data)
         href = data["href"]
-        tag  = if href && href.match(%r{^.*/tags/#{BaseController::CID_OR_ID_MATCHER}$})
+        tag  = if href && href.match(%r{^.*/tags/#{ApplicationRecord::CID_OR_ID_MATCHER}$})
                  klass = collection_class(:tags)
-                 klass.find(from_cid(href.split('/').last))
+                 klass.find(ApplicationRecord.uncompress_id(href.split('/').last))
                end
         tag.present? ? tag_path_to_spec(tag.name).merge(:id => tag.id) : {}
       end

--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -1,7 +1,5 @@
 module Api
   class Filter
-    include CompressedIds
-
     OPERATORS = {
       "!=" => {:default => "!=", :regex => "REGULAR EXPRESSION DOES NOT MATCH", :null => "IS NOT NULL"},
       "<=" => {:default => "<="},
@@ -82,7 +80,9 @@ module Api
                                end
                              end
 
-      filter_value = from_cid(filter_value) if filter_attr =~ /[_]?id$/ && cid?(filter_value)
+      if filter_attr =~ /[_]?id$/ && ApplicationRecord.compressed_id?(filter_value)
+        filter_value = ApplicationRecord.uncompress_id(filter_value)
+      end
 
       if filter_value =~ /%|\*/
         filter_value = "/\\A#{Regexp.escape(filter_value)}\\z/"


### PR DESCRIPTION
This now lives [elsewhere](https://github.com/ManageIQ/manageiq-ui-classic/blob/d5f2918daf4061c278ffc0e27c0d4dedbd591395/app/controllers/mixins/compressed_ids.rb) so probably best if we weren't coupled to it. IMO this is probably
better anyway, since:

1. less indirection
2. typing isn't the bottleneck

/cc @Fryguy 
@miq-bot assign @abellotti 
@miq-bot add-label api, technical debt
