### PR TITLE
Remove deprecated Gemfile.dev.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ ca/root
 certs/v2_key
 config/secrets.yml*
 coverage/
-Gemfile.dev.rb
 Gemfile.lock*
 GUID
 openstack_environments.yml

--- a/Gemfile
+++ b/Gemfile
@@ -238,16 +238,6 @@ def override_gem(name, *args)
   end
 end
 
-# Load developer specific Gemfile
-#   Developers can create a file called Gemfile.dev.rb containing any gems for
-#   their local development.  This can be any gem under evaluation that other
-#   developers may not need or may not easily install, such as rails-dev-boost,
-#   any git based gem, and compiled gems like rbtrace or memprof.
-dev_gemfile = File.expand_path("Gemfile.dev.rb", __dir__)
-if File.exist?(dev_gemfile)
-  Bundler::UI::Shell.new.warn "** Gemfile.dev.rb deprecated, please move it to bundler.d/"
-  eval_gemfile(dev_gemfile)
-end
-
 # Load other additional Gemfiles
+#   Developers can create a file ending in .rb under bundler.d/ to specify additional development dependencies
 Dir.glob(File.join(__dir__, 'bundler.d/*.rb')).each { |f| eval_gemfile(File.expand_path(f, __dir__)) }


### PR DESCRIPTION
Based on:
https://github.com/ManageIQ/manageiq/pull/14908
http://talk.manageiq.org/t/gemfile-dev-rb-is-moving/2306/3