### PR TITLE
Adds virtual totals for servers, vms and hosts to Physical Infrastructure Providers

### DIFF
--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -25,12 +25,12 @@ module ManageIQ::Providers
       physical_servers.inject(0) { |t, physical_server| physical_server.host.nil? ? t : t + 1 }
     end
 
-    def total_hosts; count_physical_servers_with_host; end
+    alias total_hosts count_physical_servers_with_host
 
     def count_vms
       physical_servers.inject(0) { |t, physical_server| physical_server.host.nil? ? t : t + physical_server.host.vms.size }
     end
 
-    def total_vms; count_vms; end
+    alias total_vms count_vms
   end
 end

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -1,5 +1,9 @@
 module ManageIQ::Providers
   class PhysicalInfraManager < BaseManager
+    virtual_total :total_physical_servers,    :physical_servers
+    virtual_column :total_hosts,              :type => :integer
+    virtual_column :total_vms,                :type => :integer
+
     class << model_name
       define_method(:route_key) { "ems_physical_infras" }
       define_method(:singular_route_key) { "ems_physical_infra" }
@@ -16,5 +20,17 @@ module ManageIQ::Providers
     def validate_authentication_status
       {:available => true, :message => nil}
     end
+
+    def count_physical_servers_with_host
+      physical_servers.inject(0) { |t, physical_server| physical_server.host.nil? ? t : t + 1 }
+    end
+
+    def total_hosts; count_physical_servers_with_host; end
+
+    def count_vms
+      physical_servers.inject(0) { |t, physical_server| physical_server.host.nil? ? t : t + physical_server.host.vms.size }
+    end
+
+    def total_vms; count_vms; end
   end
 end

--- a/spec/factories/physical_infra_manager.rb
+++ b/spec/factories/physical_infra_manager.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :generic_physical_infra,
+          :class => "ManageIQ::Providers::PhysicalInfraManager" do
+  end
+end

--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -1,0 +1,43 @@
+require 'xclarity_client'
+
+describe ManageIQ::Providers::PhysicalInfraManager do
+  before :all do
+    @auth = { :user => 'admin', :pass => 'smartvm', :host => 'localhost', :port => '3000' }
+  end
+
+  it 'will count physical servers' do
+    ps = FactoryGirl.create(:physical_server)
+    pim = FactoryGirl.create(:generic_physical_infra,
+                             :name     => "LXCA",
+                             :hostname => "0.0.0.0")
+
+    pim.physical_servers = [ps]
+    expect(pim.total_physical_servers).to be(1)
+  end
+
+  it 'will count hosts' do
+    ps = FactoryGirl.create(:physical_server)
+    host = FactoryGirl.create(:host)
+    pim = FactoryGirl.create(:generic_physical_infra,
+                             :name     => "LXCA",
+                             :hostname => "0.0.0.0")
+
+    ps.host = host
+    pim.physical_servers = [ps]
+    expect(pim.total_hosts).to be(1)
+  end
+
+  it 'will count vms' do
+    ps = FactoryGirl.create(:physical_server)
+    host = FactoryGirl.create(:host)
+    vm = FactoryGirl.create(:vm)
+    pim = FactoryGirl.create(:generic_physical_infra,
+                             :name     => "LXCA",
+                             :hostname => "0.0.0.0")
+
+    host.vms = [vm]
+    ps.host = host
+    pim.physical_servers = [ps]
+    expect(pim.total_vms).to be(1)
+  end
+end


### PR DESCRIPTION
This data will enable additional detail in the UI and via the REST API for determining how many physical servers, hosts and virtual machines are being managed by a particular provider.  The relationships between these resources is already maintained.

Overrides the total_hosts, total_vms attributes of ExtManagementSystem and adds the attribute total_physical_servers.

@miq-bot add_label enhancement, wip