### PR TITLE
change ManageIQ::Environment to run bundle install on plugin_setup

### DIFF
--- a/lib/generators/provider/templates/bin/setup
+++ b/lib/generators/provider/templates/bin/setup
@@ -9,4 +9,4 @@ unless gem_root.join("spec/manageiq").exist?
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
-ManageIQ::Environment.manageiq_plugin_setup
+ManageIQ::Environment.manageiq_plugin_setup(gem_root)

--- a/lib/generators/provider/templates/bin/update
+++ b/lib/generators/provider/templates/bin/update
@@ -11,4 +11,4 @@ else
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
-ManageIQ::Environment.manageiq_plugin_setup
+ManageIQ::Environment.manageiq_plugin_update

--- a/lib/generators/provider/templates/bin/update
+++ b/lib/generators/provider/templates/bin/update
@@ -11,4 +11,4 @@ else
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
-ManageIQ::Environment.manageiq_plugin_update
+ManageIQ::Environment.manageiq_plugin_setup(gem_root)

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -10,11 +10,20 @@ module ManageIQ
       plugin_root = Pathname.new(caller_locations.last.absolute_path).dirname.parent
 
       install_bundler
-      bundle_update(plugin_root)
+      bundle_install(plugin_root)
 
       ensure_config_files
 
       create_database_user if ENV["CI"]
+
+      setup_test_environment(:task_prefix => 'app:', :root => plugin_root)
+    end
+
+    def self.manageiq_plugin_update
+      # determine plugin root dir. Assume we are called from a 'bin/setup' script in the plugin root
+      plugin_root = Pathname.new(caller_locations.last.absolute_path).dirname.parent
+
+      bundle_update(plugin_root)
 
       setup_test_environment(:task_prefix => 'app:', :root => plugin_root)
     end
@@ -57,7 +66,7 @@ module ManageIQ
     end
 
     def self.bundle_update(root = APP_ROOT)
-      system!("bundle update #{bundle_params}", :chdir => root)
+      system!("bundle update", :chdir => root)
     end
 
     def self.bundle_params

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -5,9 +5,9 @@ module ManageIQ
   module Environment
     APP_ROOT = Pathname.new(__dir__).join("../..")
 
-    def self.manageiq_plugin_setup
+    def self.manageiq_plugin_setup(plugin_root = nil)
       # determine plugin root dir. Assume we are called from a 'bin/setup' script in the plugin root
-      plugin_root = Pathname.new(caller_locations.last.absolute_path).dirname.parent
+      plugin_root ||= Pathname.new(caller_locations.last.absolute_path).dirname.parent
 
       install_bundler
       bundle_install(plugin_root)
@@ -19,9 +19,9 @@ module ManageIQ
       setup_test_environment(:task_prefix => 'app:', :root => plugin_root)
     end
 
-    def self.manageiq_plugin_update
+    def self.manageiq_plugin_update(plugin_root = nil)
       # determine plugin root dir. Assume we are called from a 'bin/setup' script in the plugin root
-      plugin_root = Pathname.new(caller_locations.last.absolute_path).dirname.parent
+      plugin_root ||= Pathname.new(caller_locations.last.absolute_path).dirname.parent
 
       bundle_update(plugin_root)
 


### PR DESCRIPTION
* only pass bundle_params for bundle install
* change plugin_setup task to run bundle install
* add plugin_update task to run bundle update

continued from https://github.com/ManageIQ/manageiq/pull/15508 I think its worth to add an `manageiq_plugin_update` method, as it seems to be different to run `bundle install` vs `bundle update`.

reverts parts of https://github.com/ManageIQ/manageiq/pull/15585
similar to the revert in https://github.com/ManageIQ/manageiq/pull/15588

@Fryguy @bdunne @cben 