### PR TITLE
Remove methods for Azure sample orchestration

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -20,17 +20,6 @@ class OrchestrationTemplate < ApplicationRecord
   attr_accessor :remote_proxy
   alias remote_proxy? remote_proxy
 
-  # Try to create the template if the name is not found in table
-  def self.seed
-    Vmdb::Plugins.instance.vmdb_plugins.each do |plugin|
-      Dir.glob(plugin.root.join('content', 'orchestration_templates', '*.{yaml,yml}')).each do |file|
-        hash = YAML.load_file(file)
-        next if hash[:type].constantize.find_by(:name => hash[:name])
-        find_or_create_by_contents(hash)
-      end
-    end
-  end
-
   # available templates for ordering an orchestration service
   def self.available
     where(:draft => false, :orderable => true)

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -284,53 +284,6 @@ describe OrchestrationTemplate do
     end
   end
 
-  describe ".seed" do
-    let(:azure_template) { "azure-single-vm-from-user-image" }
-
-    before do
-      mock_engine = double(:root => Rails.root.join('spec', 'fixtures', 'vmdb_plugin_root'))
-      allow(Vmdb::Plugins.instance).to receive(:vmdb_plugins).and_return([mock_engine])
-    end
-
-    context "the first time seeding" do
-      it "adds templates from default location" do
-        OrchestrationTemplate.seed
-        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
-      end
-    end
-
-    context "when the seeding has been run before" do
-      before do
-        OrchestrationTemplate.seed
-      end
-
-      let(:seeded_template) { OrchestrationTemplate.find_by(:name => azure_template) }
-
-      it "does not add new templates from following runs" do
-        OrchestrationTemplate.seed
-        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
-      end
-
-      it "does not add new template if the original template has been only renamed" do
-        seeded_template.update_attributes(:name => 'other')
-        OrchestrationTemplate.seed
-        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(0)
-      end
-
-      it "does not add new template if the original template has modified content" do
-        seeded_template.update_attributes(:content => '{}')
-        OrchestrationTemplate.seed
-        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
-      end
-
-      it "adds new template if the original template has been renamed and modified" do
-        seeded_template.update_attributes(:name => 'other', :content => '{}')
-        OrchestrationTemplate.seed
-        expect(OrchestrationTemplate.where(:name => azure_template).count).to eq(1)
-      end
-    end
-  end
-
   describe "#deployment_options" do
     it do
       options = subject.deployment_options


### PR DESCRIPTION
This removes seeding used for the sample orchestration template for Azure in favor of Lifecycle provisioning because the template does not support managed images and was originally provided as a provisioning option before Lifecycle provisioning for Azure was implemented fully.

https://bugzilla.redhat.com/show_bug.cgi?id=1470491

related:
[azure] https://github.com/ManageIQ/manageiq-providers-azure/pull/107

@miq-bot add_label bug
@miq-bot assign @gmcculloug 