### PR TITLE
Handle SIGTERM in run_single_worker.rb

### DIFF
--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -72,7 +72,8 @@ unless options[:dry_run]
            end
 
   begin
-    worker.class::Runner.start_worker(runner_options.merge(:guid => worker.guid))
+    runner_options[:guid] = worker.guid
+    worker.class::Runner.new(runner_options).tap(&:setup_sigterm_trap).start
   ensure
     worker.delete
   end


### PR DESCRIPTION
Termination of workers via the `MiqServer::WorkerManager` currently happens by sending a exit message over DRB to the worker that it will process in between doing jobs (so nothing is halfway in flight).  The `MiqServer` will wait for a specific amount of time (timeout defined in the settings, but defaults to `5.minutes` or so usually) before killing it (at this point, it is assumed the worker is stuck).

Currently, `SIGTERMS` are trapped and handled by the worker runner class to run the `do_exit` method, but they don't allow the work currently in progress to finish.  The addition of the `#setup_sigterm_trap` method will introduce `Kernel` traps that properly inform the worker that once they have finished with their next round of work, they should exit.


Steps for Testing/QA
--------------------

* Apply the following diff (needed becuase the VimBroker won't be present, and adds some handy debugging output):
  
  ```diff
  diff --git a/app/models/miq_generic_worker/runner.rb b/app/models/miq_generic_worker/runner.rb
  index 022db94..15c0175 100644
  --- a/app/models/miq_generic_worker/runner.rb
  +++ b/app/models/miq_generic_worker/runner.rb
  @@ -1,3 +1,3 @@
   class MiqGenericWorker::Runner < MiqQueueWorkerBase::Runner
  -  self.delay_startup_for_vim_broker = true # NOTE: For ems_operations and smartstate roles
  +  self.delay_startup_for_vim_broker = false # NOTE: For ems_operations and smartstate roles
   end
  diff --git a/app/models/miq_queue_worker_base/runner.rb b/app/models/miq_queue_worker_base/runner.rb
  index 206066b..0179d9d 100644
  --- a/app/models/miq_queue_worker_base/runner.rb
  +++ b/app/models/miq_queue_worker_base/runner.rb
  @@ -96,6 +96,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
     end

     def deliver_queue_message(msg)
  +    print "delivering queue message #{msg.class_name}.#{msg.method_name}..."
       reset_poll_escalate if poll_method == :sleep_poll_escalate

       begin
  @@ -128,6 +129,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
         #
         clean_broker_connection
       end
  +    puts "done!"
     end

     def deliver_message(msg)
  ```
  
* Create some long running work for your worker to act on (the time it sleeps in `:args` can be adjusted as needed):
  
  ```console
  $ bin/rails runner 'MiqQueue.put :class_name => "Kernel", :method_name => "sleep", :args => 200, :zone => MiqServer.my_server.zone.name, :queue_name => "generic"'
  ```
  
* Start a worker using the `run_single_worker.rb` script:
  
  ```console
  $ ruby lib/workers/bin/run_single_worker.rb MiqGenericWorker
  ```
  
* Wait for the worker to start processing the job, then interrupt it (Crtl-C).

The worker should output ` done!` before exiting.