### PR TITLE
Add Container Environment Variables feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4946,7 +4946,7 @@
 - :name: Containers Explorer
   :description: Everything under Containers
   :feature_type: node
-  :identifier: containers
+  :identifier: container
   :children:
   - :name: Relationships
     :description: Everything under All Containers Accordion
@@ -4975,6 +4975,10 @@
         :description: Display Timelines for Containers
         :feature_type: view
         :identifier: container_timeline
+      - :name: Environment Variables
+        :description: Display Environment Variables for Containers
+        :feature_type: view
+        :identifier: container_env_vars
     - :name: Modify
       :description: Modify Containers
       :feature_type: admin

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -217,7 +217,7 @@
 - :name: containers
   :description: Compute / Containers / Containers
   :url: /container/show_list
-  :rbac_feature_name: containers
+  :rbac_feature_name: container_show_list
   :startup: true
 - :name: container_nodes
   :description: Compute / Containers / Container Nodes

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -42,7 +42,7 @@
   - container_service
   - container_replicator
   - container_group
-  - containers
+  - container
   - container_node
   - persistent_volume
   - container_build
@@ -1017,7 +1017,7 @@
   - container_service
   - container_route
   - container_project
-  - containers
+  - container
   - container_topology
   - container_dashboard
   - ems_infra_dashboard


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1422206

This PR includes 2 changes:
* Fixing containers explorer feature identifier from `containers` to `container`. 
* Adding new feature for Container Environment variables. 

![envvars](https://user-images.githubusercontent.com/11769555/30067020-4acc6000-9262-11e7-9db3-f48e7bf050c2.png)
