### PR TITLE
[WIP] [FINE] Avoid memory bloat when saving openshift images

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -219,10 +219,13 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_image_registry_id] = h[:container_image_registry][:id] unless h[:container_image_registry].nil?
     end
 
-    save_inventory_multi(ems.container_images, hashes, :use_association, [:image_ref, :container_image_registry_id],
-                         [:labels, :docker_labels], :container_image_registry, true)
-    store_ids_for_new_records(ems.container_images, hashes,
-                              [:image_ref, :container_image_registry_id])
+    save_inventory_with_thin_association(ems,
+                                         :container_images,
+                                         hashes,
+                                         [:image_ref, :container_image_registry_id],
+                                         [:labels, :docker_labels],
+                                         :container_image_registry,
+                                         true)
   end
 
   def save_container_image_registries_inventory(ems, hashes)

--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -33,6 +33,23 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
+  # instead of storing records, only store ids
+  class IdTypedIndex < TypedIndex
+    def initialize(ids, find_key, model)
+      @key_attribute_types = find_key.map { |k| model.type_for_attribute(k) }
+
+      # find the records keys for the given records
+      records = model.where(:id => ids).pluck(*find_key, model.primary_key)
+
+      # Index the records by the values from the find_key
+      @record_index = records.each_with_object({}) do |keys_and_val, h|
+        h.store_path(*keys_and_val)
+      end
+
+      @find_key = find_key
+    end
+  end
+
   def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [], disconnect = false)
     association.reset
 
@@ -74,6 +91,44 @@ module EmsRefresh::SaveInventoryHelper
     association.push(new_records)
   end
 
+  def save_inventory_with_thin_association(parent, association, hashes, find_key,
+                                           child_keys = [], extra_keys = [],
+                                           disconnect = false)
+    relation      = parent.association(association).reflection
+    model         = parent.association(association).klass
+    assoc_attrs   = parent.association(association).reader.scope_attributes
+    deletes_index = model.pluck(relation.active_record_primary_key)
+                         .index_by { |x| x }
+
+    child_keys = Array.wrap(child_keys)
+    remove_keys = Array.wrap(extra_keys) + child_keys
+    record_index = IdTypedIndex.new(deletes_index.values, find_key, model)
+    inventory_ids = []
+
+    hashes.each do |h|
+      found = nil
+      ActiveRecord::Base.transaction do
+        found = save_inventory_with_findkey(model, h.except(*remove_keys).merge(assoc_attrs), deletes_index, nil, record_index, true)
+        save_child_inventory(found, h, child_keys)
+        found.save
+        # store both found and new ids for updating stored_ids
+        inventory_ids << found.id
+      end
+    end
+
+    # Delete the items no longer found
+    deletes = deletes_index.values
+    unless deletes.blank?
+      ActiveRecord::Base.transaction do
+        delete_records = model.where(:id => deletes)
+        _log.info("[#{association}] Deleting #{log_format_deletes(delete_records)}")
+        disconnect ? delete_records.each(&:disconnect_inv) : association.delete(delete_records)
+      end
+    end
+
+    store_ids_for_record_ids(inventory_ids, model, hashes, find_key)
+  end
+
   def save_inventory_single(type, parent, hash, child_keys = [], extra_keys = [], disconnect = false)
     child = parent.send(type)
     if hash.blank?
@@ -91,15 +146,16 @@ module EmsRefresh::SaveInventoryHelper
     save_child_inventory(child, hash, child_keys)
   end
 
-  def save_inventory_with_findkey(association, hash, deletes, new_records, record_index)
+  def save_inventory_with_findkey(association, hash, deletes, new_records, record_index, id_only = false)
     # Find the record, and update if found, else create it
     found = record_index.fetch(hash)
     if found.nil?
-      found = association.build(hash.except(:id))
-      new_records << found
+      found = association.public_send(id_only ? :new : :build, hash.except(:id))
+      new_records << found if new_records
     else
+      found = association.find(found) if id_only
       update_attributes!(found, hash, [:id, :type])
-      deletes.delete(found) unless deletes.blank?
+      deletes.delete(id_only ? found.id : found) unless deletes.blank?
     end
     found
   end
@@ -134,6 +190,16 @@ module EmsRefresh::SaveInventoryHelper
       record = record_index[build_index_from_hash(keys, hash, record_class)]
       hash[:id] = record.id
     end
+  end
+
+  def store_ids_for_record_ids(ids, model, hashes, keys)
+    return if ids.blank?
+
+    keys = Array(keys)
+    # Lets first index the hashes based on keys, so we can do O(1) lookups
+    record_index = IdTypedIndex.new(ids, keys, model)
+
+    hashes.each { |hash| hash[:id] = record_index.fetch(hash) }
   end
 
   def build_index_from_hash(keys, hash, record_class)


### PR DESCRIPTION
Mostly introduces a new method into `save_inventory_helper.rb`, `save_inventory_with_thin_association`, which is a memory efficient version of `save_inventory_multi`.

This method effectively the same as `save_inventory_multi`, but does so without referencing the parent object to build the association, avoiding needing to keep all of the active record objects that would be created in this call in memory throughout the rest of the refresh (since they are applied to the parent object via a `<<`, they then stick with the ems for the rest of the refresh instead of being garbage collected once they are done).

This also removes the `ActiveRecord::Base.transaction` around saving every single image, and only wraps it for each individual image (meaning any child objects are part of the same transaction, but not ALL of the images being saved).

Beyond that, to achieve this, we are making sure no references to the main object are retained any longer than they need to be (or at all when possible), so this means determining the main object we are building through the reflection, but also not instantiating it through the `CollectionProxy` (via `#build`), but using new on the reflection object, and making sure we apply the `scope_attributes` from the reflection before saving the object.

The downside is we are using a bunch of private API's to do this in a generic manor, and this has no real speed improvements to the refresh (besides maybe some lighter queries, which will improve environments will low latency between worker and DB).


Links
-----

* Redo of https://github.com/ManageIQ/manageiq/pull/15923


Steps for Testing/QA
--------------------

Compare the memory usage when running a openshift refresh with a lot of images with this branch and that of the `fine` branch.