### PR TITLE
Fix saving of refresh stats

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -162,7 +162,7 @@ module ManagerRefresh::SaveCollection
         rails_delete = %i(destroy delete).include?(inventory_collection.delete_method)
         if !rails_delete && inventory_collection.model_class.respond_to?(inventory_collection.delete_method)
           # We have custom delete method defined on a class, that means it supports batch destroy
-          # TODO(lsmola) store deleted records to IC
+          inventory_collection.store_deleted_records(records.map { |x| {:id => record_key(x, primary_key)} })
           inventory_collection.model_class.public_send(inventory_collection.delete_method, records.map { |x| record_key(x, primary_key) })
         else
           # We have either standard :destroy and :delete rails method, or custom instance level delete method

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -125,7 +125,6 @@ module ManagerRefresh::SaveCollection
                                   hash
                                 end
               assign_attributes_for_update!(hash_for_update, update_time)
-              inventory_collection.store_updated_records([{:id => primary_key_value}])
 
               hash_for_update[:id] = primary_key_value
               hashes_for_update << hash_for_update
@@ -185,6 +184,7 @@ module ManagerRefresh::SaveCollection
 
       def update_records!(all_attribute_keys, hashes)
         return if hashes.blank?
+        inventory_collection.store_updated_records(hashes)
         query = build_update_query(all_attribute_keys, hashes)
         get_connection.execute(query)
       end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/15761

The batch disconnected records were not stored in stats. Do batch update stats for the whole batch at once.