### PR TITLE
Return compact orchestration stacks

### DIFF
--- a/app/controllers/api/subcollections/orchestration_stacks.rb
+++ b/app/controllers/api/subcollections/orchestration_stacks.rb
@@ -2,7 +2,7 @@ module Api
   module Subcollections
     module OrchestrationStacks
       def orchestration_stacks_query_resource(object)
-        object.orchestration_stacks
+        object.orchestration_stacks.compact
       end
 
       #


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1470309

In the event that orchestration_stacks returns `[nil]`, the API is raising the error ` "undefined method `keys' for nil:NilClass"` because it's trying to treat `nil` as an object. 

This likely only happens due to bad data, but is a simple enough fix to resolve the issue in this BZ.

@miq_bot add_label bug, api
@miq_bot assign @gtanzillo 
cc: @imtayadeway 
