### PR TITLE
Reverse the default of wait_for_worker_monitor

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -1,6 +1,4 @@
 class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
-  self.wait_for_worker_monitor = false
-
   def prepare
     ObjectSpace.garbage_collect
     # Overriding prepare so we can set started when we're ready

--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -8,8 +8,6 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
 
   include DuplicateBlocker
 
-  self.wait_for_worker_monitor = false
-
   OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
     [:ems_id, 'EMS Instance ID', String],
   ]

--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker/runner.rb
@@ -1,2 +1,3 @@
 class ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner < ::MiqQueueWorkerBase::Runner
+  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker to start for ems_metrics_collector role, TODO: only for VMware
 end

--- a/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb
@@ -3,6 +3,8 @@ class ManageIQ::Providers::BaseManager::RefreshWorker::Runner < ::MiqQueueWorker
     [:ems_id, 'EMS Instance ID', String],
   ]
 
+  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker for ems_inventory role, TODO: only for VMware
+
   def log_prefix
     @log_prefix ||= "EMS [#{@ems.hostname}] as [#{@ems.authentication_userid}]"
   end

--- a/app/models/miq_ems_refresh_core_worker/runner.rb
+++ b/app/models/miq_ems_refresh_core_worker/runner.rb
@@ -1,8 +1,6 @@
 require 'thread'
 
 class MiqEmsRefreshCoreWorker::Runner < MiqWorker::Runner
-  self.wait_for_worker_monitor = false
-
   OPTIONS_PARSER_SETTINGS = MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
     [:ems_id, 'EMS Instance ID', String],
   ]

--- a/app/models/miq_generic_worker/runner.rb
+++ b/app/models/miq_generic_worker/runner.rb
@@ -1,2 +1,3 @@
 class MiqGenericWorker::Runner < MiqQueueWorkerBase::Runner
+  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker to start because of ems_operations and smartstate roles
 end

--- a/app/models/miq_priority_worker/runner.rb
+++ b/app/models/miq_priority_worker/runner.rb
@@ -1,3 +1,2 @@
 class MiqPriorityWorker::Runner < MiqQueueWorkerBase::Runner
-  self.wait_for_worker_monitor = false
 end

--- a/app/models/miq_smart_proxy_worker/runner.rb
+++ b/app/models/miq_smart_proxy_worker/runner.rb
@@ -1,2 +1,3 @@
 class MiqSmartProxyWorker::Runner < MiqQueueWorkerBase::Runner
+  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker to start for smartproxy role
 end

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -1,6 +1,4 @@
 class MiqVimBrokerWorker::Runner < MiqWorker::Runner
-  self.wait_for_worker_monitor = false
-
   def after_initialize
     require 'thread'
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -84,8 +84,7 @@ class MiqWorker::Runner
   ###############################
 
   def self.wait_for_worker_monitor?
-    @wait_for_worker_monitor = true if @wait_for_worker_monitor.nil?
-    @wait_for_worker_monitor
+    !!@wait_for_worker_monitor
   end
 
   class << self

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -1,10 +1,6 @@
 module MiqWebServerRunnerMixin
   extend ActiveSupport::Concern
 
-  included do
-    self.wait_for_worker_monitor = false
-  end
-
   def do_work
   end
 


### PR DESCRIPTION
A majority of workers do not need to wait for the server to start, so
changing the default simplifies the code and also identifies which
workers actually need to wait.  In researching this, we found that the
only reason that workers are waiting is to actually wait for the vmware
broker to start and provide its connection pool.  Follow up PRs will
change this from wait_for_worker_monitor to "wait for broker", and we
can further make this more specific to vmware only classes.


See also https://github.com/ManageIQ/manageiq/pull/14257#issuecomment-317818016 for a description of how the wait_for_worker_monitor manifests as a "wait for broker" scenario.

cc @carbonin 
@jrafanie Please review.