### PR TITLE
Allow compressed ids when updating a service dialog

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -126,7 +126,7 @@ class Dialog < ApplicationRecord
     updated_tabs = []
     tabs.each do |dialog_tab|
       if dialog_tab.key?('id')
-        DialogTab.find(dialog_tab['id']).tap do |tab|
+        DialogTab.find(self.class.uncompress_id(dialog_tab['id'])).tap do |tab|
           tab.update_attributes(dialog_tab.except('dialog_groups'))
           tab.update_dialog_groups(dialog_tab['dialog_groups'])
           updated_tabs << tab

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -19,7 +19,7 @@ class DialogGroup < ApplicationRecord
     fields.each do |field|
       field['options'].try(:symbolize_keys!)
       if field.key?('id')
-        DialogField.find(field['id']).tap do |dialog_field|
+        DialogField.find(self.class.uncompress_id(field['id'])).tap do |dialog_field|
           resource_action_fields = field.delete('resource_action') || {}
           update_resource_fields(resource_action_fields, dialog_field)
           dialog_field.update_attributes(field)

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -34,7 +34,7 @@ class DialogTab < ApplicationRecord
     updated_groups = []
     groups.each do |group|
       if group.key?('id')
-        DialogGroup.find(group['id']).tap do |dialog_group|
+        DialogGroup.find(self.class.uncompress_id(group['id'])).tap do |dialog_group|
           dialog_group.update_attributes(group.except('dialog_fields'))
           dialog_group.update_dialog_fields(group['dialog_fields'])
           updated_groups << dialog_group

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -346,6 +346,37 @@ describe Dialog do
         end.to change(dialog.reload.dialog_tabs, :count).by(-1)
       end
     end
+
+    context 'compresssed ids' do
+      let(:updated_content) do
+        [
+          {
+            'id'            => dialog_tab.first.id,
+            'label'         => 'updated_label_foo',
+            'dialog_groups' => [
+              { 'id'            => dialog_group.first.compressed_id,
+                'label'         => 'updated_label_bar',
+                'dialog_fields' =>
+                                   [{'id' => dialog_field.first.compressed_id, 'label' => 'updated_label_baz'}]}
+            ]
+          }
+        ]
+      end
+
+      before do
+        dialog.dialog_tabs << FactoryGirl.create(:dialog_tab)
+      end
+
+      it 'updates the content' do
+        dialog.update_tabs(updated_content)
+
+        tab = dialog.dialog_tabs.first
+        group = tab.dialog_groups.first
+        expect(tab.label).to eq('updated_label_foo')
+        expect(group.label).to eq('updated_label_bar')
+        expect(group.dialog_fields.first.label).to eq('updated_label_baz')
+      end
+    end
   end
 
   context "#dialog_fields" do

--- a/spec/requests/api/service_dialogs_spec.rb
+++ b/spec/requests/api/service_dialogs_spec.rb
@@ -122,13 +122,13 @@ describe "Service Dialogs API" do
           'label'   => 'updated label',
           'content' => {
             'dialog_tabs' => [
-              'id'            => dialog_tab.id,
+              'id'            => dialog_tab.compressed_id,
               'label'         => 'updated tab label',
               'dialog_groups' => [
                 {
-                  'id'            => dialog_group.id,
+                  'id'            => dialog_group.compressed_id,
                   'dialog_fields' => [
-                    { 'id' => dialog_field.id }
+                    { 'id' => dialog_field.compressed_id }
                   ]
                 }
               ]


### PR DESCRIPTION
Resolves https://github.com/ManageIQ/manageiq/issues/15434 

`uncompress_ids` works with both non-compressed and compressed ids. Adding this into the update methods allows the API to work with the newly compressed IDs that are passed back 

@miq-bot add_label bug, api, services
@miq-bot assign @gtanzillo 
cc: @martinpovolny @imtayadeway 