### PR TITLE
Use custom buttons ids from relation instead of from CustomButtonSet#set_data[:button_order]

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -51,7 +51,7 @@ class CustomButtonSet < ApplicationRecord
   #  - filtered custom_button_sets array when all visibilty expression custom buttons have been evaluated to false
   def self.filter_with_visibility_expression(custom_button_sets, object)
     custom_button_sets.each_with_object([]) do |custom_button_set, ret|
-      custom_button_from_set = CustomButton.where(:id => custom_button_set.set_data[:button_order]).select(:id, :visibility_expression)
+      custom_button_from_set = CustomButton.where(:id => custom_button_set.custom_buttons.pluck(:id)).select(:id, :visibility_expression)
       filtered_ids = custom_button_from_set.select { |x| x.evaluate_visibility_expression_for(object) }.pluck(:id)
       if filtered_ids.present?
         custom_button_set.set_data[:button_order] = filtered_ids

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -29,6 +29,10 @@ describe CustomButtonSet do
     let(:set_data)          { {:applies_to_class => "Vm", :button_order => [custom_button_1.id, custom_button_2.id]} }
     let(:custom_button_set) { FactoryGirl.create(:custom_button_set, :name => "set_1", :set_data => set_data) }
 
+    before do
+      [custom_button_1, custom_button_2].each { |x| custom_button_set.add_member(x) }
+    end
+
     context 'when all CustomButtons#visibility_expression=nil' do
       let(:miq_expression) { nil }
 


### PR DESCRIPTION
we cannot rely on CustomButtonSet#set_date[:button_order] as well
as on CustomButtonSet#custom_buttons

also, it was a problem for UI specs, but it was solved in this commit https://github.com/ManageIQ/manageiq-ui-classic/pull/1824/commits/3f46a605cd4ad6d737b6180904178477f4ccf13f
(it was about keeping CustomButtonSet#set_date[:button_order]  same as CustomButtonSet#custom_buttons )

@miq-bot add_label technical_debt
@mit-bot assign @gtanzillo 

cc @martinpovolny 

## Links
method added here
https://github.com/ManageIQ/manageiq/pull/15725

