### PR TITLE
raise not found error on DELETE of authentications

### DIFF
--- a/app/controllers/api/authentications_controller.rb
+++ b/app/controllers/api/authentications_controller.rb
@@ -22,6 +22,8 @@ module Api
       raise "Delete not supported for #{authentication_ident(auth)}" unless auth.respond_to?(:delete_in_provider_queue)
       task_id = auth.delete_in_provider_queue
       action_result(true, "Deleting #{authentication_ident(auth)}", :task_id => task_id)
+    rescue ActiveRecord::RecordNotFound => err
+      @req.method == :delete ? raise(err) : action_result(false, err.to_s)
     rescue => err
       action_result(false, err.to_s)
     end

--- a/spec/requests/api/authentications_spec.rb
+++ b/spec/requests/api/authentications_spec.rb
@@ -466,6 +466,14 @@ RSpec.describe 'Authentications API' do
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    it 'will raise an error if the authentication does not exist' do
+      api_basic_authorize action_identifier(:authentications, :delete, :resource_actions, :delete)
+
+      run_delete(authentications_url(999_999))
+
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe 'OPTIONS /api/authentications' do


### PR DESCRIPTION
DELETE /api/authentications/:id should raise a `not found` for invalid authentications. It is currently sending back a `204` as if it's a success due to the catching of the exception and returning it as an action result.

This is inconsistent with other areas of the API where DELETE returns a not found for invalid records.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1476869

@miq-bot add_label bug, api
@miq-bot assign @abellotti 
