### PR TITLE
fix shared example path in provider generator spec_helper.rb template

### DIFF
--- a/lib/generators/provider/provider_generator.rb
+++ b/lib/generators/provider/provider_generator.rb
@@ -49,6 +49,7 @@ class ProviderGenerator < Rails::Generators::NamedBase
     template "lib/tasks_private/spec.rake"
     empty_directory "spec/factories"
     empty_directory "spec/models/manageiq/providers/#{provider_name}"
+    empty_directory "spec/support"
     template "spec/spec_helper.rb"
   end
 

--- a/lib/generators/provider/templates/spec/spec_helper.rb
+++ b/lib/generators/provider/templates/spec/spec_helper.rb
@@ -10,3 +10,4 @@ end
 # end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
+Dir[ManageIQ::Providers::<%= class_name %>::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
The generated `spec_helper` would include from the wrong path and so providers would not find the existing shared examples (as in [this PR](https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/6)
