### PR TITLE
Make spawn an option again

### DIFF
--- a/app/models/embedded_ansible_worker.rb
+++ b/app/models/embedded_ansible_worker.rb
@@ -17,6 +17,7 @@ class EmbeddedAnsibleWorker < MiqWorker
         Thread.exit
       end
     end
+    nil # return no pid
   end
 
   def kill

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -11,6 +11,7 @@ class MiqWorker::Runner
 
   INTERRUPT_SIGNALS = ["SIGINT", "SIGTERM"]
 
+  # DELETE ME
   OPTIONS_PARSER_SETTINGS = [
     [:guid,       'EVM Worker GUID',       String],
   ]

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -23,6 +23,10 @@ opt_parser = OptionParser.new do |opts|
     options[:dry_run] = val
   end
 
+  opts.on("-g=GUID", "--guid=GUID", "Find an existing worker record instead of creating") do |val|
+    options[:guid] = val
+  end
+
   opts.on("-h", "--help", "Displays this help") do
     puts opts
     exit
@@ -52,7 +56,12 @@ require File.expand_path("../../../config/environment", __dir__)
 worker_class = worker_class.constantize
 worker_class.before_fork
 unless options[:dry_run]
-  worker = worker_class.create_worker_record
+  worker = if options[:guid]
+             worker_class.find_by!(:guid => options[:guid])
+           else
+             worker_class.create_worker_record
+           end
+
   begin
     worker.class::Runner.start_worker(:guid => worker.guid)
   ensure


### PR DESCRIPTION
This is nearly a no-op for the existing forking setup, but allows you to spawn workers instead via an environment variable.  

~~We had to add some complexity for subclasses that implement `start_runner` because we don't want to bypass their implementation.~~  

EDIT: Embedded ansible worker was changed to implement both of the
start_runner fork/spawn methods to ensure the threaded implementation is
used.

`MIQ_SPAWN_WORKERS=true bin/rake evm:start`  => Kernel.spawn
`MIQ_SPAWN_WORKERS=false bin/rake evm:start` => fork
`bin/rake evm:start` => fork

Note, when using @NickLaMuro's singular_worker script, the second commit is needed to avoid having millions of worker rows. 