### PR TITLE
Fix test failures when tmp dir is a symlink

### DIFF
--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -144,14 +144,14 @@ describe VMDB::Util do
     it "entry is a symlink to origin file, origin file is added with symlink's name" do
       entry = 'ROOT' + symlink_level_1
       zip_entry = Zip::Entry.new(zip, entry, nil, nil, nil, nil, nil, nil, ztime)
-      expect(zip).to receive(:add).with(zip_entry, origin_file.path)
+      expect(zip).to receive(:add).with(zip_entry, File.realpath(origin_file.path))
       expect(described_class.send(:add_zip_entry, zip, symlink_level_1, zip_file)).to eq([entry, mtime])
     end
 
     it "entry is a symlink to symlink to origin file, origin file is added with symlink's name" do
       entry = 'ROOT' + symlink_level_2
       zip_entry = Zip::Entry.new(zip, entry, nil, nil, nil, nil, nil, nil, ztime)
-      expect(zip).to receive(:add).with(zip_entry, origin_file.path)
+      expect(zip).to receive(:add).with(zip_entry, File.realpath(origin_file.path))
       expect(described_class.send(:add_zip_entry, zip, symlink_level_2, zip_file)).to eq([entry, mtime])
     end
 


### PR DESCRIPTION
In the tests for `spec/lib/vmdb/util_spec.rb`, the stub for the `zip.add` method assumes it will receive a file from a tmp file, that is created in a let statement (in this case, `origin_file`), which just makes use of Ruby's `Tempfile` class.

On certain OS's (OSX in this case), this might generate a file in a tmp directory that is actually a symlink to another directory.  `origin_file.path` in this case is actually pointing to the symlinked version of that path.

The code this is testing will make sure to follow the symlink of the zip entry that is being added, but it turns out that the `origin_file` for that symlink (used in the stub) can also be a symlink depending on what `Tempfile.new` returns.  Adding a `File.realpath` around the `origin_file.path` in the method stub makes certain that we are always getting the proper origin file.


Links
-----
* https://github.com/ManageIQ/manageiq/issues/15420


Steps for Testing/QA
--------------------
Have @chrisarcand check this out and run the tests on his machine :trollface: