### PR TITLE
[WIP] Add operations for LoadBalancer

### DIFF
--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -6,6 +6,8 @@ class LoadBalancer < ApplicationRecord
   include TenantIdentityMixin
   include CloudTenancyMixin
 
+  include_concern 'Operations'
+
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"

--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -58,22 +58,6 @@ class LoadBalancer < ApplicationRecord
     "#{load_balancer_manager.class.name}::LoadBalancer".constantize
   end
 
-  def raw_update_load_balancer(_options = {})
-    raise NotImplementedError, _("raw_update_load_balancer must be implemented in a subclass")
-  end
-
-  def update_load_balancer(options = {})
-    raw_update_load_balancer(options)
-  end
-
-  def raw_delete_load_balancer
-    raise NotImplementedError, _("raw_delete_load_balancer must be implemented in a subclass")
-  end
-
-  def delete_load_balancer
-    raw_delete_load_balancer
-  end
-
   def raw_status
     raise NotImplementedError, _("raw_status must be implemented in a subclass")
   end

--- a/app/models/load_balancer/operations.rb
+++ b/app/models/load_balancer/operations.rb
@@ -1,0 +1,19 @@
+module LoadBalancer::Operations
+  extend ActiveSupport::Concern
+
+  def update_load_balancer(options={})
+    raw_update_load_balancer(options)
+  end
+
+  def raw_update_load_balancer(_options={})
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
+  def delete_load_balancer
+    raw_delete_load_balancer
+  end
+
+  def raw_delete_load_balancer
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+end


### PR DESCRIPTION
Moved `update` and `delete` methods from LoadBalancer model to Operations module (according to this [comment](https://github.com/ManageIQ/manageiq/pull/15615#issuecomment-318424272)), in order to expose it in Automate engine
https://github.com/ManageIQ/manageiq-automation_engine/pull/62