### PR TITLE
Parse default value in Service Dialog 

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -27,7 +27,7 @@ class DialogFieldSerializer < Serializer
     end
 
     field_as_json = dialog_field.as_json(:methods => [:type, :values])
-    field_as_json["default_value"] = field_as_json["default_value"].split(",").to_json if dialog_field.try(:force_multi_value)
+    field_as_json["default_value"] = field_as_json["default_value"].split(",") if dialog_field.try(:force_multi_value)
     included_attributes(field_as_json, all_attributes).merge(extra_attributes)
   end
 end

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -25,6 +25,9 @@ class DialogFieldSerializer < Serializer
       category = Category.find_by(:id => dialog_field.category)
       dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
     end
-    included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)
+
+    field_as_json = dialog_field.as_json(:methods => [:type, :values])
+    field_as_json["default_value"] = field_as_json["default_value"].split(",").to_json if dialog_field.try(:force_multi_value)
+    included_attributes(field_as_json, all_attributes).merge(extra_attributes)
   end
 end

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -150,7 +150,7 @@ describe DialogFieldSerializer do
                      :category_name        => "best category ever",
                      :category_description => "best category ever"
                    },
-                   "default_value"           => default_values.split(",").to_json
+                   "default_value"           => default_values.split(",")
           ))
       end
     end

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -138,7 +138,9 @@ describe DialogFieldSerializer do
         allow(dialog_field).to receive(:values).and_return("values")
       end
 
-      it "serializes the category name and description" do
+      it "serializes the category name, description and default value" do
+        default_values = "one,two"
+        dialog_field.update_attributes(:default_value => default_values)
         expect(dialog_field_serializer.serialize(dialog_field))
           .to eq(expected_serialized_values.merge(
                    "resource_action"         => "serialized resource action",
@@ -147,7 +149,8 @@ describe DialogFieldSerializer do
                      :category_id          => "123",
                      :category_name        => "best category ever",
                      :category_description => "best category ever"
-                   }
+                   },
+                   "default_value"           => default_values.split(",").to_json
           ))
       end
     end


### PR DESCRIPTION
Second PR for described issue in https://github.com/ManageIQ/manageiq/issues/15877 - essentially the `default_value` is stored as a string but needs to be parsed as an array to work properly in drop downs

Any thoughts on a better way to go about this?  @d-m-u 

@miq-bot add_label services, enhancement 
