### PR TITLE
Add operations for NetworkPort

### DIFF
--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -1,6 +1,8 @@
 class NetworkPort < ApplicationRecord
   include NewWithTypeStiMixin
   include CloudTenancyMixin
+  include_concern 'Operations'
+
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"

--- a/app/models/network_port/operations.rb
+++ b/app/models/network_port/operations.rb
@@ -1,0 +1,19 @@
+module NetworkPort::Operations
+  extend ActiveSupport::Concern
+
+  def update_network_port(options = {})
+    raw_update_network_port(options)
+  end
+
+  def raw_update_network_port(_options = {})
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
+  def delete_network_port
+    raw_delete_network_port
+  end
+
+  def raw_delete_network_port
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+end


### PR DESCRIPTION
Added `update` and `delete` operations to NetworkPort in order to expose it in Automate engine