### PR TITLE
miq_group_id is required by automate.

### DIFF
--- a/app/models/automation_task.rb
+++ b/app/models/automation_task.rb
@@ -20,6 +20,8 @@ class AutomationTask < MiqRequestTask
     args[:class_name]       = options[:class_name]
     args[:instance_name]    = options[:instance_name]
     args[:user_id]          = options[:user_id]
+    args[:miq_group_id]     = options[:miq_group_id] || User.find(options[:user_id]).current_group.id
+    args[:tenant_id]        = options[:tenant_id] || User.find(options[:user_id]).current_tenant.id
     args[:automate_message] = options[:message]
 
     MiqAeEngine.deliver(args)

--- a/spec/models/automation_task_spec.rb
+++ b/spec/models/automation_task_spec.rb
@@ -1,7 +1,7 @@
 describe AutomationTask do
   before(:each) do
     allow(MiqServer).to receive(:my_zone).and_return("default")
-    admin         = FactoryGirl.create(:user_admin)
+    @admin       = FactoryGirl.create(:user_admin)
 
     @ae_instance = "IIII"
     @ae_message  = "MMMM"
@@ -9,16 +9,21 @@ describe AutomationTask do
     @ae_var2     = "wwww"
     @ae_var3     = "xxxx"
 
-    @attrs   = {:var1 => @ae_var1, :var2 => @ae_var2, :var3 => @ae_var3, :userid => admin.userid}
-    @options = {:attrs => @attrs, :instance => @instance, :message => @message, :user_id => admin.id, :delivered_on => Time.now.utc.to_s}
-    @at = FactoryGirl.create(:automation_task, :state => 'pending', :status => 'Ok', :userid => admin.userid, :options => @options)
+    @attrs   = {:var1 => @ae_var1, :var2 => @ae_var2, :var3 => @ae_var3, :userid => @admin.userid}
+    @options = {:attrs => @attrs, :instance => @instance, :message => @message, :user_id => @admin.id, :delivered_on => Time.now.utc.to_s}
+    @at = FactoryGirl.create(:automation_task, :state => 'pending', :status => 'Ok', :userid => @admin.userid, :options => @options)
     @ar = FactoryGirl.create(:automation_request)
     @ar.automation_tasks << @at
     @ar.save!
   end
 
   it "#execute" do
-    expect(MiqAeEngine).to receive(:deliver).once
+    options = {
+      :user_id      => @admin.id,
+      :miq_group_id => @admin.current_group.id,
+      :tenant_id    => @admin.current_tenant.id
+    }
+    expect(MiqAeEngine).to receive(:deliver).with(hash_including(options)).once
     @at.execute
     expect(@ar.reload.message).to eq("#{AutomationRequest::TASK_DESCRIPTION} initiated")
   end


### PR DESCRIPTION
A user may belong to multiple groups.
miq_group_id became required via https://github.com/ManageIQ/manageiq-automation_engine/pull/61.

Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/61.

https://bugzilla.redhat.com/show_bug.cgi?id=1467364

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, euwe/yes, fine/yes
cc @mkanoor 