### PR TITLE
Refresh graph logging: use graphviz syntax

### DIFF
--- a/app/models/manager_refresh/save_collection/topological_sort.rb
+++ b/app/models/manager_refresh/save_collection/topological_sort.rb
@@ -7,14 +7,8 @@ module ManagerRefresh::SaveCollection
 
         layers = ManagerRefresh::Graph::TopologicalSort.new(graph).topological_sort
 
-        sorted_graph_log = "Topological sorting of manager #{ems.name} with ---nodes---:\n#{graph.nodes.join("\n")}\n"
-        sorted_graph_log += "---edges---:\n#{graph.edges.map { |x| "<#{x.first}, #{x.last}>" }.join("\n")}\n"
-        sorted_graph_log += "---resulted in these layers processable in parallel:"
-
-        layers.each_with_index do |layer, index|
-          sorted_graph_log += "\n----- Layer #{index} -----: \n#{layer.select { |x| !x.saved? }.join("\n")}"
-        end
-
+        sorted_graph_log = "Topological sorting of manager #{ems.name} resulted in these layers processable in parallel:\n"
+        sorted_graph_log += graph.to_graphviz(:layers => layers)
         _log.info(sorted_graph_log)
 
         layers.each_with_index do |layer, index|

--- a/spec/models/manager_refresh/graph_spec.rb
+++ b/spec/models/manager_refresh/graph_spec.rb
@@ -1,0 +1,58 @@
+describe ManagerRefresh::Graph do
+  let(:node1) { OpenStruct.new(:whatever => 'foo') }
+  let(:node2) { OpenStruct.new(:name => 'bar', :x => 2) }
+  let(:node3) { OpenStruct.new(:name => 'bar', :x => 3) }
+  let(:node4) { OpenStruct.new(:name => 'quux') }
+  let(:edges) { [[node1, node2], [node1, node3], [node2, node4]] }
+  let(:fixed_edges) { [] }
+
+  class TestGraph < described_class
+    def initialize(nodes, edges, fixed_edges)
+      @nodes = nodes
+      @edges = edges
+      @fixed_edges = fixed_edges
+    end
+  end
+
+  let(:graph) { TestGraph.new([node1, node2, node3, node4], edges, fixed_edges) }
+
+  describe '#to_graphviz' do
+    it 'prints the graph' do
+      # sensitive to node and edge order, but test controls this
+      expect(graph.to_graphviz).to eq(<<-'DOT'.strip_heredoc)
+        digraph {
+            "#<OpenStruct whatever=\"foo\">"; 	// #<OpenStruct whatever="foo">
+            bar_0; 	// #<OpenStruct name="bar", x=2>
+            bar_1; 	// #<OpenStruct name="bar", x=3>
+            quux; 	// #<OpenStruct name="quux">
+          // edges:
+          "#<OpenStruct whatever=\"foo\">" -> bar_0;
+          "#<OpenStruct whatever=\"foo\">" -> bar_1;
+          bar_0 -> quux;
+        }
+      DOT
+    end
+
+    it 'prints the graph with layers' do
+      layers = ManagerRefresh::Graph::TopologicalSort.new(graph).topological_sort
+      expect(graph.to_graphviz(:layers => layers)).to eq(<<-'DOT'.strip_heredoc)
+        digraph {
+          subgraph cluster_0 {  label = "Layer 0";
+            "#<OpenStruct whatever=\"foo\">"; 	// #<OpenStruct whatever="foo">
+          }
+          subgraph cluster_1 {  label = "Layer 1";
+            bar_0; 	// #<OpenStruct name="bar", x=2>
+            bar_1; 	// #<OpenStruct name="bar", x=3>
+          }
+          subgraph cluster_2 {  label = "Layer 2";
+            quux; 	// #<OpenStruct name="quux">
+          }
+          // edges:
+          "#<OpenStruct whatever=\"foo\">" -> bar_0;
+          "#<OpenStruct whatever=\"foo\">" -> bar_1;
+          bar_0 -> quux;
+        }
+      DOT
+    end
+  end
+end

--- a/tools/log_processing/graph_refresh_render_digraph.sh
+++ b/tools/log_processing/graph_refresh_render_digraph.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# During graph refresh something like this is printed to log:
+# ... Topological sorting of manager ... resulted in these layers ...:
+# digraph {
+#   ...
+# }
+
+# This is suggested command to render a pretty graph from it.
+# Requires Graphviz installed.
+
+echo 'Paste the lines from `digraph {` to `}` inclusive on stdin.'
+
+set -v
+
+# unflatten's -l2 flag is arbitrary heuristic, might be better without.
+unflatten -l2 -f |
+  dot -Gstyle=dotted -Grankdir=LR -Granksep=1 -Gfontname=sans -Nshape=box -Nstyle=rounded -Ncolor=gray -Nfontname=monospace |
+  edgepaint |
+  dot -Tsvg -o refresh-graph.svg
+
+xdg-open refresh-graph.svg


### PR DESCRIPTION
I felt like doing something silly yesterday evening.  Now I finally have something pretty to show for ~~my~~ Ladislav's efforts :-)

![2.after.svg](https://rawgit.com/cben/ba81cd462484664986ae410df27fd67a/raw/669d4bd73536590948f3fa9b125fe47c351ef3d8/2.after.svg)


After we DAGify and topologically sort the inventory graph into layers, we currently dump it into evm.log in an ad-hoc format:
```
[----] I, [2017-08-15T11:34:07.680227 #9636:2ae4cddb50d8]  INFO -- : MIQ(ManagerRefresh::SaveCollection::TopologicalSort.save_collections) Topological sorting of manager scale-ocp-36-c03 with ---nodes---:
InventoryCollection:<ContainerProject>
InventoryCollection:<CustomAttribute>
InventoryCollection:<CustomAttribute>
...
---edges---:
<InventoryCollection:<ContainerNode>, InventoryCollection:<ContainerCondition>>
<InventoryCollection:<ContainerNode>, InventoryCollection:<CustomAttribute>>
...
---resulted in these layers processable in parallel:
----- Layer 0 -----: 
InventoryCollection:<ContainerProject>
InventoryCollection:<CustomAttribute>
...
----- Layer 1 -----: 
...
```

This PR instead dumps it in GraphViz compatible syntax, which I tried to keep a bit shorter and at least as readable:
```
[----] I, [2017-08-15T11:36:05.171471 #9636:2ae4cddb50d8]  INFO -- : MIQ(ManagerRefresh::SaveCollection::TopologicalSort.save_collections) Topological sorting of manager scale-ocp-36-c03 resulted in these layers processable in parallel:
digraph {
  subgraph cluster_0 {  label = "Layer 0";
    container_projects; 	// InventoryCollection:<ContainerProject>
    custom_attributes_0; 	// InventoryCollection:<CustomAttribute>
    custom_attributes_1; 	// InventoryCollection:<CustomAttribute>
    ...
  }
  subgraph cluster_1 {  label = "Layer 1";
  ...
  // edges:
  container_nodes -> container_conditions_0;
  container_nodes -> custom_attributes_2;
  ...
}
```
but then can be pasted into (thanks to @anpc and @yaacov for some fine tuning ;-))
```
unflatten -l2 -f | dot -Gstyle=dotted -Grankdir=LR -Granksep=1 -Gfontname=sans -Nshape=box -Nstyle=rounded -Ncolor=gray -Nfontname=monospace | edgepaint | dot -Tsvg -o g.svg
```
producing the above image: :tada:

https://gist.github.com/cben/ba81cd462484664986ae410df27fd67a has all fulls texts with images.

- The function tries to use `InventoryCollection#name` but technically in this class shouldn't assume that so has a fallback to `.to_s`.  Above gist has example of output it would do if `.name` wasn't available:
  ```
    "InventoryCollection:<ContainerNode>" -> "InventoryCollection:<ContainerCondition>_0";
  ```
  The long node names are properly quoted and work, just make it look [ugly](https://rawgit.com/cben/ba81cd462484664986ae410df27fd67a/raw/669d4bd73536590948f3fa9b125fe47c351ef3d8/4.to_s.svg).

- The function supports just dumping a graph, without layers.  Again, above gist has example, [output here](https://rawgit.com/cben/ba81cd462484664986ae410df27fd67a/raw/669d4bd73536590948f3fa9b125fe47c351ef3d8/3.no_layers.svg).  (dot's ranking algorithm just happens to lay them out in similar layers.)

@miq-bot add-label developer, enhancement

cc @Ladas @agrare what do you think?
probably deserves a test.  perhaps it can also be handy *in* other tests?