### PR TITLE
[WIP] Load Vmdb::Plugins via bundler

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -15,22 +15,21 @@ module Vmdb
     end
 
     def register_vmdb_plugins
-      Rails.application.railties.each do |railtie|
-        next unless railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
-        register_vmdb_plugin(railtie)
+      plugin_registry.plugins.each do |plugin|
+        register_vmdb_plugin(plugin)
       end
 
       @vmdb_plugins
     end
 
-    def register_vmdb_plugin(engine)
-      @vmdb_plugins << engine
+    def register_vmdb_plugin(plugin)
+      @vmdb_plugins << plugin
 
-      register_automate_domains(engine)
-      register_provider_plugin(engine)
+      register_automate_domains(plugin)
+      register_provider_plugin(plugin)
 
       # make sure STI models are recognized
-      DescendantLoader.instance.descendants_paths << engine.root.join('app')
+      DescendantLoader.instance.descendants_paths << plugin.root.join('app')
     end
 
     def registered_provider_plugin_names
@@ -47,15 +46,24 @@ module Vmdb
 
     private
 
-    def register_provider_plugin(engine)
-      if engine.class.name.start_with?("ManageIQ::Providers::")
-        provider_name = ManageIQ::Providers::Inflector.provider_name(engine).underscore.to_sym
-        @registered_provider_plugin_map[provider_name] = engine
+    def plugin_registry
+      @plugin_registry ||= build_plugin_registry
+    end
+
+    def build_plugin_registry
+      require_relative "plugins/registry/rails.rb"
+      Vmdb::Plugins::Registry::Rails.instance
+    end
+
+    def register_provider_plugin(plugin)
+      if plugin_registry.provider_plugin? plugin
+        provider_name = plugin_registry.provider_name(plugin)
+        @registered_provider_plugin_map[provider_name] = plugin
       end
     end
 
-    def register_automate_domains(engine)
-      Dir.glob(engine.root.join("content", "automate", "*")).each do |domain_directory|
+    def register_automate_domains(plugin)
+      Dir.glob(plugin.root.join("content", "automate", "*")).each do |domain_directory|
         @registered_automate_domains << AutomateDomain.new(domain_directory)
       end
     end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -51,8 +51,13 @@ module Vmdb
     end
 
     def build_plugin_registry
-      require_relative "plugins/registry/rails.rb"
-      Vmdb::Plugins::Registry::Rails.instance
+      if defined?(Rails)
+        require_relative "plugins/registry/rails.rb"
+        Vmdb::Plugins::Registry::Rails.instance
+      else
+        require_relative "plugins/registry/bundler.rb"
+        Vmdb::Plugins::Registry::Bundler.instance
+      end
     end
 
     def register_provider_plugin(plugin)

--- a/lib/vmdb/plugins/registry/bundler.rb
+++ b/lib/vmdb/plugins/registry/bundler.rb
@@ -1,0 +1,65 @@
+module Vmdb
+  class Plugins
+    module Registry
+      class Bundler
+        class Plugin
+          def initialize(spec)
+            @spec = spec
+          end
+
+          def name
+            @spec.name
+          end
+
+          def root
+            @root ||= Pathname.new @spec.gem_dir
+          end
+        end
+
+        include Singleton
+
+        # FIXME:  Don't rely on this constant for determining non-provider
+        # based plugins
+        #
+        # Instead find a way to do the equaivalent of `vmdb_plugin?` without
+        # having to load the class (file in the root, modularize the code
+        # containing `def vmdb_root?`, etc.)
+        NON_PROVIDER_PLUGINS = %w(automation_engine content ui-classic).freeze
+
+        attr_reader :plugins, :provider_plugins
+
+        def initialize
+          @plugins = fetch_plugins
+        end
+
+        def provider_name(plugin)
+          plugin.name.gsub("manageiq-providers-", "")
+        end
+
+        def provider_plugin?(plugin)
+          provider_plugins.include? plugin
+        end
+
+        private
+
+        def fetch_plugins
+          plugin_gems.map do |spec|
+            Plugin.new(spec)
+          end
+        end
+
+        def plugin_gems
+          ::Bundler.locked_gems.specs.select do |spec|
+            spec.name.match(/^manageiq-(providers-.*|#{NON_PROVIDER_PLUGINS.join("|")})$/)
+          end
+        end
+
+        def provider_plugins
+          @provider_plugins ||= @plugins.select do |plugin|
+            plugin.name.start_with?("manageiq-providers-")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vmdb/plugins/registry/rails.rb
+++ b/lib/vmdb/plugins/registry/rails.rb
@@ -1,0 +1,37 @@
+module Vmdb
+  class Plugins
+    module Registry
+      class Rails
+        include Singleton
+
+        attr_reader :plugins, :provider_plugins
+
+        def initialize
+          @plugins = fetch_plugins
+        end
+
+        def provider_name(plugin)
+          ManageIQ::Providers::Inflector.provider_name(plugin).underscore.to_sym
+        end
+
+        def provider_plugin?(plugin)
+          provider_plugins.include? plugin
+        end
+
+        private
+
+        def fetch_plugins
+          ::Rails.application.railties.select do |railtie|
+            railtie.class.name.start_with?("ManageIQ::Providers::") || railtie.try(:vmdb_plugin?)
+          end
+        end
+
+        def provider_plugins
+          @provider_plugins ||= @plugins.select do |engine|
+            engine.class.name.start_with?("ManageIQ::Providers::")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a registry interface for loading `Vmdb::Plugins`, adds not only the existing Rails Engine mechanism as one of the registry adapters (still the default), but includes an additional registry interface for loading via Bundler.

This also lays the groundwork for a more verbose plugin registry system that is "pluggable", and hopefully less dependent on needing "all the things" to run.  This is in no way implemented in this PR, but will hopefully help facilitate that in the future™.

Steps for Testing/QA
--------------------
Ideally this is a low risk PR, so nothing should change by default with these changes.