### PR TITLE
Utility for diagnose pg locked - Step 2

### DIFF
--- a/tools/pg_inspector/cli.rb
+++ b/tools/pg_inspector/cli.rb
@@ -1,12 +1,14 @@
 require 'trollop'
 require 'pg_inspector/util'
 require 'pg_inspector/active_connections_to_yaml'
+require 'pg_inspector/servers_to_yaml'
 
 module PgInspector
   class Cli
     attr_accessor :cmd
     SUB_COMMANDS = {
-      :active_connections => ::PgInspector::ActiveConnectionsYAML
+      :active_connections => ::PgInspector::ActiveConnectionsYAML,
+      :servers            => ::PgInspector::ServersYAML
     }.freeze
 
     def self.run(args)
@@ -32,9 +34,9 @@ pg_inspector is a tool to inspect ManageIQ process caused deadlock in PostgreSQL
 BANNER
         stop_on(SUB_COMMANDS.keys.map(&:to_s))
       end
-      current_operation = SUB_COMMANDS[args.shift.to_sym]
-      if current_operation
-        self.cmd = current_operation.new
+      current_operation = args.shift
+      if current_operation && SUB_COMMANDS[current_operation.to_sym]
+        self.cmd = SUB_COMMANDS[current_operation.to_sym].new
       else
         Trollop.educate
       end

--- a/tools/pg_inspector/cli.rb
+++ b/tools/pg_inspector/cli.rb
@@ -7,8 +7,8 @@ module PgInspector
   class Cli
     attr_accessor :cmd
     SUB_COMMANDS = {
-      :active_connections => ::PgInspector::ActiveConnectionsYAML,
-      :servers            => ::PgInspector::ServersYAML
+      :active_connections => ActiveConnectionsYAML,
+      :servers            => ServersYAML
     }.freeze
 
     def self.run(args)

--- a/tools/pg_inspector/servers_to_yaml.rb
+++ b/tools/pg_inspector/servers_to_yaml.rb
@@ -1,0 +1,86 @@
+require 'trollop'
+require 'pg'
+require 'pg_inspector/error'
+require 'pg_inspector/pg_inspector_operation'
+require 'pg_inspector/util'
+
+module PgInspector
+  class ServersYAML < PgInspectorOperation
+    HELP_MSG_SHORT = "Dump ManageIQ server information to YAML file".freeze
+
+    def parse_options(args)
+      self.options = Trollop.options(args) do
+        banner <<-BANNER
+
+#{HELP_MSG_SHORT}
+
+Use password in PGPASSWORD environment if no password file given.
+The file will be named as <output>_MM-DD-YYYY_HH:MM:SS.yml. Time is local time.
+
+Options:
+BANNER
+        opt(:pg_host, "PostgreSQL host name or address",
+            :type => :string, :short => "s", :default => "127.0.0.1")
+        opt(:port, "PostgreSQL server port",
+            :short => "p", :default => 5432)
+        opt(:user, "PostgreSQL user",
+            :type => :string, :short => "u", :default => "postgres")
+        opt(:database, "ManageIQ Database to output server information",
+            :type => :string, :short => "d", :default => "vmdb_production")
+        opt(:output, "Output file prefix",
+            :type => :string, :short => "o", :default => "server")
+        opt(:password_file, "File content to use as password",
+            :type => :string, :short => "f")
+      end
+    end
+
+    def run
+      Util.dump_to_yml_file(
+        table_from_db_conn(
+          connect_pg_server, "miq_servers"
+        ), "ManageIQ server information", make_output_file_name(options[:output])
+      )
+    end
+
+    private
+
+    def connect_pg_server
+      conn_options = {
+        :dbname => options[:database],
+        :host   => options[:pg_host],
+        :port   => options[:port]
+      }
+      if options[:user]
+        conn_options[:user] = options[:user]
+      end
+      if options[:password_file]
+        conn_options[:password] = Util.readfile(options[:password_file]).strip
+      elsif ENV["PGPASSWORD"]
+        conn_options[:password] = ENV["PGPASSWORD"]
+      end
+      PG::Connection.open(conn_options)
+    rescue PG::Error => e
+      Util.error_exit(e)
+    end
+
+    def table_from_db_conn(conn, table_name)
+      query = <<-SQL
+SELECT *
+FROM #{table_name};
+SQL
+      result = []
+      res = conn.exec_params(query)
+      res.each do |row|
+        result << row
+      end
+      result
+    rescue PG::Error => e
+      Util.error_exit(e)
+    end
+
+    def make_output_file_name(base_name)
+      timestamp = Time.new.getlocal.strftime("%m-%d-%Y_%H:%M:%S")
+      "#{base_name}_#{timestamp}.yml"
+    end
+  end
+end

--- a/tools/pg_inspector/servers_to_yaml.rb
+++ b/tools/pg_inspector/servers_to_yaml.rb
@@ -54,12 +54,12 @@ BANNER
         conn_options[:user] = options[:user]
       end
       if options[:password_file]
-        conn_options[:password] = Util.readfile(options[:password_file]).strip
+        conn_options[:password] = File.read(options[:password_file]).strip
       elsif ENV["PGPASSWORD"]
         conn_options[:password] = ENV["PGPASSWORD"]
       end
       PG::Connection.open(conn_options)
-    rescue PG::Error => e
+    rescue => e
       Util.error_exit(e)
     end
 

--- a/tools/pg_inspector/util.rb
+++ b/tools/pg_inspector/util.rb
@@ -24,5 +24,11 @@ module PgInspector
       $stderr.puts e_msg
       exit(exit_code)
     end
+
+    def self.readfile(filename)
+      File.read(filename)
+    rescue => e
+      error_exit(e)
+    end
   end
 end

--- a/tools/pg_inspector/util.rb
+++ b/tools/pg_inspector/util.rb
@@ -24,11 +24,5 @@ module PgInspector
       $stderr.puts e_msg
       exit(exit_code)
     end
-
-    def self.readfile(filename)
-      File.read(filename)
-    rescue => e
-      error_exit(e)
-    end
   end
 end


### PR DESCRIPTION
server IDs to friendly names. Since zone name and zone id can be obtained from step 1, we do in this step is to look up only IP address and hostname based on the compressed form server id we got from step 1.
**Story**: https://www.pivotaltracker.com/n/projects/1608513/stories/147876483

\cc @yrudman @jrafanie @gtanzillo 

@miq-bot add-label wip, tools