### PR TITLE
choose build pod by name AND namespace

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -157,7 +157,8 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_node_id]       = h.fetch_path(:container_node, :id)
       h[:container_replicator_id] = h.fetch_path(:container_replicator, :id)
       h[:container_project_id]    = h.fetch_path(:project, :id)
-      h[:container_build_pod_id]  = ems.container_build_pods.find_by(:name => h[:build_pod_name]).try(:id)
+      h[:container_build_pod_id]  = ems.container_build_pods.find_by(:name      => h[:build_pod_name],
+                                                                     :namespace => h.fetch_path(:project, :name)).try(:id)
     end
 
     save_inventory_multi(ems.container_groups, hashes, :use_association, [:ems_ref],


### PR DESCRIPTION
This will ensure that the ContainerBuildPod associated with a ContainerGroup is from the same namespace.

Tests are in https://github.com/ManageIQ/manageiq-providers-openshift/pull/36 due to the inexistance of tests for this file in this repo.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1474076