### PR TITLE
Add a marker file for determining when the ansible setup has been run

### DIFF
--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -242,10 +242,12 @@ describe EmbeddedAnsible do
     end
 
     context "with a key file" do
-      let(:key_file) { Tempfile.new("SECRET_KEY") }
+      let(:key_file)      { Tempfile.new("SECRET_KEY") }
+      let(:complete_file) { Tempfile.new("embedded_ansible_setup_complete") }
 
       before do
         stub_const("EmbeddedAnsible::SECRET_KEY_FILE", key_file.path)
+        allow(described_class).to receive(:setup_complete_file).and_return(complete_file.path)
       end
 
       after do
@@ -260,6 +262,17 @@ describe EmbeddedAnsible do
           miq_database.ansible_secret_key = key
 
           expect(described_class.configured?).to be true
+        end
+
+        it "returns false when the key is configured but the complete file is missing" do
+          key = "verysecret"
+          key_file.write(key)
+          key_file.close
+          miq_database.ansible_secret_key = key
+
+          complete_file.unlink
+
+          expect(described_class.configured?).to be false
         end
 
         it "returns false when there is no key in the database" do


### PR DESCRIPTION
This ensures that we have a definitive way to determine if we have successfully run the setup for embedded ansible on a particular server

Before this change, the thread running the setup could be killed and when we tried to start the service again, we would see #configured? as true even if we didn't run through the whole playbook.

Now, we will not write this marker file until we finish running the playbook so the next worker will know to attempt the setup if the previous one was killed.

https://bugzilla.redhat.com/show_bug.cgi?id=1474427