### PR TITLE
[FINE] Check the current region when creating a new user

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -126,7 +126,7 @@ module Authenticator
 
           matching_groups = match_groups(groups_for(identity))
           userid = userid_for(identity, username)
-          user   = User.find_or_initialize_by(:userid => userid)
+          user   = User.in_my_region.find_or_initialize_by(:userid => userid)
           update_user_attributes(user, username, identity)
           user.miq_groups = matching_groups
 

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -48,7 +48,7 @@ module Authenticator
     def autocreate_user(username)
       # when default group for ldap users is enabled, create the user
       return unless config[:default_group_for_users]
-      default_group = MiqGroup.find_by(:description => config[:default_group_for_users])
+      default_group = MiqGroup.in_my_region.find_by(:description => config[:default_group_for_users])
       return unless default_group
       create_user_from_ldap(username) { [default_group] }
     end


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq/pull/15516
https://bugzilla.redhat.com/show_bug.cgi?id=1467529

This PR addresses an issue where a replicated user record was incorrectly evaluated
in the global region resulting in a global region user record not being created.

**Steps for Testing/QA [Optional]**

Set up a global and a remote region, with replication, both back to the same AD directory.
Log in to the remote region with a valid user.
Log in to the global region with the same valid user.

If both logins succeed the BZ fix is confirmed