### PR TITLE
[WIP] Remove unused ContainerVolumeKubernetes subclass

### DIFF
--- a/app/models/container_volume_kubernetes.rb
+++ b/app/models/container_volume_kubernetes.rb
@@ -1,2 +1,0 @@
-class ContainerVolumeKubernetes < ContainerVolume
-end


### PR DESCRIPTION
@zakiva please review.
It's not used anywhere now.
Refresh used to assign this type prior to #5926:
https://github.com/ManageIQ/manageiq/pull/5926/files#diff-0324981fdb3019ce6d98f9c86d97f2bbL712
Could anybody still have this type in their DB and we need a migration?
Or can we assume `type` has been rewritten by refreshes to
'ContainerVolume'?  (what about archived records?)

@miq-bot add-label provider/containers, technical debt