### PR TITLE
Fix virtual attribute selection

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -166,7 +166,9 @@ module Api
         if resource.class < ApplicationRecord
           # is relation in 'attribute' variable plural in the model class (from 'resource.class') ?
           if [:has_many, :has_and_belongs_to_many].include?(resource.class.reflection_with_virtual(attribute).try(:macro))
-            Rbac.filtered(resource.public_send(attribute))
+            resource_attr = resource.public_send(attribute)
+            return resource_attr unless resource_attr.try(:first).kind_of?(ApplicationRecord)
+            Rbac.filtered(resource_attr)
           else
             Rbac.filtered_object(resource).try(:public_send, attribute)
           end

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -445,6 +445,18 @@ describe "Services API" do
       expect_result_resources_to_include_hrefs("resources", @svc1_vm_list)
     end
 
+    it "supports expansion of virtual attributes" do
+      run_get services_url, :expand => "resources", :attributes => "power_states"
+
+      expected = {
+        "resources" => [
+          a_hash_including("power_states" => svc1.power_states)
+        ]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "can query vms as subcollection via expand" do
       run_get services_url(svc1.id), :expand => "vms"
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1461939

When expanding a virtual attribute that is an array of values (ie, `power_states => ["ok","ok"]` on a service), it is currently failing with the error: 
```
{"error":{"kind":"internal_server_error","message":"undefined method `id' for \"on\":String","klass":"NoMethodError"}}
```

This is due to these values being passed to `Rbac.filterer`, which is looking for `id` of object. This fix avoids sending the value of the virtual attribute to filterer. 

@miq-bot add_label api, bug
@miq-bot assign @abellotti 
cc: @AllenBW 