### PR TITLE
Remove ActsAsTaggable mixin from EmsFolder

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -3,8 +3,6 @@ class EmsFolder < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
-  acts_as_miq_taggable
-
   include SerializedEmsRefObjMixin
   include ProviderObjectMixin
 


### PR DESCRIPTION
@miq-bot assign @gtanzillo 
@miq-bot add_label rbac, core

There is no use of ActsAsTaggable mixin for EmsFolder model
EmsFolder class is also skipped from RBAC to applying tag filters:
https://github.com/ManageIQ/manageiq/blob/master/lib/rbac/filterer.rb#L54

based on these facts I believe that  `ActsAsTaggable` is unused here.


Not sure who can confirm it.