### PR TITLE
[WIP] Collect allocated storage for container groups

### DIFF
--- a/app/models/metric/pod_storage.rb
+++ b/app/models/metric/pod_storage.rb
@@ -1,0 +1,12 @@
+  module Metric::PodStorage
+  def self.fill_pod_allocated_storage(obj)
+    return {} unless obj.kind_of? ContainerGroup
+
+    sum_storage = obj.persistent_volumes.inject(0) {|sum, volume| sum + volume.capacity[:storage] if volume.capacity.present?}
+
+    # feels like an integer overflow? volume.capacity[:storage] could be 10737418240
+    {
+      :derived_vm_allocated_disk_storage => sum_storage
+    }
+  end
+end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -43,19 +43,22 @@ module Metric::Rollup
       :cpu_usage_rate_average,
       :derived_vm_numvcpus,
       :derived_memory_used,
-      :net_usage_rate_average
+      :net_usage_rate_average,
+      :derived_vm_allocated_disk_storage
     ],
     :ContainerService_container_groups    => [
       :cpu_usage_rate_average,
       :derived_vm_numvcpus,
       :derived_memory_used,
-      :net_usage_rate_average
+      :net_usage_rate_average,
+      :derived_vm_allocated_disk_storage
     ],
     :ContainerReplicator_container_groups => [
       :cpu_usage_rate_average,
       :derived_vm_numvcpus,
       :derived_memory_used,
-      :net_usage_rate_average
+      :net_usage_rate_average,
+      :derived_vm_allocated_disk_storage
     ],
     :AvailabilityZone_vms                 => [
       :cpu_usage_rate_average,
@@ -186,6 +189,7 @@ module Metric::Rollup
     new_perf.reverse_merge!(orig_perf)
     new_perf.merge!(Metric::Processing.process_derived_columns(obj, new_perf, hour)) unless DERIVED_COLS_EXCLUDED_CLASSES.include?(obj.class.base_class.name)
     new_perf.merge!(Metric::Statistic.calculate_stat_columns(obj, hour))
+    new_perf.merge!(Metric::PodStorage.fill_pod_allocated_storage(obj))
 
     new_perf
   end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/15023

Take sum of all persistent volume storage capacity as the `derived_vm_allocated_disk_storage` field in metric rollups. This will be filled in hourly rollups.

@yaacov @zakiva @cben Please review
cc @simon3z 