### PR TITLE
Simplify fix_auth database connectivity

### DIFF
--- a/spec/tools/fix_auth/cli_spec.rb
+++ b/spec/tools/fix_auth/cli_spec.rb
@@ -6,37 +6,37 @@ describe FixAuth::Cli do
   describe "#parse" do
     it "should assign defaults" do
       opts = described_class.new.parse([], {})
-             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+             .options.slice(:hostname, :username, :password, :hardcode, :database)
       expect(opts).to eq(
-        :username  => "root",
-        :databases => %w(vmdb_production))
+        :username => "root",
+        :database => "vmdb_production")
     end
 
     it "should pickup env variables" do
       opts = described_class.new.parse([], "PGUSER" => "envuser", "PGPASSWORD" => "envpass", "PGHOST" => "envhost")
-             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+             .options.slice(:hostname, :username, :password, :hardcode, :database)
       expect(opts).to eq(
-        :username  => "envuser",
-        :databases => %w(vmdb_production),
-        :password  => "envpass",
-        :hostname  => "envhost")
+        :username => "envuser",
+        :database => "vmdb_production",
+        :password => "envpass",
+        :hostname => "envhost")
     end
 
     it "should parse database names" do
-      opts = described_class.new.parse(%w(DB1 DB2))
-             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+      opts = described_class.new.parse(%w(DB1))
+             .options.slice(:hostname, :username, :password, :hardcode, :database)
       expect(opts).to eq(
-        :username  => "root",
-        :databases => %w(DB1 DB2))
+        :username => "root",
+        :database => "DB1")
     end
 
     it "should parse hardcoded password" do
       opts = described_class.new.parse(%w(-P hardcoded))
-             .options.slice(:hostname, :username, :password, :hardcode, :databases)
+             .options.slice(:hostname, :username, :password, :hardcode, :database)
       expect(opts).to eq(
-        :username  => "root",
-        :databases => %w(vmdb_production),
-        :hardcode  => "hardcoded")
+        :username => "root",
+        :database => "vmdb_production",
+        :hardcode => "hardcoded")
     end
 
     it "defaults to updating the database" do

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -7,8 +7,8 @@ module FixAuth
     def parse(args, env = {})
       args.shift if args.first == "--" # Handle when called through script/runner
       self.options = Trollop.options(args) do
-        banner "Usage: ruby #{$PROGRAM_NAME} [options] [database1] [database2] [...]\n" \
-               "       ruby #{$PROGRAM_NAME} [options] -P new_password [database1] [...] to replace all passwords"
+        banner "Usage: ruby #{$PROGRAM_NAME} [options] database [...]\n" \
+               "       ruby #{$PROGRAM_NAME} [options] -P new_password database [...] to replace all passwords"
 
         opt :verbose,  "Verbose",           :short => "v"
         opt :dry_run,  "Dry Run",           :short => "d"
@@ -26,7 +26,7 @@ module FixAuth
         opt :legacy_key, "Legacy Key",      :type => :string, :short => "K"
       end
 
-      options[:databases] = args.presence || %w(vmdb_production)
+      options[:database] = args.first || "vmdb_production"
       # default to updating the db
       options[:db] = true if !options[:key] && !options[:databaseyml]
       self.options = options.delete_if { |_n, v| v.blank? }


### PR DESCRIPTION
Change `fix_auth` from updating multiple databases to only update 1 database.
This was never used to update multiple databases. (It was a possible developer only use case that never panned out)

The intent:

1. Get away from the unneeded (and unsavory) `clear_active_connections!`
2. Prep for using `database.yml` instead of the custom AR connectivity method. (unsure, but simplification to one database makes this a possibility)

@NickLaMuro This is in response to a small fraction of #15336