### PR TITLE
Set user's group to the requester group.

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -31,7 +31,9 @@ module MiqRequestMixin
   end
 
   def get_user
-    @user ||= User.find_by_userid(userid)
+    @user ||= User.find_by(:userid => userid).tap do |u|
+      u.current_group_by_description = options[:requester_group] if options[:requester_group]
+    end
   end
   alias_method :tenant_identity, :get_user
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -412,4 +412,24 @@ describe MiqRequest do
       expect { described_class.class_from_request_data({}) }.to raise_error("Invalid request_type")
     end
   end
+
+  context "#get_user" do
+    let(:root_tenant) { Tenant.seed }
+    let(:tenant1)     { FactoryGirl.create(:tenant, :parent => root_tenant) }
+    let(:group1)      { FactoryGirl.create(:miq_group, :description => 'Group 1', :tenant => root_tenant) }
+    let(:group2)      { FactoryGirl.create(:miq_group, :description => 'Group 2', :tenant => tenant1) }
+    let(:user)        { FactoryGirl.create(:user, :miq_groups => [group1, group2], :current_group => group1) }
+
+    it "takes the requester group" do
+      request = FactoryGirl.create(:miq_provision_request, :requester => user, :options => {:requester_group => group2.description})
+      expect(user.current_group).to eq(group1)
+      expect(request.get_user.current_group).to eq(group2)
+    end
+
+    it "stays with user's current group" do
+      request = FactoryGirl.create(:miq_provision_request, :requester => user)
+      expect(user.current_group).to eq(group1)
+      expect(request.get_user.current_group).to eq(group1)
+    end
+  end
 end


### PR DESCRIPTION
User's current group might have changed before the provision finishes.
So the user's current group from DB may be different from the user's group when the request is made.

Need to set the user's group back to requester group the user is in when the provision is submitted.
Therefore the provisioned instances may belong to the right user/group/tenant.

Includes https://github.com/ManageIQ/manageiq-content/pull/156.
Includes https://github.com/ManageIQ/manageiq-automation_engine/pull/61.

https://bugzilla.redhat.com/show_bug.cgi?id=1467364

@miq-bot assign @gmcculloug 
@miq-bot add_label services, euwe/yes, fine/yes