### PR TITLE
Fix embedded ansible spec tests

### DIFF
--- a/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
+++ b/spec/support/ansible_shared/automation_manager/configuration_script_source.rb
@@ -33,7 +33,7 @@ shared_examples_for "ansible configuration_script_source" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} creation",
           :op_arg  => "(name=My Project)",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -106,7 +106,7 @@ shared_examples_for "ansible configuration_script_source" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} deletion",
           :op_arg  => "(manager_ref=#{tower_project.id})",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -152,7 +152,7 @@ shared_examples_for "ansible configuration_script_source" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} update",
           :op_arg  => "()",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end

--- a/spec/support/ansible_shared/automation_manager/credential.rb
+++ b/spec/support/ansible_shared/automation_manager/credential.rb
@@ -36,7 +36,7 @@ shared_examples_for "ansible credential" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} creation",
           :op_arg  => "(name=My Credential)",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -98,7 +98,7 @@ shared_examples_for "ansible credential" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} deletion",
           :op_arg  => "(manager_ref=#{credential.id})",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end
@@ -145,7 +145,7 @@ shared_examples_for "ansible credential" do
         :options => {
           :op_name => "#{described_class::FRIENDLY_NAME} update",
           :op_arg  => "()",
-          :tower   => "Tower(manager_id=#{manager.id})"
+          :tower   => "EMS(manager_id=#{manager.id})"
         }
       }
     end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/10 changed the notification name from `Tower` to `EMS`, update the specs for embedded ansible to match.