### PR TITLE
[Performance] MiqGroup.seed

### DIFF
--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -6,10 +6,11 @@ class ServerRole < ApplicationRecord
   validates_uniqueness_of   :name
 
   def self.seed
+    server_roles = all.index_by(&:name)
     CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/).each do |csv_row|
       action = csv_row.to_hash
 
-      rec = find_by(:name => action['name'])
+      rec = server_roles[action['name']]
       if rec.nil?
         _log.info("Creating Server Role [#{action['name']}]")
         create(action)


### PR DESCRIPTION
Seeding occurs for every boot of every evmserver. It is also in a mutex.
So reducing timing and queries is important for us
Focusing on top 10 worst offenders

- assigning `group.miq_user_role` was causing a bunch of sub queries, so we added an `if` block
- remove N+1 from `ServerRole`

|       ms |       bytes | objects |query | query ms|     rows |`comments`
|      ---:|         ---:|     ---:|  ---:|     ---:|      ---:| ---
|    230.0 | 11,079,289* | 144,502 |   88 |    64.0 |       53 |`MiqGroup` before
|    179.2 | 7,823,389* | 107,821 |    6 |    37.1 |       53 |`MiqGroup` after
| 22% | 29% | 25% | 93% | 42% | 0% | `delta`

\* Memory usage does not reflect 921 freed objects. 

|       ms |   bytes | objects |query | query ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|    112.1 | 1,717,076* |  22,025 |   20 |    14.5 |       20 |`ServerRole` before
|     96.9 | 1,050,869* |  14,724 |    1 |     7.3 |       20 |`ServerRole` after
| 13.6% | 39% | 33% | 95% | 49.7% | 0% | delta

\* Memory usage does not reflect 134 freed objects. 


Spurred by
https://bugzilla.redhat.com/show_bug.cgi?id=1422671