### PR TITLE
Remove Host name uniqueness check and retry-loop

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -173,15 +173,7 @@ module EmsRefresh::SaveInventoryInfra
           found.update_attributes(h)
         end
 
-        # Handle duplicate names coming in because of duplicate hostnames.
-        begin
-          found.save!
-        rescue ActiveRecord::RecordInvalid
-          raise if found.errors[:name].blank?
-          old_name = Host.where("name LIKE ?", "#{found.name.sub(/ - \d+$/, "")}%").order("LENGTH(name) DESC").order("name DESC").first.name
-          found.name = old_name =~ / - \d+$/ ? old_name.succ : "#{old_name} - 2"
-          retry
-        end
+        found.save!
 
         disconnects.delete(found)
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -33,7 +33,6 @@ class Host < ApplicationRecord
   }.freeze
 
   validates_presence_of     :name
-  validates_uniqueness_of   :name
   validates_inclusion_of    :user_assigned_os, :in => ["linux_generic", "windows_generic", nil]
   validates_inclusion_of    :vmm_vendor, :in => VENDOR_TYPES.keys
 

--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -129,16 +129,5 @@ describe EmsRefresh::SaveInventoryInfra do
       hosts = Host.all
       expect(hosts.length).to eq(data.length)
     end
-
-    it "should not change the name of a host every refresh if there are duplicate names" do
-      FactoryGirl.create(:host, :ems_id => nil,     :ems_ref => "host-1", :name => "localhost",     :hostname => "localhost")
-      FactoryGirl.create(:host, :ems_id => @ems.id, :ems_ref => "host-2", :name => "localhost - 2", :hostname => "localhost")
-
-      data = [{:name => 'localhost', :hostname => 'localhost', :ems_ref => "host-2"}]
-
-      EmsRefresh.save_hosts_inventory(@ems, data)
-
-      expect(Host.where(:ems_ref => "host-2").first.name).to eq("localhost - 2")
-    end
   end
 end


### PR DESCRIPTION
Is this still a requirement?  It is making the graph refresh save strategy for hosts more complicated.

cc @Ladas 