### PR TITLE
Run the setup playbook if we see that an upgrade has happened

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -11,6 +11,7 @@ class EmbeddedAnsible
   HTTP_PORT              = 54_321
   HTTPS_PORT             = 54_322
   WAIT_FOR_ANSIBLE_SLEEP = 1.second
+  TOWER_VERSION_FILE     = "/var/lib/awx/.tower_version".freeze
 
   def self.available?
     return true if MiqEnvironment::Command.is_container?
@@ -34,6 +35,10 @@ class EmbeddedAnsible
     return false unless File.exist?(SECRET_KEY_FILE)
     key = miq_database.ansible_secret_key
     key.present? && key == File.read(SECRET_KEY_FILE)
+  end
+
+  def self.upgrade?
+    local_tower_version != tower_rpm_version
   end
 
   def self.alive?
@@ -87,7 +92,7 @@ class EmbeddedAnsible
   end
 
   def self.appliance_start
-    if configured?
+    if configured? && !upgrade?
       services.each { |service| LinuxAdmin::Service.new(service).start.enable }
     else
       configure_secret_key
@@ -229,4 +234,14 @@ class EmbeddedAnsible
     ActiveRecord::Base.connection
   end
   private_class_method :database_connection
+
+  def self.local_tower_version
+    File.read(TOWER_VERSION_FILE).strip
+  end
+  private_class_method :local_tower_version
+
+  def self.tower_rpm_version
+    LinuxAdmin::Rpm.info("ansible-tower-server")["version"]
+  end
+  private_class_method :tower_rpm_version
 end


### PR DESCRIPTION
The playbook needs to run on upgrades and ansible tower will refuse to start if it isn't.

https://bugzilla.redhat.com/show_bug.cgi?id=1465590
