### PR TITLE
Add group in manageiq payload for ansible automation.

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -66,6 +66,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
       'api_token' => Api::UserTokenService.new.generate_token(evm_owner.userid, 'api'),
       'service'   => href_slug,
       'user'      => evm_owner.href_slug,
+      'group'     => miq_group.href_slug,
       'action'    => action
     }.merge(request_options_extra_vars)
   end

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -144,13 +144,14 @@ describe(ServiceAnsiblePlaybook) do
       miq_request_task = FactoryGirl.create(:miq_request_task)
       miq_request_task.update_attributes(:options => {:request_options => {:manageiq_extra_vars => control_extras}})
       loaded_service.update_attributes(:evm_owner        => FactoryGirl.create(:user),
+                                       :miq_group        => FactoryGirl.create(:miq_group),
                                        :miq_request_task => miq_request_task)
     end
 
     it 'creates an Ansible Tower job' do
       expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job) do |jobtemp, opts|
         expect(jobtemp).to eq(tower_job_temp)
-        exposed_miq = %w(api_url api_token service user) + control_extras.keys
+        exposed_miq = %w(api_url api_token service user group) + control_extras.keys
         expect(opts[:extra_vars].delete('manageiq').keys).to include(*exposed_miq)
 
         expected_opts = provision_options[:provision_job_options].except(:hosts)


### PR DESCRIPTION
Need to catch the group that the user is in when the job is launched in a multiple groups context.

https://bugzilla.redhat.com/show_bug.cgi?id=1480019

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes, services