### PR TITLE
Flavors create and add methods

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -893,6 +893,14 @@
       :description: Edit Tags of Flavor
       :feature_type: control
       :identifier: flavor_tag
+    - :name: Add Flavor
+      :description: Add Flavor
+      :feature_type: control
+      :identifier: flavor_create
+    - :name: Delete Flavor
+      :description: Delete Flavor
+      :feature_type: control
+      :identifier: flavor_delete   
 
 # EmsInfra
 - :name: Infrastructure Providers

--- a/spec/models/flavor_spec.rb
+++ b/spec/models/flavor_spec.rb
@@ -1,0 +1,35 @@
+describe Flavor do
+  let(:ems) { FactoryGirl.create(:ems_openstack) }
+
+  context 'when calling raw_create_flavor methods' do
+    it 'raises NotImplementedError' do
+      expect do
+        subject.class.raw_create_flavor(1, {})
+      end.to raise_error(NotImplementedError, "raw_create_flavor must be implemented in a subclass")
+    end
+  end
+
+  context 'when calling raw_create_flavor methods' do
+    it 'raises NotImplementedError' do
+      expect do
+        subject.raw_delete_flavor
+      end.to raise_error(NotImplementedError, "raw_delete_flavor must be implemented in a subclass")
+    end
+  end
+
+  context 'when calling create_flavor method' do
+    it 'should call raw_create_flavor' do
+      flavor_double = class_double('ManageIQ::Providers::Openstack::CloudManager::Flavor')
+      allow(subject.class).to receive(:class_by_ems).and_return(flavor_double)
+      expect(flavor_double).to receive(:raw_create_flavor)
+      subject.class.create_flavor(ems.id, {})
+    end
+  end
+
+  context 'when calling delete_flavor method' do
+    it 'should call raw_delete_flavor' do
+      expect(subject).to receive(:raw_delete_flavor)
+      subject.delete_flavor
+    end
+  end
+end


### PR DESCRIPTION
Added interface methods for creating and deleting flavors and made small
refactoring of existing method. 0penstack part will be implemented in
[manageiq-providers-openstack](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/cloud_manager/flavor.rb).