### PR TITLE
A tool for converting miqldap auth to external auth with sssd

### DIFF
--- a/spec/tools/miqldap_to_sssd/authconfig_spec.rb
+++ b/spec/tools/miqldap_to_sssd/authconfig_spec.rb
@@ -1,0 +1,41 @@
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+
+require "authconfig"
+
+describe MiqLdapToSssd::AuthConfig do
+  before do
+    stub_const("LOGGER", double)
+    allow(LOGGER).to receive(:debug)
+  end
+
+  describe '#run_auth_config' do
+    before do
+      @initial_settings = {:mode => "bob", :ldaphost => ["hostname"], :ldapport => 22}
+    end
+
+    it 'invokes authconfig with valid parameters' do
+      expect(AwesomeSpawn).to receive(:run)
+        .with("authconfig",
+              :params => { :ldapserver=        => "bob://hostname:22",
+                           :ldapbasedn=        => nil,
+                           :enablesssd         => nil,
+                           :enablesssdauth     => nil,
+                           :enablelocauthorize => nil,
+                           :enableldap         => nil,
+                           :enableldapauth     => nil,
+                           :disableldaptls     => nil,
+                           :enablerfc2307bis   => nil,
+                           :enablecachecreds   => nil,
+                           :update             => nil})
+        .and_return(double(:command_line => "authconfig", :failure? => false))
+      described_class.new(@initial_settings).run_auth_config
+    end
+
+    it 'handles authconfig failures' do
+      expect(LOGGER).to receive(:fatal)
+      expect(AwesomeSpawn).to receive(:run)
+        .and_return(double(:command_line => "authconfig", :failure? => true, :error => "malfunction"))
+      expect { described_class.new(@initial_settings).run_auth_config }.to raise_error(MiqLdapToSssd::AuthConfigError)
+    end
+  end
+end

--- a/spec/tools/miqldap_to_sssd/cli_spec.rb
+++ b/spec/tools/miqldap_to_sssd/cli_spec.rb
@@ -1,0 +1,38 @@
+$LOAD_PATH << Rails.root.join("tools")
+
+require "miqldap_to_sssd/cli"
+
+describe MiqLdapToSssd::Cli do
+  before do
+    @all_options = :tls_cacert, :tls_cacertdir, :basedn_domain, :only_change_userids, :skip_post_coversion_userid_change
+    stub_const("LOGGER", double)
+    allow(LOGGER).to receive(:debug)
+  end
+
+  describe "#parse" do
+    it "should assign defaults" do
+      opts = described_class.new.parse([]).options.slice(*@all_options)
+      expect(opts).to eq(:only_change_userids => false, :skip_post_coversion_userid_change => false)
+    end
+
+    it "should parse base DN domain names" do
+      opts = described_class.new.parse(%w(-d example.com)).options.slice(:basedn_domain)
+      expect(opts).to eq(:basedn_domain => "example.com")
+    end
+
+    it "should parse TLS cacert path and directory" do
+      opts = described_class.new.parse(%w(-c /a/path/to/a/cacert)).options.slice(:tls_cacert, :tls_cacertdir)
+      expect(opts).to eq(:tls_cacert => "/a/path/to/a/cacert", :tls_cacertdir => "/a/path/to/a")
+    end
+
+    it "can only updating the userids" do
+      opts = described_class.new.parse(%w(-n)).options.slice(*@all_options)
+      expect(opts).to eq(:only_change_userids => true, :skip_post_coversion_userid_change => false)
+    end
+
+    it "can skip updating the userids after the conversion" do
+      opts = described_class.new.parse(%w(-s)).options.slice(*@all_options)
+      expect(opts).to eq(:only_change_userids => false, :skip_post_coversion_userid_change => true)
+    end
+  end
+end

--- a/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
@@ -1,0 +1,90 @@
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+
+require "configure_apache"
+require "tempfile"
+require "fileutils"
+
+describe MiqLdapToSssd::ConfigureApache do
+  before do
+    stub_const("LOGGER", double)
+    allow(LOGGER).to receive(:debug)
+    @spec_name = File.basename(__FILE__).split(".rb").first.freeze
+  end
+
+  describe '#onfigure' do
+    let(:manageiq_pam_conf) do
+      <<-EOT.strip_heredoc
+        manageiq pam conf data
+      EOT
+    end
+
+    let(:manageiq_remote_user_conf) do
+      <<-EOT.strip_heredoc
+        manageiq remote user conf data
+      EOT
+    end
+
+    let(:manageiq_external_auth_conf) do
+      <<-EOT.strip_heredoc
+        KrbMethodK5Passwd  Off
+        KrbAuthRealms      <%= realm %>
+        Krb5KeyTab         /etc/http.keytab
+      EOT
+    end
+
+    let(:expected_manageiq_external_auth_conf) do
+      <<-EOT.strip_heredoc
+        KrbMethodK5Passwd  Off
+        KrbAuthRealms      bob.your.uncle.com
+        Krb5KeyTab         /etc/http.keytab
+      EOT
+    end
+
+    before do
+      @initial_settings = {:basedn_domain => "bob.your.uncle.com"}
+
+      @test_dir = "#{Dir.tmpdir}/#{@spec_name}"
+      @template_dir = "#{@test_dir}/TEMPLATE"
+      stub_const("MiqLdapToSssd::ConfigureApache::TEMPLATE_DIR", @template_dir)
+
+      @httpd_conf_dir = "#{@test_dir}/etc/httpd/conf.d"
+      FileUtils.mkdir_p @httpd_conf_dir
+      @httpd_template_dir = FileUtils.mkdir_p("#{@template_dir}/#{@httpd_conf_dir}")[0]
+      stub_const("MiqLdapToSssd::ConfigureApache::HTTPD_CONF_DIR", @httpd_conf_dir)
+
+      @pam_conf_dir = "#{@test_dir}/etc/pam.d"
+      FileUtils.mkdir_p @pam_conf_dir
+      @pam_template_dir = FileUtils.mkdir_p("#{@template_dir}/#{@pam_conf_dir}")[0]
+      stub_const("MiqLdapToSssd::ConfigureApache::PAM_CONF_DIR", @pam_conf_dir)
+
+      File.open("#{@pam_template_dir}/httpd-auth", "w") { |f| f.write(manageiq_pam_conf) }
+      File.open("#{@httpd_template_dir}/manageiq-remote-user.conf", "w") { |f| f.write(manageiq_remote_user_conf) }
+      File.open("#{@httpd_template_dir}/manageiq-external-auth.conf.erb", "w") do |f|
+        f.write(manageiq_external_auth_conf)
+      end
+    end
+
+    after do
+      FileUtils.rm_rf(@test_dir)
+    end
+
+    it 'creates the httpd and pam config files' do
+      described_class.new(@initial_settings).configure
+      expect(File.read("#{@pam_conf_dir}/httpd-auth")).to eq(manageiq_pam_conf)
+      expect(File.read("#{@httpd_conf_dir}/manageiq-remote-user.conf")).to eq(manageiq_remote_user_conf)
+      expect(File.read("#{@httpd_conf_dir}/manageiq-external-auth.conf")).to eq(expected_manageiq_external_auth_conf)
+    end
+
+    it 'raises an error when a TEMPLATE file is missing' do
+      FileUtils.rm_f("#{@pam_template_dir}/httpd-auth")
+      expect(LOGGER).to receive(:fatal)
+      expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureApacheError)
+    end
+
+    it 'raises an error when KrbAuthRealms is missing from manageiq-external-auth.conf' do
+      File.open("#{@httpd_template_dir}/manageiq-external-auth.conf.erb", "w") { |f| f.write("hello walls") }
+      expect(LOGGER).to receive(:fatal)
+      expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureApacheError)
+    end
+  end
+end

--- a/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
@@ -1,0 +1,39 @@
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+
+require "configure_appliance_settings"
+
+describe MiqLdapToSssd::ConfigureApplianceSettings do
+  before do
+    stub_const("LOGGER", double)
+    allow(LOGGER).to receive(:debug)
+    @auth_config = {
+      :authentication => {:ldaphost   => ["my-ldaphost"],
+                          :mode       => "ldap",
+                          :httpd_role => false,
+                          :ldap_role  => true}
+    }
+  end
+
+  describe '#configure' do
+    let!(:miq_server) { EvmSpecHelper.local_guid_miq_server_zone[1] }
+    before do
+      stub_local_settings(miq_server)
+    end
+
+    it 'upates the authentication settings for external auth' do
+      # Needed to avoid pitfalls of not running on a live appliance with real settings
+      allow_any_instance_of(Vmdb::Settings).to receive(:activate)
+      allow_any_instance_of(ConfigurationManagementMixin).to receive(:reload_all_server_settings)
+
+      Vmdb::Settings.save!(miq_server, @auth_config)
+      Settings.reload!
+
+      described_class.new.configure
+
+      config = miq_server.get_config("vmdb")
+      expect(config.config.fetch_path(:authentication, :mode)).to eq("httpd")
+      expect(config.config.fetch_path(:authentication, :ldap_role)).to eq(false)
+      expect(config.config.fetch_path(:authentication, :httpd_role)).to eq(true)
+    end
+  end
+end

--- a/spec/tools/miqldap_to_sssd/configure_selinux_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_selinux_spec.rb
@@ -1,0 +1,78 @@
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+
+require "configure_selinux"
+
+describe MiqLdapToSssd::ConfigureSELinux do
+  before do
+    stub_const("LOGGER", double)
+    allow(LOGGER).to receive(:debug)
+  end
+
+  describe '#configure' do
+    before do
+      @initial_settings = {:ldapport => '22'}
+    end
+
+    it 'invokes semanage and setsebool with valid parameters' do
+      expect(AwesomeSpawn).to receive(:run).once
+        .with("semanage",
+              :params => {nil => "port",
+                          :a  => nil,
+                          :t  => "ldap_port_t",
+                          :p  => %w(tcp 22)})
+        .and_return(double(:command_line => "semanage", :failure? => false))
+
+      expect(AwesomeSpawn).to receive(:run).once
+        .with("setsebool",
+              :params => {:P=>%w(allow_httpd_mod_auth_pam on)})
+        .and_return(double(:command_line => "semanage", :failure? => false))
+
+      expect(AwesomeSpawn).to receive(:run).once
+        .with("setsebool",
+              :params => {:P=>%w(httpd_dbus_sssd on)})
+        .and_return(double(:command_line => "semanage", :failure? => false))
+
+      expect { described_class.new(@initial_settings).configure }.to_not raise_error
+    end
+
+    it 'handles semanage already defined result' do
+      expect(LOGGER).to_not receive(:fatal)
+      expect(AwesomeSpawn).to receive(:run).once
+        .and_return(double(:command_line => "semanage", :failure? => true, :error => "malfunction already defined"))
+
+      expect(AwesomeSpawn).to receive(:run).once
+        .with("setsebool",
+              :params => {:P=>%w(allow_httpd_mod_auth_pam on)})
+        .and_return(double(:command_line => "semanage", :failure? => false))
+
+      expect(AwesomeSpawn).to receive(:run).once
+        .with("setsebool",
+              :params => {:P=>%w(httpd_dbus_sssd on)})
+        .and_return(double(:command_line => "semanage", :failure? => false))
+
+      expect { described_class.new(@initial_settings).configure }.to_not raise_error
+    end
+
+    it 'handles semanage failures' do
+      expect(LOGGER).to receive(:fatal).with("semanage failed with: malfunction")
+      expect(AwesomeSpawn).to receive(:run)
+        .and_return(double(:command_line => "semanage", :failure? => true, :error => "malfunction"))
+      expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureSELinuxError)
+    end
+
+    it 'handles setsebool failures' do
+      expect(LOGGER).to receive(:fatal).with("setsebool failed with: malfunction")
+      expect(AwesomeSpawn).to receive(:run).once
+        .with("semanage",
+              :params => {nil => "port",
+                          :a  => nil,
+                          :t  => "ldap_port_t",
+                          :p  => %w(tcp 22)})
+        .and_return(double(:command_line => "semanage", :failure? => false))
+
+      expect(AwesomeSpawn).to receive(:run)
+        .and_return(double(:command_line => "setsebool", :failure? => true, :error => "malfunction"))
+      expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureSELinuxError)
+    end
+  end
+end

--- a/tools/miqldap_to_sssd.rb
+++ b/tools/miqldap_to_sssd.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+# usage: ruby miqldap_to_sssd -h
+#
+# upgrades authentication mode from LDAP(s) to External Auth with SSSD
+# Alternatively, it will update all user records to have a userid in UPN format
+
+if __FILE__ == $PROGRAM_NAME
+  $LOAD_PATH.push(File.expand_path(__dir__))
+  $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(miqldap_to_sssd))))
+end
+
+require File.expand_path('../config/environment', __dir__)
+
+require 'authconfig'
+require 'cli'
+require 'configure_apache'
+require 'configure_appliance_settings'
+require 'configure_database'
+require 'configure_selinux'
+require 'configure_sssd_rules'
+require 'miqldap_configuration'
+require 'converter'
+require 'services'
+require 'sssd_conf'
+
+module MiqLdapToSssd
+  LOGGER = Logger.new('log/miqldap_to_sssd.log')
+
+  LOGGER.formatter = proc do |severity, time, _progname, msg|
+    "[#{time}] #{severity}: #{msg}\n"
+  end
+
+  MiqLdapToSssd::Cli.run(ARGV) if __FILE__ == $PROGRAM_NAME
+end

--- a/tools/miqldap_to_sssd/authconfig.rb
+++ b/tools/miqldap_to_sssd/authconfig.rb
@@ -1,0 +1,42 @@
+require 'awesome_spawn'
+require 'miqldap_configuration'
+
+module MiqLdapToSssd
+  class AuthConfigError < StandardError; end
+
+  class AuthConfig
+    attr_reader :initial_settings
+
+    def initialize(initial_settings)
+      @initial_settings = initial_settings
+    end
+
+    def run_auth_config
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      ldapserver = "#{initial_settings[:mode]}://#{initial_settings[:ldaphost][0]}:#{initial_settings[:ldapport]}"
+      params = {
+        :ldapserver=        => ldapserver,
+        :ldapbasedn=        => initial_settings[:basedn],
+        :enablesssd         => nil,
+        :enablesssdauth     => nil,
+        :enablelocauthorize => nil,
+        :enableldap         => nil,
+        :enableldapauth     => nil,
+        :disableldaptls     => nil,
+        :enablerfc2307bis   => nil,
+        :enablecachecreds   => nil,
+        :update             => nil
+      }
+
+      result = AwesomeSpawn.run("authconfig", :params => params)
+      LOGGER.debug("Ran command: #{result.command_line}")
+
+      if result.failure?
+        error_message = "authconfig failed with: #{result.error}"
+        LOGGER.fatal(error_message)
+        raise AuthConfigError, error_message
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/cli.rb
+++ b/tools/miqldap_to_sssd/cli.rb
@@ -1,0 +1,55 @@
+require 'trollop'
+
+module MiqLdapToSssd
+  class Cli
+    attr_accessor :options
+
+    def parse(args)
+      args.shift if args.first == "--" # Handle when called through script/runner
+
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      self.options = Trollop.options(args) do
+        banner "Usage: ruby #{$PROGRAM_NAME} [options]\n"
+
+        opt :basedn_domain,
+            "The Base DN domain name, e.g. example.com",
+            :short   => "d",
+            :default => nil,
+            :type    => :string
+
+        opt :tls_cacert,
+            "Path to certificate file",
+            :short   => "c",
+            :default => nil,
+            :type    => :string
+
+        opt :only_change_userids,
+            "normalize the userids then exit",
+            :short   => "n",
+            :default => false,
+            :type    => :flag
+
+        opt :skip_post_coversion_userid_change,
+            "Do the MiqLdap to SSSD conversion but skip the normalizing of the userids",
+            :short   => "s",
+            :default => false,
+            :type    => :flag
+      end
+
+      options[:tls_cacertdir] = File.dirname(options[:tls_cacert]) unless options[:tls_cacert].nil?
+      self.options = options.delete_if { |_n, v| v.nil? }
+      LOGGER.debug("User provided settings: #{options}")
+
+      self
+    end
+
+    def run
+      Converter.new(options).run
+    end
+
+    def self.run(args)
+      new.parse(args).run
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/configure_apache.rb
+++ b/tools/miqldap_to_sssd/configure_apache.rb
@@ -1,0 +1,54 @@
+require 'fileutils'
+
+module MiqLdapToSssd
+  class ConfigureApacheError < StandardError; end
+
+  class ConfigureApache
+    TEMPLATE_DIR     = "/var/www/miq/system/TEMPLATE".freeze
+    ALT_TEMPLATE_DIR = "/opt/rh/cfme-appliance/TEMPLATE".freeze
+    HTTPD_CONF_DIR   = "/etc/httpd/conf.d".freeze
+    PAM_CONF_DIR     = "/etc/pam.d".freeze
+
+    attr_reader :initial_settings, :template_dir
+
+    def initialize(initial_settings)
+      @initial_settings = initial_settings
+      @template_dir = Dir.exist?(TEMPLATE_DIR) ? TEMPLATE_DIR : ALT_TEMPLATE_DIR
+    end
+
+    def configure
+      LOGGER.debug("Invoked #{self.class}\##{__method__} template_dir #{template_dir}")
+      create_files
+      update_realm
+    end
+
+    private
+
+    def create_files
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      begin
+        FileUtils.cp("#{template_dir}#{PAM_CONF_DIR}/httpd-auth", "#{PAM_CONF_DIR}/httpd-auth")
+        FileUtils.cp("#{template_dir}#{HTTPD_CONF_DIR}/manageiq-remote-user.conf", HTTPD_CONF_DIR)
+        FileUtils.cp("#{template_dir}#{HTTPD_CONF_DIR}/manageiq-external-auth.conf.erb",
+                     "#{HTTPD_CONF_DIR}/manageiq-external-auth.conf")
+      rescue Errno::ENOENT => err
+        LOGGER.fatal(err.message)
+        raise ConfigureApacheError, err.message
+      end
+    end
+
+    def update_realm
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      begin
+        miq_ext_auth = File.read("#{HTTPD_CONF_DIR}/manageiq-external-auth.conf")
+        miq_ext_auth[/(\s*)KrbAuthRealms(\s*)(.*)/, 3] = initial_settings[:basedn_domain]
+        File.write("#{HTTPD_CONF_DIR}/manageiq-external-auth.conf", miq_ext_auth)
+      rescue Errno::ENOENT, IndexError => err
+        LOGGER.fatal(err.message)
+        raise ConfigureApacheError, err.message
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/configure_appliance_settings.rb
+++ b/tools/miqldap_to_sssd/configure_appliance_settings.rb
@@ -1,0 +1,31 @@
+require 'fileutils'
+
+module MiqLdapToSssd
+  class ConfigureApplianceSettingsError < StandardError; end
+
+  class ConfigureApplianceSettings
+    attr_reader :initial_settings
+
+    def configure
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      new_settings = {
+        :authentication => {:mode       => "httpd",
+                            :httpd_role => Settings.authentication.ldap_role,
+                            :ldap_role  => false}
+      }
+
+      log_configuration("Initial", Settings.authentication)
+      MiqServer.my_server.set_config(new_settings)
+      log_configuration("Updated", Settings.authentication)
+    end
+
+    private
+
+    def log_configuration(current_state, auth_config)
+      LOGGER.debug("#{current_state}       mode: #{auth_config[:mode]}")
+      LOGGER.debug("#{current_state} httpd_role: #{auth_config[:httpd_role]}")
+      LOGGER.debug("#{current_state}  ldap_role: #{auth_config[:ldap_role]}")
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/configure_database.rb
+++ b/tools/miqldap_to_sssd/configure_database.rb
@@ -1,0 +1,80 @@
+require 'fileutils'
+require 'inifile'
+
+module MiqLdapToSssd
+  CHANGE_MODES = %w(httpd ldaps ldap).freeze
+
+  class ConfigureDatabaseError < StandardError; end
+
+  class ConfigureDatabase
+    attr_reader :sssd_domain
+
+    def initialize
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+      @sssd_domain = domain_from_sssd
+      LOGGER.debug("#{__method__} sssd_domain #{sssd_domain}")
+    end
+
+    def change_userids_to_upn
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+      LOGGER.debug("Normalizing userids to User Principal Name (UPN)")
+
+      return unless CHANGE_MODES.include?(Settings.authentication.to_hash[:mode])
+
+      User.all.map do |u|
+        next if %w(consumption_admin admin).include?(u.userid)
+
+        LOGGER.debug("Updating userid #{u.userid}")
+        save_new_or_delete_duplicate_userid(update_the_userid(u))
+      end
+    end
+
+    private
+
+    def update_the_userid(u)
+      if u.userid.include?(",")
+        LOGGER.debug("userid was generated from an MiqLdap login using OpenLdap.")
+        u.userid = dn_to_upn(u.userid)
+      elsif u.userid.include?("@")
+        LOGGER.debug("userid was Generated from an MiqLdap login using Active Directory")
+        u.userid = u.userid.downcase
+      else
+        LOGGER.debug("userid was generated from an SSSD login")
+        u.userid = "#{u.userid}@#{sssd_domain}".downcase
+      end
+      LOGGER.debug("The updated user name is #{u.userid}")
+      u
+    end
+
+    def save_new_or_delete_duplicate_userid(u)
+      LOGGER.debug("Invoked #{self.class}\##{__method__} userid #{u.userid}")
+      check_duplicate_u = find_user(u.userid)
+      if check_duplicate_u.nil? || check_duplicate_u.id == u.id
+        LOGGER.debug("Saving userid #{u.userid}")
+        u.save
+      else
+        LOGGER.debug("Deleting this user, duplicate found #{u.id}")
+        u.delete
+      end
+    end
+
+    def domain_from_sssd
+      sssd_ini = IniFile.load(SSSD_CONF_FILE)
+      return if sssd_ini.nil?
+
+      sssd_ini.sections[sssd_ini.sections.index { |s| s.include?("domain/") }].split("/")[1]
+    end
+
+    def dn_to_upn(userid)
+      domain = userid.split(",").collect { |p| p.split('dc=')[1] }.compact.join('.')
+      user = userid.split(",").collect { |p| p.split('=')[1] }[0]
+
+      "#{user}@#{domain}".downcase
+    end
+
+    def find_user(userid)
+      user = User.find_by_userid(userid)
+      user || User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/configure_selinux.rb
+++ b/tools/miqldap_to_sssd/configure_selinux.rb
@@ -1,0 +1,58 @@
+require 'awesome_spawn'
+
+module MiqLdapToSssd
+  class ConfigureSELinuxError < StandardError; end
+
+  class ConfigureSELinux
+    attr_reader :initial_settings
+
+    def initialize(initial_settings)
+      @initial_settings = initial_settings
+    end
+
+    def configure
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+      enable_non_standard_ldap_port(initial_settings[:ldapport])
+      establish_permission("allow_httpd_mod_auth_pam")
+      establish_permission("httpd_dbus_sssd")
+    end
+
+    private
+
+    def enable_non_standard_ldap_port(port_number)
+      LOGGER.debug("Invoked #{self.class}\##{__method__}(#{port_number})")
+      return if %w(389 636).include?(port_number)
+
+      params = {
+        nil => "port",
+        :a  => nil,
+        :t  => "ldap_port_t",
+        :p  => ["tcp", port_number]
+      }
+
+      result = AwesomeSpawn.run("semanage", :params => params)
+      LOGGER.debug("Ran command: #{result.command_line}")
+
+      if result.failure?
+        error_message = "semanage failed with: #{result.error}"
+        return if error_message.include?("already defined")
+
+        LOGGER.fatal(error_message)
+        raise ConfigureSELinuxError, error_message
+      end
+    end
+
+    def establish_permission(permission_name)
+      LOGGER.debug("Invoked #{self.class}\##{__method__}(#{permission_name})")
+      params = {:P => [permission_name, "on"] }
+      result = AwesomeSpawn.run("setsebool", :params => params)
+      LOGGER.debug("Ran command: #{result.command_line}")
+
+      if result.failure?
+        error_message = "setsebool failed with: #{result.error}"
+        LOGGER.fatal(error_message)
+        raise ConfigureSELinuxError, error_message
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/configure_sssd_rules.rb
+++ b/tools/miqldap_to_sssd/configure_sssd_rules.rb
@@ -1,0 +1,26 @@
+require 'fileutils'
+
+module MiqLdapToSssd
+  class ConfigureSssdRulesError < StandardError; end
+
+  class ConfigureSssdRules
+    CFG_RULES_FILE = "/usr/share/sssd/cfg_rules.ini".freeze
+
+    def self.disable_tls
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      message = "Converting from unsecured LDAP authentication to SSSD. This is dangerous. Passwords are not encrypted"
+      puts(message)
+      LOGGER.warn(message)
+
+      begin
+        open(CFG_RULES_FILE, 'a') do |f|
+          f << "option = ldap_auth_disable_tls_never_use_in_production\n"
+        end
+      rescue Errno::ENOENT => err
+        LOGGER.fatal(err.message)
+        raise ConfigureSssdRulesError, err.message
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/converter.rb
+++ b/tools/miqldap_to_sssd/converter.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+
+module MiqLdapToSssd
+  SSSD_CONF_FILE = "/etc/sssd/sssd.conf".freeze
+  SSSD_ALREADY_CONFIGURED = "ERROR: #{SSSD_CONF_FILE} already exists. No changes will be made. Exiting".freeze
+
+  class Converter
+    attr_accessor :options, :initial_settings
+
+    def initialize(args = {})
+      self.options = args.delete_if { |_k, v| v.blank? }
+      self.initial_settings = MiqLdapConfiguration.new(options).retrieve_initial_settings
+
+      LOGGER.debug("#{File.basename(__FILE__)} - #{__method__} User provided settings: #{options}")
+      LOGGER.debug("Initial Settings #{initial_settings}")
+    end
+
+    def run
+      LOGGER.debug("Running #{$PROGRAM_NAME}")
+
+      do_conversion unless initial_settings[:only_change_userids]
+      ConfigureDatabase.new.change_userids_to_upn unless initial_settings[:skip_post_coversion_userid_change]
+
+      Services.restart
+
+      LOGGER.debug("#{$PROGRAM_NAME} Conversion Completed")
+      puts("#{$PROGRAM_NAME} Conversion Completed")
+    end
+
+    private
+
+    def do_conversion
+      exit_if_sssd_is_already_configured
+      AuthConfig.new(initial_settings).run_auth_config
+      SssdConf.new(initial_settings).update
+      disable_tls
+      ConfigureApache.new(initial_settings).configure
+      ConfigureSELinux.new(initial_settings).configure
+      ConfigureApplianceSettings.new.configure
+    end
+
+    def disable_tls
+      ConfigureSssdRules.disable_tls if initial_settings[:mode] == "ldap"
+    end
+
+    def exit_if_sssd_is_already_configured
+      if File.exist?(SSSD_CONF_FILE)
+        puts(SSSD_ALREADY_CONFIGURED)
+        LOGGER.error(SSSD_ALREADY_CONFIGURED)
+        exit
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/miqldap_configuration.rb
+++ b/tools/miqldap_to_sssd/miqldap_configuration.rb
@@ -1,0 +1,58 @@
+module MiqLdapToSssd
+  class MiqLdapConfigurationArgumentError < StandardError; end
+
+  class MiqLdapConfiguration
+    NO_TLS_CERTS      = "TLS certificate were not provided and are required when mode is ldaps".freeze
+    NO_BASE_DN_DOMAIN = "Unable to determine base DN domain name\nA Base DN domain name must be " <<
+                        "specified on the command line when a Base DN is not already configured.".freeze
+
+    attr_accessor :initial_settings
+
+    def initialize(options = {})
+      self.initial_settings = current_authentication_settings.merge(options)
+    end
+
+    def retrieve_initial_settings
+      check_for_tls_certs
+      derive_domain
+    end
+
+    private
+
+    def check_for_basedn_domain
+      if initial_settings[:basedn_domain].nil? && initial_settings[:basedn].nil?
+        LOGGER.fatal(NO_BASE_DN_DOMAIN)
+        raise MiqLdapConfigurationArgumentError, NO_BASE_DN_DOMAIN
+      end
+    end
+
+    def check_for_tls_certs
+      if initial_settings[:mode] == "ldaps" && initial_settings[:tls_cacert].nil?
+        LOGGER.fatal(NO_TLS_CERTS)
+        raise MiqLdapConfigurationArgumentError, NO_TLS_CERTS
+      end
+    end
+
+    def current_authentication_settings
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      settings = Settings.authentication.to_hash
+      LOGGER.debug("Current authentication settings: #{settings}")
+
+      settings
+    end
+
+    def derive_domain
+      check_for_basedn_domain
+
+      # If the caller did not provide a base DN domain name derive it from the configured Base DN.
+      if initial_settings[:basedn_domain].nil?
+        initial_settings[:basedn_domain] = initial_settings[:basedn].split(",").collect do |p|
+          p.split('dc=')[1]
+        end.compact.join('.')
+      end
+
+      initial_settings
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/services.rb
+++ b/tools/miqldap_to_sssd/services.rb
@@ -1,0 +1,21 @@
+require 'linux_admin'
+
+module MiqLdapToSssd
+  class Services
+    def self.restart
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      LOGGER.debug("\nRestarting httpd, if running ...")
+      httpd_service = LinuxAdmin::Service.new("httpd")
+      httpd_service.restart if httpd_service.running?
+
+      LOGGER.debug("Restarting sssd and configure it to start on reboots ...")
+      sssd_service = LinuxAdmin::Service.new("sssd")
+      sssd_service.restart.enable if sssd_service.running?
+
+      LOGGER.debug("Restarting evmserverd and configure it to start on reboots ...")
+      evmserverd_service = LinuxAdmin::Service.new("evmserverd")
+      evmserverd_service.restart.enable if evmserverd_service.running?
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/sssd_conf.rb
+++ b/tools/miqldap_to_sssd/sssd_conf.rb
@@ -1,0 +1,52 @@
+require 'iniparse'
+require 'sssd_conf/domain'
+require 'sssd_conf/ifp'
+require 'sssd_conf/pam'
+require 'sssd_conf/sssd'
+
+module MiqLdapToSssd
+  class SssdConf
+    attr_reader :initial_settings, :sssd_conf_contents
+
+    def initialize(initial_settings)
+      @initial_settings = initial_settings
+      @sssd_conf_contents = sssd_conf_to_hash
+    end
+
+    def update
+      LOGGER.debug("Invoked #{self.class}\##{__method__}")
+
+      [Domain, Sssd, Pam, Ifp].each do |section_class|
+        section = section_class.new(initial_settings)
+        sssd_conf_contents[section.section_name.to_sym] = section.update_attribute_values(sssd_conf_contents)
+      end
+
+      write_updates(sssd_conf_contents)
+    end
+
+    private
+
+    def sssd_conf_to_hash
+      IniParse.open(SSSD_CONF_FILE).to_hash.deep_transform_keys! do |key|
+        key = key.downcase
+        key.start_with?("domain/") ? :domain : key.to_sym
+      end
+    end
+
+    def write_updates(sssd_conf_contents)
+      File.open(SSSD_CONF_FILE, "w") do |f|
+        sssd_conf_contents.each do |section, values|
+          if section == :domain
+            f.write("\n[domain/#{initial_settings[:basedn_domain]}]\n")
+            f.write("\n[application/#{initial_settings[:basedn_domain]}]\n")
+          else
+            f.write("\n[#{section}]\n")
+          end
+          values.each do |attribute, value|
+            f.write("#{attribute} = #{value}\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/sssd_conf/common.rb
+++ b/tools/miqldap_to_sssd/sssd_conf/common.rb
@@ -1,0 +1,29 @@
+require 'miqldap_configuration'
+
+module MiqLdapToSssd
+  class Common
+    USER_ATTRS = %w(mail givenname sn displayname domainname).freeze
+
+    attr_reader :initial_settings, :installation_specific_fields
+
+    def initialize(installation_specific_fields, initial_settings)
+      @installation_specific_fields = installation_specific_fields
+      @initial_settings = initial_settings
+    end
+
+    def section_name
+      self.class.name.downcase.split('::').last
+    end
+
+    def new_attribute_values
+      installation_specific_fields.each_with_object({}) do |attribute, hsh|
+        hsh[attribute.to_sym] = public_send(attribute)
+      end
+    end
+
+    def update_attribute_values(current_attribute_values)
+      current_attribute_values[section_name.to_sym] ||= {}
+      current_attribute_values[section_name.to_sym].merge(new_attribute_values)
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/sssd_conf/domain.rb
+++ b/tools/miqldap_to_sssd/sssd_conf/domain.rb
@@ -1,0 +1,142 @@
+require 'sssd_conf/common'
+
+module MiqLdapToSssd
+  class DomainError < StandardError; end
+
+  class Domain < Common
+    attr_accessor :active_directory
+
+    def initialize(initial_settings)
+      self.active_directory = determine_if_active_directory_configured(initial_settings)
+
+      super(%w(entry_cache_timeout
+               ldap_auth_disable_tls_never_use_in_production
+               ldap_default_bind_dn
+               ldap_default_authtok
+               ldap_group_member
+               ldap_group_name
+               ldap_group_object_class
+               ldap_group_search_base
+               ldap_network_timeout
+               ldap_pwd_policy
+               ldap_schema
+               ldap_tls_cacert
+               ldap_tls_cacertdir
+               ldap_uri
+               ldap_user_extra_attrs
+               ldap_user_gid_number
+               ldap_user_name
+               ldap_user_object_class
+               ldap_user_search_base
+               ldap_user_uid_number), initial_settings)
+    end
+
+    def entry_cache_timeout
+      "600"
+    end
+
+    def ldap_auth_disable_tls_never_use_in_production
+      initial_settings[:mode] == "ldaps" ? false : true
+    end
+
+    def ldap_default_bind_dn
+      initial_settings[:bind_dn]
+    end
+
+    def ldap_default_authtok
+      initial_settings[:bind_pwd]
+    end
+
+    def ldap_group_member
+      "member"
+    end
+
+    def ldap_group_name
+      "cn"
+    end
+
+    def ldap_group_object_class
+      active_directory? ? "group" : "groupOfNames"
+    end
+
+    def ldap_group_search_base
+      initial_settings[:basedn]
+    end
+
+    def ldap_network_timeout
+      "3"
+    end
+
+    def ldap_pwd_policy
+      "none"
+    end
+
+    def ldap_schema
+      active_directory? ? "AD" : "rfc2307bis"
+    end
+
+    def ldap_tls_cacert
+      initial_settings[:mode] == "ldaps" ? initial_settings[:tls_cacert] : nil
+    end
+
+    def ldap_tls_cacertdir
+      initial_settings[:mode] == "ldaps" ? initial_settings[:tls_cacertdir] : "/etc/openldap/cacerts/"
+    end
+
+    def ldap_uri
+      initial_settings[:ldaphost].map do |host|
+        "#{initial_settings[:mode]}://#{host}:#{initial_settings[:ldapport]}"
+      end.join(",")
+    end
+
+    def ldap_user_extra_attrs
+      USER_ATTRS.join(", ")
+    end
+
+    def ldap_user_gid_number
+      active_directory? ? "primaryGroupID" : "gidNumber"
+    end
+
+    def ldap_user_name
+      return if active_directory?
+
+      case initial_settings[:user_type]
+      when "dn-uid"
+        "uid"
+      when "dn-cn"
+        "cn"
+      else
+        raise DomainError, "Invalid user_type ->#{initial_settings[:user_type]}<-"
+      end
+    end
+
+    def ldap_user_object_class
+      "person"
+    end
+
+    def ldap_user_search_base
+      active_directory? ? initial_settings[:basedn] : initial_settings[:user_suffix]
+    end
+
+    def ldap_user_uid_number
+      "uidNumber"
+    end
+
+    private
+
+    def active_directory?
+      active_directory
+    end
+
+    def determine_if_active_directory_configured(initial_settings)
+      case initial_settings[:user_type]
+      when "userprincipalname", "mail", "samaccountname"
+        true
+      when "dn-uid", "dn-cn"
+        false
+      else
+        raise DomainError, "Invalid user_type ->#{initial_settings[:user_type]}<-"
+      end
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/sssd_conf/ifp.rb
+++ b/tools/miqldap_to_sssd/sssd_conf/ifp.rb
@@ -1,0 +1,17 @@
+require 'sssd_conf/common'
+
+module MiqLdapToSssd
+  class Ifp < Common
+    def initialize(initial_settings)
+      super(%w(allowed_uids user_attributes), initial_settings)
+    end
+
+    def allowed_uids
+      "apache, root"
+    end
+
+    def user_attributes
+      USER_ATTRS.map { |attr| "+#{attr}" }.join(", ")
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/sssd_conf/pam.rb
+++ b/tools/miqldap_to_sssd/sssd_conf/pam.rb
@@ -1,0 +1,13 @@
+require 'sssd_conf/common'
+
+module MiqLdapToSssd
+  class Pam < Common
+    def initialize(initial_settings)
+      super(%w(pam_app_services), initial_settings)
+    end
+
+    def pam_app_services
+      "httpd-auth"
+    end
+  end
+end

--- a/tools/miqldap_to_sssd/sssd_conf/sssd.rb
+++ b/tools/miqldap_to_sssd/sssd_conf/sssd.rb
@@ -1,0 +1,33 @@
+require 'sssd_conf/common'
+
+module MiqLdapToSssd
+  class Sssd < Common
+    def initialize(initial_settings)
+      super(%w(config_file_version
+               default_domain_suffix
+               domains
+               sbus_timeout
+               services), initial_settings)
+    end
+
+    def config_file_version
+      "2"
+    end
+
+    def default_domain_suffix
+      initial_settings[:basedn_domain]
+    end
+
+    def domains
+      initial_settings[:basedn_domain]
+    end
+
+    def sbus_timeout
+      "30"
+    end
+
+    def services
+      "nss, pam, ifp"
+    end
+  end
+end


### PR DESCRIPTION
MiQ is delivered with the built in LDAP client, MiqLdap. Maintaining an MiQ proprietary LDAP
client is unnecessary as there are multiple mechanisms built into the operating system that provide an interface to an LDAP directory.

This PR provides a tool that will convert an MiQ appliances authentication configuration from
using the MiQ proprietary LDAP client to using SSSD packaged into the operating system.

The user records created in the DB by the MiqLdap client were assigned a userid of either
a _**Distinguished Name**_ when backed to an LDAP directory or a _**User Principal Name**_
when backed to an Active Directory, configured as an LDAP directory. This tool also, optionally,
changes all userids to  _**User Principal Name**_ format.

Related PR, [15535](https://github.com/ManageIQ/manageiq/pull/15535) updates external authentication to always store the user record in the DB with a userid in 
_**User Principal Name**_ format. This tool can be used to convert MiQ authentication
from mode: LDAP(S) to SSSD however until PR [15535](https://github.com/ManageIQ/manageiq/pull/15535) is merged duplicate user records will be created.

Steps for Testing/QA [Optional]
-------------------------------

Configure MiQ for both authentication modes of LDAP and LDAPS against both an
LDAP directory and an Active Directory.

Login with a valid user confirm the user record is created in the DB.

Run this tool to convert the authentication mode to external auth with SSSD

Login with the same valid user from step 2 and confirm there is only 1 user record with
a userid in _**User Principal Name**_ format. 