### PR TITLE
[FINE] Normalize the username entered at login to lowercase

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -126,7 +126,7 @@ module Authenticator
 
           matching_groups = match_groups(groups_for(identity))
           userid = userid_for(identity, username)
-          user   = User.in_my_region.find_or_initialize_by(:userid => userid)
+          user   = find_or_initialize_user(userid)
           update_user_attributes(user, username, identity)
           user.miq_groups = matching_groups
 
@@ -153,6 +153,12 @@ module Authenticator
           raise
         end
       end
+    end
+
+    def find_or_initialize_user(userid)
+      user   = User.find_by_userid(userid)
+      user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
+      user ||  User.new(:userid => userid)
     end
 
     def authenticate_with_http_basic(username, password, request = nil, options = {})
@@ -278,7 +284,7 @@ module Authenticator
     end
 
     def normalize_username(username)
-      username
+      username.downcase
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1480654

This is a cherry pick from 88a312c28a
The cherry pick was not clean and had to be finished manually due to layout change of affected files.

LDAP does a case sensitive match of the user name but AD will
do a case insensitive match. By normalizing the userid to
lowercase when using external auth both backed to either
an LDAP directory or AD both will authenticate but only one DB
record, in all lowercase, will be created, even if the user
attempted to login with a mixed case username when backed to AD.

Upstream BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1448787

## Steps for Testing/QA

### Test the AD case:

1. Configure an appliance to use authentication Mode: External (httpd) to an AD directory
2. Attempt to login to an appliance with a valid username in mixed case, e.g.: tEsTuSeR1
3. Confirm one user record, with the userid in lowercase, was created.
4. Attempt to login again with a valid username in mixed case but different from step 1. e.g. TestUser1
5. Repeat step 3 with the same username but varying which letters in the username are upper and which are lowercase
6. Confirm the user can log in but only one DB record, with the userid in lowercase, is created.


### Test the LDAP case:

1. Configure an appliance to use authentication Mode: External (httpd) to an LDAP directory
2. Attempt to login to an appliance with a valid username, the case must match what is in the LDAP directory because LDAP does a case sensitive lookup
3. Confirm one user record, with the userid in lowercase, was created.
4. Confirm attempts to login to the appliance with the case of the username not matching what is in LDAP fail
