### PR TITLE
[EUWE] correct field names in reports

### DIFF
--- a/app/controllers/report_controller/reports/editor.rb
+++ b/app/controllers/report_controller/reports/editor.rb
@@ -440,7 +440,7 @@ module ReportController::Reports::Editor
     f = @edit[:new][:field_order][f_idx]  # Get the field element
     field_sub_type = MiqExpression.get_col_info(f.last)[:format_sub_type]
     field_data_type = MiqExpression.get_col_info(f.last)[:data_type]
-    field_name = f.last.include?(".") ? f.last.split(".").last.tr("-", ".") : f.last.split("-").last
+    field_name = MiqExpression.parse_field_or_tag(f.last).report_column
     case parm
     when "style"  # New CSS class chosen
       if value.blank?

--- a/app/views/report/_form_styling.html.haml
+++ b/app/views/report/_form_styling.html.haml
@@ -18,7 +18,7 @@
     %tbody
       - @edit[:new][:field_order].each_with_index do |f, f_idx|
         - field_type = MiqExpression.get_col_info(f.last.split("__").first)[:format_sub_type]
-        - col_name = f.last.include?(".") ? f.last.split(".").last.gsub("-", ".") : f.last.split("-").last
+        - col_name = MiqExpression.parse_field_or_tag(f.last).report_column
         - styles = @edit.fetch_path(:new, :col_options, col_name, :style) || []
         %tr
           %td

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -352,6 +352,10 @@ class MiqExpression
     @context_type = ctype
   end
 
+  def self.parse_field_or_tag(str)
+    MiqExpression::Field.parse(str) || MiqExpression::CountField.parse(str) || MiqExpression::Tag.parse(str)
+  end
+
   def self.proto?
     return @proto if defined?(@proto)
     @proto = VMDB::Config.new("vmdb").config.fetch_path(:product, :proto)

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -12,7 +12,7 @@ class MiqExpression::Field
   ParseError = Class.new(StandardError)
 
   def self.parse(field)
-    match = FIELD_REGEX.match(field) or raise ParseError, field
+    (match = FIELD_REGEX.match(field)) || raise(ParseError, field)
     new(match[:model_name].constantize, match[:associations].to_s.split("."), match[:virtual_custom_column] ||
         match[:column])
   end
@@ -93,6 +93,10 @@ class MiqExpression::Field
     else
       target.type_for_attribute(column).type
     end
+  end
+
+  def report_column
+    (associations + [column]).join('.')
   end
 
   private

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,20 +1,45 @@
 class MiqExpression::Tag
-  def self.parse(tag)
-    klass, ns = tag.split(".")
-    ns = "/" + ns.split("-").join("/")
-    ns = ns.sub(/(\/user_tag\/)/, "/user/") # replace with correct namespace for user tags
-    new(klass.constantize, ns)
+  REGEX = /
+(?<model_name>([[:alnum:]]*(::)?)+)
+\.(?<associations>([a-z_]+\.)*)
+(?<namespace>\bmanaged|user_tag\b)
+-(?<column>[a-z]+[_[:alnum:]]+)
+/x
+
+  def self.parse(field)
+    parsed_params = parse_params(field) || return
+    managed = parsed_params[:namespace] == self::MANAGED_NAMESPACE
+    new(parsed_params[:model_name], parsed_params[:associations], parsed_params[:column], managed)
   end
 
-  attr_reader :model, :namespace
+  MANAGED_NAMESPACE      = 'managed'.freeze
+  USER_NAMESPACE         = 'user'.freeze
 
-  def initialize(model, namespace)
+  attr_reader :model, :namespace, :column
+
+  def initialize(model, _associations, column, managed = true)
     @model = model
-    @namespace = namespace
+    @column = column
+    @base_namespace = managed ? MANAGED_NAMESPACE : USER_NAMESPACE
+    @namespace = "/#{@base_namespace}/#{column}"
   end
 
   def contains(value)
     ids = model.find_tagged_with(:any => value, :ns => namespace).pluck(:id)
     model.arel_attribute(:id).in(ids)
+  end
+
+  def report_column
+    "#{@base_namespace}.#{column}"
+  end
+
+  def self.parse_params(field)
+    match = self::REGEX.match(field) || return
+    # convert matches to hash to format
+    # {:model_name => 'User', :associations => ...}
+    parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]
+    parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize || return
+    parsed_params[:associations] = parsed_params[:associations].to_s.split(".")
+    parsed_params
   end
 end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe '#report_column' do
+    it 'returns the correct format for a field' do
+      field = MiqExpression::Field.parse('Vm.miq_provision.miq_request-requester_name')
+      expect(field.report_column).to eq('miq_provision.miq_request.requester_name')
+    end
+  end
+
   describe "#date?" do
     it "returns false for fields of column type other than :date" do
       field = described_class.new(Vm, [], "name")

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe MiqExpression::Tag do
+  describe '#report_column' do
+    it 'returns the correct format for a tag' do
+      tag = MiqExpression::Tag.parse('Vm.managed-environment')
+      expect(tag.report_column).to eq('managed.environment')
+    end
+  end
+end


### PR DESCRIPTION
Euwe version of https://github.com/ManageIQ/manageiq/pull/14905

Needed to add a couple of missing elements (`REGEX` and `parse_params`) to resolve conflicts and make this work. Tried to cherry pick as little as possible from the latest implementation of `MiqExpression` and only take what was necessary to get it to work as expected while fixing the BZ.

@miq-bot add_label euwe/yes, bug

Screenshot of the report after this fix - properly colors the "Approved by" column 
<img width="1435" alt="screen shot 2017-07-03 at 11 48 28 am" src="https://user-images.githubusercontent.com/2433314/27800038-b2ea4cce-5fe5-11e7-9f20-c02ccf9ded2e.png">
