### PR TITLE
Replace wait_for_worker_monitor with delay_startup_for_vim_broker

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker/runner.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner < ::MiqQueueWorkerBase::Runner
-  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker to start for ems_metrics_collector role, TODO: only for VMware
+  self.delay_startup_for_vim_broker = true # NOTE: For ems_metrics_collector role, TODO: only for VMware
 end

--- a/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::BaseManager::RefreshWorker::Runner < ::MiqQueueWorker
     [:ems_id, 'EMS Instance ID', String],
   ]
 
-  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker for ems_inventory role, TODO: only for VMware
+  self.delay_startup_for_vim_broker = true # NOTE: For ems_inventory role, TODO: only for VMware
 
   def log_prefix
     @log_prefix ||= "EMS [#{@ems.hostname}] as [#{@ems.authentication_userid}]"

--- a/app/models/miq_generic_worker/runner.rb
+++ b/app/models/miq_generic_worker/runner.rb
@@ -1,3 +1,3 @@
 class MiqGenericWorker::Runner < MiqQueueWorkerBase::Runner
-  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker to start because of ems_operations and smartstate roles
+  self.delay_startup_for_vim_broker = true # NOTE: For ems_operations and smartstate roles
 end

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -92,11 +92,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def message_delivery_suspended?
-    if self.class.require_vim_broker?
-      return true unless MiqVimBrokerWorker.available?
-    end
-
-    false
+    self.class.delay_queue_delivery_for_vim_broker? && !MiqVimBrokerWorker.available?
   end
 
   def deliver_queue_message(msg)

--- a/app/models/miq_smart_proxy_worker/runner.rb
+++ b/app/models/miq_smart_proxy_worker/runner.rb
@@ -1,3 +1,3 @@
 class MiqSmartProxyWorker::Runner < MiqQueueWorkerBase::Runner
-  self.wait_for_worker_monitor = true # NOTE: Really means wait for broker to start for smartproxy role
+  self.delay_startup_for_vim_broker = true # NOTE: For smartproxy role
 end

--- a/spec/models/miq_ui_worker/runner_spec.rb
+++ b/spec/models/miq_ui_worker/runner_spec.rb
@@ -1,5 +1,0 @@
-describe MiqUiWorker::Runner do
-  it ".wait_for_worker_monitor?" do
-    expect(described_class.wait_for_worker_monitor?).to be_falsey
-  end
-end


### PR DESCRIPTION
This continues the work of 9e99ba02 to morph `wait_for_worker_monitor`
into what it actually has become under the covers.  Additionally, there
is the similarly named `requires_vim_broker`, which really means to delay
the queue delivery loop when the broker goes down.  This commit renames
that for clarity (with a temporary alias until we can change the
callers).

cc @carbonin 
@jrafanie Please review.