### PR TITLE
Utility for diagnose pg locked - Step 3.1

### DIFF
--- a/tools/pg_inspector/active_connections_to_human.rb
+++ b/tools/pg_inspector/active_connections_to_human.rb
@@ -127,9 +127,7 @@ module PgInspector
     end
 
     def process_other_process(activity)
-      activity["spid"] = activity["pid"].to_i
-      activity.delete("pid")
-      activity
+      process_activity_shared(activity)
     end
 
     def push_other_process(result, activity)
@@ -149,7 +147,7 @@ module PgInspector
       activity["application_name"].start_with?("MIQ")
     end
 
-    def process_miq_activity(activity)
+    def process_activity_shared(activity)
       activity["datid"] = activity["datid"].to_i
       activity["spid"] = activity["pid"].to_i
       activity.delete("pid")
@@ -159,6 +157,11 @@ module PgInspector
       activity["xact_start"] = to_utc(activity["xact_start"])
       activity["query_start"] = to_utc(activity["query_start"])
       activity["state_change"] = to_utc(activity["state_change"])
+      activity
+    end
+
+    def process_miq_activity(activity)
+      process_activity_shared(activity)
       process_miq_activity_application_name(activity)
     end
 

--- a/tools/pg_inspector/active_connections_to_human.rb
+++ b/tools/pg_inspector/active_connections_to_human.rb
@@ -153,6 +153,8 @@ module PgInspector
       activity.delete("pid")
       activity["usesysid"] = activity["usesysid"].to_i
       activity["client_port"] = activity["client_port"].to_i
+      activity["backend_xid"] = activity["backend_xid"].to_i if activity["backend_xid"]
+      activity["backend_xmin"] = activity["backend_xmin"].to_i if activity["backend_xmin"]
       activity["backend_start"] = to_utc(activity["backend_start"])
       activity["xact_start"] = to_utc(activity["xact_start"])
       activity["query_start"] = to_utc(activity["query_start"])


### PR DESCRIPTION
Now the human readable yaml format is strictly divided into servers, workers, connections and other_processes. And some confusing in `spid` and `pid` has been fixed. `pid` always mean the process's pid. For connections from other processes, we can't get it from its application name, so it doesn't have a `pid` field in yaml. `spid` always mean the sql pid for a connection. Each connection has a `spid` and each worker/server process has a `pid`. Host name and IP address is only for servers. But port is per connection. Also, a connection can belongs to either a worker or a server process. If it belongs to a server, it has only `server_compressed_id`. If it belongs to a worker, it has both `server_compressed_id` and `worker_compressed_id`.

\cc @jrafanie @gtanzillo 