### PR TITLE
Changed task_id to tracking_label

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -390,14 +390,14 @@ class MiqRequest < ApplicationRecord
 
     # self.create_request_tasks
     MiqQueue.put(
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => "create_request_tasks",
-      :zone        => options.fetch(:miq_zone, my_zone),
-      :role        => my_role,
-      :task_id     => "#{self.class.name.underscore}_#{id}",
-      :msg_timeout => 3600,
-      :deliver_on  => deliver_on
+      :class_name     => self.class.name,
+      :instance_id    => id,
+      :method_name    => "create_request_tasks",
+      :zone           => options.fetch(:miq_zone, my_zone),
+      :role           => my_role,
+      :tracking_label => "#{self.class.name.underscore}_#{id}",
+      :msg_timeout    => 3600,
+      :deliver_on     => deliver_on
     )
   end
 

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -140,12 +140,12 @@ class MiqRequestTask < ApplicationRecord
 
       zone ||= source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
       MiqQueue.put(
-        :class_name  => 'MiqAeEngine',
-        :method_name => 'deliver',
-        :args        => [args],
-        :role        => 'automate',
-        :zone        => options.fetch(:miq_zone, zone),
-        :task_id     => my_task_id,
+        :class_name     => 'MiqAeEngine',
+        :method_name    => 'deliver',
+        :args           => [args],
+        :role           => 'automate',
+        :zone           => options.fetch(:miq_zone, zone),
+        :tracking_label => my_task_id,
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else
@@ -166,14 +166,14 @@ class MiqRequestTask < ApplicationRecord
     zone = source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
 
     queue_options.reverse_merge!(
-      :class_name   => self.class.name,
-      :instance_id  => id,
-      :method_name  => "execute",
-      :zone         => options.fetch(:miq_zone, zone),
-      :role         => miq_request.my_role,
-      :task_id      => my_task_id,
-      :deliver_on   => deliver_on,
-      :miq_callback => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
+      :class_name     => self.class.name,
+      :instance_id    => id,
+      :method_name    => "execute",
+      :zone           => options.fetch(:miq_zone, zone),
+      :role           => miq_request.my_role,
+      :tracking_label => my_task_id,
+      :deliver_on     => deliver_on,
+      :miq_callback   => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )
     MiqQueue.put(queue_options)
 

--- a/app/models/miq_request_task/post_install_callback.rb
+++ b/app/models/miq_request_task/post_install_callback.rb
@@ -20,12 +20,12 @@ module MiqRequestTask::PostInstallCallback
 
   def provision_completed_queue
     MiqQueue.put(
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => 'provision_completed',
-      :zone        => my_zone,
-      :role        => my_role,
-      :task_id     => my_task_id,
+      :class_name     => self.class.name,
+      :instance_id    => id,
+      :method_name    => 'provision_completed',
+      :zone           => my_zone,
+      :role           => my_role,
+      :tracking_label => my_task_id,
     )
   end
 

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -50,13 +50,13 @@ module MiqRequestTask::StateMachine
   def signal_queue(phase)
     method_name, args = phase == :abort ? [:signal_abort, []] : [:signal, [phase]]
     MiqQueue.put(
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => method_name,
-      :args        => args,
-      :zone        => my_zone,
-      :role        => my_role,
-      :task_id     => my_task_id,
+      :class_name     => self.class.name,
+      :instance_id    => id,
+      :method_name    => method_name,
+      :args           => args,
+      :zone           => my_zone,
+      :role           => my_role,
+      :tracking_label => my_task_id,
     )
   end
 
@@ -71,13 +71,13 @@ module MiqRequestTask::StateMachine
   def requeue_phase
     save # Save current phase_context
     MiqQueue.put(
-      :class_name   => self.class.name,
-      :instance_id  => id,
-      :method_name  => phase,
-      :deliver_on   => 10.seconds.from_now.utc,
-      :zone         => my_zone,
-      :role         => my_role,
-      :task_id      => my_task_id,
+      :class_name     => self.class.name,
+      :instance_id    => id,
+      :method_name    => phase,
+      :deliver_on     => 10.seconds.from_now.utc,
+      :zone           => my_zone,
+      :role           => my_role,
+      :tracking_label => my_task_id,
       :miq_callback => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )
   end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -12,8 +12,8 @@ class MiqScheduleWorker::Jobs
   end
 
   def miq_server_worker_log_status
-    queue_work(:class_name  => "MiqServer", :method_name => "log_status", :tracking_label => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
-    queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :tracking_label => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqServer", :method_name => "log_status",     :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def vmdb_database_connection_log_statistics
@@ -62,7 +62,7 @@ class MiqScheduleWorker::Jobs
 
   def job_proxy_dispatcher_dispatch
     if JobProxyDispatcher.waiting?
-      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :tracking_label => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate")
+      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate")
     end
   end
 

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -12,8 +12,8 @@ class MiqScheduleWorker::Jobs
   end
 
   def miq_server_worker_log_status
-    queue_work(:class_name  => "MiqServer", :method_name => "log_status",     :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
-    queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqServer", :method_name => "log_status", :tracking_label => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
+    queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :tracking_label => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def vmdb_database_connection_log_statistics
@@ -62,7 +62,7 @@ class MiqScheduleWorker::Jobs
 
   def job_proxy_dispatcher_dispatch
     if JobProxyDispatcher.waiting?
-      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :task_id => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate")
+      queue_work_on_each_zone(:class_name => "JobProxyDispatcher", :method_name => "dispatch", :tracking_label => "job_dispatcher", :priority => MiqQueue::HIGH_PRIORITY, :role => "smartstate")
     end
   end
 

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -274,7 +274,7 @@ module MiqProvisionQuotaMixin
     prov_ids = []
     MiqQueue
       .where(:method_name => 'deliver', :state => %w(ready dequeue), :class_name => 'MiqAeEngine')
-      .where("task_id like ?", '%miq_provision_%')
+      .where("tracking_label like ?", '%miq_provision_%')
       .each do |q|
         if q.args
           args = q.args.first

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -38,12 +38,12 @@ class ServiceReconfigureTask < MiqRequestTask
       }
 
       MiqQueue.put(
-        :class_name  => 'MiqAeEngine',
-        :method_name => 'deliver',
-        :args        => [args],
-        :role        => 'automate',
-        :zone        => zone,
-        :task_id     => "#{self.class.name.underscore}_#{id}"
+        :class_name     => 'MiqAeEngine',
+        :method_name    => 'deliver',
+        :args           => [args],
+        :role           => 'automate',
+        :zone           => zone,
+        :tracking_label => "#{self.class.name.underscore}_#{id}"
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -94,12 +94,12 @@ class ServiceTemplateProvisionTask < MiqRequestTask
 
   def queue_post_provision
     MiqQueue.put(
-      :class_name   => self.class.name,
-      :instance_id  => id,
-      :method_name  => "do_post_provision",
-      :deliver_on   => 1.minutes.from_now.utc,
-      :task_id      => "#{self.class.name.underscore}_#{id}",
-      :miq_callback => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
+      :class_name     => self.class.name,
+      :instance_id    => id,
+      :method_name    => "do_post_provision",
+      :deliver_on     => 1.minutes.from_now.utc,
+      :tracking_label => "#{self.class.name.underscore}_#{id}",
+      :miq_callback   => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )
   end
 
@@ -145,12 +145,12 @@ class ServiceTemplateProvisionTask < MiqRequestTask
 
       zone ||= source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
       MiqQueue.put(
-        :class_name  => 'MiqAeEngine',
-        :method_name => 'deliver',
-        :args        => [args],
-        :role        => 'automate',
-        :zone        => options.fetch(:miq_zone, zone),
-        :task_id     => "#{self.class.name.underscore}_#{id}"
+        :class_name     => 'MiqAeEngine',
+        :method_name    => 'deliver',
+        :args           => [args],
+        :role           => 'automate',
+        :zone           => options.fetch(:miq_zone, zone),
+        :tracking_label => "#{self.class.name.underscore}_#{id}"
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -83,12 +83,12 @@ describe ServiceReconfigureTask do
         }
         expect(user.current_tenant).to be_truthy
         expect(MiqQueue).to receive(:put).with(
-          :class_name  => 'MiqAeEngine',
-          :method_name => 'deliver',
-          :args        => [automate_args],
-          :role        => 'automate',
-          :zone        => nil,
-          :task_id     => "service_reconfigure_task_#{task.id}")
+          :class_name     => 'MiqAeEngine',
+          :method_name    => 'deliver',
+          :args           => [automate_args],
+          :role           => 'automate',
+          :zone           => nil,
+          :tracking_label => "service_reconfigure_task_#{task.id}")
         task.deliver_to_automate
       end
 

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -121,14 +121,14 @@ describe ServiceTemplateProvisionTask do
         allow(@request).to receive(:approved?).and_return(true)
         allow(MiqServer).to receive(:my_zone).and_return('a_zone')
         expect(MiqQueue).to receive(:put).with(
-          :class_name   => 'ServiceTemplateProvisionTask',
-          :instance_id  => @task_0.id,
-          :method_name  => 'execute',
-          :role         => 'ems_operations',
-          :zone         => 'a_zone',
-          :task_id      => "service_template_provision_task_#{@task_0.id}",
-          :deliver_on   => nil,
-          :miq_callback => miq_callback)
+          :class_name     => 'ServiceTemplateProvisionTask',
+          :instance_id    => @task_0.id,
+          :method_name    => 'execute',
+          :role           => 'ems_operations',
+          :zone           => 'a_zone',
+          :tracking_label => "service_template_provision_task_#{@task_0.id}",
+          :deliver_on     => nil,
+          :miq_callback   => miq_callback)
         @task_0.execute_queue
       end
 

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -95,12 +95,12 @@ describe ServiceTemplateProvisionTask do
         }
         allow(@request).to receive(:approved?).and_return(true)
         expect(MiqQueue).to receive(:put).with(
-          :class_name  => 'MiqAeEngine',
-          :method_name => 'deliver',
-          :args        => [automate_args],
-          :role        => 'automate',
-          :zone        => 'special',
-          :task_id     => "service_template_provision_task_#{@task_0.id}")
+          :class_name     => 'MiqAeEngine',
+          :method_name    => 'deliver',
+          :args           => [automate_args],
+          :role           => 'automate',
+          :zone           => 'special',
+          :tracking_label => "service_template_provision_task_#{@task_0.id}")
         @task_0.deliver_to_automate
       end
 


### PR DESCRIPTION
The task_id in queues can be used for 2 purposes
1. Create multiple tasks with the same task_id so that they can run one after the other
2. Logging to help debugging a workflow (e.g. service provisioning)

In the places where the task_id is being used for tracking a collection of tasks, this PR changes it to tracking_label.
