### PR TITLE
fix master failure: use a_collection_containing_exactly

### DIFF
--- a/spec/requests/api/alert_definitions_spec.rb
+++ b/spec/requests/api/alert_definitions_spec.rb
@@ -22,14 +22,14 @@ describe "Alerts Definitions API" do
       "name"      => "alert_definitions",
       "count"     => 2,
       "subcount"  => 2,
-      "resources" => [
+      "resources" => a_collection_containing_exactly(
         {
           "href" => a_string_matching(alert_definitions_url(alert_definitions[0].id))
         },
         {
           "href" => a_string_matching(alert_definitions_url(alert_definitions[1].id))
         }
-      ]
+      )
     )
   end
 


### PR DESCRIPTION
Fixes master test failure. 

Spec needs to use `a_collection_containing_exactly` over `[]` to account for items not being returned in order. 

cc: @imtayadeway @NickLaMuro 

@miq-bot assign @gtanzillo 
@miq-bot add_label bug/sporadic test failure