### PR TITLE
manageiq env plugins should update everything on bin/update

### DIFF
--- a/lib/generators/provider/templates/lib/tasks_private/spec.rake
+++ b/lib/generators/provider/templates/lib/tasks_private/spec.rake
@@ -1,6 +1,6 @@
 namespace :spec do
   desc "Setup environment specs"
-  task :setup => ["app:test:initialize", "app:test:verify_no_db_access_loading_rails_environment", "app:test:setup_db"]
+  task :setup => ["app:test:vmdb:setup"]
 end
 
 desc "Run all specs"

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -10,7 +10,7 @@ module ManageIQ
       plugin_root = Pathname.new(caller_locations.last.absolute_path).dirname.parent
 
       install_bundler
-      bundle_install(plugin_root)
+      bundle_update(plugin_root)
 
       ensure_config_files
 
@@ -58,8 +58,8 @@ module ManageIQ
       system('bundle check', :chdir => root) || system!('bundle install', :chdir => root)
     end
 
-    def self.bundle_update
-      system!('bundle update')
+    def self.bundle_update(root = APP_ROOT)
+      system!('bundle update', :chdir => root)
     end
 
     def self.create_database

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -19,7 +19,7 @@ module ManageIQ
         create_database_user
       end
 
-      setup_test_environment
+      setup_test_environment(:task_prefix => 'app:', :root => plugin_root)
     end
 
     def self.ensure_config_files
@@ -55,7 +55,7 @@ module ManageIQ
     end
 
     def self.bundle_install(root = APP_ROOT)
-      system('bundle check', :chdir => root) || system('bundle install', :chdir => root)
+      system('bundle check', :chdir => root) || system!('bundle install', :chdir => root)
     end
 
     def self.bundle_update
@@ -77,9 +77,9 @@ module ManageIQ
       run_rake_task("db:seed")
     end
 
-    def self.setup_test_environment
+    def self.setup_test_environment(task_prefix: '', root: APP_ROOT)
       puts "\n== Resetting tests =="
-      run_rake_task("test:vmdb:setup")
+      run_rake_task("#{task_prefix}test:vmdb:setup", :root => root)
     end
 
     def self.reset_automate_domain
@@ -122,12 +122,14 @@ module ManageIQ
       File.read(gemfile).match(/gem\s+['"]bundler['"],\s+['"](.+?)['"]/)[1]
     end
 
-    def self.run_rake_task(task)
-      system!("#{APP_ROOT.join("bin/rails")} #{task}")
+    def self.run_rake_task(task, root: APP_ROOT)
+      system!("bin/rails #{task}", :chdir => root)
     end
 
     def self.system!(*args)
-      system(*args, :chdir => APP_ROOT) || abort("\n== Command #{args} failed ==")
+      options = args.last.kind_of?(Hash) ? args.pop : {}
+      options[:chdir] ||= APP_ROOT
+      system(*args, options) || abort("\n== Command #{args} failed in #{options[:chdir]} ==")
     end
   end
 end

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -4,19 +4,22 @@ if defined?(RSpec) && defined?(RSpec::Core::RakeTask)
 namespace :test do
   namespace :vmdb do
     desc "Setup environment for vmdb specs"
-    task :setup => [:initialize, :verify_no_db_access_loading_rails_environment] do
+    task :setup => [:initialize, :verify_no_db_access_loading_rails_environment] do |rake_task|
+      # in case we are called from an engine or plugin, the task might be namespaced under 'app:'
+      # i.e. it's 'app:test:vmdb:setup'. Then we have to call the tasks in here under the 'app:' namespace too
+      app_prefix = rake_task.name.chomp('test:vmdb:setup')
       if ENV['PARALLEL']
         database_config = Pathname.new(__dir__).expand_path + "../../config/database.yml"
         if File.readlines(database_config).grep(/TEST_ENV_NUMBER/).size > 0
           require 'parallel_tests'
-          ParallelTests::CLI.new.run(["--type", "rspec"] + ["-e", "bin/rake evm:db:reset"])
+          ParallelTests::CLI.new.run(["--type", "rspec"] + ["-e", "bin/rails #{app_prefix}evm:db:reset"])
         else
           puts "Oops! Your database.yml doesn't appear to support parallel tests!"
           puts "Update your config/database.yml with TEST_ENV_NUMBER as seen in the example (database.pg.yml), then try again."
           exit(1)
         end
       else
-        Rake::Task['test:setup_db'].invoke
+        Rake::Task["#{app_prefix}test:setup_db"].invoke
       end
     end
   end


### PR DESCRIPTION
provider devs need to go through some manual commands to update their env to the latest miq branch. I.e. they would need to run `bin/update; bundle update; rake spec:setup`

this PR 
* changes `manageiq_plugin_setup` to run `bundle update` --> `bin/update` will actually update your dependencies
* make the rake task `test:vmdb:setup` work when run from `app:test:vmdb:setup`
* thus removes the need to have a `Gemfile.lock` inside `spec/manageiq` because no rake task is run from within this directory

see https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/11 how this would work in a provider