### PR TITLE
[REARCH] Container workers

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
@@ -1,9 +1,15 @@
 class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   include PerEmsTypeWorkerMixin
 
   self.required_roles = ["ems_metrics_collector"]
+
+  def self.supports_container?
+    true
+  end
 
   def self.normalized_type
     @normalized_type ||= "ems_metrics_collector_worker"

--- a/app/models/miq_ems_metrics_processor_worker.rb
+++ b/app/models/miq_ems_metrics_processor_worker.rb
@@ -1,4 +1,6 @@
 class MiqEmsMetricsProcessorWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.required_roles       = ["ems_metrics_processor"]
@@ -6,5 +8,9 @@ class MiqEmsMetricsProcessorWorker < MiqQueueWorkerBase
 
   def friendly_name
     @friendly_name ||= "C&U Metrics Processor"
+  end
+
+  def self.supports_container?
+    true
   end
 end

--- a/app/models/miq_event_handler.rb
+++ b/app/models/miq_event_handler.rb
@@ -1,6 +1,12 @@
 class MiqEventHandler < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.required_roles       = ["event"]
   self.default_queue_name   = "ems"
+
+  def self.supports_container?
+    true
+  end
 end

--- a/app/models/miq_generic_worker.rb
+++ b/app/models/miq_generic_worker.rb
@@ -1,7 +1,13 @@
 class MiqGenericWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.default_queue_name     = "generic"
   self.check_for_minimal_role = false
   self.workers                = -> { MiqServer.minimal_env? ? 1 : worker_settings[:count] }
+
+  def self.supports_container?
+    true
+  end
 end

--- a/app/models/miq_priority_worker.rb
+++ b/app/models/miq_priority_worker.rb
@@ -1,9 +1,15 @@
 class MiqPriorityWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.default_queue_name   = "generic"
 
   def self.queue_priority
     MiqQueue::HIGH_PRIORITY
+  end
+
+  def self.supports_container?
+    true
   end
 end

--- a/app/models/miq_reporting_worker.rb
+++ b/app/models/miq_reporting_worker.rb
@@ -1,6 +1,12 @@
 class MiqReportingWorker < MiqQueueWorkerBase
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.required_roles       = ["reporting"]
   self.default_queue_name   = "reporting"
+
+  def self.supports_container?
+    true
+  end
 end

--- a/app/models/miq_schedule_worker.rb
+++ b/app/models/miq_schedule_worker.rb
@@ -1,4 +1,6 @@
 class MiqScheduleWorker < MiqWorker
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Jobs
   require_nested :Runner
 
@@ -7,4 +9,8 @@ class MiqScheduleWorker < MiqWorker
     return MiqServer.minimal_env_options.include?('schedule') ? 1 : 0 if MiqServer.minimal_env?
     return 1
   }
+
+  def self.supports_container?
+    true
+  end
 end

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -92,6 +92,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def check_not_responding(class_name = nil)
+    return [] if MiqEnvironment::Command.is_container?
     processed_workers = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)

--- a/app/models/miq_server/worker_management/monitor/stop.rb
+++ b/app/models/miq_server/worker_management/monitor/stop.rb
@@ -37,7 +37,9 @@ module MiqServer::WorkerManagement::Monitor::Stop
     worker_set_monitor_status(w.pid, monitor_status)
     worker_set_monitor_reason(w.pid, monitor_reason)
 
-    if w.respond_to?(:terminate)
+    if w.containerized_worker?
+      w.stop_container
+    elsif w.respond_to?(:terminate)
       w.terminate
     else
       w.update_attributes(:status => MiqWorker::STATUS_STOPPING)

--- a/app/models/miq_server/worker_management/monitor/system_limits.rb
+++ b/app/models/miq_server/worker_management/monitor/system_limits.rb
@@ -9,11 +9,13 @@ module MiqServer::WorkerManagement::Monitor::SystemLimits
   }
 
   def kill_workers_due_to_resources_exhausted?
+    return false if MiqEnvironment::Command.is_container?
     options = worker_monitor_settings[:kill_algorithm].merge(:type => :kill)
     invoke_algorithm(options)
   end
 
   def enough_resource_to_start_worker?(worker_class)
+    return true if MiqEnvironment::Command.is_container?
     # HACK, sync_config is done in the server, while this method is called from miq_worker
     # This method should move to the worker and the server should pass the settings.
     sync_config if worker_monitor_settings.nil? || child_worker_settings.nil?

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -2,6 +2,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
   extend ActiveSupport::Concern
 
   def validate_worker(w)
+    return true if MiqEnvironment::Command.is_container?
     time_threshold   = get_time_threshold(w)
     restart_interval = get_restart_interval(w)
     memory_threshold = get_memory_threshold(w)

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -31,6 +31,6 @@ class MiqUiWorker < MiqWorker
   end
 
   def container_image_name
-    "docker.io/carbonin/manageiq-ui-worker"
+    "manageiq/manageiq-ui-worker"
   end
 end

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -20,4 +20,17 @@ class MiqUiWorker < MiqWorker
   end
 
   include MiqWebServerWorkerMixin
+  include MiqWorker::ServiceWorker
+
+  def self.supports_container?
+    true
+  end
+
+  def container_port
+    3001
+  end
+
+  def container_image_name
+    "docker.io/carbonin/manageiq-ui-worker"
+  end
 end

--- a/app/models/miq_ui_worker/runner.rb
+++ b/app/models/miq_ui_worker/runner.rb
@@ -1,3 +1,8 @@
 class MiqUiWorker::Runner < MiqWorker::Runner
   include MiqWebServerRunnerMixin
+
+  def prepare
+    super
+    MiqApache::Control.start if MiqEnvironment::Command.is_container?
+  end
 end

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -1,4 +1,6 @@
 class MiqVimBrokerWorker < MiqWorker
+  include MiqWorker::ReplicaPerWorker
+
   require_nested :Runner
 
   self.required_roles         = lambda {
@@ -18,6 +20,10 @@ class MiqVimBrokerWorker < MiqWorker
     return self.has_minimal_env_option? ? 1 : 0 if MiqServer.minimal_env?
     return 1
   }
+
+  def self.supports_container?
+    true
+  end
 
   def self.has_required_role?
     return false if emses_to_monitor.empty?

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -10,4 +10,9 @@ class MiqWebServiceWorker < MiqWorker
   end
 
   include MiqWebServerWorkerMixin
+  include MiqWorker::ServiceWorker
+
+  def self.supports_container?
+    true
+  end
 end

--- a/app/models/miq_websocket_worker.rb
+++ b/app/models/miq_websocket_worker.rb
@@ -11,4 +11,9 @@ class MiqWebsocketWorker < MiqWorker
   end
 
   include MiqWebServerWorkerMixin
+  include MiqWorker::ServiceWorker
+
+  def self.supports_container?
+    true
+  end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -502,6 +502,8 @@ class MiqWorker < ApplicationRecord
   end
 
   def status_update
+    return if MiqEnvironment::Command.is_container?
+
     begin
       pinfo = MiqProcess.processInfo(pid)
     rescue Errno::ESRCH

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -373,6 +373,10 @@ class MiqWorker < ApplicationRecord
     MiqEnvironment::Command.is_container? && supports_container?
   end
 
+  def containerized_worker?
+    self.class.containerized_worker?
+  end
+
   def start_runner
     if ENV['MIQ_SPAWN_WORKERS'] || !Process.respond_to?(:fork)
       start_runner_via_spawn

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -431,10 +431,10 @@ class MiqWorker < ApplicationRecord
 
   def start
     self.pid = start_runner
-    save
+    save unless containerized_worker?
 
     msg = "Worker started: ID [#{id}], PID [#{pid}], GUID [#{guid}]"
-    MiqEvent.raise_evm_event_queue(miq_server, "evm_worker_start", :event_details => msg, :type => self.class.name)
+    MiqEvent.raise_evm_event_queue(miq_server || MiqServer.my_server, "evm_worker_start", :event_details => msg, :type => self.class.name)
 
     _log.info(msg)
     self

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -1,0 +1,33 @@
+require 'kubeclient'
+
+class MiqWorker
+  module ContainerCommon
+    extend ActiveSupport::Concern
+
+    def configure_worker_deployment(definition, replicas = 0)
+      definition[:spec][:replicas] = replicas
+      definition[:spec][:template][:spec][:terminationGracePeriodSeconds] = self.class.worker_settings[:stopping_timeout].seconds
+
+      container = definition[:spec][:template][:spec][:containers].first
+      container[:image] = "#{container_image_name}:#{container_image_tag}"
+      container[:env] << {:name => "WORKER_CLASS_NAME", :value => self.class.name}
+    end
+
+    def scale_deployment
+      ContainerOrchestrator.new.scale(worker_deployment_name, self.class.workers_configured_count)
+      delete_container_objects if self.class.workers_configured_count.zero?
+    end
+
+    def container_image_name
+      "docker.io/carbonin/manageiq-base-worker"
+    end
+
+    def container_image_tag
+      "latest"
+    end
+
+    def worker_deployment_name
+      @worker_deployment_name ||= "#{self.class.name}-#{queue_name}".underscore.dasherize.gsub("/", "-")
+    end
+  end
+end

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -27,7 +27,11 @@ class MiqWorker
     end
 
     def worker_deployment_name
-      @worker_deployment_name ||= "#{self.class.name}-#{queue_name}".underscore.dasherize.gsub("/", "-")
+      @worker_deployment_name ||= begin
+        deployment_name = abbreviated_class_name.dup.chomp("Worker").sub("Manager", "").sub(/^Miq/, "")
+        deployment_name << "-#{Array(ems_id).map { |id| ApplicationRecord.split_id(id).last }.join("-")}" if respond_to?(:ems_id)
+        deployment_name.underscore.dasherize.tr("/", "-")
+      end
     end
   end
 end

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -19,7 +19,7 @@ class MiqWorker
     end
 
     def container_image_name
-      "docker.io/carbonin/manageiq-base-worker"
+      "manageiq/manageiq-base-worker"
     end
 
     def container_image_tag

--- a/app/models/miq_worker/deployment_per_worker.rb
+++ b/app/models/miq_worker/deployment_per_worker.rb
@@ -1,0 +1,20 @@
+class MiqWorker
+  module DeploymentPerWorker
+    extend ActiveSupport::Concern
+
+    def create_container_objects
+      ContainerOrchestrator.new.create_deployment_config(worker_deployment_name) do |definition|
+        configure_worker_deployment(definition, 1)
+        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "QUEUE", :value => queue_name}
+      end
+    end
+
+    def delete_container_objects
+      ContainerOrchestrator.new.delete_deployment_config(worker_deployment_name)
+    end
+
+    def stop_container
+      delete_container_objects
+    end
+  end
+end

--- a/app/models/miq_worker/deployment_per_worker.rb
+++ b/app/models/miq_worker/deployment_per_worker.rb
@@ -5,7 +5,7 @@ class MiqWorker
     def create_container_objects
       ContainerOrchestrator.new.create_deployment_config(worker_deployment_name) do |definition|
         configure_worker_deployment(definition, 1)
-        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "QUEUE", :value => queue_name}
+        definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_IDS", :value => Array.wrap(self.class.ems_id_from_queue_name(queue_name)).join(",")}
       end
     end
 

--- a/app/models/miq_worker/replica_per_worker.rb
+++ b/app/models/miq_worker/replica_per_worker.rb
@@ -1,0 +1,20 @@
+class MiqWorker
+  module ReplicaPerWorker
+    extend ActiveSupport::Concern
+
+    def create_container_objects
+      ContainerOrchestrator.new.create_deployment_config(worker_deployment_name) do |definition|
+        configure_worker_deployment(definition)
+      end
+      scale_deployment
+    end
+
+    def delete_container_objects
+      ContainerOrchestrator.new.delete_deployment_config(worker_deployment_name)
+    end
+
+    def stop_container
+      scale_deployment
+    end
+  end
+end

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -32,10 +32,6 @@ class MiqWorker
       scale_deployment
     end
 
-    def worker_deployment_name
-      @worker_deployment_name ||= self.class.name.underscore.dasherize
-    end
-
     def add_readiness_probe(container_definition)
       container_definition[:readinessProbe] = {
         :tcpSocket           => {:port => SERVICE_PORT},

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -47,7 +47,7 @@ class MiqWorker
 
     # Can be overriden by including classes
     def container_image_name
-      "docker.io/carbonin/manageiq-webserver-worker"
+      "manageiq/manageiq-webserver-worker"
     end
   end
 end

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -1,0 +1,57 @@
+class MiqWorker
+  module ServiceWorker
+    extend ActiveSupport::Concern
+
+    SERVICE_PORT = 3000
+
+    def create_container_objects
+      orchestrator = ContainerOrchestrator.new
+
+      orchestrator.create_service(worker_deployment_name, SERVICE_PORT)
+      orchestrator.create_deployment_config(worker_deployment_name) do |definition|
+        configure_worker_deployment(definition)
+
+        definition[:spec][:serviceName] = worker_deployment_name
+        container = definition[:spec][:template][:spec][:containers].first
+        container[:ports] = [{:containerPort => SERVICE_PORT}]
+        container[:env] << {:name => "PORT", :value => container_port.to_s}
+        container[:env] << {:name => "BINDING_ADDRESS", :value => "0.0.0.0"}
+        add_readiness_probe(container)
+      end
+
+      scale_deployment
+    end
+
+    def delete_container_objects
+      orch = ContainerOrchestrator.new
+      orch.delete_deployment_config(worker_deployment_name)
+      orch.delete_service(worker_deployment_name)
+    end
+
+    def stop_container
+      scale_deployment
+    end
+
+    def worker_deployment_name
+      @worker_deployment_name ||= self.class.name.underscore.dasherize
+    end
+
+    def add_readiness_probe(container_definition)
+      container_definition[:readinessProbe] = {
+        :tcpSocket           => {:port => SERVICE_PORT},
+        :initialDelaySeconds => 60,
+        :timeoutSeconds      => 3
+      }
+    end
+
+    # Can be overriden by including classes
+    def container_port
+      SERVICE_PORT
+    end
+
+    # Can be overriden by including classes
+    def container_image_name
+      "docker.io/carbonin/manageiq-webserver-worker"
+    end
+  end
+end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -1,4 +1,6 @@
 module PerEmsWorkerMixin
+  include MiqWorker::DeploymentPerWorker
+
   extend ActiveSupport::Concern
 
   included do
@@ -9,6 +11,10 @@ module PerEmsWorkerMixin
   end
 
   module ClassMethods
+    def supports_container?
+      true
+    end
+
     def ems_class
       ExtManagementSystem
     end

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -1,0 +1,48 @@
+describe MiqWorker::ContainerCommon do
+  describe "#worker_deployment_name" do
+    let(:test_cases) do
+      [
+        {:subject => MiqGenericWorker.new, :name => "generic"},
+        {:subject => MiqUiWorker.new,      :name => "ui"},
+        {:subject => ManageIQ::Providers::Openshift::ContainerManager::EventCatcher.new(:queue_name => "ems_2"), :name => "openshift-container-event-catcher-2"},
+        {:subject => ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker.new, :name => "redhat-network-metrics-collector"}
+      ]
+    end
+
+    it "returns the correct name for each worker" do
+      test_cases.each { |test| expect(test[:subject].worker_deployment_name).to eq(test[:name]) }
+    end
+
+    it "no worker deployment names are over 60 characters" do
+      # OpenShift does not allow deployment names over 63 characters
+      # We also want to leave some for the ems_id so we compare against 60 to be safe
+      MIQ_WORKER_TYPES_IN_KILL_ORDER.each do |klass|
+        expect(klass.constantize.new.worker_deployment_name.length).to be <= 60
+      end
+    end
+  end
+
+  describe "#scale_deployment" do
+    let(:orchestrator) { double("ContainerOrchestrator") }
+
+    before do
+      allow(ContainerOrchestrator).to receive(:new).and_return(orchestrator)
+    end
+
+    it "scales the deployment to the number of configured workers" do
+      allow(MiqGenericWorker).to receive(:worker_settings).and_return(:count => 2)
+
+      expect(orchestrator).to receive(:scale).with("generic", 2)
+      MiqGenericWorker.new.scale_deployment
+    end
+
+    it "deletes the container objects if the worker count is zero" do
+      allow(MiqGenericWorker).to receive(:worker_settings).and_return(:count => 0)
+
+      expect(orchestrator).to receive(:scale).with("generic", 0)
+      worker = MiqGenericWorker.new
+      expect(worker).to receive(:delete_container_objects)
+      worker.scale_deployment
+    end
+  end
+end


### PR DESCRIPTION
Run workers in OpenShift containers.

This change allows the server to start workers by talking to OpenShift and creating deployments and scaling them when needed.

This also stubs out some existing functionality which is process specific and doesn't apply to workers running in containers.
