### PR TITLE
[Rearch] Use memcached for sending messages to workers

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -147,8 +147,22 @@ module MiqServer::WorkerManagement::Monitor
       start_apache               if roles_changed &&  apache_needed?
 
       reset_queue_messages       if config_changed || roles_changed
+
+      update_sync_timestamp(@last_sync)
     end
 
     return resync_needed, sync_message
+  end
+
+  def set_last_change(key, value)
+    key_store.set(key, value)
+  end
+
+  def key_store
+    @key_store ||= Dalli::Client.new(MiqMemcached.server_address, :namespace => "server_monitor")
+  end
+
+  def update_sync_timestamp(last_sync)
+    set_last_change("last_config_change", last_sync)
   end
 end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -308,6 +308,18 @@ describe "MiqWorker Monitor" do
             end
           end
         end
+
+        context "for messaging through a key store" do
+          before do
+            allow(@miq_server).to receive(:key_store).and_return(@key_store)
+            @ts = Time.now.utc
+          end
+
+          it "should update timestamp with config or role changes" do
+            expect(@miq_server).to receive(:set_last_change).with("last_config_change", @ts)
+            @miq_server.update_sync_timestamp(@ts)
+          end
+        end
       end
 
       context "threshold validation" do


### PR DESCRIPTION
Use memcached and a timestamp as a mechanism for telling workers to synchronize their config and role without going through a Drb connection.

When the worker monitor detects that they have changes it stores the timestamp in memcached in the key that corresponds to the thing that changes. The workers check memcachd each time they heartbeat and if the timestamp is greater than the timestamp of the last sync it will fabricate the message that corresponds to the thing that changed and process it.
 
