### PR TITLE
Azure Classic Credential added for embedded Ansible

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_classic_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_classic_credential.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureClassicCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureClassicCredential
+end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -1,4 +1,4 @@
-# This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential.  We are not modeling the deprecated Azure classic
+# This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
 end


### PR DESCRIPTION
Corresponds to the addition in https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/13

@miq-bot add_labels enhancement, providers/ansible_tower, fine/yes