### PR TITLE
Cast virtual attribute 'Hardware#ram_size_in_bytes' to bigint

### DIFF
--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -198,6 +198,11 @@ describe Hardware do
 
       expect(virtual_column_sql_value(Hardware, "ram_size_in_bytes")).to eq(5.megabytes)
     end
+
+    it "does not raise error if return value bigger than PostgreSQL's integer type" do
+      FactoryGirl.create(:hardware, :memory_mb => 131_015)
+      expect { virtual_column_sql_value(Hardware, "ram_size_in_bytes") }.to_not raise_error
+    end
   end
 
   # this is disks + ram_size_in_bytes


### PR DESCRIPTION
There is `PG::NumericValueOutOfRange` thrown in report on  `ram_size_in_bytes`

https://bugzilla.redhat.com/show_bug.cgi?id=1464154

@miq-bot add-label bug, fine/yes

\cc @gtanzillo 