### PR TITLE
Clean up passing of inventory collection argument

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
@@ -3,8 +3,8 @@ module ManagerRefresh::SaveCollection
     class ConcurrentSafe < ManagerRefresh::SaveCollection::Saver::Base
       private
 
-      def update_record!(inventory_collection, record, hash, inventory_object)
-        assign_attributes_for_update!(hash, inventory_collection, time_now)
+      def update_record!(record, hash, inventory_object)
+        assign_attributes_for_update!(hash, time_now)
         record.assign_attributes(hash.except(:id, :type))
 
         if !inventory_object.inventory_collection.check_changed? || record.changed?
@@ -21,13 +21,13 @@ module ManagerRefresh::SaveCollection
         inventory_object.id = record.id
       end
 
-      def create_record!(inventory_collection, hash, inventory_object)
+      def create_record!(hash, inventory_object)
         all_attribute_keys = hash.keys
         hash               = inventory_collection.model_class.new(hash).attributes.symbolize_keys
-        assign_attributes_for_create!(hash, inventory_collection, time_now)
+        assign_attributes_for_create!(hash, time_now)
 
         result_id = ActiveRecord::Base.connection.insert_sql(
-          build_insert_query(inventory_collection, all_attribute_keys, [hash])
+          build_insert_query(all_attribute_keys, [hash])
         )
         inventory_object.id = result_id
         inventory_collection.store_created_records(inventory_object)

--- a/app/models/manager_refresh/save_collection/saver/default.rb
+++ b/app/models/manager_refresh/save_collection/saver/default.rb
@@ -3,7 +3,7 @@ module ManagerRefresh::SaveCollection
     class Default < ManagerRefresh::SaveCollection::Saver::Base
       private
 
-      def update_record!(inventory_collection, record, hash, inventory_object)
+      def update_record!(record, hash, inventory_object)
         record.assign_attributes(hash.except(:id, :type))
         if !inventory_collection.check_changed? || record.changed?
           record.save
@@ -13,7 +13,7 @@ module ManagerRefresh::SaveCollection
         inventory_object.id = record.id
       end
 
-      def create_record!(inventory_collection, hash, inventory_object)
+      def create_record!(hash, inventory_object)
         record = inventory_collection.model_class.create!(hash.except(:id))
         inventory_collection.store_created_records(record)
 

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -15,7 +15,7 @@ module ManagerRefresh::SaveCollection
         "#{quote_column_name(key)} = EXCLUDED.#{quote_column_name(key)}"
       end
 
-      def build_insert_query(inventory_collection, all_attribute_keys, hashes)
+      def build_insert_query(all_attribute_keys, hashes)
         all_attribute_keys_array = all_attribute_keys.to_a
         table_name               = inventory_collection.model_class.table_name
         values                   = hashes.map do |hash|
@@ -67,7 +67,7 @@ module ManagerRefresh::SaveCollection
         ActiveRecord::Base.connection.quote_column_name(key)
       end
 
-      def build_update_query(inventory_collection, all_attribute_keys, hashes)
+      def build_update_query(all_attribute_keys, hashes)
         # We want to ignore type and create timestamps when updating
         all_attribute_keys_array = all_attribute_keys.to_a.delete_if { |x| %i(type created_at created_on).include?(x) }
         all_attribute_keys_array << :id
@@ -102,7 +102,7 @@ module ManagerRefresh::SaveCollection
         update_query
       end
 
-      def build_multi_selection_query(inventory_collection, hashes)
+      def build_multi_selection_query(hashes)
         inventory_collection.build_multi_selection_condition(hashes, unique_index_columns)
       end
 


### PR DESCRIPTION
Depends on (refactoring of the same code):
- [x] https://github.com/ManageIQ/manageiq/pull/15701

Cleanup passing of inventory_collection argument and rather use the getter defined on a saver object.
