### PR TITLE
Batch saving timestamps enhancement

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -596,22 +596,32 @@ module ManagerRefresh
       @supports_sti_cache
     end
 
-    def supports_timestamps_on_variant?
-      if @supports_timestamps_on_variant.nil?
-        @supports_timestamps_on_variant = (model_class.column_names.include?("created_on") &&
-          model_class.column_names.include?("updated_on") &&
-          ActiveRecord::Base.record_timestamps)
+    def supports_created_on?
+      if @supports_created_on_cache.nil?
+        @supports_created_on_cache = (model_class.column_names.include?("created_on") && ActiveRecord::Base.record_timestamps)
       end
-      @supports_timestamps_on_variant
+      @supports_created_on_cache
     end
 
-    def supports_timestamps_at_variant?
-      if @supports_timestamps_at_variant.nil?
-        @supports_timestamps_at_variant = (model_class.column_names.include?("created_at") &&
-          model_class.column_names.include?("updated_at") &&
-          ActiveRecord::Base.record_timestamps)
+    def supports_updated_on?
+      if @supports_updated_on_cache.nil?
+        @supports_updated_on_cache = (model_class.column_names.include?("updated_on") && ActiveRecord::Base.record_timestamps)
       end
-      @supports_timestamps_at_variant
+      @supports_updated_on_cache
+    end
+
+    def supports_created_at?
+      if @supports_created_at_cache.nil?
+        @supports_created_at_cache = (model_class.column_names.include?("created_at") && ActiveRecord::Base.record_timestamps)
+      end
+      @supports_created_at_cache
+    end
+
+    def supports_updated_at?
+      if @supports_updated_at_cache.nil?
+        @supports_updated_at_cache = (model_class.column_names.include?("updated_at") && ActiveRecord::Base.record_timestamps)
+      end
+      @supports_updated_at_cache
     end
 
     def targeted?

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -614,11 +614,6 @@ module ManagerRefresh
       @supports_timestamps_at_variant
     end
 
-    def supports_last_sync_on?
-      @supports_last_sync_on = model_class.column_names.include?("last_sync_on") if @supports_last_sync_on.nil?
-      @supports_last_sync_on
-    end
-
     def targeted?
       targeted
     end

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -196,14 +196,14 @@ module ManagerRefresh::SaveCollection
       end
 
       def assign_attributes_for_update!(hash, update_time)
-        hash[:updated_on]   = update_time if inventory_collection.supports_timestamps_on_variant?
-        hash[:updated_at]   = update_time if inventory_collection.supports_timestamps_at_variant?
+        hash[:updated_on]   = update_time if inventory_collection.supports_updated_on?
+        hash[:updated_at]   = update_time if inventory_collection.supports_updated_at?
       end
 
       def assign_attributes_for_create!(hash, create_time)
         hash[:type]         = inventory_collection.model_class.name if inventory_collection.supports_sti? && hash[:type].nil?
-        hash[:created_on]   = create_time if inventory_collection.supports_timestamps_on_variant?
-        hash[:created_at]   = create_time if inventory_collection.supports_timestamps_at_variant?
+        hash[:created_on]   = create_time if inventory_collection.supports_created_on?
+        hash[:created_at]   = create_time if inventory_collection.supports_created_at?
         assign_attributes_for_update!(hash, create_time)
       end
     end

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -196,7 +196,6 @@ module ManagerRefresh::SaveCollection
       end
 
       def assign_attributes_for_update!(hash, update_time)
-        hash[:last_sync_on] = update_time if inventory_collection.supports_last_sync_on?
         hash[:updated_on]   = update_time if inventory_collection.supports_timestamps_on_variant?
         hash[:updated_at]   = update_time if inventory_collection.supports_timestamps_at_variant?
       end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -58,8 +58,10 @@ module ManagerRefresh::SaveCollection
           all_attribute_keys.merge(attributes_index[index].keys)
         end
 
-        all_attribute_keys += [:created_on, :updated_on] if inventory_collection.supports_timestamps_on_variant?
-        all_attribute_keys += [:created_at, :updated_at] if inventory_collection.supports_timestamps_at_variant?
+        all_attribute_keys << :created_at if inventory_collection.supports_created_at?
+        all_attribute_keys << :updated_at if inventory_collection.supports_updated_at?
+        all_attribute_keys << :created_on if inventory_collection.supports_created_on?
+        all_attribute_keys << :updated_on if inventory_collection.supports_updated_on?
 
         _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection.size} *************")
 

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -58,7 +58,6 @@ module ManagerRefresh::SaveCollection
           all_attribute_keys.merge(attributes_index[index].keys)
         end
 
-        all_attribute_keys << :last_sync_on if inventory_collection.supports_last_sync_on?
         all_attribute_keys += [:created_on, :updated_on] if inventory_collection.supports_timestamps_on_variant?
         all_attribute_keys += [:created_at, :updated_at] if inventory_collection.supports_timestamps_at_variant?
 

--- a/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
@@ -276,12 +276,6 @@ describe ManagerRefresh::SaveInventory do
             expect(@data[:key_pairs].updated_records).to match_array(record_stats([]))
 
             # Check the changed timestamps
-            if options[:saver_strategy] == :batch
-              # TODO(lsmola) last_sync_on is not set by a model, investigate
-              expect(@vm3.last_sync_on).to be > time_before_refresh
-              expect(@vm31.last_sync_on).to be > time_before_refresh
-              expect(@vm2.last_sync_on).to be > time_before_refresh
-            end
             expect(@vm3.created_on).to be > time_before_refresh
             expect(@vm3.updated_on).to be > time_before_refresh
             expect(@vm31.created_on).to be > time_before_refresh


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/15761

We want to test for created and updated timestamps separately. Since e.g. ContainerImage models has only :created_at. And we want to get rid of setting last_sync_on, since that is controlled via SSA