### PR TITLE
Make override_gem logging controllable by GEMFILE_SILENT env var

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -233,7 +233,12 @@ def override_gem(name, *args)
 
     calling_file = caller_locations.detect { |loc| !loc.path.include?("lib/bundler") }.path
     gem(name, *args).tap do
-      warn "** override_gem: #{name}, #{args.inspect}, caller: #{calling_file}" unless ENV["RAILS_ENV"] == "production"
+      verbose = if ENV["GEMFILE_SILENT"]
+                  %w(false 0).include?(ENV["GEMFILE_SILENT"])
+                else
+                  ENV["RAILS_ENV"] != "production"
+                end
+      warn "** override_gem: #{name}, #{args.inspect}, caller: #{calling_file}" if verbose
     end
   end
 end


### PR DESCRIPTION
While these `** override_gem: ...` lines are useful and I cheered their addition #14875, I now constantly run over 10 linked directories and this is too verbose and I never read it
(instead, I care what branches these dirs are on, https://github.com/cben/myenv/blob/master/bin/git-statuses helps FWIW).

=> YMMV, so made this user configurable.
=> Also supporting `GEMFILE_SILENT=0` or `GEMFILE_SILENT=false` to force seeing them in production.
The double negative is annoying.  I was thinking the var name should be opposite default behavior, but perhaps should be `GEMFILE_DEBUG=0` to silence?

@miq-bot add-label developer
@jrafanie @durandom @himdel please review