### PR TITLE
Make sure passed ids for habtm relation are unique

### DIFF
--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -50,7 +50,7 @@ module ManagerRefresh
           data[key] = value.compact.map(&:load).compact
           # We can use built in _ids methods to assign array of ids into has_many relations. So e.g. the :key_pairs=
           # relation setter will become :key_pair_ids=
-          attributes_for_saving[key.to_s.singularize + "_ids"] = data[key].map(&:id).compact
+          attributes_for_saving[key.to_s.singularize + "_ids"] = data[key].map(&:id).compact.uniq
         elsif loadable?(value) || inventory_collection_scope.association_to_foreign_key_mapping[key]
           # Lets fill also the original data, so other InventoryObject referring to this attribute gets the right
           # result

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -778,6 +778,7 @@ describe ManagerRefresh::SaveInventory do
       :flavor           => @data[:flavors].lazy_find(flavor_data(1)[:name]),
       :genealogy_parent => @data[:miq_templates].lazy_find(image_data(1)[:ems_ref]),
       :key_pairs        => [@data[:key_pairs].lazy_find(key_pair_data(1)[:name]),
+                            @data[:key_pairs].lazy_find(key_pair_data(1)[:name]),
                             @data[:key_pairs].lazy_find(key_pair_data(12)[:name])],
       :location         => @data[:networks].lazy_find("#{vm_data(1)[:ems_ref]}__public",
                                                       :key     => :hostname,


### PR DESCRIPTION
Make sure passed ids for habtm relation are unique, otherwise it could lead to duplication in the relation table or unique index constraint violation.

-- it's enhancement in a sense, that we don't need to filter the data in the parser