### PR TITLE
Removes importer association data for backwards compatibility

### DIFF
--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -10,6 +10,7 @@ class DialogFieldImporter
     if DialogField::DIALOG_FIELD_TYPES.include?(dialog_field_attributes["type"])
       dialog_field_type_class = dialog_field_attributes["type"].constantize
       resource_action_attributes = dialog_field_attributes.delete("resource_action")
+      dialog_field_attributes.delete("dialog_field_responders")
       resource_action = ResourceAction.new(resource_action_attributes)
       dialog_field = dialog_field_type_class.new(dialog_field_attributes.merge("resource_action" => resource_action))
       if dialog_field_attributes["type"] == "DialogFieldTagControl"

--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -20,6 +20,7 @@ class DialogFieldImporter
 
       dialog_field
     elsif dialog_field_attributes["type"].nil?
+      dialog_field_attributes.delete("dialog_field_responders")
       dialog_field_attributes.delete("resource_action")
       DialogField.create(dialog_field_attributes)
     else

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -4,11 +4,12 @@ describe DialogFieldImporter do
   describe "#import_field" do
     let(:dialog_field) do
       {
-        "type"            => type,
-        "name"            => "Something",
-        "label"           => "Something else",
-        "resource_action" => resource_action,
-        "options"         => options
+        "type"                    => type,
+        "name"                    => "Something",
+        "label"                   => "Something else",
+        "resource_action"         => resource_action,
+        "options"                 => options,
+        "dialog_field_responders" => ["foo_that_gets_ignored"]
       }
     end
 


### PR DESCRIPTION
This PR removes the dialog field association data from the fields currently imported by the main repo (which takes only expected dialog fields sans associations). We take out the information related to ResourceActions in much the same fashion here as well. 


Related to:
https://github.com/ManageIQ/manageiq/pull/15608

(the export code is here:)
https://github.com/ManageIQ/manageiq/pull/15740
