### PR TITLE
remove GOOD_MIGRATIONS=skip from seeding

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -74,7 +74,7 @@ module ManageIQ
 
     def self.seed_database
       puts "\n== Seeding database =="
-      run_rake_task("db:seed GOOD_MIGRATIONS=skip")
+      run_rake_task("db:seed")
     end
 
     def self.setup_test_environment


### PR DESCRIPTION
good migration gem is no longer used
as migrations have been moved to the special repo

@miq-bot add_label technical_debt

cc @jrafanie 
@miq-bot assign @Fryguy 

