### PR TITLE
Allow running workers using Foreman in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ REGION
 SyntaxCheck
 xfer_*.xml
 Thumbs.db
+Procfile
 
 # bin/
 bin/*

--- a/Gemfile
+++ b/Gemfile
@@ -194,6 +194,7 @@ end
 #
 unless ENV["APPLIANCE"]
   group :development do
+    gem "foreman"
     gem "haml_lint",        "~>0.20.0", :require => false
     gem "rubocop",          "~>0.47.0", :require => false
     gem "scss_lint",        "~>0.48.0", :require => false

--- a/Procfile.example
+++ b/Procfile.example
@@ -1,0 +1,48 @@
+# Web server workers
+# The $PORT variable is set automatically by foreman for particular workers
+# We tell foreman to start at 3000, it then increments by 1 per instance of a worker type
+# and 100 per worker type.
+#
+# So, the first ui worker will get PORT=3000 while the next will get PORT=3001
+# The first api worker will get PORT=3100 and the next will get PORT=3101
+
+# ui:        env PORT=$PORT bundle exec rails r lib/workers/bin/run_single_worker.rb MiqUiWorker
+# api:       env PORT=$PORT bundle exec rails r lib/workers/bin/run_single_worker.rb MiqWebServiceWorker
+# websocket: env PORT=$PORT bundle exec rails r lib/workers/bin/run_single_worker.rb MiqWebsocketWorker
+
+# schedule: bundle exec rails r lib/workers/bin/run_single_worker.rb MiqScheduleWorker
+
+# Queue workers
+# These workers use a default queue defined in their classes
+# We do not need to pass them a queue name
+
+# generic:           bundle exec rails r lib/workers/bin/run_single_worker.rb MiqGenericWorker
+# priority:          bundle exec rails r lib/workers/bin/run_single_worker.rb MiqPriorityWorker
+# event:             bundle exec rails r lib/workers/bin/run_single_worker.rb MiqEventHandler
+# reporting:         bundle exec rails r lib/workers/bin/run_single_worker.rb MiqReportingWorker
+# metrics_processor: bundle exec rails r lib/workers/bin/run_single_worker.rb MiqEmsMetricsProcessorWorker
+
+# Provider workers
+#
+# If you are unsure which workers to start, you can run `ruby lib/workers/bin/run_single_worker.rb -l` to list the workers available
+
+# VMware example
+# The following workers should be started to work with a VMware infrastructure EMS
+
+# vim_broker:     bundle exec rails r lib/workers/bin/run_single_worker.rb MiqVimBrokerWorker
+# vmware_metrics: bundle exec rails r lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker
+
+# Per EMS queue workers
+# These workers subscribe to a queue named based on the particular EMS they connect to
+# The "<id>" tag in these lines should be replaced by the id of the manager instance these workers apply to
+
+# vmware_refresh_<id>:      env QUEUE=ems_<id> bundle exec rails r lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
+# vmware_event_<id>:        env QUEUE=ems_<id> bundle exec rails r lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::EventCatcher
+# vmware_refresh_core_<id>: env QUEUE=ems_<id> bundle exec rails r lib/workers/bin/run_single_worker.rb MiqEmsRefreshCoreWorker
+
+# Logs
+#
+# If you also want to see the log output in the same terminal session that you see the foreman output, uncomment these lines
+
+# evm_log: tail -f log/evm.log
+# dev_log: tail -f log/development.log

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -121,7 +121,7 @@ module MiqWebServerWorkerMixin
       :server      => self.class.rails_server
     }
 
-    params[:Port] = port.kind_of?(Numeric) ? port : 3000
+    params[:Port] = port.kind_of?(Numeric) ? port : ENV["PORT"] || 3000
     params[:pid]  = self.class.pid_file(params[:Port]).to_s
 
     params

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -3,6 +3,22 @@ require 'evm_application'
 require 'evm_rake_helper'
 
 namespace :evm do
+  namespace :foreman do
+    task :start => [:environment, 'db:seed'] do
+      server = MiqServer.my_server
+
+      # Assign and activate the default roles
+      server.ensure_default_roles
+      server.activate_roles(server.server_role_names)
+
+      # Mark the server as started
+      server.update_attributes(:status => "started")
+
+      # start the workers using foreman
+      Bundler.with_clean_env { exec("foreman start --port=3000") }
+    end
+  end
+
   desc "Start the ManageIQ EVM Application"
   task :start => :environment do
     EvmApplication.start


### PR DESCRIPTION
This allows developers to start workers independently of the server in a very easy and repeatable way.

This PR add a rake task which takes care of ensuring the "server" process looks started so that the workers will run normally. Additional roles need to be set manually as the server process will not be running.

The intended use is for a developer to create their own Procfile in the root of the repo with whatever workers they need to start for the work that they are doing. Procfile was added to .gitignore so that changes to the Procfile don't dirty the git status.

The only application changes that this PR needed was the ability to set a web server worker's port using an environment variable.