### PR TITLE
Fail with descriptive message when no EMS

### DIFF
--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -26,11 +26,22 @@ class MiqProvisionRequest < MiqRequest
 
   def self.request_task_class_from(attribs)
     source_id = MiqRequestMixin.get_option(:src_vm_id, nil, attribs['options'])
-    vm_or_template = VmOrTemplate.find_by(:id => source_id)
-    raise MiqException::MiqProvisionError, "Unable to find source Template/Vm with id [#{source_id}]" if vm_or_template.nil?
+    vm_or_template = source_vm_or_template!(source_id)
 
     via = MiqRequestMixin.get_option(:provision_type, nil, attribs['options'])
     vm_or_template.ext_management_system.class.provision_class(via)
+  end
+
+  def self.source_vm_or_template!(source_id)
+    vm_or_template = VmOrTemplate.find_by(:id => source_id)
+    if vm_or_template.nil?
+      raise MiqException::MiqProvisionError, "Unable to find source Template/Vm with id [#{source_id}]"
+    end
+
+    if vm_or_template.ext_management_system.nil?
+      raise MiqException::MiqProvisionError, "Source Template/Vm with id [#{source_id}] has no EMS, unable to provision"
+    end
+    vm_or_template
   end
 
   def self.new_request_task(attribs)

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -1,21 +1,32 @@
 describe MiqProvisionRequest do
-  it ".request_task_class_from" do
-    ems = FactoryGirl.create(:ems_vmware)
-    vm = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
-    expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Vmware::InfraManager::Provision
-    expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id, :provision_type => "pxe"})).to eq ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe
+  context "#request_task_class_from" do
+    it "retrieves the provision class when the vm has EMS" do
+      ems = FactoryGirl.create(:ems_vmware)
+      vm = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+      expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Vmware::InfraManager::Provision
+      expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id, :provision_type => "pxe"})).to eq ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe
 
-    ems = FactoryGirl.create(:ems_redhat)
-    vm = FactoryGirl.create(:vm_redhat, :ext_management_system => ems)
-    expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Redhat::InfraManager::Provision
+      ems = FactoryGirl.create(:ems_redhat)
+      vm = FactoryGirl.create(:vm_redhat, :ext_management_system => ems)
+      expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Redhat::InfraManager::Provision
 
-    ems = FactoryGirl.create(:ems_openstack)
-    vm = FactoryGirl.create(:vm_openstack, :ext_management_system => ems)
-    expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Openstack::CloudManager::Provision
+      ems = FactoryGirl.create(:ems_openstack)
+      vm = FactoryGirl.create(:vm_openstack, :ext_management_system => ems)
+      expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Openstack::CloudManager::Provision
 
-    ems = FactoryGirl.create(:ems_amazon)
-    vm = FactoryGirl.create(:vm_amazon, :ext_management_system => ems)
-    expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Amazon::CloudManager::Provision
+      ems = FactoryGirl.create(:ems_amazon)
+      vm = FactoryGirl.create(:vm_amazon, :ext_management_system => ems)
+      expect(described_class.request_task_class_from('options' => {:src_vm_id => vm.id})).to eq ManageIQ::Providers::Amazon::CloudManager::Provision
+    end
+
+    it "fails to retrieve the provision class when the vm has no EMS" do
+      vm = FactoryGirl.create(:vm_redhat)
+      expect { described_class.request_task_class_from('options' => {:src_vm_id => vm.id}) }.to raise_error(MiqException::MiqProvisionError)
+    end
+
+    it "fails to retrieve the provision class when the vm does not exist" do
+      expect { described_class.request_task_class_from('options' => {:src_vm_id => -1 }) }.to raise_error(MiqException::MiqProvisionError)
+    end
   end
 
   context "A new provision request," do


### PR DESCRIPTION
When no EMS is associated with a VM or template, the provision request
fails with a non-descriptive message. Such case might happen when the VM
or template were removed from the provider side, but still exist as
archived on vmdb. The purpose of the PR is to provide a clear failure
message when there is no EMS.

https://bugzilla.redhat.com/show_bug.cgi?id=1471124
