### PR TITLE
Added redis gem for supporting ActionCable redis backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -185,6 +185,7 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
+  gem "redis",                          "~>3.0"
   gem "websocket-driver",               "~>0.6.3"
 end
 


### PR DESCRIPTION
The default backend for ActionCable's pubsub adapter is Redis. For now we're using postgresql LISTEN/NOTIFY but in the podified version I'd like to give the opportunity to use Redis instead.