### PR TITLE
[cap&u] Condense perf_capture_timer logic

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -138,8 +138,8 @@ module Metric::Capture
   def self.calc_targets_by_rollup_parent(targets)
     realtime_targets = targets.select do |target|
       target.kind_of?(Host) &&
-      perf_target_to_interval_name(target) == "realtime" &&
-      perf_capture_now?(target)
+        perf_target_to_interval_name(target) == "realtime" &&
+        perf_capture_now?(target)
     end
     realtime_targets.each_with_object({}) do |target, h|
       target.perf_rollup_parents("realtime").to_a.compact.each do |parent|
@@ -160,7 +160,7 @@ module Metric::Capture
     target_options = Hash.new { |h, k| h[k] = {:zone => zone} }
     # Create a new task for each rollup parent
     # mark each target with the rollup parent
-    targets_by_rollup_parent.keys.each_with_object(target_options) do |pkey, h|
+    targets_by_rollup_parent.each_with_object(target_options) do |(pkey, targets), h|
       name = "Performance rollup for #{pkey}"
       prev_task = MiqTask.where(:identifier => pkey).order("id DESC").first
       task_start_time = prev_task ? prev_task.context_data[:end] : default_task_start_time
@@ -175,13 +175,13 @@ module Metric::Capture
           :start    => task_start_time,
           :end      => task_end_time,
           :parent   => pkey,
-          :targets  => targets_by_rollup_parent[pkey].map { |target| "#{target.class}:#{target.id}" },
+          :targets  => targets.map { |target| "#{target.class}:#{target.id}" },
           :complete => [],
           :interval => "realtime"
         }
       )
       _log.info "Created task id: [#{task.id}] for: [#{pkey}] with targets: #{targets_by_rollup_parent[pkey].inspect} for time range: [#{task_start_time} - #{task_end_time}]"
-      targets_by_rollup_parent[pkey].each do |target|
+      targets.each do |target|
         h[target] = {
           :task_id => task.id,
           :force   => true, # Force collection since we've already verified that capture should be done now


### PR DESCRIPTION
This targets `perf_capture_timer`.
The goal is to reduce the code with these steps and add some documentation.

The code used to `calc_tasks_by_rollup_parent` to then correlate to `calc_target_options`. The new code directly creates the `arget_options` instead of the double loop. This results in a 1-2% speed improvement. But more importantly, reduction (and hopefully simplification) in code.

---
**TL;DR** The queries are identical. One hash was not created and an in memory traversal was skipped.

```ruby
[Vm.count, Vm.all.select {|vm| vm.state == "on"}.count, Host.count, Storage.count]
# => [166, 66, 8, 8]  
```

|     ms |       bytes | objects |query |query ms|     rows |`comments`
|    ---:|         ---:|     ---:|  ---:|    ---:|      ---:| ---
|  812.7 | 34,831,560* | 422,730 |  438 |  235.4 |      183 |`capu-before-4`
|  797.5 | 34,359,722* | 416,911 |  438 |  227.6 |      183 |`capu-after-3`
| 1.9% | 1% | 1% | same | n/a | same| improvement

\* all bytes do not reflect freeing 520 objects.


----
**too much data**


|     ms |       bytes | objects |query |query ms|     rows |`comments`
|    ---:|         ---:|     ---:|  ---:|    ---:|      ---:| ---
|  786.6 | 34,832,400* | 422,742 |  438 |  224.5 |      183 |`capu-before-1`
|  802.0 | 34,831,560* | 422,730 |  438 |  230.9 |      183 |`capu-before-2`
|  820.4 | 34,831,560* | 422,730 |  438 |  234.6 |      183 |`capu-before-3`
|  812.7 | 34,831,560* | 422,730 |  438 |  235.4 |      183 |`capu-before-4`
|  747.2 | 34,360,538* | 417,096 |  438 |  209.3 |      183 |`capu-after-1`
|  762.0 | 34,360,474* | 416,921 |  438 |  218.7 |      183 |`capu-after-2`
|  797.5 | 34,359,722* | 416,911 |  438 |  227.6 |      183 |`capu-after-3`
|  815.7 | 34,359,722* | 416,911 |  438 |  229.5 |      183 |`capu-after-4`

\* all bytes do not reflect freeing 520 objects.
