### PR TITLE
Fix for custom button not passing target object to dynamic dialog fields

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -89,8 +89,8 @@ class Dialog < ApplicationRecord
 
   def init_fields_with_values(values)
     dialog_field_hash.each do |key, field|
-      values[key] = field.value
       field.dialog = self
+      values[key] = field.value
     end
     dialog_field_hash.each { |key, field| values[key] = field.initialize_with_values(values) }
     dialog_field_hash.each { |_key, field| field.update_values(values) }


### PR DESCRIPTION
While running a dialog in a custom button, users were unable to get a handle to the target resource because `.value` is what calls into the automate method, but without having set `.dialog` on the `dialog_field`, it was unable to get the target resource.

This fix will ensure that the dialog is set on the field before attempting to call `.value`.

~~Tagged as WIP for now until the BZ exists.~~

https://bugzilla.redhat.com/show_bug.cgi?id=1481380

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, euwe/yes, fine/yes