### PR TITLE
Event switchboard entries for Amazon EBS events.

### DIFF
--- a/db/fixtures/ae_datastore/MIQ/.manifest.yaml
+++ b/db/fixtures/ae_datastore/MIQ/.manifest.yaml
@@ -1,0 +1,125 @@
+---
+__domain__.yaml:
+  classes: 1
+  instances: 6
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &1 2017-05-16 14:47:55.810357000 Z
+    zone: &2 !ruby/object:ActiveSupport::TimeZone
+      name: Etc/UTC
+    time: *1
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &3 2017-07-03 14:28:36.854989000 Z
+    zone: *2
+    time: *3
+  size: 204
+  sha1: ioFlk17s0U0RmXYGSxV81r9fECI=
+MIQ/System/__namespace__.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &4 2017-05-16 14:48:40.425249000 Z
+    zone: *2
+    time: *4
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &5 2017-05-16 14:48:40.425249000 Z
+    zone: *2
+    time: *5
+  size: 145
+  sha1: rs4yeLg3wssLEk0drD1PflXqfCo=
+MIQ/System/Event/__namespace__.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &6 2017-05-16 14:48:40.433687000 Z
+    zone: *2
+    time: *6
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &7 2017-05-16 14:48:40.433687000 Z
+    zone: *2
+    time: *7
+  size: 144
+  sha1: GeNzYDyU01maSjplxLq/0xoTyNk=
+MIQ/System/Event/EmsEvent/__namespace__.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &8 2017-05-16 14:48:40.436014000 Z
+    zone: *2
+    time: *8
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &9 2017-05-16 14:48:40.436014000 Z
+    zone: *2
+    time: *9
+  size: 147
+  sha1: EKkpvA4G/Zj3zJ4wyTB2ddpaq4g=
+MIQ/System/Event/EmsEvent/Amazon.class/__class__.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &10 2017-05-16 14:48:40.442044000 Z
+    zone: *2
+    time: *10
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &11 2017-05-16 14:48:40.525419000 Z
+    zone: *2
+    time: *11
+  size: 7960
+  sha1: Oheds9FHT5xT9/IB0Nbd0VgLDXY=
+MIQ/System/Event/EmsEvent/Amazon.class/AttachVolume.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &12 2017-06-30 16:10:09.317651000 Z
+    zone: *2
+    time: *12
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &13 2017-07-03 14:14:52.549251000 Z
+    zone: *2
+    time: *13
+  size: 226
+  sha1: 1t4x20KlDp5r3ICct6laRSMil6M=
+MIQ/System/Event/EmsEvent/Amazon.class/CopySnapshot.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &14 2017-06-30 16:19:30.007713000 Z
+    zone: *2
+    time: *14
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &15 2017-07-03 14:19:13.925714000 Z
+    zone: *2
+    time: *15
+  size: 226
+  sha1: BkboCvSBlBqZFkhnq0FzGXZLOyc=
+MIQ/System/Event/EmsEvent/Amazon.class/CreateSnapshot.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &16 2017-06-30 15:22:31.515422000 Z
+    zone: *2
+    time: *16
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &17 2017-07-03 14:19:21.226894000 Z
+    zone: *2
+    time: *17
+  size: 228
+  sha1: fjtzkUzZYETGEQ/qe7t0I4n9OPg=
+MIQ/System/Event/EmsEvent/Amazon.class/CreateVolume.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &18 2017-06-30 16:09:28.421141000 Z
+    zone: *2
+    time: *18
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &19 2017-07-03 13:45:35.544336000 Z
+    zone: *2
+    time: *19
+  size: 226
+  sha1: xn5/xX5xTz4YijF5+oZSRShkPDM=
+MIQ/System/Event/EmsEvent/Amazon.class/DeleteSnapshot.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &20 2017-06-30 16:06:44.458199000 Z
+    zone: *2
+    time: *20
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &21 2017-07-03 14:19:28.587929000 Z
+    zone: *2
+    time: *21
+  size: 228
+  sha1: a6p4LwfQno/3lLDZXYhbgatd5rg=
+MIQ/System/Event/EmsEvent/Amazon.class/DeleteVolume.yaml:
+  created_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &22 2017-06-30 16:07:54.034745000 Z
+    zone: *2
+    time: *22
+  updated_on: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &23 2017-07-03 13:45:50.504910000 Z
+    zone: *2
+    time: *23
+  size: 226
+  sha1: lNBzkQuzeuG1tezj/3QeuQeQn5E=

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/__class__.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/__class__.yaml
@@ -1,0 +1,433 @@
+---
+object_type: class
+version: 1.0
+object:
+  attributes:
+    description: 
+    display_name: 
+    name: Amazon
+    type: 
+    inherits: 
+    visibility: 
+    owner: 
+  schema:
+  - field:
+      aetype: assertion
+      name: guard
+      display_name: 
+      datatype: string
+      priority: 1
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: attribute
+      name: logical_event
+      display_name: 
+      datatype: string
+      priority: 2
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_entry
+      display_name: 
+      datatype: string
+      priority: 3
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel1
+      display_name: 
+      datatype: string
+      priority: 4
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth1
+      display_name: 
+      datatype: string
+      priority: 5
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel2
+      display_name: 
+      datatype: string
+      priority: 6
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth2
+      display_name: 
+      datatype: string
+      priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel3
+      display_name: 
+      datatype: string
+      priority: 8
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth3
+      display_name: 
+      datatype: string
+      priority: 9
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel4
+      display_name: 
+      datatype: string
+      priority: 10
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth4
+      display_name: 
+      datatype: string
+      priority: 11
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel5
+      display_name: 
+      datatype: string
+      priority: 12
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth5
+      display_name: 
+      datatype: string
+      priority: 13
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel6
+      display_name: 
+      datatype: string
+      priority: 14
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth6
+      display_name: 
+      datatype: string
+      priority: 15
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel7
+      display_name: 
+      datatype: string
+      priority: 16
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth7
+      display_name: 
+      datatype: string
+      priority: 17
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel8
+      display_name: 
+      datatype: string
+      priority: 18
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: meth8
+      display_name: 
+      datatype: string
+      priority: 19
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: relationship
+      name: rel9
+      display_name: 
+      datatype: string
+      priority: 20
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: on_exit
+      display_name: 
+      datatype: string
+      priority: 21
+      owner: 
+      default_value: 
+      substitute: true
+      message: create
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/attachvolume.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/attachvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: AttachVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/copysnapshot.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/copysnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CopySnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/createsnapshot.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/createsnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CreateSnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/createvolume.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/createvolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: CreateVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/deletesnapshot.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/deletesnapshot.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DeleteSnapshot
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/deletevolume.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/Amazon.class/deletevolume.yaml
@@ -1,0 +1,12 @@
+---
+object_type: instance
+version: 1.0
+object:
+  attributes:
+    display_name: 
+    name: DeleteVolume
+    inherits: 
+    description: 
+  fields:
+  - rel4:
+      value: "/System/event_handlers/event_action_refresh?target=ems"

--- a/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/EmsEvent/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: EmsEvent
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/db/fixtures/ae_datastore/MIQ/System/Event/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/Event/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: Event
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/db/fixtures/ae_datastore/MIQ/System/__namespace__.yaml
+++ b/db/fixtures/ae_datastore/MIQ/System/__namespace__.yaml
@@ -1,0 +1,10 @@
+---
+object_type: namespace
+version: 1.0
+object:
+  attributes:
+    name: System
+    description: 
+    display_name: 
+    priority: 
+    enabled: 

--- a/db/fixtures/ae_datastore/MIQ/__domain__.yaml
+++ b/db/fixtures/ae_datastore/MIQ/__domain__.yaml
@@ -1,0 +1,13 @@
+---
+object_type: domain
+version: 1.0
+object:
+  attributes:
+    name: MIQ
+    description: 
+    display_name: 
+    priority: 1
+    enabled: true
+    tenant_id: 1
+    source: user
+    top_level_namespace: 


### PR DESCRIPTION
This PR will configure entries in the event switchboard for AWS EBS events. The specific events are listed below and will trigger an EMS refresh to keep the AWS inventory up to date.


## Links:

https://bugzilla.redhat.com/show_bug.cgi?id=1449235
https://www.pivotaltracker.com/story/show/146650341


## Testing:
- [ ]  Add an AWS provider
- [ ]  Take note of the number of EBS cloud volumes
- [ ]  Add a new EBS cloud volume through the AWS Console
- [ ]  Ensure the new EBS cloud volume appears under: Storage / Block Storage / Volumes. This will indicate an event was received and went through the event switchboard where an  EMS refresh was kicked off.
- [ ] Follow the same steps for:
* DeleteVolume
* AttachVolume
* CreateSnapshot
* DeleteSnapshot
* CopySnapshot
