### PR TITLE
Have parent inventory collections as dependencies

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -423,7 +423,7 @@ module ManagerRefresh
       @custom_save_block      = custom_save_block
       @custom_reconnect_block = custom_reconnect_block
       @check_changed          = check_changed.nil? ? true : check_changed
-      @internal_attributes    = [:__feedback_edge_set_parent]
+      @internal_attributes    = [:__feedback_edge_set_parent, :__parent_inventory_collections]
       @complete               = complete.nil? ? true : complete
       @update_only            = update_only.nil? ? false : update_only
       @builder_params         = builder_params

--- a/app/models/manager_refresh/inventory_collection/scanner.rb
+++ b/app/models/manager_refresh/inventory_collection/scanner.rb
@@ -69,11 +69,14 @@ module ManagerRefresh
         if parent_inventory_collections.present?
           self.parent_inventory_collections = parent_inventory_collections.map do |inventory_collection_index|
             ic = indexed_inventory_collections[inventory_collection_index]
-            raise "Can't find InventoryCollection #{inventory_collection_index} from #{inventory_collection}" unless ic
-            # Add parent_inventory_collection as a dependency, so e.g. disconnect is done in a right order
-            (dependency_attributes[:__parent_inventory_collections] ||= Set.new) << ic
-            ic
-          end
+            if ic.nil?
+              raise "Can't find InventoryCollection #{inventory_collection_index} from #{inventory_collection}" if targeted?
+            else
+              # Add parent_inventory_collection as a dependency, so e.g. disconnect is done in a right order
+              (dependency_attributes[:__parent_inventory_collections] ||= Set.new) << ic
+              ic
+            end
+          end.compact
         end
 
         # Mark InventoryCollection as finalized aka. scanned

--- a/app/models/manager_refresh/inventory_collection/scanner.rb
+++ b/app/models/manager_refresh/inventory_collection/scanner.rb
@@ -66,10 +66,12 @@ module ManagerRefresh
         end
 
         # Transform :parent_inventory_collections symbols to InventoryCollection objects
-        if targeted? && parent_inventory_collections.present?
+        if parent_inventory_collections.present?
           self.parent_inventory_collections = parent_inventory_collections.map do |inventory_collection_index|
             ic = indexed_inventory_collections[inventory_collection_index]
             raise "Can't find InventoryCollection #{inventory_collection_index} from #{inventory_collection}" unless ic
+            # Add parent_inventory_collection as a dependency, so e.g. disconnect is done in a right order
+            (dependency_attributes[:__parent_inventory_collections] ||= Set.new) << ic
             ic
           end
         end

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -331,7 +331,8 @@ describe ManagerRefresh::SaveInventory do
               :attributes_whitelist => [:raw_power_state, :ext_management_system]
             )
 
-            expect(inventory_collection.attributes_whitelist).to match_array([:__feedback_edge_set_parent, :ems_ref,
+            expect(inventory_collection.attributes_whitelist).to match_array([:__feedback_edge_set_parent,
+                                                                              :__parent_inventory_collections, :ems_ref,
                                                                               :name, :location, :raw_power_state,
                                                                               :ext_management_system])
           end
@@ -358,7 +359,8 @@ describe ManagerRefresh::SaveInventory do
               :attributes_whitelist => [:raw_power_state, :ext_management_system]
             )
 
-            expect(inventory_collection.attributes_whitelist).to match_array([:__feedback_edge_set_parent, :uid_ems,
+            expect(inventory_collection.attributes_whitelist).to match_array([:__feedback_edge_set_parent,
+                                                                              :__parent_inventory_collections, :uid_ems,
                                                                               :name, :location, :raw_power_state,
                                                                               :ext_management_system])
           end


### PR DESCRIPTION
Have parent inventory collections as dependencies, so we always ensure that disconnect is done via parent(dependency), even if the current collection is empty.