### PR TITLE
Drop deprecated attribute 'Host#address'

### DIFF
--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -21,7 +21,7 @@ module VimConnectMixin
       options[:ems] = self
       MiqFaultTolerantVim.new(options)
     else
-      ip   = options[:ip] || address
+      ip   = options[:ip] || hostname
       user = options[:user] || authentication_userid(options[:auth_type])
       pass = options[:pass] || authentication_password(options[:auth_type])
       MiqVim.new(ip, user, pass)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -789,7 +789,6 @@ class VmOrTemplate < ApplicationRecord
     [ext_management_system, "ems", host, "host"].each_slice(2) do |ems, type|
       if ems
         params[type] = {
-          :address    => ems.address,
           :hostname   => ems.hostname,
           :ipaddress  => ems.ipaddress,
           :username   => ems.authentication_userid,


### PR DESCRIPTION
Our TravisCI tests are generating deprecation warnings:

It was introduced by #14138

This removes them.

```
DEPRECATION WARNING:
address is deprecated and will be removed from ManageIQ G-release (hostname)
(called from block in ems_host_list at
/home/travis/build/ManageIQ/manageiq/app/models/vm_or_template.rb:792)

DEPRECATION WARNING:
address is deprecated and will be removed from ManageIQ G-release (hostname)
(called from new at
/home/travis/build/ManageIQ/manageiq/app/models/mixins/vim_connect_mixin.rb:22)
```

/cc @juliancheal Is this the solution you had in mind?
/cc @abellotti Does this affect the API (thinking no)
/cc @agrare Does the fix to `vim_connect_mixin.rb` look right to you? Or just drop the `||` part?