### PR TITLE
Change the target of tag expressions

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -12,6 +12,7 @@ class MiqExpression::Field < MiqExpression::Target
 
   def self.parse(field)
     parsed_params = parse_params(field) || return
+    return unless parsed_params[:model_name]
     new(parsed_params[:model_name], parsed_params[:associations], parsed_params[:column] ||
         parsed_params[:virtual_custom_column])
   end

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,7 +1,7 @@
 class MiqExpression::Tag < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:alnum:]]*(::)?)+)
-\.(?<associations>([a-z_]+\.)*)
+(?<model_name>([[:alnum:]]*(::)?)?)
+\.?(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)
 /x

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -13,7 +13,7 @@ class MiqExpression::Target
     # convert matches to hash to format
     # {:model_name => 'User', :associations => ...}
     parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]
-    parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize || return
+    parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize
     parsed_params[:associations] = parsed_params[:associations].to_s.split(".")
     parsed_params
   end

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -18,7 +18,8 @@ class MiqExpression::Target
     parsed_params
   end
 
-  attr_reader :model, :associations, :column
+  attr_reader :column
+  attr_accessor :model, :associations
 
   def initialize(model, associations, column)
     @model = model

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe MiqExpression::Tag do
       expect(described_class.parse(tag)).to be_nil
     end
 
-    it "returns nil with invalid case managed-tag" do
+    it "supports managed-tag (no model)" do
       tag = "managed-service_level"
-      expect(described_class.parse(tag)).to be_nil
+      expect(described_class.parse(tag)).to have_attributes(:model        => nil,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/service_level")
     end
 
     it "returns nil with invalid case managed" do


### PR DESCRIPTION
Pulled out of https://github.com/ManageIQ/manageiq/pull/15623

This is needed because entitlement expressions need to be agnostic about their target - it will be set when evaluating through RBAC.

@miq-bot add-label enhancement, core
@miq-bot assign @gtanzillo 