### PR TITLE
Don't assume the current region != 99

### DIFF
--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -65,7 +65,7 @@ describe Authenticator do
     it "only returns matched group for the current region" do
       FactoryGirl.create(:miq_group,
                          :description => "group2",
-                         :id          => ApplicationRecord.id_in_region(1, 99))
+                         :id          => ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1))
       FactoryGirl.create(:miq_group, :description => "group1")
       group2 = FactoryGirl.create(:miq_group, :description => "group2")
 


### PR DESCRIPTION
This test assumes that the current region != 99 and fails with a
duplicate description violation when it is. Creating the group in the
current region + 1 fixes it.

See https://travis-ci.org/ManageIQ/manageiq/jobs/261087944 for an example of this failing.

Thanks @Fryguy for looking this over and providing the correct way to do this.

@miq-bot add-label bug/sporadic test failure
@miq-bot assign @abellotti 