### PR TITLE
Add metrics default limit to API settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@
 :api:
   :token_ttl: 10.minutes
   :authentication_timeout: 30.seconds
+  :metrics_default_limit: 1000
 :authentication:
   :basedn:
   :bind_dn:


### PR DESCRIPTION
This PR adds in the default limit for the amount of metric rollups that will be returned from the API. 

API pr: https://github.com/ManageIQ/manageiq-api/pull/4

@miq-bot add_label api
@miq-bot assign @abellotti 

cc: @gtanzillo 