### PR TITLE
[EUWE] Automate - Fixed vm_retire_extend methods typo.

### DIFF
--- a/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Cloud/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -34,7 +34,7 @@ unless vm.retires_on.nil?
 
   $evm.log("info", "VM: <#{vm_name}> new retirement date is #{vm.retires_on}")
 
-  $evm.log("info", "Inspecting retirement: <#{vm.retirement.inspect}>")
+  $evm.log("info", "Inspecting retirement: <#{vm.retirement_state}>")
 
   evm_owner_id = vm.attributes['evm_owner_id']
   owner = nil

--- a/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
+++ b/db/fixtures/ae_datastore/ManageIQ/Infrastructure/VM/Retirement/Email.class/__methods__/vm_retire_extend.rb
@@ -39,7 +39,7 @@ unless vm.retires_on.nil?
   # Resetting last warning
   # vm.retirement[:last_warn] = nil
 
-  $evm.log("info", "Inspecting retirement: <#{vm.retirement.inspect}>")
+  $evm.log("info", "Inspecting retirement: <#{vm.retirement_state}>")
 
   ######################################
   #


### PR DESCRIPTION
Fixed typo in both methods (Infrastructure and Cloud).

This change is only for the Euwe release.
https://bugzilla.redhat.com/show_bug.cgi?id=1480736



