### PR TITLE
[POC][WIP] Use Aruba for testing run_single_worker script as integration like specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -205,6 +205,7 @@ unless ENV["APPLIANCE"]
     gem "brakeman",         "~>3.3",               :require => false
     gem "capybara",         "~>2.5.0",             :require => false
     gem "coveralls",                               :require => false
+    gem "database_cleaner", "~>1.6.1",             :require => false
     gem "factory_girl",     "~>4.5.0",             :require => false
     gem "sqlite3",                                 :require => false
     gem "timecop",          "~>0.7.3",             :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -201,14 +201,15 @@ unless ENV["APPLIANCE"]
   end
 
   group :test do
-    gem "brakeman",         "~>3.3",    :require => false
-    gem "capybara",         "~>2.5.0",  :require => false
-    gem "coveralls",                    :require => false
-    gem "factory_girl",     "~>4.5.0",  :require => false
-    gem "sqlite3",                      :require => false
-    gem "timecop",          "~>0.7.3",  :require => false
-    gem "vcr",              "~>3.0.2",  :require => false
-    gem "webmock",          "~>2.3.1",  :require => false
+    gem "aruba",            ">=1.0.0.pre.alpha.1", :require => false
+    gem "brakeman",         "~>3.3",               :require => false
+    gem "capybara",         "~>2.5.0",             :require => false
+    gem "coveralls",                               :require => false
+    gem "factory_girl",     "~>4.5.0",             :require => false
+    gem "sqlite3",                                 :require => false
+    gem "timecop",          "~>0.7.3",             :require => false
+    gem "vcr",              "~>3.0.2",             :require => false
+    gem "webmock",          "~>2.3.1",             :require => false
   end
 
   group :development, :test do

--- a/lib/tasks/evm_test_helper.rb
+++ b/lib/tasks/evm_test_helper.rb
@@ -16,7 +16,9 @@ module EvmTestHelper
     #
     # Output: %w(./spec/controllers ./spec/helpers ./spec/initializers ..)
     Dir.glob("./spec/*").select do |d|
-      File.directory?(d) && !Dir.glob("#{d}/**/*_spec.rb").empty?
+      File.directory?(d) &&
+        !d.match(/^\.\/spec\/workers.*/) && # worker specs are slow.  run seperate
+        !Dir.glob("#{d}/**/*_spec.rb").empty?
     end
   end
 end

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -1,7 +1,11 @@
 FactoryGirl.define do
   factory :miq_server do
+    transient do
+      zone_name { FactoryGirl.build(:zone).name }
+    end
+
     guid            { SecureRandom.uuid }
-    zone            { FactoryGirl.build(:zone) }
+    zone            { FactoryGirl.build(:zone, :name => zone_name) }
     sequence(:name) { |n| "miq_server_#{seq_padded_for_sorting(n)}" }
     last_heartbeat  { Time.now.utc }
     status          "started"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,17 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'application_helper'
 
+# Fixing a bug with miq-kernel, should be updated to match this or just removed
+module Kernel
+  def require_relative(path)
+    if File.exist?(path)
+      require path
+    else
+      require File.join(File.dirname(caller[0]), path.to_str)
+    end
+  end
+end
+
 require 'rspec/rails'
 require 'aruba/rspec'
 require 'vcr'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ end
 
 require 'rspec/rails'
 require 'aruba/rspec'
+require 'database_cleaner'
 require 'vcr'
 require 'cgi'
 
@@ -50,8 +51,26 @@ RSpec.configure do |config|
   end
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  config.use_transactional_fixtures = true
-  config.use_instantiated_fixtures  = false
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :type => :worker) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
 
   # From rspec-rails, infer what helpers to mix in, such as `get` and
   # `post` methods in spec/controllers, without specifying type

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
   # From rspec-rails, infer what helpers to mix in, such as `get` and
   # `post` methods in spec/controllers, without specifying type
   config.infer_spec_type_from_file_location!
+  WorkerSpecHelper.setup_worker_dir_metadata(config)
 
   unless ENV['CI']
     # File store for --only-failures option
@@ -63,6 +64,7 @@ RSpec.configure do |config|
   end
 
   config.include Aruba::Api, :type => :worker
+  config.include WorkerSpecHelper, :type => :worker
 
   config.include Spec::Support::RakeTaskExampleGroup, :type => :rake_task
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'application_helper'
 
 require 'rspec/rails'
+require 'aruba/rspec'
 require 'vcr'
 require 'cgi'
 
@@ -49,6 +50,8 @@ RSpec.configure do |config|
     # File store for --only-failures option
     config.example_status_persistence_file_path = Rails.root.join("tmp/rspec_example_store.txt")
   end
+
+  config.include Aruba::Api, :type => :worker
 
   config.include Spec::Support::RakeTaskExampleGroup, :type => :rake_task
 

--- a/spec/support/worker_spec_helper.rb
+++ b/spec/support/worker_spec_helper.rb
@@ -1,0 +1,12 @@
+module WorkerSpecHelper
+  def self.setup_worker_dir_metadata(config)
+    escaped_path = Regexp.compile('spec[\\\/]workers[\\\/]')
+    config.define_derived_metadata(:file_path => escaped_path) do |metadata|
+      metadata[:type] ||= :worker
+    end
+  end
+
+  def run_single_worker_bin
+    Rails.root.join("lib", "workers", "bin", "run_single_worker.rb")
+  end
+end

--- a/spec/workers/miq_generic_worker_spec.rb
+++ b/spec/workers/miq_generic_worker_spec.rb
@@ -1,0 +1,22 @@
+describe MiqGenericWorker, :use_fixtures => false do
+  let(:cmd)     { "ruby #{run_single_worker_bin} -b MiqGenericWorker" }
+  let(:command) { last_command_started }
+  let(:hb_file) { "generic_worker.hb" }
+
+  before do
+    # This needs to be read properly from the spawned process, so we either
+    # need to create or use the existing guid in the project
+    #
+    # Also, zone must be a zone named "default" to work with the default
+    # settings in sync_config
+    server = EvmSpecHelper.remote_miq_server(:guid => MiqServer.my_guid, :zone_name => "default")
+
+    set_environment_variable("WORKER_HEARTBEAT_FILE", expand_path(hb_file))
+    set_environment_variable("WORKER_HEARTBEAT_METHOD", "file")
+    run_command(cmd, :startup_wait_time => 10)
+  end
+
+  it "starts and heartbeats properly" do
+    expect(hb_file).to be_an_existing_file
+  end
+end


### PR DESCRIPTION
Background
----------

As we start relying on the single worker script to be a more focal point of development and deployment of MangeIQ, it is important that each of the workers run as expected when being run in this fashion, exit via `SIGTERM` (but finish their current work), and load all of the necessary dependencies properly.

To achieve all of the above, it is best that we start these workers (when testing them) without inheriting the ruby object space that is already defined in the test suite, but in a new one.  [Aruba](https://github.com/cucumber/aruba) is a testing framework for doing just that, and supports being run in `rspec` (even though it does have a `cucumber` dependency).


Changes:
--------

This PR is still a work in progress, so this will most likely be updated as more things are added:

* [x] Added `aruba` and `database_cleaner` gems
  - aruba provides a framework for testing child processes, allowing to test against their stdout/stderr, exit status, and files they may have written (among other things)
  - `database_cleaner` allows us to use a `truncate` strategy for tests, meaning that database entries made from the test process will also be available in the child processes as well.  This replaces any `use_transactional_fixures` settings in `rspec`/`rails`, since they don't play nice together
* [x] Make sure that `spec/worker` files are not run with the rest of the test suite (will be a separate travis job
* [ ] Run this via a separate travis job
* [x] Updated the miq_server factory
* [x] Adds `WorkerSpecHelper`, which adds some worker spec specific additions
* [ ] Adds a sample spec for the generic worker (TODO:  Do a bit more with this spec)


Links
-----

* https://github.com/cucumber/aruba
* https://github.com/DatabaseCleaner/database_cleaner