### PR TITLE
[EUWE] Add config option to skip container_images

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -3,8 +3,8 @@ require 'shellwords'
 module ManageIQ::Providers::Kubernetes
   class ContainerManager::RefreshParser
     include Vmdb::Logging
-    def self.ems_inv_to_hashes(inventory)
-      new.ems_inv_to_hashes(inventory)
+    def self.ems_inv_to_hashes(inventory, options = Config::Options.new)
+      new.ems_inv_to_hashes(inventory, options)
     end
 
     def initialize
@@ -13,7 +13,7 @@ module ManageIQ::Providers::Kubernetes
       @label_tag_mapping = ContainerLabelTagMapping.cache
     end
 
-    def ems_inv_to_hashes(inventory)
+    def ems_inv_to_hashes(inventory, _options = Config::Options.new)
       get_nodes(inventory)
       get_namespaces(inventory)
       get_resource_quotas(inventory)

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -1,14 +1,14 @@
 module ManageIQ::Providers
   module Openshift
     class ContainerManager::RefreshParser < ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser
-      def ems_inv_to_hashes(inventory)
-        super(inventory)
+      def ems_inv_to_hashes(inventory, options = Config::Options.new)
+        super(inventory, options)
         get_projects(inventory)
         get_routes(inventory)
         get_builds(inventory)
         get_build_pods(inventory)
         get_templates(inventory)
-        get_openshift_images(inventory)
+        get_openshift_images(inventory) if options.get_container_images
         EmsRefresh.log_inv_debug_trace(@data, "data:")
         @data
       end

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -8,20 +8,22 @@ module ManageIQ::Providers
 
       OPENSHIFT_ENTITIES = [
         {:name => 'routes'}, {:name => 'projects'},
-        {:name => 'build_configs'}, {:name => 'builds'}, {:name => 'templates'},
-        {:name => 'images'}
+        {:name => 'build_configs'}, {:name => 'builds'}, {:name => 'templates'}
       ]
 
       def parse_legacy_inventory(ems)
+        request_entities = OPENSHIFT_ENTITIES.dup
+        request_entities << {:name => 'images'} if refresher_options.get_container_images
+
         kube_entities = ems.with_provider_connection(:service => KUBERNETES_EMS_TYPE) do |kubeclient|
           fetch_entities(kubeclient, KUBERNETES_ENTITIES)
         end
         openshift_entities = ems.with_provider_connection do |openshift_client|
-          fetch_entities(openshift_client, OPENSHIFT_ENTITIES)
+          fetch_entities(openshift_client, request_entities)
         end
         entities = openshift_entities.merge(kube_entities)
         EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
-        ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities)
+        ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities, refresher_options)
       end
     end
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -157,8 +157,10 @@
   :kubernetes:
     :refresh_interval: 15.minutes
   :openshift:
+    :get_container_images: true
     :refresh_interval: 15.minutes
   :openshift_enterprise:
+    :get_container_images: true
     :refresh_interval: 15.minutes
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -142,6 +142,22 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     end
   end
 
+  it 'will skip container_images if get_container_images = false' do
+    stub_settings(Settings.to_hash.deep_merge(
+      :ems_refresh => {:openshift => {:get_container_images => false}},
+    ))
+
+    VCR.use_cassette(described_class.name.underscore,
+                     :match_requests_on              => [:path,],
+                     :allow_unused_http_interactions => true) do # , :record => :new_episodes) do
+      EmsRefresh.refresh(@ems)
+    end
+
+    @ems.reload
+
+    expect(ContainerImage.count).to eq(4)
+  end
+
   def assert_table_counts
     expect(ContainerGroup.count).to eq(5)
     expect(ContainerNode.count).to eq(1)


### PR DESCRIPTION
Cherry-pick of https://github.com/ManageIQ/manageiq/pull/14606 to euwe

In some OpenShift environments the number of container images can result
in extremely large API responses to the point where the connection will
timeout, as well as save_inventory times can be dramatically longer.

This adds a config option that if set to false will not request
container images from the /ImageList endpoint and will not parse them in
the RefreshParser.

https://bugzilla.redhat.com/show_bug.cgi?id=1484549