### PR TITLE
Move common inventory collections to default ICs

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default.rb
+++ b/app/models/manager_refresh/inventory_collection_default.rb
@@ -1,2 +1,99 @@
 class ManagerRefresh::InventoryCollectionDefault
+  class << self
+    def vms(extra_attributes = {})
+      attributes = {
+        :model_class            => ::Vm,
+        :association            => :vms,
+        :delete_method          => :disconnect_inv,
+        :attributes_blacklist   => [:genealogy_parent],
+        :use_ar_object          => true, # Because of raw_power_state setter and hooks are needed for settings user
+        # TODO(lsmola) can't do batch strategy for vms because of key_pairs relation
+        :saver_strategy         => :default,
+        :batch_extra_attributes => [:power_state, :state_changed_on, :previous_state],
+        :builder_params         => {
+          :ems_id   => ->(persister) { persister.manager.id },
+          :name     => "unknown",
+          :location => "unknown",
+        }
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def miq_templates(extra_attributes = {})
+      attributes = {
+        :model_class            => ::MiqTemplate,
+        :association            => :miq_templates,
+        :delete_method          => :disconnect_inv,
+        :attributes_blacklist   => [:genealogy_parent],
+        :use_ar_object          => true, # Because of raw_power_state setter
+        :saver_strategy         => :default, # Hooks are needed for setting user
+        :batch_extra_attributes => [:power_state, :state_changed_on, :previous_state],
+        :builder_params         => {
+          :ems_id   => ->(persister) { persister.manager.id },
+          :name     => "unknown",
+          :location => "unknown",
+          :template => true
+        }
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def hardwares(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::Hardware,
+        :manager_ref                  => [:vm_or_template],
+        :association                  => :hardwares,
+        :parent_inventory_collections => [:vms, :miq_templates],
+        # TODO(lsmola) just because of default value on cpu_sockets, this can be fixed by separating instances_hardwares and images_hardwares
+        :use_ar_object                => true,
+      }
+
+      attributes[:custom_manager_uuid] = lambda do |hardware|
+        [hardware.vm_or_template.ems_ref]
+      end
+
+      attributes[:custom_db_finder] = lambda do |inventory_collection, selection, _projection|
+        relation = inventory_collection.parent.send(inventory_collection.association)
+                                       .includes(:vm_or_template)
+                                       .references(:vm_or_template)
+        relation = relation.where(:vms => {:ems_ref => selection.map { |x| x[:vm_or_template] }}) unless selection.blank?
+        relation
+      end
+
+      attributes[:targeted_arel] = lambda do |inventory_collection|
+        manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
+        inventory_collection.parent.hardwares.joins(:vm_or_template).where(
+          'vms' => {:ems_ref => manager_uuids}
+        )
+      end
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def disks(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::Disk,
+        :manager_ref                  => [:hardware, :device_name],
+        :association                  => :disks,
+        :parent_inventory_collections => [:vms],
+      }
+
+      if extra_attributes[:strategy] == :local_db_cache_all
+        attributes[:custom_manager_uuid] = lambda do |disk|
+          [disk.hardware.vm_or_template.ems_ref, disk.device_name]
+        end
+      end
+
+      attributes[:targeted_arel] = lambda do |inventory_collection|
+        manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
+        inventory_collection.parent.disks.joins(:hardware => :vm_or_template).where(
+          :hardware => {'vms' => {:ems_ref => manager_uuids}}
+        )
+      end
+
+      attributes.merge!(extra_attributes)
+    end
+  end
 end

--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -1,45 +1,5 @@
 class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh::InventoryCollectionDefault
   class << self
-    def vms(extra_attributes = {})
-      attributes = {
-        :model_class            => ::ManageIQ::Providers::CloudManager::Vm,
-        :association            => :vms,
-        :delete_method          => :disconnect_inv,
-        :attributes_blacklist   => [:genealogy_parent],
-        :use_ar_object          => true, # Because of raw_power_state setter and hooks are needed for settings user
-        # TODO(lsmola) can't do batch strategy for vms because of key_pairs relation
-        :saver_strategy         => :default,
-        :batch_extra_attributes => [:power_state, :state_changed_on, :previous_state],
-        :builder_params         => {
-          :ems_id   => ->(persister) { persister.manager.id },
-          :name     => "unknown",
-          :location => "unknown",
-        }
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def miq_templates(extra_attributes = {})
-      attributes = {
-        :model_class            => ::ManageIQ::Providers::CloudManager::Template,
-        :association            => :miq_templates,
-        :delete_method          => :disconnect_inv,
-        :attributes_blacklist   => [:genealogy_parent],
-        :use_ar_object          => true, # Because of raw_power_state setter
-        :saver_strategy         => :default, # Hooks are needed for setting user
-        :batch_extra_attributes => [:power_state, :state_changed_on, :previous_state],
-        :builder_params         => {
-          :ems_id   => ->(persister) { persister.manager.id },
-          :name     => "unknown",
-          :location => "unknown",
-          :template => true
-        }
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
     def availability_zones(extra_attributes = {})
       attributes = {
         :model_class    => ::AvailabilityZone,
@@ -77,63 +37,6 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
 
       attributes.merge!(extra_attributes)
     end
-
-    def hardwares(extra_attributes = {})
-      attributes = {
-        :model_class                  => ::Hardware,
-        :manager_ref                  => [:vm_or_template],
-        :association                  => :hardwares,
-        :parent_inventory_collections => [:vms, :miq_templates],
-        # TODO(lsmola) just because of default value on cpu_sockets, this can be fixed by separating instances_hardwares and images_hardwares
-        :use_ar_object                => true,
-      }
-
-      attributes[:custom_manager_uuid] = lambda do |hardware|
-        [hardware.vm_or_template.ems_ref]
-      end
-
-      attributes[:custom_db_finder] = lambda do |inventory_collection, selection, _projection|
-        relation = inventory_collection.parent.send(inventory_collection.association)
-                                       .includes(:vm_or_template)
-                                       .references(:vm_or_template)
-        relation = relation.where(:vms => {:ems_ref => selection.map { |x| x[:vm_or_template] }}) unless selection.blank?
-        relation
-      end
-
-      attributes[:targeted_arel] = lambda do |inventory_collection|
-        manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.hardwares.joins(:vm_or_template).where(
-          'vms' => {:ems_ref => manager_uuids}
-        )
-      end
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def disks(extra_attributes = {})
-      attributes = {
-        :model_class                  => ::Disk,
-        :manager_ref                  => [:hardware, :device_name],
-        :association                  => :disks,
-        :parent_inventory_collections => [:vms],
-      }
-
-      if extra_attributes[:strategy] == :local_db_cache_all
-        attributes[:custom_manager_uuid] = lambda do |disk|
-          [disk.hardware.vm_or_template.ems_ref, disk.device_name]
-        end
-      end
-
-      attributes[:targeted_arel] = lambda do |inventory_collection|
-        manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.disks.joins(:hardware => :vm_or_template).where(
-          :hardware => {'vms' => {:ems_ref => manager_uuids}}
-        )
-      end
-
-      attributes.merge!(extra_attributes)
-    end
-
     def networks(extra_attributes = {})
       attributes = {
         :model_class                  => ::Network,

--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -1,39 +1,5 @@
 class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh::InventoryCollectionDefault
   class << self
-    def vms(extra_attributes = {})
-      attributes = {
-        :model_class    => ::ManageIQ::Providers::InfraManager::Vm,
-        :association    => :vms,
-        :builder_params => {
-          :ems_id => ->(persister) { persister.manager.id },
-        },
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def miq_templates(extra_attributes = {})
-      attributes = {
-        :model_class    => ::ManageIQ::Providers::InfraManager::Template,
-        :association    => :miq_templates,
-        :builder_params => {
-          :ems_id => ->(persister) { persister.manager.id },
-        },
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def disks(extra_attributes = {})
-      attributes = {
-        :model_class => ::Disk,
-        :manager_ref => [:hardware, :device_name],
-        :association => :disks,
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
     def networks(extra_attributes = {})
       attributes = {
           :model_class => ::Network,
@@ -59,16 +25,6 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class => ::GuestDevice,
         :manager_ref => [:hardware, :uid_ems],
         :association => :guest_devices,
-      }
-
-      attributes.merge!(extra_attributes)
-    end
-
-    def hardwares(extra_attributes = {})
-      attributes = {
-        :model_class => ::Hardware,
-        :manager_ref => [:vm_or_template],
-        :association => :hardwares,
       }
 
       attributes.merge!(extra_attributes)


### PR DESCRIPTION
A number of inventory collections are shared between cloud and infra
managers (e.g. vms, templates, hardwares, disks).  These were duplicated
in the different managers' default inventory_collections.  This moves
these up to the base inventory collection default class.