### PR TITLE
[FINE] Fix for Bugzilla 1455563

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_service_port_config.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_service_port_config.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceContainerPortConfig < MiqAeServiceModelBase
+  class MiqAeServiceContainerServicePortConfig < MiqAeServiceModelBase
     expose :container_definition, :association => true
   end
 end


### PR DESCRIPTION
Had to fix a service model object name and file name.  Additional fix for Bugzilla 1455563.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1455563

Steps for Testing/QA
-------------------------------
```terminal
# cd <<manageiq>>
# bin/rails c
irb(main):001:0> $evm = MiqAeMethodService::MiqAeService.new(MiqAeEngine::MiqAeWorkspaceRuntime.new)
irb(main):001:0> a = $evm.vmdb(:container_service).all.first
irb(main):001:0> a.associations
irb(main):001:0> a.container_service_port_configs
```
