### PR TITLE
JobProxyDispatcher should use all container image classes

### DIFF
--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -206,8 +206,8 @@ describe JobProxyDispatcher do
           jobs_by_ems, = dispatcher.pending_container_jobs
           expect(jobs_by_ems.keys).to match_array(@container_providers.map(&:id))
 
-          expect(jobs_by_ems[@container_providers.first.id].count).to eq(1)
-          expect(jobs_by_ems[@container_providers.second.id].count).to eq(2)
+          expect(jobs_by_ems[@container_providers.first.id].count).to eq(1 * container_image_classes.count)
+          expect(jobs_by_ems[@container_providers.second.id].count).to eq(2 * container_image_classes.count)
         end
       end
 
@@ -227,30 +227,36 @@ describe JobProxyDispatcher do
         it "dispatches jobs until reaching limit" do
           stub_settings(:container_scanning => {:concurrent_per_ems => 1})
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(1)
-          # 1 per ems, one ems has 1 job and the other 2
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(
+            (3 * container_image_classes.count) - 2)
+          # 1 per ems, one ems has 1* job and the other 2*
+          # initial number of images per ems is multiplied by container_image_classes.count
         end
 
         it "does not dispach if limit is already reached" do
           stub_settings(:container_scanning => {:concurrent_per_ems => 1})
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(1)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(
+            (3 * container_image_classes.count) - 2)
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(1)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(
+            (3 * container_image_classes.count) - 2)
         end
 
         it "does not apply limit when concurrent_per_ems is 0" do
           stub_settings(:container_scanning => {:concurrent_per_ems => 0})
           dispatcher.dispatch_container_scan_jobs
           expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(0)
-          # 1 per ems, one ems has 1 job and the other 2
+          # 1 per ems, one ems has 1* job and the other 2*
+          # initial number of images per ems is multiplied by container_image_classes.count
         end
 
         it "does not apply limit when concurrent_per_ems is -1" do
           stub_settings(:container_scanning => {:concurrent_per_ems => -1})
           dispatcher.dispatch_container_scan_jobs
           expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(0)
-          # 1 per ems, one ems has 1 job and the other 2
+          # 1 per ems, one ems has 1* job and the other 2*
+          # initial number of images per ems is multiplied by container_image_classes.count
         end
       end
     end

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -192,7 +192,7 @@ describe JobProxyDispatcher do
         end
 
         it "returns only container images jobs when requested" do
-          jobs = dispatcher.pending_jobs(dispatcher.container_image_classes)
+          jobs = dispatcher.pending_jobs(dispatcher.container_image_scan_class)
           expect(jobs.count).to eq(@container_images.count)
           jobs.each do |x|
             expect(container_image_classes).to include x.target_class

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -174,6 +174,7 @@ describe JobProxyDispatcher do
     end
 
     context "with container and vms jobs" do
+      let (:container_image_classes) { ContainerImage.descendants.collect(&:name).append('ContainerImage') }
       before(:each) do
         @jobs = (@vms + @repo_vms).collect(&:raw_scan)
         User.current_user = FactoryGirl.create(:user)
@@ -191,10 +192,10 @@ describe JobProxyDispatcher do
         end
 
         it "returns only container images jobs when requested" do
-          jobs = dispatcher.pending_jobs(ContainerImage)
+          jobs = dispatcher.pending_jobs(dispatcher.container_image_classes)
           expect(jobs.count).to eq(@container_images.count)
           jobs.each do |x|
-            expect(x.target_class).to eq 'ContainerImage'
+            expect(container_image_classes).to include x.target_class
           end
           expect(jobs.count).to be > 0 # in case something unexpected goes wrong
         end
@@ -212,7 +213,7 @@ describe JobProxyDispatcher do
 
       describe "#active_container_scans_by_zone_and_ems" do
         it "returns active container acans for zone" do
-          job = @jobs.find { |j| j.target_class == ContainerImage.name }
+          job = @jobs.find { |j| container_image_classes.include?(j.target_class) }
           job.update(:dispatch_status => "active")
           provider = ExtManagementSystem.find(job.options[:ems_id])
           dispatcher.instance_variable_set(:@zone, MiqServer.my_zone) # memoized during pending_jobs call
@@ -226,29 +227,29 @@ describe JobProxyDispatcher do
         it "dispatches jobs until reaching limit" do
           stub_settings(:container_scanning => {:concurrent_per_ems => 1})
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(1)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(1)
           # 1 per ems, one ems has 1 job and the other 2
         end
 
         it "does not dispach if limit is already reached" do
           stub_settings(:container_scanning => {:concurrent_per_ems => 1})
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(1)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(1)
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(1)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(1)
         end
 
         it "does not apply limit when concurrent_per_ems is 0" do
           stub_settings(:container_scanning => {:concurrent_per_ems => 0})
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(0)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(0)
           # 1 per ems, one ems has 1 job and the other 2
         end
 
         it "does not apply limit when concurrent_per_ems is -1" do
           stub_settings(:container_scanning => {:concurrent_per_ems => -1})
           dispatcher.dispatch_container_scan_jobs
-          expect(Job.where(:target_class => ContainerImage, :dispatch_status => "pending").count).to eq(0)
+          expect(Job.where(:target_class => container_image_classes, :dispatch_status => "pending").count).to eq(0)
           # 1 per ems, one ems has 1 job and the other 2
         end
       end

--- a/spec/support/job_proxy_dispatcher_helper.rb
+++ b/spec/support/job_proxy_dispatcher_helper.rb
@@ -48,10 +48,13 @@ module Spec
 
         container_providers = []
         options[:container_providers].each_with_index do |images_count, i|
-          ems_kubernetes = FactoryGirl.create(:ems_kubernetes, :name => "test_container_provider_#{i}")
-          container_providers << ems_kubernetes
+          ems_openshift = FactoryGirl.create(:ems_openshift, :name => "test_container_provider_#{i}")
+          container_providers << ems_openshift
           images_count.times do |idx|
-            FactoryGirl.create(:container_image, :name => "test_container_images_#{idx}", :ems_id => ems_kubernetes.id)
+            FactoryGirl.create(:container_image,
+                               :name   => "test_container_images_#{idx}",
+                               :ems_id => ems_openshift.id,
+                               :type   => 'ManageIQ::Providers::Openshift::ContainerManager::ContainerImage')
           end
         end
         return hosts, proxies, storages, vms, repo_vms, container_providers

--- a/spec/support/job_proxy_dispatcher_helper.rb
+++ b/spec/support/job_proxy_dispatcher_helper.rb
@@ -50,11 +50,14 @@ module Spec
         options[:container_providers].each_with_index do |images_count, i|
           ems_openshift = FactoryGirl.create(:ems_openshift, :name => "test_container_provider_#{i}")
           container_providers << ems_openshift
+          container_image_classes = ContainerImage.descendants.append(ContainerImage)
           images_count.times do |idx|
-            FactoryGirl.create(:container_image,
-                               :name   => "test_container_images_#{idx}",
-                               :ems_id => ems_openshift.id,
-                               :type   => 'ManageIQ::Providers::Openshift::ContainerManager::ContainerImage')
+            container_image_classes.each do |cic|
+              FactoryGirl.create(:container_image,
+                                 :name   => "test_container_images_#{idx}",
+                                 :ems_id => ems_openshift.id,
+                                 :type   => cic.name)
+            end
           end
         end
         return hosts, proxies, storages, vms, repo_vms, container_providers


### PR DESCRIPTION
With the addition of new container image classes in https://github.com/ManageIQ/manageiq-providers-openshift/pull/23 the JobProxyDispatcher should now address all of them.

This changes the way that Jobs are identified by the dispatcher so that they will be found by the type of job instead of the job's target class.