### PR TITLE
Use OpenShift API to control the Ansible container

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "hamlit",                         "~>2.7.0"
 gem "inifile",                        "~>3.0",         :require => false
+gem "kubeclient",                     "~>2.4.0",       :require => false # For scaling pods at runtime
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-network_discovery",     "~>0.1.1",       :require => false
 gem "mime-types",                     "~>2.6.1",       :path => "mime-types-redirector"

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -1,0 +1,28 @@
+class ContainerOrchestrator
+  TOKEN_FILE = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
+
+  def scale(deployment_config_name, replicas)
+    connection.patch_deployment_config(deployment_config_name, { :spec => { :replicas => replicas } }, ENV["MY_POD_NAMESPACE"])
+  end
+
+  private
+
+  def connection
+    require 'kubeclient'
+
+    @connection ||=
+      Kubeclient::Client.new(
+        manager_uri,
+        :auth_options => { :bearer_token_file => TOKEN_FILE },
+        :ssl_options  => { :verify_ssl => OpenSSL::SSL::VERIFY_NONE }
+      )
+  end
+
+  def manager_uri
+    URI::HTTPS.build(
+      :host => ENV["KUBERNETES_SERVICE_HOST"],
+      :port => ENV["KUBERNETES_SERVICE_PORT"],
+      :path => "/oapi"
+    )
+  end
+end

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -53,27 +53,15 @@ class EmbeddedAnsible
   end
 
   def self.start
-    if MiqEnvironment::Command.is_container?
-      container_start
-    else
-      appliance_start
-    end
+    MiqEnvironment::Command.is_container? ? container_start : appliance_start
   end
 
   def self.stop
-    if MiqEnvironment::Command.is_container?
-      container_stop
-    else
-      appliance_stop
-    end
+    MiqEnvironment::Command.is_container? ? container_stop : appliance_stop
   end
 
   def self.disable
-    if MiqEnvironment::Command.is_container?
-      container_stop
-    else
-      appliance_disable
-    end
+    MiqEnvironment::Command.is_container? ? container_stop : appliance_disable
   end
 
   def self.services

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -64,7 +64,7 @@ class EmbeddedAnsible
     if MiqEnvironment::Command.is_container?
       container_stop
     else
-      services.each { |service| LinuxAdmin::Service.new(service).stop }
+      appliance_stop
     end
   end
 
@@ -72,7 +72,7 @@ class EmbeddedAnsible
     if MiqEnvironment::Command.is_container?
       container_stop
     else
-      services.each { |service| LinuxAdmin::Service.new(service).stop.disable }
+      appliance_disable
     end
   end
 
@@ -116,6 +116,16 @@ class EmbeddedAnsible
     raise "EmbeddedAnsible service is not responding after setup"
   end
   private_class_method :appliance_start
+
+  def self.appliance_stop
+    services.each { |service| LinuxAdmin::Service.new(service).stop }
+  end
+  private_class_method :appliance_stop
+
+  def self.appliance_disable
+    services.each { |service| LinuxAdmin::Service.new(service).stop.disable }
+  end
+  private_class_method :appliance_disable
 
   def self.container_start
     miq_database.set_ansible_admin_authentication(:password => ENV["ANSIBLE_ADMIN_PASSWORD"])


### PR DESCRIPTION
This PR mainly adds a new class called `ContainerOrchestrator`.

Its purpose is to abstract calls to the OpenShift API into easily consumable methods like `#scale` which will scale a given deployment config to a particular number of replicas.

In this PR I also change the `EmbeddedAnsible` class to utilize this in order to scale the ansible pod up when we start the embedded ansible role and scale it down when the role is disabled.

This ability requires some additional permissions for the server container which is handled using the server's service account in a separate PR to the manageiq-pods repo (https://github.com/ManageIQ/manageiq-pods/pull/174)