### PR TITLE
Support  worker heartbeat to a local file instead of Drb.

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -152,6 +152,7 @@ class MiqServer < ApplicationRecord
     #############################################################
     # Start all the configured workers
     #############################################################
+    clean_heartbeat_files
     sync_config
     start_drb_server
     sync_workers

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -219,6 +219,10 @@ class MiqWorker < ApplicationRecord
     self.class.fetch_worker_settings_from_server(miq_server, options)
   end
 
+  def heartbeat_file
+    @heartbeat_file ||= ENV["WORKER_HEARTBEAT_FILE"] || Rails.root.join("tmp", "#{guid}.hb")
+  end
+
   def self.worker_settings(options = {})
     fetch_worker_settings_from_server(MiqServer.my_server, options)
   end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -352,10 +352,34 @@ describe "MiqWorker Monitor" do
           server.setup_drb_variables
         end
 
-        it "should mark not responding if not recently heartbeated" do
-          worker.update(:last_heartbeat => 20.minutes.ago)
-          expect(server.validate_worker(worker)).to be_falsey
-          expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPING)
+        context "for heartbeat" do
+          it "should mark not responding if not recently heartbeated via Drb" do
+            worker.update(:last_heartbeat => 20.minutes.ago)
+            expect(server.validate_worker(worker)).to be_falsey
+            expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPING)
+          end
+
+          context "to a file" do
+            before do
+              ENV["WORKER_HEARTBEAT_METHOD"] = "file"
+            end
+
+            after do
+              ENV["WORKER_HEARTBEAT_METHOD"] = nil
+            end
+
+            it "should mark not responding if not recently heartbeated via file" do
+              allow(server).to receive(:workers_last_heartbeat_to_file).and_return(20.minutes.ago)
+
+              expect(server.validate_worker(worker)).to be_falsey
+              expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPING)
+            end
+
+            it "should detect responding if recently heartbeated via file" do
+              expect(server.validate_worker(worker)).to be_truthy
+              expect(worker.reload.status).to eq(MiqWorker::STATUS_READY)
+            end
+          end
         end
 
         context "for excessive memory" do


### PR DESCRIPTION
For the new architecture, we'd like to move away for using Drb. This PR takes a step in that direction by  enabling workers to heartbeat to a file instead of Drb.

https://www.pivotaltracker.com/story/show/147230943