### PR TITLE
API - refactor error handling

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -29,7 +29,20 @@ module Api
     after_action :log_api_response
 
     respond_to :json
-    ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_error(type, e) } }
+
+    # Order *Must* be from most generic to most specific
+    rescue_from(StandardError)                  { |e| api_error(:internal_server_error, e) }
+    rescue_from(NoMethodError)                  { |e| api_error(:internal_server_error, e) }
+    rescue_from(ActiveRecord::RecordNotFound)   { |e| api_error(:not_found, e) }
+    rescue_from(ActiveRecord::StatementInvalid) { |e| api_error(:bad_request, e) }
+    rescue_from(JSON::ParserError)              { |e| api_error(:bad_request, e) }
+    rescue_from(MultiJson::LoadError)           { |e| api_error(:bad_request, e) }
+    rescue_from(MiqException::MiqEVMLoginError) { |e| api_error(:unauthorized, e) }
+    rescue_from(AuthenticationError)            { |e| api_error(:unauthorized, e) }
+    rescue_from(ForbiddenError)                 { |e| api_error(:forbidden, e) }
+    rescue_from(BadRequestError)                { |e| api_error(:bad_request, e) }
+    rescue_from(NotFoundError)                  { |e| api_error(:not_found, e) }
+    rescue_from(UnsupportedMediaTypeError)      { |e| api_error(:unsupported_media_type, e) }
 
     private
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -12,7 +12,6 @@ module Api
     include_concern 'Manager'
     include_concern 'Action'
     include_concern 'Logger'
-    include_concern 'ErrorHandler'
     include_concern 'Normalizer'
     include_concern 'Renderer'
     include_concern 'Results'

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -53,5 +53,14 @@ module Api
     def collection_config
       @collection_config ||= CollectionConfig.new
     end
+
+    def api_error(type, error)
+      api_log_error("#{error.class.name}: #{error.message}")
+      # We don't want to return the stack trace, but only log it in case of an internal error
+      api_log_error("\n\n#{error.backtrace.join("\n")}") if type == :internal_server_error && !error.backtrace.empty?
+
+      render :json => ErrorSerializer.new(type, error).serialize, :status => Rack::Utils.status_code(type)
+      log_api_response
+    end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,7 +19,6 @@ module Api
     include_concern 'Generic'
     include_concern 'Authentication'
     include ActionController::HttpAuthentication::Basic::ControllerMethods
-    extend ErrorHandler::ClassMethods
 
     before_action :require_api_user_or_token, :except => [:handle_options_request]
     before_action :set_gettext_locale
@@ -31,7 +30,7 @@ module Api
     after_action :log_api_response
 
     respond_to :json
-    rescue_from_api_errors
+    ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_error(type, e) } }
 
     private
 

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -28,12 +28,17 @@ module Api
       end
 
       def api_exception_type(type, e)
-        api_error(type, e.message, e.class.name, e.backtrace.join("\n"), Rack::Utils.status_code(type))
+        api_error(type, e)
       end
 
       private
 
-      def api_error(type, message, klass, backtrace, status)
+      def api_error(type, error)
+        message = error.message
+        klass = error.class.name
+        backtrace = error.backtrace.join("\n")
+        status = Rack::Utils.status_code(type)
+
         err = {
           :kind    => type,
           :message => message,

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -1,12 +1,6 @@
 module Api
   class BaseController
     module ErrorHandler
-      module ClassMethods
-        def rescue_from_api_errors
-          ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_error(type, e) } }
-        end
-      end
-
       private
 
       def api_error(type, error)

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -1,22 +1,6 @@
 module Api
   class BaseController
     module ErrorHandler
-      # Order *Must* be from most generic to most specific
-      ERROR_MAPPING = {
-        StandardError                  => :internal_server_error,
-        NoMethodError                  => :internal_server_error,
-        ActiveRecord::RecordNotFound   => :not_found,
-        ActiveRecord::StatementInvalid => :bad_request,
-        JSON::ParserError              => :bad_request,
-        MultiJson::LoadError           => :bad_request,
-        MiqException::MiqEVMLoginError => :unauthorized,
-        AuthenticationError            => :unauthorized,
-        ForbiddenError                 => :forbidden,
-        BadRequestError                => :bad_request,
-        NotFoundError                  => :not_found,
-        UnsupportedMediaTypeError      => :unsupported_media_type
-      }.freeze
-
       #
       # Class Methods
       #

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -31,10 +31,6 @@ module Api
         api_error(type, e.message, e.class.name, e.backtrace.join("\n"), Rack::Utils.status_code(type))
       end
 
-      def api_error_type(type, message)
-        api_error(type, message, self.class.name, "", Rack::Utils.status_code(type))
-      end
-
       private
 
       def api_error(kind, message, klass, backtrace, status)

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -35,18 +35,11 @@ module Api
         backtrace = error.backtrace.join("\n")
         status = Rack::Utils.status_code(type)
 
-        err = {
-          :kind    => type,
-          :message => message,
-          :klass   => klass
-        }
-        err[:backtrace] = backtrace if Rails.env.test?
-
         api_log_error("#{klass}: #{message}")
         # We don't want to return the stack trace, but only log it in case of an internal error
         api_log_error("\n\n#{backtrace}") if type == :internal_server_error && !backtrace.empty?
 
-        render :json => {:error => err}, :status => status
+        render :json => ErrorSerializer.new(type, error).serialize, :status => status
         log_api_response
       end
     end

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -23,12 +23,8 @@ module Api
 
       module ClassMethods
         def rescue_from_api_errors
-          ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_exception_type(type, e) } }
+          ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_error(type, e) } }
         end
-      end
-
-      def api_exception_type(type, e)
-        api_error(type, e)
       end
 
       private

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -30,16 +30,11 @@ module Api
       private
 
       def api_error(type, error)
-        message = error.message
-        klass = error.class.name
-        backtrace = error.backtrace.join("\n")
-        status = Rack::Utils.status_code(type)
-
-        api_log_error("#{klass}: #{message}")
+        api_log_error("#{error.class.name}: #{error.message}")
         # We don't want to return the stack trace, but only log it in case of an internal error
-        api_log_error("\n\n#{backtrace}") if type == :internal_server_error && !backtrace.empty?
+        api_log_error("\n\n#{error.backtrace.join("\n")}") if type == :internal_server_error && !error.backtrace.empty?
 
-        render :json => ErrorSerializer.new(type, error).serialize, :status => status
+        render :json => ErrorSerializer.new(type, error).serialize, :status => Rack::Utils.status_code(type)
         log_api_response
       end
     end

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -1,10 +1,6 @@
 module Api
   class BaseController
     module ErrorHandler
-      #
-      # Class Methods
-      #
-
       module ClassMethods
         def rescue_from_api_errors
           ERROR_MAPPING.each { |error, type| rescue_from(error) { |e| api_error(type, e) } }

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -33,9 +33,9 @@ module Api
 
       private
 
-      def api_error(kind, message, klass, backtrace, status)
+      def api_error(type, message, klass, backtrace, status)
         err = {
-          :kind    => kind,
+          :kind    => type,
           :message => message,
           :klass   => klass
         }
@@ -43,7 +43,7 @@ module Api
 
         api_log_error("#{klass}: #{message}")
         # We don't want to return the stack trace, but only log it in case of an internal error
-        api_log_error("\n\n#{backtrace}") if kind == :internal_server_error && !backtrace.empty?
+        api_log_error("\n\n#{backtrace}") if type == :internal_server_error && !backtrace.empty?
 
         render :json => {:error => err}, :status => status
         log_api_response

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -1,6 +1,0 @@
-module Api
-  class BaseController
-    module ErrorHandler
-    end
-  end
-end

--- a/app/controllers/api/base_controller/error_handler.rb
+++ b/app/controllers/api/base_controller/error_handler.rb
@@ -1,16 +1,6 @@
 module Api
   class BaseController
     module ErrorHandler
-      private
-
-      def api_error(type, error)
-        api_log_error("#{error.class.name}: #{error.message}")
-        # We don't want to return the stack trace, but only log it in case of an internal error
-        api_log_error("\n\n#{error.backtrace.join("\n")}") if type == :internal_server_error && !error.backtrace.empty?
-
-        render :json => ErrorSerializer.new(type, error).serialize, :status => Rack::Utils.status_code(type)
-        log_api_response
-      end
     end
   end
 end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -6,22 +6,6 @@ module Api
   NotFoundError = Class.new(ApiError)
   UnsupportedMediaTypeError = Class.new(ApiError)
 
-  # Order *Must* be from most generic to most specific
-  ERROR_MAPPING = {
-    StandardError                  => :internal_server_error,
-    NoMethodError                  => :internal_server_error,
-    ActiveRecord::RecordNotFound   => :not_found,
-    ActiveRecord::StatementInvalid => :bad_request,
-    JSON::ParserError              => :bad_request,
-    MultiJson::LoadError           => :bad_request,
-    MiqException::MiqEVMLoginError => :unauthorized,
-    AuthenticationError            => :unauthorized,
-    ForbiddenError                 => :forbidden,
-    BadRequestError                => :bad_request,
-    NotFoundError                  => :not_found,
-    UnsupportedMediaTypeError      => :unsupported_media_type
-  }.freeze
-
   def self.encrypted_attribute?(attr)
     Environment.encrypted_attributes.include?(attr.to_s) || attr.to_s.include?('password')
   end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -6,6 +6,22 @@ module Api
   NotFoundError = Class.new(ApiError)
   UnsupportedMediaTypeError = Class.new(ApiError)
 
+  # Order *Must* be from most generic to most specific
+  ERROR_MAPPING = {
+    StandardError                  => :internal_server_error,
+    NoMethodError                  => :internal_server_error,
+    ActiveRecord::RecordNotFound   => :not_found,
+    ActiveRecord::StatementInvalid => :bad_request,
+    JSON::ParserError              => :bad_request,
+    MultiJson::LoadError           => :bad_request,
+    MiqException::MiqEVMLoginError => :unauthorized,
+    AuthenticationError            => :unauthorized,
+    ForbiddenError                 => :forbidden,
+    BadRequestError                => :bad_request,
+    NotFoundError                  => :not_found,
+    UnsupportedMediaTypeError      => :unsupported_media_type
+  }.freeze
+
   def self.encrypted_attribute?(attr)
     Environment.encrypted_attributes.include?(attr.to_s) || attr.to_s.include?('password')
   end

--- a/lib/services/api/error_serializer.rb
+++ b/lib/services/api/error_serializer.rb
@@ -1,0 +1,22 @@
+module Api
+  class ErrorSerializer
+    attr_reader :kind, :error
+
+    def initialize(kind, error)
+      @kind = kind
+      @error = error
+    end
+
+    def serialize
+      result = {
+        :error => {
+          :kind    => kind,
+          :message => error.message,
+          :klass   => error.class.name
+        }
+      }
+      result[:error][:backtrace] = error.backtrace.join("\n") if Rails.env.test?
+      result
+    end
+  end
+end


### PR DESCRIPTION
A few related refactorings that resulted in net ✂️ and (to me, at least) greater clarity and separation of responsibilities by preferring composition over inheritance. In summary:

* Prefer straightforward `rescue_from` declarations because they're part of the Rails DSL. 
* Replace the `ErrorHandler` mixin with an `ErrorSerializer` object
* Delete some dead code

@miq-bot add-label api, refactoring, technical debt
@miq-bot assign @abellotti 