### PR TITLE
Bump manageiq-smartstate gem version to 0.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,7 +167,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.1.1",       :require => false
+  gem "manageiq-smartstate",            "~>0.1.3",       :require => false
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb


### PR DESCRIPTION
In order to finish implementation of changes for https://bugzilla.redhat.com/show_bug.cgi?id=1475540 the above gem version needs to be updated.  This will be backported to fine.



Links [Optional]
----------------

* https://github.com/ManageIQ/manageiq-smartstate/pull/25
* https://bugzilla.redhat.com/show_bug.cgi?id=1475540

@roliveri please merge so this Blocker bug can be back ported to Fine.  Thanks.