### PR TITLE
De-couple DescendantLoader from Rails

### DIFF
--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -1,3 +1,5 @@
+require_relative "extensions/descendant_loader.rb"
+
 class ActsAsArModel
   include Vmdb::Logging
 
@@ -21,7 +23,11 @@ class ActsAsArModel
     superclass == ActsAsArModel ? self : superclass.base_class
   end
 
-  class << self; alias_method :base_model, :base_class; end
+  class << self
+    alias base_model base_class
+
+    prepend DescendantLoader::ArDescendantsWithLoader
+  end
 
   #
   # Column methods

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -63,6 +63,13 @@ class DescendantLoader
     io.puts
   end
 
+  def self.setup
+    return if @setup_complete
+    ActiveRecord::Base.singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
+    ActiveSupport::Dependencies.send(:prepend, DescendantLoader::AsDependenciesClearWithLoader)
+    @setup_complete = true
+  end
+
   # Extract class definitions (namely: a list of which scopes it might
   # be defined in [depending on runtime details], the name of the class,
   # and the name of its superclass), given a path to a ruby script file.
@@ -266,9 +273,7 @@ class DescendantLoader
   end
 end
 
-ActiveRecord::Base.singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
-ActiveSupport::Dependencies.send(:prepend, DescendantLoader::AsDependenciesClearWithLoader)
-ActsAsArModel.singleton_class.send(:prepend, DescendantLoader::ArDescendantsWithLoader)
+DescendantLoader.setup
 
 at_exit do
   DescendantLoader.instance.save_cache!

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -45,6 +45,9 @@
 #   When Active Record calls `Bbb.descendants` to construct the `type`
 #   condition, `Ccc` is automatically loaded.
 #
+
+require "active_record"
+
 class DescendantLoader
   CACHE_VERSION = 2
 

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -47,6 +47,7 @@
 #
 
 require "active_record"
+require_relative "../manageiq"
 
 class DescendantLoader
   CACHE_VERSION = 2
@@ -169,7 +170,7 @@ class DescendantLoader
   # RubyParser is slow, so wrap it in a simple mtime-based cache.
   module Cache
     def cache_path
-      Rails.root.join('tmp/cache/sti_loader.yml')
+      ManageIQ.root.join('tmp/cache/sti_loader.yml')
     end
 
     def load_cache
@@ -209,7 +210,7 @@ class DescendantLoader
 
   module Mapper
     def descendants_paths
-      @descendants_paths ||= [Rails.root.join("app/models")]
+      @descendants_paths ||= [ManageIQ.root.join("app/models")]
     end
 
     def class_inheritance_relationships


### PR DESCRIPTION
Does the following to allow DescendantLoader to be loaded without a full Rails dependency:

* Moves the patches to ActiveRecord and ActiveSupport from the bottom of the file to a dedicated `.setup` method.
* Moves applying the patch to `ActsAsArModel` into that file, which then only applies the patch when `ActsAsArModel` is loaded (we own this code, so no need to monkey patch it with `.send`).
* Requires `ActiveRecord` as part of `DescendantLoader`, which allows the `.setup` method to function.
* Makes use of `lib/manageiq.rb` instead of Rails functions, allowing other instance methods to function.

This is part of allowing `Vmdb::Settings` to be loaded without Rails, since `Vmdb::Plugins` makes use of `DescendantLoader`.


Verbose description
--------------------
aka: "Read this section if you are not into the whole `tl; dr;` thing"

Say you had a metrics collector for `VMWare` that was mostly a pure ruby script (this is a "completely original theoretical idea" that I came with on my own... :trollface: ), and really didn't need much of Rails beyond the few models it needed to put in to the database.  The active record code might not even be entirely necessary if we change the queuing system.

That said, the `Vmdb::Settings` code would still be most likely be necessary for this process (and/or container), and others like it, for it to boot up and be configurable via the main ManageIQ application.  The `lib/vmdb/settings.rb` file, while by default won't use `Vmdb::Plugins` (where `DescendantLoader` is used directly), but far down the stack of `Vmdb::Settings::init`, it does call out to `Vmdb::Plugins` (and eventually `DescendantLoader`):

https://github.com/ManageIQ/manageiq/blob/cd17a20/lib/vmdb/settings.rb#L18
https://github.com/ManageIQ/manageiq/blob/cd17a20/lib/vmdb/settings.rb#L65
https://github.com/ManageIQ/manageiq/blob/cd17a20/lib/vmdb/settings.rb#L85
https://github.com/ManageIQ/manageiq/blob/cd17a20/lib/vmdb/settings.rb#L130
https://github.com/ManageIQ/manageiq/blob/cd17a20/lib/vmdb/settings.rb#L114

Above being the lines numbers from an approximation of the callstack starting from the line of `Vmdb::Settings.init` down to the line in `Vmdb::Settings#template_roots` that calls `Vmdb::Plugins`.

### Explanation of End Goal and why QA steps is so minimal

End goal for this would be to be able to allow the following to work:

```console
$ bundle exec ruby -Ilib -e "require 'vmdb/settings'; Vmdb::Settings.init"
```

But has a bunch of other pre-requisites that aren't handled in this PR:

* Load `MoreCoreExtensions::Shared::Nested` to allow `lib/patches/config_patches.rb` to be loaded properly
* Merge https://github.com/ManageIQ/manageiq/pull/15461 (or something with the same kind of affect) to allow plugins to be loaded without `Rails` being loaded
* `require 'lib/manageiq'` and change all instances of `Rails.root` and `Rails.env` to `ManageIQ.root` and `ManageIQ.env` respectively (see https://github.com/ManageIQ/manageiq/pull/15020 for some background)
* Include a `require` of `active_record` and autoload `ActiveRecord::Base` so `config` works properly and `require_dependency` is defined.
* Require `vmdb/logging` in some fashion (currently used in `Vmdb::Plugins`, but assumes autoloading is setup)

The other option to simplify some of those steps above would be to implement our own autoloading rule set, similar to what I did/described here:

https://github.com/ManageIQ/manageiq/pull/15174#issuecomment-315468186

But again, something that is out of scope for this PR.  Doing the end goal would be a lengthy process of multiple PRs, and this is a small component of that.


Misc Historical Context
-----------------------

A few PRs were merged prior to this one (one significantly so) that made the changes here necessary:

* _Register VMDB plugins_: #12221
* _Allow Vmdb::Plugins to work through code reloads in development._: #15057

The first was needed when we switched to a provider plugins in separate repos architecture, and the second just makes sense to avoid devs having to restart their application/console session when changing code (which is slow).  Both clearly wouldn't have tried to account for this case when those PR's were conceived, but now attribute to why this PR was necessary to solve the `require "vmdb/settings"` issue.

Mostly included this section because I discussed (parts of) this with @Fryguy at some point, and he was un-aware of some of the changes above.  Also, I didn't include this originally since I figured most people would not care for the full explanation in the steps for testing this changes "works".


Links
-----
* https://www.pivotaltracker.com/story/show/146936263


Steps for Testing/QA [Optional]
-------------------------------
Run the following from the root of the ManageIQ directory:

```console
$ bundle exec ruby -Ilib -e "require 'extensions/descendant_loader'; puts DescendantLoader.descendants_paths"
```

Test with both this branch and master.
  