### PR TITLE
Set up dialog_field relationships through DialogFieldAssociations

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -6,6 +6,22 @@ class DialogField < ApplicationRecord
   belongs_to :dialog_group
   has_one :resource_action, :as => :resource, :dependent => :destroy
 
+  has_many :dialog_field_associations,
+           :foreign_key => :trigger_id,
+           :class_name  => :DialogFieldAssociation,
+           :dependent   => :destroy
+  has_many :reverse_dialog_field_associations,
+           :foreign_key => :respond_id,
+           :class_name  => :DialogFieldAssociation,
+           :dependent   => :destroy
+
+  has_many :dialog_field_responders,
+           :source  => :respond,
+           :through => :dialog_field_associations
+  has_many :dialog_field_triggers,
+           :source  => :trigger,
+           :through => :reverse_dialog_field_associations
+
   alias_attribute :order, :position
 
   validates_presence_of   :name

--- a/app/models/dialog_field_association.rb
+++ b/app/models/dialog_field_association.rb
@@ -1,0 +1,4 @@
+class DialogFieldAssociation < ActiveRecord::Base
+  belongs_to :trigger, :class_name => :DialogField
+  belongs_to :respond, :class_name => :DialogField
+end


### PR DESCRIPTION
This will allow us to set up associations directly between dialog fields, which we will be using for the targeted auto refresh. ~There are two associations, `dialog_field_trigger_associations` and `dialog_field_respond_associations`. I (originally) went with the verbose name but I think just `trigger_associations` and `respond_associations` is fine too.~

This PR requires a migration, which can be [found here](https://github.com/ManageIQ/manageiq-schema/pull/41).

https://www.pivotaltracker.com/story/show/148838143

@miq-bot assign @gmcculloug 