### PR TITLE
Fail explicitly for MAS validation failure

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -225,7 +225,7 @@ class MiqAlert < ApplicationRecord
     status.event_ems_ref = ems_ref unless ems_ref.blank?
     status.resolved = resolved
     status.evaluated_on = Time.now.utc
-    status.save
+    status.save!
     miq_alert_statuses << status
   end
 

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -190,6 +190,15 @@ describe MiqAlert do
         expect(mas.severity).to eq(nil)
       end
 
+      it "raises an exception when miq_alert_status creation fails" do
+        expect do
+          @alert.evaluate(
+            [@vm.class.base_class.name, @vm.id],
+            :ems_event => FactoryGirl.create(:ems_event, :full_data => {:severity => 'undefined'})
+          )
+        end.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
       it "miq_alert_status.url = ems_event.full_data.url if present" do
         @alert.evaluate(
           [@vm.class.base_class.name, @vm.id],


### PR DESCRIPTION
During `MiqAlert.evaluate` when creating a new MiqAlertStatus, validation can fail[1].
In those cases we should fail the operation. Otherwise we can have a MiqAlert evaluated as true and silently not create a MAS.

[1] e.g `mas.severity` = 'unknown'