### PR TITLE
Re-adding "Create Service Dialog from Container Template" feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4800,6 +4800,10 @@
       :description: Edit Tags of Container Template
       :feature_type: control
       :identifier: container_template_tag
+    - :name: Create Service Dialog from Container Template
+      :description: Create Service Dialog from Container Template
+      :identifier: service_dialog_from_ct
+      :feature_type: admin
 
 # ContainerService
 - :name: Services


### PR DESCRIPTION
This feature was accidentally removed in https://github.com/ManageIQ/manageiq/pull/15592

before:
![before](https://user-images.githubusercontent.com/3450808/28589103-a910a2b8-714a-11e7-84e5-ea8261a079f9.png)

after:
![after](https://user-images.githubusercontent.com/3450808/28589292-765b00a6-714b-11e7-8e40-14196d938b42.png)

@dclarizio please review/merge