### PR TITLE
Use ovirt-engine-sdk by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -99,7 +99,7 @@
     :purge_window_size: 10000
 :ems:
   :ems_redhat:
-    :use_ovirt_engine_sdk: false
+    :use_ovirt_engine_sdk: true
     :resolve_ip_addresses: true
     :inventory:
       :read_timeout: 1.hour


### PR DESCRIPTION
Changed the setting for using ovirt-engine-sdk to be true by default.