### PR TITLE
Fix for Drop Down List Dialog does not keep default value for Integer type

### DIFF
--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -102,7 +102,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def default_value_included_in_raw_values?
-    @raw_values.collect { |value_pair| value_pair[0] }.include?(default_value.send(value_modifier))
+    @raw_values.collect { |value_pair| value_pair[0].send(value_modifier) }.include?(default_value.send(value_modifier))
   end
 
   def static_raw_values

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -221,9 +221,9 @@ describe DialogFieldDropDownList do
               expect(dialog_field.values).to eq([[0, "zero"], [10, "ten"], [5, "five"]])
             end
 
-            it "sets the value to the first value" do
+            it "sets the value to the default value as a string" do
               dialog_field.values
-              expect(dialog_field.value).to eq("0")
+              expect(dialog_field.value).to eq("5")
             end
           end
         end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -189,8 +189,40 @@ describe DialogFieldSortedItem do
       end
 
       context "when the field is not required" do
-        it "returns the values with the first option being a nil 'None' option" do
-          expect(dialog_field.values).to eq([[nil, "<None>"], %w(test test), %w(abc abc)])
+        context "when the data type is an integer" do
+          let(:data_type) { "integer" }
+
+          before do
+            dialog_field.data_type = data_type
+          end
+
+          context "when there is a default value that matches a value in the values list" do
+            let(:default_value) { "2" }
+            let(:values) { [%w(1 1), %w(2 2), %w(3 3)] }
+
+            it "sets the default value to the matching value" do
+              dialog_field.values
+              expect(dialog_field.default_value).to eq("2")
+            end
+
+            it "returns the values with the first option being a nil 'None' option" do
+              expect(dialog_field.values).to eq([[nil, "<None>"], %w(1 1), %w(2 2), %w(3 3)])
+            end
+          end
+
+          context "when there is a default value that does not match a value in the values list" do
+            let(:default_value) { "4" }
+            let(:values) { [%w(1 1), %w(2 2), %w(3 3)] }
+
+            it "sets the default value to nil" do
+              dialog_field.values
+              expect(dialog_field.default_value).to eq(nil)
+            end
+
+            it "returns the values with the first option being a nil 'None' option" do
+              expect(dialog_field.values).to eq([[nil, "<None>"], %w(1 1), %w(2 2), %w(3 3)])
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
For static drop down lists, when setting the default value, it was being saved in the database, but when comparing to the values, the values were not being cast to an integer and thus it was comparing strings against integers and thinking the default value did not match. This PR will ensure values are cast to the proper data_type during the default_value comparison.

https://bugzilla.redhat.com/show_bug.cgi?id=1463827

@miq-bot add_label bug, fine/yes
@miq-bot assign @gmcculloug 

@gmcculloug This bug was reported on 5.8 and I don't see any clones, I'm adding the fine/yes label but I don't know if we want to add the euwe/yes label as well? Please advise.