### PR TITLE
[Performance] MiqEventDefinition.seed speedup

### DIFF
--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -1,7 +1,7 @@
 describe BottleneckEvent do
   describe ".future_event_definitions_for_obj" do
     it "contains things" do
-      MiqEventDefinition.seed_default_definitions
+      MiqEventDefinition.seed_default_definitions(MiqEventDefinition.all.group_by(&:name))
       expect(BottleneckEvent.future_event_definitions_for_obj(ManageIQ::Providers::Vmware::InfraManager::Host.new)).not_to be_empty
     end
   end

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -1,4 +1,5 @@
 describe MiqEventDefinition do
+  let(:event_defs) { MiqEventDefinition.all.group_by(&:name) }
   describe '.seed_default_events' do
     context 'there are 2 event definition sets' do
       let!(:set1) { create_set!('host_operations') }
@@ -16,7 +17,7 @@ describe MiqEventDefinition do
         context 'seeding default event definitions from that csv' do
           before do
             allow(File).to receive(:open).and_return(StringIO.new(csv))
-            MiqEventDefinition.seed_default_events
+            MiqEventDefinition.seed_default_events(event_defs)
           end
 
           it 'should create an event definition and make it a member of the set' do
@@ -37,7 +38,7 @@ describe MiqEventDefinition do
             context 'seeding again' do
               before do
                 allow(File).to receive(:open).and_return(StringIO.new(csv))
-                MiqEventDefinition.seed_default_events
+                MiqEventDefinition.seed_default_events(event_defs)
               end
 
               it 'should update the membership' do
@@ -128,7 +129,7 @@ describe MiqEventDefinition do
     context 'with defaults in db' do
       before do
         MiqEventDefinitionSet.seed
-        described_class.seed_default_events
+        described_class.seed_default_events(event_defs)
       end
 
       it "won't update an event with a definition (keyed as a string)" do


### PR DESCRIPTION
`MiqEventDefinition` is the slowest of the primordial seeds

The main culprit is the fact that `miq_sets` uses `relationships`.

|       ms |       bytes | objects |query | query ms|     rows |`comments`
|      ---:|         ---:|     ---:|  ---:|     ---:|      ---:| ---
|  2,595.0 | 51,390,823* | 645,934 |  719 | 1,653.5 |    1,036 |nop before
|  2,121.1 | 45,063,997* | 577,455 |  542 | 1,297.0 |    1,036 |nop after
| 18% | 12% | 11% | 25% | 22% | 0 | diff


details
-------

This removes a number of N+1 queries but does not remove the main culprit. That would probably require reimplementing miq_sets.

If you note the `SELECT miq_event_definitions` are merged together. `338ms+36ms => 51ms`

|       ms |       bytes | objects |query | query ms|     rows |`comments`
|      ---:|         ---:|     ---:|  ---:|     ---:|      ---:| ---
|  2,595.0 | 51,390,823* | 645,934 |  719 | 1,653.5 |    1,036 |`MiqEventDefinition-1`
|    338.8 |             |         |  178 |   305.9 |      178 |**`.SELECT "miq_event_definitions".* `**
|     36.0 |             |         |   14 |    29.1 |      166 |**`.SELECT "miq_event_definitions".* `**
|    628.8 |             |         |  167 |   579.5 |      180 |`.SELECT "miq_sets".* `
|    190.2 |             |         |  166 |   162.7 |      166 |`.SELECT "relationships"."ancestry" `
|    459.7 |             |         |  194 |   434.6 |      346 |`.SELECT "relationships".* `

|       ms |       bytes | objects |query | query ms|     rows |`comments`
|      ---:|         ---:|     ---:|  ---:|     ---:|      ---:| ---
|  2,121.1 | 45,063,997* | 577,455 |  542 | 1,297.0 |    1,036 |`MiqEventDefinition-1`
|     51.5 |             |         |   15 |    31.1 |      344 |**`.SELECT "miq_event_definitions".* `**
|    569.9 |             |         |  167 |   523.2 |      180 |`.SELECT "miq_sets".* `
|    196.6 |             |         |  166 |   167.8 |      166 |`.SELECT "relationships"."ancestry" `
|    479.0 |             |         |  194 |   455.8 |      346 |`.SELECT "relationships".* `

related to:
- https://bugzilla.redhat.com/show_bug.cgi?id=1422671
- https://github.com/ManageIQ/manageiq/pull/15586