### PR TITLE
Fix for <Choose> found as option in drop down service dialogs

### DIFF
--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -11,7 +11,7 @@ class DialogFieldRadioButton < DialogFieldSortedItem
 
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : static_raw_values
-    self.value ||= default_value if default_value_included_in_raw_values?
+    self.value ||= default_value if default_value_included?(@raw_values)
 
     @raw_values
   end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -178,49 +178,76 @@ describe DialogFieldSortedItem do
 
     context "when the field is not dynamic" do
       let(:dynamic) { false }
-      let(:default_value) { "abc" }
 
-      context "when the field is required" do
-        let(:required) { true }
+      context "when the data type is not integer" do
+        context "when the default_value is set" do
+          let(:default_value) { "abc" }
 
-        it "returns the values with the first option being a nil 'Choose' option" do
-          expect(dialog_field.values).to eq([[nil, "<Choose>"], %w(test test), %w(abc abc)])
+          context "when the field is required" do
+            let(:required) { true }
+
+            it "returns the values without the first option being a nil option" do
+              expect(dialog_field.values).to eq([%w(test test), %w(abc abc)])
+            end
+          end
+
+          context "when the field is not required" do
+            it "returns the values with the first option being a nil 'None' option" do
+              expect(dialog_field.values).to eq([[nil, "<None>"], %w(test test), %w(abc abc)])
+            end
+          end
         end
       end
 
-      context "when the field is not required" do
-        context "when the data type is an integer" do
-          let(:data_type) { "integer" }
+      context "when the data type is an integer" do
+        let(:data_type) { "integer" }
 
-          before do
-            dialog_field.data_type = data_type
+        before do
+          dialog_field.data_type = data_type
+        end
+
+        context "when there is a default value that matches a value in the values list" do
+          let(:default_value) { "2" }
+          let(:values) { [%w(1 1), %w(2 2), %w(3 3)] }
+
+          it "sets the default value to the matching value" do
+            dialog_field.values
+            expect(dialog_field.default_value).to eq("2")
           end
 
-          context "when there is a default value that matches a value in the values list" do
-            let(:default_value) { "2" }
-            let(:values) { [%w(1 1), %w(2 2), %w(3 3)] }
+          it "returns the values with the first option being a nil 'None' option" do
+            expect(dialog_field.values).to eq([[nil, "<None>"], %w(1 1), %w(2 2), %w(3 3)])
+          end
+        end
 
-            it "sets the default value to the matching value" do
-              dialog_field.values
-              expect(dialog_field.default_value).to eq("2")
-            end
+        context "when there is a default value that does not match a value in the values list" do
+          let(:default_value) { "4" }
+          let(:values) { [%w(1 1), %w(2 2), %w(3 3)] }
 
-            it "returns the values with the first option being a nil 'None' option" do
-              expect(dialog_field.values).to eq([[nil, "<None>"], %w(1 1), %w(2 2), %w(3 3)])
+          it "sets the default value to nil" do
+            dialog_field.values
+            expect(dialog_field.default_value).to eq(nil)
+          end
+
+          it "returns the values with the first option being a nil 'None' option" do
+            expect(dialog_field.values).to eq([[nil, "<None>"], %w(1 1), %w(2 2), %w(3 3)])
+          end
+        end
+
+        context "when the default value is nil" do
+          let(:default_value) { nil }
+
+          context "when the field is required" do
+            let(:required) { true }
+
+            it "returns the values with the first option being a nil 'Choose' option" do
+              expect(dialog_field.values).to eq([[nil, "<Choose>"], %w(test test), %w(abc abc)])
             end
           end
 
-          context "when there is a default value that does not match a value in the values list" do
-            let(:default_value) { "4" }
-            let(:values) { [%w(1 1), %w(2 2), %w(3 3)] }
-
-            it "sets the default value to nil" do
-              dialog_field.values
-              expect(dialog_field.default_value).to eq(nil)
-            end
-
+          context "when the field is not required" do
             it "returns the values with the first option being a nil 'None' option" do
-              expect(dialog_field.values).to eq([[nil, "<None>"], %w(1 1), %w(2 2), %w(3 3)])
+              expect(dialog_field.values).to eq([[nil, "<None>"], %w(test test), %w(abc abc)])
             end
           end
         end


### PR DESCRIPTION
For all static fields, if the default value is not chosen, the first item in the list will be a 'nil' option with a description of either `<None>` or `<Choose>`, depending on if the field is required or not. However, if a default value is chosen, this doesn't really make sense for required fields because a default value is already selected and there is no reason someone should go back to a nil value. For non-required fields, however, it makes sense to continue to have the `<None>` option even if a default value is already set.

This PR enhances the logic of when and when not to add a 'nil' option for sorted item fields.

https://bugzilla.redhat.com/show_bug.cgi?id=1462375

@miq-bot add_label bug, fine/yes, euwe/yes
@miq-bot assign @gmcculloug 

/cc @dclarizio Since you assigned this BZ to me I wanted to tag you for visibility.

@syncrou Can you review for me? I'm not super convinced that the way I handled the `nil_option` logic is optimal, but I feel like it's at least contained in a small enough method that it will be easier to make changes to if we need to down the road.