### PR TITLE
Add a virtual column for `supports_block_storage?` and `supports_cloud_object_store_container_create?`

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -143,7 +143,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_never,         :type => :integer
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
-  virtual_column :v_supports_block_storage, :type => :boolean
+  virtual_column :supports_block_storage,  :type => :boolean
 
   virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
   virtual_aggregate :total_memory, :hosts, :sum, :ram_size
@@ -543,7 +543,7 @@ class ExtManagementSystem < ApplicationRecord
 
   def total_vms_suspended; vm_count_by_state("suspended"); end
 
-  def v_supports_block_storage
+  def supports_block_storage
     supports_block_storage?
   end
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -144,6 +144,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
   virtual_column :supports_block_storage,  :type => :boolean
+  virtual_column :supports_cloud_object_store_container_create, :type => :boolean
 
   virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
   virtual_aggregate :total_memory, :hosts, :sum, :ram_size
@@ -545,6 +546,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_block_storage
     supports_block_storage?
+  end
+
+  def supports_cloud_object_store_container_create
+    supports_cloud_object_store_container_create?
   end
 
   def get_reserve(field)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -143,6 +143,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :total_vms_never,         :type => :integer
   virtual_column :total_vms_suspended,     :type => :integer
   virtual_total  :total_subnets,           :cloud_subnets
+  virtual_column :v_supports_block_storage, :type => :boolean
 
   virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
   virtual_aggregate :total_memory, :hosts, :sum, :ram_size
@@ -541,6 +542,8 @@ class ExtManagementSystem < ApplicationRecord
   def total_vms_never;     vm_count_by_state("never");     end
 
   def total_vms_suspended; vm_count_by_state("suspended"); end
+
+  def v_supports_block_storage; supports_block_storage?; end
 
   def get_reserve(field)
     (hosts + ems_clusters).inject(0) { |v, obj| v + (obj.send(field) || 0) }

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -543,7 +543,9 @@ class ExtManagementSystem < ApplicationRecord
 
   def total_vms_suspended; vm_count_by_state("suspended"); end
 
-  def v_supports_block_storage; supports_block_storage?; end
+  def v_supports_block_storage
+    supports_block_storage?
+  end
 
   def get_reserve(field)
     (hosts + ems_clusters).inject(0) { |v, obj| v + (obj.send(field) || 0) }

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -410,16 +410,18 @@ describe ExtManagementSystem do
   end
 
   context "virtual column :supports_block_storage" do
-    it "returns true for Amazon EBS" do
-      ems_amz_ebs = FactoryGirl.create(:ems_amazon_storage_manager_ebs)
-      expect(ems_amz_ebs.supports_block_storage).to eq(true)
+    it "returns true if block storage is supported" do
+      ems = FactoryGirl.create(:ext_management_system)
+      allow(ems).to receive(:supports_block_storage).and_return(true)
+      expect(ems.supports_block_storage).to eq(true)
     end
   end
 
   context "virtual column :supports_cloud_object_store_container_create" do
-    it "returns true for Amazon S3" do
-      ems_amz_s3 = FactoryGirl.create(:ems_amazon_storage_manager_s3)
-      expect(ems_amz_s3.supports_cloud_object_store_container_create).to eq(true)
+    it "returns true if cloud_object_store_container_create is supported" do
+      ems = FactoryGirl.create(:ext_management_system)
+      allow(ems).to receive(:supports_cloud_object_store_container_create).and_return(true)
+      expect(ems.supports_cloud_object_store_container_create).to eq(true)
     end
   end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -408,4 +408,11 @@ describe ExtManagementSystem do
       expect(ExtManagementSystem.count).to eq(1)
     end
   end
+
+  context "#v_supports_block_storage" do
+    it "returns true for Amazon EBS" do
+      ems_amz_ebs = FactoryGirl.create(:ems_amazon_storage_manager_ebs)
+      expect(ems_amz_ebs.v_supports_block_storage).to eq(true)
+    end
+  end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -409,10 +409,10 @@ describe ExtManagementSystem do
     end
   end
 
-  context "#v_supports_block_storage" do
+  context "virtual column :supports_block_storage" do
     it "returns true for Amazon EBS" do
       ems_amz_ebs = FactoryGirl.create(:ems_amazon_storage_manager_ebs)
-      expect(ems_amz_ebs.v_supports_block_storage).to eq(true)
+      expect(ems_amz_ebs.supports_block_storage).to eq(true)
     end
   end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -415,4 +415,11 @@ describe ExtManagementSystem do
       expect(ems_amz_ebs.supports_block_storage).to eq(true)
     end
   end
+
+  context "virtual column :supports_cloud_object_store_container_create" do
+    it "returns true for Amazon S3" do
+      ems_amz_s3 = FactoryGirl.create(:ems_amazon_storage_manager_s3)
+      expect(ems_amz_s3.supports_cloud_object_store_container_create).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
The following API (that used to work before), returns an empty list currently since APIs do not support filtering on non-column methods anymore.

```
/api/providers?expand=resources&attributes=id,name&filter[]=supports_block_storage?=true
```

The solution is to add a new virtual column: `v_supports_block_storage`  for `supports_block_storage?`.
And while at it, the `?` was dropped from the original name to make it more friendly in the API-based URLs

https://bugzilla.redhat.com/show_bug.cgi?id=1471162
https://bugzilla.redhat.com/show_bug.cgi?id=1471110 