### PR TITLE
[FINE] Service model revert and delete manager expose

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-orchestration_stack.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_AutomationManager_OrchestrationStack < MiqAeServiceOrchestrationStack
+    expose :manager, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-orchestration_stack.rb
@@ -1,5 +1,4 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_AutomationManager_OrchestrationStack < MiqAeServiceOrchestrationStack
-    expose :manager, :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_EmbeddedAnsible_AutomationManager_Job < MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack
+    expose :manager, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
@@ -1,5 +1,4 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_EmbeddedAnsible_AutomationManager_Job < MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack
-    expose :manager, :association => true
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-orchestration_stack.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_AutomationManager_OrchestrationStack
+    expose :manager, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-orchestration_stack.rb
@@ -1,5 +1,4 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_AutomationManager_OrchestrationStack
-    expose :manager, :association => true
   end
 end


### PR DESCRIPTION
PR restores the service models that were removed from upstream (https://github.com/ManageIQ/manageiq-automation_engine/pull/47) since they are not auto-generated on the `Fine` branch.

Second commit removes `expose :manager, :association => true` which was the main focus of the original PR.