### PR TITLE
Sort by resource id, timestamp in rollups_in_range

### DIFF
--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -62,7 +62,7 @@ class MetricRollup < ApplicationRecord
                     :capture_interval_name => capture_interval_name,
                     :timestamp             => start_date.beginning_of_day...end_date.end_of_day)
     metrics = metrics.where(:resource_id => resource_ids) if resource_ids
-    metrics
+    metrics.order(:resource_id, :timestamp => :desc)
   end
 
   def chargeback_fields_present?


### PR DESCRIPTION
The results sent back from rollups_in_range should be sorted by resource_id and timestamp. This will be needed to work with the default pagination that is being added to https://github.com/ManageIQ/manageiq-api/pull/4

@miq-bot assign @gtanzillo 
