### PR TITLE
[FINE] Set the current userid when running a report

### DIFF
--- a/app/controllers/api/reports_controller.rb
+++ b/app/controllers/api/reports_controller.rb
@@ -17,7 +17,7 @@ module Api
 
     def run_resource(type, id, _data)
       report = resource_search(id, type, MiqReport)
-      report_result = MiqReportResult.find(report.queue_generate_table)
+      report_result = MiqReportResult.find(report.queue_generate_table(:userid => User.current_user.userid))
       run_report_result(true,
                         "running report #{report.id}",
                         :task_id          => report_result.miq_task_id,

--- a/spec/requests/api/reports_spec.rb
+++ b/spec/requests/api/reports_spec.rb
@@ -205,6 +205,8 @@ RSpec.describe "reports API" do
         :success => true,
         :message => "running report #{report.id}"
       )
+      actual = MiqReportResult.find(ApplicationRecord.uncompress_id(response.parsed_body["result_id"]))
+      expect(actual.userid).to eq("api_user_id")
     end
 
     it "can schedule a run" do


### PR DESCRIPTION
With nothing specified it defaults to "system". Since we now enforce
checking the ownership of report results, the report results' userid
must be set to the current user instead.

Backport of https://github.com/ManageIQ/manageiq-api/pull/30

@miq-bot add-label api, bug
@miq-bot assign @gtanzillo 

