### PR TITLE
Ultimate batch saving speedup

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -685,6 +685,8 @@ module ManagerRefresh
     end
 
     def manager_ref_to_cols
+      # TODO(lsmola) this should contain the polymorphic _type, otherwise the IC with polymorphic unique key will get
+      # conflicts
       # Convert attributes from unique key to actual db cols
       manager_ref.map do |ref|
         association_to_foreign_key_mapping[ref] || ref
@@ -994,10 +996,12 @@ module ManagerRefresh
     end
 
     def db_collection_for_comparison_for(manager_uuids_set)
+      # TODO(lsmola) this should have the build_multi_selection_condition, like in the method above
       full_collection_for_comparison.where(manager_ref.first => manager_uuids_set)
     end
 
     def db_collection_for_comparison_for_complement_of(manager_uuids_set)
+      # TODO(lsmola) this should have the build_multi_selection_condition, like in the method above
       full_collection_for_comparison.where.not(manager_ref.first => manager_uuids_set)
     end
 

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -911,6 +911,14 @@ module ManagerRefresh
       @fixed_foreign_keys_cache
     end
 
+    def serializable_keys?(all_attribute_keys)
+      return @serializable_keys_cache unless @serializable_keys_cache.nil?
+
+      @serializable_keys_cache = all_attribute_keys.any? do |key|
+        model_class.type_for_attribute(key.to_s).respond_to?(:coder)
+      end
+    end
+
     def base_class_name
       return "" unless model_class
 

--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -15,6 +15,8 @@ module ManagerRefresh
     end
 
     def manager_uuid
+      # TODO(lsmola) should we have a separate function for uuid containing foreign keys? Probably yes, since it could
+      # speed up the ID fetching.
       id_with_keys(manager_ref)
     end
 
@@ -50,36 +52,36 @@ module ManagerRefresh
           data[key] = value.compact.map(&:load).compact
           # We can use built in _ids methods to assign array of ids into has_many relations. So e.g. the :key_pairs=
           # relation setter will become :key_pair_ids=
-          attributes_for_saving[key.to_s.singularize + "_ids"] = data[key].map(&:id).compact.uniq
+          attributes_for_saving[(key.to_s.singularize + "_ids").to_sym] = data[key].map(&:id).compact.uniq
         elsif loadable?(value) || inventory_collection_scope.association_to_foreign_key_mapping[key]
           # Lets fill also the original data, so other InventoryObject referring to this attribute gets the right
           # result
           data[key] = value.load if value.respond_to?(:load)
           if (foreign_key = inventory_collection_scope.association_to_foreign_key_mapping[key])
             # We have an association to fill, lets fill also the :key, cause some other InventoryObject can refer to it
-            record_id                          = data[key].try(:id)
-            attributes_for_saving[foreign_key] = record_id
+            record_id                                 = data[key].try(:id)
+            attributes_for_saving[foreign_key.to_sym] = record_id
 
             if (foreign_type = inventory_collection_scope.association_to_foreign_type_mapping[key])
               # If we have a polymorphic association, we need to also fill a base class name, but we want to nullify it
               # if record_id is missing
               base_class = data[key].try(:base_class_name) || data[key].class.try(:base_class).try(:name)
-              attributes_for_saving[foreign_type] = record_id ? base_class : nil
+              attributes_for_saving[foreign_type.to_sym] = record_id ? base_class : nil
             end
           elsif data[key].kind_of?(::ManagerRefresh::InventoryObject)
             # We have an association to fill but not an Activerecord association, so e.g. Ancestry, lets just load
             # it here. This way of storing ancestry is ineffective in DB call count, but RAM friendly
-            attributes_for_saving[key] = data[key].base_class_name.constantize.find_by(:id => data[key].id)
+            attributes_for_saving[key.to_sym] = data[key].base_class_name.constantize.find_by(:id => data[key].id)
           else
             # We have a normal attribute to fill
-            attributes_for_saving[key] = data[key]
+            attributes_for_saving[key.to_sym] = data[key]
           end
         else
-          attributes_for_saving[key] = value
+          attributes_for_saving[key.to_sym] = value
         end
       end
 
-      attributes_for_saving.symbolize_keys
+      attributes_for_saving
     end
 
     def assign_attributes(attributes)

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -12,9 +12,9 @@ module ManagerRefresh::SaveCollection
         # Private attrs
         @primary_key            = inventory_collection.model_class.primary_key
         @arel_primary_key       = inventory_collection.model_class.arel_attribute(primary_key)
-        @unique_index_keys      = inventory_collection.manager_ref_to_cols
+        @unique_index_keys      = inventory_collection.manager_ref_to_cols.map(&:to_sym)
         @unique_index_keys_to_s = inventory_collection.manager_ref_to_cols.map(&:to_s)
-        @select_keys            = [@primary_key.to_sym] + inventory_collection.manager_ref_to_cols
+        @select_keys            = [@primary_key] + @unique_index_keys_to_s
         @unique_db_primary_keys = Set.new
         @unique_db_indexes      = Set.new
 

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -22,8 +22,8 @@ module ManagerRefresh::SaveCollection
         inventory_collection.parent.reload if inventory_collection.parent
         @association = inventory_collection.db_collection_for_comparison
 
-        # Right not ApplicationRecordIterator in association is used for targeted refresh. Given the small amounts of
-        # records flowing through there, we probably don't need to optimize that association to fetch pure SQL.
+        # Right now ApplicationRecordIterator in association is used for targeted refresh. Given the small amount of
+        # records flowing through there, we probably don't need to optimize that association to fetch a pure SQL.
         @pure_sql_records_fetching = !inventory_collection.use_ar_object? && !@association.kind_of?(ManagerRefresh::ApplicationRecordIterator)
 
         @record_key_method = @pure_sql_records_fetching ? :pure_sql_record_key : :ar_record_key

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -66,7 +66,7 @@ module ManagerRefresh::SaveCollection
           association.find_each do |record|
             index = inventory_collection.object_index_with_keys(unique_index_keys, record)
 
-            next unless assert_distinct_relation(record)
+            next unless assert_distinct_relation(record.id)
             next unless assert_unique_record(record, index)
 
             inventory_object = inventory_objects_index.delete(index)
@@ -148,8 +148,8 @@ module ManagerRefresh::SaveCollection
         true
       end
 
-      def assert_distinct_relation(record)
-        if unique_db_primary_keys.include?(record_key(record, primary_key)) # Include on Set is O(1)
+      def assert_distinct_relation(primary_key_value)
+        if unique_db_primary_keys.include?(primary_key_value) # Include on Set is O(1)
           # Change the InventoryCollection's :association or :arel parameter to return distinct results. The :through
           # relations can return the same record multiple times. We don't want to do SELECT DISTINCT by default, since
           # it can be very slow.
@@ -161,7 +161,7 @@ module ManagerRefresh::SaveCollection
             raise("Please update :association or :arel for #{inventory_collection} to return a DISTINCT result. ")
           end
         else
-          unique_db_primary_keys << record_key(record, primary_key)
+          unique_db_primary_keys << primary_key_value
         end
         true
       end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -24,7 +24,7 @@ module ManagerRefresh::SaveCollection
             primary_key_offset = nil
             loop do
               relation    = association.select(*select_keys)
-                                       .order("#{primary_key} ASC")
+                                       .reorder("#{primary_key} ASC")
                                        .limit(batch_size)
               # Using rails way of comparing primary key instead of offset
               relation    = relation.where(arel_primary_key.gt(primary_key_offset)) if primary_key_offset

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -3,6 +3,50 @@ module ManagerRefresh::SaveCollection
     class ConcurrentSafeBatch < ManagerRefresh::SaveCollection::Saver::Base
       private
 
+      def record_key(record, key)
+        send(record_key_method, record, key)
+      end
+
+      def ar_record_key(record, key)
+        record.public_send(key)
+      end
+
+      def pure_sql_record_key(record, key)
+        record[select_keys_indexes[key]]
+      end
+
+      def batch_size_for_persisting
+        10_000
+      end
+
+      def batch_iterator(association)
+        if pure_sql_records_fetching
+          # Building fast iterator doing pure SQL query avoiding redundant creation of AR objects, responds to
+          # find_in_batches. For targeted refresh, the association can already be ApplicationRecordIterator.
+          pure_sql_iterator = lambda do |&block|
+            primary_key_offset = nil
+            loop do
+              relation    = association.select(*select_keys)
+                                       .order("#{primary_key} ASC")
+                                       .limit(batch_size)
+              # Using rails way of comparing primary key instead of offset
+              relation    = relation.where(arel_primary_key.gt(primary_key_offset)) if primary_key_offset
+              records     = get_connection.query(relation.to_sql)
+              last_record = records.last
+              block.call(records)
+
+              break if records.size < batch_size
+              primary_key_offset = record_key(last_record, primary_key)
+            end
+          end
+
+          ManagerRefresh::ApplicationRecordIterator.new(:iterator => pure_sql_iterator)
+        else
+          # Normal rails association where we will call find_in_batches
+          association
+        end
+      end
+
       def save!(association)
         attributes_index        = {}
         inventory_objects_index = {}
@@ -22,76 +66,15 @@ module ManagerRefresh::SaveCollection
         all_attribute_keys += [:created_at, :updated_at] if inventory_collection.supports_timestamps_at_variant?
 
         _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection.size} *************")
-        hashes_for_update = []
-        records_for_destroy = []
 
-        # Records that are in the DB, we will be updating or deleting them.
-        association.find_in_batches do |batch|
-          update_time = time_now
-          batch.each do |record|
-            next unless assert_distinct_relation(record)
-
-            index = inventory_collection.object_index_with_keys(unique_index_keys, record)
-            inventory_object = inventory_objects_index.delete(index)
-            hash             = attributes_index.delete(index)
-
-            if inventory_object.nil?
-              # Record was found in the DB but not sent for saving, that means it doesn't exist anymore and we should
-              # delete it from the DB.
-              if inventory_collection.delete_allowed?
-                records_for_destroy << record
-              end
-            else
-              # Record was found in the DB and sent for saving, we will be updating the DB.
-              next unless assert_referential_integrity(hash, inventory_object)
-              inventory_object.id = record.id
-
-              hash_for_update = if inventory_collection.use_ar_object?
-                                  record.assign_attributes(hash.except(:id, :type))
-                                  values_for_database(inventory_collection.model_class,
-                                                      all_attribute_keys,
-                                                      record.attributes.symbolize_keys)
-                                elsif inventory_collection.serializable_keys?(all_attribute_keys)
-                                  values_for_database(inventory_collection.model_class,
-                                                      all_attribute_keys,
-                                                      hash.symbolize_keys)
-                                else
-                                  hash.symbolize_keys
-                                end
-              assign_attributes_for_update!(hash_for_update, update_time)
-              inventory_collection.store_updated_records(record)
-
-              hash_for_update[:id] = record.id
-              hashes_for_update << hash_for_update
-            end
-          end
-
-          # Update in batches
-          if hashes_for_update.size >= batch_size
-            update_records!(all_attribute_keys, hashes_for_update)
-
-            hashes_for_update = []
-          end
-
-          # Destroy in batches
-          if records_for_destroy.size >= batch_size
-            destroy_records(records_for_destroy)
-            records_for_destroy = []
-          end
-        end
-
-        # Update the last batch
-        update_records!(all_attribute_keys, hashes_for_update)
-        hashes_for_update = [] # Cleanup so GC can release it sooner
-
-        # Destroy the last batch
-        destroy_records(records_for_destroy)
-        records_for_destroy = [] # Cleanup so GC can release it sooner
+        # TODO(lsmola) needed only because UPDATE FROM VALUES needs a specific PG typecasting, remove when fixed in PG
+        collect_pg_types!(all_attribute_keys)
+        update_or_destroy_records!(batch_iterator(association), inventory_objects_index, attributes_index, all_attribute_keys)
 
         all_attribute_keys << :type if inventory_collection.supports_sti?
         # Records that were not found in the DB but sent for saving, we will be creating these in the DB.
         if inventory_collection.create_allowed?
-          inventory_objects_index.each_slice(batch_size) do |batch|
+          inventory_objects_index.each_slice(batch_size_for_persisting) do |batch|
             create_records!(all_attribute_keys, batch, attributes_index)
           end
         end
@@ -104,7 +87,76 @@ module ManagerRefresh::SaveCollection
         raise e
       end
 
-      def destroy_records(records)
+      def update_or_destroy_records!(records_batch_iterator, inventory_objects_index, attributes_index, all_attribute_keys)
+        hashes_for_update   = []
+        records_for_destroy = []
+
+        records_batch_iterator.find_in_batches(:batch_size => batch_size) do |batch|
+          update_time = time_now
+
+          batch.each do |record|
+            next unless assert_distinct_relation(record)
+
+            # TODO(lsmola) unify this behavior with object_index_with_keys method in InventoryCollection
+            index            = unique_index_keys_to_s.map { |attribute| record_key(record, attribute).to_s }.join(inventory_collection.stringify_joiner)
+            inventory_object = inventory_objects_index.delete(index)
+            hash             = attributes_index[index]
+
+            if inventory_object.nil?
+              # Record was found in the DB but not sent for saving, that means it doesn't exist anymore and we should
+              # delete it from the DB.
+              if inventory_collection.delete_allowed?
+                records_for_destroy << record
+              end
+            else
+              # Record was found in the DB and sent for saving, we will be updating the DB.
+              next unless assert_referential_integrity(hash)
+              inventory_object.id = record_key(record, primary_key)
+
+              hash_for_update = if inventory_collection.use_ar_object?
+                                  record.assign_attributes(hash.except(:id, :type))
+                                  values_for_database(inventory_collection.model_class,
+                                                      all_attribute_keys,
+                                                      record.attributes.symbolize_keys)
+                                elsif inventory_collection.serializable_keys?(all_attribute_keys)
+                                  values_for_database(inventory_collection.model_class,
+                                                      all_attribute_keys,
+                                                      hash)
+                                else
+                                  hash
+                                end
+              assign_attributes_for_update!(hash_for_update, update_time)
+              inventory_collection.store_updated_records([{:id => record_key(record, primary_key)}])
+
+              hash_for_update[:id] = inventory_object.id
+              hashes_for_update << hash_for_update
+            end
+          end
+
+          # Update in batches
+          if hashes_for_update.size >= batch_size_for_persisting
+            update_records!(all_attribute_keys, hashes_for_update)
+
+            hashes_for_update = []
+          end
+
+          # Destroy in batches
+          if records_for_destroy.size >= batch_size_for_persisting
+            destroy_records!(records_for_destroy)
+            records_for_destroy = []
+          end
+        end
+
+        # Update the last batch
+        update_records!(all_attribute_keys, hashes_for_update)
+        hashes_for_update = [] # Cleanup so GC can release it sooner
+
+        # Destroy the last batch
+        destroy_records!(records_for_destroy)
+        records_for_destroy = [] # Cleanup so GC can release it sooner
+      end
+
+      def destroy_records!(records)
         return false unless inventory_collection.delete_allowed?
         return if records.blank?
 
@@ -112,13 +164,21 @@ module ManagerRefresh::SaveCollection
         rails_delete = %i(destroy delete).include?(inventory_collection.delete_method)
         if !rails_delete && inventory_collection.model_class.respond_to?(inventory_collection.delete_method)
           # We have custom delete method defined on a class, that means it supports batch destroy
-          inventory_collection.model_class.public_send(inventory_collection.delete_method, records.map(&:id))
+          # TODO(lsmola) store deleted records to IC
+          inventory_collection.model_class.public_send(inventory_collection.delete_method, records.map { |x| record_key(x, primary_key) })
         else
           # We have either standard :destroy and :delete rails method, or custom instance level delete method
           # Note: The standard :destroy and :delete rails method can't be batched because of the hooks and cascade destroy
           ActiveRecord::Base.transaction do
-            records.each do |record|
-              delete_record!(record)
+            if pure_sql_records_fetching
+              # For pure SQL fetching, we need to get the AR objects again, so we can call destroy
+              inventory_collection.model_class.where(:id => records.map { |x| record_key(x, primary_key) }).find_each do |record|
+                delete_record!(record)
+              end
+            else
+              records.each do |record|
+                delete_record!(record)
+              end
             end
           end
         end
@@ -126,14 +186,14 @@ module ManagerRefresh::SaveCollection
 
       def update_records!(all_attribute_keys, hashes)
         return if hashes.blank?
-
-        ActiveRecord::Base.connection.execute(build_update_query(all_attribute_keys, hashes))
+        query = build_update_query(all_attribute_keys, hashes)
+        get_connection.execute(query)
       end
 
       def create_records!(all_attribute_keys, batch, attributes_index)
         indexed_inventory_objects = {}
-        hashes = []
-        create_time = time_now
+        hashes                    = []
+        create_time               = time_now
         batch.each do |index, inventory_object|
           hash = if inventory_collection.use_ar_object?
                    record = inventory_collection.model_class.new(attributes_index.delete(index))
@@ -150,7 +210,7 @@ module ManagerRefresh::SaveCollection
 
           assign_attributes_for_create!(hash, create_time)
 
-          next unless assert_referential_integrity(hash, inventory_object)
+          next unless assert_referential_integrity(hash)
 
           hashes << hash
           # Index on Unique Columns values, so we can easily fill in the :id later
@@ -159,7 +219,7 @@ module ManagerRefresh::SaveCollection
 
         return if hashes.blank?
 
-        result = ActiveRecord::Base.connection.execute(
+        result = get_connection.execute(
           build_insert_query(all_attribute_keys, hashes)
         )
         inventory_collection.store_created_records(result)
@@ -171,8 +231,8 @@ module ManagerRefresh::SaveCollection
 
       def values_for_database(model_class, all_attribute_keys, attributes)
         all_attribute_keys.each_with_object({}) do |attribute_name, db_values|
-          type = model_class.type_for_attribute(attribute_name.to_s)
-          raw_val = attributes[attribute_name]
+          type                      = model_class.type_for_attribute(attribute_name.to_s)
+          raw_val                   = attributes[attribute_name]
           db_values[attribute_name] = type.type == :boolean ? type.cast(raw_val) : type.serialize(raw_val)
         end
       end
@@ -183,11 +243,11 @@ module ManagerRefresh::SaveCollection
         # we test if the number of results matches the expected batch size. Then if the counts do not match, the only
         # safe option is to query all the data from the DB, using the unique_indexes. The batch size will also not match
         # for every remainders(a last batch in a stream of batches)
-        if !supports_remote_data_timestamp?(all_attribute_keys) || result.count == batch_size
+        if !supports_remote_data_timestamp?(all_attribute_keys) || result.count == batch_size_for_persisting
           result.each do |inserted_record|
             key                 = unique_index_columns.map { |x| inserted_record[x.to_s] }
             inventory_object    = indexed_inventory_objects[key]
-            inventory_object.id = inserted_record["id"] if inventory_object
+            inventory_object.id = inserted_record[primary_key] if inventory_object
           end
         else
           inventory_collection.model_class.where(

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -15,10 +15,6 @@ module ManagerRefresh::SaveCollection
         record[select_keys_indexes[key]]
       end
 
-      def batch_size_for_persisting
-        10_000
-      end
-
       def batch_iterator(association)
         if pure_sql_records_fetching
           # Building fast iterator doing pure SQL query and therefore avoiding redundant creation of AR objects. The

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -21,8 +21,9 @@ module ManagerRefresh::SaveCollection
 
       def batch_iterator(association)
         if pure_sql_records_fetching
-          # Building fast iterator doing pure SQL query avoiding redundant creation of AR objects, responds to
-          # find_in_batches. For targeted refresh, the association can already be ApplicationRecordIterator.
+          # Building fast iterator doing pure SQL query and therefore avoiding redundant creation of AR objects. The
+          # iterator responds to find_in_batches, so it acts like the AR relation. For targeted refresh, the association
+          # can already be ApplicationRecordIterator, so we will skip that.
           pure_sql_iterator = lambda do |&block|
             primary_key_offset = nil
             loop do
@@ -42,7 +43,7 @@ module ManagerRefresh::SaveCollection
 
           ManagerRefresh::ApplicationRecordIterator.new(:iterator => pure_sql_iterator)
         else
-          # Normal rails association where we will call find_in_batches
+          # Normal Rails relation where we can call find_in_batches
           association
         end
       end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -200,9 +200,9 @@ module ManagerRefresh::SaveCollection
                  elsif inventory_collection.serializable_keys?(all_attribute_keys)
                    values_for_database(inventory_collection.model_class,
                                        all_attribute_keys,
-                                       attributes_index.delete(index).symbolize_keys)
+                                       attributes_index.delete(index))
                  else
-                   attributes_index.delete(index).symbolize_keys
+                   attributes_index.delete(index)
                  end
 
           assign_attributes_for_create!(hash, create_time)

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -123,7 +123,7 @@ module ManagerRefresh::SaveCollection
                                   hash
                                 end
               assign_attributes_for_update!(hash_for_update, update_time)
-              inventory_collection.store_updated_records([{:id => record_key(record, primary_key)}])
+              inventory_collection.store_updated_records([{:id => inventory_object.id}])
 
               hash_for_update[:id] = inventory_object.id
               hashes_for_update << hash_for_update

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -71,7 +71,6 @@ module ManagerRefresh::SaveCollection
       end
 
       def get_connection
-        # Cache the connection for the batch
         ActiveRecord::Base.connection
       end
 

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -151,9 +151,9 @@ module ManagerRefresh::SaveCollection
         @pg_types_cache = {}
         all_attribute_keys.each do |key|
           @pg_types_cache[key] = inventory_collection.model_class.columns_hash[key.to_s]
-                                   .try(:sql_type_metadata)
-                                   .try(:instance_values)
-                                   .try(:[], "sql_type")
+                                                     .try(:sql_type_metadata)
+                                                     .try(:instance_values)
+                                                     .try(:[], "sql_type")
         end
       end
     end


### PR DESCRIPTION
Various micro-optimizations that are together making the 2nd refresh batch saving about 2 times faster on a bigger data loads (at about 1.4M records stored it's becoming more than 2x faster)

Graph comparing the speed with the current batch saving:
![screenshot from 2017-08-08 16-20-01](https://user-images.githubusercontent.com/1737058/29076368-984ae838-7c55-11e7-9c40-bd587b864c83.png)
