### PR TITLE
Add the missing openstack Cloud Tenant translation to en.yml

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -829,6 +829,7 @@ en:
       ManageIQ::Providers::Openstack::NetworkManager::CloudSubnet:          Cloud Subnet (OpenStack)
       ManageIQ::Providers::Openstack::NetworkManager::NetworkRouter:        Network Router (OpenStack)
       ManageIQ::Providers::Openstack::InfraManager::OrchestrationStack:     Orchestration Stack (OpenStack)
+      ManageIQ::Providers::Openstack::CloudManager::CloudTenant:            Cloud Tenant (OpenStack)
       ManageIQ::Providers::Openstack::CloudManager::OrchestrationStack:     Orchestration Stack (OpenStack)
       ManageIQ::Providers::Azure::CloudManager::OrchestrationStack:         Orchestration Stack (Microsoft Azure)
       ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack:        Orchestration Stack (Amazon)


### PR DESCRIPTION
The missing entry in the yaml file caused to display the whole class name:
![screenshot from 2017-08-07 14-13-20](https://user-images.githubusercontent.com/649130/29026147-976b4e70-7b7a-11e7-9803-c4d14793c7a7.png)

After:
![screenshot from 2017-08-07 14-11-57](https://user-images.githubusercontent.com/649130/29026111-65e868ec-7b7a-11e7-8365-5c4fe52940e5.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1478802

@miq-bot add_label bug
@miq-bot assign @martinpovolny 