### PR TITLE
Drop the indirect dependency hashie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "hamlit",                         "~>2.7.0"
-gem "hashie",                         "~>3.4.6",       :require => false
 gem "htauth",                         "2.0.0",         :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "jbuilder",                       "~>2.5.0" # For the REST API


### PR DESCRIPTION
Added in ae53c98de63cb080169d78b024057928933ed122 because 3.4.5 broke
our use of omniauth

Relaxed in a9b7474ad99a79c3e5b5f78fb6a30b4080fbfe9e after 3.4.6 was
released

Locked down dc26b3fe9c7bde9579c438bbc7d09e4973c9169d to ~>3.4.5 when 3.5.0 broke omniauth again

It appears that 3.5.3+ is safe to use so we should drop this dependency
here and if needed by omniauth, that gem should be more strict with it's
dependencies.

NOTE:  @agrare do you know if we can push this stricter dependency down to omniauth?  It seems like hashie is constantly breaking them.  Also, can we upgrade the omniauth gems?

Also, we have a single usage of omniauth in [here](https://github.com/ManageIQ/manageiq/blob/0b8ccd35941f541fe3a0034e61f86c6090169a4c/config/initializers/omniauth.rb), which is why we have omniauth as a direct dependency.  My hope is this can be pushed down to the google provider and let the provider dictate it's dependencies... Any thoughts on if we can do that?