### PR TITLE
UI - temporarily use webpacker branch to prevent polluting exiting rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,6 +175,8 @@ group :ui_dependencies, :manageiq_default do # Added to Bundler.require in confi
   # Modified gems (forked on Github)
   gem "font-fabulous",                                                :git => "https://github.com/ManageIQ/font-fabulous.git", :branch => "master" # FIXME: this is just a temporary solution and it'll go to the ui-classic later
   gem "jquery-rjs",                   "=0.1.1",                       :git => "https://github.com/ManageIQ/jquery-rjs.git", :tag => "v0.1.1-1"
+  # temporary fix to prevent webpacker from modifying existing rake tasks
+  gem 'webpacker', :require => false, :git => "https://github.com/himdel/webpacker.git", :branch => "2.0-without-enhance"
 end
 
 group :web_server, :manageiq_default do


### PR DESCRIPTION
webpacker 2.0 enhances assets:precompile, which doesn't work because webpacker:compile can't be run from manageiq, only ui-components.

Merge together with https://github.com/ManageIQ/manageiq-ui-classic/pull/1859 please.