### PR TITLE
Container Template: Add object_labels

### DIFF
--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -10,6 +10,7 @@ class ContainerTemplate < ApplicationRecord
            :dependent  => :destroy
 
   serialize :objects, Array
+  serialize :object_labels, Hash
 
   acts_as_miq_taggable
 end


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq-schema/pull/32

Changes included: 
* <del>Adding `object_labels` column to `container_templates` table</del> (Extracted), parsing this field is added in https://github.com/ManageIQ/manageiq-providers-openshift/pull/25. 
* <del>Allowing the `instantiate` method to receive labels as an argument so that each created object will be tagged with these labels during instantiation</del>. moved to https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/98
* Serializing the object_labels attribute. 