### PR TITLE
Expect columns from col_order even if they are nil

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -161,7 +161,8 @@ describe MiqReport do
         expected_results = [
           {"name"                                                                                  => "test_container_images",
            "virtual_custom_attribute_CATTR#{CustomAttributeMixin::SECTION_SEPARATOR}docker_labels" => "any_value",
-           "virtual_custom_attribute_CATTR#{CustomAttributeMixin::SECTION_SEPARATOR}labels"        => "other_value"}
+           "virtual_custom_attribute_CATTR#{CustomAttributeMixin::SECTION_SEPARATOR}labels"        => "other_value",
+           "CATTR"                                                                                 => nil}
         ]
 
         expect(report_result).to match_array(expected_results)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/14312 changed MiqReport::Generator#build_table to now includes col_order columns even if they are empty

This test report sets the column order: https://github.com/agrare/manageiq/blob/ad0724f84d7f5ca159caec5fd115fe97a3d82424/spec/models/miq_report_spec.rb#L131 but is not expecting the `CATTR` column in the results

Fixes: https://travis-ci.org/ManageIQ/manageiq/jobs/249948128