### PR TITLE
Adding options field to ext_management_system

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -72,6 +72,8 @@ class ExtManagementSystem < ApplicationRecord
   validates :hostname, :presence => true, :if => :hostname_required?
   validate :hostname_uniqueness_valid?, :if => :hostname_required?
 
+  serialize :options
+
   def hostname_uniqueness_valid?
     return unless hostname_required?
     return unless hostname.present? # Presence is checked elsewhere


### PR DESCRIPTION
This will add the serialzed column `options` to `ExtManagementSystem`.
There is also a migration for `ManageIQ::Providers::Kubernetes::ContainerManager` options that where saved in `CustomAttribute`s and general settings but should be there. This takes inspiration from https://github.com/ManageIQ/manageiq/pull/13826 and https://github.com/ManageIQ/manageiq/pull/14106 but the options details will be added in a later stage in the appropriate provider modules.

RFE BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1462835