### PR TITLE
Fix Chargeable Storage rate description typo

### DIFF
--- a/db/fixtures/chargeable_fields.yml
+++ b/db/fixtures/chargeable_fields.yml
@@ -41,12 +41,12 @@
   :group: fixed
   :source: compute_2
 - :metric: derived_vm_allocated_disk_storage
-  :description: Allocated Disk Storag
+  :description: Allocated Disk Storage
   :group: storage
   :source: allocated
   :measure: Bytes Units
 - :metric: derived_vm_used_disk_storage
-  :description: Used Disk Storag
+  :description: Used Disk Storage
   :group: storage
   :source: used
   :measure: Bytes Units


### PR DESCRIPTION
This fix requires ChargeableField.seed to be run.

https://bugzilla.redhat.com/show_bug.cgi?id=1487433

Screen shot before:

![bz1487433_storage chargeback rate description prior to fix](https://user-images.githubusercontent.com/552686/30220987-79800b52-9476-11e7-826e-6c103e10b386.png)

=====================
Screen shot post code fix:

<img width="1671" alt="bz1487433_storage chargeback rate description post fix" src="https://user-images.githubusercontent.com/552686/30221002-867e9b84-9476-11e7-95c2-5096043f2e44.png">
