### PR TITLE
Generic Object Definition querying

### DIFF
--- a/app/controllers/api/object_definitions_controller.rb
+++ b/app/controllers/api/object_definitions_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  class ObjectDefinitionsController < BaseController
+    def show
+      object = fetch_object_definition(@req.c_id)
+      render_resource :object_definitions, object
+    end
+
+    private
+
+    def fetch_object_definition(id)
+      klass = collection_class(:object_definitions)
+      klass.find_by(:name => id) || klass.find(id)
+    end
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -1066,6 +1066,20 @@
       - :name: delete
       :delete:
       - :name: delete
+  :object_definitions:
+    :description: Object Definitions
+    :options:
+    - :collection
+    :verbs: *g
+    :klass: GenericObjectDefinition
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: generic_object_explorer
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: generic_object_explorer
   :orchestration_stacks:
     :description: Orchestration Stacks
     :options:

--- a/spec/requests/api/object_definitions_spec.rb
+++ b/spec/requests/api/object_definitions_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe 'ObjectDefinitions API' do
+  let(:object_def) { FactoryGirl.create(:generic_object_definition, :name => 'foo') }
+
+  describe 'GET /api/object_definitions' do
+    it 'does not list object definitions without an appropriate role' do
+      api_basic_authorize
+
+      run_get(object_definitions_url)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'lists all generic object definitions with an appropriate role' do
+      api_basic_authorize collection_action_identifier(:object_definitions, :read, :get)
+
+      expected = {
+        'count'     => 1,
+        'subcount'  => 1,
+        'name'      => 'object_definitions',
+        'resources' => [
+          hash_including('href' => a_string_matching(object_definitions_url(object_def.id)))
+        ]
+      }
+      run_get(object_definitions_url)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
+  describe 'GET /api/object_definitions/:id' do
+    it 'does not let you query object definitions without an appropriate role' do
+      api_basic_authorize
+
+      run_get(object_definitions_url(object_def.id))
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'can query an object definition by its id' do
+      api_basic_authorize collection_action_identifier(:object_definitions, :read, :get)
+
+      expected = {
+        'id'   => object_def.compressed_id,
+        'name' => object_def.name
+      }
+      run_get(object_definitions_url(object_def.id))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'can query an object definition by its name' do
+      api_basic_authorize collection_action_identifier(:object_definitions, :read, :get)
+
+      expected = {
+        'id'   => object_def.compressed_id,
+        'name' => object_def.name
+      }
+      run_get(object_definitions_url(object_def.name))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
+    it 'raises a record not found error if no object definition is found' do
+      api_basic_authorize collection_action_identifier(:object_definitions, :read, :get)
+
+      run_get(object_definitions_url('bar'))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
The first of many generic object PRs...

This PR adds:
```
GET /api/object_definitions/
GET /api/object_definitions/:id
GET /api/object_definitions/:name
```

Pivotal ticket: https://www.pivotaltracker.com/n/projects/1610125/stories/121850669

@miq-bot add_label enhancement, api
@miq-bot assign @abellotti 