### PR TITLE
Refactor MiqTask.delete_older to queue condition instead of array of IDs

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -288,9 +288,18 @@ class MiqTask < ApplicationRecord
   end
 
   def self.delete_older(ts, condition)
-    _log.info("Queuing deletion of tasks older than: #{ts}")
-    ids = where("updated_on < ?", ts).where(condition).pluck("id")
-    delete_by_id(ids)
+    _log.info("Queuing deletion of tasks older than #{ts} and with condition: #{condition}")
+    MiqQueue.put(
+      :class_name  => name,
+      :method_name => "destroy_older_by_condition",
+      :args        => [ts, condition],
+      :zone        => MiqServer.my_zone
+    )
+  end
+
+  def self.destroy_older_by_condition(ts, condition)
+    _log.info("Executing destroy_all for records older than #{ts} and with condition: #{condition}")
+    MiqTask.where("updated_on < ?", ts).where(condition).destroy_all
   end
 
   def self.delete_by_id(ids)

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -68,6 +68,7 @@ describe Metric do
             %w(Storage perf_capture_hourly)                                             => 1,
             %w(ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_realtime)     => 2,
             %w(ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_historical)   => 16,
+            %w(MiqTask destroy_older_by_condition)                                      => 1
           }
         end
 
@@ -1023,7 +1024,9 @@ describe Metric do
 
         it "should queue up enabled targets" do
           expected_targets = Metric::Targets.capture_targets
-          expect(MiqQueue.group(:method_name).count).to eq('perf_capture_realtime' => expected_targets.count, 'perf_capture_historical' => expected_targets.count * 8)
+          expect(MiqQueue.group(:method_name).count).to eq('perf_capture_realtime'      => expected_targets.count,
+                                                           'perf_capture_historical'    => expected_targets.count * 8,
+                                                           'destroy_older_by_condition' => 1)
           assert_metric_targets(expected_targets)
         end
       end


### PR DESCRIPTION
Deleting old tasks records  executed in 2 steps: Execute SQL to get list of IDs which need to be deleted (based on passed condition  and date) and queue request to ```MiqTask.destroy``` with array of IDs as argument. 

**Issue**:  when executed on schedule  (deleting performance rollup tasks) there is possibility that second request to delete old task could be added to ```MiqQueue``` before first request executed.  So, in the second request some IDs will be from the first request and attempt to destroy record by id second time will raise error.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1397247

**Solution**: Instead of queuing list of IDs to destroy - queue actual condition. Also, It would be better from performance perspective.

@miq-bot add-label bug, core
 