### PR TITLE
Add a Prototype setting for prometheus-containers

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -906,6 +906,7 @@
   :container_deployment_wizard: false
 :prototype:
   :monitoring: false
+  :prometheus-containers: false
 :recommendations:
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes


### PR DESCRIPTION
We are currently working on external monitoring using Prometheus running in an OpenShift cluster.
(new provider screen, ad hock metrics, live metrics for reports, events & alerts)

With a prototype we should be able to start merging some of that work without disrupting upstream.
