### PR TITLE
Merge retirement checks

### DIFF
--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -2,7 +2,7 @@ class LoadBalancer < ApplicationRecord
   include NewWithTypeStiMixin
   include AsyncDeleteMixin
   include ProcessTasksMixin
-  include_concern 'RetirementManagement'
+  include RetirementMixin
   include TenantIdentityMixin
   include CloudTenancyMixin
 

--- a/app/models/load_balancer/retirement_management.rb
+++ b/app/models/load_balancer/retirement_management.rb
@@ -2,16 +2,5 @@ class LoadBalancer
   module RetirementManagement
     extend ActiveSupport::Concern
     include RetirementMixin
-
-    module ClassMethods
-      def retirement_check
-        ems_ids        = MiqServer.my_server.zone.ext_management_systems.pluck(:id)
-        table          = LoadBalancer.arel_table
-        load_balancers = LoadBalancer.where(table[:retires_on].not_eq(nil)
-                                              .or(table[:retired].eq(true))
-                                              .and(table[:ems_id].in(ems_ids)))
-        load_balancers.each(&:retirement_check)
-      end
-    end
   end
 end

--- a/app/models/load_balancer/retirement_management.rb
+++ b/app/models/load_balancer/retirement_management.rb
@@ -1,6 +1,0 @@
-class LoadBalancer
-  module RetirementManagement
-    extend ActiveSupport::Concern
-    include RetirementMixin
-  end
-end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -28,20 +28,8 @@ class MiqScheduleWorker::Jobs
     queue_work_on_each_zone(:class_name  => "Job", :method_name => "check_jobs_for_timeout")
   end
 
-  def service_retirement_check
-    queue_work_on_each_zone(:class_name  => "Service", :method_name => "retirement_check")
-  end
-
-  def vm_retirement_check
-    queue_work_on_each_zone(:class_name  => "Vm", :method_name => "retirement_check")
-  end
-
-  def orchestration_stack_retirement_check
-    queue_work_on_each_zone(:class_name  => "OrchestrationStack", :method_name => "retirement_check")
-  end
-
-  def load_balancer_retirement_check
-    queue_work_on_each_zone(:class_name  => "LoadBalancer", :method_name => "retirement_check")
+  def retirement_check
+    queue_work_on_each_zone(:class_name => 'RetirementManager', :method_name => 'check')
   end
 
   def host_authentication_check_schedule

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -135,28 +135,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue :job_check_jobs_for_timeout
     end
 
-    # Schedule - Check for Retired Services
-    every = worker_settings[:service_retired_interval]
+    # Schedule - Check for retired items and start retirement
+    # TODO: remove redundant settings in follow-up pr
+    every = [worker_settings[:service_retired_interval], worker_settings[:vm_retired_interval], worker_settings[:orchestration_stack_retired_interval], worker_settings[:load_balancer_retired_interval]].min
     scheduler.schedule_every(every, :first_in => every) do
-      enqueue :service_retirement_check
-    end
-
-    # Schedule - Check for Retired VMs
-    every = worker_settings[:vm_retired_interval]
-    scheduler.schedule_every(every, :first_in => every) do
-      enqueue :vm_retirement_check
-    end
-
-    # Schedule - Check for Retired Orchestration Stacks
-    every = worker_settings[:orchestration_stack_retired_interval]
-    scheduler.schedule_every(every, :first_in => every) do
-      enqueue :orchestration_stack_retirement_check
-    end
-
-    # Schedule - Check for Retired Load Balancers
-    every = worker_settings[:load_balancer_retired_interval]
-    scheduler.schedule_every(every, :first_in => every) do
-      enqueue :load_balancer_retirement_check
+      enqueue :retirement_check
     end
 
     # Schedule - Periodic validation of authentications

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -11,7 +11,7 @@ module RetirementMixin
         object = find_by(:id => id)
         object.retire(options) if object.respond_to?(:retire)
       end
-      MiqQueue.put(:class_name => base_model.name, :method_name => "retirement_check")
+      MiqQueue.put(:class_name => 'RetirementManager', :method_name => 'check')
     end
   end
 

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -6,7 +6,7 @@ module RetirementMixin
   ERROR_RETIRING = 'error'
 
   included do
-    scope :not_scheduled_for_retirement, -> { where(arel_table[:retires_on].not_eq(nil).or(arel_table[:retired].not_eq(true))) }
+    scope :scheduled_to_retire, -> { where(arel_table[:retires_on].not_eq(nil).or(arel_table[:retired].not_eq(true))) }
   end
 
   module ClassMethods

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -5,7 +5,7 @@ class OrchestrationStack < ApplicationRecord
   include NewWithTypeStiMixin
   include AsyncDeleteMixin
   include ProcessTasksMixin
-  include_concern 'RetirementManagement'
+  include RetirementMixin
   include TenantIdentityMixin
 
   acts_as_miq_taggable

--- a/app/models/orchestration_stack/retirement_management.rb
+++ b/app/models/orchestration_stack/retirement_management.rb
@@ -1,6 +1,0 @@
-class OrchestrationStack
-  module RetirementManagement
-    extend ActiveSupport::Concern
-    include RetirementMixin
-  end
-end

--- a/app/models/orchestration_stack/retirement_management.rb
+++ b/app/models/orchestration_stack/retirement_management.rb
@@ -2,16 +2,5 @@ class OrchestrationStack
   module RetirementManagement
     extend ActiveSupport::Concern
     include RetirementMixin
-
-    module ClassMethods
-      def retirement_check
-        ems_ids = MiqServer.my_server.zone.ext_management_systems.pluck(:id)
-        table   = OrchestrationStack.arel_table
-        stacks  = OrchestrationStack.where(table[:retires_on].not_eq(nil)
-          .or(table[:retired].eq(true))
-          .and(table[:ems_id].in(ems_ids)))
-        stacks.each(&:retirement_check)
-      end
-    end
   end
 end

--- a/app/models/retirement_manager.rb
+++ b/app/models/retirement_manager.rb
@@ -3,7 +3,7 @@ class RetirementManager
     ems_ids = MiqServer.my_server.zone.ext_management_system_ids
     [LoadBalancer, OrchestrationStack, Vm, Service].each do |model|
       table = model.arel_table
-      arel = table[:retires_on].not_eq(nil).or(table[:retired].eq(true))
+      arel = table[:retires_on].not_eq(nil).or(table[:retired].not_eq(true))
       arel = arel.and(table[:ems_id].in(ems_ids)) if model.column_names.include?('ems_id') # Service not assigned to ems_ids
       model.where(arel).each(&:retirement_check)
     end

--- a/app/models/retirement_manager.rb
+++ b/app/models/retirement_manager.rb
@@ -1,11 +1,18 @@
 class RetirementManager
   def self.check
     ems_ids = MiqServer.my_server.zone.ext_management_system_ids
-    [LoadBalancer, OrchestrationStack, Vm, Service].each do |model|
-      table = model.arel_table
-      arel = table[:retires_on].not_eq(nil).or(table[:retired].not_eq(true))
-      arel = arel.and(table[:ems_id].in(ems_ids)) if model.column_names.include?('ems_id') # Service not assigned to ems_ids
-      model.where(arel).each(&:retirement_check)
+    [LoadBalancer, OrchestrationStack, Vm, Service].flat_map do |i|
+      instances = not_retired_with_zone(i, ems_ids)
+      instances.each(&:retirement_check)
     end
   end
+
+  def self.not_retired_with_zone(model, ems_ids)
+    table = model.arel_table
+    arel = table[:retires_on].not_eq(nil).or(table[:retired].not_eq(true))
+    arel = arel.and(table[:ems_id].in(ems_ids)) if model.column_names.include?('ems_id') # Service not assigned to ems_ids
+    model.where(arel)
+  end
+
+  private_class_method :not_retired_with_zone
 end

--- a/app/models/retirement_manager.rb
+++ b/app/models/retirement_manager.rb
@@ -7,8 +7,9 @@ class RetirementManager
     end
   end
 
-  private_class_method def self.not_retired_with_ems(model, ems_ids)
-    return model.not_scheduled_for_retirement unless model.column_names.include?('ems_id') # Service not assigned to ems_ids
-    model.not_scheduled_for_retirement.where(:ems_id => ems_ids)
+  def self.not_retired_with_ems(model, ems_ids)
+    return model.scheduled_to_retire unless model.column_names.include?('ems_id') # Service not assigned to ems_ids
+    model.scheduled_to_retire.where(:ems_id => ems_ids)
   end
+  private_class_method :not_retired_with_ems
 end

--- a/app/models/retirement_manager.rb
+++ b/app/models/retirement_manager.rb
@@ -1,0 +1,11 @@
+class RetirementManager
+  def self.check
+    ems_ids = MiqServer.my_server.zone.ext_management_system_ids
+    [LoadBalancer, OrchestrationStack, Vm, Service].each do |model|
+      table = model.arel_table
+      arel = table[:retires_on].not_eq(nil).or(table[:retired].eq(true))
+      arel = arel.and(table[:ems_id].in(ems_ids)) if model.column_names.include?('ems_id') # Service not assigned to ems_ids
+      model.where(arel).each(&:retirement_check)
+    end
+  end
+end

--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -2,13 +2,6 @@ module Service::RetirementManagement
   extend ActiveSupport::Concern
   include RetirementMixin
 
-  module ClassMethods
-    def retirement_check
-      services = Service.where("retires_on IS NOT NULL OR retired = ?", true)
-      services.each(&:retirement_check)
-    end
-  end
-
   def before_retirement
     children.each(&:retire_now)
   end

--- a/app/models/vm_or_template/retirement_management.rb
+++ b/app/models/vm_or_template/retirement_management.rb
@@ -2,15 +2,6 @@ module VmOrTemplate::RetirementManagement
   extend ActiveSupport::Concern
   include RetirementMixin
 
-  module ClassMethods
-    def retirement_check
-      zone    = MiqServer.my_server.zone
-      ems_ids = zone.ext_management_system_ids
-      vms     = Vm.where("(retires_on IS NOT NULL OR retired = ?) AND ems_id IN (?)", true, ems_ids)
-      vms.each(&:retirement_check)
-    end
-  end
-
   def retired_validated?
     ['off', 'never'].include?(state)
   end

--- a/spec/models/retirement_manager_spec.rb
+++ b/spec/models/retirement_manager_spec.rb
@@ -1,19 +1,19 @@
 describe RetirementManager do
   describe "#check" do
     it "with retirement date, runs retirement checks" do
-      _, _server, zone = EvmSpecHelper.local_guid_miq_server_zone
+      _, _, zone = EvmSpecHelper.local_guid_miq_server_zone
       ems = FactoryGirl.create(:ems_network, :zone => zone)
 
       load_balancer = FactoryGirl.create(:load_balancer, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
       FactoryGirl.create(:load_balancer, :retired => true)
-      orch_stack = FactoryGirl.create(:orchestration_stack, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
+      orchestration_stack = FactoryGirl.create(:orchestration_stack, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
       FactoryGirl.create(:orchestration_stack, :retired => true)
       vm = FactoryGirl.create(:vm, :retires_on => Time.zone.today + 1.day, :ems_id => ems.id)
       FactoryGirl.create(:vm, :retired => true)
       service = FactoryGirl.create(:service, :retires_on => Time.zone.today + 1.day)
       FactoryGirl.create(:service, :retired => true)
 
-      expect(RetirementManager.check).to match_array([load_balancer, orch_stack, vm, service])
+      expect(RetirementManager.check).to match_array([load_balancer, orchestration_stack, vm, service])
     end
   end
 end

--- a/spec/models/retirement_manager_spec.rb
+++ b/spec/models/retirement_manager_spec.rb
@@ -1,0 +1,19 @@
+describe RetirementManager do
+  describe "#check" do
+    it "with retirement date, runs retirement checks" do
+      _, _server, zone = EvmSpecHelper.local_guid_miq_server_zone
+      ems = FactoryGirl.create(:ems_network, :zone => zone)
+
+      load_balancer = FactoryGirl.create(:load_balancer, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
+      FactoryGirl.create(:load_balancer, :retired => true)
+      orch_stack = FactoryGirl.create(:orchestration_stack, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
+      FactoryGirl.create(:orchestration_stack, :retired => true)
+      vm = FactoryGirl.create(:vm, :retires_on => Time.zone.today + 1.day, :ems_id => ems.id)
+      FactoryGirl.create(:vm, :retired => true)
+      service = FactoryGirl.create(:service, :retires_on => Time.zone.today + 1.day)
+      FactoryGirl.create(:service, :retired => true)
+
+      expect(RetirementManager.check).to match_array([load_balancer, orch_stack, vm, service])
+    end
+  end
+end


### PR DESCRIPTION
Tests retirement checks bundled by @isimluk [here](https://github.com/ManageIQ/manageiq/pull/15104). Vms, Services, OrchestrationStacks, and LoadBalancers run basically the same code for the regular retirement_checks which is now a single queue job thanks to Šimon. The tests create two of each model, only one of which passes the arel conditions of having a retirement date in the future, not being retired already, and having an ems_id present in the list of ids from MiqServer (with the exception of Service, which isn't attached to a zone). The arel is broken out into a separate method to avoid the issue of expect_any_instance_of running on the wrong instance. 