### PR TITLE
Use full path in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
 gem "manageiq-network_discovery",     "~>0.1.2",       :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
-gem "mime-types",                     "~>2.6.1",       :path => "mime-types-redirector"
+gem "mime-types",                     "~>2.6.1",       :path => File.expand_path("mime-types-redirector", __dir__)
 gem "more_core_extensions",           "~>3.3"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false


### PR DESCRIPTION
Relative pathing can have problems if the pwd is not the manageiq
directory.  This ensures the correct path.

Related:
- https://github.com/ManageIQ/manageiq/pull/14525
- https://github.com/ManageIQ/manageiq-ui-classic/issues/1606
- https://github.com/ManageIQ/manageiq-content/issues/136

@NickLaMuro Please review
cc @mkanoor @himdel 