### PR TITLE
Display the text "Generic Object Class" in the UI (instead of Generic Object Definition)

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -726,6 +726,7 @@ en:
       Filesystem:               File
       Flavor:                   Flavor
       FloatingIp:               Floating IP
+      GenericObjectDefinition:  Generic Object Class
       Host:                     Host / Node
       HostPerformance:          Performance - Host
       IsoDatastore:             ISO Datastore


### PR DESCRIPTION
The string representation of the model `GenericObjectDefinition` in the UI needs to be
"Generic Object Class"