### PR TITLE
ContainerServicePortConfigs is missing :protocol in the index

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -197,7 +197,7 @@ module EmsRefresh::SaveInventoryContainer
 
     container_service.container_service_port_configs.reset
 
-    save_inventory_multi(container_service.container_service_port_configs, hashes, :use_association, [:ems_ref])
+    save_inventory_multi(container_service.container_service_port_configs, hashes, :use_association, [:ems_ref, :protocol])
     store_ids_for_new_records(container_service.container_service_port_configs, hashes, :ems_ref)
   end
 


### PR DESCRIPTION
ContainerServicePortConfigs is missing :protocol in the index.
Without :protocol, the combination of columns is not unique.