### PR TITLE
Don't run the broker for ems_inventory if update_driven_refresh is set

### DIFF
--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -5,6 +5,11 @@ class MiqEmsRefreshCoreWorker < MiqWorker
 
   self.required_roles = ["ems_inventory"]
 
+  def self.has_required_role?
+    return false if Settings.prototype.ems_vmware.update_driven_refresh
+    super
+  end
+
   def self.ems_class
     ManageIQ::Providers::Vmware::InfraManager
   end

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -1,13 +1,19 @@
 class MiqVimBrokerWorker < MiqWorker
   require_nested :Runner
 
-  self.required_roles         = %w(
-    ems_inventory
-    ems_metrics_collector
-    ems_operations
-    smartproxy
-    smartstate
-  )
+  self.required_roles         = lambda {
+    roles = %w(
+      ems_metrics_collector
+      ems_operations
+      smartproxy
+      smartstate
+    )
+
+    roles << 'ems_inventory' unless Settings.prototype.ems_vmware.update_driven_refresh
+
+    roles
+  }
+
   self.check_for_minimal_role = false
   self.workers                = lambda {
     return 0 unless ManageIQ::Providers::Vmware::InfraManager.use_vim_broker?

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -2,16 +2,14 @@ class MiqVimBrokerWorker < MiqWorker
   require_nested :Runner
 
   self.required_roles         = lambda {
-    roles = %w(
+    %w(
       ems_metrics_collector
       ems_operations
       smartproxy
       smartstate
-    )
-
-    roles << 'ems_inventory' unless Settings.prototype.ems_vmware.update_driven_refresh
-
-    roles
+    ).tap do |roles|
+      roles << 'ems_inventory' unless Settings.prototype.try(:ems_vmware).try(:update_driven_refresh)
+    end
   }
 
   self.check_for_minimal_role = false

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -46,7 +46,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   end
 
   def has_ems_inventory_role?
-    @active_roles.include?("ems_inventory") && !Settings.prototype.ems_vmware.update_driven_refresh
+    @active_roles.include?("ems_inventory") && !Settings.prototype.try(:ems_vmware).try(:update_driven_refresh)
   end
 
   def reset_broker_update_notification

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -45,8 +45,12 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
     end
   end
 
+  def has_ems_inventory_role?
+    @active_roles.include?("ems_inventory") && !Settings.prototype.ems_vmware.update_driven_refresh
+  end
+
   def reset_broker_update_notification
-    @active_roles.include?("ems_inventory") ? enable_broker_update_notification : disable_broker_update_notification
+    has_ems_inventory_role? ? enable_broker_update_notification : disable_broker_update_notification
   end
 
   def enable_broker_update_notification
@@ -91,7 +95,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   end
 
   def expected_broker_cache_scope
-    @active_roles.include?("ems_inventory") ? :cache_scope_ems_refresh : :cache_scope_core
+    has_ems_inventory_role? ? :cache_scope_ems_refresh : :cache_scope_core
   end
 
   def ems_ids_for_notify(address, userid)
@@ -112,7 +116,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   end
 
   def do_before_work_loop
-    if @active_roles.include?("ems_inventory") && @initial_emses_to_monitor.length > 0
+    if has_ems_inventory_role? && @initial_emses_to_monitor.length > 0
       _log.info("#{log_prefix} Queueing initial refresh for EMS.")
       EmsRefresh.queue_refresh(@initial_emses_to_monitor)
     end

--- a/spec/models/miq_ems_refresh_core_worker_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker_spec.rb
@@ -1,0 +1,17 @@
+describe MiqEmsRefreshCoreWorker do
+  context "update_driven_refresh" do
+    before do
+      stub_settings_merge(
+        :prototype => {
+          :ems_vmware => {
+            :update_driven_refresh => true
+          }
+        }
+      )
+    end
+
+    it ".has_required_role?" do
+      expect(described_class.has_required_role?).to be_falsy
+    end
+  end
+end

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -152,6 +152,14 @@ describe MiqVimBrokerWorker::Runner do
         @vim_broker_worker.create_miq_vim_broker_server
         expect(MiqVimBroker.cacheScope).to eq(:cache_scope_core)
       end
+
+      it "with ems_inventory role using update_driven_refresh" do
+        stub_settings(:prototype => {:ems_vmware => {:update_driven_refresh => true}})
+        @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])
+        expect(MiqVimBroker).to receive(:new).with(:server, 0).once
+        @vim_broker_worker.create_miq_vim_broker_server
+        expect(MiqVimBroker.cacheScope).to eq(:cache_scope_core)
+      end
     end
 
     it "#prime_all_ems" do

--- a/spec/models/miq_vim_broker_worker_spec.rb
+++ b/spec/models/miq_vim_broker_worker_spec.rb
@@ -7,4 +7,36 @@ describe MiqVimBrokerWorker do
 
     expect(described_class.emses_to_monitor).to match_array @zone.ext_management_systems
   end
+
+  context "update_driven_refresh" do
+    before do
+      stub_settings_merge(
+        :prototype => {
+          :ems_vmware => {
+            :update_driven_refresh => true
+          }
+        }
+      )
+    end
+
+    it ".required_roles" do
+      expect(described_class.required_roles.call).not_to include('ems_inventory')
+    end
+  end
+
+  context "standard refresh" do
+    before do
+      stub_settings_merge(
+        :prototype => {
+          :ems_vmware => {
+            :update_driven_refresh => false
+          }
+        }
+      )
+    end
+
+    it ".required_roles" do
+      expect(described_class.required_roles.call).to include('ems_inventory')
+    end
+  end
 end


### PR DESCRIPTION
If using `WaitForUpdates` inventory collection then disable `MiqEmsRefreshCoreWorker` and don't run the `MiqVimBrokerWorker` for the `ems_inventory` role.