### PR TITLE
Snapshot Support for Non-Managed Disks SSA

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -199,6 +199,7 @@ class VmScan < Job
                 "description"  => options[:snapshot_description]}
     snapshot['create_free_percent'] = ::Settings.snapshots.create_free_percent
     snapshot['remove_free_percent'] = ::Settings.snapshots.remove_free_percent
+    snapshot['name'] = context[:snapshot_mor]
     snapshot
   end
 


### PR DESCRIPTION
Add support so that non-managed disks can be snapshotted
for SSA.  This change passes the snapshot value returned
along for the scan call.

Two associated PRs are:
https://github.com/ManageIQ/manageiq-smartstate/pull/26
and https://github.com/ManageIQ/manageiq-providers-azure/pull/122

These changes are in support of a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1463780
Again a decision must be made as to whether or not to back port this to Fine.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1463780
* https://github.com/ManageIQ/manageiq-smartstate/pull/26

Steps for Testing/QA [Optional]
-------------------------------

Start an Azure instance that does not have a Managed Disk.  Run SSA on the instance.
@roliveri please review.  Note that this and the manageiq-smartstate PR can be merged in either order.

Also note this is a *one* line change.