### PR TITLE
Fix web console for AWS, GCE and enable for RHOS

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -81,12 +81,13 @@ class ContainerNode < ApplicationRecord
   def cockpit_url
     URI::HTTP.build(:host => kubernetes_hostname, :port => 9090)
     address = kubernetes_hostname || name
-    miq_server = ext_management_system.nil? ? nil : ext_management_system.zone.remote_cockpit_ws_miq_server
-    if miq_server
-
-    end
+    miq_server = if ext_management_system.nil? || ext_management_system.zone.remote_cockpit_ws_miq_server.nil?
+                   nil
+                 else
+                   ext_management_system.zone.remote_cockpit_ws_miq_server
+                 end
     MiqCockpit::WS.url(miq_server,
-                       MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
+                       miq_server.nil? ? nil : MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
                        address)
   end
 

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -6,6 +6,7 @@ class ContainerNode < ApplicationRecord
   include TenantIdentityMixin
   include SupportsFeatureMixin
   include ArchivedMixin
+  include CockpitMixin
   include_concern 'Purging'
 
   EXTERNAL_LOGGING_PATH = "/#/discover?_g=()&_a=(columns:!(hostname,level,kubernetes.pod_name,message),filters:!((meta:(disabled:!f,index:'%{index}',key:hostname,negate:!f),%{query})),index:'%{index}',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!(time,desc))".freeze
@@ -81,14 +82,7 @@ class ContainerNode < ApplicationRecord
   def cockpit_url
     URI::HTTP.build(:host => kubernetes_hostname, :port => 9090)
     address = kubernetes_hostname || name
-    miq_server = if ext_management_system.nil? || ext_management_system.zone.remote_cockpit_ws_miq_server.nil?
-                   nil
-                 else
-                   ext_management_system.zone.remote_cockpit_ws_miq_server
-                 end
-    MiqCockpit::WS.url(miq_server,
-                       miq_server.nil? ? nil : MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
-                       address)
+    MiqCockpit::WS.url(cockpit_server, cockpit_worker, address)
   end
 
   def evaluate_alert(_alert_id, _event)

--- a/app/models/mixins/cockpit_mixin.rb
+++ b/app/models/mixins/cockpit_mixin.rb
@@ -1,0 +1,10 @@
+module CockpitMixin
+  extend ActiveSupport::Concern
+  def cockpit_server
+    ext_management_system.try(:zone).try(:remote_cockpit_ws_miq_server)
+  end
+
+  def cockpit_worker
+    cockpit_server.nil? ? nil : MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server)
+  end
+end

--- a/app/models/mixins/cockpit_mixin.rb
+++ b/app/models/mixins/cockpit_mixin.rb
@@ -5,6 +5,6 @@ module CockpitMixin
   end
 
   def cockpit_worker
-    cockpit_server.nil? ? nil : MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server)
+    cockpit_server.nil? ? nil : MiqCockpitWsWorker.fetch_worker_settings_from_server(cockpit_server)
   end
 end

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -28,6 +28,8 @@ module Vm::Operations
   def ipv4_address
     if %w(amazon google).include?(vendor.downcase)
       public_address
+    elsif %w(openstack).include?(vendor.downcase)
+      public_address.nil? ? floating_ip_addresses.first : public_address
     else
       ipaddresses.find { |ip| IPAddr.new(ip).ipv4? }
     end

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -15,10 +15,14 @@ module Vm::Operations
 
   def cockpit_url
     return if ipaddresses.blank?
-    miq_server = ext_management_system.nil? ? nil : ext_management_system.zone.remote_cockpit_ws_miq_server
+    miq_server = if ext_management_system.nil? || ext_management_system.zone.remote_cockpit_ws_miq_server.nil?
+                   nil
+                 else
+                   ext_management_system.zone.remote_cockpit_ws_miq_server
+                 end
     MiqCockpit::WS.url(miq_server,
-                       MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
-                       ipv4_address || ipaddresses.first)
+                       miq_server.nil? ? nil : MiqCockpitWsWorker.fetch_worker_settings_from_server(miq_server),
+                       ipv4_address || ipaddresses.first).to_s
   end
 
   def ipv4_address

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -26,7 +26,15 @@ module Vm::Operations
   end
 
   def ipv4_address
-    ipaddresses.find { |ip| IPAddr.new(ip).ipv4? }
+    if %w(amazon google).include?(vendor.downcase)
+      public_address
+    else
+      ipaddresses.find { |ip| IPAddr.new(ip).ipv4? }
+    end
+  end
+
+  def public_address
+    ipaddresses.find { |ip| !Addrinfo.tcp(ip, 80).ipv4_private? }
   end
 
   def validate_collect_running_processes

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -26,7 +26,7 @@ module Vm::Operations
   end
 
   def public_address
-    ipaddresses.find { |ip| !Addrinfo.tcp(ip, 80).ipv4_private? }
+    ipaddresses.find { |ip| !Addrinfo.tcp(ip, 80).ipv4_private? && IPAddr.new(ip).ipv4? }
   end
 
   def validate_collect_running_processes

--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -22,7 +22,7 @@ module Vm::Operations
 
   def ipv4_address
     return public_address unless public_address.nil?
-    ipaddresses.find { |ip| IPAddr.new(ip).ipv4? unless ip.starts_with?('192') }
+    ipaddresses.find { |ip| IPAddr.new(ip).ipv4? && !ip.starts_with?('192') }
   end
 
   def public_address

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -14,7 +14,7 @@ describe 'VM::Operations' do
   context '#cockpit_url' do
     it '#returns a valid Cockpit url' do
       url = @vm.send(:cockpit_url)
-      expect(url).to eq('http://127.0.0.1:9090')
+      expect(url).to eq(URI::HTTP.build(:host => "127.0.0.1", :port => 9090))
     end
   end
 

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -1,25 +1,62 @@
 describe 'VM::Operations' do
   before(:each) do
-    miq_server = EvmSpecHelper.local_miq_server
-    @ems       = FactoryGirl.create(:ems_vmware, :zone => miq_server.zone)
-    @vm        = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
-    allow(@vm).to receive(:ipaddresses).and_return(@ipaddresses)
+    @miq_server = EvmSpecHelper.local_miq_server
+    @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
+    @vm         = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
+    ipaddresses = %w(fe80::21a:4aff:fe22:dde5 127.0.0.1)
+    allow(@vm).to receive(:ipaddresses).and_return(ipaddresses)
+
+    @hardware = FactoryGirl.create(:hardware)
+    @hardware.ipaddresses << '10.142.0.2'
+    @hardware.ipaddresses << '35.190.140.48'
   end
 
   context '#cockpit_url' do
     it '#returns a valid Cockpit url' do
-      @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 127.0.0.1)
-      expect(@vm).to receive(:cockpit_url).and_return('http://127.0.0.1:9090')
-      @vm.send(:cockpit_url)
+      url = @vm.send(:cockpit_url)
+      expect(url).to eq('http://127.0.0.1:9090')
     end
   end
 
   context '#ipv4_address' do
-    after(:each) { @vm.send(:return_ipv4_address) }
-
     it 'returns the existing ipv4 address' do
-      @ipaddresses = %w(fe80::21a:4aff:fe22:dde5 127.0.0.1)
-      expect(@vm).to receive(:return_ipv4_address).and_return('127.0.0.1')
+      url = @vm.send(:ipv4_address)
+      expect(url).to eq('127.0.0.1')
+    end
+
+    context 'cloud providers' do
+      before(:each) { @ipaddresses = %w(10.10.1.121 35.190.140.48) }
+      it 'returns the public ipv4 address for AWS' do
+        ems = FactoryGirl.create(:ems_google, :project => 'manageiq-dev')
+        az  = FactoryGirl.create(:availability_zone_google)
+        vm = FactoryGirl.create(:vm_google,
+                                :ext_management_system => ems,
+                                :ems_ref               => 123,
+                                :availability_zone     => az,
+                                :hardware              => @hardware)
+        allow(vm).to receive(:ipaddresses).and_return(@ipaddresses)
+        url = vm.send(:ipv4_address)
+        expect(url).to eq('35.190.140.48')
+      end
+
+      it 'returns the public ipv4 address for GCE' do
+        ems = FactoryGirl.create(:ems_amazon)
+        vm = FactoryGirl.create(:vm_amazon, :ext_management_system => ems, :hardware => @hardware)
+        allow(vm).to receive(:ipaddresses).and_return(@ipaddresses)
+        url = vm.send(:ipv4_address)
+        expect(url).to eq('35.190.140.48')
+      end
+    end
+  end
+
+  context '#public_address' do
+    it 'returns a public ipv4 address' do
+      ipaddresses = %w(10.10.1.121 35.190.140.48)
+      ems = FactoryGirl.create(:ems_amazon)
+      vm = FactoryGirl.create(:vm_amazon, :ext_management_system => ems, :hardware => @hardware)
+      allow(vm).to receive(:ipaddresses).and_return(ipaddresses)
+      url = vm.send(:public_address)
+      expect(url).to eq('35.190.140.48')
     end
   end
 end


### PR DESCRIPTION
This fixes Cockpit console from attempting to connect to AWS and GCE on private instead of public ip addresses and enables Cockpit console for RHOS.

Needs to be reviewed at the same time as https://github.com/ManageIQ/manageiq-ui-classic/pull/2039.

@miq-bot add_labels bug, core, ui

https://bugzilla.redhat.com/show_bug.cgi?id=1450109
https://bugzilla.redhat.com/show_bug.cgi?id=1451655
