### PR TITLE
Add the evm:deployment_status rake task

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -58,10 +58,10 @@ namespace :evm do
   desc "Determine the deployment scenario"
   task :deployment_status => :environment do
     status_to_code = {
-      "new_deployment" => 0,
-      "new_replica"    => 1,
-      "redeployment"   => 2,
-      "upgrade"        => 3
+      "new_deployment" => 3,
+      "new_replica"    => 4,
+      "redeployment"   => 5,
+      "upgrade"        => 6
     }
     status = EvmApplication.deployment_status
     puts "Deployment status is #{status}"

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -55,6 +55,19 @@ namespace :evm do
     EvmApplication.update_stop
   end
 
+  desc "Determine the deployment scenario"
+  task :deployment_status => :environment do
+    status_to_code = {
+      "new_deployment" => 0,
+      "new_replica"    => 1,
+      "redeployment"   => 2,
+      "upgrade"        => 3
+    }
+    status = EvmApplication.deployment_status
+    puts "Deployment status is #{status}"
+    exit status_to_code[status]
+  end
+
   task :compile_assets => 'evm:assets:compile'
   namespace :assets do
     desc "Compile assets (clobber and precompile)"

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -138,4 +138,11 @@ class EvmApplication
     _log.info("Changing REGION file from [#{old_region}] to [#{new_region}]. Restart to use the new region.")
     region_file.write(new_region)
   end
+
+  def self.deployment_status
+    return "new_deployment" if ActiveRecord::Migrator.current_version.zero?
+    return "new_replica"    if MiqServer.my_server.nil?
+    return "upgrade"        if ActiveRecord::Migrator.needs_migration?
+    "redeployment"
+  end
 end

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -94,4 +94,26 @@ describe EvmApplication do
       end
     end
   end
+
+  describe ".deployment_status" do
+    it "returns new_deployment if the database is not migrated" do
+      expect(ActiveRecord::Migrator).to receive(:current_version).and_return(0)
+      expect(described_class.deployment_status).to eq("new_deployment")
+    end
+
+    it "returns new_replica if the current server is not seeded" do
+      expect(described_class.deployment_status).to eq("new_replica")
+    end
+
+    it "returns upgrade if we need to migrate the database" do
+      EvmSpecHelper.local_miq_server
+      expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
+      expect(described_class.deployment_status).to eq("upgrade")
+    end
+
+    it "returns redeployment otherwise" do
+      EvmSpecHelper.local_miq_server
+      expect(described_class.deployment_status).to eq("redeployment")
+    end
+  end
 end


### PR DESCRIPTION
This is mainly for running within containers where we want to know if we require initialization work to be done and if we should migrate the database.

Previously this was done from (untested) bash scripts.