### PR TITLE
realtime_block for each InventoryCollection saved

### DIFF
--- a/app/models/manager_refresh/save_collection/base.rb
+++ b/app/models/manager_refresh/save_collection/base.rb
@@ -5,11 +5,13 @@ module ManagerRefresh::SaveCollection
         _log.info("Synchronizing #{ems.name} collection #{inventory_collection} of size #{inventory_collection.size} to"\
                 " the database")
 
-        if inventory_collection.custom_save_block.present?
-          _log.info("Synchronizing #{ems.name} collection #{inventory_collection} using a custom save block")
-          inventory_collection.custom_save_block.call(ems, inventory_collection)
-        else
-          save_inventory(inventory_collection)
+        Benchmark.realtime_block("SaveCollection #{inventory_collection.name}") do
+          if inventory_collection.custom_save_block.present?
+            _log.info("Synchronizing #{ems.name} collection #{inventory_collection} using a custom save block")
+            inventory_collection.custom_save_block.call(ems, inventory_collection)
+          else
+            save_inventory(inventory_collection)
+          end
         end
         _log.info("Synchronized #{ems.name} collection #{inventory_collection}")
         inventory_collection.saved = true


### PR DESCRIPTION
example:
```
 {:collect_inventory_for_targets=>8.241970777511597,
  :parse_targeted_inventory=>7.483407497406006,
  "SaveCollection container_projects"=>0.060195207595825195,
  "SaveCollection custom_attributes"=>2.52766752243042,
  "SaveCollection container_quotas"=>0.01108694076538086,
  "SaveCollection container_quota_items"=>0.00921010971069336,
  "SaveCollection container_limits"=>0.009905815124511719,
  "SaveCollection container_limit_items"=>0.009838342666625977,
  "SaveCollection container_nodes"=>0.07907748222351074,
  "SaveCollection container_image_registries"=>0.020809650421142578,
  "SaveCollection container_component_statuses"=>0.020324230194091797,
  "SaveCollection persistent_volume_claims"=>0.08918905258178711,
  "SaveCollection container_conditions"=>0.3354301452636719,
  "SaveCollection computer_systems"=>0.02820897102355957,
  "SaveCollection container_images"=>1.0156383514404297,
  "SaveCollection container_replicators"=>0.0899651050567627,
  "SaveCollection container_templates"=>3.4639806747436523,
  "SaveCollection container_builds"=>0.059538841247558594,
  "SaveCollection persistent_volumes"=>0.3799281120300293,
  "SaveCollection computer_system_hardwares"=>0.059223175048828125,
  "SaveCollection computer_system_operating_systems"=>0.046601057052612305,
  "SaveCollection container_template_parameters"=>2.485271692276001,
  "SaveCollection container_build_pods"=>0.0511317253112793,
  "SaveCollection container_groups"=>0.2097456455230713,
  "SaveCollection container_volumes"=>0.5844664573669434,
  "SaveCollection containers"=>0.3848915100097656,
  "SaveCollection container_services"=>0.4631686210632324,
  "SaveCollection container_port_configs"=>0.05856752395629883,
  "SaveCollection container_env_vars"=>0.4620339870452881,
  "SaveCollection security_contexts"=>0.12041878700256348,
  "SaveCollection container_service_port_configs"=>0.06904053688049316,
  "SaveCollection container_routes"=>0.050156354904174805,
  :save_inventory=>13.444007873535156,
  :manager_refresh_post_processing=>2.6226043701171875e-06,
  :ems_refresh=>29.16984224319458,
  :ems_total_refresh=>29.26390314102173}]
```

@agrare @Ladas is this safe to add or can it blow up the logs in some scenarios (tons of small targetted refreshes or something like that)?