### PR TITLE
Create API for the Event streams table

### DIFF
--- a/app/controllers/api/event_streams_controller.rb
+++ b/app/controllers/api/event_streams_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class EventStreamsController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -739,6 +739,24 @@
         :identifier: storage_tag
       - :name: unassign
         :identifier: storage_tag
+  :event_streams:
+    :description: Event Streams
+    :identifier: event_stream
+    :options:
+    - :collection
+    :verbs: *gp
+    :klass: EventStream
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: event_stream_show_list
+      :post:
+      - :name: query
+        :identifier: event_stream_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: event_stream_show
   :events:
     :description: Events
     :identifier: event
@@ -758,25 +776,6 @@
       :get:
       - :name: read
         :identifier: event
-  :event_streams:
-    :description: Event Streams
-    :identifier: event_stream
-    :options:
-    - :collection
-    - :subcollection
-    :verbs: *gp
-    :klass: EventStream
-    :collection_actions:
-      :get:
-      - :name: read
-        :identifier: event_stream_show_list
-      :post:
-      - :name: query
-        :identifier: event_stream_show_list
-    :resource_actions:
-      :get:
-      - :name: read
-        :identifier: event_stream
   :features:
     :description: Product Features
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -758,6 +758,25 @@
       :get:
       - :name: read
         :identifier: event
+  :event_streams:
+    :description: Event Streams
+    :identifier: event_stream
+    :options:
+    - :collection
+    - :subcollection
+    :verbs: *gp
+    :klass: EventStream
+    :collection_actions:
+      :get:
+      - :name: read
+        :identifier: event_stream_show_list
+      :post:
+      - :name: query
+        :identifier: event_stream_show_list
+    :resource_actions:
+      :get:
+      - :name: read
+        :identifier: event_stream
   :features:
     :description: Product Features
     :options:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1840,6 +1840,7 @@
         :description: Edit Event
         :feature_type: admin
         :hidden: true
+        :identifier: event_edit
   - :name: Event Streams
     :description: Endpoint event data
     :protected: true
@@ -1858,7 +1859,8 @@
         :identifier: event_stream_show_list
       - :name: Show
         :description: Display Individual Event
-        :feature_type: event_stream_show
+        :feature_type: view
+        :identifier: event_stream_show
   - :name: Actions
     :description: Everything under Policy Actions Accordion
     :protected: true

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1840,7 +1840,25 @@
         :description: Edit Event
         :feature_type: admin
         :hidden: true
-        :identifier: event_edit
+  - :name: Event Streams
+    :description: Endpoint event data
+    :protected: true
+    :feature_type: node
+    :hidden: true
+    :identifier: event_stream
+    :children:
+    - :name: View
+      :description: View Events
+      :feature_type: view
+      :identifier: event_stream_view
+      :children:
+      - :name: List
+        :description: Display Lists of Events
+        :feature_type: view
+        :identifier: event_stream_show_list
+      - :name: Show
+        :description: Display Individual Event
+        :feature_type: event_stream_show
   - :name: Actions
     :description: Everything under Policy Actions Accordion
     :protected: true

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -33,6 +33,8 @@
   - ems_cluster
   - ems_infra
   - ems_physical_infra
+  - event_stream_show_list
+  - event_stream_show
   - container_dashboard
   - ems_container
   - ems_container_deployment
@@ -113,6 +115,8 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_stream_show_list
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -200,6 +204,8 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_stream_show_list
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -353,6 +359,8 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_stream_show_list
+  - event_stream_show
   - host_new
   - host_analyze
   - host_compare
@@ -459,6 +467,8 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_stream_show_list
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -541,6 +551,8 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_stream_show_list
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -622,6 +634,8 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_stream_show_list
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -878,6 +892,8 @@
   - ems_cluster
   - ems_infra
   - ems_physical_infra
+  - event_stream_show_list
+  - event_stream_show
   - host
   - load_balancer
   - miq_ae_class_explorer
@@ -939,6 +955,8 @@
   - ems_cluster
   - ems_infra
   - ems_physical_infra
+  - event_stream_show_list
+  - event_stream_show
   - host
   - miq_ae_class_explorer
   - miq_ae_customization_explorer

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -34,7 +34,7 @@
   - ems_infra
   - ems_physical_infra
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - container_dashboard
   - ems_container
   - ems_container_deployment
@@ -116,7 +116,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -205,7 +205,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -360,7 +360,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host_new
   - host_analyze
   - host_compare
@@ -468,7 +468,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -552,7 +552,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -635,7 +635,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host_show
   - host_show_list
   - host_perf
@@ -893,7 +893,7 @@
   - ems_infra
   - ems_physical_infra
   - event_stream_show_list
-  - event_stream
+  - event_stream_show
   - host
   - load_balancer
   - miq_ae_class_explorer

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -34,7 +34,7 @@
   - ems_infra
   - ems_physical_infra
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - container_dashboard
   - ems_container
   - ems_container_deployment
@@ -116,7 +116,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host_show
   - host_show_list
   - host_perf
@@ -205,7 +205,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host_show
   - host_show_list
   - host_perf
@@ -360,7 +360,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host_new
   - host_analyze
   - host_compare
@@ -468,7 +468,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host_show
   - host_show_list
   - host_perf
@@ -552,7 +552,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host_show
   - host_show_list
   - host_perf
@@ -635,7 +635,7 @@
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host_show
   - host_show_list
   - host_perf
@@ -893,7 +893,7 @@
   - ems_infra
   - ems_physical_infra
   - event_stream_show_list
-  - event_stream_show
+  - event_stream
   - host
   - load_balancer
   - miq_ae_class_explorer

--- a/spec/factories/event_stream.rb
+++ b/spec/factories/event_stream.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :event_stream do
+    sequence(:id) { SecureRandom.random_number(100) }
+    event_type      "TestEntry"
+    source          "TestSource"
+  end
+end

--- a/spec/factories/event_stream.rb
+++ b/spec/factories/event_stream.rb
@@ -1,7 +1,5 @@
 FactoryGirl.define do
   factory :event_stream do
-    sequence(:id) { SecureRandom.random_number(100) }
-    event_type      "TestEntry"
-    source          "TestSource"
+    source "TestSource"
   end
 end

--- a/spec/factories/event_stream.rb
+++ b/spec/factories/event_stream.rb
@@ -1,5 +1,4 @@
 FactoryGirl.define do
   factory :event_stream do
-    source "TestSource"
   end
 end

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -108,7 +108,7 @@ describe "Rest API Collections" do
       FactoryGirl.create(:miq_event_definition)
       test_collection_query(:events, events_url, MiqEventDefinition)
     end
-    
+
     it "query Event Streams" do
       FactoryGirl.create(:event_stream)
       test_collection_query(:event_streams, event_streams_url, EventStream)
@@ -386,7 +386,7 @@ describe "Rest API Collections" do
       FactoryGirl.create(:miq_event_definition)
       test_collection_bulk_query(:events, events_url, MiqEventDefinition)
     end
-    
+
     it "bulk query Event Streams" do
       FactoryGirl.create(:event_stream)
       test_collection_bulk_query(:event_streams, event_streams_url, EventStream)

--- a/spec/requests/api/collections_spec.rb
+++ b/spec/requests/api/collections_spec.rb
@@ -108,6 +108,11 @@ describe "Rest API Collections" do
       FactoryGirl.create(:miq_event_definition)
       test_collection_query(:events, events_url, MiqEventDefinition)
     end
+    
+    it "query Event Streams" do
+      FactoryGirl.create(:event_stream)
+      test_collection_query(:event_streams, event_streams_url, EventStream)
+    end
 
     it "query Features" do
       FactoryGirl.create(:miq_product_feature, :identifier => "vm_auditing")
@@ -380,6 +385,11 @@ describe "Rest API Collections" do
     it "bulk query Events" do
       FactoryGirl.create(:miq_event_definition)
       test_collection_bulk_query(:events, events_url, MiqEventDefinition)
+    end
+    
+    it "bulk query Event Streams" do
+      FactoryGirl.create(:event_stream)
+      test_collection_bulk_query(:event_streams, event_streams_url, EventStream)
     end
 
     it "bulk query Flavors" do

--- a/spec/requests/api/event_streams_spec.rb
+++ b/spec/requests/api/event_streams_spec.rb
@@ -1,0 +1,52 @@
+
+# REST API Request Tests - Event Streams
+#
+# Event primary collection:
+#   /api/event_streams
+#
+#
+describe "Events API" do
+  let(:event_stream_list) { EventStream.pluck(:id) }
+
+  def create_events(count)
+    count.times { FactoryGirl.create(:event_stream) }
+  end
+
+  context "Event Stream collection" do
+    it "query invalid event_stream" do
+      api_basic_authorize action_identifier(:event_streams, :read, :resource_actions, :get)
+
+      run_get event_streams_url(999_999)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "query event_streams with no entries defined" do
+      api_basic_authorize collection_action_identifier(:event_streams, :read, :get)
+
+      run_get event_streams_url
+
+      expect_empty_query_result(:event_streams)
+    end
+
+    it "query event_streams" do
+      api_basic_authorize collection_action_identifier(:event_streams, :read, :get)
+      create_events(3)
+
+      run_get event_streams_url
+
+      expect_query_result(:event_streams, 3, 3)
+      expect_result_resources_to_include_hrefs("resources",
+                                               EventStream.pluck(:id).collect { |id| /^.*#{event_streams_url(id)}$/ })
+    end
+
+    it "query event_streams in expanded form" do
+      api_basic_authorize collection_action_identifier(:event_streams, :read, :get)
+      create_events(3)
+
+      run_get event_streams_url, :expand => "resources"
+
+      expect_query_result(:event_streams, 3, 3)
+    end
+  end
+end

--- a/spec/requests/api/event_streams_spec.rb
+++ b/spec/requests/api/event_streams_spec.rb
@@ -6,11 +6,7 @@
 #
 #
 describe "Events API" do
-  let(:event_stream_list) { EventStream.pluck(:id) }
-
-  def create_events(count)
-    count.times { FactoryGirl.create(:event_stream) }
-  end
+  let(:event_stream_list) { EventStream.pluck(:source) }
 
   context "Event Stream collection" do
     it "query invalid event_stream" do
@@ -31,7 +27,7 @@ describe "Events API" do
 
     it "query event_streams" do
       api_basic_authorize collection_action_identifier(:event_streams, :read, :get)
-      create_events(3)
+      FactoryGirl.create_list(:event_stream, 3)
 
       run_get event_streams_url
 
@@ -42,11 +38,12 @@ describe "Events API" do
 
     it "query event_streams in expanded form" do
       api_basic_authorize collection_action_identifier(:event_streams, :read, :get)
-      create_events(3)
+      FactoryGirl.create_list(:event_stream, 1)
 
       run_get event_streams_url, :expand => "resources"
 
-      expect_query_result(:event_streams, 3, 3)
+      expect_query_result(:event_streams, 1, 1)
+      expect_result_resources_to_include_data("resources", "source" => event_stream_list)
     end
   end
 end


### PR DESCRIPTION
Exposes the event_streams table through the MIQ REST API.  This enables events generated by endpoints managed by the provider to be surfaced via REST.

@miq-bot add_label enhancement, wip