### PR TITLE
Add $SEEDING_LOCK_TIMEOUT for high latency seeding

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -60,15 +60,18 @@ class MiqGroup < ApplicationRecord
     ldap_to_filters = filter_map_file.exist? ? YAML.load_file(filter_map_file) : {}
     root_tenant = Tenant.root_tenant
 
+    groups = all.includes(:entitlement).index_by(&:description)
+    roles  = MiqUserRole.where("name like '%EvmRole-%'").index_by(&:name)
+
     role_map.each_with_index do |(group_name, role_name), index|
-      group = find_by(:description => group_name) || new(:description => group_name)
-      user_role = MiqUserRole.find_by(:name => "EvmRole-#{role_name}")
+      group = groups[group_name] || new(:description => group_name)
+      user_role = roles["EvmRole-#{role_name}"]
       if user_role.nil?
         raise StandardError,
               _("Unable to find user_role 'EvmRole-%{role_name}' for group '%{group_name}'") %
                 {:role_name => role_name, :group_name => group_name}
       end
-      group.miq_user_role       = user_role
+      group.miq_user_role       = user_role if group.entitlement.try(:miq_user_role_id) != user_role.id
       group.sequence            = index + 1
       group.entitlement.filters = ldap_to_filters[group_name]
       group.group_type          = SYSTEM_GROUP

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -63,10 +63,10 @@ class EvmDatabase
     classes ||= PRIMORDIAL_CLASSES + (seedable_model_class_names - PRIMORDIAL_CLASSES)
     classes -= exclude_list
 
+    lock_timeout = ENV["SEEDING_LOCK_TIMEOUT"].to_i # default: 600
+    lock_timeout = 10.minutes if lock_timeout == 0
     # Only 1 machine can go through this at a time
-    # Populating the DB takes 20 seconds
-    # Not populating the db takes 3 seconds
-    MiqDatabase.with_lock(10.minutes) do
+    MiqDatabase.with_lock(lock_timeout) do
       classes.each do |klass|
         begin
           klass = klass.constantize if klass.kind_of?(String)
@@ -90,6 +90,9 @@ class EvmDatabase
     end
 
     _log.info("Seeding... Complete")
+  rescue Timeout::Error
+    _log.error("Timed out seeding database (#{lock_timeout} seconds).")
+    raise
   end
 
   def self.host


### PR DESCRIPTION
### Before

Since seeding can only be performed on one system at a time, we set a timeout to limit our blocking of systems.

The initial seeding over a WAN can take longer than our timeout of 10 minutes.
So the initial seeding times out, the database never gets populated, and the app will never run.

### Solution:

Add a variable to temporarily increase the seeding timeout.
This will give the app enough time for the initial seeding of the database.

Since subsequent seeding is quicker, this option (env variable) only needs to be used for the first boot of the application.

In addition, a more descriptive error message has been to the log.


https://bugzilla.redhat.com/show_bug.cgi?id=1422671

To test, I ran:

```bash
SEEDING_LOCK_TIMEOUT=1 bundle exec rails s
```

