### PR TITLE
When trying to find char layout for middleware messaging return correct file path

### DIFF
--- a/app/models/middleware_messaging.rb
+++ b/app/models/middleware_messaging.rb
@@ -20,7 +20,7 @@ class MiddlewareMessaging < ApplicationRecord
   end
 
   def chart_layout_path
-    "#{self.class.name.gsub(/::/, '_')}_#{messaging_type.parameterize(:separator => '_')}"
+    "#{self.class.name.demodulize}_#{messaging_type.parameterize(:separator => '_')}"
   end
 
   def self.supported_models


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/1880
Problem was with incorrect path to file, which is `MiddlewareMessaging_jms_topic.yaml` but before the path for which was asked was `ManageIQ_Providers_Hawkular_MiddlewareManager_MiddlewareMessaging_jms_queue.yaml` as you can see the old path contains module as well.

### Steps to reproduce
Middleware->Messagings->JMS Queue or JMS Topic summary page, clicking on Monitoring->Utilization