### PR TITLE
require credentials when creating a provider

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -20,6 +20,7 @@ module Api
 
     def create_resource(type, _id, data = {})
       assert_id_not_specified(data, type)
+      raise BadRequestError, "Must specify credentials" if data[CREDENTIALS_ATTR].nil? && !data.keys.include?(*CONNECTION_ATTRS)
 
       create_provider(data)
     end
@@ -197,7 +198,6 @@ module Api
       provider_data = data.except(*RESTRICTED_ATTRS)
       invalid_keys  = provider_data.keys - provider_klass.columns_hash.keys - ENDPOINT_ATTRS - CONNECTION_ATTRS
       raise BadRequestError, "Invalid Provider attributes #{invalid_keys.join(', ')} specified" if invalid_keys.present?
-
       specify_zone(provider_data, data, options)
       provider_data
     end

--- a/spec/requests/api/providers_spec.rb
+++ b/spec/requests/api/providers_spec.rb
@@ -15,6 +15,7 @@
 #
 describe "Providers API" do
   ENDPOINT_ATTRS = Api::ProvidersController::ENDPOINT_ATTRS
+  CREDENTIALS_ATTR = Api::ProvidersController::CREDENTIALS_ATTR
 
   let(:default_credentials) { {"userid" => "admin1", "password" => "password1"} }
   let(:metrics_credentials) { {"userid" => "admin2", "password" => "password2", "auth_type" => "metrics"} }
@@ -45,10 +46,14 @@ describe "Providers API" do
 
   let(:sample_vmware) do
     {
-      "type"      => "ManageIQ::Providers::Vmware::InfraManager",
-      "name"      => "sample vmware",
-      "hostname"  => "sample_vmware.provider.com",
-      "ipaddress" => "100.200.300.1"
+      "type"        => "ManageIQ::Providers::Vmware::InfraManager",
+      "name"        => "sample vmware",
+      "hostname"    => "sample_vmware.provider.com",
+      "ipaddress"   => "100.200.300.1",
+      "credentials" => {
+        "userid"   => "uname",
+        "password" => "pword"
+      }
     }
   end
   let(:sample_rhevm) do
@@ -60,6 +65,10 @@ describe "Providers API" do
       "ipaddress"             => "100.200.300.2",
       "security_protocol"     => "kerberos",
       "certificate_authority" => certificate_authority,
+      "credentials"           => {
+        "userid"   => "uname",
+        "password" => "pword"
+      }
     }
   end
 
@@ -185,7 +194,7 @@ describe "Providers API" do
   end
 
   context "Provider custom_attributes" do
-    let(:provider) { FactoryGirl.create(:ext_management_system, sample_rhevm) }
+    let(:provider) { FactoryGirl.create(:ext_management_system, sample_rhevm.except("credentials")) }
     let(:provider_url) { providers_url(provider.id) }
     let(:ca1) { FactoryGirl.create(:custom_attribute, :name => "name1", :value => "value1") }
     let(:ca2) { FactoryGirl.create(:custom_attribute, :name => "name2", :value => "value2") }
@@ -339,6 +348,14 @@ describe "Providers API" do
       expect_bad_request(/unsupported/i)
     end
 
+    it "requires credentials if no connection_configurations are specified" do
+      api_basic_authorize collection_action_identifier(:providers, :create)
+
+      run_post(providers_url, gen_request(:create, [{"name" => "name3"}]))
+
+      expect_bad_request("Must specify credentials")
+    end
+
     it "supports requests with valid provider_class" do
       api_basic_authorize collection_action_identifier(:providers, :read, :get)
 
@@ -417,7 +434,7 @@ describe "Providers API" do
     it "rejects provider creation with invalid type specified" do
       api_basic_authorize collection_action_identifier(:providers, :create)
 
-      run_post(providers_url, "name" => "sample provider", "type" => "BogusType")
+      run_post(providers_url, "name" => "sample provider", "type" => "BogusType", "credentials" => {})
 
       expect_bad_request(/Invalid provider type BogusType/i)
     end
@@ -430,7 +447,7 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => [
-          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR)))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -452,7 +469,7 @@ describe "Providers API" do
           expect(response).to have_http_status(:ok)
           expected = {
             "results" => [
-              a_hash_including({"id" => kind_of(String)}.merge(sample_containers.except(*ENDPOINT_ATTRS)))
+              a_hash_including({"id" => kind_of(String)}.merge(sample_containers.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR)))
             ]
           }
           expect(response.parsed_body).to include(expected)
@@ -473,7 +490,7 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => [
-          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR)))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -490,7 +507,7 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => [
-          a_hash_including({"id" => kind_of(String)}.merge(sample_vmware.except(*ENDPOINT_ATTRS)))
+          a_hash_including({"id" => kind_of(String)}.merge(sample_vmware.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR)))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -509,7 +526,7 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => [
-          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR)))
         ]
       }
       expect(response.parsed_body).to include(expected)
@@ -530,8 +547,8 @@ describe "Providers API" do
       expect(response).to have_http_status(:ok)
       expected = {
         "results" => a_collection_containing_exactly(
-          a_hash_including({"id" => kind_of(String)}.merge(sample_vmware.except(*ENDPOINT_ATTRS))),
-          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS)))
+          a_hash_including({"id" => kind_of(String)}.merge(sample_vmware.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR))),
+          a_hash_including({"id" => kind_of(String)}.merge(sample_rhevm.except(*ENDPOINT_ATTRS, CREDENTIALS_ATTR)))
         )
       }
       expect(response.parsed_body).to include(expected)
@@ -560,6 +577,7 @@ describe "Providers API" do
           expected = {"id"   => a_kind_of(String),
                       "type" => containers_class,
                       "name" => "sample containers provider with multiple endpoints"}
+
           results = response.parsed_body["results"]
           expect(results.first).to include(expected)
 
@@ -597,7 +615,7 @@ describe "Providers API" do
     it "supports single resource edit" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
+      provider = FactoryGirl.create(:ext_management_system, sample_rhevm.except("credentials"))
 
       run_post(providers_url(provider.id), gen_request(:edit, "name" => "updated provider", "port" => "8080"))
 
@@ -609,7 +627,7 @@ describe "Providers API" do
     it "only returns real attributes" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
+      provider = FactoryGirl.create(:ext_management_system, sample_rhevm.except("credentials"))
 
       run_post(providers_url(provider.id), gen_request(:edit, "name" => "updated provider", "port" => "8080"))
 
@@ -621,7 +639,7 @@ describe "Providers API" do
     it "supports updates of credentials" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryGirl.create(:ext_management_system, sample_vmware)
+      provider = FactoryGirl.create(:ext_management_system, sample_vmware.except("credentials"))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       run_post(providers_url(provider.id), gen_request(:edit,
@@ -684,7 +702,7 @@ describe "Providers API" do
     it "supports additions of credentials" do
       api_basic_authorize collection_action_identifier(:providers, :edit)
 
-      provider = FactoryGirl.create(:ext_management_system, sample_rhevm)
+      provider = FactoryGirl.create(:ext_management_system, sample_rhevm.except("credentials"))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       run_post(providers_url(provider.id), gen_request(:edit,
@@ -795,7 +813,7 @@ describe "Providers API" do
     it "supports single provider refresh" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
+      provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
 
       run_post(providers_url(provider.id), gen_request(:refresh))
@@ -806,10 +824,10 @@ describe "Providers API" do
     it "supports multiple provider refreshes" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      p1 = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
+      p1 = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
       p1.update_authentication(:default => default_credentials.symbolize_keys)
 
-      p2 = FactoryGirl.create(:ext_management_system, sample_rhevm.symbolize_keys.except(:type))
+      p2 = FactoryGirl.create(:ext_management_system, sample_rhevm.symbolize_keys.except(:type, :credentials))
       p2.update_authentication(:default => default_credentials.symbolize_keys)
 
       run_post(providers_url, gen_request(:refresh, [{"href" => providers_url(p1.id)},
@@ -821,7 +839,7 @@ describe "Providers API" do
     it "provider refresh are created with a task" do
       api_basic_authorize collection_action_identifier(:providers, :refresh)
 
-      provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type))
+      provider = FactoryGirl.create(:ext_management_system, sample_vmware.symbolize_keys.except(:type, :credentials))
       provider.update_authentication(:default => default_credentials.symbolize_keys)
       provider.authentication_type(:default).update(:status => "Valid")
 
@@ -873,7 +891,7 @@ describe "Providers API" do
   end
 
   describe 'Providers import VM' do
-    let(:provider)      { FactoryGirl.create(:ems_redhat, sample_rhevm) }
+    let(:provider)      { FactoryGirl.create(:ems_redhat, sample_rhevm.except("credentials")) }
     let(:provider_url)  { providers_url(provider.id) }
 
     let(:vm)            { FactoryGirl.create(:vm_vmware) }


### PR DESCRIPTION
Currently, credentials are not required when creating a new provider via the api, which differs from the Classic UI which requires that credentials be added. This PR makes credentials required *if* there are no connection attributes specified (container providers only supply connection attributes) 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1467692

@miq-bot add_label wip, api, bz
@miq-bot assign @abellotti 