### PR TITLE
Fix broken alert export spec failure

### DIFF
--- a/spec/lib/task_helpers/exports/alerts_spec.rb
+++ b/spec/lib/task_helpers/exports/alerts_spec.rb
@@ -9,7 +9,8 @@ describe TaskHelpers::Exports::Alerts do
           "description"        => "Alert Export Test",
           "options"            => nil,
           "db"                 => nil,
-          "expression"         => nil,
+          "miq_expression"     => nil,
+          "hash_expression"    => nil,
           "responds_to_events" => nil,
           "enabled"            => true,
           "read_only"          => nil


### PR DESCRIPTION
Caused by https://github.com/ManageIQ/manageiq-schema/pull/49

There are probably ways to make this test less brittle, but I'd rather just fix it in this PR to get master back to 💚 

@miq-bot add-label test
@miq-bot assign @agrare 