### PR TITLE
[FINE] Do not downcase the amazon IAM username

### DIFF
--- a/app/models/authenticator/amazon.rb
+++ b/app/models/authenticator/amazon.rb
@@ -133,5 +133,9 @@ module Authenticator
         :log_formatter     => Aws::Log::Formatter.new(Aws::Log::Formatter.default.pattern.chomp)
       )
     end
+
+    def normalize_username(username)
+      username
+    end
   end
 end

--- a/spec/models/authenticator/amazon_spec.rb
+++ b/spec/models/authenticator/amazon_spec.rb
@@ -1,8 +1,8 @@
 require 'aws-sdk'
 
 describe Authenticator::Amazon do
-  AWS_ROOT_USER_KEY = 'aws_root_key'
-  AWS_IAM_USER_KEY = 'aws_iam_key'
+  AWS_ROOT_USER_KEY = 'aws_root_key'.freeze
+  AWS_IAM_USER_KEY = 'AWS_IAM_KEY'.freeze
 
   subject { Authenticator::Amazon.new(config) }
 


### PR DESCRIPTION
(manually picked from https://github.com/ManageIQ/manageiq-providers-amazon/commit/3a2408b4cee5e32b22dc67a1db6c96aac912c318)

The code has been refactored on the master branch. It has been moved to
the https://github.com/ManageIQ/manageiq-providers-amazon repository.

The master PR for this change is:
https://github.com/ManageIQ/manageiq-providers-amazon/pull/296


This commit addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1489596


Summary:

Fix authentication mode: amazon

### Description:

This PR address a regression that was introduce by PR 15796 which
caused a regression in authentication preventing logins when the authentication
mode is configured for "Amazon"

### Notes to QE on how to test this fix:

Configure an appliance for authentication mode of "Amazon"
Configure an valid group on the appliance for a valid Amazon user.
Attempt to login with valid user credentials from the Amazon account.

