### PR TITLE
Move rails-controller-testing to :test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ gem "pg-pglogical",                   "~>1.1.0",       :require => false
 gem "puma",                           "~>3.3.0"
 gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.0.2"
-gem "rails-controller-testing",                        :require => false
 gem "rails-i18n",                     "~>5.x"
 gem "responders",                     "~>2.0"
 gem "rest-client",                    "~>2.0.0",       :require => false
@@ -122,6 +121,7 @@ unless ENV["APPLIANCE"]
     gem "capybara",         "~>2.5.0",  :require => false
     gem "coveralls",                    :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
+    gem "rails-controller-testing",     :require => false
     gem "sqlite3",                      :require => false
     gem "timecop",          "~>0.7.3",  :require => false
     gem "vcr",              "~>3.0.2",  :require => false


### PR DESCRIPTION
[`rails-controller-testing`](https://github.com/rails/rails-controller-testing) simply allows for the `assigns` interface to exist when testing controllers.  This should only be needed when running the tests, so move this to the `:test` group in bundler.

This won't really do much (performance wise, since it is a `:require => false`, but it is just cleaning up our main dependencies a bit.  Alternatively, we could move this to the plugin gems that actually have controller tests that make use of this functionality (currently, none of the API tests seem to use this interface), and delete this gem as a dependency for `manageiq`.

Links
-----

* https://github.com/rails/rails-controller-testing
* Added in https://github.com/ManageIQ/manageiq/commit/96297565 as part of https://github.com/ManageIQ/manageiq/pull/5982