### PR TITLE
Exports new DialogFieldAssociations data

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -11,10 +11,9 @@ class DialogFieldSerializer < Serializer
 
   def serialize(dialog_field, all_attributes = false)
     serialized_resource_action = @resource_action_serializer.serialize(dialog_field.resource_action)
-
     extra_attributes = {
-      "resource_action"      => serialized_resource_action,
-      "trigger_associations" => dialog_field.trigger_associations.map(&:name)
+      "resource_action"         => serialized_resource_action,
+      "dialog_field_responders" => dialog_field.dialog_field_responders.map(&:name)
     }
 
     if dialog_field.dynamic?
@@ -26,7 +25,6 @@ class DialogFieldSerializer < Serializer
       category = Category.find_by(:id => dialog_field.category)
       dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
     end
-
     included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)
   end
 end

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -13,7 +13,8 @@ class DialogFieldSerializer < Serializer
     serialized_resource_action = @resource_action_serializer.serialize(dialog_field.resource_action)
 
     extra_attributes = {
-      "resource_action" => serialized_resource_action
+      "resource_action"      => serialized_resource_action,
+      "trigger_associations" => dialog_field.trigger_associations.map(&:name)
     }
 
     if dialog_field.dynamic?

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -3,9 +3,10 @@ describe DialogFieldSerializer do
   let(:dialog_field_serializer) { described_class.new(resource_action_serializer) }
 
   describe "#serialize" do
-    let(:dialog_field) { DialogFieldTextBox.new(expected_serialized_values.merge(:resource_action => resource_action)) }
+    let(:dialog_field) { DialogFieldTextBox.new(expected_serialized_values.merge(:resource_action => resource_action, :dialog_field_responders => dialog_field_responders)) }
     let(:type) { "DialogFieldTextBox" }
     let(:resource_action) { ResourceAction.new }
+    let(:dialog_field_responders) { [] }
     let(:options) { {"options" => true} }
     let(:expected_serialized_values) do
       {
@@ -59,8 +60,9 @@ describe DialogFieldSerializer do
         it 'serializes the dialog_field with the correct attributes' do
           expect(dialog_field_serializer.serialize(dialog_field, all_attributes))
             .to eq(expected_serialized_values.merge(
-                     "resource_action" => "serialized resource action",
-                     "values"          => "dynamic values"
+                     "resource_action"         => "serialized resource action",
+                     "values"                  => "dynamic values",
+                     "dialog_field_responders" => dialog_field_responders
             ))
         end
       end
@@ -88,7 +90,8 @@ describe DialogFieldSerializer do
         it "serializes the dialog_field with the correct values" do
           expect(dialog_field_serializer.serialize(dialog_field, all_attributes))
             .to eq(expected_serialized_values.merge(
-                     "resource_action" => "serialized resource action"
+                     "resource_action"         => "serialized resource action",
+                     "dialog_field_responders" => dialog_field_responders
             ))
         end
       end
@@ -103,12 +106,24 @@ describe DialogFieldSerializer do
                           'resource_action' => 'serialized resource action',
             ))
         end
+
+        context 'with associations' do
+          let(:dialog_field_responders) { [FactoryGirl.build(:dialog_field_text_box)] }
+
+          it 'serializes the dialog_field with all attributes and non_empty associations' do
+            expect(dialog_field_serializer.serialize(dialog_field, dialog_field_responders))
+              .to include(expected_serialized_values.merge(
+                            "resource_action"         => "serialized resource action",
+                            "dialog_field_responders" => ["Dialog Field"]
+              ))
+          end
+        end
       end
     end
 
     context "when the dialog_field is a tag control type" do
       let(:dialog_field) do
-        DialogFieldTagControl.new(expected_serialized_values.merge(:resource_action => resource_action))
+        DialogFieldTagControl.new(expected_serialized_values.merge(:resource_action => resource_action, :dialog_field_responders => dialog_field_responders))
       end
 
       let(:type) { "DialogFieldTagControl" }
@@ -124,8 +139,9 @@ describe DialogFieldSerializer do
       it "serializes the category name and description" do
         expect(dialog_field_serializer.serialize(dialog_field))
           .to eq(expected_serialized_values.merge(
-                   "resource_action" => "serialized resource action",
-                   "options"         => {
+                   "resource_action"         => "serialized resource action",
+                   "dialog_field_responders" => dialog_field_responders,
+                   "options"                 => {
                      :category_id          => "123",
                      :category_name        => "best category ever",
                      :category_description => "best category ever"


### PR DESCRIPTION
Allows us to include the relationship data set up between dialog fields for targeted auto refresh by the two associations (trigger and response) in the dialog export (here: [corresponding main repo PR](https://github.com/ManageIQ/manageiq/pull/15566) and necessary [migration](https://github.com/ManageIQ/manageiq-schema/pull/41)). The additional metadata that's introduced includes two fields: a "trigger_id" and "respond_id" added via the extra_attributes in the serializer with an array of field names in the associations. 

      dialog_fields:
      - name: name
        description: Name of the newly created virtual machine
        data_type: 
        notes: 
        ...
       dialog_field_responders:
        - resource_group
        - new_resource_group
        - param_adminUserName
        - param_operatingSystemType

Related to:
PR https://github.com/ManageIQ/manageiq/pull/15724
PR https://github.com/ManageIQ/manageiq/pull/15740

PR https://github.com/ManageIQ/manageiq/pull/15566 (merged)
https://github.com/ManageIQ/manageiq-schema/pull/41 (merged)