### PR TITLE
Manage passing varying data types to security_groups

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_amazon_dialogs_template.yaml
@@ -176,7 +176,7 @@
           :description: Security Groups
           :required: false
           :display: :edit
-          :data_type: :integer
+          :data_type: :array_integer
         :floating_ip_address:
           :values_from:
             :method: :allowed_floating_ip_addresses

--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -178,7 +178,7 @@
           :description: Security Groups
           :required: false
           :display: :edit
-          :data_type: :integer
+          :data_type: :array_integer
         :floating_ip_address:
           :values_from:
             :method: :allowed_floating_ip_addresses

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -512,6 +512,14 @@ describe MiqRequestWorkflow do
       expect(workflow.cast_value(1, :button)).to      eq(1)
     end
 
+    it 'array_integer' do
+      good_array = ["23", "2", 2, 10]
+      bad_array = ["sdf", "#", 2, 10]
+
+      expect(workflow.cast_value(good_array, :array_integer)).to eq([23, 2, 2, 10])
+      expect(workflow.cast_value(bad_array, :array_integer)).to eq([0, 0, 2, 10])
+    end
+
     it 'other' do
       expect(workflow.cast_value('data', :other)).to eq('data')
       expect(workflow.cast_value(1, :other)).to      eq(1)


### PR DESCRIPTION
We need to handle REST API calls with arbitrary `:security_groups` values.

This change allows any value passed in to be validated (or not) without causing an `Exception`

https://bugzilla.redhat.com/show_bug.cgi?id=1432578
