### PR TITLE
Add UiConstants back to the web server worker mixin

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -24,6 +24,8 @@ module MiqWebServerWorkerMixin
     end
 
     def preload_for_worker_role
+      ::UiConstants
+
       configure_secret_token
     end
 


### PR DESCRIPTION
This is needed to start the server
Seems to have been removed by 1e29ba1a3762e7300c105d776d7e642d591ab017

Without this we get an uninitialized constant error, specifically `ApplicationController::PPCHOICES`

/cc @jrafanie 