### PR TITLE
Register product feature for stopping domains

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3973,7 +3973,7 @@
       :identifier: middleware_domain_tag
     - :name: Stop Middleware Domain
       :description: Stop Middleware Domain
-      :feature_type: admin
+      :feature_type: control
       :identifier: middleware_domain_stop
 
 # Middleware Server Group

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3971,6 +3971,10 @@
       :description: Edit Tags of Middleware Domains
       :feature_type: control
       :identifier: middleware_domain_tag
+    - :name: Stop Middleware Domain
+      :description: Stop Middleware Domain
+      :feature_type: admin
+      :identifier: middleware_domain_stop
 
 # Middleware Server Group
 - :name: Middleware Server Group


### PR DESCRIPTION
Adds the required product feature for stopping middleware domains `middleware_domain_stop`

Required by:
https://github.com/ManageIQ/manageiq-ui-classic/pull/1753

@miq-bot add_label fine/no, providers/hawkular