### PR TITLE
Add server MB usage to rake evm:status and status_full.

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -81,11 +81,12 @@ class EvmApplication
        s.drb_uri,
        s.started_on && s.started_on.iso8601,
        s.last_heartbeat && s.last_heartbeat.iso8601,
+       (mem = (s.proportional_set_size || s.memory_usage)).nil? ? "" : mem / 1.megabyte,
        s.is_master,
        s.active_role_names.join(':'),
       ]
     end
-    header = ["Zone", "Server", "Status", "ID", "PID", "SPID", "URL", "Started On", "Last Heartbeat", "Master?", "Active Roles"]
+    header = ["Zone", "Server", "Status", "ID", "PID", "SPID", "URL", "Started On", "Last Heartbeat", "MB Usage", "Master?", "Active Roles"]
     puts data.unshift(header).tableize
   end
 


### PR DESCRIPTION
Similar to https://github.com/ManageIQ/manageiq/pull/15375 committed in 5be3b4555ec32578e51cacd86ea046139d6d661a but for the server process.

```
03:57:00 ~/Code/manageiq (add_server_mb_usage_in_evm_status) (2.4.1) + bin/rails evm:status
** Using session_store: ActionDispatch::Session::MemCacheStore
Checking EVM status...
 Zone    | Server | Status  |            ID |   PID |  SPID | URL                     | Started On           | Last Heartbeat       | MB Usage | Master? | Active Roles
---------+--------+---------+---------------+-------+-------+-------------------------+----------------------+----------------------+----------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------
 default | EVM    | started | 1000000000001 | 39527 | 39538 | druby://127.0.0.1:61862 | 2017-06-27T19:55:04Z | 2017-06-27T19:56:46Z |      194 | true    | automate:database_operations:database_owner:ems_inventory:ems_operations:event:reporting:scheduler:smartstate:user_interface:web_services:websocket

 Worker Type       | Status  |            ID |   PID | SPID  |     Server id | Queue Name / URL    | Started On           | Last Heartbeat       | MB Usage
-------------------+---------+---------------+-------+-------+---------------+---------------------+----------------------+----------------------+----------
 MiqGenericWorker  | started | 1000000000117 | 39541 | 39575 | 1000000000001 | generic             | 2017-06-27T19:55:36Z | 2017-06-27T19:57:01Z |      194
 MiqScheduleWorker | started | 1000000000118 | 39542 | 39576 | 1000000000001 |                     | 2017-06-27T19:55:36Z | 2017-06-27T19:56:50Z |      273
 MiqUiWorker       | started | 1000000000119 | 39543 |       | 1000000000001 | http://0.0.0.0:3000 | 2017-06-27T19:55:36Z | 2017-06-27T19:57:01Z |      176
```