### PR TITLE
small changes to provider generator

### DIFF
--- a/lib/generators/provider/provider_generator.rb
+++ b/lib/generators/provider/provider_generator.rb
@@ -7,6 +7,9 @@ class ProviderGenerator < Rails::Generators::NamedBase
   class_option :path, :type => :string, :default => 'plugins',
                :desc => "Create provider at given path"
 
+  class_option :vcr, :type => :boolean, :default => false,
+               :desc => "Enable VCR cassettes (default off)"
+
   alias provider_name file_name
 
   def initialize(*args)

--- a/lib/generators/provider/templates/.travis.yml
+++ b/lib/generators/provider/templates/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- '2.3.1'
+- '2.3.3'
 - '2.4.1'
 sudo: false
 cache: bundler

--- a/lib/generators/provider/templates/bin/update
+++ b/lib/generators/provider/templates/bin/update
@@ -11,4 +11,4 @@ else
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s
-ManageIQ::Environment.manageiq_plugin_setup(gem_root)
+ManageIQ::Environment.manageiq_plugin_update(gem_root)

--- a/lib/generators/provider/templates/spec/spec_helper.rb
+++ b/lib/generators/provider/templates/spec/spec_helper.rb
@@ -2,12 +2,17 @@ if ENV['CI']
   require 'simplecov'
   SimpleCov.start
 end
-
+<% if options[:vcr] %>
+VCR.configure do |config|
+  config.ignore_hosts 'codeclimate.com' if ENV['CI']
+  config.cassette_library_dir = File.join(ManageIQ::Providers::<%= class_name %>::Engine.root, 'spec/vcr_cassettes')
+end
+<% else %>
 # Uncomment in case you use vcr cassettes
 # VCR.configure do |config|
 #   config.ignore_hosts 'codeclimate.com' if ENV['CI']
 #   config.cassette_library_dir = File.join(ManageIQ::Providers::<%= class_name %>::Engine.root, 'spec/vcr_cassettes')
 # end
-
+<% end %>
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[ManageIQ::Providers::<%= class_name %>::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
* actually call update from update script
* always configure vcr cassettes. This does no harm and makes it easier to re-run the generator
* bump to ruby 2.3.3 in travis.yml

note: those changes are already in open PRs to the provider repos

@miq-bot assign @Fryguy