### PR TITLE
Ensure dialog field associations are being saved properly

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -125,6 +125,12 @@ class DialogField < ApplicationRecord
     DialogFieldSerializer.serialize(self)
   end
 
+  def update_dialog_field_responders(id_list)
+    dialog_field_responders.destroy_all
+
+    self.dialog_field_responders = available_dialog_field_responders(id_list) unless id_list.blank?
+  end
+
   def deep_copy
     dup.tap do |new_field|
       new_field.resource_action = resource_action.dup
@@ -132,6 +138,10 @@ class DialogField < ApplicationRecord
   end
 
   private
+
+  def available_dialog_field_responders(id_list)
+    DialogField.find(id_list.collect { |id| self.class.uncompress_id(id) })
+  end
 
   def default_resource_action
     build_resource_action if resource_action.nil?

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -22,7 +22,8 @@ class DialogGroup < ApplicationRecord
         DialogField.find(self.class.uncompress_id(field['id'])).tap do |dialog_field|
           resource_action_fields = field.delete('resource_action') || {}
           update_resource_fields(resource_action_fields, dialog_field)
-          dialog_field.update_attributes(field.except('id', 'href', 'dialog_group_id'))
+          dialog_field.update_attributes(field.except('id', 'href', 'dialog_group_id', 'dialog_field_responders'))
+          dialog_field.update_dialog_field_responders(field['dialog_field_responders'])
           updated_fields << dialog_field
         end
       else

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -73,9 +73,10 @@ describe DialogFieldSerializer do
         it 'serializes the dialog_field with all attributes' do
           expect(dialog_field_serializer.serialize(dialog_field, all_attributes))
             .to include(expected_serialized_values.merge(
-                          'id'              => dialog_field.id,
-                          'resource_action' => 'serialized resource action',
-                          'values'          => 'dynamic values'
+                          'id'                      => dialog_field.id,
+                          'resource_action'         => 'serialized resource action',
+                          'dialog_field_responders' => [],
+                          'values'                  => 'dynamic values'
             ))
         end
       end
@@ -102,8 +103,9 @@ describe DialogFieldSerializer do
         it 'serializes the dialog_field with all attributes' do
           expect(dialog_field_serializer.serialize(dialog_field, all_attributes))
             .to include(expected_serialized_values.merge(
-                          'id'              => dialog_field.id,
-                          'resource_action' => 'serialized resource action',
+                          'id'                      => dialog_field.id,
+                          'resource_action'         => 'serialized resource action',
+                          'dialog_field_responders' => [],
             ))
         end
 

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -178,4 +178,35 @@ describe DialogField do
   it "does not use attr_accessor for default_value" do
     expect(described_class.new(:default_value => "test")[:default_value]).to eq("test")
   end
+
+  describe "#update_dialog_field_responders" do
+    let(:dialog_field) { described_class.create(:name => "field1", :label => "field1") }
+    let(:dialog_field2) { described_class.create(:name => "field2", :label => "field2") }
+    let(:dialog_field3) { described_class.create(:name => "field3", :label => "field3") }
+
+    before do
+      dialog_field.dialog_field_responders = [dialog_field3]
+    end
+
+    context "when the given list is not empty" do
+      it "rebuilds the responder list based on the compressed IDs" do
+        dialog_field.update_dialog_field_responders([dialog_field2.compressed_id])
+        expect(dialog_field.dialog_field_responders).to eq([dialog_field2])
+      end
+    end
+
+    context "when the given list is empty" do
+      it "destroys the responders" do
+        dialog_field.update_dialog_field_responders([])
+        expect(dialog_field.dialog_field_responders).to eq([])
+      end
+    end
+
+    context "when the given list is nil" do
+      it "destroys the responders without crashing" do
+        dialog_field.update_dialog_field_responders(nil)
+        expect(dialog_field.dialog_field_responders).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -29,9 +29,9 @@ describe DialogGroup do
     context 'a collection of dialog fields containing two objects with ids and one without an id' do
       let(:updated_fields) do
         [
-          { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label'},
-          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label'},
-          { 'name' => 'new field', 'label' => 'new field label' }
+          { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label', 'dialog_field_responders' => []},
+          { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label', 'dialog_field_responders' => []},
+          { 'name' => 'new field', 'label' => 'new field label', 'dialog_field_responders' => [] }
         ]
       end
       it 'creates or updates the dialog fields' do
@@ -46,9 +46,9 @@ describe DialogGroup do
       let(:updated_fields) do
         [
           { 'id' => dialog_fields.first.id, 'label' => 'updated_field_label', 'resource_action' =>
-            {'resource_type' => 'DialogField', 'ae_attributes' => {}} },
+            {'resource_type' => 'DialogField', 'ae_attributes' => {}}, 'dialog_field_responders' => [] },
           { 'id' => dialog_fields.last.id, 'label' => 'updated_field_label', 'resource_action' =>
-            {'id' => resource_action.id, 'resource_type' => 'DialogField'} }
+            {'id' => resource_action.id, 'resource_type' => 'DialogField'}, 'dialog_field_responders' => []}
         ]
       end
       it 'updates the dialog fields' do
@@ -62,7 +62,7 @@ describe DialogGroup do
     context 'with a dialog field removed from the dialog fields' do
       let(:updated_fields) do
         [
-          { 'id' => dialog_fields.first.id }
+          { 'id' => dialog_fields.first.id, 'dialog_field_responders' => [] }
         ]
       end
 


### PR DESCRIPTION
When saving, the API simply calls `update_attributes` on the dialog (which then cascades down through the tabs, groups, and fields), so this is needed to ensure that when the update call comes in, the responders are saved.

https://www.pivotaltracker.com/story/show/148013513