### PR TITLE
Update model to support LXCA config patterns

### DIFF
--- a/app/models/configuration_template.rb
+++ b/app/models/configuration_template.rb
@@ -1,0 +1,3 @@
+class ConfigurationTemplate < ApplicationRecord
+  belongs_to :ext_management_system, :foreign_key => "ems_id"
+end

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -23,6 +23,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
 
     child_keys = [
       :physical_servers,
+      :configuration_templates
     ]
 
     # Save and link other subsections
@@ -49,6 +50,20 @@ module EmsRefresh::SaveInventoryPhysicalInfra
     child_keys = [:computer_system, :asset_details, :hosts]
     save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
+  end
+
+  def save_configuration_templates_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+
+    ems.configuration_templates.reset
+    deletes = if target == ems
+                :use_association
+              else
+                []
+              end
+
+    save_inventory_multi(ems.configuration_templates, hashes, deletes, [:ems_ref])
+    store_ids_for_new_records(ems.configuration_templates, hashes, :ems_ref)
   end
 
   #

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -59,6 +59,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :customization_specs, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :storage_profiles,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :physical_servers,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :configuration_templates, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6375,6 +6375,26 @@
       :feature_type: view
       :identifier: guest_device_show
 
+# Configuration Templates
+- :name: Configuration Templates
+  :description: Everything under Configuration Templates
+  :feature_type: node
+  :identifier: configuration_template
+  :children:
+  - :name: View
+    :description: View Configuration Template
+    :feature_type: view
+    :identifier: configuration_template_view
+    :children:
+    - :name: List
+      :description: Display Lists of Configuration Templates
+      :feature_type: view
+      :identifier: configuration_template_show_list
+    - :name: Show
+      :description: Display Individual Configuration Templates
+      :feature_type: view
+      :identifier: configuration_template_show
+
 # Physical Infrastructure Topology
 - :name: Physical Infra Topology
   :description: Physical Infra Topology


### PR DESCRIPTION
This PR adds model support for Lenovo XClarity Administrator (LXCA) configuration patterns which can be thought of as templates describing the configuration of physical systems. These "templates" are used by LXCA to configure hardware such as servers, switches, and storage.