### PR TITLE
Allow MiqWorker.required_roles to be a lambda

### DIFF
--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -117,6 +117,20 @@ describe MiqWorker do
         check_has_required_role(["bah"], false)
       end
     end
+
+    context "when worker roles is a lambda" do
+      it "that is empty" do
+        check_has_required_role(-> { [] }, true)
+      end
+
+      it "that is a subset of server roles" do
+        check_has_required_role(-> { ["foo"] }, true)
+      end
+
+      it "that is not a subset of server roles" do
+        check_has_required_role(-> { ["bah"] }, false)
+      end
+    end
   end
 
   context ".workers_configured_count" do


### PR DESCRIPTION
Allow for more complex deployment configurations allow the required_roles property of MiqWorker to be a lambda similar to `MiqWorker.workers`

This will allow us to change the roles for which a worker will start depending on config, for example start the `MiqVimBrokerWorker` for the `ems_inventory` role only if we aren't using a collector/persister split.