### PR TITLE
Converting userids to UPN format to avoid duplicate user records

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -118,9 +118,8 @@ module Authenticator
           end
 
           matching_groups = match_groups(groups_for(identity))
-          userid = userid_for(identity, username)
-          user   = find_or_initialize_user(userid)
-          update_user_attributes(user, username, identity)
+          userid, user = find_or_initialize_user(identity, username)
+          update_user_attributes(user, userid, identity)
           user.miq_groups = matching_groups
 
           if matching_groups.empty?
@@ -148,10 +147,12 @@ module Authenticator
       end
     end
 
-    def find_or_initialize_user(userid)
+    def find_or_initialize_user(identity, username)
+      userid = userid_for(identity, username)
       user   = User.find_by_userid(userid)
       user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
-      user ||  User.new(:userid => userid)
+      user ||=  User.new(:userid => userid)
+      [userid, user]
     end
 
     def authenticate_with_http_basic(username, password, request = nil, options = {})

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -151,7 +151,7 @@ module Authenticator
       userid = userid_for(identity, username)
       user   = User.find_by_userid(userid)
       user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
-      user ||=  User.new(:userid => userid)
+      user ||= User.new(:userid => userid)
       [userid, user]
     end
 

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -62,8 +62,8 @@ module Authenticator
       upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain].downcase}"
 
       user = find_userid_as_upn(upn_username)
-      user ||= find_userid_as_username(identity, username, upn_username)
       user ||= find_userid_as_distinguished_name(user_attrs, upn_username)
+      user ||= find_userid_as_username(identity, username, upn_username)
       user ||= User.new(:userid => upn_username)
 
       [upn_username, user]
@@ -72,7 +72,8 @@ module Authenticator
     private
 
     def find_userid_as_upn(upn_username)
-      User.find_by_userid(upn_username)
+      user = User.find_by_userid(upn_username)
+      user || User.in_my_region.where('lower(userid) = ?', upn_username).order(:lastlogon).last
     end
 
     def find_userid_as_username(identity, username, upn_username)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -57,9 +57,9 @@ module Authenticator
 
     def find_or_initialize_user(identity, username)
       user_attrs, _membership_list = identity
-      return super(identity, username) if user_attrs[:domain].nil?
+      return super if user_attrs[:domain].nil?
 
-      upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain].downcase}"
+      upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain]}".downcase
 
       user = find_userid_as_upn(upn_username)
       user ||= find_userid_as_distinguished_name(user_attrs, upn_username)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -43,10 +43,10 @@ module Authenticator
       MiqGroup.strip_group_domains(membership_list)
     end
 
-    def update_user_attributes(user, _username, identity)
+    def update_user_attributes(user, username, identity)
       user_attrs, _membership_list = identity
 
-      user.userid     = user_attrs[:username]
+      user.userid     = username
       user.first_name = user_attrs[:firstname]
       user.last_name  = user_attrs[:lastname]
       user.email      = user_attrs[:email] unless user_attrs[:email].blank?
@@ -55,7 +55,42 @@ module Authenticator
       user.name       = user.userid if user.name.blank?
     end
 
+    def find_or_initialize_user(identity, username)
+      user_attrs, _membership_list = identity
+      return super(identity, username) if user_attrs[:domain].nil?
+
+      upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain].downcase}"
+
+      user = find_userid_as_upn(upn_username)
+      user ||= find_userid_as_username(identity, username, upn_username)
+      user ||= find_userid_as_distinguished_name(user_attrs, upn_username)
+      user ||= User.new(:userid => upn_username)
+
+      [upn_username, user]
+    end
+
     private
+
+    def find_userid_as_upn(upn_username)
+      User.find_by_userid(upn_username)
+    end
+
+    def find_userid_as_username(identity, username, upn_username)
+      userid = userid_for(identity, username)
+      user   = User.find_by_userid(userid)
+      user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
+      $audit_log.info("Updating userid from #{user.userid} to #{upn_username}") unless user.blank?
+
+      user
+    end
+
+    def find_userid_as_distinguished_name(user_attrs, upn_username)
+      dn_domain = user_attrs[:domain].downcase.split(".").map { |s| "dc=#{s}" }.join(",")
+      user = User.in_my_region.where("userid LIKE ?", "%=#{user_attrs[:username]},%,#{dn_domain}").last
+      $audit_log.info("Updating userid from #{user.userid} to #{upn_username}") unless user.blank?
+
+      user
+    end
 
     def user_details_from_external_directory(username)
       ext_user_attrs = user_attrs_from_external_directory(username)
@@ -63,7 +98,8 @@ module Authenticator
                     :fullname  => ext_user_attrs["displayname"],
                     :firstname => ext_user_attrs["givenname"],
                     :lastname  => ext_user_attrs["sn"],
-                    :email     => ext_user_attrs["mail"]}
+                    :email     => ext_user_attrs["mail"],
+                    :domain    => ext_user_attrs["domainname"]}
       [user_attrs, MiqGroup.get_httpd_groups_by_user(username)]
     end
 
@@ -72,7 +108,8 @@ module Authenticator
                     :fullname  => request.headers['X-REMOTE-USER-FULLNAME'],
                     :firstname => request.headers['X-REMOTE-USER-FIRSTNAME'],
                     :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
-                    :email     => request.headers['X-REMOTE-USER-EMAIL']}
+                    :email     => request.headers['X-REMOTE-USER-EMAIL'],
+                    :domain    => request.headers['X-REMOTE-USER-DOMAIN']}
       [user_attrs, (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:]/)]
     end
 
@@ -80,7 +117,7 @@ module Authenticator
       return unless username
       require "dbus"
 
-      attrs_needed = %w(mail givenname sn displayname)
+      attrs_needed = %w(mail givenname sn displayname domainname)
 
       sysbus = DBus.system_bus
       ifp_service   = sysbus["org.freedesktop.sssd.infopipe"]

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -195,7 +195,7 @@ describe Authenticator::Httpd do
       let(:dn) { 'cn=sally,ou=people,ou=prod,dc=example,dc=com' }
       let(:config) { {:httpd_role => true} }
 
-      let(:username) { 'sally' }
+      let(:username) { 'saLLy' }
       let(:user_groups) { 'wibble@fqdn:bubble@fqdn' }
 
       let(:headers) do

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -242,9 +242,9 @@ describe Authenticator::Httpd do
       end
 
       context "when user record is for a different region" do
-        let(:my_region_number) { Classification.my_region_number }
-        let(:other_region) { Classification.my_region_number + 1 }
-        let(:other_region_id) { other_region * Classification.rails_sequence_factor + 1 }
+        let(:my_region_number) { ApplicationRecord.my_region_number }
+        let(:other_region) { ApplicationRecord.my_region_number + 1 }
+        let(:other_region_id) { other_region * ApplicationRecord.rails_sequence_factor + 1 }
 
         it "does not modify the user record when userid is in username format" do
           sally_username = FactoryGirl.create(:user, :userid => 'sally', :id => other_region_id)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -65,6 +65,7 @@ describe Authenticator::Httpd do
         'X-Remote-User-FirstName' => 'Alice',
         'X-Remote-User-LastName'  => 'Aardvark',
         'X-Remote-User-Email'     => 'alice@example.com',
+        'X-Remote-User-Domain'    => 'example.com',
         'X-Remote-User-Groups'    => user_groups,
       }
     end
@@ -190,6 +191,77 @@ describe Authenticator::Httpd do
       end
     end
 
+    context "with potential for multiple user records" do
+      let(:dn) { 'cn=sally,ou=people,ou=prod,dc=example,dc=com' }
+      let(:config) { {:httpd_role => true} }
+
+      let(:username) { 'sally' }
+      let(:user_groups) { 'wibble@fqdn:bubble@fqdn' }
+
+      let(:headers) do
+        super().merge('X-Remote-User-FullName'  => 'Sally Porsche',
+                      'X-Remote-User-FirstName' => 'Sally',
+                      'X-Remote-User-LastName'  => 'Porsche',
+                      'X-Remote-User-Email'     => 'Sally@example.com')
+      end
+
+      context "when user record with userid in upn format already exists" do
+        let!(:sally_username) { FactoryGirl.create(:user, :userid => 'sally') }
+        let!(:sally_dn) { FactoryGirl.create(:user, :userid => dn) }
+        let!(:sally_upn) { FactoryGirl.create(:user, :userid => 'sally@example.com') }
+
+        it "leaves user record with userid in username format unchanged" do
+          expect(-> { authenticate }).to_not change { sally_username.reload.userid }
+        end
+
+        it "leaves user record with userid in distinguished name format unchanged" do
+          expect(-> { authenticate }).to_not change { sally_dn.reload.userid }
+        end
+
+        it "leaves user record with userid in upn format unchanged" do
+          expect(-> { authenticate }).to_not change { sally_upn.reload.userid }
+        end
+      end
+
+      context "when user record with userid in upn format does not already exists" do
+        it "updates userid from username format to upn format" do
+          sally_username = FactoryGirl.create(:user, :userid => 'sally')
+          expect(-> { authenticate }).to change { sally_username.reload.userid }.from("sally").to("sally@example.com")
+        end
+
+        it "updates userid from distinguished name format to upn format" do
+          sally_dn = FactoryGirl.create(:user, :userid => dn)
+          expect(-> { authenticate }).to change { sally_dn.reload.userid }.from(dn).to("sally@example.com")
+        end
+
+        it "does not modify userid if already in upn format" do
+          sally_upn = FactoryGirl.create(:user, :userid => 'sally@example.com')
+          expect(-> { authenticate }).to_not change { sally_upn.reload.userid }
+        end
+      end
+
+      context "when user record is for a different region" do
+        let(:my_region_number) { Classification.my_region_number }
+        let(:other_region) { Classification.my_region_number + 1 }
+        let(:other_region_id) { other_region * Classification.rails_sequence_factor + 1 }
+
+        it "does not modify the user record when userid is in username format" do
+          sally_username = FactoryGirl.create(:user, :userid => 'sally', :id => other_region_id)
+          expect(-> { authenticate }).to_not change { sally_username.reload.userid }
+        end
+
+        it "does not modify the user record when userid is in distinguished name format" do
+          sally_dn = FactoryGirl.create(:user, :userid => dn, :id => other_region_id)
+          expect(-> { authenticate }).to_not change { sally_dn.reload.userid }
+        end
+
+        it "does not modify the user record when userid is in already upn format" do
+          sally_upn = FactoryGirl.create(:user, :userid => 'sally@example.com', :id => other_region_id)
+          expect(-> { authenticate }).to_not change { sally_upn.reload.userid }
+        end
+      end
+    end
+
     context "with unknown username in mixed case" do
       let(:username) { 'bOb' }
       let(:headers) do
@@ -254,7 +326,7 @@ describe Authenticator::Httpd do
         end
 
         it "creates a new User" do
-          expect(-> { authenticate }).to change { User.where(:userid => 'bob').count }.from(0).to(1)
+          expect(-> { authenticate }).to change { User.where(:userid => 'bob@example.com').count }.from(0).to(1)
         end
 
         context "with no matching groups" do
@@ -279,7 +351,7 @@ describe Authenticator::Httpd do
             expect(AuditEvent).to receive(:failure).with(
               :event   => 'authorize',
               :userid  => 'bob',
-              :message => "Authentication failed for userid bob, unable to match user's group membership to an EVM role",
+              :message => "Authentication failed for userid bob@example.com, unable to match user's group membership to an EVM role",
             )
             authenticate
           end
@@ -319,8 +391,8 @@ describe Authenticator::Httpd do
                           'X-Remote-User-Email'     => 'sam@example.com')
           end
 
-          it "creates a new User with name set to the userid" do
-            expect(-> { authenticate }).to change { User.where(:name => 'sam').count }.from(0).to(1)
+          it "creates a new User with the userid set to the UPN" do
+            expect(-> { authenticate }).to change { User.where(:name => 'sam@example.com').count }.from(0).to(1)
           end
         end
       end
@@ -345,17 +417,19 @@ describe Authenticator::Httpd do
         end
 
         it "should return user attributes hash for valid user" do
-          requested_attrs = %w(mail givenname sn displayname)
+          requested_attrs = %w(mail givenname sn displayname domainname)
 
           jdoe_attrs = [{"mail"        => ["jdoe@example.com"],
                          "givenname"   => ["John"],
                          "sn"          => ["Doe"],
-                         "displayname" => ["John Doe"]}]
+                         "displayname" => ["John Doe"],
+                         "domainname"  => ["example.com"]}]
 
           expected_jdoe_attrs = {"mail"        => "jdoe@example.com",
                                  "givenname"   => "John",
                                  "sn"          => "Doe",
-                                 "displayname" => "John Doe"}
+                                 "displayname" => "John Doe",
+                                 "domainname"  => "example.com"}
 
           allow(@ifp_interface).to receive(:GetUserAttr).with('jdoe', requested_attrs).and_return(jdoe_attrs)
 

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -206,9 +206,9 @@ describe Authenticator::Httpd do
       end
 
       context "when user record with userid in upn format already exists" do
-        let!(:sally_username) { FactoryGirl.create(:user, :userid => 'sally') }
+        let!(:sally_username) { FactoryGirl.create(:user, :userid => 'sAlly') }
         let!(:sally_dn) { FactoryGirl.create(:user, :userid => dn) }
-        let!(:sally_upn) { FactoryGirl.create(:user, :userid => 'sally@example.com') }
+        let!(:sally_upn) { FactoryGirl.create(:user, :userid => 'sAlly@example.com') }
 
         it "leaves user record with userid in username format unchanged" do
           expect(-> { authenticate }).to_not change { sally_username.reload.userid }
@@ -218,8 +218,9 @@ describe Authenticator::Httpd do
           expect(-> { authenticate }).to_not change { sally_dn.reload.userid }
         end
 
-        it "leaves user record with userid in upn format unchanged" do
-          expect(-> { authenticate }).to_not change { sally_upn.reload.userid }
+        it "downcases user record with userid in upn format" do
+          expect(-> { authenticate })
+            .to change { sally_upn.reload.userid }.from("sAlly@example.com").to("sally@example.com")
         end
       end
 

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -22,7 +22,7 @@ describe Authenticator do
 
     it 'Updates the user groups when no matching groups' do
       expect(authenticator).to receive(:find_external_identity)
-        .and_return([{:username => user.userid, :fullname => user.name}, []])
+        .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, []])
 
       authenticator.authorize(task.id, user.userid)
       expect(user.reload.miq_groups).to be_empty
@@ -30,7 +30,7 @@ describe Authenticator do
 
     it 'Updates the user groups' do
       expect(authenticator).to receive(:find_external_identity)
-        .and_return([{:username => user.userid, :fullname => user.name}, groups.collect(&:name)])
+        .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, groups.collect(&:name)])
 
       authenticator.authorize(task.id, user.userid)
       expect(user.reload.miq_groups).to match_array(groups)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424618

# The Issue:
The issue this PR will address is that the various mechanism available for MiQ customers to use for authentication and authorization do not create user records with a common userid.

# Brief Definitions:

###  _user principal name (upn)_ format
This format is: _username_**@**_domain name_

**e.g.:** `sally@example.com`

###  _distinguished name (dn)_ format
This format exposes the directory layout and is of the form:
**cn|uid=**_"username"_**,ou=**_"level1"_**, ou=**_"level2"_...**,dc=**_"domain"_**,dc=**_"domain"_

**e.g.:** cn=sally,ou=people,ou=prod,dc=example,dc=com

###  _username_ 
This format is simply the username.

**e.g.:** sally

# Issue Details:

The matrix of possible configurations creating userids in different formats is large. They can be either UPN, DN, or username.

One example is the likely scenario where a customer manually migrated, not using the automated conversion tool currently under development, from using our _MiqLdap_ client to _External Auth_.

The MiqLdap client would have created a user record with the userid in UPN format

**e.g.:**  `_sally@example.com_`

or, depending on configuration in DN format

**e.g.:** `cn=sally,ou=people,ou=prod,dc=example,dc=com`

Using external auth, when the same user credentials are specified, a user record is created with a userid of simply the username

**e.g.:**  `_sally_`

Resulting in duplicate user records for the same user.

# The Solution:

Ultimately a UUID should be made available from the underlying directory infrastructure that could be used as the userid but this is not yet available. Working with the IdM team and Alberto Bellotti it was decided the best solution at the moment is to standardize the userid to be _user principal name (upn)_ format.

We could provide a migration that would update every user record to have a userid in UPN format. However it is possible to avoid the pitfalls associated with such a migration by simply updating the user record to have a userid in UPN format at user login.

Once a user record in UPN format is found user records with a related userid would be ignored.
I had considered destroying any user records with related userids once the UPN formatted one is found but have decided against it. Although in the normal flow of usage this should never happen. However in the event of the unpredictable, ignoring such records instead of destroying them would allow customers the ability to address such inconsistencies.

# The Related PRs:

The following associated PRs in different repos are required for this PR and must be merged at the same  #time.

- PR [127](https://github.com/ManageIQ/manageiq-appliance/pull/127) in repo ManageIQ/manageiq-appliance

- PR [424](https://github.com/ManageIQ/manageiq_docs/pull/424) in repo ManageIQ/manageiq_docs

- PR [250](https://github.com/ManageIQ/manageiq-gems-pending/pull/250) in repo ManageIQ/_manageie-gems-pending_

This and the above PRs should all be merged at the same time.

# Note:

This change requires new support in the underlying SSSD code. Updates were
required to provide the domain name when MiQ is configured to use  _External Authentication_ (Mode: External (httpd)

The BZs that track this work are:

- https://bugzilla.redhat.com/show_bug.cgi?id=1425891
- https://bugzilla.redhat.com/show_bug.cgi?id=1455254

The fixes for these BZs are targeted for RHEL 7.4 GA and CentOS 7.4

**_Therefor this change should not be merged until MiQ appliance builds migrate to  RHEL 7.4 GA and CentOS 7.4_**


Steps for Testing/QA
-------------------------------

1. The way to test this is to configure MiQ to use the _MiqLdap_ client (Mode: LDAP) for authentication.
2. Log in with a valid user/group
3. Then manually reconfigure the appliance to  use _External Authentication_ (Mode: External (httpd)) for authentication.
4. Log in with the same valid user/group from step 2.
5. Confirm there is only a single user created.
