### PR TITLE
Fix bundle override in ManageIQ::Environment

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -52,12 +52,18 @@ module ManageIQ
     end
 
     def self.bundle_install(root = APP_ROOT)
-      system('bundle check', :chdir => root) || system!('bundle install', :chdir => root)
+      system("bundle check", :chdir => root) ||
+        system!("bundle install #{bundle_params}", :chdir => root)
     end
 
     def self.bundle_update(root = APP_ROOT)
-      system!('bundle update', :chdir => root)
+      system!("bundle update #{bundle_params}", :chdir => root)
     end
+
+    def self.bundle_params
+      "--jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}" if ENV['CI']
+    end
+    private_class_method :bundle_params
 
     def self.create_database
       puts "\n== Updating database =="


### PR DESCRIPTION
Commit 04d9a75b overrides Travis' built-in bundle install, which handles
bundle caching as well as parallel installs and retries, but did so
without any of those feature causing them to be lost in all of the
provider repos.

http://talk.manageiq.org/t/can-we-speed-up-small-repos-on-travis/2533

@bdunne Please review.
cc @durandom @cben 