### PR TITLE
Move snapshot_delete to core CloudVolumeSnapshot model

### DIFF
--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -25,4 +25,40 @@ class CloudVolumeSnapshot < ApplicationRecord
   def my_zone
     self.class.my_zone(ext_management_system)
   end
+
+  def delete_snapshot_queue(userid = "system", _options = {})
+    task_opts = {
+      :action => "deleting volume snapshot #{inspect} in #{ext_management_system.inspect}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'delete_snapshot',
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def delete_snapshot
+    raw_delete_snapshot
+  rescue => e
+    notification_options = {
+      :snapshot_op => 'delete',
+      :subject     => "[#{name}]",
+      :error       => e.to_s
+    }
+    Notification.create(:type => :vm_snapshot_failure, :options => notification_options)
+
+    raise e
+  end
+
+  def raw_delete_snapshot
+    raise NotImplementedError, _("raw_delete_snapshot must be implemented in a subclass")
+  end
 end


### PR DESCRIPTION
Move snapshot_delete and snapshot_delete_queue to core CloudVolumeSnapshot model. Before that they were in amazon provider plugin.

Recording of notification example: http://k00.fr/jbn3j

Reference: https://github.com/ManageIQ/manageiq-providers-amazon/pull/260#issuecomment-309530761
