### PR TITLE
Memoize Metric::Capture.capture_cols

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -9,7 +9,7 @@ module Metric::Capture
   HISTORICAL_PRIORITY = MiqQueue::LOW_PRIORITY
 
   def self.capture_cols
-    Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float && c[0, 7] != "derived" }.compact
+    @capture_cols ||= Metric.columns_hash.collect { |c, h| c.to_sym if h.type == :float && c[0, 7] != "derived" }.compact
   end
 
   def self.historical_days


### PR DESCRIPTION
`capture_cols` will always be the same regardless of when it is called, unless a database update happens to the metrics table, in which the process would be restarted after the migration has happened anyway, and it will get reloaded then.

This method is hit frequently on the metrics collectors, so this prevents a bunch of objects from being allocated multiple times when doing `perf_capture_realtime`:

On a sample benchmark for `perf_capture_realtime`:

|   |  |
| --- | --- |
| Before |  20172 objects allocated from this method alone |
| After  |  None (after being memoize)               |


Links
-----
* Related effort:  https://github.com/ManageIQ/manageiq/pull/15757
* https://bugzilla.redhat.com/show_bug.cgi?id=1458392