### PR TITLE
Override `MiqWorker::Runner.start` in MiqWebServerRunnerMixin

### DIFF
--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -11,29 +11,26 @@ module MiqWebServerRunnerMixin
     at_exit { do_exit("Exit request received.") }
   end
 
-  module ClassMethods
-    def start_worker(*args)
-      runner = self.new(*args)
-      _log.info("URI: #{runner.worker.uri}")
+  def start
+    _log.info("URI: #{worker.uri}")
 
-      # Do all the SQL worker preparation in the main thread
-      runner.prepare
+    # Do all the SQL worker preparation in the main thread
+    prepare
 
-      # The heartbeating will be done in a separate thread
-      Thread.new { runner.run }
+    # The heartbeating will be done in a separate thread
+    Thread.new { run }
 
-      runner.worker.class.configure_secret_token
-      start_rails_server(runner.worker.rails_server_options)
-    end
+    worker.class.configure_secret_token
+    start_rails_server(worker.rails_server_options)
+  end
 
-    def start_rails_server(options)
-      require "rails/commands/server"
+  def start_rails_server(options)
+    require "rails/commands/server"
 
-      _log.info("With options: #{options.except(:app).inspect}")
-      Rails::Server.new(options).tap do |server|
-        Dir.chdir(Vmdb::Application.root)
-        server.start
-      end
+    _log.info("With options: #{options.except(:app).inspect}")
+    Rails::Server.new(options).tap do |server|
+      Dir.chdir(Vmdb::Application.root)
+      server.start
     end
   end
 end


### PR DESCRIPTION
We need to do this because MiqWebServerRunnerMixin overrides `.start_worker` to start the rails server. This needs to happen.

Broken in 7776e35c877e2ee344f858dbd3c46d58543a2b16

Without this change, you cannot access the UI using `foreman start`

edit:
-----------------------------------------------------------------

This allows us access to the worker object in run_single_worker.rb and also allows the web service workers to start the rails server which was broken in 7776e35.

The original change altered the call in run_single_worker.rb to call Runner#start rather than Runner.start_worker which missed this code when running a web server worker.