### PR TITLE
Add memory usage to worker status in rake evm:status and status_full

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -102,11 +102,12 @@ class EvmApplication
            w.miq_server_id,
            w.queue_name || w.uri,
            w.started_on && w.started_on.iso8601,
-           w.last_heartbeat && w.last_heartbeat.iso8601]
+           w.last_heartbeat && w.last_heartbeat.iso8601,
+           (mem = (w.proportional_set_size || w.memory_usage)).nil? ? "" : mem / 1.megabyte]
       end
     end
 
-    header = ["Worker Type", "Status", "ID", "PID", "SPID", "Server id", "Queue Name / URL", "Started On", "Last Heartbeat"]
+    header = ["Worker Type", "Status", "ID", "PID", "SPID", "Server id", "Queue Name / URL", "Started On", "Last Heartbeat", "MB Usage"]
     puts data.unshift(header).tableize unless data.empty?
   end
 


### PR DESCRIPTION
I was using this locally for measuring worker sizes and thought it might be helpful to others.

```
04:43:06 ~/Code/manageiq (add_memory_information_to_status) (2.4.1) + bin/rake evm:status
** Using session_store: ActionDispatch::Session::MemCacheStore
Checking EVM status...
 Zone    | Server | Status  |            ID |   PID |  SPID | URL                     | Started On           | Last Heartbeat       | Master? | Active Roles
---------+--------+---------+---------------+-------+-------+-------------------------+----------------------+----------------------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------
 default | EVM    | started | 1000000000001 | 89807 | 89834 | druby://127.0.0.1:60899 | 2017-06-15T20:15:19Z | 2017-06-15T20:17:31Z | true    | automate:database_operations:database_owner:ems_inventory:ems_operations:event:reporting:scheduler:smartstate:user_interface:web_services:websocket

 Worker Type       | Status  |            ID |   PID | SPID  |     Server id | Queue Name / URL    | Started On           | Last Heartbeat       | MB Usage
-------------------+---------+---------------+-------+-------+---------------+---------------------+----------------------+----------------------+----------
 MiqGenericWorker  | started | 1000000000339 | 89838 | 89847 | 1000000000001 | generic             | 2017-06-15T20:15:19Z | 2017-06-15T20:17:46Z |
 MiqScheduleWorker | started | 1000000000340 | 89841 | 89848 | 1000000000001 |                     | 2017-06-15T20:15:19Z | 2017-06-15T20:17:37Z | 239 MB
 MiqUiWorker       | started | 1000000000341 | 89844 |       | 1000000000001 | http://0.0.0.0:3000 | 2017-06-15T20:15:20Z | 2017-06-15T20:17:44Z | 236 MB
```

Note, any worker with a nil value will show up as an empty string.

Note, this also shows up when you call `evm:status_full` to see multiple servers and the workers on those servers.