### PR TITLE
Remove remains of container definition

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -11,7 +11,6 @@ module ManageIQ::Providers
     has_many :container_services, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
     has_many :containers, -> { active }, :foreign_key => :ems_id
-    has_many :container_definitions, -> { active }, :foreign_key => :ems_id
     has_many :container_projects, -> { active }, :foreign_key => :ems_id
     has_many :container_quotas, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
@@ -44,7 +43,6 @@ module ManageIQ::Providers
     has_many :all_container_groups, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerGroup"
     has_many :all_container_projects, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerProject"
     has_many :all_container_images, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerImage"
-    has_many :all_container_definitions, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerDefinition"
 
 
     virtual_column :port_show, :type => :string


### PR DESCRIPTION
`ContainerDefinition` and `Container` were unified to one class, no need for these.
(Plus its generating errors) 


@cben @Ladas Please review
cc @simon3z 

@miq-bot add_label provider/containers, bug