### PR TITLE
Fix URL to Compute/Containers/Containers in miq_shortcuts

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -216,7 +216,7 @@
   :startup: true
 - :name: containers
   :description: Compute / Containers / Containers
-  :url: /container/explorer
+  :url: /container/show_list
   :rbac_feature_name: containers
   :startup: true
 - :name: container_nodes


### PR DESCRIPTION
Replace ```container/explorer``` with proper action URL (```container/show_list```)

https://bugzilla.redhat.com/show_bug.cgi?id=1466350