### PR TITLE
Add update methods for NetworkRouter

### DIFF
--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -3,6 +3,8 @@ class NetworkRouter < ApplicationRecord
   include SupportsFeatureMixin
   include CloudTenancyMixin
 
+  include_concern 'Operations'
+
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"

--- a/app/models/network_router/operations.rb
+++ b/app/models/network_router/operations.rb
@@ -1,0 +1,11 @@
+module NetworkRouter::Operations
+  extend ActiveSupport::Concern
+
+  def update_network_router(options = {})
+    raw_update_network_router(options)
+  end
+
+  def raw_update_network_router(_options = {})
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+end


### PR DESCRIPTION
Added `update` and `raw_update` methods for Network Router model in order to expose `update` operations in Automate engine: https://github.com/ManageIQ/manageiq-automation_engine/pull/54