### PR TITLE
Let vmware_web_service autoload the VimTypes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ end
 
 group :vmware, :manageiq_default do
   manageiq_plugin "manageiq-providers-vmware"
-  gem "vmware_web_service",             "~>0.1.1",       :require => false
+  gem "vmware_web_service",             "~>0.1.4"
 end
 
 ### shared dependencies

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -3,9 +3,6 @@ module Vmdb
     def self.init
       _log.info "- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['MIQ_GUID']: #{ENV['MIQ_GUID']}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}"
 
-      # When these classes are deserialized in ActiveRecord (e.g. EmsEvent, MiqQueue), they need to be preloaded
-      require 'VMwareWebService/VimTypes'
-
       # UiWorker called in Development Mode
       #   * command line(rails server)
       #   * debugger


### PR DESCRIPTION
We moved the eager load of VimTypes.rb to vmware_web_service as
autoloads in:
https://github.com/ManageIQ/vmware_web_service/pull/18

This landed in 0.1.4: https://github.com/ManageIQ/vmware_web_service/commits/v0.1.4

We need to require the gem now so we can autoload in the gem instead of eager loading
in the main app. We can't take advantage of Rails autoloading because
the VimTypes.rb doesn't follow the rails patterns for naming.
