### PR TITLE
Rename `hashes` variables that now hold hashes/collections

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -1,9 +1,11 @@
 module EmsRefresh::SaveInventory
-  def save_ems_inventory(ems, hashes, target = nil, disconnect = true)
-    if hashes.kind_of?(Array)
-      ManagerRefresh::SaveInventory.save_inventory(ems, hashes)
+  # Parsed inventory can come as hash of hashes or array of InventoryCollection's.
+  def save_ems_inventory(ems, hashes_or_collections, target = nil, disconnect = true)
+    if hashes_or_collections.kind_of?(Array)
+      ManagerRefresh::SaveInventory.save_inventory(ems, hashes_or_collections) # InventoryCollections.
       return
     end
+    hashes = hashes_or_collections
 
     case ems
     when EmsCloud                                           then save_ems_cloud_inventory(ems, hashes, target, disconnect)


### PR DESCRIPTION
Refresh parsers once produced hash of hashes for save_inventory code, but now may also produce array of `InventoryCollection`s for graph saving code.  This renames some misleading `hashes` variables.

- I'm not sure `parsed` is the best name but in that context we don't really care what's inside...  Suggestions welcome.

@miq-bot add-label refactoring