### PR TITLE
Add my_zone to Service Orchestration.

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -83,6 +83,10 @@ class ServiceOrchestration < Service
     assign_vms_owner
   end
 
+  def my_zone
+    orchestration_manager.try(:my_zone) || super
+  end
+
   private
 
   def add_stack_to_resource

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -56,13 +56,31 @@ describe ServiceOrchestration do
   end
 
   describe "#my_zone" do
-    it "takes the zone from ext_management_system" do
+    it "deployed stack, takes the zone from ext_management_system" do
       deployed_stack.ext_management_system = manager_by_setter
       expect(deployed_stack.my_zone).to eq(manager_by_setter.my_zone)
     end
 
-    it "returns nil if ext_management_system is not valid" do
-      expect(deployed_stack.my_zone).to eq(nil)
+    it "deployed stack, returns nil zone if ext_management_system is not valid" do
+      expect(deployed_stack.my_zone).to be_nil
+    end
+
+    it "service, takes the zone from orchestration_manager" do
+      ems = FactoryGirl.create(:ems_amazon, :zone => FactoryGirl.create(:zone))
+      deployed_stack.direct_vms << FactoryGirl.create(:vm_amazon, :ext_management_system => ems)
+      expect(service_with_deployed_stack.my_zone).to eq(service.orchestration_manager.my_zone)
+    end
+
+    it "service, takes the zone from VM ext_management_system if no orchestration_manager" do
+      ems = FactoryGirl.create(:ems_amazon, :zone => FactoryGirl.create(:zone))
+      deployed_stack.direct_vms << FactoryGirl.create(:vm_amazon, :ext_management_system => ems)
+      service.orchestration_manager = nil
+      expect(service_with_deployed_stack.my_zone).to eq(service_with_deployed_stack.vms.first.ext_management_system.my_zone)
+    end
+
+    it "service, returns nil zone if no orchestration_manager and no VMs" do
+      service.orchestration_manager = nil
+      expect(service_with_deployed_stack.my_zone).to be_nil
     end
   end
 


### PR DESCRIPTION
Service Retirement attempts to queue the request_service_retire event to the proper zone which is available through the Service VMs. The zone is nil if there are no Service VMs. Getting the zone from the service_template.my_zone should resolve this issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1458011

