### PR TITLE
orchestrate destroy of dependent managers

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -432,16 +432,14 @@ class ExtManagementSystem < ApplicationRecord
     update!(:enabled => true)
   end
 
+  # override destroy_queue from AsyncDeleteMixin
   def self.destroy_queue(ids)
-    ids = Array.wrap(ids)
-    _log.info("Queuing destroy of #{name} with the following ids: #{ids.inspect}")
-    ids.each do |id|
-      schedule_destroy_queue(id)
-    end
+    find(Array.wrap(ids)).each(&:destroy_queue)
   end
 
-  # override destroy_queue from AsyncDeleteMixin
   def destroy_queue
+    _log.info("Queuing destroy of #{self.class.name} with id: #{id}")
+    child_managers.each(&:destroy_queue)
     self.class.schedule_destroy_queue(id)
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -408,6 +408,14 @@ describe ExtManagementSystem do
       ems.destroy
       expect(ExtManagementSystem.count).to eq(1)
     end
+
+    it "queues up destroy for child_managers" do
+      child_manager = FactoryGirl.create(:ext_management_system)
+      ems = FactoryGirl.create(:ext_management_system, :child_managers => [child_manager])
+      expect(described_class).to receive(:schedule_destroy_queue).with(ems.id)
+      expect(described_class).to receive(:schedule_destroy_queue).with(child_manager.id)
+      described_class.destroy_queue(ems.id)
+    end
   end
 
   context "virtual column :supports_block_storage" do


### PR DESCRIPTION
With orchestrated destroy of managers we wait until all workers
are shutdown before actually destroying the ems.

This means, all dependent workers, like network_manager, must
be destroyed as well before we can destroy the cloud manager

I introduce a child_manager association and queues up a destroy of all child_managers

https://github.com/ManageIQ/manageiq/pull/14848

@cben @Ladas @jrafanie 