### PR TITLE
Don't use secure sessions in containers

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -10,7 +10,7 @@ else
 
   session_options = {}
   if MiqEnvironment::Command.is_appliance?
-    session_options[:secure]   = true
+    session_options[:secure]   = true unless MiqEnvironment::Command.is_container?
     session_options[:httponly] = true
   end
 


### PR DESCRIPTION
This allows us to use http inside the application and move the SSL logic to the route