### PR TITLE
Legacy metrics capture -> ActiveMetrics adapter

### DIFF
--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -66,7 +66,7 @@ module Metric::CiMixin::Processing
 
           rt_fields.map do |k, v|
             {
-              :timestamp   => Time.parse(ts),
+              :timestamp   => ts,
               :metric_name => k,
               :value       => v,
               :resource    => self,

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -61,8 +61,15 @@ module Metric::CiMixin::Processing
         rt_rows.flat_map do |ts, rt|
           rt.merge!(Metric::Processing.process_derived_columns(self, rt, interval_name == 'realtime' ? Metric::Helper.nearest_hourly_timestamp(ts) : nil))
           rt.delete_nils
-          rt_tags   = rt.slice(*%i(capture_interval_name capture_interval resource_name)).symbolize_keys
-          rt_fields = rt.except(*%i(capture_interval_name capture_interval resource_name timestamp instance_id class_name resource_type resource_id))
+          rt_tags   = rt.slice(:capture_interval_name, :capture_interval, :resource_name).symbolize_keys
+          rt_fields = rt.except(:capture_interval_name,
+                                :capture_interval,
+                                :resource_name,
+                                :timestamp,
+                                :instance_id,
+                                :class_name,
+                                :resource_type,
+                                :resource_id)
 
           rt_fields.map do |k, v|
             {

--- a/config/initializers/active_metrics.rb
+++ b/config/initializers/active_metrics.rb
@@ -1,0 +1,1 @@
+ActiveMetrics::Base.establish_connection(:adapter => "miq_postgres", :database => "metrics_spike")

--- a/config/initializers/active_metrics.rb
+++ b/config/initializers/active_metrics.rb
@@ -1,1 +1,2 @@
-ActiveMetrics::Base.establish_connection(:adapter => "miq_postgres", :database => "metrics_spike")
+# Note: The legacy Postgresql adapter ignores everything except the adapter name here, just stealing the current ActiveRecord connection.
+ActiveMetrics::Base.establish_connection(:adapter => "miq_postgres", :database => "manageiq_metrics")

--- a/lib/active_metrics/connection_adapters/miq_postgres_adapter.rb
+++ b/lib/active_metrics/connection_adapters/miq_postgres_adapter.rb
@@ -5,6 +5,7 @@ module ActiveMetrics
     class MiqPostgresAdapter < AbstractAdapter
       include Vmdb::Logging
 
+      # TODO Use the actual configuration from the initializer or whatever
       def self.create_connection(_config)
         ActiveRecord::Base.connection
       end

--- a/lib/active_metrics/connection_adapters/miq_postgres_adapter.rb
+++ b/lib/active_metrics/connection_adapters/miq_postgres_adapter.rb
@@ -1,0 +1,86 @@
+require 'active_metrics/connection_adapters/abstract_adapter'
+
+module ActiveMetrics
+  module ConnectionAdapters
+    class MiqPostgresAdapter < AbstractAdapter
+      include Vmdb::Logging
+
+      def self.create_connection(_config)
+        ActiveRecord::Base.connection
+      end
+
+      def write_multiple(*metrics)
+        metrics.flatten!
+
+        flatten_metrics(metrics).each do |interval_name, by_resource|
+          by_resource.each do |resource, by_timestamp|
+            start_time = by_timestamp.keys.min
+            end_time   = by_timestamp.keys.max
+            data       = by_timestamp.values
+            write_rows(interval_name, resource, start_time, end_time, data)
+          end
+        end
+
+        metrics
+      end
+
+      private
+
+      def flatten_metrics(metrics)
+        {}.tap do |index|
+          metrics.each do |m|
+            interval_name = m.fetch_path(:tags, :capture_interval_name)
+            resource = m[:resource] || m.fetch_path(:tags, :resource_type).safe_constantize.find(m.fetch_path(:tags, :resource_id))
+            fields = index.fetch_path(interval_name, resource, m[:timestamp]) || m[:tags].symbolize_keys.except(:resource_type, :resource_id).merge(:timestamp => m[:timestamp])
+            fields[m[:metric_name].to_sym] = m[:value]
+            index.store_path(interval_name, resource, m[:timestamp], fields)
+          end
+        end
+      end
+
+      def write_rows(interval_name, resource, start_time, end_time, data)
+        log_header = "[#{interval_name}]"
+
+        # Read all the existing perfs for this time range to speed up lookups
+        obj_perfs, = Benchmark.realtime_block(:db_find_prev_perfs) do
+          Metric::Finders.hash_by_capture_interval_name_and_timestamp(resource, start_time, end_time, interval_name)
+        end
+
+        _klass, meth = Metric::Helper.class_and_association_for_interval_name(interval_name)
+
+        # Create or update the performance rows from the hashes
+        _log.info("#{log_header} Processing #{data.length} performance rows...")
+        a = u = 0
+        data.each do |v|
+          ts = v[:timestamp]
+          perf = nil
+
+          Benchmark.realtime_block(:process_perfs) do
+            perf = obj_perfs.fetch_path(interval_name, ts)
+            perf ||= obj_perfs.store_path(interval_name, ts, resource.send(meth).build(:resource_name => resource.name))
+            perf.new_record? ? a += 1 : u += 1
+
+            v.reverse_merge!(perf.attributes.symbolize_keys)
+            v.delete("id") # Remove protected attributes
+            v.merge!(Metric::Processing.process_derived_columns(resource, v, interval_name == 'realtime' ? Metric::Helper.nearest_hourly_timestamp(ts) : nil))
+          end
+
+          # TODO: Should we change this into a single metrics.push like we do in ems_refresh?
+          Benchmark.realtime_block(:process_perfs_db) { perf.update_attributes(v) }
+
+          if interval_name == 'hourly'
+            Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
+          end
+        end
+
+        if interval_name == 'hourly'
+          _log.info("#{log_header} Adding missing timestamp intervals...")
+          Benchmark.realtime_block(:add_missing_intervals) { Metric::Processing.add_missing_intervals(resource, "hourly", start_time, end_time) }
+          _log.info("#{log_header} Adding missing timestamp intervals...Complete")
+        end
+
+        _log.info("#{log_header} Processing #{data.length} performance rows...Complete - Added #{a} / Updated #{u}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This moves the current write interface in metrics processing to an ActiveMetrics adapter pattern.

Presumably one can now write an adapter for a different backend such as Elasticsearch that conforms to this interface with minimal hair pulling.