### PR TITLE
Quota - Calculate quota values for active provisions. 

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -329,11 +329,18 @@ module MiqProvisionQuotaMixin
   def service_quota_values(request, result)
     request.service_template.service_resources.each do |sr|
       if request.service_template.service_type == 'composite'
-        # "will deal with this later"
+        bundle_quota_values(sr, result)
       else
         next if request.service_template.prov_type.starts_with?("generic")
         vm_quota_values(sr.resource, result)
       end
+    end
+  end
+
+  def bundle_quota_values(service_resource, result)
+    return if service_resource.resource.prov_type.starts_with?('generic')
+    service_resource.resource.service_resources.each do |sr|
+      vm_quota_values(sr.resource, result)
     end
   end
 

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -22,6 +22,8 @@ class ServiceTemplateProvisionRequest < MiqRequest
   delegate :picture, :to => :service_template, :allow_nil => true
 
   alias_method :user, :get_user
+  #include MiqProvisionMixin
+  include MiqProvisionQuotaMixin
 
   def process_service_order
     case options[:cart_state]

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -22,7 +22,6 @@ class ServiceTemplateProvisionRequest < MiqRequest
   delegate :picture, :to => :service_template, :allow_nil => true
 
   alias_method :user, :get_user
-  #include MiqProvisionMixin
   include MiqProvisionQuotaMixin
 
   def process_service_order

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -141,7 +141,7 @@ describe MiqProvisionRequest do
                                                        :tenant      => user.current_tenant,
                                                        :source      => vm_template,
                                                        :src_vm_id   => vm_template.id,
-                                                       :options     => prov_options)
+                                                       :options     => prov_options.merge(:owner_email => user.email, :requester_group => user.miq_groups.first.description))
           end
 
           def request_queue_entry(request)
@@ -177,8 +177,8 @@ describe MiqProvisionRequest do
             ems = FactoryGirl.create(:ems_vmware)
             vmware_tenant = FactoryGirl.create(:tenant)
             group = FactoryGirl.create(:miq_group, :tenant => vmware_tenant)
-            @vmware_user1 = FactoryGirl.create(:user, :miq_groups => [group])
-            @vmware_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+            @vmware_user1 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
+            @vmware_user2 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
             hardware = FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 512)
             @vmware_template = FactoryGirl.create(:template_vmware,
                                                   :ext_management_system => ems,
@@ -198,8 +198,8 @@ describe MiqProvisionRequest do
                                      :availability_zones => [FactoryGirl.create(:availability_zone_google)])
             google_tenant = FactoryGirl.create(:tenant)
             group = FactoryGirl.create(:miq_group, :tenant => google_tenant)
-            @google_user1 = FactoryGirl.create(:user, :miq_groups => [group])
-            @google_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+            @google_user1 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
+            @google_user2 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
             @google_template = FactoryGirl.create(:template_google, :ext_management_system => ems)
             flavor = FactoryGirl.create(:flavor_google, :ems_id => ems.id,
                                         :cpus => 4, :cpu_cores => 1, :memory => 1024)
@@ -249,8 +249,8 @@ describe MiqProvisionRequest do
               it_behaves_like "check_quota"
             end
 
-            context "active_provisions_by_user," do
-              let(:quota_method) { :active_provisions_by_user }
+            context "active_provisions_by_owner," do
+              let(:quota_method) { :active_provisions_by_owner }
               let(:counts_hash) do
                 {:count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 2.gigabytes}
               end
@@ -275,8 +275,8 @@ describe MiqProvisionRequest do
               it_behaves_like "check_quota"
             end
 
-            context "active_provisions_by_user," do
-              let(:quota_method) { :active_provisions_by_user }
+            context "active_provisions_by_owner," do
+              let(:quota_method) { :active_provisions_by_owner }
               let(:counts_hash) do
                 {:count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes}
               end

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -117,7 +117,7 @@ describe MiqProvisionRequest do
         end
 
         it "should return stats from quota methods" do
-          prov_options = {:number_of_vms => [2, '2'], :owner_email => 'tester@miq.com', :vm_memory => ['1024', '1024'], :number_of_cpus => [2, '2']}
+          prov_options = {:number_of_vms => [2, '2'], :owner_email => 'tester@miq.com', :vm_memory => [1024, '1024'], :number_of_cpus => [2, '2']}
           @pr2 = FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm_template.id, :options => prov_options)
 
           stats = @pr.check_quota(:requests_by_owner)
@@ -125,9 +125,176 @@ describe MiqProvisionRequest do
 
           expect(stats[:class_name]).to eq("MiqProvisionRequest")
           expect(stats[:count]).to eq(2)
-          expect(stats[:memory]).to eq(2048)
+          expect(stats[:memory]).to eq(2.gigabytes)
           expect(stats[:cpu]).to eq(4)
           expect(stats.fetch_path(:active, :class_name)).to eq("MiqProvision")
+        end
+
+        it "should return stats from quota methods" do
+          prov_options = {:number_of_vms => [2, '2'], :owner_email => 'tester@miq.com', :vm_memory => [1024, '1024'], :number_of_cpus => [2, '2']}
+          @pr2 = FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm_template.id, :options => prov_options)
+
+          stats = @pr.check_quota(:requests_by_owner)
+          expect(stats).to be_kind_of(Hash)
+          expect(stats[:class_name]).to eq("MiqProvisionRequest")
+          expect(stats[:count]).to eq(2)
+          expect(stats[:memory]).to eq(2.gigabytes)
+          expect(stats[:cpu]).to eq(4)
+          expect(stats.fetch_path(:active, :class_name)).to eq("MiqProvision")
+        end
+
+        context "for cloud and infra providers," do
+          def create_task(user, request)
+            FactoryGirl.create(:miq_request_task, :miq_request => request, :miq_request_id => request.id, :type => 'MiqProvision', :description => "task", :tenant => user.current_tenant)
+          end
+
+          def create_request(user, vm_template, prov_options)
+            FactoryGirl.create(:miq_provision_request, :requester => user, :description => "request",
+                                                                           :tenant => user.current_tenant,
+                                                                           :source => vm_template,
+                                                                           :src_vm_id => vm_template.id,
+                                                                           :options => prov_options)
+          end
+
+          def request_queue_entry(request)
+            FactoryGirl.create(:miq_queue,
+                               :state       => MiqQueue::STATE_DEQUEUE,
+                               :instance_id => request.id,
+                               :class_name  => 'MiqProvisionRequest',
+                               :method_name => 'create_request_tasks')
+          end
+
+          def task_queue_entry(task)
+            FactoryGirl.create(:miq_queue,
+                               :state       => MiqQueue::STATE_DEQUEUE,
+                               :args        => [{:object_type => "Provision", :object_id => task.id}],
+                               :task_id     => 'miq_provision_task',
+                               :class_name  => 'MiqAeEngine',
+                               :method_name => 'deliver')
+          end
+
+          def create_test_task(user, template)
+            request = create_request(user, template, {})
+            create_task(user, request)
+            request
+          end
+
+          def queue(requests)
+            requests.each do |request|
+              request.miq_request_tasks.empty? ? request_queue_entry(request) : task_queue_entry(request.miq_request_tasks.first)
+            end
+          end
+
+          let(:vmware_tasks) do
+            ems = FactoryGirl.create(:ems_vmware)
+            vmware_tenant = FactoryGirl.create(:tenant)
+            group = FactoryGirl.create(:miq_group, :tenant => vmware_tenant)
+            @vmware_user1 = FactoryGirl.create(:user, :miq_groups => [group])
+            @vmware_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+            hardware = FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 512)
+            @vmware_template = FactoryGirl.create(:template_vmware,
+                                                  :ext_management_system => ems,
+                                                  :hardware              => hardware)
+            prov_options = {:number_of_vms => [2, '2'], :vm_memory => [1024, '1024'], :number_of_cpus => [2, '2']}
+            requests = []
+            2.times { requests << create_request(@vmware_user1, @vmware_template, prov_options) }
+            create_task(@vmware_user1, requests.first)
+
+            2.times { requests << create_request(@vmware_user2, @vmware_template, prov_options) }
+            create_task(@vmware_user2, requests.last)
+            requests
+          end
+
+          let(:google_tasks) do
+            ems = FactoryGirl.create(:ems_google_with_authentication,
+                                     :availability_zones => [FactoryGirl.create(:availability_zone_google)])
+            google_tenant = FactoryGirl.create(:tenant)
+            group = FactoryGirl.create(:miq_group, :tenant => google_tenant)
+            @google_user1 = FactoryGirl.create(:user, :miq_groups => [group])
+            @google_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+            @google_template = FactoryGirl.create(:template_google, :ext_management_system => ems)
+            flavor = FactoryGirl.create(:flavor_google, :ems_id => ems.id,
+                                        :cpus => 4, :cpu_cores => 1, :memory => 1024)
+            prov_options = {:number_of_vms => 1, :src_vm_id => vm_template.id, :boot_disk_size => ["10.GB", "10 GB"],
+                            :placement_auto => [true, 1], :instance_type => [flavor.id, flavor.name]}
+            requests = []
+            2.times { requests << create_request(@google_user1, @google_template, prov_options) }
+            create_task(@google_user1, requests.first)
+
+            2.times { requests << create_request(@google_user2, @google_template, prov_options) }
+            create_task(@google_user2, requests.last)
+            requests
+          end
+
+          shared_examples_for "check_quota" do
+            it "check" do
+              load_queue
+              stats = request.check_quota(quota_method)
+              expect(stats).to include(counts_hash)
+            end
+          end
+
+          context "active_provisions," do
+            let(:load_queue) { queue(vmware_tasks | google_tasks) }
+            let(:request) { create_test_task(@vmware_user1, @vmware_template) }
+            let(:quota_method) { :active_provisions }
+            let(:counts_hash) do
+              { :count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 44.gigabytes }
+            end
+            it_behaves_like "check_quota"
+          end
+
+          context "infra," do
+            let(:load_queue) { queue(vmware_tasks | google_tasks) }
+            let(:request) { create_test_task(@vmware_user1, @vmware_template) }
+            let(:counts_hash) do
+              { :count => 8, :memory => 8.gigabytes, :cpu => 16, :storage => 4.gigabytes }
+            end
+
+            context "active_provisions_by_tenant," do
+              let(:quota_method) { :active_provisions_by_tenant }
+              it_behaves_like "check_quota"
+            end
+
+            context "active_provisions_by_group," do
+              let(:quota_method) { :active_provisions_by_group }
+              it_behaves_like "check_quota"
+            end
+
+            context "active_provisions_by_user," do
+              let(:quota_method) { :active_provisions_by_user }
+              let(:counts_hash) do
+                { :count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 2.gigabytes }
+              end
+              it_behaves_like "check_quota"
+            end
+          end
+
+          context "cloud," do
+            let(:load_queue) { queue(vmware_tasks | google_tasks) }
+            let(:request) { create_test_task(@google_user1, @google_template) }
+            let(:counts_hash) do
+              { :count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes }
+            end
+
+            context "active_provisions_by_tenant," do
+              let(:quota_method) { :active_provisions_by_tenant }
+              it_behaves_like "check_quota"
+            end
+
+            context "active_provisions_by_group," do
+              let(:quota_method) { :active_provisions_by_group }
+              it_behaves_like "check_quota"
+            end
+
+            context "active_provisions_by_user," do
+              let(:quota_method) { :active_provisions_by_user }
+              let(:counts_hash) do
+                { :count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes }
+              end
+              it_behaves_like "check_quota"
+            end
+          end
         end
       end
 

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -130,30 +130,18 @@ describe MiqProvisionRequest do
           expect(stats.fetch_path(:active, :class_name)).to eq("MiqProvision")
         end
 
-        it "should return stats from quota methods" do
-          prov_options = {:number_of_vms => [2, '2'], :owner_email => 'tester@miq.com', :vm_memory => [1024, '1024'], :number_of_cpus => [2, '2']}
-          @pr2 = FactoryGirl.create(:miq_provision_request, :requester => user, :src_vm_id => vm_template.id, :options => prov_options)
-
-          stats = @pr.check_quota(:requests_by_owner)
-          expect(stats).to be_kind_of(Hash)
-          expect(stats[:class_name]).to eq("MiqProvisionRequest")
-          expect(stats[:count]).to eq(2)
-          expect(stats[:memory]).to eq(2.gigabytes)
-          expect(stats[:cpu]).to eq(4)
-          expect(stats.fetch_path(:active, :class_name)).to eq("MiqProvision")
-        end
-
         context "for cloud and infra providers," do
           def create_task(user, request)
             FactoryGirl.create(:miq_request_task, :miq_request => request, :miq_request_id => request.id, :type => 'MiqProvision', :description => "task", :tenant => user.current_tenant)
           end
 
           def create_request(user, vm_template, prov_options)
-            FactoryGirl.create(:miq_provision_request, :requester => user, :description => "request",
-                                                                           :tenant => user.current_tenant,
-                                                                           :source => vm_template,
-                                                                           :src_vm_id => vm_template.id,
-                                                                           :options => prov_options)
+            FactoryGirl.create(:miq_provision_request, :requester   => user,
+                                                       :description => "request",
+                                                       :tenant      => user.current_tenant,
+                                                       :source      => vm_template,
+                                                       :src_vm_id   => vm_template.id,
+                                                       :options     => prov_options)
           end
 
           def request_queue_entry(request)
@@ -166,11 +154,11 @@ describe MiqProvisionRequest do
 
           def task_queue_entry(task)
             FactoryGirl.create(:miq_queue,
-                               :state       => MiqQueue::STATE_DEQUEUE,
-                               :args        => [{:object_type => "Provision", :object_id => task.id}],
-                               :task_id     => 'miq_provision_task',
-                               :class_name  => 'MiqAeEngine',
-                               :method_name => 'deliver')
+                               :state          => MiqQueue::STATE_DEQUEUE,
+                               :args           => [{:object_type => "Provision", :object_id => task.id}],
+                               :tracking_label => 'miq_provision_task',
+                               :class_name     => 'MiqAeEngine',
+                               :method_name    => 'deliver')
           end
 
           def create_test_task(user, template)
@@ -239,7 +227,7 @@ describe MiqProvisionRequest do
             let(:request) { create_test_task(@vmware_user1, @vmware_template) }
             let(:quota_method) { :active_provisions }
             let(:counts_hash) do
-              { :count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 44.gigabytes }
+              {:count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 44.gigabytes}
             end
             it_behaves_like "check_quota"
           end
@@ -248,7 +236,7 @@ describe MiqProvisionRequest do
             let(:load_queue) { queue(vmware_tasks | google_tasks) }
             let(:request) { create_test_task(@vmware_user1, @vmware_template) }
             let(:counts_hash) do
-              { :count => 8, :memory => 8.gigabytes, :cpu => 16, :storage => 4.gigabytes }
+              {:count => 8, :memory => 8.gigabytes, :cpu => 16, :storage => 4.gigabytes}
             end
 
             context "active_provisions_by_tenant," do
@@ -264,7 +252,7 @@ describe MiqProvisionRequest do
             context "active_provisions_by_user," do
               let(:quota_method) { :active_provisions_by_user }
               let(:counts_hash) do
-                { :count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 2.gigabytes }
+                {:count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 2.gigabytes}
               end
               it_behaves_like "check_quota"
             end
@@ -274,7 +262,7 @@ describe MiqProvisionRequest do
             let(:load_queue) { queue(vmware_tasks | google_tasks) }
             let(:request) { create_test_task(@google_user1, @google_template) }
             let(:counts_hash) do
-              { :count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes }
+              {:count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes}
             end
 
             context "active_provisions_by_tenant," do
@@ -290,7 +278,7 @@ describe MiqProvisionRequest do
             context "active_provisions_by_user," do
               let(:quota_method) { :active_provisions_by_user }
               let(:counts_hash) do
-                { :count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes }
+                {:count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes}
               end
               it_behaves_like "check_quota"
             end

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -16,7 +16,7 @@ describe ServiceTemplateProvisionRequest do
                                                                 :source_type => "ServiceTemplate",
                                                                 :source_id   => template.id,
                                                                 :process     => true,
-                                                                :options     => prov_options)
+                                                                :options     => prov_options.merge(:owner_email => user.email))
       end
 
       def request_queue_entry(request)
@@ -69,8 +69,8 @@ describe ServiceTemplateProvisionRequest do
         let(:vmware_tasks) do
           ems = FactoryGirl.create(:ems_vmware)
           group = FactoryGirl.create(:miq_group, :tenant => FactoryGirl.create(:tenant))
-          @vmware_user1 = FactoryGirl.create(:user, :miq_groups => [group])
-          @vmware_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+          @vmware_user1 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
+          @vmware_user2 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
           @vmware_template = FactoryGirl.create(:template_vmware,
                                                 :ext_management_system => ems,
                                                 :hardware              => FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 512))
@@ -111,8 +111,8 @@ describe ServiceTemplateProvisionRequest do
           it_behaves_like "check_quota"
         end
 
-        context "active_provisions_by_user," do
-          let(:quota_method) { :active_provisions_by_user }
+        context "active_provisions_by_owner," do
+          let(:quota_method) { :active_provisions_by_owner }
           let(:counts_hash) do
             {:count => 3, :memory => 3.gigabytes, :cpu => 8, :storage => 1_610_612_736}
           end
@@ -134,8 +134,8 @@ describe ServiceTemplateProvisionRequest do
           ems = FactoryGirl.create(:ems_google_with_authentication,
                                    :availability_zones => [FactoryGirl.create(:availability_zone_google)])
           group = FactoryGirl.create(:miq_group, :tenant => FactoryGirl.create(:tenant))
-          @google_user1 = FactoryGirl.create(:user, :miq_groups => [group])
-          @google_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+          @google_user1 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
+          @google_user2 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
 
           @google_template = FactoryGirl.create(:template_google, :ext_management_system => ems)
           flavor = FactoryGirl.create(:flavor_google, :ems_id => ems.id,
@@ -178,8 +178,8 @@ describe ServiceTemplateProvisionRequest do
           it_behaves_like "check_quota"
         end
 
-        context "active_provisions_by_user," do
-          let(:quota_method) { :active_provisions_by_user }
+        context "active_provisions_by_owner," do
+          let(:quota_method) { :active_provisions_by_owner }
           let(:counts_hash) do
             {:count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes}
           end

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -50,7 +50,6 @@ describe ServiceTemplateProvisionRequest do
       def create_service_bundle(user, items, options = {})
         build_model_from_vms(items)
         request = build_service_template_request("top", user, :dialog => {"test" => "dialog"})
-        #byebug
         res = request.service_template.service_resources.first.resource.service_resources.first.resource
         res.options.merge!(options)
         res.save

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -1,0 +1,179 @@
+describe ServiceTemplateProvisionRequest do
+  include Spec::Support::QuotaHelper
+  include Spec::Support::ServiceTemplateHelper
+
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  context "quota methods" do
+    context "for cloud and infra providers," do
+      def create_task(user, request)
+        FactoryGirl.create(:service_template_provision_task, :miq_request => request, :miq_request_id => request.id, :type => 'ServiceTemplateProvisionTask', :description => "task", :tenant => user.current_tenant)
+      end
+
+      def create_request(user, template, prov_options = {})
+        FactoryGirl.create(:service_template_provision_request, :requester => user, :description => "request",
+                                                                       :tenant_id => user.current_tenant.id,
+                                                                       :source_type => "ServiceTemplate",
+                                                                       :source_id => template.id,
+                                                                       :process => true,
+                                                                       :options => prov_options)
+      end
+
+      def request_queue_entry(request)
+        FactoryGirl.create(:miq_queue,
+                           :state       => MiqQueue::STATE_DEQUEUE,
+                           :instance_id => request.id,
+                           :class_name  => 'ServiceTemplateProvisionRequest',
+                           :method_name => 'create_request_tasks')
+      end
+
+      def task_queue_entry(task)
+        FactoryGirl.create(:miq_queue,
+                           :state       => MiqQueue::STATE_DEQUEUE,
+                           :args        => [{:object_type => "ServiceTemplateProvisionRequest", :object_id => task.id}],
+                           :task_id     => 'service_template_provision_task',
+                           :class_name  => 'MiqAeEngine',
+                           :method_name => 'deliver')
+      end
+
+      def create_test_task(user, service_template)
+        request = create_request(user, service_template)
+        create_task(user, request)
+        request
+      end
+
+      def queue(requests)
+        requests.each do |request|
+          request.miq_request_tasks.empty? ? request_queue_entry(request) : task_queue_entry(request.miq_request_tasks.first)
+        end
+      end
+
+      # def create_service_bundle(user, items)
+      #   build_model_from_vms(items)
+      #   build_service_template_request("top", user, :dialog => {"test" => "dialog"})
+      # end
+
+      let(:vmware_tasks) do
+        ems = FactoryGirl.create(:ems_vmware)
+        vmware_tenant = FactoryGirl.create(:tenant)
+        group = FactoryGirl.create(:miq_group, :tenant => vmware_tenant)
+        @vmware_user1 = FactoryGirl.create(:user, :miq_groups => [group])
+        @vmware_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+        @vmware_template = FactoryGirl.create(:template_vmware,
+                                              :ext_management_system => ems,
+                                              :hardware              => FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 512))
+        @vmware_prov_options = {:number_of_vms => [2, '2'], :vm_memory => [1024, '1024'], :number_of_cpus => [2, '2']}
+        requests = []
+
+        @vm_template = @vmware_template
+
+        @user = @vmware_user1
+        2.times { requests << build_vmware_service_item }
+        create_task(@user, requests.first)
+
+        @user = @vmware_user2
+        2.times { requests << build_vmware_service_item }
+        create_task(@user, requests.last)
+        requests.each { |r| r.update_attributes(:tenant_id => @user.current_tenant.id) }
+        requests
+      end
+
+      def build_google_service_item
+        options = {:requester => @user}.merge(@google_prov_options)
+        model = {"google_service_item" => {:type      => 'atomic',
+                                           :prov_type => 'google',
+                                           :request   => options}}
+        build_service_template_tree(model)
+        @service_request = build_service_template_request("google_service_item", @user, :dialog => {"test" => "dialog"})
+      end
+
+      let(:google_tasks) do
+        ems = FactoryGirl.create(:ems_google_with_authentication,
+                                 :availability_zones => [FactoryGirl.create(:availability_zone_google)])
+        google_tenant = FactoryGirl.create(:tenant)
+        group = FactoryGirl.create(:miq_group, :tenant => google_tenant)
+        @google_user1 = FactoryGirl.create(:user, :miq_groups => [group])
+        @google_user2 = FactoryGirl.create(:user, :miq_groups => [group])
+
+        @google_template = FactoryGirl.create(:template_google, :ext_management_system => ems)
+        flavor = FactoryGirl.create(:flavor_google, :ems_id => ems.id,
+                                    :cpus => 4, :cpu_cores => 1, :memory => 1024)
+        @google_prov_options = {:number_of_vms => 1, :src_vm_id => @google_template.id, :boot_disk_size => ["10.GB", "10 GB"],
+                        :placement_auto => [true, 1], :instance_type => [flavor.id, flavor.name]}
+        requests = []
+
+        @vm_template = @google_template
+
+        @user = @google_user1
+        2.times { requests << build_google_service_item }
+        create_task(@user, requests.first)
+
+        @user = @google_user2
+        2.times { requests << build_google_service_item }
+        create_task(@user, requests.last)
+
+        requests.each { |r| r.update_attributes(:tenant_id => @user.current_tenant.id) }
+        requests
+      end
+
+      shared_examples_for "check_quota" do
+        it "check" do
+          load_queue
+          stats = request.check_quota(quota_method)
+          expect(stats).to include(counts_hash)
+        end
+      end
+
+      context "infra," do
+        let(:load_queue) { queue(vmware_tasks) }
+        let(:request) { create_test_task(@vmware_user1, @vmware_template) }
+        let(:counts_hash) do
+          { :count => 4, :memory => 4.gigabytes, :cpu => 16, :storage => 2.gigabytes }
+        end
+
+        context "active_provisions_by_tenant," do
+          let(:quota_method) { :active_provisions_by_tenant }
+          it_behaves_like "check_quota"
+        end
+
+        context "active_provisions_by_group," do
+          let(:quota_method) { :active_provisions_by_group }
+          it_behaves_like "check_quota"
+        end
+
+        context "active_provisions_by_user," do
+          let(:quota_method) { :active_provisions_by_user }
+          let(:counts_hash) do
+            { :count => 2, :memory => 2.gigabytes, :cpu => 8, :storage => 1.gigabytes }
+          end
+          it_behaves_like "check_quota"
+        end
+      end
+
+      context "cloud," do
+        let(:load_queue) { queue(google_tasks) }
+        let(:request) { create_test_task(@google_user1, @google_template) }
+        let(:counts_hash) do
+          { :count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes }
+        end
+
+        context "active_provisions_by_tenant," do
+          let(:quota_method) { :active_provisions_by_tenant }
+          it_behaves_like "check_quota"
+        end
+
+        context "active_provisions_by_group," do
+          let(:quota_method) { :active_provisions_by_group }
+          it_behaves_like "check_quota"
+        end
+
+        context "active_provisions_by_user," do
+          let(:quota_method) { :active_provisions_by_user }
+          let(:counts_hash) do
+            { :count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes }
+          end
+          it_behaves_like "check_quota"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -10,12 +10,13 @@ describe ServiceTemplateProvisionRequest do
       end
 
       def create_request(user, template, prov_options = {})
-        FactoryGirl.create(:service_template_provision_request, :requester => user, :description => "request",
-                                                                       :tenant_id => user.current_tenant.id,
-                                                                       :source_type => "ServiceTemplate",
-                                                                       :source_id => template.id,
-                                                                       :process => true,
-                                                                       :options => prov_options)
+        FactoryGirl.create(:service_template_provision_request, :requester   => user,
+                                                                :description => "request",
+                                                                :tenant_id   => user.current_tenant.id,
+                                                                :source_type => "ServiceTemplate",
+                                                                :source_id   => template.id,
+                                                                :process     => true,
+                                                                :options     => prov_options)
       end
 
       def request_queue_entry(request)
@@ -28,11 +29,11 @@ describe ServiceTemplateProvisionRequest do
 
       def task_queue_entry(task)
         FactoryGirl.create(:miq_queue,
-                           :state       => MiqQueue::STATE_DEQUEUE,
-                           :args        => [{:object_type => "ServiceTemplateProvisionRequest", :object_id => task.id}],
-                           :task_id     => 'service_template_provision_task',
-                           :class_name  => 'MiqAeEngine',
-                           :method_name => 'deliver')
+                           :state          => MiqQueue::STATE_DEQUEUE,
+                           :args           => [{:object_type => "ServiceTemplateProvisionRequest", :object_id => task.id}],
+                           :tracking_label => 'service_template_provision_task',
+                           :class_name     => 'MiqAeEngine',
+                           :method_name    => 'deliver')
       end
 
       def create_test_task(user, service_template)
@@ -97,7 +98,7 @@ describe ServiceTemplateProvisionRequest do
         let(:load_queue) { queue(vmware_tasks) }
         let(:request) { create_test_task(@vmware_user1, @vmware_template) }
         let(:counts_hash) do
-          { :count => 6, :memory => 6.gigabytes, :cpu => 16, :storage => 3.gigabytes }
+          {:count => 6, :memory => 6.gigabytes, :cpu => 16, :storage => 3.gigabytes}
         end
 
         context "active_provisions_by_tenant," do
@@ -113,7 +114,7 @@ describe ServiceTemplateProvisionRequest do
         context "active_provisions_by_user," do
           let(:quota_method) { :active_provisions_by_user }
           let(:counts_hash) do
-            { :count => 3, :memory => 3.gigabytes, :cpu => 8, :storage => 1_610_612_736 }
+            {:count => 3, :memory => 3.gigabytes, :cpu => 8, :storage => 1_610_612_736}
           end
           it_behaves_like "check_quota"
         end
@@ -164,7 +165,7 @@ describe ServiceTemplateProvisionRequest do
         let(:load_queue) { queue(google_tasks) }
         let(:request) { create_test_task(@google_user1, @google_template) }
         let(:counts_hash) do
-          { :count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes }
+          {:count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes}
         end
 
         context "active_provisions_by_tenant," do
@@ -180,7 +181,7 @@ describe ServiceTemplateProvisionRequest do
         context "active_provisions_by_user," do
           let(:quota_method) { :active_provisions_by_user }
           let(:counts_hash) do
-            { :count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes }
+            {:count => 2, :memory => 2048, :cpu => 8, :storage => 20.gigabytes}
           end
           it_behaves_like "check_quota"
         end


### PR DESCRIPTION
Modified provision quota mixin to calculate active or inflight provisions. 
The changes are meant only as a temporary measure for quota calculations.
 
Updated quota mixin to reflect changes in method and object names.
Added methods for tenant and group active provisions and for quota item calculations.
Added tests.

https://bugzilla.redhat.com/show_bug.cgi?id=1456819

