### PR TITLE
[FINE] Converting userids to UPN format to avoid duplicate user records

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -125,9 +125,8 @@ module Authenticator
           end
 
           matching_groups = match_groups(groups_for(identity))
-          userid = userid_for(identity, username)
-          user   = find_or_initialize_user(userid)
-          update_user_attributes(user, username, identity)
+          userid, user = find_or_initialize_user(identity, username)
+          update_user_attributes(user, userid, identity)
           user.miq_groups = matching_groups
 
           if matching_groups.empty?
@@ -155,10 +154,12 @@ module Authenticator
       end
     end
 
-    def find_or_initialize_user(userid)
+    def find_or_initialize_user(identity, username)
+      userid = userid_for(identity, username)
       user   = User.find_by_userid(userid)
       user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
-      user ||  User.new(:userid => userid)
+      user ||= User.new(:userid => userid)
+      [userid, user]
     end
 
     def authenticate_with_http_basic(username, password, request = nil, options = {})

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -43,10 +43,11 @@ module Authenticator
       MiqGroup.strip_group_domains(membership_list)
     end
 
-    def update_user_attributes(user, _username, identity)
+    def update_user_attributes(user, username, identity)
       user_attrs, _membership_list = identity
 
-      user.userid     = user_attrs[:username]
+      $audit_log.info("Updating userid from #{user.userid} to #{username}") if user.userid != username
+      user.userid     = username
       user.first_name = user_attrs[:firstname]
       user.last_name  = user_attrs[:lastname]
       user.email      = user_attrs[:email] unless user_attrs[:email].blank?
@@ -55,7 +56,39 @@ module Authenticator
       user.name       = user.userid if user.name.blank?
     end
 
+    def find_or_initialize_user(identity, username)
+      user_attrs, _membership_list = identity
+      return super if user_attrs[:domain].nil?
+
+      upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain]}".downcase
+
+      user = find_userid_as_upn(upn_username)
+      user ||= find_userid_as_distinguished_name(user_attrs)
+      user ||= find_userid_as_username(identity, username)
+      user ||= User.new(:userid => upn_username)
+
+      [upn_username, user]
+    end
+
     private
+
+    def find_userid_as_upn(upn_username)
+      user = User.find_by_userid(upn_username)
+      user || User.in_my_region.where('lower(userid) = ?', upn_username).order(:lastlogon).last
+    end
+
+    def find_userid_as_username(identity, username)
+      userid = userid_for(identity, username)
+      user   = User.find_by_userid(userid)
+      user ||= User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
+      user
+    end
+
+    def find_userid_as_distinguished_name(user_attrs)
+      dn_domain = user_attrs[:domain].downcase.split(".").map { |s| "dc=#{s}" }.join(",")
+      user = User.in_my_region.where("userid LIKE ?", "%=#{user_attrs[:username]},%,#{dn_domain}").last
+      user
+    end
 
     def user_details_from_external_directory(username)
       ext_user_attrs = user_attrs_from_external_directory(username)
@@ -63,7 +96,8 @@ module Authenticator
                     :fullname  => ext_user_attrs["displayname"],
                     :firstname => ext_user_attrs["givenname"],
                     :lastname  => ext_user_attrs["sn"],
-                    :email     => ext_user_attrs["mail"]}
+                    :email     => ext_user_attrs["mail"],
+                    :domain    => ext_user_attrs["domainname"]}
       [user_attrs, MiqGroup.get_httpd_groups_by_user(username)]
     end
 
@@ -72,7 +106,8 @@ module Authenticator
                     :fullname  => request.headers['X-REMOTE-USER-FULLNAME'],
                     :firstname => request.headers['X-REMOTE-USER-FIRSTNAME'],
                     :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
-                    :email     => request.headers['X-REMOTE-USER-EMAIL']}
+                    :email     => request.headers['X-REMOTE-USER-EMAIL'],
+                    :domain    => request.headers['X-REMOTE-USER-DOMAIN']}
       [user_attrs, (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:]/)]
     end
 
@@ -80,7 +115,7 @@ module Authenticator
       return unless username
       require "dbus"
 
-      attrs_needed = %w(mail givenname sn displayname)
+      attrs_needed = %w(mail givenname sn displayname domainname)
 
       sysbus = DBus.system_bus
       ifp_service   = sysbus["org.freedesktop.sssd.infopipe"]

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -23,7 +23,7 @@ describe Authenticator do
 
     it 'Updates the user groups when no matching groups' do
       expect(authenticator).to receive(:find_external_identity)
-        .and_return([{:username => user.userid, :fullname => user.name}, []])
+        .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, []])
 
       authenticator.authorize(task.id, user.userid)
       expect(user.reload.miq_groups).to be_empty
@@ -31,7 +31,7 @@ describe Authenticator do
 
     it 'Updates the user groups' do
       expect(authenticator).to receive(:find_external_identity)
-        .and_return([{:username => user.userid, :fullname => user.name}, groups.collect(&:name)])
+        .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, groups.collect(&:name)])
 
       authenticator.authorize(task.id, user.userid)
       expect(user.reload.miq_groups).to match_array(groups)


### PR DESCRIPTION
Manually cherry-picked out of
https://github.com/ManageIQ/manageiq/pull/15535

(cherry picked from commit 53c1704a56db62a1751665f52323c0e496f32669)
Merge pull request #15535 from jvlcek/bz1424618_dup_users

https://bugzilla.redhat.com/show_bug.cgi?id=1487689

See: https://github.com/ManageIQ/manageiq/pull/15535 for full description of this change.
 