### PR TITLE
Remove rails-controller-testing from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -205,7 +205,6 @@ unless ENV["APPLIANCE"]
     gem "capybara",         "~>2.5.0",  :require => false
     gem "coveralls",                    :require => false
     gem "factory_girl",     "~>4.5.0",  :require => false
-    gem "rails-controller-testing",     :require => false
     gem "sqlite3",                      :require => false
     gem "timecop",          "~>0.7.3",  :require => false
     gem "vcr",              "~>3.0.2",  :require => false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'application_helper'
 
-require 'rails-controller-testing'
 require 'rspec/rails'
 require 'vcr'
 require 'cgi'


### PR DESCRIPTION
[ManageIQ/manageiq-ui-classic](https://github.com/ManageIQ/manageiq-ui-classic) should be the only repo that is currently needing this gem (possibly [ManageIQ/manageiq-api](https://github.com/ManageIQ/manageiq-api)), so make those dev dependencies for those projects directly, and prevent them from being required by every other project that inherits from this one doesn't need `rails-controller-testing`.

Merge order between this PR and https://github.com/ManageIQ/manageiq-ui-classic/pull/1953 is something that should be discussed.


Links
-----

* https://github.com/ManageIQ/manageiq-ui-classic
* https://github.com/ManageIQ/manageiq-api
* Related PR:  https://github.com/ManageIQ/manageiq-ui-classic/pull/1953


Steps for Testing/QA
--------------------

The test suite running find should be enough of an indicator that this works fine in this repo.