### PR TITLE
Remove unused google oauth route :fire: :scissors:

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,8 +89,6 @@ Vmdb::Application.routes.draw do
   # ping response for load balancing
   get '/ping' => 'ping#index'
 
-  match "/auth/:provider/callback" => "sessions#create", :via => :get
-
   if Rails.env.development? && defined?(Rails::Server)
     logger = Logger.new(STDOUT)
     logger.level = Logger.const_get(::Settings.log.level_websocket.upcase)


### PR DESCRIPTION
It was added in: 1c661394fc90931ca5e585eecaf573f5b98e5af1
The only location routing to /auth was removed in: 5cf9fc93bb38dd2c09f2cf622be254a312907a56

cc @himdel @agrare  :fire: ✂️  🗑 