### PR TITLE
Save key pairs in Authentication table

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -36,7 +36,8 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::AuthPrivateKey
     klass.create(
       :name        => created_key_pair.name,
       :fingerprint => created_key_pair.fingerprint,
-      :resource    => ext_management_system
+      :resource    => ext_management_system,
+      :auth_key    => created_key_pair.private_key
     )
   end
 


### PR DESCRIPTION
Save the key information in authentication table.

Fixes https://github.com/ManageIQ/manageiq/issues/13102