### PR TITLE
Bump to non-broken network discovery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "hamlit",                         "~>2.7.0"
 gem "inifile",                        "~>3.0",         :require => false
 gem "kubeclient",                     "~>2.4.0",       :require => false # For scaling pods at runtime
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
-gem "manageiq-network_discovery",     "~>0.1.1",       :require => false
+gem "manageiq-network_discovery",     "~>0.1.2",       :require => false
 gem "mime-types",                     "~>2.6.1",       :path => "mime-types-redirector"
 gem "more_core_extensions",           "~>3.3"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)


### PR DESCRIPTION
It was broken by some cleanup/namespacing work and fixed in:
https://github.com/ManageIQ/manageiq-network_discovery/pull/3