### PR TITLE
support find and lazy_find by other fields than manager_ref

### DIFF
--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -15,7 +15,11 @@ module ManagerRefresh
     end
 
     def manager_uuid
-      manager_ref.map { |attribute| data[attribute].try(:id) || data[attribute].to_s }.join("__")
+      id_with_keys(manager_ref)
+    end
+
+    def id_with_keys(keys)
+      keys.map { |attribute| data[attribute].try(:id) || data[attribute].to_s }.join("__")
     end
 
     def to_raw_lazy_relation

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -2,10 +2,12 @@ module ManagerRefresh
   class InventoryObjectLazy
     include Vmdb::Logging
 
-    attr_reader :ems_ref, :inventory_collection, :key, :default
+    attr_reader :ems_ref, :ref, :inventory_collection, :key, :default
 
-    def initialize(inventory_collection, ems_ref, key: nil, default: nil)
+    # TODO: ems_ref is inaccurate name, doubly so if it depends on ref.
+    def initialize(inventory_collection, ems_ref, ref: :manager_ref, key: nil, default: nil)
       @ems_ref              = ems_ref
+      @ref                  = ref
       @inventory_collection = inventory_collection
       @key                  = key
       @default              = default
@@ -17,8 +19,9 @@ module ManagerRefresh
 
     def inspect
       suffix = ""
+      suffix += ", ref: #{ref}" if ref.present?
       suffix += ", key: #{key}" if key.present?
-      "InventoryObjectLazy:('#{self}', #{inventory_collection})#{suffix}"
+      "InventoryObjectLazy:('#{self}', #{inventory_collection}#{suffix})"
     end
 
     def to_raw_lazy_relation
@@ -75,7 +78,7 @@ module ManagerRefresh
     end
 
     def load_object
-      inventory_collection.find(to_s)
+      inventory_collection.find(to_s, :ref => ref)
     end
   end
 end


### PR DESCRIPTION
Rationale:
Kubernetes API gives us permanently unique "UID"s, but expresses links to other objects via "name"s that are only only momentarily unique.
[https://kubernetes.io/docs/concepts/overview/working-with-objects/names/]

We want to keep using the UIDs are ems_ref and graph refresh's manager_ref.
But we need ability to lazy_find by name.
This PR is POC for extending InventoryCollection with extra indexes as suggested in
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/30#issuecomment-309667365

- [ ] incomplete, just the parts I needed
- [ ] missing tests & docs
- [ ] naming is bad...

@Ladas @agrare Would you have time to flesh this out?

Ideas that _might_ make it friendlier:
- embed which index inside the `foo__bar` strings, so once constructed you don't need to pass around which index you're referring to ?
  then we can mix all indexes in one hash (this may be a decision that's hard reverse?).
- autodetect index from keys passed to find_by / lazy_find_by ?