### PR TITLE
[WIP] [Rearch] Replace MiqQueue with ActiveMQ Artemis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -249,3 +249,5 @@ end
 
 # Load other additional Gemfiles
 Dir.glob(File.join(__dir__, 'bundler.d/*.rb')).each { |f| eval_gemfile(File.expand_path(f, __dir__)) }
+
+gem 'stomp'

--- a/app/models/active_mq_client.rb
+++ b/app/models/active_mq_client.rb
@@ -2,9 +2,10 @@ require 'stomp'
 
 class ActiveMqClient < Stomp::Client
   def self.open(long_live = false, client_id = nil)
+    # TODO: need to be able to configure host
     hosts = [{:login => "admin", :passcode => "smartvm", :host => "127.0.0.1", :port => 61613}]
     headers = {}
-    headers.merge!(:host => "127.0.0.1", :"accept-version" => "1.2", :"heart-beat" => "2000,2000") if long_live
+    headers.merge!(:host => "127.0.0.1", :"accept-version" => "1.2", :"heart-beat" => "2000,0") if long_live
     headers.merge!(:"client-id" => client_id) if client_id
 
     super(:hosts => hosts, :connect_headers => headers)

--- a/app/models/active_mq_client.rb
+++ b/app/models/active_mq_client.rb
@@ -1,0 +1,12 @@
+require 'stomp'
+
+class ActiveMqClient < Stomp::Client
+  def self.open(long_live = false, client_id = nil)
+    hosts = [{:login => "admin", :passcode => "smartvm", :host => "127.0.0.1", :port => 61613}]
+    headers = {}
+    headers.merge!(:host => "127.0.0.1", :"accept-version" => "1.2", :"heart-beat" => "2000,2000") if long_live
+    headers.merge!(:"client-id" => client_id) if client_id
+
+    super(:hosts => hosts, :connect_headers => headers)
+  end
+end

--- a/app/workers/amq_consumer.rb
+++ b/app/workers/amq_consumer.rb
@@ -1,0 +1,10 @@
+client = ActiveMqClient.open(true)
+
+ARGV.each do |arg|
+  service, resource = arg.split('.')
+  MiqQueue.subscribe_background_job(client, :service => service, :resource => resource)
+end
+
+loop do
+  sleep(1)
+end


### PR DESCRIPTION
We are going to replace `MiqQueue#put` with a group of `put_###` methods.

The first one is `put_background_job`. It accepts `class_name`, `method_name` and `instance_id` so the subscriber knows exactly what to do.

The sample worker subscribes the queue for background job and executes.
The address and queue_name in ActiveMQ is `queue/<service>.<resource>`. `none` means no resource affinity.

@miq-bot add wip, core/queue
cc @kbrock @mkanoor 