### PR TITLE
Fixed bug:  wrong year  in Last Start Time

### DIFF
--- a/lib/extensions/ar_adapter/ar_dba/postgresql.rb
+++ b/lib/extensions/ar_adapter/ar_dba/postgresql.rb
@@ -851,7 +851,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
     start_time = select_value(<<-SQL, "Select last start date/time")
                                  SELECT pg_postmaster_start_time()
                               SQL
-    ActiveRecord::Type::Time.new.deserialize(start_time)
+    ActiveRecord::Type::DateTime.new.deserialize(start_time)
   end
 
   def analyze_table(table)


### PR DESCRIPTION
Wrong year for `Last Start Time`was shown on VMDV Summary screen

https://bugzilla.redhat.com/show_bug.cgi?id=1339612

**BEFORE:**
<img width="754" alt="before" src="https://user-images.githubusercontent.com/6556758/27653649-c7ffbe04-5c0d-11e7-9b92-cfd601df1aeb.png">

**AFTER:**
<img width="798" alt="after" src="https://user-images.githubusercontent.com/6556758/27653671-d8cebb54-5c0d-11e7-879d-fc88d9588dc7.png">

@miq-bot add-label bug

