### PR TITLE
add flavors info in instance provisioning

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -58,6 +58,11 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def display_name_for_name_description(ci)
+    if ci.type == 'ManageIQ::Providers::Openstack::CloudManager::Flavor'
+      ram = ActionController::Base.helpers.number_to_human_size(ci.memory)
+      root_disk_size = ActionController::Base.helpers.number_to_human_size(ci.root_disk_size)
+      return "#{ci.name}: #{ci.cpus} CPUs, #{ram} RAM, #{root_disk_size} Root Disk"
+    end
     ci.description.blank? ? ci.name : "#{ci.name}: #{ci.description}"
   end
 


### PR DESCRIPTION
Flavors information when selecting flavor in instance provisioning.

<img width="1359" alt="screen shot 2017-09-06 at 14 39 44" src="https://user-images.githubusercontent.com/20123872/30112394-8a093afe-9311-11e7-8b32-354b5742f95e.png">
