### PR TITLE
Set default server roles from env

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -63,7 +63,7 @@ class MiqServer < ApplicationRecord
     if roles != starting_roles
       # tell the server to pick up the role change
       server = MiqServer.my_server
-      server.set_assigned_roles
+      server.sync_assigned_roles
       server.sync_active_roles
       server.set_active_role_flags
     end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -118,18 +118,17 @@ class MiqServer < ApplicationRecord
     puts "** #{msg}"
 
     starting_server_record
+    ensure_default_roles
 
     #############################################################
     # Server Role Assignment
     #
-    # 1. Deactivate all roles from last time
-    # 2. Set assigned roles from configuration
-    # 3. Assert database_owner role - based on vmdb being local
-    # 4. Role activation should happen inside monitor_servers
-    # 5. Synchronize active roles to monitor for role changes
+    # - Deactivate all roles from last time
+    # - Assert database_owner role - based on vmdb being local
+    # - Role activation should happen inside monitor_servers
+    # - Synchronize active roles to monitor for role changes
     #############################################################
     deactivate_all_roles
-    set_assigned_roles
     set_database_owner_role(EvmDatabase.local?)
     monitor_servers
     monitor_server_roles if self.is_master?

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -50,7 +50,7 @@ module MiqServer::RoleManagement
     save
   end
 
-  def set_assigned_roles
+  def sync_assigned_roles
     self.role = ::Settings.server.role
   end
 

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -55,7 +55,8 @@ module MiqServer::RoleManagement
   end
 
   def ensure_default_roles
-    self.role = (ENV["DEFAULT_ROLES"] || ::Settings.server.role) if role.blank?
+    MiqServer.my_server.add_settings_for_resource(:server => {:role => ENV["DEFAULT_ROLES"]}) if role.blank? && ENV["DEFAULT_ROLES"].present?
+    sync_assigned_roles
   end
 
   def deactivate_all_roles

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -54,6 +54,10 @@ module MiqServer::RoleManagement
     self.role = ::Settings.server.role
   end
 
+  def ensure_default_roles
+    self.role = (ENV["DEFAULT_ROLES"] || ::Settings.server.role) if role.blank?
+  end
+
   def deactivate_all_roles
     deactivate_roles("*")
   end

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -55,7 +55,7 @@ module MiqServer::RoleManagement
   end
 
   def ensure_default_roles
-    MiqServer.my_server.add_settings_for_resource(:server => {:role => ENV["DEFAULT_ROLES"]}) if role.blank? && ENV["DEFAULT_ROLES"].present?
+    MiqServer.my_server.add_settings_for_resource(:server => {:role => ENV["MIQ_SERVER_DEFAULT_ROLES"]}) if role.blank? && ENV["MIQ_SERVER_DEFAULT_ROLES"].present?
     sync_assigned_roles
   end
 

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -144,7 +144,7 @@ module MiqServer::WorkerManagement::Monitor
       end
 
       sync_config                if config_changed
-      set_assigned_roles         if config_changed
+      sync_assigned_roles        if config_changed
       log_role_changes           if roles_changed
       sync_active_roles          if roles_changed
       set_active_role_flags      if roles_changed

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -52,7 +52,6 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
           context "'smartproxy' server and roles deactivated" do
             before(:each) do
               # Overwrite so that we set our own assigned roles instead of from config file
-              allow_any_instance_of(MiqServer).to receive(:set_assigned_roles).and_return(nil)
               allow_any_instance_of(MiqServer).to receive(:sync_workers).and_return(nil)
               allow_any_instance_of(MiqServer).to receive(:sync_log_level).and_return(nil)
               allow_any_instance_of(MiqServer).to receive(:wait_for_started_workers).and_return(nil)

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -51,16 +51,10 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
 
           context "'smartproxy' server and roles deactivated" do
             before(:each) do
-              # Overwrite so that we set our own assigned roles instead of from config file
-              allow_any_instance_of(MiqServer).to receive(:sync_workers).and_return(nil)
-              allow_any_instance_of(MiqServer).to receive(:sync_log_level).and_return(nil)
-              allow_any_instance_of(MiqServer).to receive(:wait_for_started_workers).and_return(nil)
-
               server_roles = [FactoryGirl.create(:server_role, :name => "smartproxy", :max_concurrent => 0)]
 
               @server1.deactivate_all_roles
-              @server1.role    = 'smartproxy'
-              allow_any_instance_of(Host).to receive_messages(:missing_credentials? => false)
+              @server1.role = 'smartproxy'
             end
 
             it "will have no roles active" do


### PR DESCRIPTION
Set default server roles from `ENV["MIQ_SERVER_DEFAULT_ROLES"]` if they don't already exist.  This allows us to pass the default roles in the env variable to the backend manageiq container.  (don't include UI/WS/etc. which will never receive traffic)

For the frontend, we don't provide the env variable and it will take the defaults from `Settings`.

cc @jrafanie @carbonin 