### PR TITLE
Use proper multi select condition

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -89,7 +89,7 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
         relation = inventory_collection.parent.send(inventory_collection.association)
                                        .includes(:vm_or_template)
                                        .references(:vm_or_template)
-        relation = relation.where(:vms => {:ems_ref => selection[:vm_or_template]}) unless selection.blank?
+        relation = relation.where(:vms => {:ems_ref => selection.map { |x| x[:vm_or_template] }}) unless selection.blank?
         relation
       end
 
@@ -135,13 +135,26 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
         :parent_inventory_collections => [:vms],
       }
 
-      if extra_attributes[:strategy] == :local_db_cache_all
-        attributes[:custom_manager_uuid] = lambda do |network|
-          [network.hardware.vm_or_template.ems_ref, network.description]
-        end
+      attributes[:custom_manager_uuid] = lambda do |network|
+        [network.hardware.vm_or_template.ems_ref, network.description]
       end
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:custom_db_finder] = lambda do |inventory_collection, selection, _projection|
+        relation = inventory_collection.parent.send(inventory_collection.association)
+                                       .joins(:hardware => :vm_or_template)
+                                       .references(:hardware => :vm_or_template)
+
+        unless selection.blank?
+          vms_ems_refs = selection.map { |x| x[:hardware] }.uniq
+          descriptions = selection.map { |x| x[:description] }.uniq
+
+          relation = relation.where(:hardware => {'vms' => {:ems_ref => vms_ems_refs}})
+          relation = relation.where(:description => descriptions)
+        end
+        relation
+      end
+
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.networks.joins(:hardware => :vm_or_template).where(
           :hardware => {'vms' => {:ems_ref => manager_uuids}}

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -81,10 +81,7 @@ module ManagerRefresh::SaveCollection
       end
 
       def build_multi_selection_query(inventory_collection, hashes)
-        cond = hashes.map do |hash|
-          "(#{inventory_collection.unique_index_columns.map { |x| ActiveRecord::Base.connection.quote(hash[x]) }.join(",")})"
-        end.join(",")
-        "(#{inventory_collection.unique_index_columns.join(",")}) IN (#{cond})"
+        inventory_collection.build_multi_selection_condition(hashes, inventory_collection.unique_index_columns)
       end
 
       def quote(value, name = nil, inventory_collection = nil)


### PR DESCRIPTION
Right now we are using this for loading from the db:
"col1 IN [a,b] AND col2 IN [e,f]"
which does give incorrect results since we need to load exact
combination:
"(col1, col2) IN [(a,e), (b,f), (b,e)]

The exact combination is especially needed when we are
determining if we should create/delete/update the records.

Unifying the compare and loading from the db to the correct
multiselect query. And using it on appropriate places.