### PR TITLE
Do not limit width of table when downloading report in text format

### DIFF
--- a/app/models/miq_report/formatters/text.rb
+++ b/app/models/miq_report/formatters/text.rb
@@ -2,6 +2,7 @@ module MiqReport::Formatters::Text
   def to_text
     ReportFormatter::ReportRenderer.render(:text) do |e|
       e.options.mri = (self) # set the MIQ_Report instance in the formatter
+      e.options.ignore_table_width = true
     end
   end
   alias_method :to_txt, :to_text


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1442857

@miq-bot close_issue https://github.com/ManageIQ/manageiq/issues/6875

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/29035117-821501d6-7b68-11e7-9b7a-b1e2e5d3c76e.gif)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/29035164-9e636102-7b68-11e7-8451-6ccbe3ae0451.gif)

@miq-bot add-label bug, core, euwe/yes, fine/yes

\cc @gtanzillo 
