### PR TITLE
Fix "Don't use parentheses around a method call."

### DIFF
--- a/app/controllers/api/providers_controller.rb
+++ b/app/controllers/api/providers_controller.rb
@@ -92,7 +92,7 @@ module Api
         attribute["value"] = attribute.delete("field_type").safe_constantize.parse(attribute["value"])
       end
       attribute["section"] ||= "metadata" unless @req.action == "edit"
-      if attribute["section"].present? && !(CustomAttribute::ALLOWED_API_SECTIONS.include? attribute["section"])
+      if attribute["section"].present? && !CustomAttribute::ALLOWED_API_SECTIONS.include?(attribute["section"])
         raise "Invalid attribute section specified: #{attribute["section"]}"
       end
       attribute

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -22,7 +22,7 @@ module Vm::Operations
   end
 
   def ipv4_address
-    ipaddresses.find { |ip| (IPAddr.new ip).ipv4? }
+    ipaddresses.find { |ip| IPAddr.new(ip).ipv4? }
   end
 
   def validate_collect_running_processes

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -18,9 +18,7 @@ module Vmdb
     end
 
     def self.find_available_locales_via_directories
-      Dir.entries(locale_path)
-        .select { |entry| File.directory?(File.join(locale_path, entry)) && entry != '.' && entry != '..' }
-        .sort
+      Dir.entries(locale_path).select { |entry| File.directory?(File.join(locale_path, entry)) && entry != '.' && entry != '..' }.sort
     end
 
     def self.supported_locales

--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -19,7 +19,7 @@ module Vmdb
 
     def self.find_available_locales_via_directories
       Dir.entries(locale_path)
-        .select { |entry| (File.directory? File.join(locale_path, entry)) && entry != '.' && entry != '..' }
+        .select { |entry| File.directory?(File.join(locale_path, entry)) && entry != '.' && entry != '..' }
         .sort
     end
 


### PR DESCRIPTION
Confusion caused by not using parentheses around method params
