### PR TITLE
Use update:ui rake task, instead of update:bower

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ RUN source /etc/default/evm && \
     npm install bower yarn -g && \
     gem install bundler --conservative && \
     bundle install && \
-    rake update:bower && \
+    rake update:ui && \
     bin/rails log:clear tmp:clear && \
     rake evm:compile_assets && \
     rake evm:compile_sti_loader && \

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -37,7 +37,7 @@ module ManageIQ
     def self.while_updating_bower
       # Run bower in a thread and continue to do the non-js stuff
       puts "Updating bower assets in parallel..."
-      bower_thread = Thread.new { update_bower }
+      bower_thread = Thread.new { update_ui }
       bower_thread.abort_on_exception = true
 
       yield
@@ -106,8 +106,8 @@ module ManageIQ
       system!(%q(psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres))
     end
 
-    def self.update_bower
-      system!("bundle exec rake update:bower")
+    def self.update_ui
+      system!("bundle exec rake update:ui")
     end
 
     def self.bundler_version


### PR DESCRIPTION
The idea being that the UI should know what to update, not the backend..

Right now, as of https://github.com/ManageIQ/manageiq-ui-classic/pull/1699, `update:ui` just runs `update:bower` and `update:yarn`.

It will soon also run `webpack:compile`, and eventually drop `update:bower`, none of which should visible on the backend.


This just updates all the mentions of `update:bower` with `update:ui` in manageiq/.

Similar PRs to appliance-build and manageiq-pods will follow.