### PR TITLE
Fix minor typos/issues with PR #15818

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -48,6 +48,7 @@ class MiqWorker::Runner
     $log ||= Rails.logger
 
     @server = MiqServer.my_server(true)
+    @sigterm_received = false
 
     worker_initialization
     after_initialize

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -343,7 +343,7 @@ class MiqWorker::Runner
 
       # Should be caught by the rescue in `#start` and will run do_exit from
       # there.
-      raise Interrupt if @sigterm_recieved
+      raise Interrupt if @sigterm_received
 
       do_gc
       self.class.log_ruby_object_usage(worker_settings[:top_ruby_object_classes_to_log].to_i)
@@ -469,8 +469,8 @@ class MiqWorker::Runner
   # received from the container management system (aka OpenShift).  The SIGINT
   # trap is mostly a developer convenience.
   def setup_sigterm_trap
-    Kernel.trap("TERM") { @sigterm_recieved = true }
-    Kernel.trap("INT")  { @sigterm_recieved = true }
+    Kernel.trap("TERM") { @sigterm_received = true }
+    Kernel.trap("INT")  { @sigterm_received = true }
   end
 
   protected


### PR DESCRIPTION
tl; dr;
-------
http://fingerofblame.org/blame/QGpyYWZhbmll  (he should have caught in review... tsk tsk)


Fixes
-----
* Typo in the instance variable, `@sigterm_received`, (was `@sigterm_recieved`)
* Accessing `@sigterm_received` when it hadn't been initialized would cause warnings when run in ruby's verbose mode (so we should prevent that)


Links
-----
* https://github.com/ManageIQ/manageiq/pull/15818


Steps for Testing/QA
--------------------
Same as in https://github.com/ManageIQ/manageiq/pull/15818