### PR TITLE
Add runners needed for Prometheus alert collection

### DIFF
--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -34,6 +34,7 @@ MIQ_WORKER_TYPES = {
   "ManageIQ::Providers::Openshift::ContainerManager::EventCatcher"            => %i(manageiq_default),
   "ManageIQ::Providers::Openshift::ContainerManager::MetricsCollectorWorker"  => %i(manageiq_default),
   "ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker"           => %i(manageiq_default),
+  "ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher"           => %i(manageiq_default),
   "ManageIQ::Providers::Openstack::CloudManager::EventCatcher"                => %i(manageiq_default),
   "ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker"      => %i(manageiq_default),
   "ManageIQ::Providers::Openstack::CloudManager::RefreshWorker"               => %i(manageiq_default),
@@ -136,6 +137,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
   ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher
   ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
+  ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher
   ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher
   MiqUiWorker
   MiqWebsocketWorker

--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -26,6 +26,7 @@ MIQ_WORKER_TYPES = {
   "ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher"           => %i(manageiq_default),
   "ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCollectorWorker" => %i(manageiq_default),
   "ManageIQ::Providers::Kubernetes::ContainerManager::RefreshWorker"          => %i(manageiq_default),
+  "ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher"          => %i(manageiq_default),
   "ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher"           => %i(manageiq_default),
   "ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshWorker"          => %i(manageiq_default),
   "ManageIQ::Providers::Microsoft::InfraManager::RefreshWorker"               => %i(manageiq_default),
@@ -133,6 +134,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Hawkular::DatawarehouseManager::EventCatcher
   ManageIQ::Providers::Google::CloudManager::EventCatcher
   ManageIQ::Providers::Kubernetes::ContainerManager::EventCatcher
+  ManageIQ::Providers::Kubernetes::MonitoringManager::EventCatcher
   ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
   ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher
   MiqUiWorker


### PR DESCRIPTION
Add new Prometheus workers so they can be started.

Depends on:
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/40
https://github.com/ManageIQ/manageiq-providers-openshift/pull/22