### PR TITLE
Container Template: Add :miq_class for each object

### DIFF
--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -36,7 +36,7 @@ class ContainerTemplate < ApplicationRecord
                                           :objects    => objects,
                                           :parameters => params)
     create_objects(processed_template['objects'], project)
-    @created_objects.each { |obj| obj[:kind] = MIQ_ENTITY_MAPPING[obj[:kind]] }
+    @created_objects.each { |obj| obj[:miq_class] = MIQ_ENTITY_MAPPING[obj[:kind]] }
   end
 
   def process_template(client, template)


### PR DESCRIPTION
Adding `miq_class` attribute to each object (hash) that returned by `instantiate` method, instead of converting the `kind` attribute since the resource kind is needed in order to allow automation to rollback in case of a service failure.  