### PR TITLE
Fix log_hashes with a nil

### DIFF
--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -40,7 +40,7 @@ module Vmdb
       fh.info("---")
 
       fh.info("DATABASE settings:")
-      VMDBLogger.log_hashes(fh, Rails.configuration.database_configuration[Rails.env])
+      VMDBLogger.log_hashes(fh, ActiveRecord::Base.connection_config)
       fh.info("DATABASE settings END")
       fh.info("---")
     end


### PR DESCRIPTION
In container environments, the database is provided via ENV variable and `Rails.configuration.database_configuration` is then `{}`.  `ActiveRecord::Base` has the correct connection configuration for the current environment