### PR TITLE
MiqExpression::Target#to_s

### DIFF
--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -18,6 +18,10 @@ class MiqExpression::CountField < MiqExpression::Target
     super(model, associations, nil)
   end
 
+  def to_s
+    [model, *associations].join(".")
+  end
+
   private
 
   def tag_values

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -25,6 +25,10 @@ class MiqExpression::Field < MiqExpression::Target
     !!(model < ApplicationRecord)
   end
 
+  def to_s
+    "#{[model, *associations].join(".")}-#{column}"
+  end
+
   def attribute_supported_by_sql?
     !custom_attribute_column? && target.attribute_supported_by_sql?(column)
   end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -9,7 +9,7 @@ class MiqExpression::Tag < MiqExpression::Target
   MANAGED_NAMESPACE      = 'managed'.freeze
   USER_NAMESPACE         = 'user'.freeze
 
-  attr_reader :namespace
+  attr_reader :namespace, :base_namespace
 
   def self.parse(field)
     return unless field.include?('managed') || field.include?('user_tag')
@@ -22,6 +22,10 @@ class MiqExpression::Tag < MiqExpression::Target
     super(model, associations, column)
     @base_namespace = managed ? MANAGED_NAMESPACE : USER_NAMESPACE
     @namespace = "/#{@base_namespace}/#{column}"
+  end
+
+  def to_s
+    "#{[model, *associations, base_namespace].compact.join(".")}-#{column}"
   end
 
   def numeric?

--- a/spec/lib/miq_expression/count_field_spec.rb
+++ b/spec/lib/miq_expression/count_field_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe MiqExpression::CountField do
       expect(described_class.parse(count_field)).to be_nil
     end
   end
+
+  describe "#to_s" do
+    it "renders count fields in string form" do
+      count_field = described_class.new(Vm, ["disks"])
+      expect(count_field.to_s).to eq("Vm.disks")
+    end
+
+    it "can handle multiple associations" do
+      count_field = described_class.new(Vm, %w(hardware disks))
+      expect(count_field.to_s).to eq("Vm.hardware.disks")
+    end
+  end
 end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#to_s" do
+    it "renders fields in string form" do
+      field = described_class.new("Vm", [], "name")
+      expect(field.to_s).to eq("Vm-name")
+    end
+
+    it "can handle associations" do
+      field = described_class.new("Vm", ["host"], "name")
+      expect(field.to_s).to eq("Vm.host-name")
+    end
+  end
+
   describe '#report_column' do
     it 'returns the correct format for a field' do
       field = MiqExpression::Field.parse('Vm.miq_provision.miq_request-requester_name')

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -63,6 +63,23 @@ RSpec.describe MiqExpression::Tag do
     end
   end
 
+  describe "#to_s" do
+    it "renders tags in string form" do
+      tag = described_class.new("Vm", [], "environment")
+      expect(tag.to_s).to eq("Vm.managed-environment")
+    end
+
+    it "can handle model-less tags" do
+      tag = described_class.new(nil, [], "environment")
+      expect(tag.to_s).to eq("managed-environment")
+    end
+
+    it "can handle associations" do
+      tag = described_class.new("Vm", ["host"], "environment")
+      expect(tag.to_s).to eq("Vm.host.managed-environment")
+    end
+  end
+
   describe '#report_column' do
     it 'returns the correct format for a tag' do
       tag = MiqExpression::Tag.parse('Vm.managed-environment')


### PR DESCRIPTION
Customizes MiqExpression::Target#to_s so that it may serialize the respective field/tag/count back into its "original form". Pulled out of/required by https://github.com/ManageIQ/manageiq/pull/15623

@miq-bot add-label core, enhancement
@miq-bot assign @gtanzillo 