### PR TITLE
ovn: introducing ovn as ovirt's network provider

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -5,7 +5,7 @@ class CloudTenant < ApplicationRecord
   include NewWithTypeStiMixin
   extend ActsAsTree::TreeWalker
 
-  belongs_to :ext_management_system, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::CloudManager"
+  belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_one    :source_tenant, :as => :source, :class_name => 'Tenant'
   has_many   :security_groups
   has_many   :cloud_networks

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -26,7 +26,7 @@ module HasNetworkManagerMixin
 
     def ensure_managers
       ensure_network_manager
-      network_manager.name = "#{name} Network Manager"
+      network_manager.name = "#{name} Network Manager" if network_manager
       ensure_managers_zone_and_provider_region
     end
 

--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -46,6 +46,7 @@
 - ems-type:openstack
 - ems-type:openstack_infra
 - ems-type:openstack_network
+- ems-type:redhat_network
 - ems-type:rhevm
 - ems-type:scvmm
 - ems-type:swift

--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -45,6 +45,9 @@ MIQ_WORKER_TYPES = {
   "ManageIQ::Providers::Redhat::InfraManager::EventCatcher"                   => %i(manageiq_default),
   "ManageIQ::Providers::Redhat::InfraManager::MetricsCollectorWorker"         => %i(manageiq_default),
   "ManageIQ::Providers::Redhat::InfraManager::RefreshWorker"                  => %i(manageiq_default),
+  "ManageIQ::Providers::Redhat::NetworkManager::EventCatcher"                 => %i(manageiq_default),
+  "ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker"       => %i(manageiq_default),
+  "ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker"                => %i(manageiq_default),
   "ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker"         => %i(manageiq_default),
   "ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker"          => %i(manageiq_default),
   "ManageIQ::Providers::Vmware::CloudManager::EventCatcher"                   => %i(manageiq_default),
@@ -80,6 +83,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Vmware::InfraManager::MetricsCollectorWorker
   ManageIQ::Providers::Openstack::CloudManager::MetricsCollectorWorker
   ManageIQ::Providers::Openstack::NetworkManager::MetricsCollectorWorker
+  ManageIQ::Providers::Redhat::NetworkManager::MetricsCollectorWorker
   ManageIQ::Providers::Openstack::InfraManager::MetricsCollectorWorker
   EmbeddedAnsibleWorker
   MiqReportingWorker
@@ -107,6 +111,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Redhat::InfraManager::RefreshWorker
   ManageIQ::Providers::Openstack::CloudManager::RefreshWorker
   ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker
+  ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker
   ManageIQ::Providers::Openstack::InfraManager::RefreshWorker
   ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker
   ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker
@@ -124,6 +129,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Redhat::InfraManager::EventCatcher
   ManageIQ::Providers::Openstack::CloudManager::EventCatcher
   ManageIQ::Providers::Openstack::NetworkManager::EventCatcher
+  ManageIQ::Providers::Redhat::NetworkManager::EventCatcher
   ManageIQ::Providers::Openstack::InfraManager::EventCatcher
   ManageIQ::Providers::Amazon::CloudManager::EventCatcher
   ManageIQ::Providers::Azure::CloudManager::EventCatcher

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -153,9 +153,14 @@ FactoryGirl.define do
   end
 
   factory :ems_redhat,
+          :parent => :ems_redhat_with_ensure_managers do
+    after(:build) { |ems_redhat| ems_redhat.class.skip_callback(:save, :before, :ensure_managers, :raise => false) }
+  end
+
+  factory :ems_redhat_with_ensure_managers,
           :aliases => ["manageiq/providers/redhat/infra_manager"],
-          :class   => "ManageIQ::Providers::Redhat::InfraManager",
-          :parent  => :ems_infra do
+          :class => "ManageIQ::Providers::Redhat::InfraManager",
+          :parent => :ems_infra do
   end
 
   factory :ems_redhat_v3,

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -41,6 +41,7 @@ describe ExtManagementSystem do
       "openstack_network"           => "OpenStack Network",
       "lenovo_ph_infra"             => "Lenovo XClarity",
       "nuage_network"               => "Nuage Network Manager",
+      "redhat_network"              => "Redhat Network",
       "rhevm"                       => "Red Hat Virtualization",
       "scvmm"                       => "Microsoft System Center VMM",
       "vmwarews"                    => "VMware vCenter",


### PR DESCRIPTION
oVirts network provider has 'neutron like' api. Therefore, it has tenants.
Since oVirt provider is infra provider (and not cloud provider), tenants
had to be extracted to support infra provider as parent ems.