### PR TITLE
[FINE] Fix provisioning from PXE using OvirtSDK

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -346,9 +346,9 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
     def find_mac_address_on_network(nics, network, log)
       ext_management_system.with_provider_connection(VERSION_HASH) do |connection|
         nic = nics.detect do |n|
-          connection.follow_link(n.vnic_profile).network.id == network[:id]
+          connection.follow_link(n.vnic_profile).network.id == network.id
         end
-        log.warn "Cannot find NIC with network id=#{network[:id].inspect}" if nic.nil?
+        log.warn "Cannot find NIC with network id=#{network.id}" if nic.nil?
         nic && nic.mac && nic.mac.address
       end
     end


### PR DESCRIPTION
There was a bug in provisioning from PXE using the OvirtSDK,
Trying to call [:id] on an instance of OvirtSDK::Network.

This fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1461857