### PR TITLE
Wrong time var used for timestamps

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -109,14 +109,14 @@ module ManagerRefresh::SaveCollection
       end
 
       def assign_attributes_for_update!(hash, inventory_collection, update_time)
-        hash[:last_sync_on] = time if inventory_collection.supports_last_sync_on?
+        hash[:last_sync_on] = update_time if inventory_collection.supports_last_sync_on?
         hash[:updated_on]   = update_time if inventory_collection.supports_timestamps_on_variant?
         hash[:updated_at]   = update_time if inventory_collection.supports_timestamps_at_variant?
       end
 
       def assign_attributes_for_create!(hash, inventory_collection, create_time)
         hash[:type]         = inventory_collection.model_class.name if inventory_collection.supports_sti? && hash[:type].blank?
-        hash[:last_sync_on] = time if inventory_collection.supports_last_sync_on?
+        hash[:last_sync_on] = create_time if inventory_collection.supports_last_sync_on?
         hash[:created_on]   = create_time if inventory_collection.supports_timestamps_on_variant?
         hash[:created_at]   = create_time if inventory_collection.supports_timestamps_at_variant?
       end


### PR DESCRIPTION
Wrong time var used for timestamps, caused by typo

