### PR TITLE
[EUWE] Remove HTML from node names of Simulation tree

### DIFF
--- a/app/controllers/application_controller/expression_html.rb
+++ b/app/controllers/application_controller/expression_html.rb
@@ -63,7 +63,9 @@ module ApplicationController::ExpressionHtml
       fcolor = calculate_font_color(exp["result"])
       temp_exp = copy_hash(exp)
       temp_exp.delete("result")
-      exp_string << "<font color=#{fcolor}>" << MiqExpression.to_human(temp_exp) << "</font>"
+      exp_string = content_tag(:font, :color => fcolor) do
+        MiqExpression.to_human(temp_exp)
+      end
       exp_tooltip << MiqExpression.to_human(temp_exp)
     end
     return exp_string, exp_tooltip

--- a/app/presenters/tree_builder_policy_simulation.rb
+++ b/app/presenters/tree_builder_policy_simulation.rb
@@ -2,6 +2,10 @@
 class TreeBuilderPolicySimulation < TreeBuilder
   # exp_build_string method needed
   include ApplicationController::ExpressionHtml
+  include ActionView::Context
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::CaptureHelper
 
   has_kids_for Hash, [:x_get_tree_hash_kids]
 

--- a/spec/presenters/tree_builder_policy_simulation_spec.rb
+++ b/spec/presenters/tree_builder_policy_simulation_spec.rb
@@ -101,10 +101,10 @@ describe TreeBuilderPolicySimulation do
       parent_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, grand_parent_two, false).first
       kid_one = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_one, false).first
       kid_two = @policy_simulation_tree.send(:x_get_tree_hash_kids, parent_two, false).first
-      expect(kid_one[:text]).to eq("<b>Scope: </b> <font color=red>FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1</font>")
+      expect(kid_one[:text]).to eq("<b>Scope: </b> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
       expect(kid_one[:image]).to eq('na')
       expect(kid_one[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1")
-      expect(kid_two[:text]).to eq("<b>Expression: </b> <font color=red>FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1</font>")
+      expect(kid_two[:text]).to eq("<b>Expression: </b> <font color=\"red\">FIND VM and Instance.Files : Name INCLUDES &quot;nb&quot; CHECK COUNT &gt;= 1</font>")
       expect(kid_two[:image]).to eq('na')
       expect(kid_two[:tip]).to eq("FIND VM and Instance.Files : Name INCLUDES \"nb\" CHECK COUNT >= 1")
     end


### PR DESCRIPTION
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1460696

Remove HTML from node names in the tree in Control-> Simulation
under Policy Simulation Results.

Before:
![html1](https://user-images.githubusercontent.com/13417815/27798907-6a0d32ea-6013-11e7-9a0b-e25125f5a28a.png)

After:
![html2](https://user-images.githubusercontent.com/13417815/27798912-6bd50846-6013-11e7-8bd8-817bd73761ea.png)
