### PR TITLE
Rate selection using union of all tags in reporting(consumption) period

### DIFF
--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -1,7 +1,7 @@
 class Chargeback
   class ConsumptionWithRollups < Consumption
     delegate :timestamp, :resource, :resource_id, :resource_name, :resource_type, :parent_ems,
-             :hash_features_affecting_rate, :tag_list_with_prefix, :parents_determining_rate,
+             :hash_features_affecting_rate, :parents_determining_rate,
              :to => :first_metric_rollup_record
 
     def initialize(metric_rollup_records, start_time, end_time)
@@ -11,6 +11,10 @@ class Chargeback
 
     def tag_names
       first_metric_rollup_record.tag_names.split('|')
+    end
+
+    def tag_list_with_prefix
+      @tag_list_with_prefix ||= @rollups.map(&:tag_list_with_prefix).flatten.uniq
     end
 
     def max(metric)

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -10,14 +10,16 @@ class Chargeback
     end
 
     def hash_features_affecting_rate
-      tags = tag_names.reject { |n| n.starts_with?('folder_path_') }.sort.join('|')
-      keys = [tags] + first_metric_rollup_record.resource_parents.map(&:id)
-      keys += [first_metric_rollup_record.resource.container_image, timestamp] if resource_type == Container.name
-      keys.join('_')
+      @hash_features_affecting_rate ||= begin
+        tags = tag_names.reject { |n| n.starts_with?('folder_path_') }.sort.join('|')
+        keys = [tags] + first_metric_rollup_record.resource_parents.map(&:id)
+        keys += [first_metric_rollup_record.resource.container_image, timestamp] if resource_type == Container.name
+        keys.join('_')
+      end
     end
 
     def tag_names
-      @rollups.inject([]) do |memo, rollup|
+      @tag_names ||= @rollups.inject([]) do |memo, rollup|
         memo |= rollup.tag_names.split('|') if rollup.tag_names.present?
         memo
       end

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -1,7 +1,7 @@
 class Chargeback
   class ConsumptionWithRollups < Consumption
     delegate :timestamp, :resource, :resource_id, :resource_name, :resource_type, :parent_ems,
-             :hash_features_affecting_rate, :parents_determining_rate,
+             :parents_determining_rate,
              :to => :first_metric_rollup_record
 
     def initialize(metric_rollup_records, start_time, end_time)
@@ -9,8 +9,18 @@ class Chargeback
       @rollups = metric_rollup_records
     end
 
+    def hash_features_affecting_rate
+      tags = tag_names.reject { |n| n.starts_with?('folder_path_') }.sort.join('|')
+      keys = [tags] + first_metric_rollup_record.resource_parents.map(&:id)
+      keys += [first_metric_rollup_record.resource.container_image, timestamp] if resource_type == Container.name
+      keys.join('_')
+    end
+
     def tag_names
-      first_metric_rollup_record.tag_names.split('|')
+      @rollups.inject([]) do |memo, rollup|
+        memo |= rollup.tag_names.split('|') if rollup.tag_names.present?
+        memo
+      end
     end
 
     def tag_list_with_prefix

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -1,13 +1,6 @@
 module Metric::ChargebackHelper
   TAG_MANAGED_PREFIX = "/tag/managed/".freeze
 
-  def hash_features_affecting_rate
-    tags = tag_names.split('|').reject { |n| n.starts_with?('folder_path_') }.sort.join('|')
-    keys = [tags] + resource_parents.map(&:id)
-    keys += [resource.container_image, timestamp] if resource_type == Container.name
-    keys.join('_')
-  end
-
   def tag_prefix
     klass_prefix = case resource_type
                    when Container.name        then 'container_image'

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -67,6 +67,16 @@ describe ChargebackContainerImage do
 
     subject { ChargebackContainerImage.build_results_for_report_ChargebackContainerImage(options).first.first }
 
+    context 'when first metric rollup has tag_names=nil' do
+      before do
+        @container.metric_rollups.first.update_attributes(:tag_names => nil)
+      end
+
+      it "fixed_compute" do
+        expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
+      end
+    end
+
     it "fixed_compute" do
       expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
     end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -65,6 +65,18 @@ describe ChargebackContainerProject do
 
     subject { ChargebackContainerProject.build_results_for_report_ChargebackContainerProject(options).first.first }
 
+    context 'when first metric rollup has tag_names=nil' do
+      before do
+        @project.metric_rollups.first.update_attributes(:tag_names => nil)
+      end
+
+      it "cpu" do
+        metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day, @project)
+        expect(subject.cpu_cores_used_metric).to eq(metric_used)
+        expect(subject.cpu_cores_used_cost).to be_within(0.01).of(metric_used * hourly_rate * hours_in_day)
+      end
+    end
+
     it "cpu" do
       metric_used = used_average_for(:cpu_usage_rate_average, hours_in_day, @project)
       expect(subject.cpu_cores_used_metric).to eq(metric_used)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -130,6 +130,24 @@ describe ChargebackVm do
 
       subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
 
+      context 'when first metric rollup has tag_names=nil' do
+        before do
+          options[:tag] = nil
+          options[:entity_id] = @vm1.id
+          @vm1.metric_rollups.first.update_attributes(:tag_names => nil)
+        end
+
+        it "cpu" do
+          expect(subject.cpu_allocated_metric).to eq(cpu_count)
+          used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day, @vm1)
+          expect(subject.cpu_used_metric).to eq(used_metric)
+
+          expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
+          expect(subject.cpu_used_cost).to eq(used_metric * hourly_rate * hours_in_day)
+          expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
+        end
+      end
+
       it "cpu" do
         expect(subject.cpu_allocated_metric).to eq(cpu_count)
         used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_day, @vm1)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -499,6 +499,8 @@ describe ChargebackVm do
         [rate_assignment_options_1, rate_assignment_options_2].each do |rate_assignment|
           metric_rollup.tag_names = rate_assignment[:tag].first.tag.send(:name_path)
           uniq_rates = chargeback_vm.get(consumption)
+          consumption.instance_variable_set(:@tag_names, nil)
+          consumption.instance_variable_set(:@hash_features_affecting_rate, nil)
           expect([rate_assignment[:cb_rate]]).to match_array(uniq_rates)
         end
       end


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq/pull/15857

### Issue:
Metric rollups are grouped to so called consumption. we are charging and selection rates regard to consumption.  Tags to determine which rates should be selected were taken from first metric rollup
of consumption but it is possible that this rollup don't  have tags yet and it was causing the issue.

### Solution:
Fix is about taking tags from whole consumption period.

@gtanzillo I did small changes on your code and I added and fix specs. Thanks!

@miq-bot assign @gtanzillo 

@miq-bot add_label chargeback, bug


