### PR TITLE
Add validate_blacklist method for VM pre-provisioning

### DIFF
--- a/app/models/miq_request_workflow/dialog_field_validation.rb
+++ b/app/models/miq_request_workflow/dialog_field_validation.rb
@@ -37,4 +37,12 @@ module MiqRequestWorkflow::DialogFieldValidation
       error
     end
   end
+
+  def validate_blacklist(_field, _values, dlg, fld, value)
+    blacklist = fld[:blacklist]
+    return _("%{name} is required") % {:name => required_description(dlg, fld)} if value.blank?
+    if blacklist && blacklist.include?(value)
+      _("%{name} may not contain blacklisted value") % {:name => required_description(dlg, fld)}
+    end
+  end
 end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -358,6 +358,22 @@ describe MiqRequestWorkflow do
     end
   end
 
+  context "#validate_blacklist" do
+    let(:blacklist) { {:blacklist => ['foo', 'bar']} }
+
+    it "returns nil if the value is not blacklisted" do
+      expect(workflow.validate_blacklist(nil, {}, {}, blacklist, 'test')).to be_nil
+    end
+
+    it "returns a formatted message when the value is blacklisted" do
+      expect(workflow.validate_blacklist(nil, {}, {}, blacklist, 'foo')).to eq("'/' may not contain blacklisted value")
+    end
+
+    it "returns an error when no value exists" do
+      expect(workflow.validate_blacklist(nil, {}, {}, blacklist, '')).to eq "'/' is required"
+    end
+  end
+
   context "#validate regex" do
     let(:regex) { {:required_regex => "^n@test.com$"} }
     let(:regex_two) { {:required_regex => "^n$"} }


### PR DESCRIPTION
This modifies the `MiqRequestWorkflow::DialogFieldValidation` module by adding a `validate_blacklist` method that provisioning templates can then hook into.

Specifically, this is needed for Azure (though possibly other providers) which have special blacklists for VM usernames and passwords that would pass a regex check but are not considered valid by Microsoft. For example, you cannot use "abc@123" as a password for Azure VM's, even though that would normally pass a validity check.

These lists are too long to be put into a regex validation directly. It simply isn't practical, so I believe a separate method is necessary.

For more information please see https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq

Partially solves https://bugzilla.redhat.com/show_bug.cgi?id=1454829. The other half will happen on the Azure provider side.