### PR TITLE
Use non beta version of rugged

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem "ruby-dbus" # For external auth
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.1",       :require => false
 gem "rufus-scheduler",                "~>3.1.3",       :require => false
-gem "rugged",                         "=0.25.0b10",    :require => false
+gem "rugged",                         "~>0.25.0",      :require => false
 gem "secure_headers",                 "~>3.0.0"
 gem "simple-rss",                     "~>1.3.1",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false


### PR DESCRIPTION
When adding support for self signed certificates in rugged we had to use a beta version. Now that rugged supports self signed certificates we can switch to the release version.