### PR TITLE
[EUWE] Fix pdf report error for networking switch

### DIFF
--- a/app/controllers/infra_networking_controller.rb
+++ b/app/controllers/infra_networking_controller.rb
@@ -60,8 +60,8 @@ class InfraNetworkingController < ApplicationController
                       :url  => "/infra_networking/x_show/#{@record.id}?display=hosts")
       @showtype = "hosts"
     when "download_pdf", "main"
-      get_tagdata(@configuration_job)
-      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record..name},
+      get_tagdata(@record)
+      drop_breadcrumb(:name => _("%{name} (Summary)") % {:name => @record.name},
                       :url  => "/infra_networking/show/#{@record.id}")
       @showtype = "main"
       set_summary_pdf_data if %w(download_pdf).include?(@display)


### PR DESCRIPTION
Fixing:
* incorrect instance variable name: `@configuration_job` should be `@record`
* extra dot `.` in `@record..name` 

This is euwe only, the problem is not present in current ManageIQ master.

https://bugzilla.redhat.com/show_bug.cgi?id=1460938