### PR TITLE
Force status removal and default value

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -16,6 +16,7 @@ class MiqRequestTask < ApplicationRecord
   default_value_for :phase_context, {}
   default_value_for :options,       {}
   default_value_for :state,         'pending'
+  default_value_for :status,        'Ok'
 
   delegate :request_class, :task_description, :to => :class
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -293,6 +293,13 @@ describe MiqRequest do
         expect(request.description).to_not eq(description)
       end
 
+      it 'with 1 task having a Denied status reset to ok for the resulting request_task' do
+        request.options[:src_vm_id] = template.id
+        request.status = 'Denied'
+        new_request = request.create_request_task(template.id)
+        expect(new_request.status).to eq 'Ok'
+      end
+
       it 'with 0 tasks' do
         allow(request).to receive(:requested_task_idx).and_return([])
         request.post_create_request_tasks
@@ -303,6 +310,14 @@ describe MiqRequest do
         allow(request).to receive(:requested_task_idx).and_return([1, 2])
         request.post_create_request_tasks
         expect(request.description).to eq(description)
+      end
+
+      it '#clean_up_keys_for_request_task' do
+        # The db stores 'state' as 'request_state' Pulling out that value to allow the raw arrays to match
+        removable_keys = MiqRequest::REQUEST_UNIQUE_KEYS - ['state']
+        expect(request.attributes.keys & removable_keys).to match_array removable_keys
+        cleaned_attribs = request.send(:clean_up_keys_for_request_task)
+        expect(cleaned_attribs).to_not match_array(removable_keys)
       end
     end
 


### PR DESCRIPTION
When we copy the `MiqRequest` to `MiqRequestTask` there is a case where status was not passing validation if it was originally set to 'Denied'

This addresses that issue by removing the `status` column at copy and then setting the default value of `status` to 'Ok' in the `MiqRequestTask`

https://bugzilla.redhat.com/show_bug.cgi?id=1460158

