### PR TITLE
[EUWE] Hotfix/azure vm provision ae state machine

### DIFF
--- a/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/azure/cloud_manager/provision/cloning.rb
@@ -11,7 +11,7 @@ module ManageIQ::Providers::Azure::CloudManager::Provision::Cloning
 
   def find_destination_in_vmdb(vm_uid_hash)
     ems_ref = vm_uid_hash.values.join("\\")
-    ManageIQ::Providers::Azure::CloudManager::Vm.find_by(:ems_ref => ems_ref.downcase)
+    ManageIQ::Providers::Azure::CloudManager::Vm.find_by("lower(ems_ref) = ?", ems_ref.downcase)
   end
 
   def gather_storage_account_properties

--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -43,7 +43,10 @@ module MiqProvision::StateMachine
 
   def poll_destination_in_vmdb
     update_and_notify_parent(:message => "Validating New #{destination_type}")
-
+    # fill vm_name field if is not given
+    if dest_name && phase_context[:new_vm_ems_ref] && phase_context[:new_vm_ems_ref][:vm_name].nil?
+       phase_context[:new_vm_ems_ref][:vm_name] = dest_name
+    end
     self.destination = find_destination_in_vmdb(phase_context[:new_vm_ems_ref])
     if destination
       phase_context.delete(:new_vm_ems_ref)


### PR DESCRIPTION
This PR is aim to fix azure machine can not be found in vmdb after deployment, which leads to exceed the 100 defaut retry time of executing the Automation Engine.

Let me explain you with some logs

evm.log example 1: 
```
[----] I, [2017-07-07T07:13:31.343135 #1903:1311130]  INFO -- : Q-task_id([miq_provision_474]) MIQ(ManageIQ::Providers::Azure::CloudManager::Provision#poll_destination_in_vmdb) Unable to find Vm [Zttestazurevm2] with ems_ref [{:subscription_id=>"888888888-88888-8888-8888-888888888842", :vm_resource_group=>"Default-Storage-JapanEast", :type=>"microsoft.compute/virtualmachines", :vm_name=>"Zttestazurevm2"}], will retry
```
however object in db:
```
irb(main):007:0> ManageIQ::Providers::Azure::CloudManager::Vm.where('ems_ref like ?', '%Zttestazurevm2%').first.ems_ref
=> "888888888-88888-8888-8888-888888888842\\default-storage-japaneast\\microsoft.compute/virtualmachines\\Zttestazurevm2"
```

analyse: my `vm_name` has uppercase in it and when we try to find in db, it become lower case and we we could not find it

+++++++++++++++++++

evm.log example2:
```
[----] I, [2017-07-07T13:16:51.862325 #19446:72d134]  INFO -- : Q-task_id([miq_provision_479]) MIQ(ManageIQ::Providers::Azure::CloudManager::Provision#poll_destination_in_vmdb) Unable to find Vm [zttestazurevm6] with ems_ref [{:subscription_id=>"888888888-88888-8888-8888-888888888842", :vm_resource_group=>"Default-Storage-JapanEast", :type=>"microsoft.compute/virtualmachines"}], will retry
```

analyse: my `vm_name` is not given some time in the hash when we try to find the vm in db, but the destination name is present


