### PR TITLE
Use archived? instead of ems_id.nil?

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -45,7 +45,7 @@ class Container < ApplicationRecord
   end
 
   def disconnect_inv
-    return if ems_id.nil?
+    return if archived?
     _log.info "Disconnecting Container [#{name}] id [#{id}] from EMS "
     self.deleted_on = Time.now.utc
     save

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -79,7 +79,7 @@ class ContainerGroup < ApplicationRecord
   end
 
   def disconnect_inv
-    return if ems_id.nil?
+    return if archived?
     _log.info "Disconnecting Pod [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.containers.each(&:disconnect_inv)

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -89,7 +89,7 @@ class ContainerImage < ApplicationRecord
   end
 
   def disconnect_inv
-    return if ems_id.nil?
+    return if archived?
     _log.info "Disconnecting Image [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.container_image_registry = nil

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -61,7 +61,7 @@ class ContainerProject < ApplicationRecord
   end
 
   def disconnect_inv
-    return if ems_id.nil?
+    return if archived?
     _log.info "Disconnecting Container Project [#{name}] id [#{id}] from EMS [#{ext_management_system.name}]" \
     "id [#{ext_management_system.id}] "
     self.deleted_on = Time.now.utc


### PR DESCRIPTION
We don't nullify `ems_id` for archived containers entities anymore, so instead of checking `ems_id.nil?` before disconnecting we should use the `archived?` method that checks whether `deleted_on` is nil. 