### PR TITLE
When vm removed ems relation not updated

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -669,6 +669,7 @@ class VmOrTemplate < ApplicationRecord
       self.ext_management_system = nil
       self.ems_cluster = nil
       self.raw_power_state = "unknown"
+      self.ems_id = nil
       save
     end
   end


### PR DESCRIPTION
During handling of USER_REMOVE_VM_FINISHED event we did not update
vm and ems relation. It was following query triggered:

SQL (1.7ms) UPDATE "vms" SET "updated_on" = $1, "power_state" = $2, "state_changed_on" = $3,
"previous_state" = $4, "ems_cluster_id" = $5, "raw_power_state" = $6 WHERE "vms"."id" = $7
[["updated_on", "2017-07-11 14:21:27.953014"], ["power_state", "unknown"], ["state_changed_on",
  "2017-07-11 14:21:27.950976"], ["previous_state", "down"], ["ems_cluster_id", nil],
["raw_power_state", "unknown"], ["id", 11]]

After this change the ems_id is removed properly and the query looks as following:

SQL (0.5ms) UPDATE "vms" SET "ems_id" = $1, "updated_on" = $2, "power_state" = $3,
"state_changed_on" = $4, "previous_state" = $5, "ems_cluster_id" = $6, "raw_power_state" = $7
WHERE "vms"."id" = $8 [["ems_id", nil], ["updated_on", "2017-07-11 14:32:41.082150"],
["power_state", "unknown"], ["state_changed_on", "2017-07-11 14:32:41.079699"],
["previous_state", "down"], ["ems_cluster_id", nil], ["raw_power_state", "unknown"], ["id", 12]]

Bug:
https://bugzilla.redhat.com/1468201