### PR TITLE
If the userid is not found in the DB do a case insensitive search

### DIFF
--- a/app/models/authenticator/database.rb
+++ b/app/models/authenticator/database.rb
@@ -11,7 +11,7 @@ module Authenticator
     private
 
     def _authenticate(username, password, _request)
-      user = User.find_by_userid(username)
+      user = case_insensitive_find_by_userid(username)
 
       user && user.authenticate_bcrypt(password)
     end

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -73,15 +73,11 @@ module Authenticator
     private
 
     def find_userid_as_upn(upn_username)
-      user = User.find_by_userid(upn_username)
-      user || User.in_my_region.where('lower(userid) = ?', upn_username).order(:lastlogon).last
+      case_insensitive_find_by_userid(upn_username)
     end
 
     def find_userid_as_username(identity, username)
-      userid = userid_for(identity, username)
-      user   = User.find_by_userid(userid)
-      user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
-      user
+      case_insensitive_find_by_userid(userid_for(identity, username))
     end
 
     def find_userid_as_distinguished_name(user_attrs)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1486041

If the appliance administrator manually creates a user in mixed case it would not be found.

This change will do a case insensitive search for the user. To minimize unnecessary
performance degradation, it will only do the case insensitive search if the user can
not be found as presented.

Steps for Testing/QA [Optional]
-------------------------------

1. Configure an appliance for authentication `Mode: LDAP(s)`
2. Manually configure a new user with a mixed case userid.
3. Attempt to log in as that user but enter the username in all upper case.
