### PR TITLE
[WIP] Drop collection of old realtime capture requests

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -20,6 +20,14 @@ module Metric::Capture
     historical_days.days.ago.utc.beginning_of_day
   end
 
+  def self.realtime_delayed_capture_limit_days
+    Settings.performance.realtime.delayed_capture_limit_days.to_i
+  end
+
+  def self.realtime_delayed_capture_limit
+    realtime_delayed_capture_limit_days.days.ago.utc.beginning_of_day
+  end
+
   def self.concurrent_requests(interval_name)
     requests = ::Settings.performance.concurrent_requests[interval_name]
     requests = 20 if requests < 20 && interval_name == 'realtime'

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -152,6 +152,14 @@ module Metric::CiMixin::Capture
         start_time = 4.hours.ago.utc
       end
 
+      # If the start time of a realtime capture request is many days old, (i.e.: lots of stale captures on the queue)
+      # then drop this in favor of re-queueing a split historical gap collection to prevent overloading the number of
+      # performance rows to process
+      if !start_time.nil? && start_time < Metric::Capture.realtime_delayed_capture_limit
+        _log.info "#{log_header} Skipping processing for #{log_target}#{log_time} as the start time is too long ago."
+        return
+      end
+
       interval_name_for_capture = interval_name
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -889,6 +889,8 @@
   :host_overhead:
     :memory: 2.01.percent
     :cpu: 0.15.percent
+  :realtime:
+    :delayed_capture_limit_days: 2
   :vim_cache_ttl: 1.hour
 :policy_events:
   :history:


### PR DESCRIPTION
If the realtime capture request is many days old due to stale data on the queue then don't process it.  The perf_capture_timer will re-queue historical gap collection and current realtime captures.

We've seen cases where we are processing realtime capture requests for a 20min window that are over a week old causing the provider to return many days of performance data which causes `#perf_process` to timeout.

Example:
```
Capture for ContainerNode start_time: [2017-06-03 21:24:20 UTC], end_time: [2017-06-03 21:54:17 UTC]
expected to get data as of [2017-06-03T21:24:40Z], but got data as of [2017-06-07 09:52:40 UTC].
Processing for ContainerNode for range [2017-06-07 09:52:40 UTC - 2017-06-14 01:42:40 UTC]...
Processing 26930 performance rows...
Message id: [1000031891465], timed out after 600.122446242 seconds.  Timeout threshold [600]
```

In this case we requested 20 minutes of performance data from 11 days prior, and we actually got about 1 week and 27,000 rows where a few hundred rows are typical.

/cc @blomquisg 