### PR TITLE
web service worker needs to load MiqAeDomain, etc.

### DIFF
--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -69,7 +69,7 @@ MIQ_WORKER_TYPES = {
   "MiqSmartProxyWorker"                                                       => [:smartstate],
   "MiqUiWorker"                                                               => %i(ui_dependencies web_server),
   "MiqVimBrokerWorker"                                                        => [:manageiq_default],
-  "MiqWebServiceWorker"                                                       => %i(rest_api ui_dependencies web_server),
+  "MiqWebServiceWorker"                                                       => %i(automate rest_api ui_dependencies web_server),
   "MiqWebsocketWorker"                                                        => %i(ui_dependencies web_server web_socket)
 }.freeze
 


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-api/blob/01d6d3c05e497b658558a64d8855daf7297a9e6b/config/api.yml#L218-L232

The whitelist of bundler groups are the only gems we can require/load so
we need to add anything we might possibly load in this list.