### PR TITLE
Validate presence of feed on middleware servers

### DIFF
--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -11,6 +11,8 @@ class MiddlewareServer < ApplicationRecord
   serialize :properties
   acts_as_miq_taggable
 
+  validates :feed, :presence => true
+
   def properties
     super || {}
   end

--- a/spec/factories/middleware_servers.rb
+++ b/spec/factories/middleware_servers.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :middleware_server do
     sequence(:name) { |n| "middleware_server_#{seq_padded_for_sorting(n)}" }
+    sequence(:feed) { |n| "feed_#{n}" }
   end
 
   factory :hawkular_middleware_server,


### PR DESCRIPTION
Hawkular's MiddlewareServer [relies on feed not being nil](https://github.com/cfcosta/manageiq-providers-hawkular/blob/086ef0c74b0e5a919bda68cb52bd86a3cb378d73/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb#L4) => adding a `validates_presence` to be sure.

And fixing the factory to always create a feed - to remove the need to always provide `feed` when mocking to prevent errors from `CGI.unescape`.

(This recently caused ui-classic spec failures, fixed temporarily in https://github.com/ManageIQ/manageiq-ui-classic/pull/1540 by adding that `feed` everywhere, but since according to @israel-hdez (in https://github.com/ManageIQ/manageiq-providers-hawkular/pull/20/files#r121929594), a `feed` is always there, seems that this is the right place to fix.)

@israel-hdez WDYT?