### PR TITLE
Delete no longer used PORT environment variable.

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -134,7 +134,6 @@ module MiqWebServerWorkerMixin
 
   def start
     delete_pid_file
-    ENV['PORT'] = port.to_s
     ENV['MIQ_GUID'] = guid
     super
   end


### PR DESCRIPTION
It was used in the old MiqEnvironment code for introspection to
differentiate the puma workers, but it was deleted below:

https://github.com/ManageIQ/manageiq/commit/470e26072c5243f0ab74d29a4ddde61d5cd8d735

Thanks 🙇  @carbonin 