### PR TITLE
Add Data Types to dictionary

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1088,6 +1088,14 @@ en:
       zone:                        Zone
       zones:                       Zones
 
+    data_type:
+      boolean:             Boolean
+      datetime:            Date/Time
+      float:               Float
+      integer:             Integer
+      string:              String
+      time:                Time
+
     ui_title:
       foreman:             Foreman
       ansible_tower:       Ansible Tower


### PR DESCRIPTION
These Data types would be displayed in Generic Object Definitions UI

<img width="839" alt="screen shot 2017-08-31 at 5 28 43 pm" src="https://user-images.githubusercontent.com/1538216/29950621-e0ff6738-8e71-11e7-8955-f77cca400b8c.png">

<img width="181" alt="screen shot 2017-09-01 at 8 19 36 am" src="https://user-images.githubusercontent.com/1538216/29976274-5802bec6-8eee-11e7-9b24-8af9155d8694.png">



These Data types would be required for the `OPTIONS` API of `generic_object_definitions`