### PR TITLE
Make resources accessible on tags 

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,6 +3,7 @@ class Tag < ApplicationRecord
   has_one :classification
   virtual_has_one :category,       :class_name => "Classification"
   virtual_has_one :categorization, :class_name => "Hash"
+  virtual_has_many :resources
 
   has_many :container_label_tag_mappings
 
@@ -147,6 +148,10 @@ class Tag < ApplicationRecord
           "display_name" => "#{category.description}: #{classification.description}"
         }
       end
+  end
+
+  def resources
+    taggings.collect(&:taggable)
   end
 
   private


### PR DESCRIPTION
Through the tags collection API, you cannot currently get the resources that are tagged by any given tag because there is no direct relationship between the two.

A `has_many :taggables, :through => :taggings` is not possible due to the polymorphic relationship of the taggables. Most of the solutions I have seen suggest doing it this way via virtual attribute, or creating a relationship for each specific type of resource, which does not seem like it would solve our current problem because it is too specific (and it'd be ugly)

This solution would allow the api call to be:
`GET http://localhost:3000/api/tags/:id?attributes=resources` 
or 
`GET http://localhost:3000/api/tags?expand=resources&attributes=resources`

Thoughts? Also open to whether we should call this `resources` or `taggables`
@miq-bot assign @Fryguy 
cc: @nmaludy 