### PR TITLE
Put out some API 🔥

### DIFF
--- a/spec/requests/api/automation_requests_spec.rb
+++ b/spec/requests/api/automation_requests_spec.rb
@@ -85,7 +85,7 @@ describe "Automation Requests API" do
       run_get automation_requests_url(automation_request.id)
 
       expected = {
-        "id"   => automation_request.id,
+        "id"   => automation_request.compressed_id,
         "href" => a_string_matching(automation_requests_url(automation_request.id))
       }
       expect(response).to have_http_status(:ok)

--- a/spec/requests/api/logging_spec.rb
+++ b/spec/requests/api/logging_spec.rb
@@ -5,10 +5,11 @@ describe "Logging" do
   describe "Successful Requests logging" do
     before do
       @log = StringIO.new
-      $api_log.reopen(@log)
+      @logger = Logger.new(@log)
+      $api_log.loggers << @logger
     end
 
-    after { $api_log.reopen(Rails.root.join("log", "api.log")) }
+    after { $api_log.loggers.delete(@logger) }
 
     it "logs hashed details about the request" do
       api_basic_authorize collection_action_identifier(:users, :read, :get)

--- a/spec/requests/api/provision_requests_spec.rb
+++ b/spec/requests/api/provision_requests_spec.rb
@@ -101,7 +101,7 @@ describe "Provision Requests API" do
       run_get provision_requests_url(provision_request.id)
 
       expected = {
-        "id"   => provision_request.id,
+        "id"   => provision_request.compressed_id,
         "href" => a_string_matching(provision_requests_url(provision_request.id))
       }
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
* There were a couple of specs failing owing to the collision of ManageIQ#15430
and ManageIQ#15186
* The logging specs were failing because of the collision of https://github.com/ManageIQ/manageiq/pull/15058 and https://github.com/ManageIQ/manageiq/pull/15392.

Note that while the second has been fixed with https://github.com/imtayadeway/manageiq/commit/f47a7520ab722024e64f101c790e97cd8e467c17, I'm concerned that this doesn't quite make sense. It seems to reveal that a `MulticastLogger` doesn't quite behave like a `Logger` - I don't think there's a sensible way to handle `#reopen`. Open to suggestion for a better way to fix this.

@miq-bot assign @bdunne 
@miq-bot add-label api, bug, test