### PR TITLE
Allow operator characters on the RHS of filter

### DIFF
--- a/lib/api/filter.rb
+++ b/lib/api/filter.rb
@@ -48,12 +48,21 @@ module Api
 
     def parse_filter(filter)
       logical_or = filter.gsub!(/^or /i, '').present?
-      operator, methods = OPERATORS.find { |op, _methods| filter.partition(op).second == op }
+
+      operator = nil
+      operators_from_longest_to_shortest = OPERATORS.keys.sort_by(&:size).reverse
+      filter.size.times do |i|
+        operator = operators_from_longest_to_shortest.detect do |o|
+          o == filter[(i..(i + o.size - 1))]
+        end
+        break if operator
+      end
 
       if operator.blank?
         raise BadRequestError, "Unknown operator specified in filter #{filter}"
       end
 
+      methods = OPERATORS[operator]
       filter_attr, _, filter_value = filter.partition(operator)
       filter_attr.strip!
       filter_value.strip!

--- a/spec/lib/api/filter_spec.rb
+++ b/spec/lib/api/filter_spec.rb
@@ -346,5 +346,14 @@ RSpec.describe Api::Filter do
       expected = {"=" => {"field" => "Vm-ems_id", "value" => 1_000_000_000_123}}
       expect(actual.exp).to eq(expected)
     end
+
+    it "can handle operator characters on the right hand side" do
+      filters = ["name=Vms with free space > 50 percent"]
+
+      actual = described_class.parse(filters, MiqReport)
+
+      expected = {"=" => {"field" => "MiqReport-name", "value" => "Vms with free space > 50 percent"}}
+      expect(actual.exp).to eq(expected)
+    end
   end
 end


### PR DESCRIPTION
Fixes an issue where filters with operator characters on the RHS would
return 400s. This is because it parses the operator as the first one
found anywhere in the filter. By taking a more LALR-ish approach, we
can avoid this problem by parsing it as the first operator found in
the string.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1365013

@miq-bot add-label bug, api
@miq-bot assign @abellotti 