### PR TITLE
Add MiqTemplate to InfraManager InventoryCollection

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -9,6 +9,15 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
       attributes.merge!(extra_attributes)
     end
 
+    def miq_templates(extra_attributes = {})
+      attributes = {
+        :model_class => ::ManageIQ::Providers::InfraManager::Template,
+        :association => :miq_templates,
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
     def disks(extra_attributes = {})
       attributes = {
         :model_class => ::Disk,


### PR DESCRIPTION
Adds `MiqTemplate` to the `InfraManager` default inventory collection