### PR TITLE
Allow the target attribute to be read on ResourceActionWorkflow objects

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -2,6 +2,8 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   attr_accessor :dialog
   attr_accessor :request_options
 
+  attr_reader :target
+
   def self.base_model
     ResourceActionWorkflow
   end


### PR DESCRIPTION
Because of the way the API calls work for the dialogs with the new ui-component that does all of the dialog rendering for us, we need a way to get the service template id and the service catalog id, which is stored on the target.

The related classic ui PR is [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/2067)

https://www.pivotaltracker.com/story/show/150645792

@miq-bot add_label enhancement
@miq-bot assign @gmcculloug 