### PR TITLE
Track and kill embedded ansible monitoring thread

### DIFF
--- a/app/models/embedded_ansible_worker.rb
+++ b/app/models/embedded_ansible_worker.rb
@@ -5,7 +5,12 @@ class EmbeddedAnsibleWorker < MiqWorker
   self.required_roles = ['embedded_ansible']
 
   def start_runner
-    Thread.new do
+    start_monitor_thread
+    nil # return no pid
+  end
+
+  def start_monitor_thread
+    t = Thread.new do
       begin
         self.class::Runner.start_worker(worker_options)
         # TODO: return supervisord pid
@@ -17,12 +22,34 @@ class EmbeddedAnsibleWorker < MiqWorker
         Thread.exit
       end
     end
-    nil # return no pid
+
+    t[:worker_class] = self.class.name
+    t[:worker_id]    = id
+    t
   end
 
   def kill
-    stop
+    thread = find_worker_thread_object
+
+    if thread == Thread.main
+      _log.warn("Cowardly refusing to kill the main thread.")
+    elsif thread.nil?
+      _log.info("The monitor thread for worker id: #{id} was not found, it must have already exited.")
+    else
+      _log.info("Exiting monitor thread...")
+      thread.exit
+    end
+    destroy
   end
+
+  def find_worker_thread_object
+    Thread.list.detect do |t|
+      t[:worker_id] == id && t[:worker_class] == self.class.name
+    end
+  end
+
+  alias terminate kill
+  alias stop kill
 
   def status_update
     # don't monitor the memory/cpu usage of this process yet

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -176,7 +176,6 @@ class MiqWorker::Runner
 
   def starting_worker_record
     find_worker_record
-    @worker.pid            = Process.pid
     @worker.status         = "starting"
     @worker.started_on     = Time.now.utc
     @worker.last_heartbeat = Time.now.utc
@@ -190,7 +189,7 @@ class MiqWorker::Runner
     @worker.last_heartbeat = Time.now.utc
     @worker.update_spid
     @worker.save
-    $log.info("#{self.class.name} started. ID [#{@worker.id}], PID [#{Process.pid}], GUID [#{@worker.guid}], Zone [#{MiqServer.my_zone}], Role [#{MiqServer.my_role}]")
+    $log.info("#{self.class.name} started. ID [#{@worker.id}], PID [#{@worker.pid}], GUID [#{@worker.guid}], Zone [#{MiqServer.my_zone}], Role [#{MiqServer.my_role}]")
   end
 
   def reload_worker_record
@@ -293,7 +292,7 @@ class MiqWorker::Runner
     sync_log_level
     sync_worker_settings
     sync_blacklisted_events
-    _log.info("ID [#{@worker.id}], PID [#{Process.pid}], GUID [#{@worker.guid}], Zone [#{@my_zone}], Active Roles [#{@active_roles.join(',')}], Assigned Roles [#{MiqServer.my_role}], Configuration:")
+    _log.info("ID [#{@worker.id}], PID [#{@worker.pid}], GUID [#{@worker.guid}], Zone [#{@my_zone}], Active Roles [#{@active_roles.join(',')}], Assigned Roles [#{MiqServer.my_role}], Configuration:")
     $log.log_hashes(@worker_settings)
     $log.info("---")
     $log.log_hashes(@cfg)


### PR DESCRIPTION
This PR will prevent embedded ansible monitoring threads from piling up if the setup takes a very long time, leading to the bug fixed by: https://github.com/ManageIQ/manageiq-gems-pending/pull/247.

Do we need this on euwe?

https://bugzilla.redhat.com/show_bug.cgi?id=1469307
https://bugzilla.redhat.com/show_bug.cgi?id=1468898

```
Tag the monitor thread with the worker info so we can kill it later

When the server starts the monitor thread, store the worker class and id
in the thread object so the server can then kill that thread if required
later.

Implement stop/kill/terminate in the same way:  look for the thread
containing the worker's class and id in Thread.list, exit it, and
destroy the worker row.
```

```
Delegate the pid knowledge to the worker row.

Each worker can implement their own way to invoke processes so let them
choose and persist their pid value, don't assume we can use Process.pid.

```