### PR TITLE
Add additional logging into the websocket proxy for easier debugging

### DIFF
--- a/lib/websocket_proxy.rb
+++ b/lib/websocket_proxy.rb
@@ -1,10 +1,11 @@
 class WebsocketProxy
   attr_reader :env, :url, :error
 
-  def initialize(env, console)
+  def initialize(env, console, logger)
     @env = env
     @id = SecureRandom.uuid
     @console = console
+    @logger = logger
 
     secure = Rack::Request.new(env).ssl?
     scheme = secure ? 'wss:' : 'ws:'
@@ -17,7 +18,8 @@ class WebsocketProxy
       # Set up the socket client for the proxy
       @sock = TCPSocket.open(@console.host_name, @console.port)
       init_ssl if @console.ssl
-    rescue
+    rescue => ex
+      @logger.error(ex)
       @error = true
     end
 

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -62,7 +62,7 @@ class WebsocketServer
 
   def init_proxy(env, url)
     console = SystemConsole.find_by!(:url_secret => url)
-    proxy = WebsocketProxy.new(env, console)
+    proxy = WebsocketProxy.new(env, console, logger)
     return proxy.cleanup if proxy.error
     logger.info("Starting websocket proxy for VM #{console.vm_id}")
     proxy.start

--- a/spec/lib/websocket_proxy_spec.rb
+++ b/spec/lib/websocket_proxy_spec.rb
@@ -2,9 +2,10 @@ describe WebsocketProxy do
   let(:console) { FactoryGirl.create(:system_console) }
   let(:host) { '127.0.0.1:8080' }
   let(:uri) { '/ws/console/123456789' }
+  let(:logger) { double }
   let(:env) { {'HTTP_HOST' => host, 'REQUEST_URI' => uri, 'rack.hijack' => -> {}} }
 
-  subject { described_class.new(env, console) }
+  subject { described_class.new(env, console, logger) }
 
   describe '#initialize' do
     it 'sets the URL' do


### PR DESCRIPTION
When opening a VNC/SPICE console, there is no logging message if the remote endpoint is inaccessible. This should print the possible socket exceptions into the `websocket_log` and so QE would see if the issue is with their setup or in our code.

https://bugzilla.redhat.com/show_bug.cgi?id=1464006