### PR TITLE
[Performance] MiqSearch.seed

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -329,16 +329,6 @@
     search_type: default
     db: Host
 - attributes:
-    name: default_Status / Running
-    description: Status / Running
-    filter: !ruby/object:MiqExpression
-      exp:
-        INCLUDES:
-          field: Host-power_state
-          value: "on"
-    search_type: default
-    db: Host
-- attributes:
     name: default_Status / Stopped
     description: Status / Stopped
     filter: !ruby/object:MiqExpression
@@ -377,17 +367,6 @@
         INCLUDES:
           field: Host-power_state
           value: "on"
-    search_type: default
-    db: Host
-- attributes:
-    name: default_Status / Stopped
-    description: Status / Stopped
-    filter: !ruby/object:MiqExpression
-      exp:
-        not:
-          INCLUDES:
-            field: Host-power_state
-            value: "on"
     search_type: default
     db: Host
 - attributes:


### PR DESCRIPTION
Since we run seeds on every appliance boot, and it blocks all other appliances from booting, the goal is to get seeds as fast as possible.

- remove N+1 lookups to `miq_searches`
- remove duplicate records in `yaml` file.
- display warning for duplicate records in `yaml` file.
- Was saving all records since it thought `filter` had changed. Fixes false positives.

|       ms |       bytes | objects |query | query ms |     rows |comments
|      ---:|         ---:|     ---:|  ---:|      ---:|      ---:| ---
|  1,590.1 | 33,844,512 | 401,337 |  602 |   886.3 |      119 | before
|     90.2 | 4,622,977 |  58,704 |    1 |     4.3 |      117 | after
| 94% | 86% | 85% | 99.9% | 99.5% | 2% | diff

related to:
- https://bugzilla.redhat.com/show_bug.cgi?id=1422671
- https://github.com/ManageIQ/manageiq/pull/15586