### PR TITLE
Fixed path for including miq-syntax-checker

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -1,4 +1,4 @@
-require 'miq-syntax-checker'
+require 'manageiq/automation_engine/syntax_checker'
 
 class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin


### PR DESCRIPTION
If you navigate to Automate -> Customization, the console returns:
```
F, [2017-07-12T10:44:25.500141 #28075] FATAL -- :   
F, [2017-07-12T10:44:25.500221 #28075] FATAL -- : LoadError (cannot load such file -- miq-syntax-checker):
F, [2017-07-12T10:44:25.500279 #28075] FATAL -- :   
F, [2017-07-12T10:44:25.500352 #28075] FATAL -- : activesupport (5.0.4) lib/active_support/dependencies.rb:293:in `require'
activesupport (5.0.4) lib/active_support/dependencies.rb:293:in `block in require'
activesupport (5.0.4) lib/active_support/dependencies.rb:257:in `block in load_dependency'
activesupport (5.0.4) lib/active_support/dependencies.rb:662:in `new_constants_in'
activesupport (5.0.4) lib/active_support/dependencies.rb:257:in `load_dependency'
activesupport (5.0.4) lib/active_support/dependencies.rb:293:in `require'
app/models/miq_ae_method.rb:1:in `<top (required)>'
```

This was probably caused by https://github.com/ManageIQ/manageiq-gems-pending/pull/237 and https://github.com/ManageIQ/manageiq-automation_engine/pull/51. I'm not sure if this is *The Right Way&trade;* to fix it, but I needed a quick workaround.