### PR TITLE
Add number of container using image

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -31,6 +31,7 @@ class ContainerImage < ApplicationRecord
 
   acts_as_miq_taggable
   virtual_column :display_registry, :type => :string
+  virtual_total :total_containers, :containers
 
   after_create :raise_creation_event
 

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :container do
+    sequence(:name) { |n| "container_#{seq_padded_for_sorting(n)}" }
   end
 
   factory :kubernetes_container,

--- a/spec/models/container_image/container_image_spec.rb
+++ b/spec/models/container_image/container_image_spec.rb
@@ -1,0 +1,13 @@
+describe ContainerImage do
+  it "counts containers" do
+    group = FactoryGirl.create(
+      :container_group,
+      :name           => "group",
+      :container_node => FactoryGirl.create(:container_node, :name => "node")
+    )
+    expect(FactoryGirl.create(
+      :container_image,
+      :containers => FactoryGirl.create_list(:container, 2, :container_group => group)
+    ).total_containers).to eq(2)
+  end
+end


### PR DESCRIPTION
This is to support adding `Number of Containers` column to the `ContainerImage` list view.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1474094
Screenshot of report :
![29004803-a7b47b0c-7ad6-11e7-9061-c2c77b09bc78](https://user-images.githubusercontent.com/8366181/29248112-2817b3ae-8018-11e7-8255-178eaa3030dc.png)

cc: @enoodle @Loicavenel
@simon3z 


