### PR TITLE
Add average calculation for allocated costs and metrics optionally in chargeback

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -22,7 +22,7 @@ class ChargeableField < ApplicationRecord
   def measure(consumption, options)
     return 1.0 if fixed?
     return 0 if consumption.none?(metric)
-    return consumption.max(metric) if allocated?
+    return consumption.send(options.method_for_allocated_metrics, metric) if allocated?
     return consumption.avg(metric) if used?
   end
 

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -19,7 +19,7 @@ class ChargeableField < ApplicationRecord
   validates :metric, :uniqueness => true, :presence => true
   validates :group, :source, :presence => true
 
-  def measure(consumption)
+  def measure(consumption, options)
     return 1.0 if fixed?
     return 0 if consumption.none?(metric)
     return consumption.max(metric) if allocated?

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -68,7 +68,7 @@ class Chargeback < ActsAsArModel
 
     rates.each do |rate|
       rate.rate_details_relevant_to(relevant_fields).each do |r|
-        r.charge(relevant_fields, consumption).each do |field, value|
+        r.charge(relevant_fields, consumption, @options).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = (self[field] || 0) + value
         end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -16,9 +16,22 @@ class Chargeback
     :userid,
     :ext_options,
     :include_metrics,      # enable charging allocated resources with C & U
+    :method_for_allocated_metrics
   ) do
     def self.new_from_h(hash)
       new(*hash.values_at(*members))
+    end
+
+    ALLOCATED_METHODS_WHITELIST = %i(max avg).freeze
+
+    def method_for_allocated_metrics
+      method = self[:method_for_allocated_metrics] || :max
+
+      unless ALLOCATED_METHODS_WHITELIST.include?(method)
+        raise "Invalid method for allocated calculations #{method}"
+      end
+
+      method
     end
 
     # include_metrics = nil is default value(true)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -23,10 +23,10 @@ class ChargebackRateDetail < ApplicationRecord
     'yearly'  => _('Yearly')
   }.freeze
 
-  def charge(relevant_fields, consumption)
+  def charge(relevant_fields, consumption, options)
     result = {}
     if (relevant_fields & [metric_key, cost_keys[0]]).present?
-      metric_value, cost = metric_and_cost_by(consumption)
+      metric_value, cost = metric_and_cost_by(consumption, options)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0
       end
@@ -162,8 +162,8 @@ class ChargebackRateDetail < ApplicationRecord
     chargeback_tiers.all?(&:gratis?)
   end
 
-  def metric_and_cost_by(consumption)
-    metric_value = chargeable_field.measure(consumption)
+  def metric_and_cost_by(consumption, options)
+    metric_value = chargeable_field.measure(consumption, options)
     [metric_value, hourly_cost(metric_value, consumption) * consumption.consumed_hours_in_interval]
   end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -235,6 +235,27 @@ describe ChargebackVm do
     end
 
     context "Monthly" do
+      context "calculation of allocated metrics by average" do
+        let(:start_time)  { report_run_time - 17.hours }
+        let(:finish_time) { report_run_time - 14.hours }
+        let(:options) { base_options.merge(:interval => 'monthly', :method_for_allocated_metrics => :avg) }
+
+        before do
+          mid_point = month_beginning + 10.days
+          add_metric_rollups_for(@vm1, month_beginning...mid_point, 1.hour, metric_rollup_params)
+          add_metric_rollups_for(@vm1, mid_point...month_end, 1.hour, metric_rollup_params.merge!(:derived_vm_numvcpus => 2))
+        end
+
+        subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
+
+        it "calculates cpu allocated metric" do
+          expect(subject.cpu_allocated_metric).to eq(1.6666666666666667)
+          expect(subject.cpu_allocated_cost).to eq(1200) # ?
+        end
+      end
+    end
+
+    context "Monthly" do
       let(:options) { base_options.merge(:interval => 'monthly') }
       before do
         add_metric_rollups_for(@vm1, month_beginning...month_end, 12.hours, metric_rollup_params)


### PR DESCRIPTION
@miq-bot assign @gtanzillo 

## How are metrics calculated?

let's take requested calculation 
`10 days x 24 Hours x 1 CPU x $1/CPU/Hour + `
`20 days x 24 Hours x 2 CPU x 1 CPU x $1/CPU/Hour = `
`$240 + $960 = $1200 `
`(10*24*1*1) + (20*24*2*1) = $1200`

## Inputs
- Hourly rate $1 (we are calculation in hourly rate, so no conversion is needed here )
- let's take the month of 30 days 
- 1 CPU was allocated in first 10 days in a month
- 2 CPUs were allocated in last 20 days

## Calculation with using average
first, calculate AVG of CPU allocated metrics:
10 days * 24 hours * 1 CPU = 240
20 days * 24 hours * 2 CPU =  1200.0
and in 30 days we have 720 hours
**together average is : (240 + 1200) / 720 = 1.6666666666666667**
so it means that average of allocated CPUs is  1.6666666666666667 each day.
**also, the value 1.67(depends on rounding) will be displayed on the monthly report in column ' vCPUs Allocated over Time Period'** 
and *cost* for the month (in a monthly report):
**1.66...7 * 24 * 30 = $1200**

the average is calculated on the related interval, so weekly it would be:
1. week:
AVG: 7 days with 1 CPU  so AVG is 1 CPU
COST: 1 * 24 * 7 = $168

2. week:
AVG: 3 days with 1 CPU and 4 days with 2 CPU, so (3 * 1 + 4 * 2) / 7 = 1,5714285714
COST: 1,5714285714 * 24 * 7 = $263,9999999952

3. week:
AVG:  7 days with 2 CPU  so AVG is 2 CPU
COST: 2 * 24 * 7 = $ 336 
 
....

## Calculation with using maximum
first, calculate MAX of CPU allocated metrics:
and it is **2 CPUs.**
**also, the value 2 will be displayed on the monthly report in column  `vCPUs Allocated over Time Period`** 
and *cost* for the month (in a monthly report):
**2 * 24 * 30 = $1440**





