### PR TITLE
Remove unnecessary existence expectations

### DIFF
--- a/spec/requests/api/conditions_spec.rb
+++ b/spec/requests/api/conditions_spec.rb
@@ -74,7 +74,6 @@ describe "Conditions API" do
 
       condition_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
 
-      expect(Condition.exists?(condition_id)).to be_truthy
       expect(Condition.find(condition_id).expression.class).to eq(MiqExpression)
     end
 

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -359,7 +359,6 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
 
       provider_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
-      expect(foreman_type.exists?(provider_id)).to be_truthy
       provider = foreman_type.find(provider_id)
       [:name, :type, :url].each do |item|
         expect(provider.send(item)).to eq(sample_foreman[item])
@@ -437,7 +436,6 @@ describe "Providers API" do
       expect(response.parsed_body).to include(expected)
 
       provider_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
-      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       endpoint = ExtManagementSystem.find(provider_id).default_endpoint
       expect(endpoint).to have_endpoint_attributes(sample_rhevm)
     end
@@ -460,7 +458,6 @@ describe "Providers API" do
           expect(response.parsed_body).to include(expected)
 
           provider_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
-          expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
           ems = ExtManagementSystem.find(provider_id)
           expect(ems.authentications.size).to eq(1)
           expect(ems).to have_endpoint_attributes(sample_containers)
@@ -499,7 +496,6 @@ describe "Providers API" do
       expect(response.parsed_body).to include(expected)
 
       provider_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
-      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid).to eq(default_credentials["userid"])
       expect(provider.authentication_password).to eq(default_credentials["password"])
@@ -519,7 +515,6 @@ describe "Providers API" do
       expect(response.parsed_body).to include(expected)
 
       provider_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
-      expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
       provider = ExtManagementSystem.find(provider_id)
       expect(provider.authentication_userid(:default)).to eq(default_credentials["userid"])
       expect(provider.authentication_password(:default)).to eq(default_credentials["password"])
@@ -569,7 +564,6 @@ describe "Providers API" do
           expect(results.first).to include(expected)
 
           provider_id = ApplicationRecord.uncompress_id(results.first["id"])
-          expect(ExtManagementSystem.exists?(provider_id)).to be_truthy
           provider = ExtManagementSystem.find(provider_id)
           expect(provider).to have_endpoint_attributes(default_connection["endpoint"])
           expect(provider.authentication_token).to eq(token(default_connection))

--- a/spec/requests/api/roles_spec.rb
+++ b/spec/requests/api/roles_spec.rb
@@ -111,7 +111,6 @@ describe "Roles API" do
 
       run_get "#{roles_url}/#{role_id}/", :expand => "features"
 
-      expect(MiqUserRole.exists?(role_id)).to be_truthy
       role = MiqUserRole.find(role_id)
 
       sample_role1['features'].each do |feature|
@@ -128,7 +127,6 @@ describe "Roles API" do
       expect_result_resources_to_include_keys("results", expected_attributes)
 
       role_id = ApplicationRecord.uncompress_id(response.parsed_body["results"].first["id"])
-      expect(MiqUserRole.exists?(role_id)).to be_truthy
       role = MiqUserRole.find(role_id)
       sample_role1['features'].each do |feature|
         expect(role.allows?(feature)).to be_truthy
@@ -146,8 +144,6 @@ describe "Roles API" do
       results = response.parsed_body["results"]
       r1_id = ApplicationRecord.uncompress_id(results.first["id"])
       r2_id = ApplicationRecord.uncompress_id(results.second["id"])
-      expect(MiqUserRole.exists?(r1_id)).to be_truthy
-      expect(MiqUserRole.exists?(r2_id)).to be_truthy
 
       role1 = MiqUserRole.find(r1_id)
       role2 = MiqUserRole.find(r2_id)


### PR DESCRIPTION
All these expectations are followed by `find`s, which is an acceptable
way to blow up if something goes wrong. In this case, these
precautionary expectations turn out to have negative value, since they
will fail with the unhelpful "expected truthy, got falsey" message,
instead of the more useful `RecordNotFound` error.

@miq-bot add-label api, test, technical debt
@miq-bot assign @abellotti 