### PR TITLE
spec/spec_helper.rb cleanup

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,6 @@ require 'rspec/rails'
 require 'vcr'
 require 'cgi'
 
-# FIXME: This bypasses the lookup of Javascript dependencies in tests until they can be found and uncoupled
-class << ActionController::Base.helpers
-  def image_path(path, options = {})
-    path
-  end
-end
-
 # Fail tests that try to include stuff in `main`
 require_relative 'support/test_contamination'
 Spec::Support::TestContamination.setup

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,23 +58,7 @@ RSpec.configure do |config|
     config.example_status_persistence_file_path = Rails.root.join("tmp/rspec_example_store.txt")
   end
 
-  config.include UiConstants,    :type => :view
-
-  config.include UiConstants,          :type => :controller
-  config.include Spec::Support::AuthHelper, :type => :controller
-  config.include Spec::Support::AuthHelper, :type => :helper
-
-  config.include Spec::Support::PresenterHelper, :type => :presenter
-  config.define_derived_metadata(:file_path => /spec\/presenters/) do |metadata|
-    metadata[:type] ||= :presenter
-  end
-
   config.include Spec::Support::RakeTaskExampleGroup, :type => :rake_task
-  config.include Spec::Support::ButtonHelper, :type => :button
-  config.include Spec::Support::AuthHelper, :type => :button
-  config.define_derived_metadata(:file_path => /spec\/helpers\/application_helper\/buttons/) do |metadata|
-    metadata[:type] = :button
-  end
 
   # config.before(:all) do
   #   EvmSpecHelper.log_ruby_object_usage

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,6 @@ RSpec.configure do |config|
 
   config.before(:each) do |example|
     EmsRefresh.try(:debug_failures=, true)
-    ApplicationController.handle_exceptions = false if %w(controller requests).include?(example.metadata[:type])
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
Removing code that is only needed by ManageIQ/manageiq-ui-classic or other similar repos.


Links
-----

* Related: https://github.com/ManageIQ/manageiq/pull/15852


Steps for Testing/QA
--------------------

Tested with all of these removals when running the test suite of `ManageIQ/manageiq-ui-classic` with the local `manageiq` linked up to it and using this branch, and using the specs passed as expected.  If the specs in this repo complete, this should be good to go.