### PR TITLE
Add new classes to BUTTON_CLASSES

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -14,13 +14,28 @@ class CustomButton < ApplicationRecord
   acts_as_miq_set_member
 
   BUTTON_CLASSES = [
+    AvailabilityZone,
+    CloudNetwork,
+    CloudObjectStoreContainer,
+    CloudSubnet,
     CloudTenant,
+    CloudVolume,
+    ContainerGroup,
+    ContainerImage,
+    ContainerProject,
+    ContainerTemplate,
+    ContainerVolume,
     EmsCluster,
     ExtManagementSystem,
     Host,
+    LoadBalancer,
     MiqTemplate,
+    NetworkRouter,
+    OrchestrationStack,
+    SecurityGroup,
     Service,
     Storage,
+    Switch,
     Vm,
   ].freeze
 


### PR DESCRIPTION
Add new classes to have custom buttons. 

(Toolbar builder expects `ContainerVolume` for `PersistentVolumeController`.)

https://www.pivotaltracker.com/story/show/147778977

@miq-bot add_label automate, enhancement, fine/no

UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/1912

@h-kataria please have a look, thanks :)