### PR TITLE
[EUWE] Pin google-api-client and googleauth versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,8 @@ gem "fog-google",                     "=0.5.2",        :require => false
 gem "fog-vcloud-director",            "~>0.1.6",       :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
-gem "google-api-client",              "~>0.8.6",       :require => false
+gem "google-api-client",              "=0.8.6",        :require => false
+gem "googleauth",                     "=0.5.1",        :require => false
 gem "hamlit",                         "~>2.7.0"
 gem "hashie",                         "~>3.4.6",       :require => false
 gem "high_voltage",                   "~>2.4.0"


### PR DESCRIPTION
google-api-client adds a requirement for activesupport < 5.0 in 0.8.7, we can't have that.
ref: https://github.com/google/google-api-ruby-client/commit/fd295849b9409da87db170d60ccd3fed2bcb674c

googleauth 0.5.2 loosens the dependency on the faraday gem from ~>0.9 to ~>0.12
ref: https://github.com/google/google-auth-library-ruby/commit/45ed29a098e7de5842d852d70403206c43eb10ea

This fixes the `bundle update` errors, but there might be a better approach, at least for the faraday gem (can we loosen the dependency on manageiq-api-client?)

Fixes #15617

/cc @lpichler @hstastna @durandom @kbrock 