### PR TITLE
Force ascending order

### DIFF
--- a/app/controllers/api/base_controller/parameters.rb
+++ b/app/controllers/api/base_controller/parameters.rb
@@ -90,6 +90,9 @@ module Api
         if order
           arel = arel.lower if options.map(&:downcase).include?("ignore_case")
           arel = arel.desc if order.downcase == "desc"
+          arel = arel.asc if order.downcase == "asc"
+        else
+          arel = arel.asc
         end
         arel
       end

--- a/spec/requests/api/querying_spec.rb
+++ b/spec/requests/api/querying_spec.rb
@@ -144,6 +144,20 @@ describe "Querying" do
       expect(response).to have_http_status(:bad_request)
       expect(response.parsed_body).to include(expected)
     end
+
+    it 'allows sorting by asc when other filters are applied' do
+      api_basic_authorize collection_action_identifier(:services, :read, :get)
+      svc1, _svc2 = FactoryGirl.create_list(:service, 2)
+      dept = FactoryGirl.create(:classification_department)
+      FactoryGirl.create(:classification_tag, :name => 'finance', :parent => dept)
+      Classification.classify(svc1, 'department', 'finance')
+
+      run_get services_url, :sort_by => 'created_at', :filter => ['tags.name=/managed/department/finance'],
+              :sort_order => 'asc', :limit => 20, :offset => 0
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['subcount']).to eq(1)
+    end
   end
 
   describe "Filtering vms" do


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1470260

When any `sort_by` is specified, the `arel_attribute` should be in ascending order by default. Currently, `asc` is not called either by default or when it is specified, causing an `Arel::Attributes::Attribute` to be returned, rather than `Arel::Nodes::Ascending:`, resulting in 

```
{
  "error": {
    "kind": "internal_server_error",
    "message": "undefined method `to_sql' for #\u003cArel::Attributes::Attribute:0x007f98f3460288\u003e\nDid you mean?  to_s\n               to_set",
    "klass": "NoMethodError"
  }
}
```

The test added for this comes from the exact query mentioned in this BZ which allowed me to reproduce the bug.

@miq-bot add_label bz, api
cc: @AllenBW @imtayadeway 