### PR TITLE
Fix event_catcher blacklisted events logging

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -18,8 +18,7 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
 
     @filtered_events = @ems.blacklisted_event_names
-    _log.info("#{log_prefix} Event Catcher skipping the following events:")
-    $log.log_hashes(@filtered_events)
+    _log.info("#{log_prefix} Event Catcher skipping the following events:\n#{@filtered_events.to_a.join("\n")}")
 
     configure_event_flooding_prevention if worker_settings.try(:[], :flooding_monitor_enabled)
 


### PR DESCRIPTION
The event catcher runner was printing the blacklisted events array using
the VMDBLogger#log_hashes method.  Now that this method calls .to_hash
on the argument
(https://github.com/ManageIQ/manageiq-gems-pending/pull/268)
this is throwing an exception for non-hash type arguments.

Instead of using log_hashes just log the elements of the array joined by
newlines directly.

```
/home/agrare/workspace/redhat/manageiq/plugins/manageiq-gems-pending/lib/gems/pending/util/vmdb-logger.rb:116:in `log_hashes'[----] I, [2017-09-07T09:08:21.914128 #28447:2ab55ee0f0cc]: undefined method `to_hash' for #<Array:0x00556ac8a4ef88> (NoMethodError)
Did you mean?  to_h
	from /home/agrare/workspace/redhat/manageiq/plugins/manageiq-gems-pending/lib/gems/pending/util/vmdb-logger.rb:128:in `log_hashes'
	from /home/agrare/workspace/redhat/manageiq/lib/vmdb/loggers/multicast_logger.rb:34:in `block in method_missing'
	from /usr/lib/ruby/2.3.0/set.rb:306:in `each_key'
	from /usr/lib/ruby/2.3.0/set.rb:306:in `each'
	from /home/agrare/workspace/redhat/manageiq/lib/vmdb/loggers/multicast_logger.rb:34:in `map'
	from /home/agrare/workspace/redhat/manageiq/lib/vmdb/loggers/multicast_logger.rb:34:in `method_missing'
	from /home/agrare/workspace/redhat/manageiq/app/models/manageiq/providers/base_manager/event_catcher/runner.rb:22:in `after_initialize'
```