### PR TITLE
Expose Custom Button visability/enablement

### DIFF
--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -44,7 +44,7 @@ module CustomActionsMixin
   end
 
   def serialize_button(button)
-    button.expanded_serializable_hash
+    button.expanded_serializable_hash.merge("enabled" => button.evaluate_enablement_expression_for(self))
   end
 
   def generic_custom_buttons

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -10,9 +10,11 @@ module CustomActionsMixin
 
   def custom_actions
     {
-      :buttons       => custom_buttons.collect(&:expanded_serializable_hash),
+      :buttons       => filter_by_visibility(custom_buttons).collect(&:expanded_serializable_hash),
       :button_groups => custom_button_sets_with_generics.collect do |button_set|
-        button_set.serializable_hash.merge(:buttons => button_set.children.collect(&:expanded_serializable_hash))
+        button_set.serializable_hash.merge(
+          :buttons => filter_by_visibility(button_set.children).collect(&:expanded_serializable_hash)
+        )
       end
     }
   end
@@ -35,6 +37,10 @@ module CustomActionsMixin
 
   def direct_custom_buttons
     CustomButton.buttons_for(self).select { |b| b.parent.nil? }
+  end
+
+  def filter_by_visibility(buttons)
+    buttons.select { |b| b.evaluate_visibility_expression_for(self) }
   end
 
   def generic_custom_buttons

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -20,7 +20,7 @@ module CustomActionsMixin
   end
 
   def custom_action_buttons
-    custom_buttons + custom_button_sets_with_generics.collect(&:children).flatten
+    filter_by_visibility(custom_buttons + custom_button_sets_with_generics.collect(&:children).flatten)
   end
 
   def generic_button_group

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -10,10 +10,10 @@ module CustomActionsMixin
 
   def custom_actions
     {
-      :buttons       => filter_by_visibility(custom_buttons).collect(&:expanded_serializable_hash),
+      :buttons       => filter_by_visibility(custom_buttons).collect(&method(:serialize_button)),
       :button_groups => custom_button_sets_with_generics.collect do |button_set|
         button_set.serializable_hash.merge(
-          :buttons => filter_by_visibility(button_set.children).collect(&:expanded_serializable_hash)
+          :buttons => filter_by_visibility(button_set.children).collect(&method(:serialize_button))
         )
       end
     }
@@ -41,6 +41,10 @@ module CustomActionsMixin
 
   def filter_by_visibility(buttons)
     buttons.select { |b| b.evaluate_visibility_expression_for(self) }
+  end
+
+  def serialize_button(button)
+    button.expanded_serializable_hash
   end
 
   def generic_custom_buttons

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -83,6 +83,32 @@ describe ServiceTemplate do
     end
   end
 
+  describe "#custom_action_buttons" do
+    it "does not show hidden buttons" do
+      service_template = FactoryGirl.create(:service_template, :name => "foo")
+      true_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "foo"})
+      false_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "bar"})
+      visible_button = FactoryGirl.create(:custom_button,
+                                          :applies_to_class      => "Service",
+                                          :visibility_expression => true_expression)
+      _hidden_button = FactoryGirl.create(:custom_button,
+                                          :applies_to_class      => "Service",
+                                          :visibility_expression => false_expression)
+      visible_button_in_group = FactoryGirl.create(:custom_button,
+                                                   :applies_to_class      => "Service",
+                                                   :visibility_expression => true_expression)
+      hidden_button_in_group = FactoryGirl.create(:custom_button,
+                                                  :applies_to_class      => "Service",
+                                                  :visibility_expression => false_expression)
+      FactoryGirl.create(:custom_button_set).tap do |group|
+        group.add_member(visible_button_in_group)
+        group.add_member(hidden_button_in_group)
+      end
+
+      expect(service_template.custom_action_buttons).to contain_exactly(visible_button, visible_button_in_group)
+    end
+  end
+
   context "#type_display" do
     before(:each) do
       @st1 = FactoryGirl.create(:service_template, :name => 'Service Template 1')


### PR DESCRIPTION
Resolves https://www.pivotaltracker.com/story/show/149699953

Does a couple of things:
1. When asking for a Service's `custom_actions` or `custom_action_buttons`, will only return things whose `visibility_expression` evaluates to `true` for the object at hand
2. When asking for a Service's `custom_actions`, serializes the result of the `enablement_expression` evaluated in the context of the object at hand, along with the rest of the button's attributes

From what I understand, buttons have an attribute `disabled_text` which I am assuming is there to explain the reason for its being disabled - if correct then this is already serialized and returned in the response, so nothing further needs to be done here.

/cc @AllenBW 
@miq-bot add-label enhancement
@miq-bot assign @gtanzillo 