### PR TITLE
Make networks vms relations distinct

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -12,9 +12,9 @@ class CloudNetwork < ApplicationRecord
   has_many :cloud_subnets, :dependent => :destroy
   has_many :network_routers, -> { distinct }, :through => :cloud_subnets
   has_many :public_networks, -> { distinct }, :through => :cloud_subnets
-  has_many :network_ports, :through => :cloud_subnets
+  has_many :network_ports, -> { distinct }, :through => :cloud_subnets
   has_many :floating_ips,  :dependent => :destroy
-  has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
+  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
   has_many :public_network_vms, -> { distinct }, :through => :public_network_routers, :source => :vms
   has_many :public_network_routers, :foreign_key => :cloud_network_id, :class_name => NetworkRouter
@@ -42,7 +42,7 @@ class CloudNetwork < ApplicationRecord
     end
   end
 
-  virtual_total :total_vms, :vms, :uses => :vms
+  virtual_total :total_vms, :vms
 
   def self.class_by_ems(ext_management_system, _external = false)
     # TODO: A factory on ExtManagementSystem to return class for each provider


### PR DESCRIPTION
Make networks vms relations distinct, otherwise the Vm count
could be shown as higher, if the the vm has multiple ports
plugged into the same network.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1479667
