### PR TITLE
Let ansible worker gracefully stop

### DIFF
--- a/app/models/embedded_ansible_worker.rb
+++ b/app/models/embedded_ansible_worker.rb
@@ -2,6 +2,9 @@ class EmbeddedAnsibleWorker < MiqWorker
   require_nested :Runner
   include_concern 'ObjectManagement'
 
+  # Don't allow multiple ansible monitor workers to run at once
+  self.include_stopping_workers_on_synchronize = true
+
   self.required_roles = ['embedded_ansible']
 
   def start_runner
@@ -47,9 +50,6 @@ class EmbeddedAnsibleWorker < MiqWorker
       t[:worker_id] == id && t[:worker_class] == self.class.name
     end
   end
-
-  alias terminate kill
-  alias stop kill
 
   def status_update
     # don't monitor the memory/cpu usage of this process yet

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -161,27 +161,25 @@ describe EmbeddedAnsibleWorker do
       end
     end
 
-    %w(kill stop terminate).each do |stop_method|
-      describe "##{stop_method}" do
-        it "exits the monitoring thread and destroys the worker row" do
-          thread_double = double
-          expect(thread_double).to receive(:exit)
-          allow(subject).to receive(:find_worker_thread_object).and_return(thread_double)
-          subject.public_send(stop_method)
-          expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        end
+    describe "#kill" do
+      it "exits the monitoring thread and destroys the worker row" do
+        thread_double = double
+        expect(thread_double).to receive(:exit)
+        allow(subject).to receive(:find_worker_thread_object).and_return(thread_double)
+        subject.kill
+        expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
 
-        it "destroys the worker row but refuses to kill the main thread" do
-          allow(subject).to receive(:find_worker_thread_object).and_return(Thread.main)
-          subject.public_send(stop_method)
-          expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        end
+      it "destroys the worker row but refuses to kill the main thread" do
+        allow(subject).to receive(:find_worker_thread_object).and_return(Thread.main)
+        subject.kill
+        expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
 
-        it "destroys the worker row if the monitor thread is not found" do
-          allow(subject).to receive(:find_worker_thread_object).and_return(nil)
-          subject.public_send(stop_method)
-          expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        end
+      it "destroys the worker row if the monitor thread is not found" do
+        allow(subject).to receive(:find_worker_thread_object).and_return(nil)
+        subject.kill
+        expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1474508

When the ansible worker is not responding, let it try to gracefuly exit
by marking it as stopping.  Allow, the stopping worker code to eventually
kill the worker if it doesn't exit on it's own.

While we're allowing the worker to gracefully exit, don't allow multiple
ansible monitor workers to run at once. Normally, a replacement worker
is started the moment we ask a prior worker to exit.