### PR TITLE
Proxy support for cloning ansible repo and add provider

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -826,11 +826,19 @@
     :password:
     :port:
     :user:
+    :scheme:
   :gce:
     :host:
     :password:
     :port:
     :user:
+    :scheme:
+  :embedded_ansible:
+    :host:
+    :password:
+    :port:
+    :user:
+    :scheme:
 :ldap_synchronization:
   :ldap_synchronization_schedule: "0 2 * * *"
 :log:

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -8,6 +8,7 @@ class EmbeddedAnsible
   ANSIBLE_ROLE           = "embedded_ansible".freeze
   SETUP_SCRIPT           = "ansible-tower-setup".freeze
   SECRET_KEY_FILE        = "/etc/tower/SECRET_KEY".freeze
+  SETTINGS_FILE          = "/etc/tower/settings.py".freeze
   EXCLUDE_TAGS           = "packages,migrations,firewall".freeze
   HTTP_PORT              = 54_321
   HTTPS_PORT             = 54_322
@@ -92,6 +93,7 @@ class EmbeddedAnsible
 
   def self.appliance_start
     if configured? && !upgrade?
+      update_proxy_settings
       services.each { |service| LinuxAdmin::Service.new(service).start.enable }
     else
       configure_secret_key
@@ -184,6 +186,21 @@ class EmbeddedAnsible
     end
   end
   private_class_method :configure_secret_key
+
+  def self.update_proxy_settings
+    current_contents = File.read(SETTINGS_FILE)
+    new_contents = current_contents.gsub(/^.*AWX_TASK_ENV\['(HTTPS?_PROXY|NO_PROXY)'\].*$/, "")
+
+    proxy_uri = VMDB::Util.http_proxy_uri(:embedded_ansible) || VMDB::Util.http_proxy_uri
+    if proxy_uri
+      new_contents << "\n" unless new_contents.end_with?("\n")
+      new_contents << "AWX_TASK_ENV['HTTP_PROXY'] = '#{proxy_uri}'\n"
+      new_contents << "AWX_TASK_ENV['HTTPS_PROXY'] = '#{proxy_uri}'\n"
+      new_contents << "AWX_TASK_ENV['NO_PROXY'] = '127.0.0.1'\n"
+    end
+    File.write(SETTINGS_FILE, new_contents)
+  end
+  private_class_method :update_proxy_settings
 
   def self.generate_admin_authentication
     miq_database.set_ansible_admin_authentication(:password => generate_password)

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -121,6 +121,7 @@ describe EmbeddedAnsible do
         expect(nginx_service).to receive(:enable).and_return(nginx_service)
         expect(supervisord_service).to receive(:enable).and_return(supervisord_service)
         expect(rabbitmq_service).to receive(:enable).and_return(rabbitmq_service)
+        expect(described_class).to receive(:update_proxy_settings)
       end
 
       it "waits for Ansible to respond" do
@@ -479,6 +480,36 @@ describe EmbeddedAnsible do
         auth = described_class.send(:generate_database_authentication)
         expect(auth.userid).to eq("awx")
         expect(auth.password).to eq(password)
+      end
+    end
+
+    describe ".update_proxy_settings (private)" do
+      let(:file_content) do
+        <<-EOF
+# Arbitrary line 1
+
+# Arbitrary line 2
+AWX_TASK_ENV['HTTP_PROXY'] = 'somehost'
+AWX_TASK_ENV['HTTPS_PROXY'] = 'somehost'
+AWX_TASK_ENV['NO_PROXY'] = 'somehost'
+EOF
+      end
+      let(:proxy_uri) { "http://user:password@localhost:3333" }
+      let(:settings_file) { Tempfile.new("settings.py") }
+      before do
+        settings_file.write(file_content)
+        settings_file.close
+        stub_const("EmbeddedAnsible::SETTINGS_FILE", settings_file.path)
+        expect(VMDB::Util).to receive(:http_proxy_uri).and_return(proxy_uri)
+      end
+
+      it "add current proxy info" do
+        described_class.send(:update_proxy_settings)
+        new_contents = File.read(settings_file.path)
+        expect(new_contents).to include("AWX_TASK_ENV['HTTP_PROXY'] = '#{proxy_uri}'\n")
+        expect(new_contents).to include("AWX_TASK_ENV['HTTPS_PROXY'] = '#{proxy_uri}'\n")
+        expect(new_contents).to include("AWX_TASK_ENV['NO_PROXY'] = '127.0.0.1'\n")
+        expect(new_contents).not_to include("'somehost'")
       end
     end
   end


### PR DESCRIPTION
ISSUE: currently we get proxy setting from Configuration -> Advanced but didn't use it for cloning ansible repo or add provider. In pure ipv6 network, there is no Internet access without proxy so proxy must be used.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1475954

\cc @bdunne @yrudman @gtanzillo 

@miq-bot add-label wip, bug