### PR TITLE
MulticastLogger#reopen shouldn't be used because it's backed by other loggers

### DIFF
--- a/lib/vmdb/loggers/multicast_logger.rb
+++ b/lib/vmdb/loggers/multicast_logger.rb
@@ -23,6 +23,10 @@ class MulticastLogger < Logger
     true
   end
 
+  def reopen(_logdev = nil)
+    raise NotImplementedError, "#{self.class.name} should not be reopened since it is backed by multiple loggers."
+  end
+
   private
 
   def method_missing(*args, &block)


### PR DESCRIPTION
raise NotImplementedError for now until we figure out if there is a use case for `#reopen` and what that looks like.

Based on discussions in https://github.com/ManageIQ/manageiq/pull/15510