### PR TITLE
assert_referential_integrity raise unless production

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -153,10 +153,15 @@ module ManagerRefresh::SaveCollection
       def assert_referential_integrity(hash, inventory_object)
         inventory_object.inventory_collection.fixed_foreign_keys.each do |x|
           next unless hash[x].blank?
-          _log.info("Ignoring #{inventory_object} of #{inventory_object.inventory_collection} because of missing foreign key #{x} for "\
+          subject = "#{inventory_object} of #{inventory_object.inventory_collection} because of missing foreign key #{x} for "\
                     "#{inventory_object.inventory_collection.parent.class.name}:"\
-                    "#{inventory_object.inventory_collection.parent.try(:id)}")
-          return false
+                    "#{inventory_object.inventory_collection.parent.try(:id)}"
+          if Rails.env.production?
+            _log.warn("Referential integrity check violated, ignoring #{subject}")
+            return false
+          else
+            raise("Referential integrity check violated for #{subject}")
+          end
         end
         true
       end

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -596,7 +596,7 @@ describe ManagerRefresh::SaveInventory do
             :model_class => Hardware,
             :parent      => @ems,
             :association => :hardwares,
-            :manager_ref => [:vm_or_template]
+            :manager_ref => [:virtualization_type]
           )
         end
 
@@ -615,8 +615,9 @@ describe ManagerRefresh::SaveInventory do
           ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
-          vm1 = Vm.find_by(:ems_ref => "vm_ems_ref_1")
-          expect(vm1.hardware).to eq(nil)
+          vm1 = Vm.find_by!(:ems_ref => "vm_ems_ref_1")
+          hardware1 = Hardware.find_by!(:virtualization_type => "virtualization_type_1")
+          expect(hardware1.vm_or_template).to eq(nil)
         end
 
         it "has a relation using find and loading data in a right order" do
@@ -634,8 +635,9 @@ describe ManagerRefresh::SaveInventory do
           ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
-          vm1 = Vm.find_by(:ems_ref => "vm_ems_ref_1")
-          expect(vm1.hardware.virtualization_type).to eq("virtualization_type_1")
+          vm1 = Vm.find_by!(:ems_ref => "vm_ems_ref_1")
+          hardware1 = Hardware.find_by!(:virtualization_type => "virtualization_type_1")
+          expect(hardware1.vm_or_template).to eq(vm1)
         end
 
         it "has a relation using lazy_find and loading data in a wrong order" do
@@ -653,8 +655,9 @@ describe ManagerRefresh::SaveInventory do
           ManagerRefresh::SaveInventory.save_inventory(@ems, @data.values)
 
           # Assert saved data
-          vm1 = Vm.find_by(:ems_ref => "vm_ems_ref_1")
-          expect(vm1.hardware.virtualization_type).to eq("virtualization_type_1")
+          vm1 = Vm.find_by!(:ems_ref => "vm_ems_ref_1")
+          hardware1 = Hardware.find_by!(:virtualization_type => "virtualization_type_1")
+          expect(hardware1.vm_or_template).to eq(vm1)
         end
       end
     end


### PR DESCRIPTION
When it silently does not save records, it's hard to debug...
(Well it logs a warning, but who checks log when debugging? ;-)
First you check you really produce the InventoryObjects,
then you scratch your head and scatter breakpoints in saving machinery,
until you find the `if assert_referential_integrity` — doh!
I fell on this at least twice...

This mirrors the approach in `assert_distinct_relation` of logging in
prod and exploding in console / tests.
@Ladas @agrare please what do you think?

@miq-bot add-label enhancement, developer, test