### PR TITLE
[Fine] Backport of: fixed cases causing waiting on timeout in vm_import

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager.rb
@@ -146,4 +146,11 @@ class ManageIQ::Providers::Redhat::InfraManager < ManageIQ::Providers::InfraMana
   def supports_migrate_for_all?(vms)
     vms.map(&:ems_cluster).uniq.compact.size == 1
   end
+
+  def version_higher_than?(version)
+    return false if api_version.nil?
+
+    ems_version = api_version[/\d+\.\d+\.?\d*/x]
+    Gem::Version.new(ems_version) >= Gem::Version.new(version)
+  end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_import_spec.rb
@@ -105,12 +105,17 @@ describe ManageIQ::Providers::Redhat::InfraManager::VmImport do
     let(:ems) { FactoryGirl.create(:ems_redhat) }
 
     it 'validates successfully' do
-      allow(ems).to receive(:highest_supported_api_version).and_return('4')
+      allow(ems).to receive(:api_version).and_return('4.1.5')
       expect(ems.validate_import_vm).to be_truthy
     end
 
+    it 'fails validation on old api version' do
+      allow(ems).to receive(:api_version).and_return('4.1.4')
+      expect(ems.validate_import_vm).to be_falsey
+    end
+
     it 'validates before connecting' do
-      allow(ems).to receive(:highest_supported_api_version).and_return(nil)
+      allow(ems).to receive(:api_version).and_return(nil)
       expect(ems.validate_import_vm).to be_falsey
     end
   end

--- a/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager_spec.rb
@@ -288,4 +288,49 @@ describe ManageIQ::Providers::Redhat::InfraManager do
       end
     end
   end
+
+  context "#version_higher_than?" do
+    let(:api_version) { "4.2" }
+    let(:ems) { FactoryGirl.create(:ems_redhat, :api_version => api_version) }
+
+    context "api version is higher or equal than checked version" do
+      it 'supports the right features' do
+        expect(ems.version_higher_than?("4.1")).to be_truthy
+
+        ems.api_version = "4.1.3.2-0.1.el7"
+        expect(ems.version_higher_than?("4.1")).to be_truthy
+
+        ems.api_version = "4.2.0_master"
+        expect(ems.version_higher_than?("4.1")).to be_truthy
+
+        ems.api_version = "4.2.1_master"
+        expect(ems.version_higher_than?("4.2.0")).to be_truthy
+      end
+    end
+
+    context "api version is lowergit  than checked version" do
+      let(:api_version) { "4.0" }
+      it 'supports the right features' do
+        expect(ems.version_higher_than?("4.1")).to be_falsey
+
+        ems.api_version = "4.0.3.2-0.1.el7"
+        expect(ems.version_higher_than?("4.1")).to be_falsey
+
+        ems.api_version = "4.0.0_master"
+        expect(ems.version_higher_than?("4.1")).to be_falsey
+
+        ems.api_version = "4.0.1_master"
+        expect(ems.version_higher_than?("4.0.2")).to be_falsey
+      end
+    end
+
+    context "api version not set" do
+      let(:api_version) { nil }
+      it 'always return false' do
+        expect(ems.version_higher_than?("10.1")).to be_falsey
+
+        expect(ems.version_higher_than?("0")).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a backport of ManageIQ/manageiq-providers-ovirt/pull/73/ solving the merge conflicts.

Please note this has to be backported together with ManageIQ/manageiq-content/pull/168 to avoid failing tests on the manageiq-content repo.

It tries to be a minimal backport needed but still includes all the relevant
tests.

2 problems fixed:
- allow to import only using 4.1.5+ provider.
  The reason is that the required fix (https://bugzilla.redhat.com/1477375) is
  present in 4.1.5+ and without this fix manageiq will wait until timeout
  reached.
- check if submit to the provider succeeded.
  The reason is that if the result is not checked, this state will always
  succeed and the import will again wait until timeout.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1473169