### PR TITLE
UiConstants are now autoloaded in manageiq-ui-classic

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -24,8 +24,6 @@ module MiqWebServerWorkerMixin
     end
 
     def preload_for_worker_role
-      ::UiConstants
-
       configure_secret_token
     end
 


### PR DESCRIPTION
- [x] DEPENDS ON:  https://github.com/ManageIQ/manageiq-ui-classic/pull/1658 (MERGED)

Followup to bundler groups PR:
https://github.com/ManageIQ/manageiq/pull/15459

The autoloading of ui constants in manageiq was reverted back here:
https://github.com/ManageIQ/manageiq/pull/15518