### PR TITLE
Optimize speed and stabilize the batch graph refresh memory usage

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -904,14 +904,6 @@ module ManagerRefresh
       @fixed_foreign_keys_cache
     end
 
-    def serializable_keys?(all_attribute_keys)
-      return @serializable_keys_cache unless @serializable_keys_cache.nil?
-
-      @serializable_keys_cache = all_attribute_keys.any? do |key|
-        model_class.type_for_attribute(key.to_s).respond_to?(:coder)
-      end
-    end
-
     def base_class_name
       return "" unless model_class
 

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -67,8 +67,6 @@ module ManagerRefresh::SaveCollection
 
         _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection.size} *************")
 
-        # TODO(lsmola) needed only because UPDATE FROM VALUES needs a specific PG typecasting, remove when fixed in PG
-        collect_pg_types!(all_attribute_keys)
         update_or_destroy_records!(batch_iterator(association), inventory_objects_index, attributes_index, all_attribute_keys)
 
         unless inventory_collection.custom_reconnect_block.nil?

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -51,6 +51,7 @@ module ManagerRefresh::SaveCollection
 
         inventory_collection.each do |inventory_object|
           attributes = inventory_object.attributes_with_keys(inventory_collection, all_attribute_keys)
+          # TODO(lsmola) unify this behavior with object_index_with_keys method in InventoryCollection
           index      = unique_index_keys.map { |key| attributes[key].to_s }.join(inventory_collection.stringify_joiner)
 
           # Interesting fact: not building attributes_index and using only inventory_objects_index doesn't do much
@@ -120,13 +121,11 @@ module ManagerRefresh::SaveCollection
 
               hash_for_update = if inventory_collection.use_ar_object?
                                   record.assign_attributes(hash.except(:id, :type))
-                                  values_for_database(inventory_collection.model_class,
-                                                      all_attribute_keys,
-                                                      record.attributes.symbolize_keys)
-                                elsif inventory_collection.serializable_keys?(all_attribute_keys)
-                                  values_for_database(inventory_collection.model_class,
-                                                      all_attribute_keys,
-                                                      hash)
+                                  values_for_database!(all_attribute_keys,
+                                                       record.attributes.symbolize_keys)
+                                elsif serializable_keys?
+                                  values_for_database!(all_attribute_keys,
+                                                       hash)
                                 else
                                   hash
                                 end
@@ -202,13 +201,11 @@ module ManagerRefresh::SaveCollection
         batch.each do |index, inventory_object|
           hash = if inventory_collection.use_ar_object?
                    record = inventory_collection.model_class.new(attributes_index.delete(index))
-                   values_for_database(inventory_collection.model_class,
-                                       all_attribute_keys,
-                                       record.attributes.symbolize_keys)
-                 elsif inventory_collection.serializable_keys?(all_attribute_keys)
-                   values_for_database(inventory_collection.model_class,
-                                       all_attribute_keys,
-                                       attributes_index.delete(index))
+                   values_for_database!(all_attribute_keys,
+                                        record.attributes.symbolize_keys)
+                 elsif serializable_keys?
+                   values_for_database!(all_attribute_keys,
+                                        attributes_index.delete(index))
                  else
                    attributes_index.delete(index)
                  end
@@ -234,12 +231,13 @@ module ManagerRefresh::SaveCollection
         end
       end
 
-      def values_for_database(model_class, all_attribute_keys, attributes)
-        all_attribute_keys.each_with_object({}) do |attribute_name, db_values|
-          type                      = model_class.type_for_attribute(attribute_name.to_s)
-          raw_val                   = attributes[attribute_name]
-          db_values[attribute_name] = type.type == :boolean ? type.cast(raw_val) : type.serialize(raw_val)
+      def values_for_database!(all_attribute_keys, attributes)
+        all_attribute_keys.each do |key|
+          if (type = serializable_keys[key])
+            attributes[key] = type.serialize(attributes[key])
+          end
         end
+        attributes
       end
 
       def map_ids_to_inventory_objects(indexed_inventory_objects, all_attribute_keys, hashes, result)

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -127,7 +127,7 @@ module ManagerRefresh::SaveCollection
       def quote_and_pg_type_cast(connection, value, name)
         pg_type_cast(
           connection.quote(value),
-          pg_type(name)
+          pg_types[name]
         )
       end
 
@@ -136,20 +136,6 @@ module ManagerRefresh::SaveCollection
           value
         else
           "#{value}::#{sql_type}"
-        end
-      end
-
-      def pg_type(name)
-        @pg_types_cache[name]
-      end
-
-      def collect_pg_types!(all_attribute_keys)
-        @pg_types_cache = {}
-        all_attribute_keys.each do |key|
-          @pg_types_cache[key] = inventory_collection.model_class.columns_hash[key.to_s]
-                                                     .try(:sql_type_metadata)
-                                                     .try(:instance_values)
-                                                     .try(:[], "sql_type")
         end
       end
     end


### PR DESCRIPTION
Optimize speed and stabilize the batch graph refresh memory usage

The refresh speed gain on a big environment(1.2M records) is about 10% and memory rise much less after the parsing step.