### PR TITLE
Denormalize the various atStartup methods into MiqServer::AtStartup

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -501,23 +501,6 @@ class MiqQueue < ApplicationRecord
     !finished?
   end
 
-  def self.atStartup
-    _log.info("Cleaning up queue messages...")
-    MiqQueue.where(:state => STATE_DEQUEUE).each do |message|
-      if message.handler.nil?
-        _log.warn("Cleaning message in dequeue state without worker: #{format_full_log_msg(message)}")
-      else
-        handler_server = message.handler            if message.handler.kind_of?(MiqServer)
-        handler_server = message.handler.miq_server if message.handler.kind_of?(MiqWorker)
-        next unless handler_server == MiqServer.my_server
-
-        _log.warn("Cleaning message: #{format_full_log_msg(message)}")
-      end
-      message.update_attributes(:state => STATE_ERROR) rescue nil
-    end
-    _log.info("Cleaning up queue messages... Complete")
-  end
-
   def self.format_full_log_msg(msg)
     "Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{MiqPassword.sanitize_string(msg.args.inspect)}"
   end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -261,43 +261,6 @@ class MiqRegion < ApplicationRecord
   end
 
   #
-  # Region atStartup - log all management systems
-  #
-
-  def self.atStartup
-    region = my_region
-    prefix = "#{_log.prefix} Region: [#{region.region}], name: [#{region.name}]"
-    log_under_management(prefix)
-    log_not_under_management(prefix)
-  end
-
-  def self.log_under_management(prefix)
-    total_vms     = 0
-    total_hosts   = 0
-    total_sockets = 0
-
-    ExtManagementSystem.all.each do |e|
-      vms     = e.all_vms_and_templates.count
-      hosts   = e.all_hosts.count
-      sockets = e.aggregate_physical_cpus
-      $log.info("#{prefix}, EMS: [#{e.id}], Name: [#{e.name}], IP Address: [#{e.ipaddress}], Hostname: [#{e.hostname}], VMs: [#{vms}], Hosts: [#{hosts}], Sockets: [#{sockets}]")
-
-      total_vms += vms
-      total_hosts += hosts
-      total_sockets += sockets
-    end
-    $log.info("#{prefix}, Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}], Sockets: [#{total_sockets}]")
-  end
-
-  def self.log_not_under_management(prefix)
-    hosts_objs = Host.where(:ems_id => nil)
-    hosts      = hosts_objs.count
-    vms        = VmOrTemplate.where(:ems_id => nil).count
-    sockets    = my_region.aggregate_physical_cpus(hosts_objs)
-    $log.info("#{prefix}, Not Under Management: VMs: [#{vms}], Hosts: [#{hosts}], Sockets: [#{sockets}]")
-  end
-
-  #
   # Region level metric capture always methods
   #
 

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -115,12 +115,6 @@ class MiqReportResult < ApplicationRecord
     save
   end
 
-  def self.atStartup
-    _log.info("Purging adhoc report results...")
-    purge_for_user
-    _log.info("Purging adhoc report results... complete")
-  end
-
   #########################################################################################################
   # FIXME:  Hack because userid column is overridden with multiple column info using | character
   #
@@ -140,6 +134,10 @@ class MiqReportResult < ApplicationRecord
     return parts[0] if (parts.last == 'adhoc')
     return parts[1] if (parts.last == 'schedule')
     raise _("Cannot parse userid %{user_id}") % {:user_id => userid.inspect}
+  end
+
+  def self.purge_for_all_users
+    purge_for_user(:userid => "%")
   end
 
   def self.purge_for_user(options = {})

--- a/app/models/miq_server/at_startup.rb
+++ b/app/models/miq_server/at_startup.rb
@@ -1,0 +1,74 @@
+module MiqServer::AtStartup
+  extend ActiveSupport::Concern
+  include Vmdb::Logging
+
+  module ClassMethods
+    def log_managed_entities
+      region = MiqRegion.my_region
+      prefix = "#{_log.prefix} Region: [#{region.region}], name: [#{region.name}]"
+      log_under_management(prefix)
+      log_not_under_management(prefix)
+    end
+
+    # Delete and Kill all workers that were running previously
+    def clean_all_workers
+      _log.info("Cleaning up all workers...")
+      MiqWorker.server_scope.each do |w|
+        Process.kill(9, w.pid) if w.pid && w.is_alive? rescue nil
+        w.destroy
+      end
+      _log.info("Cleaning up all workers...Complete")
+    end
+
+    def clean_dequeued_messages
+      _log.info("Cleaning up dequeued messages...")
+      MiqQueue.where(:state => MiqQueue::STATE_DEQUEUE).each do |message|
+        if message.handler.nil?
+          _log.warn("Cleaning message in dequeue state without worker: #{MiqQueue.format_full_log_msg(message)}")
+        else
+          handler_server = message.handler            if message.handler.kind_of?(MiqServer)
+          handler_server = message.handler.miq_server if message.handler.kind_of?(MiqWorker)
+          next unless handler_server == MiqServer.my_server
+
+          _log.warn("Cleaning message: #{MiqQueue.format_full_log_msg(message)}")
+        end
+        message.update_attributes(:state => MiqQueue::STATE_ERROR) rescue nil
+      end
+      _log.info("Cleaning up dequeued messages...Complete")
+    end
+
+    def purge_report_results
+      _log.info("Purging adhoc report results...")
+      MiqReportResult.purge_for_all_users
+      _log.info("Purging adhoc report results...Complete")
+    end
+
+    private
+
+    def log_under_management(prefix)
+      total_vms     = 0
+      total_hosts   = 0
+      total_sockets = 0
+
+      ExtManagementSystem.all.each do |e|
+        vms     = e.all_vms_and_templates.count
+        hosts   = e.all_hosts.count
+        sockets = e.aggregate_physical_cpus
+        $log.info("#{prefix}, EMS: [#{e.id}], Name: [#{e.name}], IP Address: [#{e.ipaddress}], Hostname: [#{e.hostname}], VMs: [#{vms}], Hosts: [#{hosts}], Sockets: [#{sockets}]")
+
+        total_vms += vms
+        total_hosts += hosts
+        total_sockets += sockets
+      end
+      $log.info("#{prefix}, Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}], Sockets: [#{total_sockets}]")
+    end
+
+    def log_not_under_management(prefix)
+      hosts_objs = Host.where(:ems_id => nil)
+      hosts      = hosts_objs.count
+      vms        = VmOrTemplate.where(:ems_id => nil).count
+      sockets    = MiqRegion.my_region.aggregate_physical_cpus(hosts_objs)
+      $log.info("#{prefix}, Not Under Management: VMs: [#{vms}], Hosts: [#{hosts}], Sockets: [#{sockets}]")
+    end
+  end
+end

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -24,7 +24,7 @@ module MiqServer::NtpManagement
   end
 
   # Called when zone ntp settings changed... run by the appropriate server
-  # Also, called in atStartup of miq_server and on a configuration change for the server
+  # Also, called in start of miq_server and on a configuration change for the server
   def ntp_reload(ntp_settings = server_ntp_settings)
     # matches ntp_reload_queue's guard clause
     return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_container?

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -32,10 +32,6 @@ class MiqWorker < ApplicationRecord
   PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time proportional_set_size)
 
   PROCESS_TITLE_PREFIX = "MIQ:".freeze
-  def self.atStartup
-    # Delete and Kill all workers that were running previously
-    clean_all_workers
-  end
 
   def self.atShutdown
     stop_all_workers
@@ -244,13 +240,6 @@ class MiqWorker < ApplicationRecord
     find_current(server_id).each(&:restart)
   end
 
-  def self.clean_workers
-    server_scope.each do |w|
-      Process.kill(9, w.pid) if w.pid && w.is_alive? rescue nil
-      w.destroy
-    end
-  end
-
   def self.status_update
     find_current.each(&:status_update)
   end
@@ -287,10 +276,6 @@ class MiqWorker < ApplicationRecord
 
   def self.restart_all_workers(server_id = nil)
     MiqWorker.restart_workers(server_id)
-  end
-
-  def self.clean_all_workers
-    MiqWorker.clean_workers
   end
 
   def self.status_update_all

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -36,64 +36,15 @@ describe MiqQueue do
     end
   end
 
-  context "With messages left in dequeue at startup," do
-    before do
-      _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+  describe "#check_for_timeout" do
+    it "will destroy a dequeued message when it times out" do
+      handler = FactoryGirl.create(:miq_ems_refresh_worker)
+      msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => handler, :msg_timeout => 1.minute)
 
-      @other_miq_server = FactoryGirl.create(:miq_server, :zone => @miq_server.zone)
-
-      @worker       = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
-      @other_worker = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @other_miq_server.id)
-    end
-
-    context "where worker has a message in dequeue" do
-      before do
-        @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @worker)
-      end
-
-      it "will destroy the message when it times out" do
-        @msg.update_attributes(:msg_timeout => 1.minutes)
-        begin
-          Timecop.travel 10.minute
-          expect($log).to receive(:warn)
-          expect(@msg).to receive(:destroy)
-          @msg.check_for_timeout
-        ensure
-          Timecop.return
-        end
-      end
-
-      it "should cleanup message on startup" do
-        MiqQueue.atStartup
-
-        @msg.reload
-        expect(@msg.state).to eq(MiqQueue::STATE_ERROR)
-      end
-    end
-
-    context "where worker on other server has a message in dequeue" do
-      before do
-        @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @other_worker)
-      end
-
-      it "should not cleanup message on startup" do
-        MiqQueue.atStartup
-
-        @msg.reload
-        expect(@msg.state).to eq(MiqQueue::STATE_DEQUEUE)
-      end
-    end
-
-    context "message in dequeue without a worker" do
-      before do
-        @msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE)
-      end
-
-      it "should cleanup message on startup" do
-        MiqQueue.atStartup
-
-        @msg.reload
-        expect(@msg.state).to eq(MiqQueue::STATE_ERROR)
+      Timecop.travel(10.minutes) do
+        expect($log).to receive(:warn)
+        expect(msg).to receive(:destroy)
+        msg.check_for_timeout
       end
     end
   end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -42,14 +42,6 @@ describe MiqRegion do
     end
   end
 
-  it ".log_not_under_management" do
-    MiqRegion.seed
-    FactoryGirl.create(:host_vmware)
-    FactoryGirl.create(:vm_vmware)
-    expect($log).to receive(:info).with(/VMs: \[1\], Hosts: \[1\]/)
-    described_class.log_not_under_management("")
-  end
-
   context ".seed" do
     before do
       @region_number = 99

--- a/spec/models/miq_server/at_startup_spec.rb
+++ b/spec/models/miq_server/at_startup_spec.rb
@@ -1,0 +1,51 @@
+describe MiqServer, "::AtStartup" do
+  describe ".clean_dequeued_messages" do
+    before do
+      _guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+    end
+
+    context "where worker has a message in dequeue" do
+      it "should cleanup message on startup" do
+        worker = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => @miq_server.id)
+        msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => worker)
+
+        described_class.clean_dequeued_messages
+
+        msg.reload
+        expect(msg.state).to eq(MiqQueue::STATE_ERROR)
+      end
+    end
+
+    context "where worker on other server has a message in dequeue" do
+      it "should not cleanup message on startup" do
+        other_miq_server = FactoryGirl.create(:miq_server, :zone => @zone)
+        other_worker = FactoryGirl.create(:miq_ems_refresh_worker, :miq_server_id => other_miq_server.id)
+        msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => other_worker)
+
+        described_class.clean_dequeued_messages
+
+        msg.reload
+        expect(msg.state).to eq(MiqQueue::STATE_DEQUEUE)
+      end
+    end
+
+    context "message in dequeue without a worker" do
+      it "should cleanup message on startup" do
+        msg = FactoryGirl.create(:miq_queue, :state => MiqQueue::STATE_DEQUEUE)
+
+        described_class.clean_dequeued_messages
+
+        msg.reload
+        expect(msg.state).to eq(MiqQueue::STATE_ERROR)
+      end
+    end
+  end
+
+  it ".log_not_under_management (private)" do
+    MiqRegion.seed
+    FactoryGirl.create(:host_vmware)
+    FactoryGirl.create(:vm_vmware)
+    expect($log).to receive(:info).with(/VMs: \[1\], Hosts: \[1\]/)
+    described_class.send(:log_not_under_management, "")
+  end
+end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,17 +1,6 @@
 describe MiqServer do
   include_examples ".seed called multiple times"
 
-  it ".atStartup" do
-    MiqRegion.seed
-    described_class::RUN_AT_STARTUP.each do |klass|
-      next unless klass.respond_to?(:atStartup)
-      expect(klass.constantize).to receive(:atStartup)
-    end
-
-    expect(Vmdb.logger).to receive(:log_backtrace).never
-    described_class.atStartup
-  end
-
   context ".my_guid" do
     let(:guid_file) { Rails.root.join("GUID") }
 


### PR DESCRIPTION
As I was working on extracting the ManageIQ Orchestrator, this particular set up of methods were confusing being scattered all over the place.  This contains them to one location, which makes it much easier to understand.  Also it kills that silly camelCase method :wink:

Note that this PR includes #15905 indirectly, so if that one is merged first, then this one will conflict (which is OK)

One enlightening thing was that we purge all MiqReportResults for all users at boot o_O ... I kept it for now, but o_O

@jrafanie @carbonin Please review.