### PR TITLE
Load consumption factories

### DIFF
--- a/spec/support/factory_girl_helper.rb
+++ b/spec/support/factory_girl_helper.rb
@@ -20,8 +20,13 @@ end
 require 'factory_girl'
 # in case we are running as an engine, the factories are located in the dummy app
 FactoryGirl.definition_file_paths << 'spec/manageiq/spec/factories'
+
+ENGINE_NAMESPACES_FOR_LOADING_FACTORIES = %w(
+  ManageIQ::Providers
+).freeze
+
 # also add factories from provider gems until miq codebase does not use any provider specific factories anymore
-Rails::Engine.subclasses.select { |e| e.name.starts_with?("ManageIQ::Providers") }.each do |engine|
+Rails::Engine.subclasses.select { |e| ENGINE_NAMESPACES_FOR_LOADING_FACTORIES.any? { |x| e.name.starts_with?(x) } }.each do |engine|
   FactoryGirl.definition_file_paths << File.join(engine.root, 'spec', 'factories')
 end
 FactoryGirl.find_definitions

--- a/spec/support/factory_girl_helper.rb
+++ b/spec/support/factory_girl_helper.rb
@@ -23,6 +23,7 @@ FactoryGirl.definition_file_paths << 'spec/manageiq/spec/factories'
 
 ENGINE_NAMESPACES_FOR_LOADING_FACTORIES = %w(
   ManageIQ::Providers
+  ManageIQ::Consumption
 ).freeze
 
 # also add factories from provider gems until miq codebase does not use any provider specific factories anymore


### PR DESCRIPTION
there is repo https://github.com/miq-consumption/manageiq-consumption
(currently used with Miq only thru Gemfile.dev.rb)
and after discussion with @sergio-ocon we need to run `rspec` from core repo.
but for it we need to load factories from https://github.com/miq-consumption/manageiq-consumption 
so I am doing it as it was added for providers (`ManageIQ::Providers`) but I am not sure if it is the right way in our case
cc @gtanzillo @sergio-ocon @aljesusg  


@miq-bot assign @chrisarcand 






