### PR TITLE
Get tag details for no specific model

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -802,7 +802,7 @@ class MiqExpression
     opts = {:typ => "all", :include_model => true}.merge(opts)
     if opts[:typ] == "tag"
       tags_for_model = if TAG_CLASSES.include?(model)
-                         tag_details(model, model, opts)
+                         tag_details(model, opts)
                        else
                          []
                        end
@@ -810,7 +810,7 @@ class MiqExpression
       TAG_CLASSES.invert.each do |name, tc|
         next if tc.constantize.base_class == model.constantize.base_class
         path = [model, name].join(".")
-        result.concat(tag_details(tc, path, opts))
+        result.concat(tag_details(path, opts))
       end
       @classifications = nil
       return tags_for_model.concat(result.sort! { |a, b| a.to_s <=> b.to_s })
@@ -829,7 +829,7 @@ class MiqExpression
         custom_details = _custom_details_for(model, opts)
         result.concat(custom_details.sort_by(&:to_s)) unless custom_details.empty?
       end
-      result.concat(tag_details(model, model, opts)) if opts[:include_tags] == true && TAG_CLASSES.include?(model)
+      result.concat(tag_details(model, opts)) if opts[:include_tags] == true && TAG_CLASSES.include?(model)
     end
 
     model_details = _model_details(relats, opts)
@@ -873,7 +873,7 @@ class MiqExpression
       else
         result.concat(get_column_details(ref[:columns], parent[:class_path], parent[:assoc_path], opts))
         if opts[:include_tags] == true && TAG_CLASSES.include?(parent[:assoc_class])
-          result.concat(tag_details(parent[:assoc_class], parent[:class_path], opts))
+          result.concat(tag_details(parent[:class_path], opts))
         end
       end
 
@@ -882,7 +882,7 @@ class MiqExpression
     result
   end
 
-  def self.tag_details(model, path, opts)
+  def self.tag_details(path, opts)
     result = []
     @classifications ||= categories
     @classifications.each do |name, cat|
@@ -927,7 +927,7 @@ class MiqExpression
         c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES)
       end
       td = if TAG_CLASSES.include?(cb_model)
-             tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
+             tag_details(model, {}) + _custom_details_for(cb_model, {})
            else
              []
            end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -919,8 +919,9 @@ class MiqExpression
       model_details(model, :include_model => false, :include_tags => true, :interval => interval)
     elsif Chargeback.db_is_chargeback?(model)
       cb_model = Chargeback.report_cb_model(model)
-      model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) } +
-        tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
+      md = model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) }
+      td = tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
+      md + td
     else
       model_details(model, :include_model => false, :include_tags => true)
     end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -801,7 +801,11 @@ class MiqExpression
 
     opts = {:typ => "all", :include_model => true}.merge(opts)
     if opts[:typ] == "tag"
-      tags_for_model = tag_details(model, model, opts)
+      tags_for_model = if TAG_CLASSES.include?(model)
+                         tag_details(model, model, opts)
+                       else
+                         []
+                       end
       result = []
       TAG_CLASSES.invert.each do |name, tc|
         next if tc.constantize.base_class == model.constantize.base_class
@@ -825,8 +829,7 @@ class MiqExpression
         custom_details = _custom_details_for(model, opts)
         result.concat(custom_details.sort_by(&:to_s)) unless custom_details.empty?
       end
-
-      result.concat(tag_details(model, model, opts)) if opts[:include_tags] == true
+      result.concat(tag_details(model, model, opts)) if opts[:include_tags] == true && TAG_CLASSES.include?(model)
     end
 
     model_details = _model_details(relats, opts)
@@ -869,7 +872,9 @@ class MiqExpression
         result.concat(get_column_details(ref[:columns], parent[:class_path], parent[:assoc_path], opts)) if parent[:multivalue]
       else
         result.concat(get_column_details(ref[:columns], parent[:class_path], parent[:assoc_path], opts))
-        result.concat(tag_details(parent[:assoc_class], parent[:class_path], opts)) if opts[:include_tags] == true
+        if opts[:include_tags] == true && TAG_CLASSES.include?(parent[:assoc_class])
+          result.concat(tag_details(parent[:assoc_class], parent[:class_path], opts))
+        end
       end
 
       result.concat(_model_details(ref, opts))
@@ -878,7 +883,6 @@ class MiqExpression
   end
 
   def self.tag_details(model, path, opts)
-    return [] unless TAG_CLASSES.include?(model)
     result = []
     @classifications ||= categories
     @classifications.each do |name, cat|
@@ -922,7 +926,11 @@ class MiqExpression
       md = model_details(model, :include_model => false, :include_tags => true).select do |c|
         c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES)
       end
-      td = tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
+      td = if TAG_CLASSES.include?(cb_model)
+             tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
+           else
+             []
+           end
       md + td
     else
       model_details(model, :include_model => false, :include_tags => true)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -919,7 +919,9 @@ class MiqExpression
       model_details(model, :include_model => false, :include_tags => true, :interval => interval)
     elsif Chargeback.db_is_chargeback?(model)
       cb_model = Chargeback.report_cb_model(model)
-      md = model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) }
+      md = model_details(model, :include_model => false, :include_tags => true).select do |c|
+        c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES)
+      end
       td = tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
       md + td
     else

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -916,13 +916,13 @@ class MiqExpression
     if model.to_s == "VimPerformanceTrend"
       VimPerformanceTrend.trend_model_details(interval.to_s)
     elsif model.ends_with?("Performance")
-      MiqExpression.model_details(model, :include_model => false, :include_tags => true, :interval => interval)
+      model_details(model, :include_model => false, :include_tags => true, :interval => interval)
     elsif Chargeback.db_is_chargeback?(model)
       cb_model = Chargeback.report_cb_model(model)
-      MiqExpression.model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) } +
-        MiqExpression.tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
+      model_details(model, :include_model => false, :include_tags => true).select { |c| c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES) } +
+        tag_details(cb_model, model, {}) + _custom_details_for(cb_model, {})
     else
-      MiqExpression.model_details(model, :include_model => false, :include_tags => true)
+      model_details(model, :include_model => false, :include_tags => true)
     end
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -3233,4 +3233,18 @@ describe MiqExpression do
       expect(expression.exp).to eq("=" => {"count" => "Vm.disks", "value" => "1"})
     end
   end
+
+  describe ".tag_details" do
+    it "returns the tags when no path is given" do
+      Tenant.seed
+      FactoryGirl.create(
+        :classification,
+        :name        => "env",
+        :description => "Environment",
+        :children    => [FactoryGirl.create(:classification)]
+      )
+      actual = described_class.tag_details(nil, {})
+      expect(actual).to eq([["My Company Tags : Environment", "managed-env"]])
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://www.pivotaltracker.com/story/show/148795011

Best viewed as a series of commits, because some refactorings were needed to make this happen. Basically, `.tag_details` had a control parameter, `model`, only used to decide whether to return early with an empty array. By moving this out of the method and onto the callers, nothing further was needed in order for this method to return the right thing when no specific model is known.

@miq-bot assign @gtanzillo 
@miq-bot add-label enhancement