### PR TITLE
fixing inconsistency of previous migration for showback

### DIFF
--- a/db/migrate/20170619175855_change_showback_column_name.rb
+++ b/db/migrate/20170619175855_change_showback_column_name.rb
@@ -1,0 +1,6 @@
+class ChangeShowbackColumnName < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :showback_rates, :fixed_rate_subunit, :fixed_rate_subunits
+    rename_column :showback_rates, :variable_rate_subunit, :variable_rate_subunits
+  end
+end

--- a/db/schema.yml
+++ b/db/schema.yml
@@ -5956,9 +5956,9 @@ showback_price_plans:
 - updated_at
 showback_rates:
 - id
-- fixed_rate_subunit
+- fixed_rate_subunits
 - fixed_rate_currency
-- variable_rate_subunit
+- variable_rate_subunits
 - variable_rate_currency
 - calculation
 - category


### PR DESCRIPTION
There was an inconsistency in the previous migration.
Some currencies were named _subunits, while others _subunit.

We need consistency in order to make Money work the same with all the concepts.

It solves an issue with the previous migration