### PR TITLE
Support logins when "Get User Groups from LDAP" is not checked

### DIFF
--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -118,7 +118,7 @@ module Authenticator
 
     def plain_username_from_dn_or_upn(username)
       return username.split("@").first if username.include?("@")
-      username[/=(.*?),/m, 1]
+      username[/=(.*?),/m, 1] || username
     end
 
     def userid_for(lobj, username)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -103,8 +103,22 @@ module Authenticator
     end
 
     def userprincipal_for(username)
+      return find_user_in_db(username) unless authorize?
+
       lobj = find_external_identity(username)
       User.find_by_userid(userid_for(lobj, username))
+    end
+
+    def find_user_in_db(username)
+      user = User.find_by_userid(username)
+      return user unless user.nil?
+
+      User.find_by_userid(plain_username_from_dn_or_upn(username))
+    end
+
+    def plain_username_from_dn_or_upn(username)
+      return username.split("@").first if username.include?("@")
+      username[/=(.*?),/m, 1]
     end
 
     def userid_for(lobj, username)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -16,10 +16,6 @@ module Authenticator
       end
     end
 
-    def lookup_by_identity(username)
-      super || User.find_by_userid(plain_username_from_dn_or_upn(username))
-    end
-
     def autocreate_user(username)
       # when default group for ldap users is enabled, create the user
       return unless config[:default_group_for_users]
@@ -46,12 +42,6 @@ module Authenticator
     def ldap_bind(username, password)
       ldap = MiqLdap.new(:auth => config)
       ldap if ldap.bind(username, password)
-    end
-
-    def plain_username_from_dn_or_upn(username)
-      username = miq_ldap.fqusername(username)
-      return username.split("@").first if username.include?("@")
-      username[/=(.*?),/m, 1] || username
     end
 
     def create_user_from_ldap(username)

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -62,7 +62,6 @@ describe Authenticator::Ldap do
       'rootdn' => {:password => 'verysecret'},
       'alice'  => alice_data,
       'bob'    => bob_data,
-      'bobby'  => bobby_data,
       'betty'  => betty_data,
       'sam'    => sam_data,
     }
@@ -86,17 +85,6 @@ describe Authenticator::Ldap do
       :givenname         => 'Bob',
       :sn                => 'Builderson',
       :mail              => 'bob@example.com',
-      :groups            => %w(wibble bubble),
-    }
-  end
-  let(:bobby_data) do
-    {
-      :userprincipalname => 'bobby',
-      :password          => 'secret',
-      :displayname       => 'Bobby Builderson',
-      :givenname         => 'Bobby',
-      :sn                => 'Builderson',
-      :mail              => 'bobby@example.com',
       :groups            => %w(wibble bubble),
     }
   end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -169,8 +169,7 @@ describe Authenticator::Ldap do
       end
 
       it "refuses users that don't exist in LDAP" do
-        expect(subject).to receive(:userprincipal_for)
-        expect(-> { subject.lookup_by_identity('carol') }).to raise_error(/credentials are not configured/)
+        expect(subject.lookup_by_identity('carol')).to eq(nil)
       end
     end
 
@@ -204,8 +203,7 @@ describe Authenticator::Ldap do
       end
 
       it "refuses users that don't exist in LDAP" do
-        expect(subject).to receive(:userprincipal_for)
-        expect(-> { subject.lookup_by_identity('carol') }).to raise_error(/no data for user/)
+        expect(subject.lookup_by_identity('carol')).to eq(nil)
       end
     end
   end
@@ -402,11 +400,6 @@ describe Authenticator::Ldap do
 
           it "succeeds" do
             expect(authenticate).to be_a(User)
-          end
-
-          it "looks in ldap" do
-            expect(subject).to receive(:find_or_create_by_ldap)
-            authenticate
           end
 
           it "records two successful audit entries" do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -143,6 +143,22 @@ describe Authenticator::Ldap do
       end
     end
 
+    context "validates the username but failes to auto-create it" do
+      let(:error_string) { "Unable to auto-create user because LDAP bind credentials are not configured" }
+      it "when username is simple format" do
+        expect { subject.lookup_by_identity('big_alice') }.to raise_error(RuntimeError, error_string)
+      end
+
+      it "when username is UPN format" do
+        expect { subject.lookup_by_identity('big_alice@example.com') }.to raise_error(RuntimeError, error_string)
+      end
+
+      it "when username is dn" do
+        expect { subject.lookup_by_identity('cn=big_alice,ou=prod,dc=example,dc=com') }
+          .to raise_error(RuntimeError, error_string)
+      end
+    end
+
     it "normalizes usernames" do
       expect(subject.lookup_by_identity('aXlice')).to eq(alice)
     end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -141,22 +141,8 @@ describe Authenticator::Ldap do
   end
 
   describe '#lookup_by_identity' do
-    context "finds existing users" do
-      it "when username is simple format" do
-        expect(subject.lookup_by_identity('alice')).to eq(alice)
-      end
-
-      it "when username is UPN format" do
-        expect(subject.lookup_by_identity('alice@example.com')).to eq(alice)
-      end
-
-      it "when username is dn" do
-        expect(subject.lookup_by_identity('cn=alice,ou=prod,dc=example,dc=com')).to eq(alice)
-      end
-    end
-
-    it "normalizes usernames" do
-      expect(subject.lookup_by_identity('aXlice')).to eq(alice)
+    it "finds existing users" do
+      expect(subject.lookup_by_identity('alice')).to eq(alice)
     end
 
     context "using internal authorization" do

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -129,8 +129,18 @@ describe Authenticator::Ldap do
   end
 
   describe '#lookup_by_identity' do
-    it "finds existing users" do
-      expect(subject.lookup_by_identity('alice')).to eq(alice)
+    context "finds existing users" do
+      it "when username is simple format" do
+        expect(subject.lookup_by_identity('alice')).to eq(alice)
+      end
+
+      it "when username is UPN format" do
+        expect(subject.lookup_by_identity('alice@example.com')).to eq(alice)
+      end
+
+      it "when username is dn" do
+        expect(subject.lookup_by_identity('cn=alice,ou=prod,dc=example,dc=com')).to eq(alice)
+      end
     end
 
     it "normalizes usernames" do

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -14,6 +14,7 @@ describe Authenticator::Ldap do
 
   context ".lookup_by_identity" do
     let(:current_user) { @auth.lookup_by_identity(@username) }
+    let(:autocreate_current_user) { @auth.autocreate_user(@username) }
 
     before do
       @username    = "upnuser"
@@ -30,7 +31,7 @@ describe Authenticator::Ldap do
 
     it "user exists" do
       user = FactoryGirl.create(:user_admin, :userid => @fqusername)
-      allow(@auth).to receive(:userprincipal_for).and_return(user)
+      allow(@auth).to receive(:lookup_by_identity).and_return(user)
       expect(current_user).to eq(user)
     end
 
@@ -38,8 +39,9 @@ describe Authenticator::Ldap do
       group = create_super_admin_group
       setup_to_create_user(group)
 
-      expect(current_user).to be_present
-      expect(User.all.size).to eq(1)
+      expect(current_user).to eq(nil)
+      autocreate_current_user
+      expect(User.all.size).to eq(0)
     end
   end
 
@@ -84,7 +86,6 @@ describe Authenticator::Ldap do
 
         context "with default group for users enabled" do
           it "group exists" do
-            allow(@auth).to receive(:find_or_create_by_ldap)
             group = create_super_admin_group
             setup_to_create_user(group)
             @auth_config[:authentication][:default_group_for_users] = group.description

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -37,11 +37,11 @@ describe Authenticator::Ldap do
 
     it "user does not exist" do
       group = create_super_admin_group
+      @auth_config[:authentication][:default_group_for_users] = group.name
       setup_to_create_user(group)
 
-      expect(current_user).to eq(nil)
-      autocreate_current_user
-      expect(User.all.size).to eq(0)
+      expect(autocreate_current_user).to be_present
+      expect(User.all.size).to eq(1)
     end
   end
 


### PR DESCRIPTION
When not getting groups from LDAP the user is manually created in
the DB. It is unlikely the admin will create the user in the UPN
or DN formats as return from searching the directory. So this PR
will also try to find the user by simple username.

https://bugzilla.redhat.com/show_bug.cgi?id=1442791

Steps for Testing/QA
-------------------------------

1. Configure MiQ authentication with mode LDAP(S)
2. Do not select _Get User Groups from LDAP_
3. Ensure _Base DN_ and _Bind DN_ had not been filled in.
4. Manually create a test user with a simple username, not a full DN or UPN e.g. **_testuser_**, and assign the user a group.
5. Confirm attempts to log in with the test user succeed.