### PR TITLE
Adds check for circular association references to dialog import

### DIFF
--- a/app/models/dialog_field_association_validator.rb
+++ b/app/models/dialog_field_association_validator.rb
@@ -1,0 +1,19 @@
+class DialogFieldAssociationValidator
+  class DialogFieldAssociationCircularReferenceError < StandardError; end
+
+  def circular_references?(associations)
+    keys_list = associations.collect(&:keys).flatten
+    values_list = associations.collect(&:values).flatten
+    associations.each do |association|
+      association.values.flatten.each do |responder|
+        association.values.first.delete(responder) unless keys_list.include?(responder)
+      end
+    end
+    associations.each do |association|
+      associations.delete(association) unless values_list.include?(association.keys.first)
+    end
+    circular_keys = associations.collect(&:keys).flatten.to_set
+    circular_values = associations.collect(&:values).flatten.to_set
+    circular_keys == circular_values unless circular_keys.empty? && circular_values.empty?
+  end
+end

--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -126,9 +126,7 @@ class DialogImportService
         )
       )
       fields = new_or_existing_dialog.dialog_fields
-      associations = build_association_list(dialog)
-      next if associations.empty?
-      associations.each do |association|
+      build_association_list(dialog).each do |association|
         association.values.each do |values|
           values.each do |responder|
             next if fields.select { |field| field.name == responder }.empty?

--- a/spec/models/dialog_field_association_validator_spec.rb
+++ b/spec/models/dialog_field_association_validator_spec.rb
@@ -1,0 +1,36 @@
+describe DialogFieldAssociationValidator do
+  let(:dialog_field_association_validator) { described_class.new }
+
+  describe "circular_references" do
+    context "when the associations are blank" do
+      let(:associations) { {} }
+
+      it "returns false" do
+        expect(dialog_field_association_validator.circular_references(associations)).to eq(false)
+      end
+    end
+
+    context "when the associations are not blank" do
+      context "when there are no circular references" do
+        it "returns false" do
+          expect(dialog_field_association_validator.circular_references("foo" => ["baz"])).to eq(false)
+          expect(dialog_field_association_validator.circular_references("foo" => %w(foo2 foo4), "foo2" => ["foo3"], "foo3" => ["foo4"])).to eq(false)
+        end
+      end
+
+      context "when there are circular references" do
+        it "returns true on the trivial case" do
+          expect(dialog_field_association_validator.circular_references("foo" => ["baz"], "baz" => ["foo"])).to eq(%w(baz foo))
+        end
+
+        it "returns true on the non-trivial case" do
+          expect(dialog_field_association_validator.circular_references("foo" => %w(foo2 foo4), "foo2" => ["foo3"], "foo3" => %w(foo5 foo4), "foo5" => ["foo2"])).to eq(%w(foo2 foo3))
+        end
+
+        it "returns true on the non-trivial case" do
+          expect(dialog_field_association_validator.circular_references("foo" => %w(foo2 foo4), "foo2" => ["foo3"], "foo4" => ["foo"])).to eq(%w(foo4 foo))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a circular dialog field association reference checker to the dialog import validation to make sure we're not importing a dialog with associations that look like this:
["field1", "field3"] and ["field3", "field1"] (field 1 triggering field 3, and field 3 triggering 1 in return), which errors. To hit the circular reference error the same field must be a trigger of one field and also responder of a different field. The association validator collects a list of all the associations and removes all responders that are not present in the list of triggers of other fields and all triggers that are not other field's responders.  

**Links**
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/2056