### PR TITLE
Optimize insert query loading

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -38,6 +38,13 @@ module ManagerRefresh::SaveCollection
             WHERE EXCLUDED.remote_data_timestamp IS NULL OR (EXCLUDED.remote_data_timestamp > #{table_name}.remote_data_timestamp)
           }
         end
+
+        if inventory_collection.dependees.present?
+          insert_query += %{
+            RETURNING id,#{inventory_collection.unique_index_columns.join(",")}
+          }
+        end
+
         insert_query
       end
 


### PR DESCRIPTION
Optimize insert query loading, using a Returning clause properly. This way we can spare another query for loading back the data. We need to load back the inserted data, to get their primary keys.
