### PR TITLE
Cleanup bin scripts for consistency

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,30 +1,20 @@
 #!/usr/bin/env ruby
 require_relative '../lib/manageiq/environment'
-require 'optparse'
 
-options = {
-  # Don't run tests by default if we are in a prod env since no task exists.
-  :do_tests => ENV['RAILS_ENV'] != "production",
-  :do_db => true
-}
+if ARGV.any?
+  puts <<-EOS
+Usage: bin/setup
 
-OptionParser.new do |opts|
-  opts.banner = "Usage: setup [options]"
-  opts.on("-d", "--no-db", "Do not prepare db") do
-    options[:do_db] = false
-  end
-  opts.on("-t", "--no-tests", "Do not perform tests") do
-    options[:do_tests] = false
-  end
-  opts.on("-h", "--help", "Displays this help") do
-    puts opts
-    exit
-  end
-end.parse!
+Environment Variable Options:
+    SKIP_DATABASE_SETUP  Skip the creation, migration, and seeding of the
+                         database.
+    SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
+                         true in production mode since the tasks do not exist.
+EOS
+  exit 1
+end
 
 Dir.chdir ManageIQ::Environment::APP_ROOT do
-  # This script is a starting point to setup your application.
-  # Add necessary setup steps to this file.
   ManageIQ::Environment.ensure_config_files
 
   puts '== Installing dependencies =='
@@ -32,16 +22,14 @@ Dir.chdir ManageIQ::Environment::APP_ROOT do
   ManageIQ::Environment.bundle_install
 
   ManageIQ::Environment.while_updating_bower do
-    if options[:do_db]
-      # Note, we deviate from the default rails db:setup here because
-      # it invokes the db:setup rake task which creates the db from the
-      # schema (and seeds it), but doesn't run through migrations.
+    unless ENV["SKIP_DATABASE_SETUP"]
       ManageIQ::Environment.create_database
       ManageIQ::Environment.migrate_database
       ManageIQ::Environment.seed_database
     end
 
-    ManageIQ::Environment.setup_test_environment if options[:do_tests]
+    ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
   end
+
   ManageIQ::Environment.clear_logs_and_temp
 end

--- a/bin/update
+++ b/bin/update
@@ -1,26 +1,33 @@
 #!/usr/bin/env ruby
 require_relative '../lib/manageiq/environment'
 
-# Don't run tests by default if we are in a prod env since no task exists.
-ENV["SKIP_TEST_RESET"] = '1' if ENV['RAILS_ENV'] == 'production'
+if ARGV.any?
+  puts <<-EOS
+Usage: bin/update
+
+Environment Variable Options:
+    SKIP_DATABASE_SETUP  Skip the migration and seeding of the database.
+    SKIP_TEST_RESET      Skip the creation of the test enviroment.  Defaults to
+                         true in production mode since the tasks do not exist.
+    SKIP_AUTOMATE_RESET  Skip the reset of the automate domain.
+EOS
+  exit 1
+end
+
+ENV["SKIP_TEST_RESET"] = 'true' if ENV['RAILS_ENV'] == 'production'
 
 Dir.chdir ManageIQ::Environment::APP_ROOT do
-  # This script is a way to update your development environment automatically.
-  # Add necessary update steps to this file.
   ManageIQ::Environment.ensure_config_files
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler
-
-  # TODO: This unlocks your dependencies and installs all updates.
-  # From: https://github.com/ManageIQ/manageiq/pull/11137
-  # It should be 'bundle check' || 'bundle install'.
-  # If we need a "reset all the things" script, we should call it bin/reset.
   ManageIQ::Environment.bundle_update
 
   ManageIQ::Environment.while_updating_bower do
-    ManageIQ::Environment.migrate_database
-    ManageIQ::Environment.seed_database
+    unless ENV["SKIP_DATABASE_SETUP"]
+      ManageIQ::Environment.migrate_database
+      ManageIQ::Environment.seed_database
+    end
 
     ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
     ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]

--- a/docker-assets/docker_initdb
+++ b/docker-assets/docker_initdb
@@ -27,7 +27,7 @@ echo "== Checking MIQ database status =="
 		pidof memcached
 		test $? -ne 0 && /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -d
 		echo "** Starting DB setup"
-		${APP_ROOT}/bin/setup --no-tests
+		SKIP_TEST_RESET=true ${APP_ROOT}/bin/setup
 		test $? -ne 0 && echo "!! ${APP_ROOT}/docker-assets/docker_setup failed to run" && exit 1
 		echo "** MIQ database has been initialized"
 		exit 0


### PR DESCRIPTION
Each of the bin scripts have a different way to pass configuration, so I made them consistent via ENV vars (one less dependency).  I also

- added some nice help output to each to describe the various env vars
- Removed the pointless comments
- cleaned up the bookend output for updating bower assets
- change clear_obsolete to be more consistent with other file manipulation within the file by using FileUtils.

I started working on #15926 , but some of these inconsistencies were getting in the way.

@jrafanie @chrisarcand Please review.