### PR TITLE
Fix Core Refresher if there is no ems_vmware setting

### DIFF
--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -6,7 +6,7 @@ class MiqEmsRefreshCoreWorker < MiqWorker
   self.required_roles = ["ems_inventory"]
 
   def self.has_required_role?
-    return false if Settings.prototype.ems_vmware.update_driven_refresh
+    return false if Settings.prototype.try(:ems_vmware).try(:update_driven_refresh)
     super
   end
 


### PR DESCRIPTION
Until https://github.com/ManageIQ/manageiq-providers-vmware/pull/76 is merged there will not be a `Settings.prototype.ems_vmware` so currently the core refresh worker will raise an exception when starting up.

cc @carbonin 