### PR TITLE
Adding ContainerImage subclasses

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -83,20 +83,6 @@ class ContainerImage < ApplicationRecord
     !plist.blank?
   end
 
-  def annotate_deny_execution(causing_policy)
-    # TODO: support sti and replace check with inplementing only for OpenShift providers
-    unless ext_management_system.kind_of?(ManageIQ::Providers::Openshift::ContainerManagerMixin)
-      _log.error("#{__method__} only applicable for OpenShift Providers")
-      return
-    end
-    ext_management_system.annotate(
-      "image",
-      digest,
-      "security.manageiq.org/failed-policy" => causing_policy,
-      "images.openshift.io/deny-execution"  => "true"
-    )
-  end
-
   def openscap_failed_rules_summary
     openscap_rule_results.where(:result => "fail").group(:severity).count.symbolize_keys
   end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -308,6 +308,7 @@ module EmsRefresh::SaveInventoryContainer
 
     hashes.each do |h|
       h[:container_image_registry_id] = h[:container_image_registry][:id] unless h[:container_image_registry].nil?
+      h[:type] ||= 'ContainerImage'
     end
 
     save_inventory_multi(ems.container_images, hashes, deletes, [:image_ref, :container_image_registry_id],

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -737,12 +737,7 @@ class MiqAction < ApplicationRecord
       return
     end
 
-    unless rec.try(:ext_management_system).kind_of?(ManageIQ::Providers::Openshift::ContainerManagerMixin)
-      MiqPolicy.logger.error("#{error_prefix} only applicable for OpenShift Providers")
-      return
-    end
-
-    unless rec.digest.present?
+    unless rec.respond_to?(:annotate_deny_execution)
       MiqPolicy.logger.error("#{error_prefix} ContainerImage is not linked with an OpenShift image")
       return
     end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -218,6 +218,17 @@ describe MiqAction do
     end
   end
 
+  context "#action_container_image_annotate_deny_execution" do
+    let(:container_image) { FactoryGirl.create(:container_image) }
+    let(:event) { FactoryGirl.create(:miq_event_definition, :name => "whatever") }
+    let(:action) { FactoryGirl.create(:miq_action, :name => "container_image_annotate_deny_execution") }
+
+    it "will not annotate if the method is unavailable" do
+      expect(MiqQueue).to receive(:put).exactly(0).times
+      action.action_container_image_annotate_deny_execution(action, container_image, :event => event)
+    end
+  end
+
   context '.create_default_actions' do
     context 'seeding default actions from a file with 3 csv rows and some comments' do
       before do


### PR DESCRIPTION
This will add `ContainerImage` subclasses: `BasicContainerImage` and `OpenshiftContainerImage`. This will allow to treat container images from different sources differently.

Openshift provider complementing PR: https://github.com/ManageIQ/manageiq-providers-openshift/issues/23