### PR TITLE
Adds new NotificationTypes - VM destroy, Cloud Volume and Cloud Volume Snapshot actions

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -174,3 +174,13 @@
   :expires_in: 24.hours
   :level: :error
   :audience: global
+- :name: vm_destroy_success
+  :message: 'Destroying Virtual Machine %{subject} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: vm_destroy_error
+  :message: 'Destroying Virtual Machine %{subject} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -184,3 +184,53 @@
   :expires_in: 24.hours
   :level: :error
   :audience: global
+- :name: cloud_volume_attach_success
+  :message: 'Attaching Volume %{subject} to Instance %{instance_name} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_attach_error
+  :message: 'Attaching Volume %{subject} to Instance %{instance_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
+- :name: cloud_volume_detach_success
+  :message: 'Detaching Volume %{subject} from Instance %{instance_name} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_detach_error
+  :message: 'Detaching Volume %{subject} from Instance %{instance_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
+- :name: cloud_volume_create_success
+  :message: 'Creating Volume %{volume_name} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_create_error
+  :message: 'Creating Volume %{volume_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
+- :name: cloud_volume_update_success
+  :message: 'Updating Volume %{subject} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_update_error
+  :message: 'Updating Volume %{subject} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
+- :name: cloud_volume_delete_success
+  :message: 'Deleting Volume %{subject} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_delete_error
+  :message: 'Deleting Volume %{subject} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -234,3 +234,23 @@
   :expires_in: 24.hours
   :level: :error
   :audience: global
+- :name: cloud_volume_snapshot_create_success
+  :message: 'Creating Snapshot %{snapshot_name} of Volume %{volume_name} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_snapshot_create_error
+  :message: 'Creating Snapshot %{snapshot_name} of Volume %{volume_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
+- :name: cloud_volume_snapshot_delete_success
+  :message: 'Deleting Snapshot %{subject} of Volume %{volume_name} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: cloud_volume_snapshot_delete_error
+  :message: 'Deleting Snapshot %{subject} of Volume %{volume_name} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global


### PR DESCRIPTION
In order to have actions in OpenStack provider create Notifications we need new NotificationTypes for them. Associated PR for OpenStack provider is https://github.com/ManageIQ/manageiq-providers-openstack/pull/85
