### PR TITLE
Skip blank/nil references while populating the refresher db index

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -1062,7 +1062,12 @@ module ManagerRefresh
         selection  = nil
         projection = nil
       else
-        selection  = extract_references(new_references)
+        references = extract_references(new_references)
+        selection = if references.empty?
+                      nil
+                    else
+                      references
+                    end
         projection = nil
       end
 
@@ -1099,6 +1104,7 @@ module ManagerRefresh
       hash_uuids_by_ref = []
 
       new_references.each do |manager_uuid|
+        next if manager_uuid.nil? || manager_uuid.blank?
         uuids = manager_uuid.split(stringify_joiner)
 
         reference = {}


### PR DESCRIPTION
This patch prevents the refresher from throwing an exception if a nil or blank uuid is passed in as a reference to be found. Also fixes a related exception if extract_references returns no results, since the empty list instead of a nil results in a query failing with a syntax error.