### PR TITLE
Ignore Output and Exit cops in worker bins

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -40,6 +40,12 @@ FileName:
 Metrics/LineLength:
   Exclude:
     - Gemfile
+Rails/Exit:
+  Exclude:
+    - lib/workers/bin/*
+Rails/Output:
+  Exclude:
+    - lib/workers/bin/*
 Style/ExtraSpacing:
   Exclude:
     - Gemfile


### PR DESCRIPTION
Script files are meant to output and be in charge of their own exits and exit statuses, and since the workers bin files currently live here, these cops will just add noise to future PRs modifying these scripts.

So just exclude them.

Links
-----
* Example PR where this is happening:  https://github.com/ManageIQ/manageiq/pull/15494