### PR TITLE
Add Storage feature to container administrator role

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -984,6 +984,7 @@
   - vms_filter_accord
   - instances_filter_accord
   - datacenter_controller
+  - storage
   - storage_pod
   - dashboard
   - miq_report


### PR DESCRIPTION
the user with role EvmRole_container-administrator has access to ` Compute -> Infra -> Datastores -> Datastore Clusters` according to the his feature `'storage_pod'` but ownership of feature `'storage_pod'` is not enough to display menu ` Compute -> Infra -> Datastores ` at all, 
so I am adding to ability to display the menu. ('storage')

`Compute -> Infra -> Datastores -> Datastore Clusters` **is accordion** `Compute -> Infra -> Datastores`

before
<img width="682" alt="screen shot 2017-07-31 at 15 25 25" src="https://user-images.githubusercontent.com/14937244/28779740-7f895700-7604-11e7-9cc6-647c5fbaeaf7.png">


after
<img width="820" alt="screen shot 2017-07-31 at 15 18 13" src="https://user-images.githubusercontent.com/14937244/28779660-494af78e-7604-11e7-9266-81f37029078a.png">

please review @zakiva  (I think it was intended, correct me if not)
 

@miq-bot assign @gtanzillo 

@miq-bot add_label bug

