### PR TITLE
[EUWE] Fix adding new group with tags

### DIFF
--- a/app/presenters/tree_builder_tags.rb
+++ b/app/presenters/tree_builder_tags.rb
@@ -35,7 +35,7 @@ class TreeBuilderTags < TreeBuilder
   def set_locals_for_render
     locals = super
     locals.merge!(:id_prefix         => 'tags_',
-                  :check_url         => "/ops/rbac_group_field_changed/#{@group.present? ? @group.id : "new"}___",
+                  :check_url         => "/ops/rbac_group_field_changed/#{(@group.present? && !@group.id.nil?) ? @group.id : "new"}___",
                   :oncheck           => @edit.nil? ? nil : "miqOnCheckUserFilters",
                   :checkboxes        => true,
                   :highlight_changes => true,


### PR DESCRIPTION
If @group exists but has no id use "new" instead of an id.

Before:
<img width="878" alt="screen shot 2017-06-15 at 1 35 37 pm" src="https://user-images.githubusercontent.com/9210860/27179602-9cdd757e-51cf-11e7-923d-5bed93c6a40c.png">

After:
<img width="877" alt="screen shot 2017-06-15 at 1 33 44 pm" src="https://user-images.githubusercontent.com/9210860/27179603-9cfb7f42-51cf-11e7-9acf-25f550ee5667.png">

Links:

https://bugzilla.redhat.com/show_bug.cgi?id=1449397

Steps for Testing/QA :

Configuration -> Access Control -> Groups -> Configuration -> Add a new group -> select any tag in <tenant_name> Tags tree -> click save

@miq-bot add_label ui, bug, blocker, euwe/yes, darga/no, fine/no