### PR TITLE
Checks PXE customization templates for unique names

### DIFF
--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -5,7 +5,7 @@ class CustomizationTemplate < ApplicationRecord
   has_many   :pxe_images, :through => :pxe_image_type
 
   validates :pxe_image_type, :presence => true, :unless => :system?
-  # validates :name,           :uniqueness => { :scope => :pxe_image_type }
+  validates :name,           :uniqueness => { :scope => :pxe_image_type }, :unique_within_region => true
 
   def self.seed_file_name
     @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")


### PR DESCRIPTION
PXE customization templates shouldn't allow duplicates by name. Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1449116