### PR TITLE
Fix service dialog edit

### DIFF
--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -22,7 +22,7 @@ class DialogGroup < ApplicationRecord
         DialogField.find(self.class.uncompress_id(field['id'])).tap do |dialog_field|
           resource_action_fields = field.delete('resource_action') || {}
           update_resource_fields(resource_action_fields, dialog_field)
-          dialog_field.update_attributes(field)
+          dialog_field.update_attributes(field.except('id', 'href', 'dialog_group_id'))
           updated_fields << dialog_field
         end
       else

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -35,7 +35,7 @@ class DialogTab < ApplicationRecord
     groups.each do |group|
       if group.key?('id')
         DialogGroup.find(self.class.uncompress_id(group['id'])).tap do |dialog_group|
-          dialog_group.update_attributes(group.except('dialog_fields'))
+          dialog_group.update_attributes(group.except('id', 'href', 'dialog_tab_id', 'dialog_fields'))
           dialog_group.update_dialog_fields(group['dialog_fields'])
           updated_groups << dialog_group
         end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -284,13 +284,16 @@ describe Dialog do
     let(:updated_content) do
       [
         {
-          'id'            => dialog_tab.first.id,
+          'id'            => dialog_tab.first.compressed_id,
           'label'         => 'updated_label',
           'dialog_groups' => [
-            { 'id'            => dialog_group.first.id,
+            { 'id'            => dialog_group.first.compressed_id,
+              'dialog_tab_id' => dialog_tab.first.compressed_id,
               'dialog_fields' =>
                                  [{
-                                   'id' => dialog_field.first.id}] },
+                                   'id'              => dialog_field.first.id,
+                                   'dialog_group_id' => dialog_group.first.compressed_id
+                                 }] },
             {
               'label'         => 'group 2',
               'dialog_fields' => [{


### PR DESCRIPTION
Resolving more compressed id problems for the dialog editor

When updating a dialog, the `content` that is passed to it includes a `dialog_id` or `dialog_tab_id` etc...on update, this was being interpreted as a `10` (or whatever region it's in), causing it to no longer be associated with the correct dialog. In addition, the IDs for those object were being interpreted as so, causing a unique key violation (amongst other problems).

While this is a temporary fix to get the dialog editor working, I think that we need to revisit the way we handle compressed ids. If we are sending out compressed ids, we should be uncompressing them on the way back in, or we may run into more problems like this. (cc: @abellotti @imtayadeway )

cc: @romanblanco, @martinpovolny 

@miq-bot assign @gtanzillo 
@miq-bot add_label bug