### PR TITLE
Do not try to start/stop apache unless running on an appliance

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -86,10 +86,14 @@ module MiqServer::EnvironmentManagement
   # Apache
   #
   def start_apache
+    return unless MiqEnvironment::Command.is_appliance?
+
     MiqApache::Control.start
   end
 
   def stop_apache
+    return unless MiqEnvironment::Command.is_appliance?
+
     MiqApache::Control.stop
   end
 


### PR DESCRIPTION
Eliminates errors and failure to start workers when running ManageIQ in a non-appliance env.