### PR TITLE
Only remove my process' pidfile.

### DIFF
--- a/lib/pid_file.rb
+++ b/lib/pid_file.rb
@@ -21,7 +21,7 @@ class PidFile
   end
 
   def remove
-    FileUtils.rm(@fname) if File.file?(@fname)
+    FileUtils.rm(@fname) if pid == Process.pid
   end
 
   def create(remove_on_exit = true)

--- a/spec/lib/pid_file_spec.rb
+++ b/spec/lib/pid_file_spec.rb
@@ -40,8 +40,8 @@ describe PidFile do
       @pid_file.remove
     end
 
-    it "deletes when file does exist" do
-      allow(File).to receive(:file?).with(@fname).and_return(true)
+    it "deletes when file exist and is our process" do
+      allow(@pid_file).to receive(:pid).and_return(Process.pid)
       expect(FileUtils).to receive(:rm).with(@fname).once
       @pid_file.remove
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1464698

at_exit handlers created in the server process are inherited when the
server forks workers.  As soon as one of these workers exits, this
at_exit was being run and removing the server's pidfile.  This allowed a
subsequent rake evm:start or systemctl start evmserverd to fail to
detect an existing server process, allowing a second MIQ Server to
start.

We can workaround this by only removing a pidfile that matches my
Process.pid.