### PR TITLE
Move ESX specifics out of ::Host#detect_discovered_hypervisor

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -167,7 +167,6 @@ class Host < ApplicationRecord
   include AuthenticationMixin
   include AsyncDeleteMixin
   include ComplianceMixin
-  include VimConnectMixin
   include AvailabilityMixin
 
   before_create :make_smart
@@ -902,25 +901,6 @@ class Host < ApplicationRecord
       self.ipaddress   = ipaddr
       self.vmm_vendor  = "microsoft"
       self.vmm_product = "Hyper-V"
-    elsif ost.hypervisor.include?(:esx)
-      self.name        = "VMware ESX Server (#{ipaddr})"
-      self.ipaddress   = ipaddr
-      self.vmm_vendor  = "vmware"
-      self.vmm_product = "Esx"
-      if has_credentials?(:ws)
-        begin
-          with_provider_connection(:ip => ipaddr) do |vim|
-            _log.info("VIM Information for ESX Host with IP Address: [#{ipaddr}], Information: #{vim.about.inspect}")
-            self.vmm_product     = vim.about['name'].dup.split(' ').last
-            self.vmm_version     = vim.about['version']
-            self.vmm_buildnumber = vim.about['build']
-            self.name            = "#{vim.about['name']} (#{ipaddr})"
-          end
-        rescue => err
-          _log.warn("Cannot connect to ESX Host with IP Address: [#{ipaddr}], Username: [#{authentication_userid(:ws)}] because #{err.message}")
-        end
-      end
-      self.type = %w(esx esxi).include?(vmm_product.to_s.downcase) ? "ManageIQ::Providers::Vmware::InfraManager::HostEsx" : "ManageIQ::Providers::Vmware::InfraManager::Host"
     elsif ost.hypervisor.include?(:ipmi)
       find_method       = :find_by_ipmi_address
       self.name         = "IPMI (#{ipaddr})"


### PR DESCRIPTION
This cleans up the main method and allows us to remove VimConnectMixin

Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/106