### PR TITLE
Move UTF_16BE_BOM, UTF_16LE_BOM from UiConstants

### DIFF
--- a/app/models/filesystem.rb
+++ b/app/models/filesystem.rb
@@ -13,6 +13,9 @@ class Filesystem < ApplicationRecord
   virtual_column :contents,           :type => :string,  :uses => {:binary_blob => :binary_blob_parts}
   virtual_column :contents_available, :type => :boolean, :uses => :binary_blob
 
+  UTF_16BE_BOM = [254, 255].freeze
+  UTF_16LE_BOM = [255, 254].freeze
+
   def self.host_service_group_condition(host_service_group_id)
     arel_table[:host_service_group_id].eq(host_service_group_id)
   end


### PR DESCRIPTION
### Issue: #1661 

#### Needs to be merged together with https://github.com/ManageIQ/manageiq-ui-classic/pull/2086

Definitions of constants `UTF_16BE_BOM` and `UTF_16LE_BOM` were removed from `UiConstants` - `manageiq-ui-classic/app/helpers/ui_constants.rb`. They were moved to `Filesystem` - `manageiq/app/models/filesystem.rb`.

/cc @martinpovolny @mzazrivec @romanblanco