### PR TITLE
[EUWE] Toolbar - listen for updateToolbarCount event

### DIFF
--- a/app/assets/javascripts/controllers/toolbar_controller.js
+++ b/app/assets/javascripts/controllers/toolbar_controller.js
@@ -13,7 +13,9 @@
   */
   function subscribeToSubject() {
     ManageIQ.angular.rxSubject.subscribe(function(event) {
-      if (event.rowSelect) {
+      if (event.eventType === 'updateToolbarCount') {
+        this.MiQToolbarSettingsService.setCount(event.countSelected);
+      } else if (event.rowSelect) {
         this.onRowSelect(event.rowSelect);
       } else if (event.redrawToolbar) {
         this.onUpdateToolbar(event.redrawToolbar);


### PR DESCRIPTION
This is present in master (and fine) since https://github.com/ManageIQ/manageiq-ui-classic/pull/72, but the PR never got backported to euwe.

The changes introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/1058 to fix https://bugzilla.redhat.com/show_bug.cgi?id=1440142 do rely on this bit of functionality.

Adding :).

euwe bz: https://bugzilla.redhat.com/show_bug.cgi?id=1444037
and https://bugzilla.redhat.com/show_bug.cgi?id=1444178

---

Testing:

1. go to Network > Security Groups
1. click "Check all" - items will get checked and the Policy toolbar will ungray
1. re-sort (click on the "Name" header)

before: no items are checked but the Policy toolbar is active
after: no items are checked and the Policy toolbar is gray