### PR TITLE
[FINE] [SCVMM] Quote the argument to -VMHost when provisioning.

### DIFF
--- a/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/microsoft/infra_manager/provision/cloning.rb
@@ -122,7 +122,7 @@ module ManageIQ::Providers::Microsoft::InfraManager::Provision::Cloning
 
       $vm = New-SCVirtualMachine \
         -Name '#{dest_name}' \
-        -VMHost #{dest_host} \
+        -VMHost '#{dest_host}' \
         -Path '#{dest_mount_point}' \
         -VMTemplate #{template_ps_script}; \
       Set-SCVirtualMachine -VM $vm \


### PR DESCRIPTION
If the argument to `-VMHost` contains a hyphen then currently provisioning will fail because it will misinterpret the hyphen as the start of another switch, e.g. `-VMHost foo - bar` should be `-VMHost 'foo - bar'`.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1461584