### PR TITLE
Revert "Fix bundle override in ManageIQ::Environment"

### DIFF
--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -52,18 +52,12 @@ module ManageIQ
     end
 
     def self.bundle_install(root = APP_ROOT)
-      system("bundle check", :chdir => root) ||
-        system!("bundle install #{bundle_params}", :chdir => root)
+      system('bundle check', :chdir => root) || system!('bundle install', :chdir => root)
     end
 
     def self.bundle_update(root = APP_ROOT)
-      system!("bundle update #{bundle_params}", :chdir => root)
+      system!('bundle update', :chdir => root)
     end
-
-    def self.bundle_params
-      "--jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}" if ENV['CI']
-    end
-    private_class_method :bundle_params
 
     def self.create_database
       puts "\n== Updating database =="


### PR DESCRIPTION
ManageIQ/manageiq#15585 unfortunately broke Travis in all provider repos, as `bundle update` doesn't take `--path`.
I'm testing a better fix (`env BUNDLE_PATH`), but until @Fryguy or @bdunne wake up to discuss that, I hope someone can merge this revert.