### PR TITLE
Use correct identifier for VM Retirement

### DIFF
--- a/config/api.yml
+++ b/config/api.yml
@@ -2381,7 +2381,7 @@
       - :name: reset
         :identifier: vm_reset
       - :name: retire
-        :identifier: vm_retire
+        :identifier: vm_retire_now
       - :name: set_owner
         :identifier: vm_edit
       - :name: set_ownership
@@ -2430,7 +2430,7 @@
       - :name: reset
         :identifier: vm_reset
       - :name: retire
-        :identifier: vm_retire
+        :identifier: vm_retire_now
       - :name: delete
         :identifier: vm_delete
       - :name: set_owner


### PR DESCRIPTION
Currently, the vm "retire" action is using the product feature `vm_retire` which aligns to [Set Retirement Date](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_product_features.yml#L5594-L5597). The identifier that should be used is `vm_retire_now` which is the correct product feature for immediately retiring a VM.

The response for before the fix if the user does not have "Set Retirement Date" permissions but has "Retire Now" permissions:
```
"error":{"kind":"forbidden","message":"Use of Action retire is forbidden","klass":"Api::ForbiddenError"}}
```

Response after the fix is applied to use the correct product feature:
```
{"success":true,"message":"VM id:10000000001997 name:'jenkins' retiring","href":"http://localhost:3000/api/vms/10000000001997"}
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1464093

@miq-bot add_label api, bug, euwe/yes, fine/yes
@miq-bot assign @abellotti 

cc: @yrudman 