### PR TITLE
MiqQueue.put remove temp variables

### DIFF
--- a/app/models/manageiq/providers/native_operation_workflow.rb
+++ b/app/models/manageiq/providers/native_operation_workflow.rb
@@ -72,7 +72,7 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
     role     = options[:role] || "ems_operations"
     priority = options[:priority] || MiqQueue::NORMAL_PRIORITY
 
-    queue_options = {
+    MiqQueue.put(
       :class_name  => self.class.name,
       :method_name => "signal",
       :instance_id => id,
@@ -82,9 +82,7 @@ class ManageIQ::Providers::NativeOperationWorkflow < Job
       :task_id     => guid,
       :args        => args,
       :deliver_on  => deliver_on
-    }
-
-    MiqQueue.put(queue_options)
+    )
   end
 
   alias initializing dispatch_start

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1016,16 +1016,15 @@ class MiqAction < ApplicationRecord
       target.send(target_method, *target_args)
     else
       MiqPolicy.logger.info("#{log_prefix} Queueing #{log_suffix}")
-      args = {
+      MiqQueue.put(
         :class_name  => static ? target.name : target.class.name,
         :method_name => target_method,
+        :instance_id => static ? nil : target.id,
         :args        => target_args,
         :role        => role,
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => zone
-      }
-      args[:instance_id] = target.id unless static
-      MiqQueue.put(args)
+      )
     end
   end
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -44,6 +44,7 @@ describe MiqAction do
       q_options = {
         :class_name  => 'MiqAeEngine',
         :method_name => 'deliver',
+        :instance_id => nil,
         :args        => [@args],
         :role        => 'automate',
         :zone        => nil,
@@ -120,6 +121,7 @@ describe MiqAction do
       q_options = {
         :class_name  => "MiqAeEvent",
         :method_name => "raise_synthetic_event",
+        :instance_id => nil,
         :args        => [@vm, @event.name, @aevent],
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => "vm_zone",
@@ -378,6 +380,7 @@ describe MiqAction do
       q_options = {
         :class_name  => "MiqAction",
         :method_name => "queue_email",
+        :instance_id => nil,
         :args        => [{:to => nil, :from => "cfadmin@cfserver.com"}],
         :role        => "notifier",
         :priority    => 20,


### PR DESCRIPTION
As we are merging our code, it is easier to keep track of the method calls if we pass an inline hash to `MiqQueue.put` rather than putting into a temporary variable.