### PR TITLE
add all features as a virtual column

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -131,6 +131,7 @@ module SupportsFeatureMixin
   included do
     QUERYABLE_FEATURES.keys.each do |feature|
       supports_not(feature)
+      virtual_column("supports_#{feature}?", :type => :boolean) if respond_to?(:virtual_column)
     end
   end
 

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -131,7 +131,13 @@ module SupportsFeatureMixin
   included do
     QUERYABLE_FEATURES.keys.each do |feature|
       supports_not(feature)
-      virtual_column("supports_#{feature}?", :type => :boolean) if respond_to?(:virtual_column)
+      if respond_to?(:virtual_column)
+        virtual_column("supports_#{feature}", :type => :boolean)
+
+        define_method("supports_#{feature}") do
+          public_send("supports_#{feature}?")
+        end
+      end
     end
   end
 

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -276,4 +276,10 @@ describe SupportsFeatureMixin do
       expect(NukeablePost.new(:bribe => false).supports_nuke?).to be true
     end
   end
+
+  context "for active record classes" do
+    it "adds a virtual attribute for each supported feature" do
+      expect(Vm.attribute_names.include?('supports_start?')).to be_truthy
+    end
+  end
 end

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -279,7 +279,7 @@ describe SupportsFeatureMixin do
 
   context "for active record classes" do
     it "adds a virtual attribute for each supported feature" do
-      expect(Vm.attribute_names.include?('supports_start?')).to be_truthy
+      expect(Vm.attribute_names.include?('supports_start')).to be_truthy
     end
   end
 end


### PR DESCRIPTION
@AparnaKarve @imtayadeway this is a more generalized approach to https://github.com/ManageIQ/manageiq/pull/15600

But

* I'm not sure how adding [that](https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/supports_feature_mixin.rb#L61-L123) many virtual columns to *all* models would impact performance
* can't we change the REST API to filter on methods?
* would dropping the `?` be an backwards incompatiblity change?

