### PR TITLE
We always want to setup the sample manageiq test db

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -14,8 +14,9 @@ module ManageIQ
       if ENV["CI"]
         write_region_file
         create_database_user
-        setup_test_environment
       end
+
+      setup_test_environment
     end
 
     def self.ensure_config_files


### PR DESCRIPTION
ManageIQ could have new columns added so we want to migrate/reset our
sample manageiq app's test db when running bin/setup or bin/update.

For a mostly unrelated PR [1] that was open for a while, another PR [2]
with a dependent migration on manageiq were both merged causing my
development branch for [1] to fail because I had already setup the
initial test database and bin/setup and bin/update were not migrating
the test database to include the newly added column.

[1] https://github.com/ManageIQ/manageiq-providers-amazon/pull/256
[2] https://github.com/ManageIQ/manageiq-providers-amazon/pull/259