### PR TITLE
Add heartbeat_check script for file-based worker process heartbeating

### DIFF
--- a/app/models/miq_server/worker_management/monitor/settings.rb
+++ b/app/models/miq_server/worker_management/monitor/settings.rb
@@ -30,8 +30,8 @@ module MiqServer::WorkerManagement::Monitor::Settings
   def get_time_threshold(worker)
     settings = @child_worker_settings[worker.class.settings_name]
 
-    heartbeat_timeout  = settings[:heartbeat_timeout] || 2.minutes
-    starting_timeout   = settings[:starting_timeout] || 10.minutes
+    heartbeat_timeout  = settings[:heartbeat_timeout] || Workers::MiqDefaults.heartbeat_timeout
+    starting_timeout   = settings[:starting_timeout] || Workers::MiqDefaults.starting_timeout
 
     return starting_timeout if MiqWorker::STATUSES_STARTING.include?(worker.status)
 

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -224,7 +224,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def heartbeat_file
-    @heartbeat_file ||= ENV["WORKER_HEARTBEAT_FILE"] || Rails.root.join("tmp", "#{guid}.hb")
+    @heartbeat_file ||= Workers::MiqDefaults.heartbeat_file(guid)
   end
 
   def self.worker_settings(options = {})

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -441,7 +441,7 @@ class MiqWorker < ApplicationRecord
     # Note, a 'stopping' worker heartbeats in DRb but NOT to
     # the database, so we can see how long it's been
     # 'stopping' by checking the last_heartbeat.
-    stopping_timeout = self.class.worker_settings[:stopping_timeout] || 10.minutes
+    stopping_timeout = self.class.worker_settings[:stopping_timeout] || Workers::MiqDefaults.stopping_timeout
     status == MiqWorker::STATUS_STOPPING && last_heartbeat < stopping_timeout.seconds.ago
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -384,8 +384,8 @@ class MiqWorker::Runner
     do_exit("Error heartbeating to MiqServer because #{err.class.name}: #{err.message}", 1)
   end
 
-  def heartbeat_to_file
-    timeout = worker_settings[:heartbeat_timeout] || Workers::MiqDefaults.heartbeat_timeout
+  def heartbeat_to_file(timeout = nil)
+    timeout ||= worker_settings[:heartbeat_timeout] || Workers::MiqDefaults.heartbeat_timeout
     File.write(@worker.heartbeat_file, (Time.now.utc + timeout).to_s)
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -1,6 +1,5 @@
 require 'miq-process'
 require 'thread'
-require 'fileutils'
 
 class MiqWorker::Runner
   class TemporaryFailure < RuntimeError
@@ -386,7 +385,8 @@ class MiqWorker::Runner
   end
 
   def heartbeat_to_file
-    FileUtils.touch(@worker.heartbeat_file)
+    timeout = worker_settings[:heartbeat_timeout] || Workers::MiqDefaults.heartbeat_timeout
+    File.write(@worker.heartbeat_file, (Time.now.utc + timeout).to_s)
   end
 
   def do_gc

--- a/lib/workers/bin/heartbeat_check.rb
+++ b/lib/workers/bin/heartbeat_check.rb
@@ -1,0 +1,34 @@
+require "optparse"
+
+options = {}
+opt_parser = OptionParser.new do |opts|
+  opts.banner = "usage: #{File.basename($PROGRAM_NAME, '.rb')} [HEARTBEAT_FILE]"
+
+  opts.on("-b=HBFILE", "--heartbeat-file=HBFILE", "Heartbeat file to read (overrides arg val)") do |val|
+    options[:heartbeat_file] = val
+  end
+
+  opts.on("-g=GUID", "--guid=GUID", "Use this guid for finding the heartbeat file") do |val|
+    options[:guid] = val
+  end
+
+  opts.on("-v", "--[no-]verbose", "Verbose output") do |val|
+    options[:verbose] = val
+  end
+
+  opts.on("-h", "--help", "Displays this help") do
+    puts opts
+    exit
+  end
+end
+opt_parser.parse!
+
+require "English"
+require File.expand_path("../../heartbeat.rb", __FILE__)
+heartbeat_file   = options[:heartbeat_file] || ARGV[0]
+heartbeat_file ||= Workers::MiqDefaults.heartbeat_file(options[:guid])
+
+exit_status = Workers::Heartbeat.file_check(heartbeat_file)
+
+at_exit { puts $ERROR_INFO.status if options[:verbose] }
+exit exit_status

--- a/lib/workers/heartbeat.rb
+++ b/lib/workers/heartbeat.rb
@@ -1,0 +1,22 @@
+require_relative "miq_defaults"
+
+module Workers
+  class Heartbeat
+    def self.file_check(heartbeat_file = Workers::MiqDefaults.heartbeat_file)
+      if File.exist?(heartbeat_file)
+        current_time = Time.now.utc
+        contents     = File.read(heartbeat_file)
+        mtime        = File.mtime(heartbeat_file).utc
+        timeout      = if contents.empty?
+                         (mtime + Workers::MiqDefaults.heartbeat_timeout).utc
+                       else
+                         Time.parse(contents).utc
+                       end
+
+        current_time < timeout
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/workers/miq_defaults.rb
+++ b/lib/workers/miq_defaults.rb
@@ -17,5 +17,10 @@ module Workers
     def self.stopping_timeout
       STOPPING_TIMEOUT
     end
+
+    def self.heartbeat_file(guid = nil)
+      guid ||= "miq_worker"
+      ENV["WORKER_HEARTBEAT_FILE"] || File.expand_path("../../../tmp/#{guid}.hb", __FILE__)
+    end
   end
 end

--- a/lib/workers/miq_defaults.rb
+++ b/lib/workers/miq_defaults.rb
@@ -1,0 +1,21 @@
+require "active_support/core_ext/numeric/time"
+
+module Workers
+  class MiqDefaults
+    HEARTBEAT_TIMEOUT = 2.minutes.freeze
+    STARTING_TIMEOUT  = 10.minutes.freeze
+    STOPPING_TIMEOUT  = 10.minutes.freeze
+
+    def self.heartbeat_timeout
+      HEARTBEAT_TIMEOUT
+    end
+
+    def self.starting_timeout
+      STARTING_TIMEOUT
+    end
+
+    def self.stopping_timeout
+      STOPPING_TIMEOUT
+    end
+  end
+end

--- a/spec/lib/workers/heartbeat_spec.rb
+++ b/spec/lib/workers/heartbeat_spec.rb
@@ -1,0 +1,72 @@
+require "workers/heartbeat"
+
+shared_examples_for "heartbeat file checker" do |heartbeat_file = nil|
+  # This is used instead of just passing in the `heartbeat_file` value directly
+  # into the method because we can splat it in the argument list and force a "no
+  # args" method call in each of the tests
+  let(:file_check_args)    { [heartbeat_file].compact }
+  let(:calculated_hb_file) { Pathname.new(heartbeat_file || ENV["WORKER_HEARTBEAT_FILE"]) }
+  around do |example|
+    FileUtils.mkdir_p(calculated_hb_file.parent)
+    File.write(calculated_hb_file, "")
+
+    example.run
+
+    FileUtils.rm_f(calculated_hb_file.to_s)
+  end
+
+  it "returns false when the heartbeat file does not exist" do
+    FileUtils.rm_f calculated_hb_file.to_s # Early delete
+    expect(Workers::Heartbeat.file_check(*file_check_args)).to eq(false)
+  end
+
+  it "returns true with a newly created heartbeat file with no content" do
+    expect(Workers::Heartbeat.file_check(*file_check_args)).to eq(true)
+  end
+
+  it "returns false with a stale heartbeat file with no content" do
+    to_the_future = (2.minutes + 2.seconds).from_now
+    Timecop.travel(to_the_future) do
+      expect(Workers::Heartbeat.file_check(*file_check_args)).to eq(false)
+    end
+  end
+
+  it "returns true with a heartbeat file with content within the timeout" do
+    # Set timeout in heartbeat file
+    File.write(calculated_hb_file, 3.minutes.from_now)
+
+    to_the_future = (2.minutes + 2.seconds).from_now
+    Timecop.travel(to_the_future) do
+      expect(Workers::Heartbeat.file_check(*file_check_args)).to eq(true)
+    end
+  end
+end
+
+describe Workers::Heartbeat do
+  describe ".file_check" do
+    context "using the default heartbeat_file" do
+      let(:test_heartbeat_file) { ManageIQ.root.join("tmp", "spec", "test.hb") }
+
+      around do |example|
+        # This is given the highest priority when calling
+        # Workers::MiqDefaults.heartbeat_file.
+        #
+        # Trying to avoid using mocks...
+        old_env = ENV["WORKER_HEARTBEAT_FILE"]
+        ENV["WORKER_HEARTBEAT_FILE"] = test_heartbeat_file.to_s
+
+        example.run
+
+        ENV["WORKER_HEARTBEAT_FILE"] = old_env
+      end
+
+      it_should_behave_like "heartbeat file checker"
+    end
+
+    context "when passing in a filepath as an argument" do
+      other_heartbeat_file = ManageIQ.root.join("tmp", "spec", "other.hb").to_s
+
+      it_should_behave_like "heartbeat file checker", other_heartbeat_file
+    end
+  end
+end


### PR DESCRIPTION
Adds heartbeat_check script which basically works with the docker's `HEALTHCHECK` interface:

https://docs.docker.com/engine/reference/builder/#healthcheck

So it will return 0 if the healthcheck passes, and 1 otherwise.

How it evaluates the healthcheck:

* Return 1 if no healthcheck file exists.
* Return 1 if the contents of the file are empty, and the mtime of the file + the default timeout for the worker have passed
* Return 1 if contents of the file are present, and the time parsed from the file has already passed (the time in the file should be the time at which the worker wrote that it's heartbeat timeout has since passed)
* Return 0 if either the contents of the file are present with a parsed timeout value, or a timeout value of the mtime of the file + the default worker heartbeat_timeout, has still not passed.

The healthcheck file can be passed in as the first ARG, as a cli option, ENV variable (same as it would be set in the worker process), or by passing in the guid, and it will evaluate where file should exist from that.  Finally, if none of those are provided, it will then assume it is in `tmp/miq_worker.hb`.  Again, if the file doesn't exist, it will still return a 1 exit status.

Links
-----
* https://www.pivotaltracker.com/story/show/148172745
* https://docs.docker.com/engine/reference/builder/#healthcheck

Steps for Testing/QA
--------------------
Try a few different scenarios for testing the script

1. With no worker running
    - run the script:  `$ ruby lib/workers/bin/healthbeat_check.rb -v`
    - it should return 1
2. With a random file
    - create a fake heartbeat script:  `$ touch fake.hb`
    - run the script:  `$ ruby lib/workers/bin/healthbeat_check.rb -v fake.hb`
    - it should return 0
    - wait 2 minutes or more
    - run the script:  `$ ruby lib/workers/bin/healthbeat_check.rb -v fake.hb`
    - it should return 1
3. With a running worker with the `WORKER_HEARTBEAT_FILE` ENV var set:
    - set `WORKER_HEARTBEAT_FILE`:  `$ export WORKER_HEARTBEAT_FILE=real.hb`
    - run a worker:  `$ ruby libworkers/bin/run_single_worker.rb MiqUiWorker`
    - wait for it to start
    - run the script:  `$ ruby lib/workers/bin/healthbeat_check.rb -v`
    - it should return 0
    - try this a few more times after a bit, and it should always return 0
4. With a running worker, without using the ENV variable
    - unset the above ENV variable (if needed):  `$ unset WORKER_HEARTBEAT_FILE`
    - run a worker:  `$ ruby libworkers/bin/run_single_worker.rb MiqUiWorker`
    - wait for it to start
    - look in your `tmp/` dir for the `.hb` file (something like `2345-23ref-as32s-23rfsd.hb`
    - run the script:  `$ ruby lib/workers/bin/healthbeat_check.rb -v 2345-23ref-as32s-23rfsd.hb`
    - it should return 0
    - run the script (using the guid):  `$ ruby lib/workers/bin/healthbeat_check.rb -v --guid "2345-23ref-as32s-23rfsd"`
    - it should return 0