### PR TITLE
Create Snapshot for Azure

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -244,7 +244,8 @@ class VmScan < Job
           #       or, make type-specific Job classes.
           if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
-          elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
+          elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
+            vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
           else
             delete_snapshot(mor)
@@ -499,7 +500,8 @@ class VmScan < Job
         set_status("Deleting snapshot before aborting job")
         if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
-        elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
+        elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
+          vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
         else
           delete_snapshot(mor)

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -102,6 +102,8 @@ class VmScan < Job
       if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm) ||
          vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm)
         return unless create_snapshot(vm)
+      elsif vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) && vm.require_snapshot_for_scan?
+        return unless create_snapshot(vm)
       elsif vm.require_snapshot_for_scan?
         proxy = MiqServer.find(miq_server_id)
 

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -245,7 +245,7 @@ class VmScan < Job
           if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
           elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-                vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
+                (vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) && vm.require_snapshot_for_scan?)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
           else
             delete_snapshot(mor)
@@ -501,7 +501,7 @@ class VmScan < Job
         if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
         elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-              vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
+              (vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) && vm.require_snapshot_for_scan?)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
         else
           delete_snapshot(mor)

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -245,7 +245,7 @@ class VmScan < Job
           if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
           elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-            vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
+                vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
           else
             delete_snapshot(mor)
@@ -501,7 +501,7 @@ class VmScan < Job
         if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
         elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-          vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
+              vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm)
           vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
         else
           delete_snapshot(mor)


### PR DESCRIPTION
For Azure VMs check if a snapshot is required for SSA and if
so call the snapshot code.

On this go-round the snapshot will only be required for Managed Disks.

This is one of several PRs required to add support for SSA for Managed Disks,
that is is response to the following BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=1475540
and
https://bugzilla.redhat.com/show_bug.cgi?id=1459612

A PR for the azure-armrest gem has already been merged in advance of this:
https://github.com/ManageIQ/azure-armrest/pull/299

A PR for the manageiq-smartstate gem has been submitted as well:
https://github.com/ManageIQ/manageiq-smartstate/pull/23

In addition a PR for the manageiq-providers-azure repo was added:
https://github.com/ManageIQ/manageiq-providers-azure/pull/117

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1475540
* https://bugzilla.redhat.com/show_bug.cgi?id=1459612
* https://github.com/ManageIQ/azure-armrest/pull/299
* https://github.com/ManageIQ/manageiq-smartstate/pull/23
* https://github.com/ManageIQ/manageiq-providers-azure/pull/117

Steps for Testing/QA
-------------------------------

Add an Azure VM with a Managed Disk.
Run SmartState Analysis against the VM.

@roliveri @hsong-rh please review.  