### PR TITLE
Logging to STDOUT in JSON format for containers

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -5,6 +5,7 @@ GlobalVars:
   - $api_log
   - $aws_log
   - $azure_log
+  - $container_log
   - $datawarehouse_log
   - $fog_log
   - $lenovo_log

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -41,31 +41,37 @@ module Vmdb
 
       $audit_log         = AuditLogger.new(path_dir.join("audit.log"))
       $container_log     = ContainerLogger.new
-      $log               = MulticastLogger.new(VMDBLogger.new(path_dir.join("evm.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $rails_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("#{Rails.env}.log"))).tap  { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $fog_log           = MulticastLogger.new(FogLogger.new(path_dir.join("fog.log"))).tap            { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $policy_log        = MulticastLogger.new(VMDBLogger.new(path_dir.join("policy.log"))).tap        { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $vim_log           = MulticastLogger.new(VMDBLogger.new(path_dir.join("vim.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $rhevm_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("rhevm.log"))).tap         { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $aws_log           = MulticastLogger.new(VMDBLogger.new(path_dir.join("aws.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $lenovo_log        = MulticastLogger.new(VMDBLogger.new(path_dir.join("lenovo.log"))).tap        { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $kube_log          = MulticastLogger.new(VMDBLogger.new(path_dir.join("kubernetes.log"))).tap    { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $mw_log            = MulticastLogger.new(VMDBLogger.new(path_dir.join("middleware.log"))).tap    { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $datawarehouse_log = MulticastLogger.new(VMDBLogger.new(path_dir.join("datawarehouse.log"))).tap { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $scvmm_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("scvmm.log"))).tap         { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $azure_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("azure.log"))).tap         { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $api_log           = MulticastLogger.new(VMDBLogger.new(path_dir.join("api.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $websocket_log     = MulticastLogger.new(VMDBLogger.new(path_dir.join("websocket.log"))).tap     { |l| l.loggers << $container_log if ENV["CONTAINER"] }
-      $miq_ae_logger     = MulticastLogger.new(VMDBLogger.new(path_dir.join("automation.log"))).tap    { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $log               = create_multicast_logger(path_dir.join("evm.log"))
+      $rails_log         = create_multicast_logger(path_dir.join("#{Rails.env}.log"))
+      $fog_log           = create_multicast_logger(path_dir.join("fog.log"), FogLogger)
+      $policy_log        = create_multicast_logger(path_dir.join("policy.log"))
+      $vim_log           = create_multicast_logger(path_dir.join("vim.log"))
+      $rhevm_log         = create_multicast_logger(path_dir.join("rhevm.log"))
+      $aws_log           = create_multicast_logger(path_dir.join("aws.log"))
+      $lenovo_log        = create_multicast_logger(path_dir.join("lenovo.log"))
+      $kube_log          = create_multicast_logger(path_dir.join("kubernetes.log"))
+      $mw_log            = create_multicast_logger(path_dir.join("middleware.log"))
+      $datawarehouse_log = create_multicast_logger(path_dir.join("datawarehouse.log"))
+      $scvmm_log         = create_multicast_logger(path_dir.join("scvmm.log"))
+      $azure_log         = create_multicast_logger(path_dir.join("azure.log"))
+      $api_log           = create_multicast_logger(path_dir.join("api.log"))
+      $websocket_log     = create_multicast_logger(path_dir.join("websocket.log"))
+      $miq_ae_logger     = create_multicast_logger(path_dir.join("automation.log"))
 
       configure_external_loggers
     end
+
+    def self.create_multicast_logger(log_file_path, logger_class = VMDBLogger)
+      MulticastLogger.new(logger_class.new(log_file_path)).tap do |l|
+        l.loggers << $container_log if ENV["CONTAINER"]
+      end
+    end
+    private_class_method :create_multicast_logger
 
     def self.configure_external_loggers
       require 'awesome_spawn'
       AwesomeSpawn.logger = $log
     end
-
     private_class_method :configure_external_loggers
 
 

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -39,23 +39,24 @@ module Vmdb
     def self.create_loggers
       path_dir = ManageIQ.root.join("log")
 
-      $log               = VMDBLogger.new(path_dir.join("evm.log"))
-      $rails_log         = VMDBLogger.new(path_dir.join("#{ManageIQ.env}.log"))
       $audit_log         = AuditLogger.new(path_dir.join("audit.log"))
-      $fog_log           = FogLogger.new(path_dir.join("fog.log"))
-      $policy_log        = VMDBLogger.new(path_dir.join("policy.log"))
-      $vim_log           = VMDBLogger.new(path_dir.join("vim.log"))
-      $rhevm_log         = VMDBLogger.new(path_dir.join("rhevm.log"))
-      $aws_log           = VMDBLogger.new(path_dir.join("aws.log"))
-      $lenovo_log        = VMDBLogger.new(path_dir.join("lenovo.log"))
-      $kube_log          = VMDBLogger.new(path_dir.join("kubernetes.log"))
-      $mw_log            = VMDBLogger.new(path_dir.join("middleware.log"))
-      $datawarehouse_log = VMDBLogger.new(path_dir.join("datawarehouse.log"))
-      $scvmm_log         = VMDBLogger.new(path_dir.join("scvmm.log"))
-      $azure_log         = VMDBLogger.new(path_dir.join("azure.log"))
-      $api_log           = VMDBLogger.new(path_dir.join("api.log"))
-      $websocket_log     = VMDBLogger.new(path_dir.join("websocket.log"))
-      $miq_ae_logger     = VMDBLogger.new(path_dir.join("automation.log"))
+      $container_log     = ContainerLogger.new
+      $log               = MulticastLogger.new(VMDBLogger.new(path_dir.join("evm.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $rails_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("#{Rails.env}.log"))).tap  { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $fog_log           = MulticastLogger.new(FogLogger.new(path_dir.join("fog.log"))).tap            { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $policy_log        = MulticastLogger.new(VMDBLogger.new(path_dir.join("policy.log"))).tap        { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $vim_log           = MulticastLogger.new(VMDBLogger.new(path_dir.join("vim.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $rhevm_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("rhevm.log"))).tap         { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $aws_log           = MulticastLogger.new(VMDBLogger.new(path_dir.join("aws.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $lenovo_log        = MulticastLogger.new(VMDBLogger.new(path_dir.join("lenovo.log"))).tap        { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $kube_log          = MulticastLogger.new(VMDBLogger.new(path_dir.join("kubernetes.log"))).tap    { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $mw_log            = MulticastLogger.new(VMDBLogger.new(path_dir.join("middleware.log"))).tap    { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $datawarehouse_log = MulticastLogger.new(VMDBLogger.new(path_dir.join("datawarehouse.log"))).tap { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $scvmm_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("scvmm.log"))).tap         { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $azure_log         = MulticastLogger.new(VMDBLogger.new(path_dir.join("azure.log"))).tap         { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $api_log           = MulticastLogger.new(VMDBLogger.new(path_dir.join("api.log"))).tap           { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $websocket_log     = MulticastLogger.new(VMDBLogger.new(path_dir.join("websocket.log"))).tap     { |l| l.loggers << $container_log if ENV["CONTAINER"] }
+      $miq_ae_logger     = MulticastLogger.new(VMDBLogger.new(path_dir.join("automation.log"))).tap    { |l| l.loggers << $container_log if ENV["CONTAINER"] }
 
       configure_external_loggers
     end

--- a/lib/vmdb/loggers/container_logger.rb
+++ b/lib/vmdb/loggers/container_logger.rb
@@ -1,0 +1,53 @@
+module Vmdb::Loggers
+  class ContainerLogger < VMDBLogger
+    def initialize(logdev = STDOUT, *args)
+      super
+      self.level = DEBUG
+      self.formatter = Formatter.new
+    end
+
+    def level=(_new_level)
+      super(DEBUG) # We want everything written to the ContainerLogger written to STDOUT
+    end
+
+    def filename
+      "STDOUT"
+    end
+
+    class Formatter < VMDBLogger::Formatter
+      SEVERITY_MAP = {
+        "DEBUG"   => "debug",
+        "INFO"    => "info",
+        "WARN"    => "warning",
+        "ERROR"   => "err",
+        "FATAL"   => "crit",
+        "UNKNOWN" => "unknown"
+        # Others that don't match up: alert emerg notice trace
+      }.freeze
+
+      def call(severity, time, progname, msg)
+        # From https://github.com/ViaQ/elasticsearch-templates/releases Downloads asciidoc
+        {
+          :@timestamp => format_datetime(time),
+          :hostname   => hostname,
+          :level      => translate_error(severity),
+          :message    => prefix_task_id(msg2str(msg)),
+          :pid        => $PROCESS_ID,
+          :tid        => Thread.current.object_id,
+          :service    => progname,
+          # :tags => "tags string",
+        }.to_json << "\n"
+      end
+
+      private
+
+      def hostname
+        @hostname ||= ENV["HOSTNAME"]
+      end
+
+      def translate_error(level)
+        SEVERITY_MAP[level] || "unknown"
+      end
+    end
+  end
+end

--- a/lib/vmdb/loggers/container_logger.rb
+++ b/lib/vmdb/loggers/container_logger.rb
@@ -33,7 +33,7 @@ module Vmdb::Loggers
           :level      => translate_error(severity),
           :message    => prefix_task_id(msg2str(msg)),
           :pid        => $PROCESS_ID,
-          :tid        => Thread.current.object_id,
+          :tid        => thread_id,
           :service    => progname,
           # :tags => "tags string",
         }.to_json << "\n"
@@ -43,6 +43,10 @@ module Vmdb::Loggers
 
       def hostname
         @hostname ||= ENV["HOSTNAME"]
+      end
+
+      def thread_id
+        Thread.current.object_id.to_s(16)
       end
 
       def translate_error(level)

--- a/lib/vmdb/loggers/multicast_logger.rb
+++ b/lib/vmdb/loggers/multicast_logger.rb
@@ -1,0 +1,31 @@
+class MulticastLogger < Logger
+  attr_accessor :loggers
+
+  def initialize(*loggers)
+    require 'set'
+    @loggers = Set.new(loggers)
+    @level   = DEBUG
+  end
+
+  def level=(new_level)
+    loggers.each { |l| l.level = new_level }
+    super
+  end
+
+  def filename
+    loggers.first.filename
+  end
+
+  [:log_backtrace, :log_hashes].each do |method|
+    define_method(method) do |*args|
+      loggers.map { |l| l.send(method, *args) }.first
+    end
+  end
+
+  def add(*args, &block)
+    severity = args.first || UNKNOWN
+    return true if severity < @level
+    loggers.each { |l| l.send(:add, *args, &block) }
+    true
+  end
+end

--- a/spec/lib/vmdb/loggers/container_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/container_logger_spec.rb
@@ -1,0 +1,15 @@
+describe Vmdb::Loggers::ContainerLogger::Formatter do
+  it "stuff" do
+    time = Time.now
+    result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")
+    expect(JSON.parse(result)).to have_attributes(
+      "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N "),
+      "hostname"   => ENV["HOSTNAME"],
+      "level"      => "info",
+      "message"    => "testing 1, 2, 3",
+      "pid"        => $PROCESS_ID,
+      "service"    => "some_program",
+      "tid"        => Thread.current.object_id.to_s(16),
+    )
+  end
+end

--- a/spec/lib/vmdb/loggers/multicast_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/multicast_logger_spec.rb
@@ -1,0 +1,29 @@
+describe MulticastLogger do
+  let(:logger1) { Logger.new(StringIO.new) }
+  let(:logger2) { Logger.new(StringIO.new) }
+  subject { described_class.new(logger1, logger2) }
+
+  context "#add" do
+    it "forwards to the other loggers" do
+      expect(logger1).to receive(:add).with(1, nil, "test message")
+      expect(logger2).to receive(:add).with(1, nil, "test message")
+
+      subject.info("test message")
+    end
+
+    it "only forwards the message if the severity is correct" do
+      subject.level = 1
+      logger1.level = 0
+
+      [logger1, logger2].each { |l| expect(l).not_to receive(:add) }
+
+      subject.debug("test message")
+    end
+  end
+
+  it "#level= updates the log level on all backing devices" do
+    [logger1, logger2, subject].each { |l| expect(l.level).to eq(0) }
+    subject.level = 3
+    [logger1, logger2, subject].each { |l| expect(l.level).to eq(3) }
+  end
+end


### PR DESCRIPTION
- Add a StdoutLogger and ContainerFormatter for use in container environment
- Add a multicast logger allowing a caller to write to a single "logger" interface and have the message forwarded to multiple backing loggers
- $log remains the interface to the callers, but it can now be backed by a MulticastLogger in the container environment which will write to both evm.log in the old format and the StdoutLogger in the format that will be parsed by fluentd and sent to elasticsearch.