### PR TITLE
save_vms_inventory needs to respect disconnect flag

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -36,9 +36,9 @@ module EmsRefresh::SaveInventory
     target = ems if target.nil? && disconnect
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
-    disconnects = if target.kind_of?(ExtManagementSystem) || target.kind_of?(Host)
+    disconnects = if disconnect && (target.kind_of?(ExtManagementSystem) || target.kind_of?(Host))
                     target.vms_and_templates.reload.to_a
-                  elsif target.kind_of?(Vm)
+                  elsif disconnect && target.kind_of?(Vm)
                     [target.ruby_clone]
                   else
                     []


### PR DESCRIPTION
When we provision new vm we call `save_ems_inventory_no_disconnect` which updates the db with disconnect flag set to false. `save_vms_inventory` ignores the flag and disconnects the vms (ems set to nil). This patch fixes the issue.