### PR TITLE
Fix chargeback report with unassigned rates

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -69,7 +69,7 @@ module MiqReport::Formatting
     # Chargeback Reports: Add the selected currency in the assigned rate to options
     if Chargeback.db_is_chargeback?(db)
       @rates_cache ||= Chargeback::RatesCache.new
-      options[:unit] = @rates_cache.currency_for_report
+      options[:unit] = @rates_cache.currency_for_report if @rates_cache.currency_for_report
     end
 
     format.merge!(options) if format # Merge additional options that were passed in as overrides


### PR DESCRIPTION
caused by https://github.com/ManageIQ/manageiq/pull/13857

Fill `:unit` only if we can determine unit from rates

otherwise

method `ApplicationController.helpers.number_with_delimiter` is called
 (thru  `apply_format_function` and `format_currency_with_delimiter` is called)
with parameters:
`ApplicationController.helpers.number_to_currency('0.0', {:unit => nil} )`
which is causing the error.

## Test Scenario
1. Try to generate chargeback report and don't assign any rates
it will throw an error, 
with this fix it will generate report but without cost values (there are no rates assigned)

## Links 
https://bugzilla.redhat.com/show_bug.cgi?id=1470546

@miq-bot add_label bug, reporting
@miq-bot assign @gtanzillo 

cc @isimluk 
