### PR TITLE
[EUWE] Handle possibility of no orchestration stacks for Azure

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/refresh_parser.rb
@@ -533,7 +533,7 @@ module ManageIQ::Providers
 
       # Remap from children to parent
       def update_nested_stack_relations
-        @data[:orchestration_stacks].each do |stack|
+        Array(@data[:orchestration_stacks]).each do |stack|
           stack[:children].each do |child_stack_id|
             child_stack = @data_index.fetch_path(:orchestration_stacks, child_stack_id)
             child_stack[:parent] = stack if child_stack

--- a/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/refresher_spec.rb
@@ -51,6 +51,21 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
     @ems.reload
   end
 
+  context "template deployments" do
+    let(:template_deployment_service) { double }
+
+    before do
+      allow(template_deployment_service).to receive(:api_version=)
+      allow(Azure::Armrest::TemplateDeploymentService).to receive(:new).and_return(template_deployment_service)
+    end
+
+    it "orchestration stack parsing handles an empty list of template deployments" do
+      allow(template_deployment_service).to receive(:list).and_return([])
+      setup_ems_and_cassette
+      expect(OrchestrationStack.count).to eql(0)
+    end
+  end
+
   context "proxy support" do
     let(:proxy) { URI::HTTP.build(:host => 'localhost', :port => 8080) }
 


### PR DESCRIPTION
This is a backport of https://github.com/ManageIQ/manageiq-providers-azure/pull/84 for the Euwe branch. That PR could not be directly backported because of some fundamental changes that happened between Euwe and Fine.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1467405