### PR TITLE
Add instantiation_attributes to Container Template Parameter

### DIFF
--- a/app/models/container_template_parameter.rb
+++ b/app/models/container_template_parameter.rb
@@ -1,4 +1,8 @@
 class ContainerTemplateParameter < ApplicationRecord
   include CustomAttributeMixin
   belongs_to :container_template
+
+  def instantiation_attributes
+    attributes.slice("name", "value", "generate", "from", "required")
+  end
 end


### PR DESCRIPTION
Converts the Container Template Parameter to a hash with only relevant attributes for instantiation. 
This will be used by the `instantiate` method of Container Template in https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/97. 