### PR TITLE
Metric rollups at the Service level

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -91,7 +91,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   end
 
   def perf_rollup_parents(interval_name = nil)
-    [availability_zone, host_aggregates].compact.flatten unless interval_name == 'realtime'
+    [availability_zone, host_aggregates, service].compact.flatten unless interval_name == 'realtime'
   end
 
   #

--- a/app/models/metric/ci_mixin/targets.rb
+++ b/app/models/metric/ci_mixin/targets.rb
@@ -6,6 +6,7 @@ module Metric::CiMixin::Targets
     when ManageIQ::Providers::Kubernetes::ContainerManager::Container then true
     when ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup then true
     when ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode then true
+    when Service then true
     # going to treat an availability_zone like a host wrt perf_capture settings
     when Host, EmsCluster, AvailabilityZone, HostAggregate then Metric::Targets.perf_capture_always[:host_and_cluster]
     when Storage then                            Metric::Targets.perf_capture_always[:storage]

--- a/app/models/metric/processing.rb
+++ b/app/models/metric/processing.rb
@@ -34,7 +34,8 @@ module Metric::Processing
     EmsCluster,
     ExtManagementSystem,
     MiqRegion,
-    MiqEnterprise
+    MiqEnterprise,
+    Service
   ]
 
   def self.process_derived_columns(obj, attrs, ts = nil)
@@ -54,6 +55,7 @@ module Metric::Processing
 
     DERIVED_COLS.each do |col|
       dummy, group, typ, mode = col.to_s.split("_")
+      next if group == "vm" && obj.kind_of?(Service) && typ != "count"
       case typ
       when "available"
         # Do not derive "available" values if there haven't been any usage

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -68,6 +68,25 @@ module Metric::Rollup
       :derived_memory_used,
       :net_usage_rate_average,
       :disk_usage_rate_average
+    ],
+    :Service_vms                           => [
+      :cpu_ready_delta_summation,
+      :cpu_system_delta_summation,
+      :cpu_usage_rate_average,
+      :cpu_usagemhz_rate_average,
+      :cpu_used_delta_summation,
+      :cpu_wait_delta_summation,
+      :derived_vm_allocated_disk_storage,
+      :derived_vm_numvcpus,
+      :derived_vm_used_disk_storage,
+      :derived_memory_used,
+      :derived_memory_available,
+      :disk_devicelatency_absolute_average,
+      :disk_kernellatency_absolute_average,
+      :disk_queuelatency_absolute_average,
+      :disk_usage_rate_average,
+      :mem_usage_absolute_average,
+      :net_usage_rate_average,
     ]
   }
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -26,6 +26,9 @@ class Service < ApplicationRecord
   belongs_to :service_template               # Template this service was cloned from
 
   has_many :dialogs, -> { distinct }, :through => :service_template
+  has_many :metrics, :as => :resource
+  has_many :metric_rollups, :as => :resource
+  has_many :vim_performance_states, :as => :resource
 
   has_one :miq_request_task, :dependent => :nullify, :as => :destination
   has_one :miq_request, :through => :miq_request_task
@@ -60,6 +63,7 @@ class Service < ApplicationRecord
   include ProcessTasksMixin
   include TenancyMixin
   include SupportsFeatureMixin
+  include Metric::CiMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'
@@ -387,5 +391,15 @@ class Service < ApplicationRecord
       :args        => options
     )
     _log.info "Added to queue: generate_chargeback_report for service #{name}"
+  end
+
+  #
+  # Metric methods
+  #
+
+  PERF_ROLLUP_CHILDREN = :vms
+
+  def perf_rollup_parents(interval_name = nil)
+    [].compact unless interval_name == 'realtime'
   end
 end

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -172,8 +172,17 @@ class VimPerformanceState < ApplicationRecord
   def capture_assoc_ids
     result = {}
     ASSOCIATIONS.each do |assoc|
-      method = assoc
-      method = (resource.kind_of?(EmsCluster) ? :all_vms_and_templates : :vms_and_templates) if assoc == :vms
+      method = if assoc == :vms
+                 if resource.kind_of?(EmsCluster)
+                   :all_vms_and_templates
+                 elsif resource.kind_of?(Service)
+                   :vms
+                 else
+                   :vms_and_templates
+                 end
+               else
+                 assoc
+               end
       next unless resource.respond_to?(method)
       assoc_recs = resource.send(method)
       has_state = assoc_recs[0] && assoc_recs[0].respond_to?(:state)

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -38,7 +38,8 @@ class VimPerformanceTagValue < ApplicationRecord
     "ContainerGroup"      => [],
     "ContainerProject"    => [],
     "ContainerService"    => [],
-    "ContainerReplicator" => []
+    "ContainerReplicator" => [],
+    "Service"             => [:vms]
   }
 
   def self.build_from_performance_record(parent_perf, options = {:save => true})

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1598,7 +1598,7 @@ class VmOrTemplate < ApplicationRecord
   PERF_ROLLUP_CHILDREN = nil
 
   def perf_rollup_parents(interval_name = nil)
-    [host].compact unless interval_name == 'realtime'
+    [host, service].compact unless interval_name == 'realtime'
   end
 
   # Called from integrate ws to kick off scan for vdi VMs

--- a/spec/factories/vm_amazon.rb
+++ b/spec/factories/vm_amazon.rb
@@ -8,5 +8,9 @@ FactoryGirl.define do
         FactoryGirl.create(:ems_amazon, :vms => [x])
       end
     end
+
+    trait :powered_off do
+      raw_power_state "stopped"
+    end
   end
 end

--- a/spec/models/metric/processing_spec.rb
+++ b/spec/models/metric/processing_spec.rb
@@ -28,6 +28,28 @@ describe Metric::Processing do
   end
 
   context ".process_derived_columns" do
+    context "services" do
+      let(:vm_amazon_a) { FactoryGirl.create(:vm_amazon) }
+      let(:vm_amazon_b) { FactoryGirl.create(:vm_amazon, :powered_off) }
+      let(:service) { FactoryGirl.create(:service) }
+      let(:metric_a) { FactoryGirl.create(:metric_rollup_vm_hr, :resource => vm_amazon_a) }
+      let(:metric_b) { FactoryGirl.create(:metric_rollup_vm_hr, :resource => vm_amazon_b) }
+
+      before do
+        service.add_resource(vm_amazon_a)
+        service.add_resource(vm_amazon_b)
+        service.save
+      end
+
+      it "calculates derived values" do
+        derived_columns = described_class.process_derived_columns(service, metric_a.attributes.symbolize_keys)
+
+        expect(derived_columns[:derived_vm_count_on]).to eq(1)
+        expect(derived_columns[:derived_vm_count_off]).to eq(1)
+        expect(derived_columns[:derived_vm_count_total]).to eq(2)
+      end
+    end
+
     context "on :derived_host_sockets" do
       let(:hardware) { FactoryGirl.create(:hardware, :cpu_sockets => 2) }
       let(:host) { FactoryGirl.create(:host, :hardware => hardware) }

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -292,6 +292,22 @@ describe Metric do
           assert_perf_capture_now @vm, :with_alerts
         end
       end
+
+      context "services" do
+        let(:service) { FactoryGirl.create(:service) }
+
+        before do
+          service.add_resource(@vm)
+          service.save
+          MiqQueue.delete_all
+        end
+
+        it "queues service rollups" do
+          @vm.perf_rollup_to_parents("hourly", "2010-04-14T21:51:10Z", "2010-04-14T22:50:50Z")
+
+          expect(MiqQueue.all.pluck(:class_name).uniq).to eq(%w(Service))
+        end
+      end
     end
 
     context "with a small environment and time_profile" do


### PR DESCRIPTION
This adds metric rollups at the service level from a service's VMs


@miq-bot add_label wip, services, enhancement 

daily sample:
```
 #<MetricRollup:0x007f853471fcd0
 id: 10000001262445,
 timestamp: Mon, 07 Aug 2017 00:00:00 UTC +00:00,
 capture_interval: 86400,
 resource_type: "Service",
 resource_id: 10000000000540,
 cpu_usage_rate_average: 0.215822872211595,
 cpu_usagemhz_rate_average: 0.0,
 mem_usage_absolute_average: 0.0,
 disk_usage_rate_average: 0.0,
 net_usage_rate_average: 0.274660377872475,
 sys_uptime_absolute_latest: 0.0,
 created_on: Mon, 07 Aug 2017 17:57:28 UTC +00:00,
 derived_cpu_available: 0.0,
 derived_memory_available: 1024.0,
 derived_memory_used: 0.0,
 derived_cpu_reserved: 0.0,
 derived_memory_reserved: 0.0,
 derived_vm_count_on: 2,
 derived_host_count_on: 0,
 derived_vm_count_off: 0,
 derived_host_count_off: 0,
 derived_storage_total: 0.0,
 derived_storage_free: 0.0,
 capture_interval_name: "daily",
 assoc_ids: {:vms=>{:on=>[10000000003077, 10000000003090], :off=>[]}},
 cpu_ready_delta_summation: 0.0,
 cpu_system_delta_summation: 0.0,
 cpu_wait_delta_summation: 0.0,
 resource_name: "jill-metrics-testing",
 cpu_used_delta_summation: 0.0,
 tag_names: "environment/dev|function/app",
 parent_host_id: nil,
 parent_ems_cluster_id: nil,
 parent_storage_id: nil,
 parent_ems_id: nil,
 derived_storage_vm_count_registered: 0.0,
 derived_storage_vm_count_unregistered: 0.0,
 derived_storage_vm_count_unmanaged: 0.0,
 derived_storage_used_registered: 0.0,
 derived_storage_used_unregistered: 0.0,
 derived_storage_used_unmanaged: 0.0,
 derived_storage_snapshot_registered: 0.0,
 derived_storage_snapshot_unregistered: 0.0,
 derived_storage_snapshot_unmanaged: 0.0,
 derived_storage_mem_registered: 0.0,
 derived_storage_mem_unregistered: 0.0,
 derived_storage_mem_unmanaged: 0.0,
 derived_storage_disk_registered: 0.0,
 derived_storage_disk_unregistered: 0.0,
 derived_storage_disk_unmanaged: 0.0,
 derived_storage_vm_count_managed: 0.0,
 derived_storage_used_managed: 0.0,
 derived_storage_snapshot_managed: 0.0,
 derived_storage_mem_managed: 0.0,
 derived_storage_disk_managed: 0.0,
 min_max:
  {:min_cpu_usage_rate_average=>0.201016666666667,
   :max_cpu_usage_rate_average=>0.310938888888889,
   :min_cpu_usagemhz_rate_average=>0.0,
   :max_cpu_usagemhz_rate_average=>0.0,
   :min_mem_usage_absolute_average=>0.0,
   :max_mem_usage_absolute_average=>0.0,
   :min_disk_usage_rate_average=>0.0,
   :max_disk_usage_rate_average=>0.0,
   :min_net_usage_rate_average=>0.153255447048611,
   :max_net_usage_rate_average=>0.491146057581019,
   :min_derived_memory_available=>1024.0,
   :max_derived_memory_available=>1024.0,
   :min_derived_memory_used=>0.0,
   :max_derived_memory_used=>0.0,
   :min_derived_vm_count_on=>2.0,
   :max_derived_vm_count_on=>2.0,
   :min_derived_host_count_on=>0.0,
   :max_derived_host_count_on=>0.0,
   :min_derived_vm_count_off=>0.0,
   :max_derived_vm_count_off=>0.0,
   :min_derived_host_count_off=>0.0,
   :max_derived_host_count_off=>0.0,
   :min_cpu_ready_delta_summation=>0.0,
   :max_cpu_ready_delta_summation=>0.0,
   :min_cpu_system_delta_summation=>0.0,
   :max_cpu_system_delta_summation=>0.0,
   :min_cpu_wait_delta_summation=>0.0,
   :max_cpu_wait_delta_summation=>0.0,
   :min_cpu_used_delta_summation=>0.0,
   :max_cpu_used_delta_summation=>0.0,
   :min_disk_devicelatency_absolute_average=>0.0,
   :max_disk_devicelatency_absolute_average=>0.0,
   :min_disk_kernellatency_absolute_average=>0.0,
   :max_disk_kernellatency_absolute_average=>0.0,
   :min_disk_queuelatency_absolute_average=>0.0,
   :max_disk_queuelatency_absolute_average=>0.0,
   :min_derived_vm_used_disk_storage=>17179869184.0,
   :max_derived_vm_used_disk_storage=>17179869184.0,
   :min_derived_vm_allocated_disk_storage=>17179869184.0,
   :max_derived_vm_allocated_disk_storage=>17179869184.0,
   :min_derived_vm_numvcpus=>2.0,
   :max_derived_vm_numvcpus=>2.0,
   :min_derived_host_count_total=>0.0,
   :max_derived_host_count_total=>0.0,
   :min_derived_vm_count_total=>2.0,
   :max_derived_vm_count_total=>2.0},
 intervals_in_rollup: 18,
 mem_vmmemctl_absolute_average: 0.0,
 mem_vmmemctltarget_absolute_average: 0.0,
 mem_swapin_absolute_average: 0.0,
 mem_swapout_absolute_average: 0.0,
 mem_swapped_absolute_average: 0.0,
 mem_swaptarget_absolute_average: 0.0,
 disk_devicelatency_absolute_average: 0.0,
 disk_kernellatency_absolute_average: 0.0,
 disk_queuelatency_absolute_average: 0.0,
 derived_vm_used_disk_storage: 17179869184.0,
 derived_vm_allocated_disk_storage: 17179869184.0,
 derived_vm_numvcpus: 2.0,
 time_profile_id: 10000000000001,
 derived_host_sockets: 0,
 derived_host_count_total: 0,
 derived_vm_count_total: 2,
 stat_container_group_create_rate: 0,
 stat_container_group_delete_rate: 0,
 stat_container_image_registration_rate: 0>
```

hourly sample:
```
 #<MetricRollup:0x007f853a616a40
 id: 10000001262309,
 timestamp: Mon, 07 Aug 2017 17:00:00 UTC +00:00,
 capture_interval: nil,
 resource_type: "Service",
 resource_id: 10000000000540,
 cpu_usage_rate_average: 0.222178366475377,
 cpu_usagemhz_rate_average: 0.0,
 mem_usage_absolute_average: 0.0,
 disk_usage_rate_average: 0.0,
 net_usage_rate_average: 0.312048918313343,
 sys_uptime_absolute_latest: nil,
 created_on: Mon, 07 Aug 2017 17:56:21 UTC +00:00,
 derived_cpu_available: nil,
 derived_memory_available: 1024.0,
 derived_memory_used: 0.0,
 derived_cpu_reserved: nil,
 derived_memory_reserved: nil,
 derived_vm_count_on: 2,
 derived_host_count_on: 0,
 derived_vm_count_off: 0,
 derived_host_count_off: 0,
 derived_storage_total: nil,
 derived_storage_free: nil,
 capture_interval_name: "hourly",
 assoc_ids: {:vms=>{:on=>[10000000003077, 10000000003090], :off=>[]}},
 cpu_ready_delta_summation: 0.0,
 cpu_system_delta_summation: 0.0,
 cpu_wait_delta_summation: 0.0,
 resource_name: "jill-metrics-testing",
 cpu_used_delta_summation: 0.0,
 tag_names: "environment/dev|function/app",
 parent_host_id: nil,
 parent_ems_cluster_id: nil,
 parent_storage_id: nil,
 parent_ems_id: nil,
 derived_storage_vm_count_registered: nil,
 derived_storage_vm_count_unregistered: nil,
 derived_storage_vm_count_unmanaged: nil,
 derived_storage_used_registered: nil,
 derived_storage_used_unregistered: nil,
 derived_storage_used_unmanaged: nil,
 derived_storage_snapshot_registered: nil,
 derived_storage_snapshot_unregistered: nil,
 derived_storage_snapshot_unmanaged: nil,
 derived_storage_mem_registered: nil,
 derived_storage_mem_unregistered: nil,
 derived_storage_mem_unmanaged: nil,
 derived_storage_disk_registered: nil,
 derived_storage_disk_unregistered: nil,
 derived_storage_disk_unmanaged: nil,
 derived_storage_vm_count_managed: nil,
 derived_storage_used_managed: nil,
 derived_storage_snapshot_managed: nil,
 derived_storage_mem_managed: nil,
 derived_storage_disk_managed: nil,
 min_max: nil,
 intervals_in_rollup: nil,
 mem_vmmemctl_absolute_average: nil,
 mem_vmmemctltarget_absolute_average: nil,
 mem_swapin_absolute_average: nil,
 mem_swapout_absolute_average: nil,
 mem_swapped_absolute_average: nil,
 mem_swaptarget_absolute_average: nil,
 disk_devicelatency_absolute_average: 0.0,
 disk_kernellatency_absolute_average: 0.0,
 disk_queuelatency_absolute_average: 0.0,
 derived_vm_used_disk_storage: 17179869184.0,
 derived_vm_allocated_disk_storage: 17179869184.0,
 derived_vm_numvcpus: 2.0,
 time_profile_id: nil,
 derived_host_sockets: nil,
 derived_host_count_total: 0,
 derived_vm_count_total: 2,
 stat_container_group_create_rate: nil,
 stat_container_group_delete_rate: nil,
 stat_container_image_registration_rate: nil>
```