### PR TITLE
[WIP] Don`t use array for determination whether model is taggable

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -3,8 +3,6 @@ class EmsFolder < ApplicationRecord
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"
 
-  acts_as_miq_taggable
-
   include SerializedEmsRefObjMixin
   include ProviderObjectMixin
 

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -51,8 +51,6 @@ module Rbac
       VmOrTemplate
     )
 
-    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User)
-
     BELONGSTO_FILTER_CLASSES = %w(
       VmOrTemplate
       Host
@@ -417,7 +415,7 @@ module Rbac
 
     def get_managed_filter_object_ids(scope, filter)
       klass = scope.respond_to?(:klass) ? scope.klass : scope
-      return nil if !TAGGABLE_FILTER_CLASSES.include?(safe_base_class(klass).name) || filter.blank?
+      return nil if !klass.include?(ActsAsTaggable) || filter.blank?
       scope.find_tags_by_grouping(filter, :ns => '*').reorder(nil)
     end
 


### PR DESCRIPTION
WIP: this needs to be merged first https://github.com/ManageIQ/manageiq/pull/15419

this property can be determined directly from class with asking whether the mixin is included.

@miq-bot add_label rbac, technical_debt

@miq-bot assign @gtanzillo