### PR TITLE
Allow `lib/vmdb/logging.rb` to be required without needing Rails autoloading

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -1,7 +1,5 @@
 require 'util/vmdb-logger'
 
-Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }
-
 module Vmdb
   def self.logger
     $log
@@ -85,3 +83,5 @@ module Vmdb
     end
   end
 end
+
+Dir.glob(File.join(File.dirname(__FILE__), "loggers", "*")).each { |f| require f }

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -1,3 +1,4 @@
+require 'manageiq'
 require 'util/vmdb-logger'
 
 module Vmdb
@@ -36,10 +37,10 @@ module Vmdb
     private
 
     def self.create_loggers
-      path_dir = Rails.root.join("log")
+      path_dir = ManageIQ.root.join("log")
 
       $log               = VMDBLogger.new(path_dir.join("evm.log"))
-      $rails_log         = VMDBLogger.new(path_dir.join("#{Rails.env}.log"))
+      $rails_log         = VMDBLogger.new(path_dir.join("#{ManageIQ.env}.log"))
       $audit_log         = AuditLogger.new(path_dir.join("audit.log"))
       $fog_log           = FogLogger.new(path_dir.join("fog.log"))
       $policy_log        = MirroredLogger.new(path_dir.join("policy.log"),        "<PolicyEngine> ")

--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -4,8 +4,15 @@ module Vmdb
   class LogProxy < Struct.new(:klass, :separator)
     LEVELS = [:debug, :info, :warn, :error]
 
-    delegate *LEVELS.map { |level| :"#{level}?" },
-             :log_backtrace, :level, :to => :logger
+    # def debug?
+    # def info?
+    # def warn?
+    # def error?
+    # def log_backtrace
+    # def level
+    (LEVELS.map { |l| :"#{l}?" } + [:log_backtrace, :level]).each do |method|
+      define_method(method) { |*args| logger.send(method, *args) }
+    end
 
     LEVELS.each do |level|
       define_method(level) do |msg = nil, &blk|


### PR DESCRIPTION
tl; dr;
-------
Allows the following to work:

```console
$ bundle exec ruby -I lib -e 'require "manageiq-gems-pending"; require "vmdb/logging"; Vmdb::Loggers.init'
```

Summary
-------
Through black magic, or some load order/autoloading secret sauce, we are able to include "vmdb/logging", or even "vmdb/logger", without issue when booting our application so that we don't run into errors like `undefined constant Loggers for Vmdb` and such.  But when loading on it's own, it was impossible.

This PR makes some changes to not only make autoloading function, but make the "vmdb/logging" lib less dependent on Rails for it's functionality.


Links
-----
* https://www.pivotaltracker.com/story/show/147058229
* Was originally going to include [this effort](https://github.com/ManageIQ/manageiq/pull/15358) as part of this PR, but we are going to hold off on that until we decide on the `manageiq-core` gem (working title) contents and plan.
* Will be used probably in the following efforts:
  - https://github.com/ManageIQ/manageiq/pull/15174
  - https://github.com/ManageIQ/manageiq/pull/14916
  - https://github.com/ManageIQ/manageiq/pull/15342

Steps for Testing/QA
--------------------
* Tests pass?
* Can you run the script at the top just fine on this branch? (does it also fail on master?)