### PR TITLE
Ansible runtime - Create and Launch a JobTemplate

### DIFF
--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_payload.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_payload.rb
@@ -1,3 +1,65 @@
 class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload <
   ManageIQ::Providers::AutomationManager::ConfigurationScriptPayload
+
+  include AnsiblePlaybookMixin
+
+  # create ServiceTemplate and supporting ServiceResources and ResourceActions
+  # options
+  #   :name
+  #   :description
+  #   :config_info
+  #     :variables
+  #     :hosts
+  #     :credential_id
+  #     :network_credential_id
+  #     :cloud_credential_id
+  #     :playbook_id
+  #
+  def self.run(options, auth_user = nil)
+    auth_user ||= 'system'
+    name = options[:name]
+    description = options[:description]
+    info = options[:config_info]
+    results, tower_id = ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload.send(:create_job_template, build_name(name), description, info, auth_user)
+    launch(results, tower_id, auth_user)
+  end
+
+  def self.launch(results, tower_id, auth_user)
+    task_id = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.launch_in_provider_queue(tower_id, results.id, results.name, auth_user)
+    task = MiqTask.wait_for_taskid(task_id)
+    raise task.message unless task.status == "Ok"
+    task.task_results
+  end
+
+  def self.build_name(basic_name)
+    "#{basic_name}_#{Time.zone.now.to_i}"
+  end
+  private_class_method :build_name
+
+  def self.build_parameter_list(name, description, info)
+    playbook = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook.find(info[:playbook_id])
+    tower = playbook.manager
+    params = {
+      :name           => name,
+      :description    => description || '',
+      :project        => playbook.configuration_script_source.manager_ref,
+      :playbook       => playbook.name,
+      :inventory      => info[:inventory],
+      :become_enabled => info[:become_enabled].present?,
+      :verbosity      => info[:verbosity].presence || 0,
+    }
+    if info[:extra_vars]
+      params[:extra_vars] = info[:extra_vars].transform_values do |val|
+        val.kind_of?(String) ? val : val[:default] # TODO: support Hash only
+      end.to_json
+    end
+
+    [:credential, :cloud_credential, :network_credential].each do |credential|
+      cred_sym = "#{credential}_id".to_sym
+      params[credential] = Authentication.find(info[cred_sym]).manager_ref if info[cred_sym]
+    end
+
+    [tower, params.compact]
+  end
+  private_class_method :build_parameter_list
 end

--- a/app/models/mixins/ansible_playbook_mixin.rb
+++ b/app/models/mixins/ansible_playbook_mixin.rb
@@ -1,0 +1,16 @@
+module AnsiblePlaybookMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    private
+
+    def create_job_template(name, description, info, auth_user)
+      tower, params = build_parameter_list(name, description, info)
+
+      task_id = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.create_in_provider_queue(tower.id, params, auth_user)
+      task = MiqTask.wait_for_taskid(task_id)
+      raise task.message unless task.status == "Ok"
+      [task.task_results, tower.id]
+    end
+  end
+end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -65,7 +65,8 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   def self.create_job_templates(service_name, description, config_info, auth_user, service_template = nil)
     [:provision, :retirement, :reconfigure].each_with_object({}) do |action, hash|
       next unless new_job_template_required?(config_info[action], action, service_template)
-      hash[action] = { :configuration_template => create_job_template(build_name(service_name, action), description, config_info[action], auth_user) }
+      new_template, _tower_id = create_job_template(build_name(service_name, action), description, config_info[action], auth_user)
+      hash[action] = { :configuration_template => new_template }
     end
   end
   private_class_method :create_job_templates

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -1,4 +1,6 @@
 class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
+  include AnsiblePlaybookMixin
+
   before_destroy :check_retirement_potential, :prepend => true
   around_destroy :around_destroy_callback, :prepend => true
 
@@ -72,16 +74,6 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
     "miq_#{basic_name}_#{action}"
   end
   private_class_method :build_name
-
-  def self.create_job_template(name, description, info, auth_user)
-    tower, params = build_parameter_list(name, description, info)
-
-    task_id = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.create_in_provider_queue(tower.id, params, auth_user)
-    task = MiqTask.wait_for_taskid(task_id)
-    raise task.message unless task.status == "Ok"
-    task.task_results
-  end
-  private_class_method :create_job_template
 
   def self.build_parameter_list(name, description, info)
     playbook = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook.find(info[:playbook_id])

--- a/spec/models/manageiq/providers/embedded_automation_manager/configuration_script_payload_spec.rb
+++ b/spec/models/manageiq/providers/embedded_automation_manager/configuration_script_payload_spec.rb
@@ -1,0 +1,91 @@
+describe ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload do
+  let(:miq_task) { FactoryGirl.create(:miq_task) }
+  let(:user)     { FactoryGirl.create(:user_with_group) }
+  let(:auth_one) { FactoryGirl.create(:authentication, :manager_ref => 6) }
+  let(:auth_two) { FactoryGirl.create(:authentication, :manager_ref => 10) }
+
+  let(:script_source) { FactoryGirl.create(:configuration_script_source, :manager => ems) }
+
+  let(:service_template_catalog) { FactoryGirl.create(:service_template_catalog) }
+  let(:provider) { FactoryGirl.create(:provider_embedded_ansible, :default_inventory => 1) }
+  let(:ems)      { FactoryGirl.create(:automation_manager_ansible_tower, :provider => provider) }
+
+  let(:playbook) do
+    FactoryGirl.create(:embedded_playbook,
+                       :configuration_script_source => script_source,
+                       :manager                     => ems)
+  end
+
+  let(:job_template) do
+    FactoryGirl.create(:embedded_ansible_configuration_script,
+                       :variables => options.fetch_path(:config_info, :extra_vars),
+                       :manager   => ems)
+  end
+
+  let(:options) do
+    {
+      :name        => 'test_ansible_catalog_item',
+      :description => 'test ansible',
+      :config_info => {
+        :hosts                 => 'many',
+        :verbosity             => 3,
+        :credential_id         => auth_one.id,
+        :network_credential_id => auth_two.id,
+        :playbook_id           => playbook.id
+      }
+    }
+  end
+
+  let(:options_two) do
+    options.deep_merge(
+      :config_info => {
+        :extra_vars => {
+          'key1' => {:default => 'val1'},
+          'key2' => {:default => 'val2'}
+        }
+      }
+    )
+  end
+
+  describe 'running_playbooks' do
+    it '#run' do
+      expect(described_class).to receive(:create_job_template).and_return(job_template)
+      expect(described_class).to receive(:launch).with(job_template, any_args, 'system')
+      described_class.run(options)
+    end
+
+    it '#launch' do
+      task_id = rand(10)
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript).to receive(:launch_in_provider_queue).with(10, job_template.id, job_template.name, 'system').and_return(task_id)
+      allow(MiqTask).to receive(:wait_for_taskid).with(task_id).and_return(miq_task)
+      described_class.launch(job_template, 10, 'system')
+    end
+
+    it '#build_parameter_list' do
+      name = options[:name]
+      catalog_extra_vars = options_two
+      description = options[:description]
+      info = options[:config_info]
+      _tower, params = described_class.send(:build_parameter_list, name, description, info)
+      _tower_two, params_two = described_class.send(:build_parameter_list,
+                                                    catalog_extra_vars[:name],
+                                                    catalog_extra_vars[:description],
+                                                    catalog_extra_vars[:config_info])
+
+      expect(params).to have_attributes(
+        :name               => name,
+        :description        => description,
+        :verbosity          => 3,
+        :credential         => '6',
+        :network_credential => '10'
+      )
+
+      expect(params.keys).to_not include(:extra_vars, :cloud_credentials)
+      expect(params_two.keys).to include(:extra_vars)
+      expect(JSON.parse(params_two[:extra_vars])).to have_attributes(
+        'key1' => 'val1',
+        'key2' => 'val2'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Build and launch an Ansible Playbook.

Example:

Build a hash including all the needed information to populate a job template:

```
options = { :name => 'test_runner', :description => 'TEST RUNNER',  :config_info => { :hosts => 'blah',  :credential_id => '3',  :inventory => '3',  :playbook_id => '6163'}}
```

Run the subsequent playbook and return a `JSON`ified version of the `job`:

```
ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload.run(options)
=> "{\"id\":143,\"type\":\"job\",\"url\":\"/api/v1/jobs/143/\",\"related\":{\"created_by\":\"/api/v1/users/1/\",\"modified_by\":\"/api/v1/users/1/\",\"labels\":\"/api/v1/jobs/143/labels/\",\"inventory\":\"/api/v1/inventories/3/\",\"project\":\"/api/v1/projects/166/\",\"credential\":\"/api/v1/credentials/3/\",\"unified_job_template\":\"/api/v1/job_templates/196/\",\"stdout\":\"/api/v1/jobs/143/stdout/\",\"job_host_summaries\":\"/api/v1/jobs/143/job_host_summaries/\",\"job_tasks\":\"/api/v1/jobs/143/job_tasks/\",\"job_plays\":\"/api/v1/jobs/143/job_plays/\",\"job_events\":\"/api/v1/jobs/143/job_events/\",\"notifications\":\"/api/v1/jobs/143/notifications/\",\"activity_stream\":\"/api/v1/jobs/143/activity_stream/\",\"job_template\":\"/api/v1/job_templates/196/\",\"start\":\"/api/v1/jobs/143/start/\",\"cancel\":\"/api/v1/jobs/143/cancel/\",\"relaunch\":\"/api/v1/jobs/143/relaunch/\"},\"summary_fields\":{\"job_template\":{\"id\":196,\"name\":\"db_runner_1502392142\",\"description\":\"TEST RUNNER\"},\"inventory\":{\"id\":3,\"name\":\"TEST Empty Groups\",\"description\":\"\",\"has_active_failures\":false,\"total_hosts\":2,\"hosts_with_active_failures\":0,\"total_groups\":1,\"groups_with_active_failures\":0,\"has_inventory_sources\":false,\"total_inventory_sources\":0,\"inventory_sources_with_failures\":0},\"credential\":{\"id\":3,\"name\":\"DB Mac\",\"description\":\"test_runner on the mac\",\"kind\":\"ssh\",\"cloud\":false},\"unified_job_template\":{\"id\":196,\"name\":\"test_runner_1502392142\",\"description\":\"DB RUNNER\",\"unified_job_type\":\"job\"},\"project\":{\"id\":166,\"name\":\"local_playbooks\",\"description\":\"Local Playbooks\",\"status\":\"ok\"},\"created_by\":{\"id\":1,\"username\":\"admin\",\"first_name\":\"\",\"last_name\":\"\"},\"modified_by\":{\"id\":1,\"username\":\"admin\",\"first_name\":\"\",\"last_name\":\"\"},\"labels\":{\"count\":0,\"results\":[]}},\"created\":\"2017-08-10T19:09:10.793Z\",\"modified\":\"2017-08-10T19:09:10.866Z\",\"name\":\"db_runner_1502392142\",\"description\":\"DB RUNNER\",\"job_type\":\"run\",\"inventory\":3,\"project\":166,\"playbook\":\"debug.yml\",\"credential\":3,\"cloud_credential\":null,\"network_credential\":null,\"forks\":0,\"limit\":\"\",\"verbosity\":0,\"extra_vars\":\"{}\",\"job_tags\":\"\",\"force_handlers\":false,\"skip_tags\":\"\",\"start_at_task\":\"\",\"unified_job_template\":196,\"launch_type\":\"manual\",\"status\":\"pending\",\"failed\":false,\"started\":null,\"finished\":null,\"elapsed\":0.0,\"job_args\":\"\",\"job_cwd\":\"\",\"job_env\":{},\"job_explanation\":\"\",\"result_stdout\":\"Waiting for results...\",\"result_traceback\":\"\",\"job_template\":196,\"passwords_needed_to_start\":[],\"ask_variables_on_launch\":false,\"ask_limit_on_launch\":false,\"ask_tags_on_launch\":false,\"ask_job_type_on_launch\":false,\"ask_inventory_on_launch\":false,\"ask_credential_on_launch\":false}"
```

https://www.pivotaltracker.com/story/show/149699697

https://www.pivotaltracker.com/story/show/149700349

https://www.pivotaltracker.com/story/show/149700177

Caveats:

1. All data used in the options hash is currently known to the VMDB. Ids match vmdb entries.  The code calls the subsequent `manager_ref` entries to talk back to the Ansible Inside API.
2. Dependent on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/21
3. The `build_parameter_list` method is basically the same as what is in `ServiceTemplateAnsiblePlaybook`, I decided to not move it to the `AnsiblePlaybookMixin` due to my thought that it probably will be changing before this PR is merged.  If not - I'll move it.
