### PR TITLE
Backport? (copy) the applicable parts of "New Tower credential types"

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -1,4 +1,4 @@
 # This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential.  We are not modeling the deprecated Azure classic
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential <
-  ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::GoogleCredential
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -1,3 +1,3 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential <
-  ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::NetworkCredential
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::OpenstackCredential
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rackspace_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rackspace_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RackspaceCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::RackspaceCredential
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/satellite6_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/satellite6_credential.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Satellite6Credential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Satellite6Credential
 end

--- a/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
+++ b/spec/vcr_cassettes/manageiq/providers/ansible_tower/automation_manager/refresher_v2.yml
@@ -9529,7 +9529,7 @@ http_interactions:
         "", "last_name": ""}}, "created": "2015-12-17T16:55:29.495Z", "modified":
         "2015-12-17T21:27:48.511Z", "name": "Openstack", "description": "RHOS in NC",
         "user": 2, "team": null, "kind": "openstack", "cloud": true, "host": "http://10.8.96.4:5000/v2.0",
-        "username": "admin", "password": "$encrypted$", "security_token": "", "project":
+        "username": "admin", "password": "$encrypted$", "security_token": "", "domain": "d.com", "project":
         "admin", "ssh_key_data": "", "ssh_key_unlock": "", "become_method": "", "become_username":
         "", "become_password": "", "vault_password": ""}, {"id": 3, "type": "credential",
         "url": "/api/v1/credentials/3/", "related": {"created_by": "/api/v1/users/1/",


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/9

This was revealed by a test failure on the Network Credential in https://github.com/ManageIQ/manageiq/pull/15594 and took forever to debug.

I don't know what else may be missing, but that should be it for https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/9
This is yet another reason to merge https://github.com/ManageIQ/manageiq/pull/15594 since the part that is tested would have been exposed much earlier on.
cc @carbonin @Fryguy @jrafanie 