### PR TITLE
Evaluate visibility expressions for CustomButtons

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -142,7 +142,7 @@ class CustomButton < ApplicationRecord
 
   def evaluate_visibility_expression_for(object)
     return true unless visibility_expression
-    return false if enablement_expression && !object # list
+    return false if visibility_expression && !object # object == nil, method is called for list of objects
     visibility_expression.lenient_evaluate(object)
   end
 

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -140,6 +140,12 @@ class CustomButton < ApplicationRecord
     enablement_expression.lenient_evaluate(object)
   end
 
+  def evaluate_visibility_expression_for(object)
+    return true unless visibility_expression
+    return false if enablement_expression && !object # list
+    visibility_expression.lenient_evaluate(object)
+  end
+
   # End - Helper methods to support moving automate columns to resource_actions table
 
   def self.parse_uri(uri)

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -21,6 +21,40 @@ describe CustomButtonSet do
     end
   end
 
+  describe '.filter_with_visibility_expression' do
+    let(:vm_1)              { FactoryGirl.create(:vm_vmware, :name => 'vm_1') }
+    let(:custom_button_1)   { FactoryGirl.create(:custom_button, :applies_to => vm_1) }
+    let(:miq_expression)    { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => "vm_1"}) }
+    let(:custom_button_2)   { FactoryGirl.create(:custom_button, :applies_to => vm_1, :visibility_expression => miq_expression) }
+    let(:set_data)          { {:applies_to_class => "Vm", :button_order => [custom_button_1.id, custom_button_2.id]} }
+    let(:custom_button_set) { FactoryGirl.create(:custom_button_set, :name => "set_1", :set_data => set_data) }
+
+    context 'when all CustomButtons#visibility_expression=nil' do
+      let(:miq_expression) { nil }
+
+      it 'returns same array CustomButtonSet as input' do
+        expect(described_class.filter_with_visibility_expression([custom_button_set], vm_1)).to eq([custom_button_set])
+      end
+    end
+
+    context 'when any visibility_expression is evaluated to false and any to true' do
+      let(:miq_expression_false) { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => "vm_2"}) }
+      let(:custom_button_1)      { FactoryGirl.create(:custom_button, :applies_to => vm_1, :visibility_expression => miq_expression_false) }
+
+      it 'returns filtered array of CustomButtonSet and CustomButtons' do
+        set = described_class.filter_with_visibility_expression([custom_button_set], vm_1).first
+        expect(set.set_data[:button_order]).to eq([custom_button_2.id])
+      end
+
+      context 'all CustomButtons#visibility_expression are evaluated to false' do
+        let(:miq_expression)    { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => 'vm_2'}) }
+        it 'returns empty array of CustomButtonSet' do
+          expect(described_class.filter_with_visibility_expression([custom_button_set], vm_1)).to be_empty
+        end
+      end
+    end
+  end
+
   it "#deep_copy" do
     service_template1 = FactoryGirl.create(:service_template)
     service_template2 = FactoryGirl.create(:service_template)


### PR DESCRIPTION
method `CustomButtonSet#filter_with_visibility_expression` is called when custom buttons are going to display - the method is doing filtering:

## how  filter_with_visibility_expression works

(from https://github.com/ManageIQ/manageiq/pull/15725/commits/36bff4709fc6e22b88ab0f3458ed422dd0029429) 
```
  # Params:
  #   custom_button_sets: <Array>CustomButtonSet
  #   object: for this object are evaluated visibility_expression of CustomButtons
  #           one CustomButtonSet contains any CustomButtons,
  #           CustomButtonSet has stored this ids of CustomButtons in array CustomButton#set_data[:button_order]
  # Returns:
  #   <Array>CustomButtonSet
  #
  # example:
  # let's have:
  # custom_buttons_set =
  #   <Array> [<CustomButtonSet> id: 10000000000075,
  #     set_data:
  #       {:button_order=> [1, 2]}, list ids of custom buttons in custom button set (group of buttons in UI)
  # ... ]
  # object = Vm.first
  #
  # then CustomButtonSet.filter_with_visibility_expression(custom_button_sets, object) returns:
  #  - same custom_button_sets array when all visibility expressions are not populated(CustomButton#visibility_expression = nil)
  #  - same custom_button_sets array but with filtered list custom buttons ids in each custom button set from
  #    custom_button_sets when any visibility expression is evaluated to true
  #    - ids of custom buttons with visibility expression which are evaluated to false are removed from CustomButtonSet#set_data[:button_order]
  #  - filtered custom_button_sets array when all visibilty expression custom buttons have been evaluated to false
```

## Links
UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/1824
first part of https://www.pivotaltracker.com/story/show/147780767 - visibility of custom buttons
