### PR TITLE
Add Openscap Result to VM model

### DIFF
--- a/app/models/openscap_result.rb
+++ b/app/models/openscap_result.rb
@@ -1,5 +1,6 @@
 class OpenscapResult < ApplicationRecord
   belongs_to :container_image
+  belongs_to :resource,              :polymorphic => true
   has_one    :binary_blob,           :dependent => :destroy, :autosave => true, :as => :resource, :required => true
   has_many   :openscap_rule_results, :dependent => :destroy, :autosave => true
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -112,6 +112,8 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :storage_files, :dependent => :destroy
   has_many                  :storage_files_files, -> { where "rsc_type = 'file'" }, :class_name => "StorageFile"
 
+  has_one                   :openscap_result, :as => :resource, :dependent => :destroy
+
   # EMS Events
   has_many                  :ems_events, ->(vmt) { where(["vm_or_template_id = ? OR dest_vm_or_template_id = ?", vmt.id, vmt.id]).order(:timestamp) },
                             :class_name => "EmsEvent"


### PR DESCRIPTION
Adding association to Openscap Result for Vm_or_template model to
be able to link scan results to multiple Vm types.

This is part of Openscap scanning integration to OpenStack provider.

Links
----------------

* https://github.com/ManageIQ/manageiq-schema/pull/42

Steps for Testing/QA
-------------------------------

This PR does not bring new end-user functionality. Will be tested together with OpenStack Openscap integration. 