### PR TITLE
Move user can login validation to manageiq (from ui classic)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,7 +267,7 @@ class User < ApplicationRecord
   end
 
   def self.missing_user_features(db_user)
-    if !db_user || !db_user.userid
+    if !db_user
       "User"
     elsif !db_user.current_group
       "Group"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -266,6 +266,16 @@ class User < ApplicationRecord
     current_user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
   end
 
+  def self.missing_user_features(db_user)
+    if !db_user || !db_user.userid
+      "User"
+    elsif !db_user.current_group
+      "Group"
+    elsif !db_user.current_group.miq_user_role
+      "Role"
+    end
+  end
+
   def self.seed
     seed_data.each do |user_attributes|
       user_id = user_attributes[:userid]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -81,6 +81,27 @@ describe User do
     end
   end
 
+  describe ".missing_user_features" do
+    it "user with group and role returns nil" do
+      user = FactoryGirl.create(:user_admin)
+      expect(User.missing_user_features(user)).to be_nil
+    end
+
+    it "no user returns 'User'" do
+      expect(User.missing_user_features(nil)).to eq "User"
+    end
+
+    it "missing group returns 'Group'" do
+      user = FactoryGirl.create(:user)
+      expect(User.missing_user_features(user)).to eq "Group"
+    end
+
+    it "missing role returns 'Role'" do
+      user = FactoryGirl.create(:user_with_group)
+      expect(User.missing_user_features(user)).to eq "Role"
+    end
+  end
+
   describe "role methods" do
     let(:user) do
       FactoryGirl.create(:user,


### PR DESCRIPTION
Move missing_user_features to the User model from [ui-classic](https://github.com/ManageIQ/manageiq-ui-classic/blob/0f76b9fee3f0cd790e35877c12aa92ad1d257750/app/services/user_validation_service.rb#L61-L69)

It is used in UI classic and the rest api but seems like a model concern if a user can login.  

Note, you cannot start the web service worker without the ui-classic because of this single method.

Note, I'm not in love with the method name or it's contents or that it's a class method but wanted to move this first, get some tests around it and remove/change it and it's callers from ui-classic and the api repo.  Suggestions welcome.

This PR is required for the following PRs:
* https://github.com/ManageIQ/manageiq-api/issues/9
* https://github.com/ManageIQ/manageiq-ui-classic/issues/1868