### PR TITLE
Adding sti mixin to container_image base class

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -5,6 +5,7 @@ class ContainerImage < ApplicationRecord
   include TenantIdentityMixin
   include CustomAttributeMixin
   include ArchivedMixin
+  include NewWithTypeStiMixin
   include_concern 'Purging'
 
   DOCKER_IMAGE_PREFIX = "docker://"


### PR DESCRIPTION
According to https://github.com/ManageIQ/manageiq-providers-openshift/pull/23#discussion_r125321201 . We already have `acts_as_miq_taggable` so only adding `NewWithTypesStiMixin`