### PR TITLE
[EUWE] Display Ansible tower job templates filters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -800,7 +800,7 @@ module ApplicationHelper
        ems_container vm miq_template offline retired templates
        host service storage ems_cloud ems_cluster flavor
        ems_network security_group floating_ip cloud_subnet network_router network_port cloud_network
-       load_balancer provider_foreman
+       load_balancer provider_foreman configuration_scripts
        ems_storage cloud_volume cloud_object_store_container
        resource_pool ems_infra ontap_storage_system ontap_storage_volume
        ontap_file_share snia_local_file_system ontap_logical_disk

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -41,6 +41,21 @@ class MiqSearch < ApplicationRecord
     where("search_type=? or (search_type=? and (search_key is null or search_key<>?))", "global", "default", "_hidden_")
   end
 
+  def self.visible_to_current_user
+    where(:search_type => 'user', :search_key => User.current_user.userid)
+  end
+
+  def self.filters_by_type(type)
+    case type
+    when "global" # Global filters
+      visible_to_all
+    when "my"     # My filters
+      visible_to_current_user
+    else
+      raise "Error: #{type} is not a proper filter type!"
+    end
+  end
+
   def self.get_expressions_by_model(db)
     get_expressions(:db => db.to_s)
   end

--- a/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
@@ -29,10 +29,12 @@ class TreeBuilderConfigurationManagerConfigurationScripts < TreeBuilder
 
     objects.push(:id          => "global",
                  :text        => _("Global Filters"),
+                 :image       => "folder",
                  :tip         => _("Global Shared Filters"),
                  :cfmeNoClick => true)
     objects.push(:id          => "my",
                  :text        => _("My Filters"),
+                 :image       => "folder",
                  :tip         => _("My Personal Filters"),
                  :cfmeNoClick => true)
     count_only_or_objects(count_only, objects)

--- a/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
+++ b/app/presenters/tree_builder_configuration_manager_configuration_scripts.rb
@@ -19,13 +19,32 @@ class TreeBuilderConfigurationManagerConfigurationScripts < TreeBuilder
 
   # Get root nodes count/array for explorer tree
   def x_get_tree_roots(count_only, _options)
-    count_only_or_objects(count_only,
-                          Rbac.filtered(ManageIQ::Providers::AnsibleTower::ConfigurationManager.order("lower(name)"),
-                                        :match_via_descendants => ConfigurationScript), "name")
+    objects = []
+    templates = Rbac.filtered(ManageIQ::Providers::AnsibleTower::ConfigurationManager.order("lower(name)"),
+                              :match_via_descendants => ConfigurationScript)
+
+    templates.each do |temp|
+      objects.push(temp)
+    end
+
+    objects.push(:id          => "global",
+                 :text        => _("Global Filters"),
+                 :tip         => _("Global Shared Filters"),
+                 :cfmeNoClick => true)
+    objects.push(:id          => "my",
+                 :text        => _("My Filters"),
+                 :tip         => _("My Personal Filters"),
+                 :cfmeNoClick => true)
+    count_only_or_objects(count_only, objects)
   end
 
   def x_get_tree_cmat_kids(object, count_only)
     count_only_or_objects(count_only,
                           Rbac.filtered(ManageIQ::Providers::AnsibleTower::ConfigurationManager::ConfigurationScript.where(:manager_id => object.id)), "name")
+  end
+
+  def x_get_tree_custom_kids(object, count_only, options)
+    objects = MiqSearch.where(:db => options[:leaf]).filters_by_type(object[:id])
+    count_only_or_objects(count_only, objects, 'description')
   end
 end

--- a/app/views/layouts/listnav/_explorer.html.haml
+++ b/app/views/layouts/listnav/_explorer.html.haml
@@ -1,5 +1,5 @@
 #accordion.panel-group
-  - if @accords.length == 1 # there is no need for JavaScript if only one accordion is present
+  - if @accords.present? && @accords.length == 1 # there is no need for JavaScript if only one accordion is present
     .panel.panel-default
       .panel-heading
         %h4.panel-title
@@ -8,7 +8,7 @@
       .panel-collapse.collapse.in
         .panel-body{:id => @accords.first[:container]}
           = render :partial => 'shared/explorer_tree', :locals => {:name => @accords.first[:name]}
-  - elsif @accords.length > 1
+  - elsif @accords.present? && @accords.length > 1
     - accord_names = @accords.map { |accord| accord[:name].to_sym }
     - @accords.each_with_index do |a, i|
       = miq_accordion_panel(a[:title], accord_names.include?(@sb[:active_accord]) ? a[:name].to_sym == @sb[:active_accord] : i == 0, a[:container]) do


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/1082
fixing https://bugzilla.redhat.com/show_bug.cgi?id=1472381

Display Ansible Tower Job Templates filters in accordion
in Configuration -> Management -> Ansible tower job templates.
Correct condition in `_explorer.html.haml` not to fail if `nil`.
