### PR TITLE
Fix/azure vm provision ae state machine

### DIFF
--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -43,6 +43,9 @@ module MiqProvision::StateMachine
 
   def poll_destination_in_vmdb
     update_and_notify_parent(:message => "Validating New #{destination_type}")
+    if dest_name && phase_context.fetch_path(:new_vm_ems_ref, :vm_name).nil?
+      phase_context.store_path(:new_vm_ems_ref, :vm_name, dest_name)
+    end
 
     self.destination = find_destination_in_vmdb(phase_context[:new_vm_ems_ref])
     if destination

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -151,5 +151,20 @@ describe MiqProvision do
         template.reload.with_relationship_type("genealogy")  { |v| expect(v.children).to eq([vm]) }
       end
     end
+
+    context "#poll_destination_in_vmdb" do
+      before do
+        allow(task).to receive(:update_and_notify_parent)
+      end
+
+      it "fill vm_name with dest_name if not exist" do
+        expect(task.phase_context[:new_vm_ems_ref][:vm_name]).to be_nil
+
+        expect(task).to receive(:signal).with(:poll_destination_in_vmdb)
+        expect(task.phase_context[:new_vm_ems_ref][:vm_name]).to eq(
+          options[:vm_target_name]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
this PR is parts of this closed PR https://github.com/ManageIQ/manageiq/issues/15530 but base on master

another parts is here https://github.com/ManageIQ/manageiq-providers-azure/pull/93

-------------------------------------------------------------------------------------------------------------------------------------------
here is the description:
This PR is aim to fix azure machine can not be found in vmdb after deployment, which leads to exceed the 100 defaut retry time of executing the Automation Engine.

Let me explain you with some logs

evm.log example:
```
[----] I, [2017-07-07T13:16:51.862325 #19446:72d134]  INFO -- : Q-task_id([miq_provision_479]) MIQ(ManageIQ::Providers::Azure::CloudManager::Provision#poll_destination_in_vmdb) Unable to find Vm [zttestazurevm6] with ems_ref [{:subscription_id=>"888888888-88888-8888-8888-888888888842", :vm_resource_group=>"Default-Storage-JapanEast", :type=>"microsoft.compute/virtualmachines"}], will retry
```

analyse: my `vm_name` is not given some time in the hash when we try to find the vm in db, but the destination name is present