### PR TITLE
Store created updated and deleted records

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -971,8 +971,10 @@ module ManagerRefresh
 
     # Returns a hash with a simple record identity
     def record_identity(record)
+      identity = record.try(:[], :id) || record.try(:[], "id") || record.try(:id)
+      raise "Cannot obtain identity of the #{record}" if identity.blank?
       {
-        :id => record.try(:[], :id) || record.try(:id)
+        :id => identity
       }
     end
 

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
@@ -3,55 +3,6 @@ module ManagerRefresh::SaveCollection
     class ConcurrentSafe < ManagerRefresh::SaveCollection::Saver::Base
       private
 
-      def save!(inventory_collection, association)
-        attributes_index        = {}
-        inventory_objects_index = {}
-        inventory_collection.each do |inventory_object|
-          attributes = inventory_object.attributes(inventory_collection)
-          index      = inventory_object.manager_uuid
-
-          attributes_index[index]        = attributes
-          inventory_objects_index[index] = inventory_object
-        end
-
-        inventory_collection_size = inventory_collection.size
-        deleted_counter           = 0
-        created_counter           = 0
-        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} *************")
-        # Records that are in the DB, we will be updating or deleting them.
-        ActiveRecord::Base.transaction do
-          association.find_each do |record|
-            next unless assert_distinct_relation(record)
-
-            index = inventory_collection.object_index_with_keys(unique_index_keys, record)
-
-            inventory_object = inventory_objects_index.delete(index)
-            hash             = attributes_index.delete(index)
-
-            if inventory_object.nil?
-              # Record was found in the DB but not sent for saving, that means it doesn't exist anymore and we should
-              # delete it from the DB.
-              deleted_counter += 1 if delete_record!(inventory_collection, record)
-            else
-              # Record was found in the DB and sent for saving, we will be updating the DB.
-              update_record!(inventory_collection, record, hash, inventory_object)
-            end
-          end
-        end
-
-        # Records that were not found in the DB but sent for saving, we will be creating these in the DB.
-        if inventory_collection.create_allowed?
-          ActiveRecord::Base.transaction do
-            inventory_objects_index.each do |index, inventory_object|
-              create_record!(inventory_collection, attributes_index.delete(index), inventory_object)
-              created_counter += 1
-            end
-          end
-        end
-        _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
-                  "updated=#{inventory_collection_size - created_counter}, deleted=#{deleted_counter} *************")
-      end
-
       def update_record!(inventory_collection, record, hash, inventory_object)
         assign_attributes_for_update!(hash, inventory_collection, time_now)
         record.assign_attributes(hash.except(:id, :type))
@@ -64,14 +15,13 @@ module ManagerRefresh::SaveCollection
           end
 
           update_query.update_all(hash)
+          inventory_collection.store_updated_records(record)
         end
 
         inventory_object.id = record.id
       end
 
       def create_record!(inventory_collection, hash, inventory_object)
-        return unless assert_referential_integrity(hash, inventory_object)
-
         all_attribute_keys = hash.keys
         hash               = inventory_collection.model_class.new(hash).attributes.symbolize_keys
         assign_attributes_for_create!(hash, inventory_collection, time_now)
@@ -80,6 +30,7 @@ module ManagerRefresh::SaveCollection
           build_insert_query(inventory_collection, all_attribute_keys, [hash])
         )
         inventory_object.id = result_id
+        inventory_collection.store_created_records(inventory_object)
       end
     end
   end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -131,7 +131,6 @@ module ManagerRefresh::SaveCollection
           assign_attributes_for_create!(hash, inventory_collection, create_time)
 
           next unless assert_referential_integrity(hash, inventory_object)
-          inventory_collection.store_created_records(hash)
 
           hashes << hash
           # Index on Unique Columns values, so we can easily fill in the :id later
@@ -143,6 +142,7 @@ module ManagerRefresh::SaveCollection
         result = ActiveRecord::Base.connection.execute(
           build_insert_query(inventory_collection, all_attribute_keys, hashes)
         )
+        inventory_collection.store_created_records(result)
         if inventory_collection.dependees.present?
           # We need to get primary keys of the created objects, but only if there are dependees that would use them
           map_ids_to_inventory_objects(inventory_collection, indexed_inventory_objects, all_attribute_keys, hashes, result)

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -21,11 +21,7 @@ module ManagerRefresh::SaveCollection
         all_attribute_keys += [:created_on, :updated_on] if inventory_collection.supports_timestamps_on_variant?
         all_attribute_keys += [:created_at, :updated_at] if inventory_collection.supports_timestamps_at_variant?
 
-        inventory_collection_size = inventory_collection.size
-        deleted_counter           = 0
-        created_counter           = 0
-        updated_counter           = 0
-        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} *************")
+        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection.size} *************")
         hashes_for_update = []
         records_for_destroy = []
 
@@ -45,7 +41,6 @@ module ManagerRefresh::SaveCollection
               # delete it from the DB.
               if inventory_collection.delete_allowed?
                 records_for_destroy << record
-                deleted_counter += 1
               end
             else
               # Record was found in the DB and sent for saving, we will be updating the DB.
@@ -69,7 +64,7 @@ module ManagerRefresh::SaveCollection
           # Update in batches
           if hashes_for_update.size >= batch_size
             update_records!(inventory_collection, all_attribute_keys, hashes_for_update)
-            updated_counter += hashes_for_update.count
+            inventory_collection.store_updated_records(hashes_for_update)
 
             hashes_for_update = []
           end
@@ -77,13 +72,13 @@ module ManagerRefresh::SaveCollection
           # Destroy in batches
           if records_for_destroy.size >= batch_size
             destroy_records(records_for_destroy)
+            inventory_collection.store_deleted_records(records_for_destroy)
             records_for_destroy = []
           end
         end
 
         # Update the last batch
         update_records!(inventory_collection, all_attribute_keys, hashes_for_update)
-        updated_counter += hashes_for_update.count
         hashes_for_update = [] # Cleanup so GC can release it sooner
 
         # Destroy the last batch
@@ -95,11 +90,12 @@ module ManagerRefresh::SaveCollection
         if inventory_collection.create_allowed?
           inventory_objects_index.each_slice(batch_size) do |batch|
             create_records!(inventory_collection, all_attribute_keys, batch, attributes_index)
-            created_counter += batch.size
           end
         end
-        _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
-                  "updated=#{updated_counter}, deleted=#{deleted_counter} *************")
+        _log.info("*************** PROCESSED #{inventory_collection}, "\
+                  "created=#{inventory_collection.created_records.count}, "\
+                  "updated=#{inventory_collection.updated_records.count}, "\
+                  "deleted=#{inventory_collection.deleted_records.count} *************")
       end
 
       def destroy_records(records)
@@ -135,6 +131,7 @@ module ManagerRefresh::SaveCollection
           assign_attributes_for_create!(hash, inventory_collection, create_time)
 
           next unless assert_referential_integrity(hash, inventory_object)
+          inventory_collection.store_created_records(hash)
 
           hashes << hash
           # Index on Unique Columns values, so we can easily fill in the :id later

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -56,6 +56,7 @@ module ManagerRefresh::SaveCollection
                                   hash.symbolize_keys
                                 end
               assign_attributes_for_update!(hash_for_update, inventory_collection, update_time)
+              inventory_collection.store_updated_records(record)
 
               hashes_for_update << hash_for_update.except(:id, :type)
             end
@@ -64,7 +65,6 @@ module ManagerRefresh::SaveCollection
           # Update in batches
           if hashes_for_update.size >= batch_size
             update_records!(inventory_collection, all_attribute_keys, hashes_for_update)
-            inventory_collection.store_updated_records(hashes_for_update)
 
             hashes_for_update = []
           end
@@ -83,6 +83,7 @@ module ManagerRefresh::SaveCollection
 
         # Destroy the last batch
         destroy_records(records_for_destroy)
+        inventory_collection.store_deleted_records(records_for_destroy)
         records_for_destroy = [] # Cleanup so GC can release it sooner
 
         all_attribute_keys << :type if inventory_collection.supports_sti?

--- a/app/models/manager_refresh/save_collection/saver/default.rb
+++ b/app/models/manager_refresh/save_collection/saver/default.rb
@@ -3,82 +3,36 @@ module ManagerRefresh::SaveCollection
     class Default < ManagerRefresh::SaveCollection::Saver::Base
       private
 
-      def save!(inventory_collection, association)
-        attributes_index        = {}
-        inventory_objects_index = {}
-        inventory_collection.each do |inventory_object|
-          attributes = inventory_object.attributes(inventory_collection)
-          index      = inventory_object.manager_uuid
-
-          attributes_index[index]        = attributes
-          inventory_objects_index[index] = inventory_object
-        end
-
-        unique_db_indexes = Set.new
-
-        inventory_collection_size = inventory_collection.size
-        deleted_counter           = 0
-        created_counter           = 0
-        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection_size} *************")
-        # Records that are in the DB, we will be updating or deleting them.
-        ActiveRecord::Base.transaction do
-          association.find_each do |record|
-            next unless assert_distinct_relation(record)
-
-            index = inventory_collection.object_index_with_keys(unique_index_keys, record)
-
-            # TODO(lsmola) can go away once we indexed our DB with unique indexes
-            if unique_db_indexes.include?(index) # Include on Set is O(1)
-              # We have a duplicate in the DB, destroy it. A find_each method does automatically .order(:id => :asc)
-              # so we always keep the oldest record in the case of duplicates.
-              _log.warn("A duplicate record was detected and destroyed, inventory_collection: "\
-                        "'#{inventory_collection}', record: '#{record}', duplicate_index: '#{index}'")
-              record.destroy
-            else
-              unique_db_indexes << index
-            end
-
-            inventory_object = inventory_objects_index.delete(index)
-            hash             = attributes_index.delete(index)
-
-            if inventory_object.nil?
-              # Record was found in the DB but not sent for saving, that means it doesn't exist anymore and we should
-              # delete it from the DB.
-              deleted_counter += 1 if delete_record!(inventory_collection, record)
-            else
-              # Record was found in the DB and sent for saving, we will be updating the DB.
-              update_record!(inventory_collection, record, hash, inventory_object)
-            end
-          end
-        end
-
-        # Records that were not found in the DB but sent for saving, we will be creating these in the DB.
-        if inventory_collection.create_allowed?
-          ActiveRecord::Base.transaction do
-            inventory_objects_index.each do |index, inventory_object|
-              hash = attributes_index.delete(index)
-              create_record!(inventory_collection, hash, inventory_object)
-              created_counter += 1
-            end
-          end
-        end
-        _log.info("*************** PROCESSED #{inventory_collection}, created=#{created_counter}, "\
-                  "updated=#{inventory_collection_size - created_counter}, deleted=#{deleted_counter} *************")
-      end
-
       def update_record!(inventory_collection, record, hash, inventory_object)
         record.assign_attributes(hash.except(:id, :type))
-        record.save if !inventory_collection.check_changed? || record.changed?
+        if !inventory_collection.check_changed? || record.changed?
+          record.save
+          inventory_collection.store_updated_records(record)
+        end
 
         inventory_object.id = record.id
       end
 
       def create_record!(inventory_collection, hash, inventory_object)
-        return unless assert_referential_integrity(hash, inventory_object)
-
         record = inventory_collection.model_class.create!(hash.except(:id))
+        inventory_collection.store_created_records(record)
 
         inventory_object.id = record.id
+      end
+
+      def assert_unique_record(record, index)
+        # TODO(lsmola) can go away once we indexed our DB with unique indexes
+        if unique_db_indexes.include?(index) # Include on Set is O(1)
+          # We have a duplicate in the DB, destroy it. A find_each method does automatically .order(:id => :asc)
+          # so we always keep the oldest record in the case of duplicates.
+          _log.warn("A duplicate record was detected and destroyed, inventory_collection: "\
+                        "'#{inventory_collection}', record: '#{record}', duplicate_index: '#{index}'")
+          record.destroy
+          return false
+        else
+          unique_db_indexes << index
+        end
+        true
       end
     end
   end

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -132,10 +132,37 @@ describe ManagerRefresh::SaveInventory do
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
+            # Check the InventoryCollection result matches what was created/deleted/updated
+            expect(@data[:vms].created_records).to match_array([])
+            expect(@data[:vms].updated_records).to match_array([{:id => @vm1.id}, {:id => @vm2.id}])
+            expect(@data[:vms].deleted_records).to match_array([])
+
             # Assert that saved data have the updated values, checking id to make sure the original records are updated
             assert_all_records_match_hashes(
               [Vm.all, @ems.vms],
               {:id => @vm1.id, :ems_ref => "vm_ems_ref_1", :name => "vm_changed_name_1", :location => "vm_location_1"},
+              {:id => @vm2.id, :ems_ref => "vm_ems_ref_2", :name => "vm_changed_name_2", :location => "vm_location_2"}
+            )
+          end
+
+          it 'updates 1 existing VM' do
+            # Fill the InventoryCollections with data, that have a modified name
+            add_data_to_inventory_collection(@data[:vms],
+                                             vm_data(1),
+                                             vm_data(2).merge(:name => "vm_changed_name_2"))
+
+            # Invoke the InventoryCollections saving
+            ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
+
+            # Check the InventoryCollection result matches what was created/deleted/updated
+            expect(@data[:vms].created_records).to match_array([])
+            expect(@data[:vms].updated_records).to match_array([{:id => @vm2.id}])
+            expect(@data[:vms].deleted_records).to match_array([])
+
+            # Assert that saved data have the updated values, checking id to make sure the original records are updated
+            assert_all_records_match_hashes(
+              [Vm.all, @ems.vms],
+              {:id => @vm1.id, :ems_ref => "vm_ems_ref_1", :name => "vm_name_1", :location => "vm_location_1"},
               {:id => @vm2.id, :ems_ref => "vm_ems_ref_2", :name => "vm_changed_name_2", :location => "vm_location_2"}
             )
           end
@@ -149,6 +176,12 @@ describe ManagerRefresh::SaveInventory do
 
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
+
+            # Check the InventoryCollection result matches what was created/deleted/updated
+            @vm3 = Vm.find_by(:ems_ref => "vm_ems_ref_3")
+            expect(@data[:vms].created_records).to match_array([{:id => @vm3.id}])
+            expect(@data[:vms].updated_records).to match_array([{:id => @vm1.id}, {:id => @vm2.id}])
+            expect(@data[:vms].deleted_records).to match_array([])
 
             # Assert that saved data contain the new VM
             assert_all_records_match_hashes(
@@ -167,6 +200,11 @@ describe ManagerRefresh::SaveInventory do
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
+            # Check the InventoryCollection result matches what was created/deleted/updated
+            expect(@data[:vms].created_records).to match_array([])
+            expect(@data[:vms].updated_records).to match_array([{:id => @vm1.id}])
+            expect(@data[:vms].deleted_records).to match_array([{:id => @vm2.id}])
+
             # Assert that saved data do miss the deleted VM
             assert_all_records_match_hashes(
               [Vm.all, @ems.vms],
@@ -182,6 +220,12 @@ describe ManagerRefresh::SaveInventory do
 
             # Invoke the InventoryCollections saving
             ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
+
+            # Check the InventoryCollection result matches what was created/deleted/updated
+            @vm3 = Vm.find_by(:ems_ref => "vm_ems_ref_3")
+            expect(@data[:vms].created_records).to match_array([{:id => @vm3.id}])
+            expect(@data[:vms].updated_records).to match_array([{:id => @vm1.id}])
+            expect(@data[:vms].deleted_records).to match_array([{:id => @vm2.id}])
 
             # Assert that saved data have the new VM and miss the deleted VM
             assert_all_records_match_hashes(


### PR DESCRIPTION
Store created updated and deleted records. This information can be than used in post refresh to e.g. queue up more jobs for created items. Or by another graph node for post processing to e.g. assign/delete records from folders.