### PR TITLE
Default to spawn automatically if fork isn't supported

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -335,7 +335,11 @@ class MiqWorker < ApplicationRecord
   end
 
   def start_runner
-    ENV['MIQ_SPAWN_WORKERS'] ? start_runner_via_spawn : start_runner_via_fork
+    if ENV['MIQ_SPAWN_WORKERS'] || !Process.respond_to?(:fork)
+      start_runner_via_spawn
+    else
+      start_runner_via_fork
+    end
   end
 
   def start_runner_via_fork


### PR DESCRIPTION
With the return of `spawn` we should default to using spawn on platforms or operating systems where `fork` isn't supported.