### PR TITLE
Adapt manageiq to new managers

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -35,11 +35,12 @@
 - ems-type:gce_network
 - ems-type:hawkular
 - ems-type:hawkular_datawarehouse
-- ems-type:monitoring # removed in https://github.com/ManageIQ/manageiq/pull/15506
 - ems-type:kubernetes
+- ems-type:kubernetes_monitor
 - ems-type:lenovo_ph_infra
 - ems-type:nuage_network
 - ems-type:openshift
+- ems-type:openshift_monitor
 - ems-type:openstack
 - ems-type:openstack_infra
 - ems-type:openstack_network

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -33,8 +33,9 @@ describe ExtManagementSystem do
       "hawkular"                    => "Hawkular",
       "hawkular_datawarehouse"      => "Hawkular Datawarehouse",
       "kubernetes"                  => "Kubernetes",
+      "kubernetes_monitor"          => "Kubernetes Monitor",
       "openshift"                   => "OpenShift",
-      "monitoring"                  => "Monitoring Manager", # removed in https://github.com/ManageIQ/manageiq/pull/15506
+      "openshift_monitor"           => "Openshift Monitor",
       "openstack"                   => "OpenStack",
       "openstack_infra"             => "OpenStack Platform Director",
       "openstack_network"           => "OpenStack Network",


### PR DESCRIPTION
Depends on: [merged] https://github.com/ManageIQ/manageiq/pull/15354

Adding two new providers to permissions file and ems_spec, should be merged after:
- [merged] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/38
- https://github.com/ManageIQ/manageiq-providers-openshift/pull/21
