### PR TITLE
Allow SSUI roles to see Service Catalog Items

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -684,6 +684,7 @@
   :miq_product_feature_identifiers:
   - about
   - all_vm_rules
+  - catalog_items_view
   - compute
   - miq_request_admin
   - miq_request_view
@@ -727,6 +728,7 @@
   - all_vm_rules
   - automation_manager
   - embedded_automation_manager
+  - catalog_items_view
   - compute
   - miq_template_clone
   - miq_template_drift


### PR DESCRIPTION
**Issue**: non-admin SSUI users can not see Service Catalog Items

https://bugzilla.redhat.com/show_bug.cgi?id=1465642

**Solution**: added ```catalog_items_view``` product feature to ```EvmRole-user_limited_self_service``` and ```EvmRole-user_self_service``` roles


**BEFORE:**
<img width="258" alt="selfservice-ui-before" src="https://user-images.githubusercontent.com/6556758/27740029-9a1c61be-5d7e-11e7-8633-16c0cf3e48d3.png">  
<img width="907" alt="selfservice-roles-before" src="https://user-images.githubusercontent.com/6556758/27740249-5b2c53dc-5d7f-11e7-99f5-821b6ae8e07b.png">

**AFTER:**
<img width="229" alt="selfservice-ui-after" src="https://user-images.githubusercontent.com/6556758/27740083-be017fa6-5d7e-11e7-9583-fa47184c3d39.png">

<img width="918" alt="selfservice-roles-after" src="https://user-images.githubusercontent.com/6556758/27740256-62aa2c56-5d7f-11e7-88e9-c966b2f08f78.png">

<img width="925" alt="selfservice-roles2-after" src="https://user-images.githubusercontent.com/6556758/27740260-680541c2-5d7f-11e7-8731-191b060b86bf.png">

@miq-bot add-label bug

\cc @gtanzillo 
