### PR TITLE
Evaluate enablement expressions for custom buttons

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -133,6 +133,13 @@ class CustomButton < ApplicationRecord
   def get_resource_action
     resource_action || build_resource_action
   end
+
+  def evaluate_enablement_expression_for(object)
+    return true unless enablement_expression
+    return false if enablement_expression && !object # list
+    enablement_expression.lenient_evaluate(object)
+  end
+
   # End - Helper methods to support moving automate columns to resource_actions table
 
   def self.parse_uri(uri)

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -7,6 +7,34 @@ describe CustomButton do
       @user = FactoryGirl.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
     end
 
+    describe '#evaluate_enablement_expression_for' do
+      let(:miq_expression) { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => 'vm_1'}) }
+      let(:vm)             { FactoryGirl.create(:vm_vmware, :name => 'vm_1') }
+      let(:custom_button) do
+        FactoryGirl.create(:custom_button, :applies_to => vm.class, :name => "foo", :description => "foo foo")
+      end
+
+      it 'evaluates enablement expression when expression is not set' do
+        expect(custom_button.evaluate_enablement_expression_for(vm)).to be_truthy
+      end
+
+      it 'evaluates enablement expression when expression is set and method is called for list' do
+        custom_button.enablement_expression = miq_expression
+        expect(custom_button.evaluate_enablement_expression_for(nil)).to be_falsey
+      end
+
+      it 'evaluates enablement expression when expression is set and evaluated to true' do
+        custom_button.enablement_expression = miq_expression
+        expect(custom_button.evaluate_enablement_expression_for(vm)).to be_truthy
+      end
+
+      it 'evaluates enablement expression when expression is set and evaluated to false' do
+        custom_button.enablement_expression = miq_expression
+        vm.name = 'XXX'
+        expect(custom_button.evaluate_enablement_expression_for(vm)).to be_falsey
+      end
+    end
+
     it "should validate there are no buttons" do
       expect(described_class.count).to eq(0)
     end


### PR DESCRIPTION
this method will be used in UI to evaluate enablement expression for the button:
 - if  enablement expression is not set then the method is evaluated as true
 - if  enablement expression is set then the method returns the result of expression evaluation
 - if  enablement expression is set and method is called for the list then the expression is evaluated as false

## Links
https://www.pivotaltracker.com/story/show/147780767