### PR TITLE
Remove the ActionController::Params monkey patch

### DIFF
--- a/lib/extensions/as_nested_params.rb
+++ b/lib/extensions/as_nested_params.rb
@@ -1,3 +1,0 @@
-ActionController::Parameters.class_eval do
-  include MoreCoreExtensions::Shared::Nested
-end


### PR DESCRIPTION
- [x] https://github.com/ManageIQ/manageiq-ui-classic/issues/1671 [MERGED]

This is only used in ui-classic, so we'll move it there.

Because of this extension, we couldn't require all of the
lib/extensions without loading ActionController.