### PR TITLE
Remove role 'migration' at startup

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -50,27 +50,6 @@ class MiqServer < ApplicationRecord
   end
 
   def self.atStartup
-    starting_roles = ::Settings.server.role
-
-    # Change the database role to database_operations
-    roles = starting_roles.dup
-    if roles.gsub!(/\bdatabase\b/, 'database_operations')
-      MiqServer.my_server.set_config(:server => {:role => roles})
-    end
-
-    # Roles Changed!
-    roles = ::Settings.server.role
-    if roles != starting_roles
-      # tell the server to pick up the role change
-      server = MiqServer.my_server
-      server.sync_assigned_roles
-      server.sync_active_roles
-      server.set_active_role_flags
-    end
-    invoke_at_startups
-  end
-
-  def self.invoke_at_startups
     _log.info("Invoking startup methods")
     RUN_AT_STARTUP.each do |klass|
       _log.info("Invoking startup method for #{klass}")

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,7 +1,7 @@
 describe MiqServer do
   include_examples ".seed called multiple times"
 
-  it ".invoke_at_startups" do
+  it ".atStartup" do
     MiqRegion.seed
     described_class::RUN_AT_STARTUP.each do |klass|
       next unless klass.respond_to?(:atStartup)
@@ -9,7 +9,7 @@ describe MiqServer do
     end
 
     expect(Vmdb.logger).to receive(:log_backtrace).never
-    described_class.invoke_at_startups
+    described_class.atStartup
   end
 
   context ".my_guid" do


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-schema/pull/58, which converts this to a one-time migration.

@jrafanie Please review.