### PR TITLE
Add queue_authentication_check to authentication mixin

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -13,7 +13,7 @@ module AuthenticationMixin
       assocs.each { |a| a.authentication_check_types_queue(:attempt => 1) }
     end
 
-    def self.queue_authentication_check(args, user_id, zone)
+    def self.validate_credentials_task(args, user_id, zone)
       task_opts = {
         :action => "Validate EMS Provider Credentials",
         :userid => user_id
@@ -37,7 +37,7 @@ module AuthenticationMixin
         error_message = task.message
       end
 
-      [!error_message.present?, error_message]
+      [error_message.blank?, error_message]
     end
   end
 

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -12,6 +12,33 @@ module AuthenticationMixin
       assocs = zone.respond_to?(assoc) ? zone.send(assoc) : []
       assocs.each { |a| a.authentication_check_types_queue(:attempt => 1) }
     end
+
+    def self.queue_authentication_check(args, user_id, zone)
+      task_opts = {
+        :action => "Validate EMS Provider Credentials",
+        :userid => user_id
+      }
+
+      queue_opts = {
+        :args        => [*args],
+        :class_name  => self,
+        :method_name => "raw_connect",
+        :queue_name  => "generic",
+        :role        => "ems_operations",
+        :zone        => zone
+      }
+
+      task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
+      task = MiqTask.wait_for_taskid(task_id, :timeout => 30)
+
+      if task.nil?
+        error_message = "Task Error"
+      elsif MiqTask.status_error?(task.status) || MiqTask.status_timeout?(task.status)
+        error_message = task.message
+      end
+
+      [!error_message.present?, error_message]
+    end
   end
 
   def supported_auth_attributes

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -258,6 +258,43 @@ describe AuthenticationMixin do
       end
     end
 
+    context ".queue_authentication_check" do
+      let(:args) { ['userid', 'password', 'foo'] }
+      let(:queue_opts) do
+        {
+          :args        => [*args],
+          :class_name  => ExtManagementSystem,
+          :method_name => "raw_connect",
+          :queue_name  => "generic",
+          :role        => "ems_operations",
+          :zone        => 'zone'
+        }
+      end
+      let(:task_opts) do
+        {
+          :action => "Validate EMS Provider Credentials",
+          :userid => 'userid'
+        }
+      end
+
+      it "returns success with no error message" do
+        ok_task = FactoryGirl.create(:miq_task, :status => 'Ok')
+        allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
+        allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(ok_task)
+
+        expect(ExtManagementSystem.queue_authentication_check(args, 'userid', 'zone')).to eq([true, nil])
+      end
+
+      it "returns failure with an error message" do
+        message = 'Login failed due to a bad username or password.'
+        error_task = FactoryGirl.create(:miq_task, :status => 'Error', :message => message)
+        allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
+        allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(error_task)
+
+        expect(ExtManagementSystem.queue_authentication_check(args, 'userid', 'zone')).to eq([false, message])
+      end
+    end
+
     context "with a host and ems" do
       before(:each) do
         @host         = FactoryGirl.create(:host_vmware_esx_with_authentication)

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -258,8 +258,8 @@ describe AuthenticationMixin do
       end
     end
 
-    context ".queue_authentication_check" do
-      let(:args) { ['userid', 'password', 'foo'] }
+    context ".validate_credentials_task" do
+      let(:args) { %w(userid password foo) }
       let(:queue_opts) do
         {
           :args        => [*args],
@@ -282,7 +282,7 @@ describe AuthenticationMixin do
         allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
         allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(ok_task)
 
-        expect(ExtManagementSystem.queue_authentication_check(args, 'userid', 'zone')).to eq([true, nil])
+        expect(ExtManagementSystem.validate_credentials_task(args, 'userid', 'zone')).to eq([true, nil])
       end
 
       it "returns failure with an error message" do
@@ -291,7 +291,7 @@ describe AuthenticationMixin do
         allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
         allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(error_task)
 
-        expect(ExtManagementSystem.queue_authentication_check(args, 'userid', 'zone')).to eq([false, message])
+        expect(ExtManagementSystem.validate_credentials_task(args, 'userid', 'zone')).to eq([false, message])
       end
     end
 


### PR DESCRIPTION
This removes the queue_authentication_check logic originally found in https://github.com/ManageIQ/manageiq-ui-classic/pull/1580 to be a class method on the provider.

This is a part of the process of moving the current credential validation in the UI to the queue.

@miq-bot add_label authentication 