### PR TITLE
upgrade puma gem to 3.7 to work with openssl 1.1 and Fedora 26

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -178,7 +178,7 @@ group :ui_dependencies, :manageiq_default do # Added to Bundler.require in confi
 end
 
 group :web_server, :manageiq_default do
-  gem "puma",                           "~>3.9.0"
+  gem "puma",                           "~>3.7.0"
   gem "responders",                     "~>2.0"
   gem "ruby-dbus" # For external auth
   gem "secure_headers",                 "~>3.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -178,7 +178,7 @@ group :ui_dependencies, :manageiq_default do # Added to Bundler.require in confi
 end
 
 group :web_server, :manageiq_default do
-  gem "puma",                           "~>3.3.0"
+  gem "puma",                           "~>3.9.0"
   gem "responders",                     "~>2.0"
   gem "ruby-dbus" # For external auth
   gem "secure_headers",                 "~>3.0.0"


### PR DESCRIPTION
Fedora 26 use openssl 1.1 and in our Gemfile requires `puma 3.3.x` which doesn't support openssl 1.1. Update to 3.9, it should work with both openssl 1.1 and older version of openssl 1.0. Mangeiq web application looks fine after this modification. Also, after this upgrade, when browse `127.0.0.1:3000` firefox doesn't complain it's insecure now (before it did).