### PR TITLE
Normalize the username entered at login to lowercase

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -270,7 +270,7 @@ module Authenticator
     end
 
     def normalize_username(username)
-      username
+      username.downcase
     end
   end
 end

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -119,7 +119,7 @@ module Authenticator
 
           matching_groups = match_groups(groups_for(identity))
           userid = userid_for(identity, username)
-          user   = User.in_my_region.find_or_initialize_by(:userid => userid)
+          user   = find_or_initialize_user(userid)
           update_user_attributes(user, username, identity)
           user.miq_groups = matching_groups
 
@@ -146,6 +146,12 @@ module Authenticator
           raise
         end
       end
+    end
+
+    def find_or_initialize_user(userid)
+      user   = User.find_by_userid(userid)
+      user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
+      user ||  User.new(:userid => userid)
     end
 
     def authenticate_with_http_basic(username, password, request = nil, options = {})

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -190,8 +190,8 @@ describe Authenticator::Httpd do
       end
     end
 
-    context "with unknown username" do
-      let(:username) { 'bob' }
+    context "with unknown username in mixed case" do
+      let(:username) { 'bOb' }
       let(:headers) do
         super().merge('X-Remote-User-FullName' => 'Bob Builderson',
                       'X-Remote-User-Email'    => 'bob@example.com')
@@ -205,12 +205,12 @@ describe Authenticator::Httpd do
         it "records one successful and one failing audit entry" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bob',
+            :userid  => 'bOb',
             :message => "User bob successfully validated by External httpd",
           )
           expect(AuditEvent).to receive(:failure).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bob',
+            :userid  => 'bOb',
             :message => "User bob authenticated but not defined in EVM",
           )
           authenticate rescue nil
@@ -233,12 +233,12 @@ describe Authenticator::Httpd do
         it "records two successful audit entries" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bob',
+            :userid  => 'bOb',
             :message => "User bob successfully validated by External httpd",
           )
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bob',
+            :userid  => 'bOb',
             :message => "Authentication successful for user bob",
           )
           expect(AuditEvent).not_to receive(:failure)
@@ -268,12 +268,12 @@ describe Authenticator::Httpd do
           it "records two successful audit entries plus one failure" do
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_httpd',
-              :userid  => 'bob',
+              :userid  => 'bOb',
               :message => "User bob successfully validated by External httpd",
             )
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_httpd',
-              :userid  => 'bob',
+              :userid  => 'bOb',
               :message => "Authentication successful for user bob",
             )
             expect(AuditEvent).to receive(:failure).with(


### PR DESCRIPTION
LDAP does a case sensitive match of the user name but AD will
do a case insensitive match. By normalizing the userid to
lowercase when using external auth both backed to either
an LDAP directory or AD both will authenticate but only one DB
record, in all lowercase, will be created, even if the user
attempted to login with a mixed case username when backed to AD.

https://bugzilla.redhat.com/show_bug.cgi?id=1448787

Steps for Testing/QA 
-------------------------------

### Test the AD case:

1. Configure an appliance to use authentication Mode: External (httpd) to an AD directory
2. Attempt to login to an appliance with a valid username in mixed case, e.g.: **_tEsTuSeR1_**
3. Confirm one user record, with the userid in lowercase, was created.
4. Attempt to login again with a valid username in mixed case but different from step 1. e.g. **_TestUser1_**
5. Repeat step 3 with the same username but varying which letters in the username are upper and which are lowercase
6. Confirm the user can log in but only one DB record, with the userid in lowercase, is created.

### Test the LDAP case:

1. Configure an appliance to use authentication Mode: External (httpd) to an LDAP directory
2. Attempt to login to an appliance with a valid username, the case must match what is in the LDAP directory because LDAP does a case sensitive lookup
3. Confirm one user record, with the userid in lowercase, was created.
4. Confirm attempts to login to the appliance with the case of the username not matching what is in LDAP fail 
