### PR TITLE
Fix non existent container showing in report

### DIFF
--- a/product/reports/170_Configuration Management - Containers/040_Recently Discovered Container Groups.yaml
+++ b/product/reports/170_Configuration Management - Containers/040_Recently Discovered Container Groups.yaml
@@ -17,7 +17,11 @@ headers:
 - Name
 - Ready Status
 - Creation
-conditions:
+conditions: !ruby/object:MiqExpression
+  exp:
+    IS NOT NULL:
+      field: ContainerGroup-deleted_on
+      value:
 order: Descending
 sortby:
 - ems_created_on

--- a/product/reports/170_Configuration Management - Containers/060_Pods per Ready Status.yaml
+++ b/product/reports/170_Configuration Management - Containers/060_Pods per Ready Status.yaml
@@ -14,7 +14,11 @@ col_order:
 headers:
 - "# Pods per Ready Status"
 - Ready Condition Status
-conditions:
+conditions: !ruby/object:MiqExpression
+  exp:
+    IS NOT NULL:
+      field: ContainerGroup-deleted_on
+      value:
 order: Ascending
 sortby:
 - ready_condition_status


### PR DESCRIPTION
Currently, we output 'archived' containers to the user in the report 'Pods per Ready Status'.
In this PR we fix this behavior to only show the user the current containers.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1435958

Screenshots:

-Before:
![screenshot from 2017-06-20 15-34-54](https://user-images.githubusercontent.com/8366181/27333557-f6134a3a-55ce-11e7-9e89-746046ace728.png)
-After:
![screenshot from 2017-06-20 15-36-30](https://user-images.githubusercontent.com/8366181/27333585-0bdcc08a-55cf-11e7-9f08-df47ed177712.png)

Notice the list shrunk from 14 to 9.
cc: @simon3z  @moolitayer @kbrock 