### PR TITLE
Add require_nested for container templates.

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -1,5 +1,6 @@
 module ManageIQ::Providers
   class ContainerManager < BaseManager
+    require_nested :ContainerTemplate
     require_nested :OrchestrationStack
 
     include AvailabilityMixin


### PR DESCRIPTION
Add require_nested to autoload the nested constant.
Follow-up of https://github.com/ManageIQ/manageiq/pull/15523.

@miq-bot assign @gmcculloug 
@miq-bot add_label refactoring, providers/containers