### PR TITLE
Fix key for regexp in miq_expression.yaml

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -287,7 +287,7 @@
   :percent:
     :short_name: <%= _("Percent") %>
     :title: <%= _("Enter a Percent (like 12.5)") %>
-  :regex:
+  :regexp:
     :short_name: <%= _("Regular Expression") %>
     :title: <%= _("Enter a Regular Expression") %>
   :string: &string


### PR DESCRIPTION
there is a lot of occurrences of `:regexp`
miq_expresion.rb and also in
app/controllers/application_controller/filter/expression.rb
and it fixes to edit of expression with regexp in UI
(report definition, filter tab)
so there is the typo in yaml.
UI error:
before:
![screen shot 2017-06-27 at 09 45 29](https://user-images.githubusercontent.com/14937244/27576651-fe40d84a-5b1d-11e7-88f9-6904445eddd2.png)
after:
![screen shot 2017-06-27 at 09 52 28](https://user-images.githubusercontent.com/14937244/27576744-614ce1fe-5b1e-11e7-8107-9398f876fba9.png)


@miq-bot add_label reporting, bug
@miq-bot assign @gtanzillo 



