### PR TITLE
Fix CI after adding new columns to custom_buttons table

### DIFF
--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -222,19 +222,21 @@ describe CustomButton do
     let(:test_button) { described_class.new(:resource_action => resource_action) }
     let(:expected_hash) do
       {
-        "id"                => nil,
-        "guid"              => nil,
-        "description"       => nil,
-        "applies_to_class"  => nil,
-        "applies_to_exp"    => nil,
-        "options"           => nil,
-        "userid"            => nil,
-        "wait_for_complete" => nil,
-        "created_on"        => nil,
-        "updated_on"        => nil,
-        "name"              => nil,
-        "visibility"        => nil,
-        "applies_to_id"     => nil
+        "id"                    => nil,
+        "guid"                  => nil,
+        "description"           => nil,
+        "disabled_text"         => nil,
+        "enablement_expression" => nil,
+        "applies_to_class"      => nil,
+        "options"               => nil,
+        "userid"                => nil,
+        "wait_for_complete"     => nil,
+        "created_on"            => nil,
+        "updated_on"            => nil,
+        "name"                  => nil,
+        "visibility"            => nil,
+        "visibility_expression" => nil,
+        "applies_to_id"         => nil
       }
     end
 


### PR DESCRIPTION
Some columns have been added/changed here:
https://github.com/ManageIQ/manageiq-schema/pull/28
https://github.com/ManageIQ/manageiq-schema/pull/29
but the related spec was not updated.

@miq-bot assign @gtanzillo 
@miq-bot add_label bug