### PR TITLE
[Rearch] Combine worker messages 'sync_config' and sync_active_role' into a single 'sync_config' message.

### DIFF
--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -35,6 +35,7 @@ module MiqServer::WorkerManagement::Heartbeat
     messages.collect do |message, *args|
       case message
       when "sync_active_roles"
+# TODO - need to deal with this
         [message, {:roles => @active_role_names}]
       else
         [message, *args]
@@ -43,13 +44,6 @@ module MiqServer::WorkerManagement::Heartbeat
   end
 
   def worker_set_message(w, message, *args)
-    # Special process for this compound message, by breaking it up into 2 simpler messages
-    if message == 'sync_active_roles_and_config'
-      worker_set_message(w, 'sync_active_roles')
-      worker_set_message(w, 'sync_config')
-      return
-    end
-
     _log.info("#{w.format_full_log_msg} is being requested to #{message}")
     @workers_lock.synchronize(:EX) do
       worker_add_message(w.pid, [message, *args]) if @workers.key?(w.pid)

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -31,16 +31,7 @@ module MiqServer::WorkerManagement::Heartbeat
       h[:queue_name] ||= queue_name
     end unless @workers_lock.nil?
 
-    # Special process the sync_ messages to send the current values of what to synchronize
-    messages.collect do |message, *args|
-      case message
-      when "sync_active_roles"
-# TODO - need to deal with this
-        [message, {:roles => @active_role_names}]
-      else
-        [message, *args]
-      end
-    end
+    messages
   end
 
   def worker_set_message(w, message, *args)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -135,13 +135,7 @@ module MiqServer::WorkerManagement::Monitor
 
     if resync_needed
       @last_sync = Time.now.utc
-      if (config_changed && roles_changed) || sync_interval_reached
-        sync_message = "sync_active_roles_and_config"
-      elsif config_changed
-        sync_message = "sync_config"
-      else
-        sync_message = "sync_active_roles"
-      end
+      sync_message = "sync_config"
 
       sync_config                if config_changed
       sync_assigned_roles        if config_changed

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -267,17 +267,15 @@ class MiqWorker::Runner
     # just consume the restarted message
   end
 
-  def message_sync_active_roles(*args)
-    _log.info("#{log_prefix} Synchronizing active roles...")
-    opts = args.extract_options!
-    sync_active_roles(opts[:roles])
-    _log.info("#{log_prefix} Synchronizing active roles complete...")
-  end
-
   def message_sync_config(*_args)
     _log.info("#{log_prefix} Synchronizing configuration...")
     sync_config
     _log.info("#{log_prefix} Synchronizing configuration complete...")
+
+    _log.info("#{log_prefix} Synchronizing active roles...")
+    opts = _args.extract_options!
+    sync_active_roles(opts[:roles])
+    _log.info("#{log_prefix} Synchronizing active roles complete...")
   end
 
   def sync_config

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -5,7 +5,6 @@ describe MiqEmsRefreshCoreWorker::Runner do
 
     # General stubbing for testing any worker (methods called during initialize)
     @worker_record = FactoryGirl.create(:miq_ems_refresh_core_worker, :queue_name => "ems_#{@ems.id}", :miq_server => server)
-    allow_any_instance_of(described_class).to receive(:sync_active_roles)
     allow_any_instance_of(described_class).to receive(:sync_config)
     allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
     allow_any_instance_of(described_class).to receive(:heartbeat_using_drb?).and_return(false)

--- a/spec/models/miq_queue_worker_base/runner_spec.rb
+++ b/spec/models/miq_queue_worker_base/runner_spec.rb
@@ -3,7 +3,6 @@ describe MiqQueueWorkerBase::Runner do
     let(:server) { EvmSpecHelper.local_miq_server }
     let(:worker) { FactoryGirl.create(:miq_generic_worker, :miq_server => server, :pid => 123) }
     let(:runner) do
-      allow_any_instance_of(MiqQueueWorkerBase::Runner).to receive(:sync_active_roles)
       allow_any_instance_of(MiqQueueWorkerBase::Runner).to receive(:sync_config)
       allow_any_instance_of(MiqQueueWorkerBase::Runner).to receive(:set_connection_pool_size)
       described_class.new(:guid => worker.guid)

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -8,7 +8,6 @@ describe MiqScheduleWorker::Runner do
       @worker = FactoryGirl.create(:miq_schedule_worker, :guid => worker_guid, :miq_server_id => @miq_server.id)
 
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:initialize_rufus)
-      allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:sync_active_roles)
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:sync_config)
       allow_any_instance_of(MiqScheduleWorker::Runner).to receive(:set_connection_pool_size)
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -288,37 +288,6 @@ describe "MiqWorker Monitor" do
           end
         end
 
-        context "when server has a single sync_active_roles message" do
-          before(:each) do
-            @miq_server.message_for_worker(@worker1.id, "sync_active_roles")
-          end
-
-          it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_active_roles', {:roles => nil}]])
-          end
-        end
-
-        context "#stop_worker followed by a single sync_active_roles_and_config message" do
-          before(:each) do
-            @miq_server.stop_worker(@worker1)
-            @miq_server.message_for_worker(@worker1.id, "sync_active_roles_and_config")
-          end
-
-          it "exit message followed by active_roles and config" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['exit'], ['sync_active_roles', {:roles => nil}], ['sync_config']])
-          end
-        end
-
-        context "when server has a single sync_active_roles_and_config message" do
-          before(:each) do
-            @miq_server.message_for_worker(@worker1.id, "sync_active_roles_and_config")
-          end
-
-          it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_active_roles', {:roles => nil}], ['sync_config']])
-          end
-        end
-
         context "when server has a single reconnect_ems message with a parameter" do
           before(:each) do
             @ems_id = 7

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -13,7 +13,6 @@ describe MiqVimBrokerWorker::Runner do
     @worker_record = FactoryGirl.create(:miq_vim_broker_worker, :guid => @worker_guid, :miq_server_id => server.id)
     @drb_uri = "drb://127.0.0.1:12345"
     allow(DRb).to receive(:uri).and_return(@drb_uri)
-    allow_any_instance_of(described_class).to receive(:sync_active_roles)
     allow_any_instance_of(described_class).to receive(:sync_config)
     allow_any_instance_of(described_class).to receive(:set_connection_pool_size)
     allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive(:authentication_check).and_return([true, ""])


### PR DESCRIPTION
Preparing for running workers in pods, we won't be able to pass messages to workers over a Drb connection. Combining
the messages into one that does both every time will simplify the implementation when we use a different mechanism.

In this case, we can simplify the logic in #15471 where memcached is new mechanism

/cc @Fryguy 