### PR TITLE
Add Metering Used Hours to chargeback report

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -20,6 +20,7 @@ class ChargeableField < ApplicationRecord
   validates :group, :source, :presence => true
 
   def measure(consumption, options)
+    return consumption.consumed_hours_in_interval if metering?
     return 1.0 if fixed?
     return 0 if consumption.none?(metric)
     return consumption.send(options.method_for_allocated_metrics, metric) if allocated?
@@ -43,6 +44,10 @@ class ChargeableField < ApplicationRecord
     ["#{rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
      "#{group}_cost",       # cost associated with metric's group (e.g. Storage Total Cost)
      'total_cost']
+  end
+
+  def metering?
+    group == 'metering' && source == 'used'
   end
 
   private

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -8,6 +8,8 @@ class Chargeback < ActsAsArModel
     :entity               => :binary,
     :tag_name             => :string,
     :fixed_compute_metric => :integer,
+    :metering_used_metric => :integer,
+    :metering_used_cost   => :float
   )
 
   def self.build_results_for_report_chargeback(options)

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -83,6 +83,8 @@ class ChargebackContainerImage < Chargeback
       "fixed_cost"            => {:grouping => [:total]},
       "memory_used_cost"      => {:grouping => [:total]},
       "memory_used_metric"    => {:grouping => [:total]},
+      "metering_used_metric"  => {:grouping => [:total]},
+      "metering_used_cost"    => {:grouping => [:total]},
       "net_io_used_cost"      => {:grouping => [:total]},
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -64,6 +64,8 @@ class ChargebackContainerProject < Chargeback
       "fixed_cost"            => {:grouping => [:total]},
       "memory_used_cost"      => {:grouping => [:total]},
       "memory_used_metric"    => {:grouping => [:total]},
+      "metering_used_metric"  => {:grouping => [:total]},
+      "metering_used_cost"    => {:grouping => [:total]},
       "net_io_used_cost"      => {:grouping => [:total]},
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -164,7 +164,9 @@ class ChargebackRateDetail < ApplicationRecord
 
   def metric_and_cost_by(consumption, options)
     metric_value = chargeable_field.measure(consumption, options)
-    [metric_value, hourly_cost(metric_value, consumption) * consumption.consumed_hours_in_interval]
+    hourly_cost = hourly_cost(metric_value, consumption)
+    cost = chargeable_field.metering? ? hourly_cost : hourly_cost * consumption.consumed_hours_in_interval
+    [metric_value, cost]
   end
 
   def first_tier?(tier,tiers)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -88,6 +88,8 @@ class ChargebackVm < Chargeback
       "memory_cost"              => {:grouping => [:total]},
       "memory_used_cost"         => {:grouping => [:total]},
       "memory_used_metric"       => {:grouping => [:total]},
+      "metering_used_cost"       => {:grouping => [:total]},
+      "metering_used_metric"     => {:grouping => [:total]},
       "net_io_used_cost"         => {:grouping => [:total]},
       "net_io_used_metric"       => {:grouping => [:total]},
       "storage_allocated_cost"   => {:grouping => [:total]},

--- a/db/fixtures/chargeable_fields.yml
+++ b/db/fixtures/chargeable_fields.yml
@@ -58,3 +58,8 @@
   :group: fixed
   :source: storage_2
   :description: Fixed Storage Cost 2
+- :metric: user_metering_hours
+  :group: metering
+  :source: used
+  :description: Metering - Hours Used
+

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -96,6 +96,16 @@
       :finish: Infinity
       :fixed_rate: 0.0
       :variable_rate: 0.0
+  - :description: Metering - Hours Used
+    :metric: user_metering_hours
+    :per_time: hourly
+    :per_unit: hours
+    :type_currency: Dollars
+    :tiers:
+    - :start: 0
+      :finish: Infinity
+      :fixed_rate: 0.0
+      :variable_rate: 1
 - :description: Default
   :guid: 7d7aaf20-5214-11df-a888-001d09066d98
   :rate_type: Storage

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -48,6 +48,7 @@
     :memory_used_cost: :currency_precision_2
     :memory_allocated_cost: :currency_precision_2
     :memory_cost: :currency_precision_2
+    :metering_used_cost: :currency_precision_2
     :storage_used_cost: :currency_precision_2
     :storage_allocated_cost: :currency_precision_2
     :storage_cost: :currency_precision_2
@@ -191,6 +192,7 @@
     :memory_used_metric: :megabytes_precision_2
     :memory_mb: :megabytes
     :mem_cpu: :megabytes
+    :metering_used_metric: :hours
     :min_derived_memory_used: :megabytes
     :ram_size: :megabytes
     :trend_derived_memory_used: :megabytes
@@ -473,6 +475,17 @@
       :name: mhz_to_human_size
       :delimiter: ","
     :precision: 1
+
+  :hours:
+    :description: Hours
+    :columns:
+    :sub_types:
+    - :hours
+    :function:
+    :function:
+      :name: number_with_delimiter
+      :delimiter: ","
+      :suffix: ! ' Hours'
 
   :mhz_precision_2:
     :description: Megahertz Avg (12.11 Mhz)

--- a/spec/factories/chargeable_field.rb
+++ b/spec/factories/chargeable_field.rb
@@ -82,4 +82,11 @@ FactoryGirl.define do
     source      'used'
     detail_measure { FactoryGirl.build(:chargeback_measure_bytes) }
   end
+
+  factory :chargeable_field_metering_used, :parent => :chargeable_field do
+    description 'Metering Used Hours'
+    metric      'metering_used_hours'
+    group       'metering'
+    source      'used'
+  end
 end

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -42,6 +42,7 @@ FactoryGirl.define do
           chargeback_rate_detail_memory_allocated
           chargeback_rate_detail_memory_used
           chargeback_rate_detail_net_io_used
+          chargeback_rate_detail_metering_used
         ).each do |factory_name|
           chargeback_rate.chargeback_rate_details << FactoryGirl.create(factory_name,
                                                                         :tiers_with_three_intervals,

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -97,4 +97,8 @@ FactoryGirl.define do
   factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
     chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
+
+  factory :chargeback_rate_detail_metering_used, :traits => [:daily], :parent => :chargeback_rate_detail do
+    chargeable_field { FactoryGirl.build(:chargeable_field_metering_used) }
+  end
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -13,7 +13,12 @@ describe ChargebackContainerImage do
 
   let(:hourly_variable_tier_rate) { {:variable_rate => hourly_rate.to_s} }
 
-  let(:detail_params) { {:chargeback_rate_detail_fixed_compute_cost => { :tiers => [hourly_variable_tier_rate] } } }
+  let(:detail_params) do
+    {
+      :chargeback_rate_detail_fixed_compute_cost => {:tiers => [hourly_variable_tier_rate]},
+      :chargeback_rate_detail_metering_used      => {:tiers => [hourly_variable_tier_rate]}
+    }
+  end
 
   let!(:chargeback_rate) do
     FactoryGirl.create(:chargeback_rate, :detail_params => detail_params)
@@ -80,6 +85,11 @@ describe ChargebackContainerImage do
     it "fixed_compute" do
       expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
     end
+
+    it 'calculates metering used hours and cost' do
+      expect(subject.metering_used_metric).to eq(hours_in_day)
+      expect(subject.metering_used_cost).to eq(hours_in_day * hourly_rate)
+    end
   end
 
   context "Monthly" do
@@ -99,6 +109,11 @@ describe ChargebackContainerImage do
     it "fixed_compute" do
       # .to be_within(0.01) is used since theres a float error here
       expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
+    end
+
+    it 'calculates metering used hours and cost' do
+      expect(subject.metering_used_metric).to eq(hours_in_month)
+      expect(subject.metering_used_cost).to eq(hours_in_month * hourly_rate)
     end
   end
 

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -18,7 +18,8 @@ describe ChargebackContainerProject do
       :chargeback_rate_detail_fixed_compute_cost => {:tiers => [hourly_variable_tier_rate]},
       :chargeback_rate_detail_cpu_cores_used     => {:tiers => [hourly_variable_tier_rate]},
       :chargeback_rate_detail_net_io_used        => {:tiers => [hourly_variable_tier_rate]},
-      :chargeback_rate_detail_memory_used        => {:tiers => [hourly_variable_tier_rate]}
+      :chargeback_rate_detail_memory_used        => {:tiers => [hourly_variable_tier_rate]},
+      :chargeback_rate_detail_metering_used      => {:tiers => [hourly_variable_tier_rate]}
     }
   end
 
@@ -99,6 +100,11 @@ describe ChargebackContainerProject do
       expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
       expect(subject.fixed_compute_metric).to eq(@metric_size)
     end
+
+    it 'calculates metering used hours and cost' do
+      expect(subject.metering_used_metric).to eq(hours_in_day)
+      expect(subject.metering_used_cost).to eq(hours_in_day * hourly_rate)
+    end
   end
 
   context "Monthly" do
@@ -132,6 +138,11 @@ describe ChargebackContainerProject do
       # .to be_within(0.01) is used since theres a float error here
       expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
       expect(subject.fixed_compute_metric).to eq(@metric_size)
+    end
+
+    it 'calculates metering used hours and cost' do
+      expect(subject.metering_used_metric).to eq(hours_in_month)
+      expect(subject.metering_used_cost).to eq(hours_in_month * hourly_rate)
     end
   end
 


### PR DESCRIPTION
**Metering Used Hours** is:
- the integer value of hours
- the duration of the chargeable period in chargeback report for the resource (VM)
- this period is set according to a time range in report  (set in UI) but it reflects when VM was 
stared and retired.
- it is related to 
https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback/consumption.rb#L7 


**Which reports ?**
Chargeback for VMs
Chargeback for Projects
Chargeback for Containers Images

**Report definition**
![screen shot 2017-10-03 at 15 17 15](https://user-images.githubusercontent.com/14937244/31127080-198689f6-a84e-11e7-8249-81e94bf3b804.png)

**Example of report:**
![screen shot 2017-10-03 at 15 00 00](https://user-images.githubusercontent.com/14937244/31126307-9ca3d620-a84b-11e7-896e-fb34fb6e1e52.png)
with rate $1 per month:
<img width="1435" alt="screen shot 2017-10-03 at 16 46 27" src="https://user-images.githubusercontent.com/14937244/31131443-77b6bb0c-a85a-11e7-8974-f06f97fa87e0.png">


so the example of the calculation is:

**Metering Used Metric** - is count of hours in **consumption period**

and we will just multiple this by hourly rate from our example it is :
`($1.0 / (31.0 * 24.0) ) * 277.0 = $0.37231182795698925`

so generic formula is:
Hourly Rate * Metering Used Metric

**Hourly Rate**
we need to convert rate from rate editor to hourly rate:
from our example:
`($1.0 / (31.0 * 24.0) )`
`(cost in rate editor / (count of hours for month/week/day - this is the 'per XXX' from rate editor ) )`


@miq-bot assign @gtanzillo 
/cc @loicavenel