### PR TITLE
Make namespace into a virtual attribute

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -4,6 +4,7 @@ class Classification < ApplicationRecord
   belongs_to :tag
 
   virtual_column :name, :type => :string
+  virtual_column :ns, :type => :string
 
   before_save    :save_tag
   before_destroy :delete_tags_and_entries


### PR DESCRIPTION
The SUI needs to determine what namespace a Category belongs to via the API, ie:
`GET /api/category?expand=resources,attributes=ns` 

This exposes the existing `ns` method as a virtual attribute to make that possible. 

@miq-bot assign @gtanzillo 
cc: @AllenBW 