### PR TITLE
Adding options_description class method to base_manager

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -27,5 +27,10 @@ module ManageIQ::Providers
     def self.default_blacklisted_event_names
       Array(::Settings.ems["ems_#{provider_name.underscore}"].try(:blacklisted_event_names))
     end
+
+    # Returns a description of the options that are stored in "options" field.
+    def self.options_description
+      {}
+    end
   end
 end


### PR DESCRIPTION
This is a metadata function that should return the description of the data that is stored in the `options` field (added in https://github.com/ManageIQ/manageiq-schema/pull/23)

requested here: https://github.com/ManageIQ/manageiq-api/pull/3#discussion_r132476373