### PR TITLE
Removed state since the default value is 'ready'

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -62,7 +62,7 @@ class MiqScheduleWorker::Jobs
 
   def job_proxy_dispatcher_dispatch
     if JobProxyDispatcher.waiting?
-      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate", :state => "ready")
+      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate")
     end
   end
 


### PR DESCRIPTION
The state value of **ready** is not needed when calling queue_work_in_each_zone since both 
the MiqQueue.put 
https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_queue.rb#L102

and MiqQueue.put_unless_exists both provide a default state of 'ready'

https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_queue.rb#L464