### PR TITLE
Avoid Tower in notifications for embedded ansible

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
@@ -3,4 +3,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScript
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
+
+  FRIENDLY_NAME = "Ansible Automation Inside Job Template".freeze
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -2,4 +2,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationScriptSource
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
+
+  FRIENDLY_NAME = "Ansible Automation Inside Project".freeze
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
+  FRIENDLY_NAME = "Ansible Automation Inside Credential".freeze
+
   def self.provider_params(params)
     super.merge(:organization => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
   end


### PR DESCRIPTION
ManageIQ should not indicate that anything "Tower" exists when dealing with Embedded Ansible.  This should change the logs and notifications to use a more "embedded ansibly" term when talking about embedded ansibly things.

Before:

    "The operation Ansible Tower Credential creation (name=...) on Tower
                   ^^^^^^^^^^^^^
    (manager_id=...) completed successfully."

After:

    "The operation Ansible Automation Inside Credential creation (name=...)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
    on EMS(manager_id=1) completed successfully."

https://bugzilla.redhat.com/show_bug.cgi?id=1458593

see also:  https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/10