### PR TITLE
Add target to event existence check

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -234,10 +234,12 @@ class EmsEvent < EventStream
     event.delete_if { |k,| k.to_s.ends_with?("_ems_ref") }
 
     new_event = EmsEvent.create(event) unless EmsEvent.exists?(
-      :event_type => event[:event_type],
-      :timestamp  => event[:timestamp],
-      :chain_id   => event[:chain_id],
-      :ems_id     => event[:ems_id]
+      :event_type  => event[:event_type],
+      :timestamp   => event[:timestamp],
+      :chain_id    => event[:chain_id],
+      :ems_id      => event[:ems_id],
+      :target_id   => event[:target_id],
+      :target_type => event[:target_type],
     )
     new_event.handle_event if new_event
     new_event


### PR DESCRIPTION
In Prometheus alerting if in one evaluation cycle, the same alert was first found to be firing
for different labels (==entities) we will get multiple alerts indistinguishable by timestamp[1]

[1]
Example, for both 
"startsAt": "2017-08-02T10:16:30.457040707Z"
and there is no other time related difference:

```
{
  "generationID": "95b45589-ebee-49ca-a1bc-978c401dfde0",
  "messages": [
    {
      "index": 1,
      "timestamp": "2017-08-02T10:17:00.472823555Z",
      "data": {
        "alerts": [
          {
            "annotations": {
              "description": "ocp-compute01.10.35.48.142.nip.io is down_d",
              "message": "ocp-compute01.10.35.48.142.nip.io is down",
              "miqTarget": "ContainerNode",
              "severity": "HIGH",
              "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
            },
            "endsAt": "0001-01-01T00:00:00Z",
            "generatorURL": "http://prometheus-1018048397-9stw4:9090/graph?g0.expr=up%7Bjob%3D%22kubernetes-nodes%22%7D+%3D%3D+1&g0.tab=0",
            "labels": {
              "alertname": "Node Down",
              "beta_kubernetes_io_arch": "amd64",
              "beta_kubernetes_io_os": "linux",
              "instance": "ocp-compute01.10.35.48.142.nip.io",
              "job": "kubernetes-nodes",
              "kubernetes_io_hostname": "ocp-compute01.10.35.48.142.nip.io",
              "logging_infra_fluentd": "true",
              "region": "primary",
              "zone": "default"
            },
            "startsAt": "2017-08-02T10:16:30.457040707Z",
            "status": "firing"
          },
          {
            "annotations": {
              "description": "ocp-compute02.10.35.48.143.nip.io is down_d",
              "message": "ocp-compute02.10.35.48.143.nip.io is down",
              "miqTarget": "ContainerNode",
              "severity": "HIGH",
              "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
            },
            "endsAt": "0001-01-01T00:00:00Z",
            "generatorURL": "http://prometheus-1018048397-9stw4:9090/graph?g0.expr=up%7Bjob%3D%22kubernetes-nodes%22%7D+%3D%3D+1&g0.tab=0",
            "labels": {
              "alertname": "Node Down",
              "beta_kubernetes_io_arch": "amd64",
              "beta_kubernetes_io_os": "linux",
              "instance": "ocp-compute02.10.35.48.143.nip.io",
              "job": "kubernetes-nodes",
              "kubernetes_io_hostname": "ocp-compute02.10.35.48.143.nip.io",
              "logging_infra_fluentd": "true",
              "region": "primary",
              "zone": "default"
            },
            "startsAt": "2017-08-02T10:16:30.457040707Z",
            "status": "firing"
          },
        ]
      }
    }
}
```