### PR TITLE
Use the Ansible service in containers rather than starting it locally

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -45,7 +45,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
     provider.name = "Embedded Ansible"
     provider.zone = server.zone
-    provider.url  = URI::HTTPS.build(:host => server.hostname || server.ipaddress, :path => "/ansibleapi/v1").to_s
+    provider.url  = provider_url
     provider.verify_ssl = 0
 
     provider.save!
@@ -68,6 +68,20 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def message_sync_config(*_args); end
 
   private
+
+  def provider_url
+    server = MiqServer.my_server(true)
+
+    if MiqEnvironment::Command.is_container?
+      host = ENV["ANSIBLE_SERVICE_NAME"]
+      path = "/api/v1"
+    else
+      host = server.hostname || server.ipaddress
+      path = "/ansibleapi/v1"
+    end
+
+    URI::HTTPS.build(:host => host, :path => path).to_s
+  end
 
   def raise_role_notification(notification_type)
     notification_options = {

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -13,6 +13,7 @@ class EmbeddedAnsible
   WAIT_FOR_ANSIBLE_SLEEP = 1.second
 
   def self.available?
+    return true if MiqEnvironment::Command.is_container?
     return false unless MiqEnvironment::Command.is_appliance?
 
     required_rpms = Set["ansible-tower-server", "ansible-tower-setup"]
@@ -24,10 +25,12 @@ class EmbeddedAnsible
   end
 
   def self.running?
+    return true if MiqEnvironment::Command.is_container?
     services.all? { |service| LinuxAdmin::Service.new(service).running? }
   end
 
   def self.configured?
+    return true if MiqEnvironment::Command.is_container?
     return false unless File.exist?(SECRET_KEY_FILE)
     key = miq_database.ansible_secret_key
     key.present? && key == File.read(SECRET_KEY_FILE)
@@ -62,10 +65,12 @@ class EmbeddedAnsible
   end
 
   def self.stop
+    return if MiqEnvironment::Command.is_container?
     services.each { |service| LinuxAdmin::Service.new(service).stop }
   end
 
   def self.disable
+    return if MiqEnvironment::Command.is_container?
     services.each { |service| LinuxAdmin::Service.new(service).stop.disable }
   end
 

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -79,11 +79,20 @@ class EmbeddedAnsible
   end
 
   def self.api_connection
+    if MiqEnvironment::Command.is_container?
+      host = ENV["ANSIBLE_SERVICE_NAME"]
+      port = 80
+    else
+      host = "localhost"
+      port = HTTP_PORT
+    end
+
     admin_auth = miq_database.ansible_admin_authentication
     AnsibleTowerClient::Connection.new(
-      :base_url => URI::HTTP.build(:host => "localhost", :path => "/api/v1", :port => HTTP_PORT).to_s,
-      :username => admin_auth.userid,
-      :password => admin_auth.password
+      :base_url   => URI::HTTP.build(:host => host, :path => "/api/v1", :port => port).to_s,
+      :username   => admin_auth.userid,
+      :password   => admin_auth.password,
+      :verify_ssl => 0
     )
   end
 

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -109,7 +109,7 @@ class EmbeddedAnsible
     miq_database.set_ansible_admin_authentication(:password => ENV["ANSIBLE_ADMIN_PASSWORD"])
 
     loop do
-      return if alive?
+      break if alive?
 
       _log.info("Waiting for Ansible container to respond")
       sleep WAIT_FOR_ANSIBLE_SLEEP

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -167,10 +167,9 @@ describe EmbeddedAnsible do
 
     describe ".api_connection" do
       around do |example|
-        old_env = ENV["ANSIBLE_SERVICE_NAME"]
         ENV["ANSIBLE_SERVICE_NAME"] = "ansible-service"
         example.run
-        ENV["ANSIBLE_SERVICE_NAME"] = old_env
+        ENV.delete("ANSIBLE_SERVICE_NAME")
       end
 
       it "connects to the ansible service when running in a container" do
@@ -388,10 +387,9 @@ describe EmbeddedAnsible do
 
     describe ".start when in a container" do
       around do |example|
-        old_env = ENV["ANSIBLE_ADMIN_PASSWORD"]
         ENV["ANSIBLE_ADMIN_PASSWORD"] = "thepassword"
         example.run
-        ENV["ANSIBLE_ADMIN_PASSWORD"] = old_env
+        ENV.delete("ANSIBLE_ADMIN_PASSWORD")
       end
 
       it "sets the admin password using the environment variable and waits for the service to respond" do

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -70,10 +70,9 @@ describe EmbeddedAnsibleWorker::Runner do
         end
 
         around do |example|
-          old_env = ENV["ANSIBLE_SERVICE_NAME"]
           ENV["ANSIBLE_SERVICE_NAME"] = "ansible-service"
           example.run
-          ENV["ANSIBLE_SERVICE_NAME"] = old_env
+          ENV.delete("ANSIBLE_SERVICE_NAME")
         end
 
         it "creates the provider with the service name for the URL" do


### PR DESCRIPTION
This PR makes the `EmbeddedAnsible` class and the `EmbeddedAnsibleWorker::Runner` container-aware. This means that their behavior will change when they detect that we are running in a container rather than in an appliance.

In an appliance we start and configure embedded ansible by installing it on one of our servers and then manage the services running local to that appliance. In the container (OpenShift) case we will have a separate container dedicated to running the Ansible service which we will configure against when our server is told to start the "embedded_ansible" role.

This allows everything else in our application to use the embedded ansible provider exactly the same as they had before.