### PR TITLE
[POC] Implement a basic bundler cache

### DIFF
--- a/bin/build_bundler_cache
+++ b/bin/build_bundler_cache
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/boot"
+
+# Builds the bundler load_path cache
+File.open(".bundler.loadpath_cache", "w") do |f|
+  $LOAD_PATH.each do |path_entry|
+    f.puts path_entry
+  end
+end
+
+# Load things that aren't loaded via bundler require
+require "rails"
+require 'active_record/railtie'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_mailer/railtie'
+require 'active_job/railtie'
+require 'sprockets/railtie'
+require 'action_cable/engine'
+
+# Patch Kernel.require to write it's successful requires to a file
+module Kernel
+  alias original_require require
+end
+
+Kernel.define_singleton_method(:require) do |file|
+  original_require(file) # if this breaks, the next part shouldn't get run
+  # puts "requiring - #{file}"
+  File.write(BUNDLER_REQUIRE_CACHE, "#{file}\n", :mode => "a")
+end
+
+# Builds the Bundler.require cache
+BUNDLER_REQUIRE_CACHE = ".bundler.require_cache"
+File.write(BUNDLER_REQUIRE_CACHE, "") # Clear the file before writing
+Bundler.require(:default, "development")

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ require 'action_cable/engine'
 #
 ENV['BUNDLER_GROUPS'] ||= "manageiq_default"
 
-if defined?(Bundler)
+if defined?(Bundler) && !ENV["WITH_BUNDLER_CACHE"]
   groups = ENV['BUNDLER_GROUPS'].split(",").collect(&:to_sym)
 
   if $DEBUG
@@ -29,6 +29,14 @@ if defined?(Bundler)
   end
 
   Bundler.require(*Rails.groups, *groups)
+else
+  File.read(".bundler.require_cache").lines.each do |file|
+    if Kernel.private_method_defined?(:gem_original_require)
+      Kernel.send(:gem_original_require, file.strip)
+    else
+      Kernel.require file.strip
+    end
+  end
 end
 
 module Vmdb

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,8 +1,17 @@
-require 'rubygems'
+if ENV["WITH_BUNDLER_CACHE"]
+  $LOAD_PATH.clear
+  $LOAD_PATH.insert(0, *File.read(".bundler.loadpath_cache").lines.map(&:strip))
 
-# Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+  require 'bundler/rubygems_integration'
+  Bundler.rubygems.reverse_rubygems_kernel_mixin
+else
+  require 'rubygems'
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-# add the lib dir of the engine if we are running as a dummy app for an engine
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__) if defined?(ENGINE_ROOT)
+  # Set up gems listed in the Gemfile.
+  ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+
+  require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+  # add the lib dir of the engine if we are running as a dummy app for an engine
+  $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__) if defined?(ENGINE_ROOT)
+end


### PR DESCRIPTION
Bundler's job at the beginning application is the following:

* Setup the `$LOAD_PATH` for all of the gems in the bundle
* Require gems in the Gemfile that aren't marked with `:required => false` and are part of the proper bundler groups.

Both of these actions are something that are currently calculated on each application boot.  In development, when things are changing rapidly, this makes sense, but in a production environment this is not necessary as the dependencies should be static, and hopefully immutable.

Using a script to cache the calculated changes made when run these two actions, we can then skip using bundler all together when running the application when opting in to use that cache.

This script included will generate the two caches (one for `$LOAD_PATH`, and one for the absolute paths of the files that should be required) that then can be activated using the ENV variable, `WITH_BUNDLER_CACHE`.


**Before:**

```console
$ bundle exec miqperf profile -mt
** Using session_store: ActionDispatch::Session::MemCacheStore

TOTAL_MEMORY_USED: 161.17578125MiB

Timings
-------
real    0m6.447s
user    0m5.160s
sys     0m1.220s
cuser   0m0.000s
csys    0m0.000s
```


**After:**

```console
$ WITH_BUNDLER_CACHE=1 bundle exec miqperf profile -mt
** Using session_store: ActionDispatch::Session::MemCacheStore

TOTAL_MEMORY_USED: 148.30859375MiB

Timings
-------
real    0m5.090s
user    0m3.940s
sys     0m1.120s
cuser   0m0.000s
csys    0m0.000s
```