### PR TITLE
Add Amazon report to standard set of reports

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -63,6 +63,7 @@
   - User
   - VimPerformanceTrend
   - Vm
+  - VmCloud
   - ManageIQ::Providers::CloudManager::Vm
   - ManageIQ::Providers::InfraManager::Vm
   - VmPerformance

--- a/product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
+++ b/product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
@@ -1,0 +1,84 @@
+---
+title: Amazon - Active VMs
+rpt_group: Custom
+rpt_type: Custom
+priority: 20
+db: VmCloud
+cols:
+- name
+- power_state
+include:
+  flavor:
+    columns:
+    - name
+  ext_management_system:
+    columns:
+    - name
+  availability_zone:
+    columns:
+    - name
+  security_groups:
+    columns:
+    - name
+col_order:
+- name
+- flavor.name
+- ext_management_system.name
+- availability_zone.name
+- security_groups.name
+- power_state
+headers:
+- Name
+- Flavor Name
+- Cloud/Infrastructure Provider Name
+- Availability Zone Name
+- Security Group Name
+- Power State
+conditions: !ruby/object:MiqExpression
+  exp:
+    and:
+    - REGULAR EXPRESSION MATCHES:
+        field: VmCloud-vendor
+        value: "/amazon/i"
+    - "=":
+        field: VmCloud-power_state
+        value: 'on'
+  context_type:
+order: Ascending
+sortby:
+- availability_zone.name
+- name
+group: c
+graph:
+dims:
+filename:
+file_mtime:
+categories: []
+timeline:
+template_type: report
+where_clause:
+db_options: {}
+generate_cols:
+generate_rows:
+col_formats:
+-
+-
+-
+-
+-
+-
+tz:
+time_profile_id:
+display_filter:
+col_options:
+  name:
+    :break_label: 'Name: '
+rpt_options:
+  :pdf:
+    :page_size: US-Letter
+  :queue_timeout:
+  :summary:
+    :hide_detail_rows: false
+miq_group_id: 10000000000002
+user_id: 10000000000001
+menu_name: Amazon - Active VMs

--- a/product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
+++ b/product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
@@ -79,6 +79,4 @@ rpt_options:
   :queue_timeout:
   :summary:
     :hide_detail_rows: false
-miq_group_id: 10000000000002
-user_id: 10000000000001
 menu_name: Amazon - Active VMs

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 143)
+    include_examples(".seed called multiple times", 144)
   end
 end


### PR DESCRIPTION
During the CloudForms Hackathon we agreed to include some of the reports we usually deliver during POCs as part of the built in reports in the product. We will create separate PR for each of the reports 


Steps for Testing/QA [Optional]
-------------------------------

- Add an Amazon provider with existing VMs 
- Create the report 
