### PR TITLE
Render ids in compressed form in API responses

### DIFF
--- a/app/controllers/api/base_controller/normalizer.rb
+++ b/app/controllers/api/base_controller/normalizer.rb
@@ -31,6 +31,8 @@ module Api
           normalize_array(value)
         elsif value.respond_to?(:attributes) || value.respond_to?(:keys)
           normalize_hash(attr, value)
+        elsif attr == "id" || attr.to_s.ends_with?("_id")
+          ApplicationRecord.compress_id(value)
         elsif Api.time_attribute?(attr)
           normalize_time(value)
         elsif Api.url_attribute?(attr)

--- a/app/controllers/api/base_controller/results.rb
+++ b/app/controllers/api/base_controller/results.rb
@@ -25,7 +25,7 @@ module Api
       end
 
       def add_task_to_result(hash, task_id)
-        hash[:task_id]   = task_id
+        hash[:task_id]   = ApplicationRecord.compress_id(task_id)
         hash[:task_href] = task_href(task_id)
         hash
       end
@@ -33,7 +33,7 @@ module Api
       def add_tasks_to_result(hash, task_ids)
         add_task_to_result(hash, task_ids.first)
         hash[:tasks] = task_ids.collect do |task_id|
-          { :id => task_id, :href => task_href(task_id) }
+          { :id => ApplicationRecord.compress_id(task_id), :href => task_href(task_id) }
         end
       end
 

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -27,7 +27,7 @@ describe "Actions API" do
 
       expect(response).to have_http_status(:ok)
 
-      action_id = response.parsed_body["results"].first["id"]
+      action_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
       expect(MiqAction.exists?(action_id)).to be_truthy
     end

--- a/spec/requests/api/alert_definitions_spec.rb
+++ b/spec/requests/api/alert_definitions_spec.rb
@@ -47,7 +47,7 @@ describe "Alerts Definitions API" do
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
       "href"        => a_string_matching(alert_definitions_url(alert_definition.id)),
-      "id"          => alert_definition.id,
+      "id"          => alert_definition.compressed_id,
       "description" => alert_definition.description,
       "guid"        => alert_definition.guid
     )
@@ -74,7 +74,7 @@ describe "Alerts Definitions API" do
     api_basic_authorize collection_action_identifier(:alert_definitions, :create)
     run_post(alert_definitions_url, sample_alert_definition)
     expect(response).to have_http_status(:ok)
-    alert_definition = MiqAlert.find(response.parsed_body["results"].first["id"])
+    alert_definition = MiqAlert.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
     expect(alert_definition).to be_truthy
     expect(alert_definition.expression.class).to eq(MiqExpression)
     expect(alert_definition.expression.exp).to eq(sample_alert_definition["expression"])
@@ -227,7 +227,8 @@ describe "Alerts Definition Profiles API" do
     run_post(alert_definition_profiles_url, sample_alert_definition_profile)
 
     expect(response).to have_http_status(:ok)
-    alert_definition_profile = MiqAlertSet.find(response.parsed_body["results"].first["id"])
+    id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
+    alert_definition_profile = MiqAlertSet.find(id)
     expect(alert_definition_profile).to be_truthy
     expect(response.parsed_body["results"].first).to include(
       "description" => sample_alert_definition_profile["description"],

--- a/spec/requests/api/alerts_spec.rb
+++ b/spec/requests/api/alerts_spec.rb
@@ -39,7 +39,7 @@ describe "Alerts API" do
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
       "href" => a_string_matching(alerts_url(alert_status.id)),
-      "id"   => alert_status.id
+      "id"   => alert_status.compressed_id
     )
   end
 
@@ -50,7 +50,7 @@ describe "Alerts API" do
     let(:expected_assignee) do
       {
         'results' => a_collection_containing_exactly(
-          a_hash_including("assignee_id" => assignee.id)
+          a_hash_including("assignee_id" => assignee.compressed_id)
         )
       }
     end
@@ -125,7 +125,7 @@ describe "Alerts API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => [
-          a_hash_including(attributes.merge("user_id" => User.current_user.id))
+          a_hash_including(attributes.merge("user_id" => User.current_user.compressed_id))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -135,7 +135,7 @@ describe "Alerts API" do
     it "create an assignment alert action reference by id" do
       attributes = {
         "action_type" => "assign",
-        "assignee"    => { "id" => assignee.id }
+        "assignee"    => { "id" => assignee.compressed_id }
       }
       api_basic_authorize subcollection_action_identifier(:alerts, :alert_actions, :create, :post)
       run_post(actions_subcollection_url, attributes)
@@ -178,9 +178,9 @@ describe "Alerts API" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
         "href"        => a_string_matching("#{alerts_url(alert.id)}/alert_actions/#{alert_action.id}"),
-        "id"          => alert_action.id,
+        "id"          => alert_action.compressed_id,
         "action_type" => alert_action.action_type,
-        "user_id"     => user.id,
+        "user_id"     => user.compressed_id,
         "comment"     => alert_action.comment,
       )
     end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Authentications API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Deleting Authentication'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -105,12 +105,12 @@ RSpec.describe 'Authentications API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Deleting Authentication'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Deleting Authentication'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -138,7 +138,7 @@ RSpec.describe 'Authentications API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Updating Authentication'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -157,12 +157,12 @@ RSpec.describe 'Authentications API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Updating Authentication'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Updating Authentication'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -224,7 +224,7 @@ RSpec.describe 'Authentications API' do
         'results' => [a_hash_including(
           'success' => true,
           'message' => 'Creating Authentication',
-          'task_id' => a_kind_of(Numeric)
+          'task_id' => a_kind_of(String)
         )]
       }
       run_post(authentications_url, create_params)
@@ -241,12 +241,12 @@ RSpec.describe 'Authentications API' do
           a_hash_including(
             'success' => true,
             'message' => 'Creating Authentication',
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => 'Creating Authentication',
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -292,16 +292,16 @@ RSpec.describe 'Authentications API' do
           a_hash_including(
             'success'   => true,
             'message'   => a_string_including("Refreshing Authentication id:#{auth.id}"),
-            'task_id'   => a_kind_of(Numeric),
+            'task_id'   => a_kind_of(String),
             'task_href' => /task/,
-            'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /task/)]
+            'tasks'     => [a_hash_including('id' => a_kind_of(String), 'href' => /task/)]
           ),
           a_hash_including(
             'success'   => true,
             'message'   => a_string_including("Refreshing Authentication id:#{auth_2.id}"),
-            'task_id'   => a_kind_of(Numeric),
+            'task_id'   => a_kind_of(String),
             'task_href' => /task/,
-            'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /task/)]
+            'tasks'     => [a_hash_including('id' => a_kind_of(String), 'href' => /task/)]
           )
         ]
       }
@@ -326,7 +326,7 @@ RSpec.describe 'Authentications API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Updating Authentication'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -350,7 +350,7 @@ RSpec.describe 'Authentications API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Updating Authentication'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -373,7 +373,7 @@ RSpec.describe 'Authentications API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Deleting Authentication'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response.parsed_body).to include(expected)
       expect(response).to have_http_status(:ok)
@@ -395,7 +395,7 @@ RSpec.describe 'Authentications API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Updating Authentication'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -439,9 +439,9 @@ RSpec.describe 'Authentications API' do
       expected = {
         'success'   => true,
         'message'   => /Refreshing Authentication/,
-        'task_id'   => a_kind_of(Numeric),
+        'task_id'   => a_kind_of(String),
         'task_href' => /task/,
-        'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /tasks/)]
+        'tasks'     => [a_hash_including('id' => a_kind_of(String), 'href' => /tasks/)]
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -35,7 +35,7 @@ describe "Automation Requests API" do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -48,7 +48,7 @@ describe "Automation Requests API" do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(AutomationRequest.exists?(task_id)).to be_truthy
     end
 
@@ -61,7 +61,7 @@ describe "Automation Requests API" do
       expect_result_resources_to_include_keys("results", %w(id approval_state type request_type status options))
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = response.parsed_body["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = response.parsed_body["results"].collect { |r| ApplicationRecord.uncompress_id(r["id"]) }
       expect(AutomationRequest.exists?(task_id1)).to be_truthy
       expect(AutomationRequest.exists?(task_id2)).to be_truthy
     end
@@ -84,7 +84,7 @@ describe "Automation Requests API" do
       run_post(automation_requests_url(automation_request.id), :action => "edit", :options => {:baz => "qux"})
 
       expected = {
-        "id"      => automation_request.id,
+        "id"      => automation_request.compressed_id,
         "options" => a_hash_including("foo" => "bar", "baz" => "qux")
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/blueprints_spec.rb
+++ b/spec/requests/api/blueprints_spec.rb
@@ -157,11 +157,11 @@ RSpec.describe "Blueprints API" do
       expected = {
         "results" => a_collection_containing_exactly(
           a_hash_including(
-            "id"   => blueprint1.id,
+            "id"   => blueprint1.compressed_id,
             "name" => "baz"
           ),
           a_hash_including(
-            "id"   => blueprint2.id,
+            "id"   => blueprint2.compressed_id,
             "name" => "qux"
           )
         )
@@ -222,8 +222,8 @@ RSpec.describe "Blueprints API" do
 
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("id" => blueprint1.id, "status" => "published"),
-          a_hash_including("id" => blueprint2.id, "status" => "published")
+          a_hash_including("id" => blueprint1.compressed_id, "status" => "published"),
+          a_hash_including("id" => blueprint2.compressed_id, "status" => "published")
         )
       }
 
@@ -281,7 +281,7 @@ RSpec.describe "Blueprints API" do
       run_post(blueprints_url(blueprint.id), :action => "publish")
 
       expected = {
-        "id"     => blueprint.id,
+        "id"     => blueprint.compressed_id,
         "status" => "published"
       }
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "categories API" do
       response.parsed_body,
       "description" => category.description,
       "href"        => categories_url(category.id),
-      "id"          => category.id
+      "id"          => category.compressed_id
     )
     expect(response).to have_http_status(:ok)
   end
@@ -97,7 +97,7 @@ RSpec.describe "categories API" do
       api_basic_authorize collection_action_identifier(:categories, :create)
 
       run_post categories_url, :name => "test", :description => "Test"
-      category = Category.find(response.parsed_body["results"].first["id"])
+      category = Category.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
 
       expect(category.tag.name).to eq("/managed/test")
     end

--- a/spec/requests/api/chargebacks_spec.rb
+++ b/spec/requests/api/chargebacks_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "chargebacks API" do
       response.parsed_body,
       "description" => chargeback_rate.description,
       "guid"        => chargeback_rate.guid,
-      "id"          => chargeback_rate.id,
+      "id"          => chargeback_rate.compressed_id,
       "href"        => chargebacks_url(chargeback_rate.id)
     )
     expect(response).to have_http_status(:ok)
@@ -63,9 +63,9 @@ RSpec.describe "chargebacks API" do
 
     expect_result_to_match_hash(
       response.parsed_body,
-      "chargeback_rate_id" => chargeback_rate.id,
+      "chargeback_rate_id" => chargeback_rate.compressed_id,
       "href"               => "#{chargebacks_url(chargeback_rate.id)}/rates/#{chargeback_rate_detail.to_param}",
-      "id"                 => chargeback_rate_detail.id,
+      "id"                 => chargeback_rate_detail.compressed_id,
       "description"        => "rate_1"
     )
     expect(response).to have_http_status(:ok)
@@ -93,7 +93,7 @@ RSpec.describe "chargebacks API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "name" => currency.name,
-      "id"   => currency.id,
+      "id"   => currency.compressed_id,
       "href" => "/api/currencies/#{currency.id}"
     )
     expect(response).to have_http_status(:ok)
@@ -121,7 +121,7 @@ RSpec.describe "chargebacks API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "name" => measure.name,
-      "id"   => measure.id,
+      "id"   => measure.compressed_id,
       "href" => "/api/measures/#{measure.id}",
     )
     expect(response).to have_http_status(:ok)

--- a/spec/requests/api/cloud_networks_spec.rb
+++ b/spec/requests/api/cloud_networks_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Cloud Networks API' do
     let(:providers_cloud_networks_url) { "#{provider_url}/cloud_networks" }
 
     it 'queries Providers cloud_networks' do
-      cloud_network_ids = provider.cloud_networks.pluck(:id)
+      cloud_network_ids = provider.cloud_networks.select(:id).collect(&:compressed_id)
       api_basic_authorize subcollection_action_identifier(:providers, :cloud_networks, :read, :get)
 
       run_get providers_cloud_networks_url, :expand => 'resources'
@@ -49,7 +49,7 @@ RSpec.describe 'Cloud Networks API' do
 
       run_get cloud_network_url
 
-      expect_single_resource_query('name' => network.name, 'id' => network.id, 'ems_ref' => network.ems_ref)
+      expect_single_resource_query('name' => network.name, 'id' => network.compressed_id, 'ems_ref' => network.ems_ref)
     end
 
     it "will not show the cloud network of a provider without the appropriate role" do

--- a/spec/requests/api/cloud_volumes_spec.rb
+++ b/spec/requests/api/cloud_volumes_spec.rb
@@ -37,7 +37,7 @@ describe "Cloud Volumes API" do
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
       "href" => a_string_matching(cloud_volumes_url(cloud_volume.id)),
-      "id"   => cloud_volume.id
+      "id"   => cloud_volume.compressed_id
     )
   end
 
@@ -62,7 +62,7 @@ describe "Cloud Volumes API" do
     expected = {
       'message' => 'Deleting Cloud Volume CloudVolume1',
       'success' => true,
-      'task_id' => a_kind_of(Numeric)
+      'task_id' => a_kind_of(String)
     }
 
     expect(response.parsed_body).to include(expected)
@@ -106,12 +106,12 @@ describe "Cloud Volumes API" do
         a_hash_including(
           'success' => true,
           'message' => a_string_including('Deleting Cloud Volume CloudVolume1'),
-          'task_id' => a_kind_of(Numeric)
+          'task_id' => a_kind_of(String)
         ),
         a_hash_including(
           'success' => true,
           'message' => a_string_including('Deleting Cloud Volume CloudVolume2'),
-          'task_id' => a_kind_of(Numeric)
+          'task_id' => a_kind_of(String)
         )
       )
     }

--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -72,7 +72,7 @@ describe "Conditions API" do
 
       expect(response).to have_http_status(:ok)
 
-      condition_id = response.parsed_body["results"].first["id"]
+      condition_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
       expect(Condition.exists?(condition_id)).to be_truthy
       expect(Condition.find(condition_id).expression.class).to eq(MiqExpression)

--- a/spec/requests/api/configuration_script_payloads_spec.rb
+++ b/spec/requests/api/configuration_script_payloads_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Configuration Script Payloads API' do
 
       expected = {
         'resources' => [
-          a_hash_including('id' => authentication.id)
+          a_hash_including('id' => authentication.compressed_id)
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -104,7 +104,7 @@ RSpec.describe 'Configuration Script Payloads API' do
         'results' => [a_hash_including(
           'success' => true,
           'message' => 'Creating Authentication',
-          'task_id' => a_kind_of(Numeric)
+          'task_id' => a_kind_of(String)
         )]
       }
       expect(response).to have_http_status(:ok)
@@ -121,12 +121,12 @@ RSpec.describe 'Configuration Script Payloads API' do
           a_hash_including(
             'success' => true,
             'message' => 'Creating Authentication',
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => 'Creating Authentication',
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -152,7 +152,7 @@ RSpec.describe 'Configuration Script Payloads API' do
       run_get("#{configuration_script_payloads_url(playbook.id)}/authentications/#{authentication.id}")
 
       expected = {
-        'id' => authentication.id
+        'id' => authentication.compressed_id
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/configuration_script_sources_spec.rb
+++ b/spec/requests/api/configuration_script_sources_spec.rb
@@ -75,12 +75,12 @@ RSpec.describe 'Configuration Script Sources API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Updating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Updating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -106,12 +106,12 @@ RSpec.describe 'Configuration Script Sources API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Deleting ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Deleting ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -137,16 +137,16 @@ RSpec.describe 'Configuration Script Sources API' do
           a_hash_including(
             'success'   => true,
             'message'   => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src.id}"),
-            'task_id'   => a_kind_of(Numeric),
+            'task_id'   => a_kind_of(String),
             'task_href' => /task/,
-            'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /task/)]
+            'tasks'     => [a_hash_including('id' => a_kind_of(String), 'href' => /task/)]
           ),
           a_hash_including(
             'success'   => true,
             'message'   => a_string_including("Refreshing ConfigurationScriptSource id:#{config_script_src_2.id}"),
-            'task_id'   => a_kind_of(Numeric),
+            'task_id'   => a_kind_of(String),
             'task_href' => /task/,
-            'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /task/)]
+            'tasks'     => [a_hash_including('id' => a_kind_of(String), 'href' => /task/)]
           )
         ]
       }
@@ -171,7 +171,7 @@ RSpec.describe 'Configuration Script Sources API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Updating ConfigurationScriptSource'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -195,7 +195,7 @@ RSpec.describe 'Configuration Script Sources API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Updating ConfigurationScriptSource'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -218,7 +218,7 @@ RSpec.describe 'Configuration Script Sources API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Updating ConfigurationScriptSource'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -262,9 +262,9 @@ RSpec.describe 'Configuration Script Sources API' do
       expected = {
         'success'   => true,
         'message'   => /Refreshing ConfigurationScriptSource/,
-        'task_id'   => a_kind_of(Numeric),
+        'task_id'   => a_kind_of(String),
         'task_href' => /task/,
-        'tasks'     => [a_hash_including('id' => a_kind_of(Numeric), 'href' => /tasks/)]
+        'tasks'     => [a_hash_including('id' => a_kind_of(String), 'href' => /tasks/)]
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -278,7 +278,7 @@ RSpec.describe 'Configuration Script Sources API' do
       expected = {
         'success' => true,
         'message' => a_string_including('Deleting ConfigurationScriptSource'),
-        'task_id' => a_kind_of(Numeric)
+        'task_id' => a_kind_of(String)
       }
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
@@ -323,7 +323,7 @@ RSpec.describe 'Configuration Script Sources API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Creating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -342,7 +342,7 @@ RSpec.describe 'Configuration Script Sources API' do
           a_hash_including(
             'success' => true,
             'message' => "Creating ConfigurationScriptSource for Manager id:#{manager.id} name: '#{manager.name}'",
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }
@@ -360,12 +360,12 @@ RSpec.describe 'Configuration Script Sources API' do
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Creating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           ),
           a_hash_including(
             'success' => true,
             'message' => a_string_including('Creating ConfigurationScriptSource'),
-            'task_id' => a_kind_of(Numeric)
+            'task_id' => a_kind_of(String)
           )
         ]
       }

--- a/spec/requests/api/custom_actions_spec.rb
+++ b/spec/requests/api/custom_actions_spec.rb
@@ -212,7 +212,7 @@ describe "Custom Actions API" do
           "buttons"       => [
             hash_including(
               "id"              => anything,
-              "resource_action" => hash_including("id" => ra2.id, "dialog_id" => ra2.dialog_id)
+              "resource_action" => hash_including("id" => ra2.compressed_id, "dialog_id" => ra2.dialog.compressed_id)
             )
           ]
         }

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -70,7 +70,7 @@ describe "Groups API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = response.parsed_body["results"].first["id"]
+      group_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -82,7 +82,7 @@ describe "Groups API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      group_id = response.parsed_body["results"].first["id"]
+      group_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqGroup.exists?(group_id)).to be_truthy
     end
 
@@ -98,14 +98,14 @@ describe "Groups API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       result = response.parsed_body["results"].first
-      created_group = MiqGroup.find_by(:id => result["id"])
+      created_group = MiqGroup.find_by(:id => ApplicationRecord.uncompress_id(result["id"]))
 
       expect(created_group).to be_present
       expect(created_group.entitlement.miq_user_role).to eq(role3)
 
       expect_result_to_match_hash(result,
-                                  "description"      => "sample_group3",
-                                  "tenant_id"        => tenant3.id)
+                                  "description" => "sample_group3",
+                                  "tenant_id"   => tenant3.compressed_id)
     end
 
     it "supports single group creation with filters specified" do
@@ -123,7 +123,7 @@ describe "Groups API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       group_id = response.parsed_body["results"][0]["id"]
-      expected_group = MiqGroup.find_by(:id => group_id)
+      expected_group = MiqGroup.find_by(:id => ApplicationRecord.uncompress_id(group_id))
       expect(expected_group).to be_present
       expect(expected_group.description).to eq(sample_group["description"])
       expect(expected_group.entitlement).to be_present
@@ -139,8 +139,8 @@ describe "Groups API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response.parsed_body["results"]
-      group1_id = results.first["id"]
-      group2_id = results.second["id"]
+      group1_id = ApplicationRecord.uncompress_id(results.first["id"])
+      group2_id = ApplicationRecord.uncompress_id(results.second["id"])
       expect(MiqGroup.exists?(group1_id)).to be_truthy
       expect(MiqGroup.exists?(group2_id)).to be_truthy
     end
@@ -169,7 +169,7 @@ describe "Groups API" do
 
       run_post(groups_url(group1.id), gen_request(:edit, "description" => "updated_group"))
 
-      expect_single_resource_query("id"          => group1.id,
+      expect_single_resource_query("id"          => group1.compressed_id,
                                    "description" => "updated_group")
       expect(group1.reload.description).to eq("updated_group")
     end
@@ -182,8 +182,8 @@ describe "Groups API" do
                                         {"href" => groups_url(group2.id), "description" => "updated_group2"}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => group1.id, "description" => "updated_group1"},
-                                    {"id" => group2.id, "description" => "updated_group2"}])
+                                   [{"id" => group1.compressed_id, "description" => "updated_group1"},
+                                    {"id" => group2.compressed_id, "description" => "updated_group2"}])
 
       expect(group1.reload.name).to eq("updated_group1")
       expect(group2.reload.name).to eq("updated_group2")

--- a/spec/requests/api/instances_spec.rb
+++ b/spec/requests/api/instances_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe "Instances API" do
       run_get("#{instances_url(@vm.id)}/load_balancers/#{@load_balancer.id}")
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => @load_balancer.id)
+      expect(response.parsed_body).to include('id' => @load_balancer.compressed_id)
     end
 
     it "will not show an instance's load balancer without the appropriate role" do

--- a/spec/requests/api/picture_spec.rb
+++ b/spec/requests/api/picture_spec.rb
@@ -27,8 +27,8 @@ describe "Pictures" do
     expect_result_to_match_hash(response.parsed_body, "id" => source_id)
     expect_result_to_have_keys(%w(id href picture))
     expect_result_to_match_hash(response.parsed_body["picture"],
-                                "id"          => picture.id,
-                                "resource_id" => template.id,
+                                "id"          => picture.compressed_id,
+                                "resource_id" => template.compressed_id,
                                 "image_href"  => /^http:.*#{picture.image_href}$/)
   end
 
@@ -38,7 +38,7 @@ describe "Pictures" do
 
       run_get service_templates_url(template.id), :attributes => "picture,picture.image_href"
 
-      expect_result_to_include_picture_href(template.id)
+      expect_result_to_include_picture_href(template.compressed_id)
     end
   end
 
@@ -48,7 +48,7 @@ describe "Pictures" do
 
       run_get services_url(service.id), :attributes => "picture,picture.image_href"
 
-      expect_result_to_include_picture_href(service.id)
+      expect_result_to_include_picture_href(service.compressed_id)
     end
   end
 
@@ -58,7 +58,7 @@ describe "Pictures" do
 
       run_get service_requests_url(service_request.id), :attributes => "picture,picture.image_href"
 
-      expect_result_to_include_picture_href(service_request.id)
+      expect_result_to_include_picture_href(service_request.compressed_id)
     end
   end
 

--- a/spec/requests/api/policies_spec.rb
+++ b/spec/requests/api/policies_spec.rb
@@ -374,7 +374,7 @@ describe "Policies API" do
     it "creates new policy" do
       api_basic_authorize collection_action_identifier(:policies, :create)
       run_post(policies_url, sample_policy.merge!(miq_policy_contents))
-      policy = MiqPolicy.find(response.parsed_body["results"].first["id"])
+      policy = MiqPolicy.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
       expect(response.parsed_body["results"].first["name"]).to eq("sample policy")
       expect(response.parsed_body["results"].first["towhat"]).to eq("ManageIQ::Providers::Redhat::InfraManager")
       expect(policy).to be_truthy
@@ -463,7 +463,7 @@ describe "Policies API" do
       expect(miq_policy.actions.count).to eq(0)
       expect(miq_policy.events.count).to eq(0)
       run_post(policies_url(miq_policy.id), gen_request(:edit, miq_policy_contents.merge('conditions_ids' => [])))
-      policy = MiqPolicy.find(response.parsed_body["id"])
+      policy = MiqPolicy.find(ApplicationRecord.uncompress_id(response.parsed_body["id"]))
       expect(response).to have_http_status(:ok)
       expect(policy.actions.count).to eq(1)
       expect(policy.events.count).to eq(1)
@@ -474,7 +474,7 @@ describe "Policies API" do
       api_basic_authorize collection_action_identifier(:policies, :edit)
       expect(miq_policy.description).to_not eq("BAR")
       run_post(policies_url(miq_policy.id), gen_request(:edit, :description => "BAR"))
-      policy = MiqPolicy.find(response.parsed_body["id"])
+      policy = MiqPolicy.find(ApplicationRecord.uncompress_id(response.parsed_body["id"]))
       expect(response).to have_http_status(:ok)
       expect(policy.description).to eq("BAR")
     end

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -60,7 +60,7 @@ describe "Provision Requests API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -74,7 +74,7 @@ describe "Provision Requests API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash])
 
-      task_id = response.parsed_body["results"].first["id"]
+      task_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqProvisionRequest.exists?(task_id)).to be_truthy
     end
 
@@ -88,7 +88,7 @@ describe "Provision Requests API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
       expect_results_to_match_hash("results", [expected_hash, expected_hash])
 
-      task_id1, task_id2 = response.parsed_body["results"].collect { |r| r["id"] }
+      task_id1, task_id2 = response.parsed_body["results"].collect { |r| ApplicationRecord.uncompress_id(r["id"]) }
       expect(MiqProvisionRequest.exists?(task_id1)).to be_truthy
       expect(MiqProvisionRequest.exists?(task_id2)).to be_truthy
     end
@@ -110,7 +110,7 @@ describe "Provision Requests API" do
         run_post(provision_requests_url(provision_request.id), :action => "edit", :options => {:baz => "qux"})
 
         expected = {
-          "id"      => provision_request.id,
+          "id"      => provision_request.compressed_id,
           "options" => a_hash_including("foo" => "bar", "baz" => "qux")
         }
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -35,7 +35,7 @@ describe "Queries API" do
       expect_query_result(:vms, 3, 3)
       expected = {
         "resources" => all(a_hash_including("href" => a_string_matching(vm_href_pattern),
-                                            "id"   => a_kind_of(Integer),
+                                            "id"   => a_kind_of(String),
                                             "guid" => anything))
       }
       expect(response.parsed_body).to include(expected)
@@ -48,7 +48,7 @@ describe "Queries API" do
       run_get vms_url, :expand => "resources", :attributes => "guid"
 
       expect_query_result(:vms, 1, 1)
-      expect_result_resources_to_match_hash([{"id" => vm1.id, "href" => vm1_url, "guid" => vm1.guid}])
+      expect_result_resources_to_match_hash([{"id" => vm1.compressed_id, "href" => vm1_url, "guid" => vm1.guid}])
     end
   end
 
@@ -59,7 +59,7 @@ describe "Queries API" do
 
       run_get vm1_url
 
-      expect_single_resource_query("id" => vm1.id, "href" => vm1_url, "guid" => vm1.guid)
+      expect_single_resource_query("id" => vm1.compressed_id, "href" => vm1_url, "guid" => vm1.guid)
     end
 
     it 'supports compressed ids' do
@@ -67,7 +67,7 @@ describe "Queries API" do
 
       run_get vms_url(ApplicationRecord.compress_id(vm1.id))
 
-      expect_single_resource_query("id" => vm1.id, "href" => vm1_url, "guid" => vm1.guid)
+      expect_single_resource_query("id" => vm1.compressed_id, "href" => vm1_url, "guid" => vm1.guid)
     end
 
     it 'returns 404 on url with trailing garbage' do
@@ -105,7 +105,7 @@ describe "Queries API" do
 
       run_get acct1_url
 
-      expect_single_resource_query("id" => acct1.id, "href" => acct1_url, "name" => acct1.name)
+      expect_single_resource_query("id" => acct1.compressed_id, "href" => acct1_url, "name" => acct1.name)
     end
 
     it "includes both id and href when expanded" do
@@ -119,7 +119,7 @@ describe "Queries API" do
       expect_query_result(:accounts, 2)
       expect_result_resources_to_include_keys("resources", %w(id href))
       expect_result_resources_to_include_hrefs("resources", vm1_accounts_url_list)
-      expect_result_resources_to_include_data("resources", "id" => [acct1.id, acct2.id])
+      expect_result_resources_to_include_data("resources", "id" => [acct1.compressed_id, acct2.compressed_id])
     end
 
     it 'supports compressed ids' do
@@ -127,7 +127,7 @@ describe "Queries API" do
 
       run_get vms_url(ApplicationRecord.compress_id(vm1.id)) + "/accounts/#{acct1.id}"
 
-      expect_single_resource_query("id" => acct1.id, "href" => acct1_url, "name" => acct1.name)
+      expect_single_resource_query("id" => acct1.compressed_id, "href" => acct1_url, "name" => acct1.name)
     end
 
     it 'returns 404 on url with trailing garbage' do

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -529,7 +529,7 @@ describe "Querying" do
         "subcount"  => 1,
         "resources" => [
           {
-            "id"        => vm.id,
+            "id"        => vm.compressed_id,
             "href"      => a_string_matching(vms_url(vm.id)),
             "href_slug" => "vms/#{vm.id}",
             "name"      => "aa",

--- a/spec/requests/api/regions_spec.rb
+++ b/spec/requests/api/regions_spec.rb
@@ -37,7 +37,7 @@ describe "Regions API" do
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body).to include(
       "href" => a_string_matching(regions_url(region.id)),
-      "id"   => region.id
+      "id"   => region.compressed_id
     )
   end
 end

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "reports API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "href"  => reports_url(report.id),
-      "id"    => report.id,
+      "id"    => report.compressed_id,
       "name"  => report.name,
       "title" => report.title
     )
@@ -149,7 +149,7 @@ RSpec.describe "reports API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "href" => "/api/reports/#{report.id}/schedules/#{schedule.id}",
-      "id"   => schedule.id,
+      "id"   => schedule.compressed_id,
       "name" => 'unit_test'
     )
     expect(response).to have_http_status(:ok)

--- a/spec/requests/api/requests_spec.rb
+++ b/spec/requests/api/requests_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Requests API" do
       run_get requests_url(service_request.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("id"   => service_request.id,
+      expect(response.parsed_body).to include("id"   => service_request.compressed_id,
                                               "href" => a_string_matching(requests_url(service_request.id)))
     end
 
@@ -109,7 +109,7 @@ RSpec.describe "Requests API" do
       run_get requests_url(service_request.id)
 
       expected = {
-        "id"   => service_request.id,
+        "id"   => service_request.compressed_id,
         "href" => a_string_matching(requests_url(service_request.id))
       }
       expect(response).to have_http_status(:ok)
@@ -192,7 +192,7 @@ RSpec.describe "Requests API" do
             "approval_state" => "pending_approval",
             "type"           => "ServiceReconfigureRequest",
             "requester_name" => api_config(:user_name),
-            "options"        => a_hash_including("src_id" => service.id)
+            "options"        => a_hash_including("src_id" => service.compressed_id)
           )
         ]
       }
@@ -221,7 +221,7 @@ RSpec.describe "Requests API" do
             "approval_state" => "approved",
             "type"           => "ServiceReconfigureRequest",
             "requester_name" => approver.name,
-            "options"        => a_hash_including("src_id" => service.id, "other_attr" => "other value")
+            "options"        => a_hash_including("src_id" => service.compressed_id, "other_attr" => "other value")
           )
         ]
       }
@@ -249,7 +249,7 @@ RSpec.describe "Requests API" do
       run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
 
       expected_response = a_hash_including(
-        "id"               => request.id,
+        "id"               => request.compressed_id,
         "workflow"         => a_hash_including("values"),
         "v_allowed_tags"   => [a_hash_including("children")],
         "v_workflow_class" => a_hash_including(
@@ -280,7 +280,7 @@ RSpec.describe "Requests API" do
       run_get requests_url(request.id), :attributes => "workflow.values"
 
       expected_response = a_hash_including(
-        "id"       => request.id,
+        "id"       => request.compressed_id,
         "workflow" => a_hash_including("values")
       )
 
@@ -300,7 +300,7 @@ RSpec.describe "Requests API" do
       run_get requests_url(request.id), :attributes => "workflow,v_allowed_tags,v_workflow_class"
 
       expected_response = a_hash_including(
-        "id"               => request.id,
+        "id"               => request.compressed_id,
         "v_workflow_class" => {}
       )
 
@@ -343,7 +343,7 @@ RSpec.describe "Requests API" do
       run_post(requests_url(request.id), gen_request(:edit, :options => { :some_option => "some_value" }))
 
       expected = {
-        "id"      => request.id,
+        "id"      => request.compressed_id,
         "options" => a_hash_including("some_option" => "some_value")
       }
 

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -107,7 +107,7 @@ describe "Roles API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = response.parsed_body["results"].first["id"]
+      role_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
       run_get "#{roles_url}/#{role_id}/", :expand => "features"
 
@@ -127,7 +127,7 @@ describe "Roles API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      role_id = response.parsed_body["results"].first["id"]
+      role_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(MiqUserRole.exists?(role_id)).to be_truthy
       role = MiqUserRole.find(role_id)
       sample_role1['features'].each do |feature|
@@ -144,8 +144,8 @@ describe "Roles API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       results = response.parsed_body["results"]
-      r1_id = results.first["id"]
-      r2_id = results.second["id"]
+      r1_id = ApplicationRecord.uncompress_id(results.first["id"])
+      r2_id = ApplicationRecord.uncompress_id(results.second["id"])
       expect(MiqUserRole.exists?(r1_id)).to be_truthy
       expect(MiqUserRole.exists?(r2_id)).to be_truthy
 
@@ -186,7 +186,7 @@ describe "Roles API" do
       run_post(roles_url(role.id), gen_request(:edit, "name"     => "updated role",
                                                       "settings" => {"restrictions"  => {"vms" => "user_or_group"}}))
 
-      expect_single_resource_query("id"       => role.id,
+      expect_single_resource_query("id"       => role.compressed_id,
                                    "name"     => "updated role",
                                    "settings" => {"restrictions" => {"vms" => "user_or_group"}})
       expect(role.reload.name).to eq("updated role")
@@ -204,8 +204,8 @@ describe "Roles API" do
                                        {"href" => roles_url(r2.id), "name" => "updated role2"}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => r1.id, "name" => "updated role1"},
-                                    {"id" => r2.id, "name" => "updated role2"}])
+                                   [{"id" => r1.compressed_id, "name" => "updated role1"},
+                                    {"id" => r2.compressed_id, "name" => "updated role2"}])
 
       expect(r1.reload.name).to eq("updated role1")
       expect(r2.reload.name).to eq("updated role2")

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -58,14 +58,14 @@ describe "Service Catalogs API" do
       expected = {
         "results" => [
           a_hash_including(
-            "id"   => kind_of(Integer),
+            "id"   => kind_of(String),
             "name" => "sample service catalog"
           )
         ]
       }
       expect(response.parsed_body).to include(expected)
 
-      sc_id = response.parsed_body["results"].first["id"]
+      sc_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -79,14 +79,14 @@ describe "Service Catalogs API" do
       expected = {
         "results" => [
           a_hash_including(
-            "id"   => kind_of(Integer),
+            "id"   => kind_of(String),
             "name" => "sample service catalog"
           )
         ]
       }
       expect(response.parsed_body).to include(expected)
 
-      sc_id = response.parsed_body["results"].first["id"]
+      sc_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
     end
@@ -99,14 +99,15 @@ describe "Service Catalogs API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including("id" => kind_of(Integer), "name" => "sc1"),
-          a_hash_including("id" => kind_of(Integer), "name" => "sc2")
+          a_hash_including("id" => kind_of(String), "name" => "sc1"),
+          a_hash_including("id" => kind_of(String), "name" => "sc2")
         )
       }
       expect(response.parsed_body).to include(expected)
 
       results = response.parsed_body["results"]
-      sc_id1, sc_id2 = results.first["id"], results.second["id"]
+      sc_id1 = ApplicationRecord.uncompress_id(results.first["id"])
+      sc_id2 = ApplicationRecord.uncompress_id(results.second["id"])
       expect(ServiceTemplateCatalog.find(sc_id1)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id2)).to be_truthy
     end
@@ -128,7 +129,7 @@ describe "Service Catalogs API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"name" => "sc", "description" => "sc description"}])
 
-      sc_id = response.parsed_body["results"].first["id"]
+      sc_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
       expect(ServiceTemplateCatalog.find(sc_id)).to be_truthy
       expect(ServiceTemplateCatalog.find(sc_id).service_templates.pluck(:id)).to match_array([st1.id, st2.id])
@@ -174,7 +175,7 @@ describe "Service Catalogs API" do
         )
       }
       expect(response.parsed_body).to include(expected)
-      expect_single_resource_query("id" => sc.id, "name" => "sc", "description" => "updated sc description")
+      expect_single_resource_query("id" => sc.compressed_id, "name" => "sc", "description" => "updated sc description")
       expect(sc.reload.description).to eq("updated sc description")
     end
 
@@ -189,8 +190,8 @@ describe "Service Catalogs API" do
                                                   {"href" => service_catalogs_url(sc2.id), "name" => "sc2 updated"}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => sc1.id, "name" => "sc1 updated", "description" => "sc1 description"},
-                                    {"id" => sc2.id, "name" => "sc2 updated", "description" => "sc2 description"}])
+                                   [{"id" => sc1.compressed_id, "name" => "sc1 updated", "description" => "sc1 description"},
+                                    {"id" => sc2.compressed_id, "name" => "sc2 updated", "description" => "sc2 description"}])
 
       expect(sc1.reload.name).to eq("sc1 updated")
       expect(sc2.reload.name).to eq("sc2 updated")
@@ -300,7 +301,7 @@ describe "Service Catalogs API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"success"               => true,
                                                 "href"                  => service_catalogs_url(sc.id),
-                                                "service_template_id"   => st.id,
+                                                "service_template_id"   => st.compressed_id,
                                                 "service_template_href" => /^.*#{service_templates_url(st.id)}$/,
                                                 "message"               => /assigning/i}])
       expect(sc.reload.service_templates.pluck(:id)).to eq([st.id])
@@ -319,7 +320,7 @@ describe "Service Catalogs API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results", [{"success"               => true,
                                                 "href"                  => service_catalogs_url(sc.id),
-                                                "service_template_id"   => st1.id,
+                                                "service_template_id"   => st1.compressed_id,
                                                 "service_template_href" => /^.*#{service_templates_url(st1.id)}$/,
                                                 "message"               => /unassigning/i}])
       expect(sc.reload.service_templates.pluck(:id)).to eq([st2.id])

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -43,7 +43,7 @@ describe "Service Dialogs API" do
       run_get service_dialogs_url(dialog1.id)
 
       expect_single_resource_query(
-        "id"    => dialog1.id,
+        "id"    => dialog1.compressed_id,
         "href"  => service_dialogs_url(dialog1.id),
         "label" => dialog1.label
       )
@@ -138,7 +138,7 @@ describe "Service Dialogs API" do
 
         expected = {
           'href'  => a_string_including(service_dialogs_url(dialog.id)),
-          'id'    => dialog.id,
+          'id'    => dialog.compressed_id,
           'label' => 'updated label'
         }
 
@@ -162,11 +162,11 @@ describe "Service Dialogs API" do
         expected = {
           'results' => a_collection_containing_exactly(
             a_hash_including(
-              'id'    => dialog.id,
+              'id'    => dialog.compressed_id,
               'label' => 'foo bar'
             ),
             a_hash_including(
-              'id'    => dialog2.id,
+              'id'    => dialog2.compressed_id,
               'label' => 'bar'
             )
           )
@@ -271,7 +271,7 @@ describe "Service Dialogs API" do
       run_get "#{service_templates_url(template.id)}/service_dialogs/#{dialog1.id}", :attributes => "content"
       expected = {
         'content' => a_collection_including(
-          a_hash_including('id' => dialog1.id)
+          a_hash_including('id' => dialog1.compressed_id)
         )}
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/service_orders_spec.rb
+++ b/spec/requests/api/service_orders_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "service orders API" do
     run_get service_orders_url("cart")
 
     expect(response).to have_http_status(:ok)
-    expect(response.parsed_body).to include("id"   => shopping_cart.id,
+    expect(response.parsed_body).to include("id"   => shopping_cart.compressed_id,
                                      "href" => a_string_matching(service_orders_url(shopping_cart.id)))
   end
 
@@ -180,7 +180,7 @@ RSpec.describe "service orders API" do
         run_get url
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body).to include("id" => service_request.id, "href" => a_string_matching(url))
+        expect(response.parsed_body).to include("id" => service_request.compressed_id, "href" => a_string_matching(url))
       end
 
       it "can add a service request to a shopping cart" do
@@ -204,7 +204,7 @@ RSpec.describe "service orders API" do
             a_hash_including(
               "success"              => true,
               "message"              => /Adding service_request/,
-              "service_request_id"   => actual_requests.first.id,
+              "service_request_id"   => actual_requests.first.compressed_id,
               "service_request_href" => a_string_matching(service_requests_url(actual_requests.first.id))
             )
           ]
@@ -244,13 +244,13 @@ RSpec.describe "service orders API" do
             a_hash_including(
               "success"              => true,
               "message"              => /Adding service_request/,
-              "service_request_id"   => actual_requests.first.id,
+              "service_request_id"   => actual_requests.first.compressed_id,
               "service_request_href" => a_string_matching(service_requests_url(actual_requests.first.id))
             ),
             a_hash_including(
               "success"              => true,
               "message"              => /Adding service_request/,
-              "service_request_id"   => actual_requests.second.id,
+              "service_request_id"   => actual_requests.second.compressed_id,
               "service_request_href" => a_string_matching(service_requests_url(actual_requests.second.id))
             )
           )
@@ -270,7 +270,7 @@ RSpec.describe "service orders API" do
           "success"              => true,
           "message"              => a_string_starting_with("Removing Service Request id:#{service_request.id}"),
           "service_request_href" => a_string_matching(service_requests_url(service_request.id)),
-          "service_request_id"   => service_request.id
+          "service_request_id"   => service_request.compressed_id
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)
@@ -301,13 +301,13 @@ RSpec.describe "service orders API" do
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_1.id}"),
               "service_request_href" => a_string_matching(service_requests_url(service_request_1.id)),
-              "service_request_id"   => service_request_1.id
+              "service_request_id"   => service_request_1.compressed_id
             ),
             a_hash_including(
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_2.id}"),
               "service_request_href" => a_string_matching(service_requests_url(service_request_2.id)),
-              "service_request_id"   => service_request_2.id
+              "service_request_id"   => service_request_2.compressed_id
             )
           )
         }
@@ -340,13 +340,13 @@ RSpec.describe "service orders API" do
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_1.id}"),
               "service_request_href" => a_string_matching(service_requests_url(service_request_1.id)),
-              "service_request_id"   => service_request_1.id
+              "service_request_id"   => service_request_1.compressed_id
             ),
             a_hash_including(
               "success"              => true,
               "message"              => a_string_starting_with("Removing Service Request id:#{service_request_2.id}"),
               "service_request_href" => a_string_matching(service_requests_url(service_request_2.id)),
-              "service_request_id"   => service_request_2.id
+              "service_request_id"   => service_request_2.compressed_id
             )
           )
         }
@@ -368,7 +368,7 @@ RSpec.describe "service orders API" do
 
         expected = {
           "href" => a_string_matching(service_orders_url(shopping_cart.id)),
-          "id"   => shopping_cart.id
+          "id"   => shopping_cart.compressed_id
         }
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to include(expected)

--- a/spec/requests/api/service_requests_spec.rb
+++ b/spec/requests/api/service_requests_spec.rb
@@ -228,7 +228,7 @@ describe "Service Requests API" do
       run_get service_requests_url(service_request.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include("id"   => service_request.id,
+      expect(response.parsed_body).to include("id"   => service_request.compressed_id,
                                        "href" => a_string_matching(service_requests_url(service_request.id)))
     end
 
@@ -271,7 +271,7 @@ describe "Service Requests API" do
       run_get service_requests_url(service_request.id)
 
       expected = {
-        "id"   => service_request.id,
+        "id"   => service_request.compressed_id,
         "href" => a_string_matching(service_requests_url(service_request.id))
       }
       expect(response).to have_http_status(:ok)
@@ -353,7 +353,7 @@ describe "Service Requests API" do
         run_post(service_requests_url(service_request.id), :action => 'add_approver', :user_id => user.id)
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.id)
+      expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
 
     it 'can add approvers to multiple service requests' do
@@ -368,8 +368,8 @@ describe "Service Requests API" do
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => service_request.id),
-          a_hash_including('id' => service_request_2.id)
+          a_hash_including('id' => service_request.compressed_id),
+          a_hash_including('id' => service_request_2.compressed_id)
         )
       }
       expect do
@@ -399,7 +399,7 @@ describe "Service Requests API" do
         run_post(service_requests_url(service_request.id), :action => 'add_approver', :user => { :id => user.id})
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.id)
+      expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
 
     it 'supports user reference hash with href' do
@@ -412,7 +412,7 @@ describe "Service Requests API" do
                  :action => 'add_approver', :user => { :href => users_url(user.id)})
       end.to change(MiqApproval, :count).by(1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.id)
+      expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
 
     it 'raises an error if no user is supplied' do
@@ -440,7 +440,7 @@ describe "Service Requests API" do
         run_post(service_requests_url(service_request.id), :action => 'remove_approver', :user_id => user.id)
       end.to change(MiqApproval, :count).by(-1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.id)
+      expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
 
     it 'can remove approvers to multiple service requests' do
@@ -455,8 +455,8 @@ describe "Service Requests API" do
 
       expected = {
         'results' => a_collection_including(
-          a_hash_including('id' => service_request.id),
-          a_hash_including('id' => service_request2.id)
+          a_hash_including('id' => service_request.compressed_id),
+          a_hash_including('id' => service_request2.compressed_id)
         )
       }
       expect do
@@ -492,7 +492,7 @@ describe "Service Requests API" do
                  :user   => { :href => users_url(user.id)})
       end.to change(MiqApproval, :count).by(-1)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.id)
+      expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
 
     it 'raises an error if no user is supplied' do
@@ -516,7 +516,7 @@ describe "Service Requests API" do
 
       run_post(service_requests_url(service_request.id), :action => 'remove_approver', :user_id => user.id)
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include('id' => service_request.id)
+      expect(response.parsed_body).to include('id' => service_request.compressed_id)
     end
   end
 
@@ -541,7 +541,7 @@ describe "Service Requests API" do
       run_post(service_requests_url(service_request.id), :action => "edit", :options => {:baz => "qux"})
 
       expected = {
-        "id"      => service_request.id,
+        "id"      => service_request.compressed_id,
         "options" => a_hash_including("foo" => "bar")
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -120,7 +120,7 @@ describe "Services API" do
 
       run_post(services_url(svc.id), gen_request(:edit, "name" => "updated svc1"))
 
-      expect_single_resource_query("id" => svc.id, "href" => services_url(svc.id), "name" => "updated svc1")
+      expect_single_resource_query("id" => svc.compressed_id, "href" => services_url(svc.id), "name" => "updated svc1")
       expect(svc.reload.name).to eq("updated svc1")
     end
 
@@ -138,7 +138,7 @@ describe "Services API" do
       run_post(services_url(svc_orchestration.id), resource)
 
       expected = {
-        'id'       => svc_orchestration.id,
+        'id'       => svc_orchestration.compressed_id,
         'ancestry' => svc1.id.to_s
       }
       expect(response.parsed_body).to include(expected)
@@ -162,7 +162,7 @@ describe "Services API" do
       run_post(services_url(svc_orchestration.id), resource)
 
       expected = {
-        'id'       => svc_orchestration.id,
+        'id'       => svc_orchestration.compressed_id,
         'ancestry' => svc1.id.to_s
       }
       expect(response.parsed_body).to include(expected)
@@ -177,7 +177,7 @@ describe "Services API" do
 
       run_put(services_url(svc.id), "name" => "updated svc1")
 
-      expect_single_resource_query("id" => svc.id, "href" => services_url(svc.id), "name" => "updated svc1")
+      expect_single_resource_query("id" => svc.compressed_id, "href" => services_url(svc.id), "name" => "updated svc1")
       expect(svc.reload.name).to eq("updated svc1")
     end
 
@@ -188,7 +188,7 @@ describe "Services API" do
                                        {"action" => "remove", "path" => "description"},
                                        {"action" => "add",    "path" => "display",     "value" => true}])
 
-      expect_single_resource_query("id" => svc.id, "name" => "updated svc1", "display" => true)
+      expect_single_resource_query("id" => svc.compressed_id, "name" => "updated svc1", "display" => true)
       expect(svc.reload.name).to eq("updated svc1")
       expect(svc.description).to be_nil
       expect(svc.display).to be_truthy
@@ -203,8 +203,8 @@ describe "Services API" do
 
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash("results",
-                                   [{"id" => svc1.id, "name" => "updated svc1"},
-                                    {"id" => svc2.id, "name" => "updated svc2"}])
+                                   [{"id" => svc1.compressed_id, "name" => "updated svc1"},
+                                    {"id" => svc2.compressed_id, "name" => "updated svc2"}])
       expect(svc1.reload.name).to eq("updated svc1")
       expect(svc2.reload.name).to eq("updated svc2")
     end
@@ -314,7 +314,7 @@ describe "Services API" do
 
       run_post(services_url(svc.id), gen_request(:retire))
 
-      expect_single_resource_query("id" => svc.id, "href" => services_url(svc.id))
+      expect_single_resource_query("id" => svc.compressed_id, "href" => services_url(svc.id))
     end
 
     it "supports single service retirement in future" do
@@ -324,7 +324,7 @@ describe "Services API" do
 
       run_post(services_url(svc.id), gen_request(:retire, "date" => ret_date, "warn" => 2))
 
-      expect_single_resource_query("id" => svc.id, "retires_on" => ret_date, "retirement_warn" => 2)
+      expect_single_resource_query("id" => svc.compressed_id, "retires_on" => ret_date, "retirement_warn" => 2)
       expect(format_retirement_date(svc.reload.retires_on)).to eq(ret_date)
       expect(svc.retirement_warn).to eq(2)
     end
@@ -338,7 +338,7 @@ describe "Services API" do
                                          [{"href" => services_url(svc1.id)},
                                           {"href" => services_url(svc2.id)}]))
 
-      expect_results_to_match_hash("results", [{"id" => svc1.id}, {"id" => svc2.id}])
+      expect_results_to_match_hash("results", [{"id" => svc1.compressed_id}, {"id" => svc2.compressed_id}])
     end
 
     it "supports multiple service retirement in future" do
@@ -351,8 +351,8 @@ describe "Services API" do
                                           {"href" => services_url(svc2.id), "date" => ret_date, "warn" => 5}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => svc1.id, "retires_on" => ret_date, "retirement_warn" => 3},
-                                    {"id" => svc2.id, "retires_on" => ret_date, "retirement_warn" => 5}])
+                                   [{"id" => svc1.compressed_id, "retires_on" => ret_date, "retirement_warn" => 3},
+                                    {"id" => svc2.compressed_id, "retires_on" => ret_date, "retirement_warn" => 5}])
       expect(format_retirement_date(svc1.reload.retires_on)).to eq(ret_date)
       expect(svc1.retirement_warn).to eq(3)
       expect(format_retirement_date(svc2.reload.retires_on)).to eq(ret_date)
@@ -455,16 +455,16 @@ describe "Services API" do
       run_get services_url(svc1.id), :expand => "vms", :attributes => "vms.cpu_total_cores"
 
       expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.id, "cpu_total_cores" => 2},
-                                           {"id" => vm2.id, "cpu_total_cores" => 4}])
+      expect_results_to_match_hash("vms", [{"id" => vm1.compressed_id, "cpu_total_cores" => 2},
+                                           {"id" => vm2.compressed_id, "cpu_total_cores" => 4}])
     end
 
     it "can query vms as subcollection via decorators with additional decorators" do
       run_get services_url(svc1.id), :expand => "vms", :attributes => "", :decorators => "vms.supports_console?"
 
       expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.id, "supports_console?" => true},
-                                           {"id" => vm2.id, "supports_console?" => true}])
+      expect_results_to_match_hash("vms", [{"id" => vm1.compressed_id, "supports_console?" => true},
+                                           {"id" => vm2.compressed_id, "supports_console?" => true}])
     end
 
     it "cannot query vms via both virtual attribute and subcollection" do
@@ -640,7 +640,7 @@ describe "Services API" do
 
       expected = {
         'resources' => [
-          a_hash_including('id' => os.id)
+          a_hash_including('id' => os.compressed_id)
         ]
       }
       expect(response).to have_http_status(:ok)
@@ -652,9 +652,7 @@ describe "Services API" do
 
       run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}")
 
-      expected = {
-        'id' => os.id
-      }
+      expected = {'id' => os.compressed_id}
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(expected)
     end
@@ -666,7 +664,7 @@ describe "Services API" do
       run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :attributes => "stdout")
 
       expected = {
-        'id'     => os.id,
+        'id'     => os.compressed_id,
         'stdout' => "default text stdout"
       }
       expect(response).to have_http_status(:ok)
@@ -680,7 +678,7 @@ describe "Services API" do
       run_get("#{services_url(svc.id)}/orchestration_stacks/#{os.id}", :attributes => "stdout", :format_attributes => "stdout=json")
 
       expected = {
-        'id'     => os.id,
+        'id'     => os.compressed_id,
         'stdout' => "json stdout"
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/snapshots_spec.rb
+++ b/spec/requests/api/snapshots_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "Snapshots API" do
         expected = {
           "create_time"       => create_time.iso8601,
           "href"              => a_string_matching("#{vms_url(vm.id)}/snapshots/#{snapshot.id}"),
-          "id"                => snapshot.id,
-          "vm_or_template_id" => vm.id
+          "id"                => snapshot.compressed_id,
+          "vm_or_template_id" => vm.compressed_id
         }
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)
@@ -332,8 +332,8 @@ RSpec.describe "Snapshots API" do
         expected = {
           "create_time"       => create_time.iso8601,
           "href"              => a_string_matching("#{instances_url(instance.id)}/snapshots/#{snapshot.id}"),
-          "id"                => snapshot.id,
-          "vm_or_template_id" => instance.id
+          "id"                => snapshot.compressed_id,
+          "vm_or_template_id" => instance.compressed_id
         }
         expect(response.parsed_body).to include(expected)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/tags_spec.rb
+++ b/spec/requests/api/tags_spec.rb
@@ -29,7 +29,7 @@ describe "Tags API" do
         expect { run_post tags_url, options }.to change(Tag, :count).by(1)
 
         result = response.parsed_body["results"].first
-        tag = Tag.find(result["id"])
+        tag = Tag.find(ApplicationRecord.uncompress_id(result["id"]))
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
         expect(result["href"]).to include(tags_url(tag.id))
@@ -44,7 +44,7 @@ describe "Tags API" do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:id => category.id}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(response.parsed_body["results"].first["id"])
+        tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -59,7 +59,7 @@ describe "Tags API" do
           run_post tags_url, :name => "test_tag", :description => "Test Tag", :category => {:name => category.name}
         end.to change(Tag, :count).by(1)
 
-        tag = Tag.find(response.parsed_body["results"].first["id"])
+        tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -73,7 +73,7 @@ describe "Tags API" do
         expect do
           run_post "#{categories_url(category.id)}/tags", :name => "test_tag", :description => "Test Tag"
         end.to change(Tag, :count).by(1)
-        tag = Tag.find(response.parsed_body["results"].first["id"])
+        tag = Tag.find(ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"]))
         tag_category = Category.find(tag.category.id)
         expect(tag_category).to eq(category)
 
@@ -271,7 +271,7 @@ describe "Tags API" do
 
       expect_single_resource_query(
         "href"           => tags_url(tag.id),
-        "id"             => tag.id,
+        "id"             => tag.compressed_id,
         "name"           => tag.name,
         "category"       => {"name" => tag.category.name,       "description" => tag.category.description},
         "classification" => {"name" => tag.classification.name, "description" => tag.classification.description}
@@ -286,7 +286,7 @@ describe "Tags API" do
 
       expect_single_resource_query(
         "href"           => tags_url(tag.id),
-        "id"             => tag.id,
+        "id"             => tag.compressed_id,
         "name"           => tag.name,
         "categorization" => {
           "name"         => tag.classification.name,

--- a/spec/requests/api/tenant_quotas_spec.rb
+++ b/spec/requests/api/tenant_quotas_spec.rb
@@ -31,8 +31,8 @@ describe "tenant quotas API" do
       expect_result_to_match_hash(
         response.parsed_body,
         "href"      => "/api/tenants/#{tenant.id}/quotas/#{quota.id}",
-        "id"        => quota.id,
-        "tenant_id" => tenant.id,
+        "id"        => quota.compressed_id,
+        "tenant_id" => tenant.compressed_id,
         "name"      => "cpu_allocated",
         "unit"      => "fixnum",
         "value"     => 1.0
@@ -100,8 +100,8 @@ describe "tenant quotas API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
         "results",
-        [{"id" => quota_1.id, "value" => 3},
-         {"id" => quota_2.id, "value" => 4}]
+        [{"id" => quota_1.compressed_id, "value" => 3},
+         {"id" => quota_2.compressed_id, "value" => 4}]
       )
       expect(quota_1.reload.value).to eq(3)
       expect(quota_2.reload.value).to eq(4)

--- a/spec/requests/api/tenants_spec.rb
+++ b/spec/requests/api/tenants_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "tenants API" do
     expect_result_to_match_hash(
       response.parsed_body,
       "href"        => tenants_url(tenant.id),
-      "id"          => tenant.id,
+      "id"          => tenant.compressed_id,
       "name"        => "Test Tenant",
       "description" => "Tenant for this test"
     )
@@ -112,7 +112,7 @@ RSpec.describe "tenants API" do
 
         expect_result_to_match_hash(response.parsed_body,
                                     "href" => tenants_url(root_tenant.id),
-                                    "id"   => root_tenant.id,
+                                    "id"   => root_tenant.compressed_id,
                                     "name" => ::Settings.server.company,
                                    )
         expect(response).to have_http_status(:ok)
@@ -141,8 +141,8 @@ RSpec.describe "tenants API" do
       expect(response).to have_http_status(:ok)
       expect_results_to_match_hash(
         "results",
-        [{"id" => tenant_1.id, "name" => "Updated Test Tenant 1"},
-         {"id" => tenant_2.id, "name" => "Updated Test Tenant 2"}]
+        [{"id" => tenant_1.compressed_id, "name" => "Updated Test Tenant 1"},
+         {"id" => tenant_2.compressed_id, "name" => "Updated Test Tenant 2"}]
       )
       expect(tenant_1.reload.name).to eq("Updated Test Tenant 1")
       expect(tenant_2.reload.name).to eq("Updated Test Tenant 2")

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = response.parsed_body["results"].first["id"]
+      user_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -165,7 +165,7 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:ok)
       expect_result_resources_to_include_keys("results", expected_attributes)
 
-      user_id = response.parsed_body["results"].first["id"]
+      user_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
       expect(User.exists?(user_id)).to be_truthy
     end
 
@@ -179,10 +179,10 @@ RSpec.describe "users API" do
 
       results = response.parsed_body["results"]
       user1_hash, user2_hash = results.first, results.second
-      expect(User.exists?(user1_hash["id"])).to be_truthy
-      expect(User.exists?(user2_hash["id"])).to be_truthy
-      expect(user1_hash["current_group_id"]).to eq(group1.id)
-      expect(user2_hash["current_group_id"]).to eq(group2.id)
+      expect(User.exists?(ApplicationRecord.uncompress_id(user1_hash["id"]))).to be_truthy
+      expect(User.exists?(ApplicationRecord.uncompress_id(user2_hash["id"]))).to be_truthy
+      expect(user1_hash["current_group_id"]).to eq(group1.compressed_id)
+      expect(user2_hash["current_group_id"]).to eq(group2.compressed_id)
     end
   end
 
@@ -208,7 +208,7 @@ RSpec.describe "users API" do
 
       run_post(users_url(user1.id), gen_request(:edit, "name" => "updated name"))
 
-      expect_single_resource_query("id" => user1.id, "name" => "updated name")
+      expect_single_resource_query("id" => user1.compressed_id, "name" => "updated name")
       expect(user1.reload.name).to eq("updated name")
     end
 
@@ -219,7 +219,7 @@ RSpec.describe "users API" do
                                                 "email" => "user1@email.com",
                                                 "group" => {"description" => group2.description}))
 
-      expect_single_resource_query("id" => user1.id, "email" => "user1@email.com", "current_group_id" => group2.id)
+      expect_single_resource_query("id" => user1.compressed_id, "email" => "user1@email.com", "current_group_id" => group2.compressed_id)
       expect(user1.reload.email).to eq("user1@email.com")
       expect(user1.reload.current_group_id).to eq(group2.id)
     end
@@ -232,8 +232,8 @@ RSpec.describe "users API" do
                                        {"href" => users_url(user2.id), "first_name" => "Jane"}]))
 
       expect_results_to_match_hash("results",
-                                   [{"id" => user1.id, "first_name" => "John"},
-                                    {"id" => user2.id, "first_name" => "Jane"}])
+                                   [{"id" => user1.compressed_id, "first_name" => "John"},
+                                    {"id" => user2.compressed_id, "first_name" => "Jane"}])
 
       expect(user1.reload.first_name).to eq("John")
       expect(user2.reload.first_name).to eq("Jane")


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1405
Resolves https://www.pivotaltracker.com/story/show/146613947

Not much to say about this one, except that you might want to put a pot of :coffee: on - big diff ahead!

@miq-bot add-label api, enhancement, bug
@miq-bot assign @abellotti 

/cc @jntullo  