### PR TITLE
Make tools easier to run

### DIFF
--- a/tools/create_evm_snapshot.rb
+++ b/tools/create_evm_snapshot.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 def usage
   puts "Error: Must pass only one of the following:"
   puts "  --vm=<vm id>"

--- a/tools/db_ping_remote.rb
+++ b/tools/db_ping_remote.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 require 'io/console'
 

--- a/tools/db_printers/print_ae_tree.rb
+++ b/tools/db_printers/print_ae_tree.rb
@@ -1,5 +1,7 @@
-# Rails.logger.level = $log.level = 0
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
 
+# Rails.logger.level = $log.level = 0
 def print_ae_tree(nodes, indent = "")
   nodes.sort_by { |n| n.name.downcase }.each do |node|
     title = node.class.name.demodulize[5..-1]

--- a/tools/db_printers/print_ems_metadata.rb
+++ b/tools/db_printers/print_ems_metadata.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 def print_subtree(subtree, indent = '')
   subtree = subtree.sort_by { |obj, _children| [obj.class.name, obj.name.downcase] }
   subtree.each do |obj, children|

--- a/tools/db_printers/print_ems_metadata_full.rb
+++ b/tools/db_printers/print_ems_metadata_full.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 def print_subtree(subtree, indent = '')
   subtree = subtree.sort_by { |obj, _children| [obj.class.name, obj.name.downcase] }
   subtree.each do |obj, children|

--- a/tools/db_printers/print_network.rb
+++ b/tools/db_printers/print_network.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 def print_switch(indent, switch)
   puts "#{indent}Switch: #{switch.name}"
   switch.lans.order("lower(name)").each do |lan|

--- a/tools/db_printers/print_relationships.rb
+++ b/tools/db_printers/print_relationships.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 def print_rels(subtree, indent = '')
   subtree = subtree.sort_by { |rel, _children| rel.resource_pair }
   subtree.each do |rel, children|

--- a/tools/db_printers/print_scsi.rb
+++ b/tools/db_printers/print_scsi.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 Host.all.each do |host|
   puts "Host: #{host.name} (id: #{host.id})"
 

--- a/tools/db_printers/print_vmdb_database.rb
+++ b/tools/db_printers/print_vmdb_database.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 def print_records(recs, indent = '')
   recs = recs.sort_by { |r| r.name.downcase }
   recs.each do |r|

--- a/tools/dba.rb
+++ b/tools/dba.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 module Dba
   def self.select(*args)
     ActiveRecord::Base.connection.send(:select, *args)

--- a/tools/delete_all_error_timeout_queue_messages.rb
+++ b/tools/delete_all_error_timeout_queue_messages.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 cond = {:state => ["error", "timeout"]}
 puts "Deleting #{MiqQueue.where(cond).count} queue messages"
 

--- a/tools/delete_ems_metadata_relationships.rb
+++ b/tools/delete_ems_metadata_relationships.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 puts "Deleting ems_metadata Relationships..."
 Relationship.where(:relationship => "ems_metadata").delete_all
 puts "Deleting ems_metadata Relationships...Complete"

--- a/tools/doc/reportable_fields_to_csv.rb
+++ b/tools/doc/reportable_fields_to_csv.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 models = MiqReport.reportable_models.collect do |m|
   [Dictionary.gettext(m, :type => :model, :notfound => :titleize).pluralize, m]
 end.sort

--- a/tools/doc/reports_to_csv.rb
+++ b/tools/doc/reports_to_csv.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../config/environment', __dir__)
+
 require 'csv'
 CSV.open("reports.csv", "w") do |csv|
   csv << %w(Name Title Group Sorting Graph Filter)

--- a/tools/evm_dump.rb
+++ b/tools/evm_dump.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 LOG_DIR = "./"
 logfile = File.join(LOG_DIR, "evm_dump.log")
 File.delete(logfile) if File.exist?(logfile)

--- a/tools/export_tags.rb
+++ b/tools/export_tags.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 output = ARGV[0]
 raise "No output file provided" if output.nil?
 

--- a/tools/feature_support_matrix.rb
+++ b/tools/feature_support_matrix.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 require 'csv'
 

--- a/tools/fix_binary_blobs_and_parts_size_column.rb
+++ b/tools/fix_binary_blobs_and_parts_size_column.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 puts "Fixing BinaryBlob and BinaryBlobPart sizes"
 
 blob_ids = BinaryBlobPart.select(:binary_blob_id).where("size != LENGTH(data)")

--- a/tools/fix_column_ordering.rb
+++ b/tools/fix_column_ordering.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 $LOAD_PATH << Rails.root.join("tools")
 
 require 'column_ordering/column_ordering'

--- a/tools/fix_disk_sizes.rb
+++ b/tools/fix_disk_sizes.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 def getDinfo(vim)
   dinfo = []
   vim.virtualMachinesByMor.each do |_k, v|

--- a/tools/fix_vm_relationships.rb
+++ b/tools/fix_vm_relationships.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 ### Used to fix VM to Parent Resource Pool relationship problems.
 # Normally seen when user clicks on a VM to view VM summary page.
 # Error is displayed "Couldn't find Relationship with id=XXXX [vm_or_template/tree_select]"

--- a/tools/import_tags.rb
+++ b/tools/import_tags.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 input = ARGV[0]
 raise "No input file provided" if input.nil?
 

--- a/tools/import_v4_provision_dialogs.rb
+++ b/tools/import_v4_provision_dialogs.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 # Convert v4-style provisioning dialogs from Ruby files into YAML format
 # and store in the miq_dialogs table.
 Dir.glob(Rails.root.join("db/fixtures/*.rb")) do |dialog_file|

--- a/tools/kill_provision.rb
+++ b/tools/kill_provision.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 st = Time.now
 @stop_message = "Provisioning stopped by external script."
 @processed = []

--- a/tools/ldap_ping.rb
+++ b/tools/ldap_ping.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 LOG_DIR = "./"
 logfile = File.join(LOG_DIR, "ldap_ping.log")
 # File.delete(logfile) if File.exist?(logfile)

--- a/tools/list_evm_snapshots.rb
+++ b/tools/list_evm_snapshots.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
 require 'rubygems'
 require 'log4r'
 require 'VMwareWebService/MiqVim'

--- a/tools/log_processing/broker_registry_counts.rb
+++ b/tools/log_processing/broker_registry_counts.rb
@@ -1,4 +1,5 @@
-RAILS_ROOT = ENV["RAILS_ENV"] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
+#!/usr/bin/env ruby
+RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
 require 'manageiq-gems-pending'
 require 'miq_logger_processor'
 

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -1,4 +1,5 @@
-RAILS_ROOT = ENV['RAILS_ENV'] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
+#!/usr/bin/env ruby
+RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
 
 require 'manageiq-gems-pending'
 require 'miq_logger_processor'

--- a/tools/log_processing/perf_timings.rb
+++ b/tools/log_processing/perf_timings.rb
@@ -1,4 +1,6 @@
-RAILS_ROOT = ENV["RAILS_ENV"] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
+#!/usr/bin/env ruby
+
+RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
 require 'manageiq-gems-pending'
 require 'miq_logger_processor'
 

--- a/tools/log_processing/split_log_by_pid_tid.rb
+++ b/tools/log_processing/split_log_by_pid_tid.rb
@@ -1,4 +1,6 @@
-RAILS_ROOT = ENV["RAILS_ENV"] ? Rails.root : File.expand_path(File.join(__dir__, %w(.. ..)))
+#!/usr/bin/env ruby
+
+RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
 require 'manageiq-gems-pending'
 require 'miq_logger_processor'
 

--- a/tools/metrics_capture_gap.rb
+++ b/tools/metrics_capture_gap.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 if ARGV.length != 2
   puts "Usage: rails runner #{$0} start_date end_date"
   puts

--- a/tools/metrics_destroy_for_time_profile.rb
+++ b/tools/metrics_destroy_for_time_profile.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 if ARGV.length != 1
   puts "Usage: rails runner #{$0} time_profile_id"
   exit 1

--- a/tools/metrics_populate_retro_tags.rb
+++ b/tools/metrics_populate_retro_tags.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 # Rails.logger.level = 0
 
 start_ts, end_ts, id_spec = ARGV

--- a/tools/purge_archived_vms.rb
+++ b/tools/purge_archived_vms.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 # Delete any records older than this:
 ARCHIVE_CUTOFF = Time.now.utc - 1.month
 # If true, do not delete anything; only report:

--- a/tools/purge_ems_events.rb
+++ b/tools/purge_ems_events.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 KEEP_EVENTS  = 6.months
 PURGE_WINDOW = 1000
 

--- a/tools/purge_host_unknown_records.rb
+++ b/tools/purge_host_unknown_records.rb
@@ -1,2 +1,5 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 class HostUnknown < Host; end
 HostUnknown.destroy_all

--- a/tools/purge_metrics.rb
+++ b/tools/purge_metrics.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 require 'trollop'
 

--- a/tools/purge_miq_report_results.rb
+++ b/tools/purge_miq_report_results.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 require 'trollop'
 

--- a/tools/purge_orphaned_tag_values.rb
+++ b/tools/purge_orphaned_tag_values.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 require 'trollop'
 

--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 require 'trollop'
 require 'rest-client'

--- a/tools/rm_evm_snapshots.rb
+++ b/tools/rm_evm_snapshots.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
 require 'rubygems'
 require 'log4r'
 require 'VMwareWebService/MiqVim'

--- a/tools/show_host_file_entries_for_vnc.rb
+++ b/tools/show_host_file_entries_for_vnc.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 ManageIQ::Providers::Vmware::Host.all.each do |host|
   if host.ipaddress.blank?
     STDERR.puts "Host ID=#{host.id.inspect}, Name=#{host.name.inspect} has no IP Address"

--- a/tools/vim_collect_inventory.rb
+++ b/tools/vim_collect_inventory.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 require 'trollop'
 ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
 opts = Trollop.options do

--- a/tools/vim_collect_perf_history.rb
+++ b/tools/vim_collect_perf_history.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 require 'trollop'
 ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
 opts = Trollop.options do

--- a/tools/vm_retirement.rb
+++ b/tools/vm_retirement.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
 def header
   output  = "Name\tOwner\tOwner Userid\tOwning Group\tRetired?\tRetirement Date\tRetirement Warning"
   output += "\n"


### PR DESCRIPTION
Support users running these as an executable, a ruby script, or through
rails runner:

```
./tools/db_ping_remote.rb
ruby tools/db_ping_remote.rb
bin/rails r tools/db_ping_remote.rb
```

Add executable permission
Add shebang for ruby
Load rails automatically for tools that require rails
[skip ci]

Similar to #14169