### PR TITLE
Add physical infra types for discovery

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -412,6 +412,10 @@ class ExtManagementSystem < ApplicationRecord
     @ems_infra_discovery_types ||= %w(virtualcenter scvmm rhevm)
   end
 
+  def self.ems_physical_infra_discovery_types
+    @ems_physical_infra_discovery_types ||= %w(lxca)
+  end
+
   def disable!
     _log.info "Disabling EMS [#{name}] id [#{id}]."
     update!(:enabled => false)


### PR DESCRIPTION
This pull request impĺements a method to return ems_physical_infra discovery types available.

So far, the only type to be supported is Lenovo XCLarity Administrator.
