### PR TITLE
Check for messages key in prefetch_below_threshold?

### DIFF
--- a/app/models/miq_server/worker_management/dequeue.rb
+++ b/app/models/miq_server/worker_management/dequeue.rb
@@ -61,7 +61,7 @@ module MiqServer::WorkerManagement::Dequeue
 
   def prefetch_below_threshold?(queue_name, wcount)
     @queue_messages_lock.synchronize(:SH) do
-      return false if @queue_messages[queue_name].nil?
+      return false unless @queue_messages.key_path?(queue_name, :messages)
       return (@queue_messages[queue_name][:messages].length <= (::Settings.server.prefetch_min_per_worker_dequeue * wcount))
     end
   end


### PR DESCRIPTION
A customer log showed a worker failure that seems to be caused by a failed `.nil?` check in the `MiqServer::WorkerManagement::Dequeue#prefetch_below_threshold?` method. Below is a snippet from their evm.log:

```
[----] I, [2017-07-10T03:44:03.429517 #2976:1267130]  INFO -- : MIQ(MiqScheduleWorker::Runner#do_work) Number of scheduled items to be processed: 2.
[----] E, [2017-07-10T03:44:08.642178 #2697:1267130] ERROR -- : MIQ(MiqServer#monitor) undefined method `length' for nil:NilClass
[----] E, [2017-07-10T03:44:08.642290 #2697:1267130] ERROR -- : [NoMethodError]: undefined method `length' for nil:NilClass  Method:[rescue in monitor]
[----] E, [2017-07-10T03:44:08.642362 #2697:1267130] ERROR -- : /var/www/miq/vmdb/app/models/miq_server/worker_management/dequeue.rb:65:in `block in prefetch_below_threshold?'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:234:in `block in sync_synchronize'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:231:in `handle_interrupt'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:231:in `sync_synchronize'
/var/www/miq/vmdb/app/models/miq_server/worker_management/dequeue.rb:63:in `prefetch_below_threshold?'
/var/www/miq/vmdb/app/models/miq_server/worker_management/dequeue.rb:104:in `block (2 levels) in populate_queue_messages'
/var/www/miq/vmdb/app/models/miq_server/worker_management/dequeue.rb:103:in `each'
/var/www/miq/vmdb/app/models/miq_server/worker_management/dequeue.rb:103:in `block in populate_queue_messages'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:234:in `block in sync_synchronize'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:231:in `handle_interrupt'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:231:in `sync_synchronize'
/var/www/miq/vmdb/app/models/miq_server/worker_management/dequeue.rb:102:in `populate_queue_messages'
/var/www/miq/vmdb/app/models/miq_server.rb:349:in `block in monitor'
/opt/rh/cfme-gemset/bundler/gems/manageiq-gems-pending-e0f3ea8755bf/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/opt/rh/cfme-gemset/bundler/gems/manageiq-gems-pending-e0f3ea8755bf/lib/gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
/var/www/miq/vmdb/app/models/miq_server.rb:349:in `monitor'
/var/www/miq/vmdb/app/models/miq_server.rb:370:in `block (2 levels) in monitor_loop'
/opt/rh/cfme-gemset/bundler/gems/manageiq-gems-pending-e0f3ea8755bf/lib/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/opt/rh/cfme-gemset/bundler/gems/manageiq-gems-pending-e0f3ea8755bf/lib/gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
/var/www/miq/vmdb/app/models/miq_server.rb:370:in `block in monitor_loop'
/var/www/miq/vmdb/app/models/miq_server.rb:369:in `loop'
/var/www/miq/vmdb/app/models/miq_server.rb:369:in `monitor_loop'
/var/www/miq/vmdb/app/models/miq_server.rb:252:in `start'
/var/www/miq/vmdb/lib/workers/evm_server.rb:65:in `start'
/var/www/miq/vmdb/lib/workers/evm_server.rb:91:in `start'
```

The proposed change just adds an explicit check on `@queue_messages[queue_name][:messages]`.

Attempts to resolve https://bugzilla.redhat.com/show_bug.cgi?id=1471232