### PR TITLE
Give active queue worker time to complete message

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -442,7 +442,7 @@ class MiqWorker < ApplicationRecord
     # the database, so we can see how long it's been
     # 'stopping' by checking the last_heartbeat.
     stopping_timeout = self.class.worker_settings[:stopping_timeout] || Workers::MiqDefaults.stopping_timeout
-    status == MiqWorker::STATUS_STOPPING && last_heartbeat < stopping_timeout.seconds.ago
+    status == MiqWorker::STATUS_STOPPING && (last_heartbeat + current_timeout.to_i) < stopping_timeout.seconds.ago
   end
 
   def validate_active_messages

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -96,7 +96,7 @@ class EvmApplication
       s.miq_workers.order(:type).each do |w|
         data <<
           [w.type,
-           w.status,
+           w.status.sub("stopping", "stop pending"),
            w.id,
            w.pid,
            w.sql_spid,

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -385,6 +385,20 @@ describe MiqWorker do
         expect(subject).to be_truthy
       end
 
+      it "true if stopping and last heartbeat is within the queue message timeout of an active message" do
+        @worker.messages << FactoryGirl.create(:miq_queue, :msg_timeout => 60.minutes)
+        @worker.update(:status         => described_class::STATUS_STOPPING,
+                       :last_heartbeat => 90.minutes.ago)
+        expect(subject).to be_truthy
+      end
+
+      it "false if stopping and last heartbeat is older than the queue message timeout of the work item" do
+        @worker.messages << FactoryGirl.create(:miq_queue, :msg_timeout => 60.minutes, :state => "dequeue")
+        @worker.update(:status         => described_class::STATUS_STOPPING,
+                       :last_heartbeat => 30.minutes.ago)
+        expect(subject).to be_falsey
+      end
+
       it "false if stopping and heartbeated recently" do
         @worker.update(:status         => described_class::STATUS_STOPPING,
                        :last_heartbeat => 1.minute.ago)


### PR DESCRIPTION
* Let queue workers process an active message 
  * In e5f4bd3, we added a 10 minute timeout that would give workers a little time to complete their work after they exceed their memory threshold before we'd kill them.  This
causes workers to be killed prematurely before completing the work item.
  * What we really want is for the work item to complete but kill the worker
if the worker has exceeded memory/time thresholds and the work item hasn't
completed in a reasonable time.  This reasonable time is the msg_timeout
associated with the queue message.
* The stop is pending, it's not actively stopping (clarify rails evm:status output)
  * The worker is probably working on a queue message that takes a long time
so we let it try to complete this work item and have a follow up work
item where we ask the worker to exit cleanly on it's own.  "Stop pending"
better describes this graceful worker exit workflow.

```
** Using session_store: ActionDispatch::Session::MemCacheStore
Checking EVM status...
 Zone    | Server | Status  |            ID |   PID |  SPID | URL                     | Started On           | Last Heartbeat       | Master? | Active Roles
---------+--------+---------+---------------+-------+-------+-------------------------+----------------------+----------------------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------
 default | EVM    | started | 1000000000001 | 38192 | 38206 | druby://127.0.0.1:50844 | 2017-07-07T21:29:20Z | 2017-07-07T21:32:34Z | true    | automate:database_operations:database_owner:ems_inventory:ems_operations:event:reporting:scheduler:smartstate:user_interface:web_services:websocket

 Worker Type      | Status       |            ID |   PID | SPID  |     Server id | Queue Name / URL    | Started On           | Last Heartbeat       | MB Usage
------------------+--------------+---------------+-------+-------+---------------+---------------------+----------------------+----------------------+----------
 MiqGenericWorker | stop pending | 1000000000207 | 38374 | 38380 | 1000000000001 | generic             | 2017-07-07T21:32:19Z | 2017-07-07T21:32:33Z |      245
 MiqUiWorker      | started      | 1000000000206 | 38234 |       | 1000000000001 | http://0.0.0.0:3000 | 2017-07-07T21:29:21Z | 2017-07-07T21:32:34Z |      533
```

https://bugzilla.redhat.com/show_bug.cgi?id=1481800