### PR TITLE
[EUWE] Add ems_refresh.openshift.store_unused_images setting

### DIFF
--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -640,7 +640,8 @@ module ManageIQ::Providers::Kubernetes
       res
     end
 
-    def parse_container_image(image, imageID)
+    # may return nil if store_new_images = false
+    def parse_container_image(image, imageID, store_new_images: true)
       container_image, container_image_registry = parse_image_name(image, imageID)
       host_port = nil
 
@@ -664,6 +665,7 @@ module ManageIQ::Providers::Kubernetes
         :container_image, :by_digest, container_image_identity)
 
       if stored_container_image.nil?
+        return nil unless store_new_images
         @data_index.store_path(
           :container_image, :by_digest,
           container_image_identity, container_image

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -8,13 +8,13 @@ module ManageIQ::Providers
         get_builds(inventory)
         get_build_pods(inventory)
         get_templates(inventory)
-        get_openshift_images(inventory) if options.get_container_images
+        get_openshift_images(inventory, options) if options.get_container_images
         EmsRefresh.log_inv_debug_trace(@data, "data:")
         @data
       end
 
-      def get_openshift_images(inventory)
-        inventory["image"].each { |img| parse_openshift_image(img) }
+      def get_openshift_images(inventory, options)
+        inventory["image"].each { |img| parse_openshift_image(img, options) }
       end
 
       def get_builds(inventory)
@@ -166,10 +166,11 @@ module ManageIQ::Providers
         end
       end
 
-      def parse_openshift_image(openshift_image)
+      def parse_openshift_image(openshift_image, options)
         id = openshift_image[:dockerImageReference] || openshift_image[:metadata][:name]
         ref = "#{ContainerImage::DOCKER_PULLABLE_PREFIX}#{id}"
-        new_result = parse_container_image(id, ref)
+        new_result = parse_container_image(id, ref, :store_new_images => options.store_unused_images)
+        return if new_result.nil? # store_unused_images = false and wasn't mentioned by any pod
 
         if openshift_image[:dockerImageManifest].present?
           begin

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -159,9 +159,11 @@
   :openshift:
     :get_container_images: true
     :refresh_interval: 15.minutes
+    :store_unused_images: true
   :openshift_enterprise:
     :get_container_images: true
     :refresh_interval: 15.minutes
+    :store_unused_images: true
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours
   :scvmm:

--- a/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/refresh_parser_spec.rb
@@ -676,6 +676,15 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser do
         expect(first_obj).to be(second_obj)
       end
     end
+
+    it "returns existing image or nil with store_new_images=false" do
+      obj1 = parser.parse_container_image(shared_image_without_host, shared_ref)
+      obj2 = parser.parse_container_image(shared_image_without_host, shared_ref, :store_new_images => false)
+      obj3 = parser.parse_container_image(shared_image_without_host, unique_ref, :store_new_images => false)
+      expect(obj1).not_to be nil
+      expect(obj2).to be obj2
+      expect(obj3).to be nil
+    end
   end
 
   describe "cross_link_node" do

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -1,4 +1,7 @@
 describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
+  let(:all_images_count) { 31 } # including /oapi/v1/images data
+  let(:pod_images_count) { 4 }  # only images mentioned by pods
+
   before(:each) do
     allow(MiqServer).to receive(:my_zone).and_return("default")
     @ems = FactoryGirl.create(:ems_openshift, :hostname => "10.35.0.174")
@@ -8,13 +11,17 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(described_class.ems_type).to eq(:openshift)
   end
 
+  def normal_refresh
+    VCR.use_cassette(described_class.name.underscore,
+                     :match_requests_on => [:path,]) do # , :record => :new_episodes) do
+      EmsRefresh.refresh(@ems)
+    end
+  end
+
   it "will perform a full refresh on openshift" do
     2.times do
       @ems.reload
-      VCR.use_cassette(described_class.name.underscore,
-                       :match_requests_on => [:path,]) do # , :record => :new_episodes) do
-        EmsRefresh.refresh(@ems)
-      end
+      normal_refresh
       @ems.reload
 
       assert_ems
@@ -29,7 +36,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       assert_specific_container_build
       assert_specific_container_build_pod
       assert_specific_container_template
-      assert_specific_container_image
+      assert_specific_running_container_image
+      assert_specific_unused_container_image(:metadata => true, :connected => true)
     end
   end
 
@@ -146,6 +154,23 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     stub_settings(Settings.to_hash.deep_merge(
       :ems_refresh => {:openshift => {:get_container_images => false}},
     ))
+    VCR.use_cassette(described_class.name.underscore,
+                     :match_requests_on              => [:path,],
+                     :allow_unused_http_interactions => true) do # , :record => :new_episodes) do
+      EmsRefresh.refresh(@ems)
+    end
+
+    @ems.reload
+
+    expect(ContainerImage.count).to eq(pod_images_count)
+    assert_specific_running_container_image
+  end
+
+  it 'will not delete previously collected metadata if get_container_images = false' do
+    normal_refresh
+    stub_settings(Settings.to_hash.deep_merge(
+      :ems_refresh => {:openshift => {:get_container_images => false}},
+    ))
 
     VCR.use_cassette(described_class.name.underscore,
                      :match_requests_on              => [:path,],
@@ -155,7 +180,10 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
 
     @ems.reload
 
-    expect(ContainerImage.count).to eq(4)
+    # Unused images are disconnected, metadata is retained either way.
+    expect(@ems.container_images.count).to eq(pod_images_count)
+    assert_specific_running_container_image
+    assert_specific_unused_container_image(:metadata => true, :connected => false)
   end
 
   def assert_table_counts
@@ -170,7 +198,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(ContainerBuild.count).to eq(1)
     expect(ContainerBuildPod.count).to eq(1)
     expect(ContainerTemplate.count).to eq(6)
-    expect(ContainerImage.count).to eq(31)
+    expect(ContainerImage.count).to eq(all_images_count)
+    expect(ContainerImage.joins(:containers).distinct.count).to eq(pod_images_count)
   end
 
   def assert_ems
@@ -325,12 +354,25 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     )
   end
 
-  def assert_specific_container_image
+  def assert_specific_unused_container_image(metadata:, connected:)
+    # An image not mentioned in /pods, only in /images, built by openshift so it has metadata.
     @container_image = ContainerImage.find_by_name("centos/postgresql-95-centos7")
 
-    expect(@container_image.ext_management_system).to eq(@ems)
-    expect(@container_image.environment_variables.count).to eq(9)
+    expect(@container_image.ext_management_system).to eq(connected ? @ems : nil)
+    expect(@container_image.environment_variables.count).to eq(metadata ? 9 : 0)
     expect(@container_image.labels.count).to eq(1)
-    expect(@container_image.docker_labels.count).to eq(9)
+    expect(@container_image.docker_labels.count).to eq(metadata ? 9 : 0)
+  end
+
+  def assert_specific_running_container_image
+    # This VCR cassette has no overlap between images running in /pods
+    # and /images from openshift registry.
+    # At least test one from /pods then.
+    @container_image = ContainerImage.find_by(:name => "openshift/mysql-55-centos7")
+
+    expect(@container_image.ext_management_system).to eq(@ems)
+    expect(@container_image.environment_variables.count).to eq(0)
+    expect(@container_image.labels.count).to eq(0)
+    expect(@container_image.docker_labels.count).to eq(0)
   end
 end


### PR DESCRIPTION
- [x] Based off #15910 [merged].

Backport
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/11, https://github.com/ManageIQ/manageiq-providers-openshift/pull/9

Option needed for new ems_refresh.openshift.store_unused_images setting

(cherry picked from https://github.com/ManageIQ/manageiq-providers-kubernetes/commit/0046549b16d166ebdaccbb2ac3ec0cfec84b5cc2)

Add ems_refresh.openshift.store_unused_images setting

(partially cherry picked from https://github.com/ManageIQ/manageiq-providers-openshift/commit/6a62bb2f9cde7f8722f58510b557bfdfc3d77ed6:
omitted the graph refresh test skip,
passing options explicitly - constructor didn't set `@options` on euwe,
adjusted for different test method signature :connected vs :archived,
simulating missing stub_settings_merge,
adjusted for different VCR cassette)

https://bugzilla.redhat.com/show_bug.cgi?id=1486483

cc @agrare @simaishi 