### PR TITLE
Adding Child Managers to EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -26,6 +26,8 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   belongs_to :provider
+  has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
+
   include CustomAttributeMixin
   belongs_to :tenant
   has_many :container_deployments, :foreign_key => :deployed_on_ems_id, :inverse_of => :deployed_on_ems


### PR DESCRIPTION
* This PR is needed for Amazon refresh consolidation PR
  and
* Orchestrate destroy of dependent managers.

It allows us to say things like:

`ems.child_managers.collect ...` which gets all the child mangers
of a parent.

This PR is needed for the following PRs

https://github.com/ManageIQ/manageiq/pull/15711 & https://github.com/ManageIQ/manageiq/pull/15590