### PR TITLE
Middleware read-only API endpoints

### DIFF
--- a/app/controllers/api/middleware_datasources_controller.rb
+++ b/app/controllers/api/middleware_datasources_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class MiddlewareDatasourcesController < BaseController
+  end
+end

--- a/app/controllers/api/middleware_deployments_controller.rb
+++ b/app/controllers/api/middleware_deployments_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class MiddlewareDeploymentsController < BaseController
+  end
+end

--- a/app/controllers/api/middleware_domains_controller.rb
+++ b/app/controllers/api/middleware_domains_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class MiddlewareDomainsController < BaseController
+  end
+end

--- a/app/controllers/api/middleware_messagings_controller.rb
+++ b/app/controllers/api/middleware_messagings_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class MiddlewareMessagingsController < BaseController
+  end
+end

--- a/app/controllers/api/middleware_servers_controller.rb
+++ b/app/controllers/api/middleware_servers_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class MiddlewareServersController < BaseController
+  end
+end

--- a/config/api.yml
+++ b/config/api.yml
@@ -55,7 +55,17 @@
     :collection_actions:
       :get:
         - :name: read
-          :identifier: middleware_server_show_list
+          :identifier: middleware_domain_show_list
+  :middleware_datasources:
+    :description: Middleware Datasources
+    :klass: MiddlewareDatasource
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_datasource_show_list
   :accounts:
     :description: Accounts
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -46,6 +46,16 @@
       :get:
         - :name: read
           :identifier: middleware_server_show_list
+  :middleware_domains:
+    :description: Middleware Domains
+    :klass: MiddlewareDomain
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_server_show_list
   :accounts:
     :description: Accounts
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -76,6 +76,16 @@
       :get:
         - :name: read
           :identifier: middleware_messaging_show_list
+  :middleware_deployments:
+    :description: Middleware Deployments
+    :klass: MiddlewareDeployment
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_deployment_show_list
   :accounts:
     :description: Accounts
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -36,6 +36,16 @@
     - :patch
     - :delete
 :collections:
+  :middleware_servers:
+    :description: Middleware Servers
+    :klass: MiddlewareServer
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_server_show_list
   :accounts:
     :description: Accounts
     :options:

--- a/config/api.yml
+++ b/config/api.yml
@@ -36,56 +36,6 @@
     - :patch
     - :delete
 :collections:
-  :middleware_servers:
-    :description: Middleware Servers
-    :klass: MiddlewareServer
-    :options:
-      - :collection
-    :verbs: *g
-    :collection_actions:
-      :get:
-        - :name: read
-          :identifier: middleware_server_show_list
-  :middleware_domains:
-    :description: Middleware Domains
-    :klass: MiddlewareDomain
-    :options:
-      - :collection
-    :verbs: *g
-    :collection_actions:
-      :get:
-        - :name: read
-          :identifier: middleware_domain_show_list
-  :middleware_datasources:
-    :description: Middleware Datasources
-    :klass: MiddlewareDatasource
-    :options:
-      - :collection
-    :verbs: *g
-    :collection_actions:
-      :get:
-        - :name: read
-          :identifier: middleware_datasource_show_list
-  :middleware_messagings:
-    :description: Middleware Messagings
-    :klass: MiddlewareMessaging
-    :options:
-      - :collection
-    :verbs: *g
-    :collection_actions:
-      :get:
-        - :name: read
-          :identifier: middleware_messaging_show_list
-  :middleware_deployments:
-    :description: Middleware Deployments
-    :klass: MiddlewareDeployment
-    :options:
-      - :collection
-    :verbs: *g
-    :collection_actions:
-      :get:
-        - :name: read
-          :identifier: middleware_deployment_show_list
   :accounts:
     :description: Accounts
     :options:
@@ -1118,6 +1068,56 @@
     - :collection
     :verbs: *g
     :klass: ChargebackRateDetailMeasure
+  :middleware_datasources:
+    :description: Middleware Datasources
+    :klass: MiddlewareDatasource
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_datasource_show_list
+  :middleware_deployments:
+    :description: Middleware Deployments
+    :klass: MiddlewareDeployment
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_deployment_show_list
+  :middleware_domains:
+    :description: Middleware Domains
+    :klass: MiddlewareDomain
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_domain_show_list
+  :middleware_messagings:
+    :description: Middleware Messagings
+    :klass: MiddlewareMessaging
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_messaging_show_list
+  :middleware_servers:
+    :description: Middleware Servers
+    :klass: MiddlewareServer
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_server_show_list
   :network_routers:
     :description: Network_Routers
     :identifier: network_router

--- a/config/api.yml
+++ b/config/api.yml
@@ -66,6 +66,16 @@
       :get:
         - :name: read
           :identifier: middleware_datasource_show_list
+  :middleware_messagings:
+    :description: Middleware Messagings
+    :klass: MiddlewareMessaging
+    :options:
+      - :collection
+    :verbs: *g
+    :collection_actions:
+      :get:
+        - :name: read
+          :identifier: middleware_messaging_show_list
   :accounts:
     :description: Accounts
     :options:

--- a/spec/requests/api/middleware_datasources_spec.rb
+++ b/spec/requests/api/middleware_datasources_spec.rb
@@ -1,0 +1,65 @@
+describe 'Middleware Datasources API' do
+  let(:datasource) { FactoryGirl.create(:middleware_datasource) }
+
+  # For some reason middleware_datasources_url is not returning the full
+  # url, just the path portion. This is a hack, but will do the trick.
+  def datasource_url
+    "http://www.example.com#{middleware_datasources_url(datasource.id)}"
+  end
+
+  describe '/' do
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+
+      run_get middleware_datasources_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns an empty listing of datasources' do
+      api_basic_authorize collection_action_identifier(:middleware_datasources, :read, :get)
+
+      run_get middleware_datasources_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_datasources',
+        'count'     => 0,
+        'resources' => [],
+        'subcount'  => 0
+      )
+    end
+
+    it 'returns a a listing of datasources' do
+      datasource
+
+      api_basic_authorize collection_action_identifier(:middleware_datasources, :read, :get)
+
+      run_get middleware_datasources_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_datasources',
+        'count'     => 1,
+        'resources' => [{
+          'href' => datasource_url
+        }],
+        'subcount'  => 1
+      )
+    end
+  end
+
+  describe '/:id' do
+    it 'returns the attributes of one datasource' do
+      api_basic_authorize
+
+      run_get middleware_datasources_url(datasource.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'href'       => datasource_url,
+        'id'         => datasource.id.to_s,
+      )
+    end
+  end
+end

--- a/spec/requests/api/middleware_datasources_spec.rb
+++ b/spec/requests/api/middleware_datasources_spec.rb
@@ -7,6 +7,10 @@ describe 'Middleware Datasources API' do
     "http://www.example.com#{middleware_datasources_url(datasource.id)}"
   end
 
+  def match_id
+    eq ApplicationRecord.compress_id(datasource.id).to_s
+  end
+
   describe '/' do
     it 'forbids access without an appropriate role' do
       api_basic_authorize
@@ -56,10 +60,8 @@ describe 'Middleware Datasources API' do
       run_get middleware_datasources_url(datasource.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(
-        'href' => datasource_url,
-        'id'   => datasource.id.to_s,
-      )
+      expect(response.parsed_body['id']).to match_id
+      expect(response.parsed_body).to include('href' => datasource_url)
     end
   end
 end

--- a/spec/requests/api/middleware_datasources_spec.rb
+++ b/spec/requests/api/middleware_datasources_spec.rb
@@ -57,8 +57,8 @@ describe 'Middleware Datasources API' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
-        'href'       => datasource_url,
-        'id'         => datasource.id.to_s,
+        'href' => datasource_url,
+        'id'   => datasource.id.to_s,
       )
     end
   end

--- a/spec/requests/api/middleware_deployments_spec.rb
+++ b/spec/requests/api/middleware_deployments_spec.rb
@@ -1,0 +1,67 @@
+describe 'Middleware Deployments API' do
+  let(:deployment) { FactoryGirl.create(:middleware_deployment) }
+
+  # For some reason middleware_deployments_url is not returning the full
+  # url, just the path portion. This is a hack, but will do the trick.
+  def deployment_url
+    "http://www.example.com#{middleware_deployments_url(deployment.id)}"
+  end
+
+  describe '/' do
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+
+      run_get middleware_deployments_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns an empty listing of deployments' do
+      api_basic_authorize collection_action_identifier(:middleware_deployments, :read, :get)
+
+      run_get middleware_deployments_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_deployments',
+        'count'     => 0,
+        'resources' => [],
+        'subcount'  => 0
+      )
+    end
+
+    it 'returns a a listing of deployments' do
+      deployment
+
+      api_basic_authorize collection_action_identifier(:middleware_deployments, :read, :get)
+
+      run_get middleware_deployments_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_deployments',
+        'count'     => 1,
+        'resources' => [{
+          'href' => deployment_url
+        }],
+        'subcount'  => 1
+      )
+    end
+  end
+
+  describe '/:id' do
+    it 'returns the attributes of one deployment' do
+      api_basic_authorize
+
+      run_get middleware_deployments_url(deployment.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'href'   => deployment_url,
+        'id'     => deployment.id.to_s,
+        'ems_id' => deployment.ems_id.to_s,
+        'name'   => deployment.name
+      )
+    end
+  end
+end

--- a/spec/requests/api/middleware_deployments_spec.rb
+++ b/spec/requests/api/middleware_deployments_spec.rb
@@ -7,6 +7,10 @@ describe 'Middleware Deployments API' do
     "http://www.example.com#{middleware_deployments_url(deployment.id)}"
   end
 
+  def match_compressed(field)
+    eq ApplicationRecord.compress_id(deployment.send(field)).to_s
+  end
+
   describe '/' do
     it 'forbids access without an appropriate role' do
       api_basic_authorize
@@ -56,11 +60,11 @@ describe 'Middleware Deployments API' do
       run_get middleware_deployments_url(deployment.id)
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['id']).to match_compressed(:id)
+      expect(response.parsed_body['ems_id']).to match_compressed(:ems_id)
       expect(response.parsed_body).to include(
-        'href'   => deployment_url,
-        'id'     => deployment.id.to_s,
-        'ems_id' => deployment.ems_id.to_s,
-        'name'   => deployment.name
+        'href' => deployment_url,
+        'name' => deployment.name
       )
     end
   end

--- a/spec/requests/api/middleware_domains_spec.rb
+++ b/spec/requests/api/middleware_domains_spec.rb
@@ -1,0 +1,66 @@
+describe 'Middleware Domains API' do
+  let(:domain) { FactoryGirl.create :middleware_domain }
+
+  # For some reason middleware_domains_url is not returning the full
+  # url, just the path portion. This is a hack, but will do the trick.
+  def domain_url
+    "http://www.example.com#{middleware_domains_url(domain.id)}"
+  end
+
+  describe '/' do
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+
+      run_get middleware_domains_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns an empty listing of domains' do
+      api_basic_authorize collection_action_identifier(:middleware_domains, :read, :get)
+
+      run_get middleware_domains_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_domains',
+        'count'     => 0,
+        'resources' => [],
+        'subcount'  => 0
+      )
+    end
+
+    it 'returns a listing of domains' do
+      domain
+
+      api_basic_authorize collection_action_identifier(:middleware_domains, :read, :get)
+
+      run_get middleware_domains_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_domains',
+        'count'     => 1,
+        'resources' => [{
+          'href' => domain_url
+        }],
+        'subcount'  => 1
+      )
+    end
+  end
+
+  describe '/:id' do
+    it 'returns the attributes of one domain' do
+      api_basic_authorize
+
+      run_get middleware_domains_url(domain.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'href'       => domain_url,
+        'id'         => domain.id.to_s,
+        'name'       => domain.name
+      )
+    end
+  end
+end

--- a/spec/requests/api/middleware_domains_spec.rb
+++ b/spec/requests/api/middleware_domains_spec.rb
@@ -7,6 +7,10 @@ describe 'Middleware Domains API' do
     "http://www.example.com#{middleware_domains_url(domain.id)}"
   end
 
+  def match_id
+    eq ApplicationRecord.compress_id(domain.id).to_s
+  end
+
   describe '/' do
     it 'forbids access without an appropriate role' do
       api_basic_authorize
@@ -56,9 +60,9 @@ describe 'Middleware Domains API' do
       run_get middleware_domains_url(domain.id)
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['id']).to match_id
       expect(response.parsed_body).to include(
         'href' => domain_url,
-        'id'   => domain.id.to_s,
         'name' => domain.name
       )
     end

--- a/spec/requests/api/middleware_domains_spec.rb
+++ b/spec/requests/api/middleware_domains_spec.rb
@@ -57,9 +57,9 @@ describe 'Middleware Domains API' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
-        'href'       => domain_url,
-        'id'         => domain.id.to_s,
-        'name'       => domain.name
+        'href' => domain_url,
+        'id'   => domain.id.to_s,
+        'name' => domain.name
       )
     end
   end

--- a/spec/requests/api/middleware_messagings_spec.rb
+++ b/spec/requests/api/middleware_messagings_spec.rb
@@ -7,6 +7,10 @@ describe 'Middleware Messagings API' do
     "http://www.example.com#{middleware_messagings_url(messaging.id)}"
   end
 
+  def match_id
+    eq ApplicationRecord.compress_id(messaging.id).to_s
+  end
+
   describe '/' do
     it 'forbids access without an appropriate role' do
       api_basic_authorize
@@ -56,10 +60,8 @@ describe 'Middleware Messagings API' do
       run_get middleware_messagings_url(messaging.id)
 
       expect(response).to have_http_status(:ok)
-      expect(response.parsed_body).to include(
-        'href' => messaging_url,
-        'id'   => messaging.id.to_s,
-      )
+      expect(response.parsed_body['id']).to match_id
+      expect(response.parsed_body).to include('href' => messaging_url)
     end
   end
 end

--- a/spec/requests/api/middleware_messagings_spec.rb
+++ b/spec/requests/api/middleware_messagings_spec.rb
@@ -1,0 +1,65 @@
+describe 'Middleware Messagings API' do
+  let(:messaging) { FactoryGirl.create(:middleware_messaging) }
+
+  # For some reason middleware_messagings_url is not returning the full
+  # url, just the path portion. This is a hack, but will do the trick.
+  def messaging_url
+    "http://www.example.com#{middleware_messagings_url(messaging.id)}"
+  end
+
+  describe '/' do
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+
+      run_get middleware_messagings_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns an empty listing of messagings' do
+      api_basic_authorize collection_action_identifier(:middleware_messagings, :read, :get)
+
+      run_get middleware_messagings_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_messagings',
+        'count'     => 0,
+        'resources' => [],
+        'subcount'  => 0
+      )
+    end
+
+    it 'returns a a listing of messagings' do
+      messaging
+
+      api_basic_authorize collection_action_identifier(:middleware_messagings, :read, :get)
+
+      run_get middleware_messagings_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_messagings',
+        'count'     => 1,
+        'resources' => [{
+          'href' => messaging_url
+        }],
+        'subcount'  => 1
+      )
+    end
+  end
+
+  describe '/:id' do
+    it 'returns the attributes of one messaging' do
+      api_basic_authorize
+
+      run_get middleware_messagings_url(messaging.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'href'       => messaging_url,
+        'id'         => messaging.id.to_s,
+      )
+    end
+  end
+end

--- a/spec/requests/api/middleware_messagings_spec.rb
+++ b/spec/requests/api/middleware_messagings_spec.rb
@@ -57,8 +57,8 @@ describe 'Middleware Messagings API' do
 
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include(
-        'href'       => messaging_url,
-        'id'         => messaging.id.to_s,
+        'href' => messaging_url,
+        'id'   => messaging.id.to_s,
       )
     end
   end

--- a/spec/requests/api/middleware_servers_spec.rb
+++ b/spec/requests/api/middleware_servers_spec.rb
@@ -1,0 +1,68 @@
+describe 'Middleware Servers API' do
+  let(:server) { FactoryGirl.create(:middleware_server) }
+
+  # For some reason middleware_servers_url is not returning the full
+  # url, just the path portion. This is a hack, but will do the trick.
+  def server_url
+    "http://www.example.com#{middleware_servers_url(server.id)}"
+  end
+
+  describe '/' do
+    it 'forbids access without an appropriate role' do
+      api_basic_authorize
+
+      run_get middleware_servers_url
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns an empty listing of servers' do
+      api_basic_authorize collection_action_identifier(:middleware_servers, :read, :get)
+
+      run_get middleware_servers_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_servers',
+        'count'     => 0,
+        'resources' => [],
+        'subcount'  => 0
+      )
+    end
+
+    it 'returns a a listing of servers' do
+      server
+
+      api_basic_authorize collection_action_identifier(:middleware_servers, :read, :get)
+
+      run_get middleware_servers_url
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq(
+        'name'      => 'middleware_servers',
+        'count'     => 1,
+        'resources' => [{
+          'href' => server_url
+        }],
+        'subcount'  => 1
+      )
+    end
+  end
+
+  describe '/:id' do
+    it 'returns the attributes of one server' do
+      api_basic_authorize
+
+      run_get middleware_servers_url(server.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        'href'       => server_url,
+        'id'         => server.id.to_s,
+        'name'       => server.name,
+        'feed'       => server.feed,
+        'properties' => server.properties,
+      )
+    end
+  end
+end

--- a/spec/requests/api/middleware_servers_spec.rb
+++ b/spec/requests/api/middleware_servers_spec.rb
@@ -7,6 +7,10 @@ describe 'Middleware Servers API' do
     "http://www.example.com#{middleware_servers_url(server.id)}"
   end
 
+  def match_id
+    eq ApplicationRecord.compress_id(server.id).to_s
+  end
+
   describe '/' do
     it 'forbids access without an appropriate role' do
       api_basic_authorize
@@ -56,9 +60,9 @@ describe 'Middleware Servers API' do
       run_get middleware_servers_url(server.id)
 
       expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['id']).to match_id
       expect(response.parsed_body).to include(
         'href'       => server_url,
-        'id'         => server.id.to_s,
         'name'       => server.name,
         'feed'       => server.feed,
         'properties' => server.properties,


### PR DESCRIPTION
This PR is the first step into generating API endpoints for middleware-related entities. Currently it covers all entities that appear on the UI menu, albeit only read-only for now.

What is covered:
- Datasources
- Deployments
- Domains
- Messagings
- Servers

What is not covered:

- Providers: this is already another endpoint, no need to duplicate it.

Next steps:

- Check with @mtho11 what resources need destructive/mutable endpoints, so that the API mimics correctly what the UI needs to do.
- Implement provider-specific data, so that we have endpoints that return all the middleware servers for one provider, for instance.
- Implement power operations, this is going to be done in the same way as the power operations on Vms.