### PR TITLE
Change database_application_name format

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -461,7 +461,7 @@ class MiqServer < ApplicationRecord
   end
 
   def database_application_name
-    "MIQ #{Process.pid} Server[#{compressed_id}], #{zone.name}[#{zone.compressed_id}]".truncate(64)
+    "MIQ|#{Process.pid}|#{compressed_id}|-|#{zone.compressed_id}|Server|#{zone.name}".truncate(64)
   end
 
   def set_database_application_name

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -514,7 +514,7 @@ class MiqWorker < ApplicationRecord
 
   def database_application_name
     zone = MiqServer.my_server.zone
-    "MIQ #{Process.pid} #{minimal_class_name}[#{compressed_id}], s[#{miq_server.compressed_id}], #{zone.name}[#{zone.compressed_id}]".truncate(64)
+    "MIQ|#{Process.pid}|#{miq_server.compressed_id}|#{compressed_id}|#{zone.compressed_id}|#{minimal_class_name}|#{zone.name}".truncate(64)
   end
 
   def format_full_log_msg


### PR DESCRIPTION
Chane database_application_name format so it's less likely to be truncated and still human readable. Now miq_server and miq_worker has a same format:
`MIQ|<pid>|<server_id>|<worker_id>|<zone_id>|<class_name>|<zone_name>`
where `<..._id>` is compressed and `<class_name>` is shorten with deleting`Miq` prefix and `Worker` suffix if any. And for servers, the worker_id is `-`
See also:
https://www.pivotaltracker.com/n/projects/1608513/stories/147871949
\cc @gtanzillo @jrafanie @yrudman 

@miq-bot add-label tools,wip