### PR TITLE
[WIP] added MiqReportResult#available_to_user? (to fix access issue with widgets)

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -27,6 +27,23 @@ class MiqReportResult < ApplicationRecord
     for_groups(user.admin_user? ? nil : user.miq_group_ids)
   }
 
+  def available_to_user?(user)
+    return true if user.admin_user?
+
+    return user.current_group_id == miq_group_id if miq_group_id
+
+    return true if userid == user.userid
+
+    user_group_or_role = userid.split("|")[1]
+    if user_group_or_role == user.current_group.try(:description) ||
+       user_group_or_role == user.miq_user_role_name ||
+       user_group_or_role == user.userid
+      return true
+    end
+
+    false
+  end
+
   before_save do
     user_info = userid.to_s.split("|")
     if user_info.length == 1


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/1627, https://github.com/ManageIQ/manageiq-ui-classic/pull/1827

**blocker for**: https://github.com/ManageIQ/manageiq-ui-classic/pull/2069 Fix widget maximize, zoom-in and pdf operation by checking other condition in addition to linked MiqGroup

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1492174

**Issue**:  `MiqReportResult.for_user(user)` will skip report results generated for widgets.
Report result records generated for widgets do not have linked user group and `miq_report_results.miq_group_id`  not set.
Also, accessibility of widget can be based on role. Role name (or group name if accessibility of widget based on role) added (with `|` separator)  in the `miq_report_results.userid` column.
![screen shot 2017-09-15 at 10 34 16 am](https://user-images.githubusercontent.com/6556758/30487441-8a686d02-9a01-11e7-81ad-145547fabfcb.png)




**Solution:** check if user can access report based on other condition (in addition to linked group)

Probably, the better way to fix above issues is to make sure that `miq_report_results.miq_group_id` is set for any report and link `MiqUserRole' to report result, but it looks like bigger task and may take more time.


 @miq-bot add-label bug, core

\cc @gtanzillo 

