### PR TITLE
Enhance the the orchestrator to deal with more objects

### DIFF
--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -1,28 +1,83 @@
+require 'kubeclient'
+
 class ContainerOrchestrator
+  include_concern 'ObjectDefinition'
+
   TOKEN_FILE = "/run/secrets/kubernetes.io/serviceaccount/token".freeze
 
   def scale(deployment_config_name, replicas)
-    connection.patch_deployment_config(deployment_config_name, { :spec => { :replicas => replicas } }, ENV["MY_POD_NAMESPACE"])
+    connection.patch_deployment_config(deployment_config_name, { :spec => { :replicas => replicas } }, my_namespace)
+  end
+
+  def create_deployment_config(name)
+    definition = deployment_config_definition(name)
+    yield(definition) if block_given?
+    connection.create_deployment_config(definition)
+  rescue KubeException => e
+    raise unless e.message =~ /already exists/
+  end
+
+  def create_service(name, port)
+    definition = service_definition(name, port)
+    yield(definition) if block_given?
+    kube_connection.create_service(definition)
+  rescue KubeException => e
+    raise unless e.message =~ /already exists/
+  end
+
+  def create_secret(name, data)
+    definition = secret_definition(name, data)
+    yield(definition) if block_given?
+    kube_connection.create_secret(definition)
+  rescue KubeException => e
+    raise unless e.message =~ /already exists/
+  end
+
+  def delete_deployment_config(name)
+    rc = kube_connection.get_replication_controllers(
+      :label_selector => "openshift.io/deployment-config.name=#{name}",
+      :namespace      => my_namespace
+    ).first
+
+    connection.delete_deployment_config(name, my_namespace)
+    delete_replication_controller(rc.metadata.name) if rc
+  end
+
+  def delete_replication_controller(name)
+    kube_connection.delete_replication_controller(name, my_namespace)
+  end
+
+  def delete_service(name)
+    kube_connection.delete_service(name, my_namespace)
+  end
+
+  def delete_secret(name)
+    kube_connection.delete_secret(name, my_namespace)
   end
 
   private
 
   def connection
-    require 'kubeclient'
-
-    @connection ||=
-      Kubeclient::Client.new(
-        manager_uri,
-        :auth_options => { :bearer_token_file => TOKEN_FILE },
-        :ssl_options  => { :verify_ssl => OpenSSL::SSL::VERIFY_NONE }
-      )
+    @connection ||= raw_connect(manager_uri("/oapi"))
   end
 
-  def manager_uri
+  def kube_connection
+    @kube_connection ||= raw_connect(manager_uri("/api"))
+  end
+
+  def raw_connect(uri)
+    Kubeclient::Client.new(
+      uri,
+      :auth_options => { :bearer_token_file => TOKEN_FILE },
+      :ssl_options  => { :verify_ssl => OpenSSL::SSL::VERIFY_NONE }
+    )
+  end
+
+  def manager_uri(path)
     URI::HTTPS.build(
       :host => ENV["KUBERNETES_SERVICE_HOST"],
       :port => ENV["KUBERNETES_SERVICE_PORT"],
-      :path => "/oapi"
+      :path => path
     )
   end
 end

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -58,12 +58,12 @@ class ContainerOrchestrator
 
     def default_environment
       [
-        {:name => "GUID",                    :value => MiqServer.my_guid},
         {:name => "DATABASE_SERVICE_NAME",   :value => ENV["DATABASE_SERVICE_NAME"]},
+        {:name => "GUID",                    :value => MiqServer.my_guid},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
-        {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
+        {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
         {:name      => "DATABASE_URL",
          :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "database-url"}}},
         {:name      => "V2_KEY",

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -1,0 +1,84 @@
+class ContainerOrchestrator
+  module ObjectDefinition
+    def deployment_config_definition(name)
+      {
+        :metadata => {
+          :name      => name,
+          :labels    => {:app => "manageiq"},
+          :namespace => my_namespace,
+        },
+        :spec     => {
+          :selector => {:name => name, :app => "manageiq"},
+          :template => {
+            :metadata => {:name => name, :labels => {:name => name, :app => "manageiq"}},
+            :spec     => {
+              :serviceAccount     => "miq-anyuid",
+              :serviceAccountName => "miq-anyuid",
+              :containers         => [{
+                :name          => name,
+                :env           => default_environment,
+                :livenessProbe => liveness_probe
+              }]
+            }
+          }
+        }
+      }
+    end
+
+    def service_definition(name, port)
+      {
+        :metadata => {
+          :name      => name,
+          :labels    => {:app => "manageiq"},
+          :namespace => my_namespace
+        },
+        :spec     => {
+          :selector => {:name => name},
+          :ports    => [{
+            :name       => "#{name}-#{port}",
+            :port       => port,
+            :targetPort => port
+          }]
+        }
+      }
+    end
+
+    def secret_definition(name, string_data)
+      {
+        :metadata   => {
+          :name      => name,
+          :labels    => {:app => "manageiq"},
+          :namespace => my_namespace
+        },
+        :stringData => string_data
+      }
+    end
+
+    def default_environment
+      [
+        {:name => "GUID",                    :value => MiqServer.my_guid},
+        {:name => "DATABASE_SERVICE_NAME",   :value => ENV["DATABASE_SERVICE_NAME"]},
+        {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
+        {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
+        {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
+        {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
+        {:name      => "DATABASE_URL",
+         :valueFrom => {:secretKeyRef=>{:name => "manageiq-secrets", :key => "database-url"}}},
+        {:name      => "V2_KEY",
+         :valueFrom => {:secretKeyRef=>{:name => "manageiq-secrets", :key => "v2-key"}}}
+      ]
+    end
+
+    def liveness_probe
+      {
+        :exec                => {:command => ["/usr/local/bin/manageiq_liveness_check"]},
+        :initialDelaySeconds => 120,
+        :timeoutSeconds      => 1
+      }
+    end
+
+    def my_namespace
+      ENV["MY_POD_NAMESPACE"]
+    end
+  end
+end

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -1,5 +1,7 @@
 class ContainerOrchestrator
   module ObjectDefinition
+    private
+
     def deployment_config_definition(name)
       {
         :metadata => {

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -6,13 +6,13 @@ class ContainerOrchestrator
       {
         :metadata => {
           :name      => name,
-          :labels    => {:app => "manageiq"},
+          :labels    => {:app => app_name},
           :namespace => my_namespace,
         },
         :spec     => {
-          :selector => {:name => name, :app => "manageiq"},
+          :selector => {:name => name, :app => app_name},
           :template => {
-            :metadata => {:name => name, :labels => {:name => name, :app => "manageiq"}},
+            :metadata => {:name => name, :labels => {:name => name, :app => app_name}},
             :spec     => {
               :serviceAccount     => "miq-anyuid",
               :serviceAccountName => "miq-anyuid",
@@ -31,7 +31,7 @@ class ContainerOrchestrator
       {
         :metadata => {
           :name      => name,
-          :labels    => {:app => "manageiq"},
+          :labels    => {:app => app_name},
           :namespace => my_namespace
         },
         :spec     => {
@@ -49,7 +49,7 @@ class ContainerOrchestrator
       {
         :metadata   => {
           :name      => name,
-          :labels    => {:app => "manageiq"},
+          :labels    => {:app => app_name},
           :namespace => my_namespace
         },
         :stringData => string_data
@@ -65,9 +65,9 @@ class ContainerOrchestrator
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
         {:name      => "DATABASE_URL",
-         :valueFrom => {:secretKeyRef=>{:name => "manageiq-secrets", :key => "database-url"}}},
+         :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "database-url"}}},
         {:name      => "V2_KEY",
-         :valueFrom => {:secretKeyRef=>{:name => "manageiq-secrets", :key => "v2-key"}}}
+         :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "v2-key"}}}
       ]
     end
 
@@ -81,6 +81,10 @@ class ContainerOrchestrator
 
     def my_namespace
       ENV["MY_POD_NAMESPACE"]
+    end
+
+    def app_name
+      I18n.t("product.name").downcase
     end
   end
 end

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -24,7 +24,7 @@ describe ContainerOrchestrator do
     it "connects to the correct uri" do
       expect(connection.api_endpoint.to_s).to eq("https://kube.example.com:8443/oapi")
       expect(connection.auth_options[:bearer_token_file]).to eq(token_path)
-      expect(connection.ssl_options[:verify_ssl]).to eq(0)
+      expect(connection.ssl_options[:verify_ssl]).to eq(1)
     end
   end
 
@@ -32,7 +32,7 @@ describe ContainerOrchestrator do
     it "connects to the correct uri" do
       expect(kube_connection.api_endpoint.to_s).to eq("https://kube.example.com:8443/api")
       expect(kube_connection.auth_options[:bearer_token_file]).to eq(token_path)
-      expect(kube_connection.ssl_options[:verify_ssl]).to eq(0)
+      expect(kube_connection.ssl_options[:verify_ssl]).to eq(1)
     end
   end
 

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -1,0 +1,160 @@
+describe ContainerOrchestrator do
+  let(:connection)      { subject.send(:connection) }
+  let(:kube_connection) { subject.send(:kube_connection) }
+  let(:token_path)      { Tempfile.new("servicetoken").path }
+  let(:kube_host)       { "kube.example.com" }
+  let(:kube_port)       { "8443" }
+  let(:namespace)       { "manageiq" }
+
+  before do
+    stub_const("ContainerOrchestrator::TOKEN_FILE", token_path)
+    ENV["KUBERNETES_SERVICE_HOST"] = kube_host
+    ENV["KUBERNETES_SERVICE_PORT"] = kube_port
+    ENV["MY_POD_NAMESPACE"] = namespace
+  end
+
+  after do
+    FileUtils.rm_f(token_path)
+    ENV.delete("KUBERNETES_SERVICE_HOST")
+    ENV.delete("KUBERNETES_SERVICE_PORT")
+    ENV.delete("MY_POD_NAMESPACE")
+  end
+
+  describe "#connection (private)" do
+    it "connects to the correct uri" do
+      expect(connection.api_endpoint.to_s).to eq("https://kube.example.com:8443/oapi")
+      expect(connection.auth_options[:bearer_token_file]).to eq(token_path)
+      expect(connection.ssl_options[:verify_ssl]).to eq(0)
+    end
+  end
+
+  describe "#kube_connection (private)" do
+    it "connects to the correct uri" do
+      expect(kube_connection.api_endpoint.to_s).to eq("https://kube.example.com:8443/api")
+      expect(kube_connection.auth_options[:bearer_token_file]).to eq(token_path)
+      expect(kube_connection.ssl_options[:verify_ssl]).to eq(0)
+    end
+  end
+
+  context "with stub connections" do
+    let(:connection_stub)      { double("OpenShiftConnection") }
+    let(:kube_connection_stub) { double("KubeConnection") }
+
+    before do
+      allow(subject).to receive(:connection).and_return(connection_stub)
+      allow(subject).to receive(:kube_connection).and_return(kube_connection_stub)
+    end
+
+    describe "#scale" do
+      it "patches the deployment config with the specified number of replicas" do
+        deployment_patch = {:spec => {:replicas => 4}}
+        expect(connection_stub).to receive(:patch_deployment_config).with("deployment", deployment_patch, namespace)
+
+        subject.scale("deployment", 4)
+      end
+    end
+
+    describe "#create_deployment_config" do
+      it "creates a deployment config with the given name and edits" do
+        expect(connection_stub).to receive(:create_deployment_config) do |definition|
+          expect(definition[:metadata][:name]).to eq("test")
+          expect(definition[:metadata][:namespace]).to eq("manageiq")
+
+          expect(definition[:spec][:template][:spec][:serviceAccount]).to eq("test-account")
+          expect(definition[:spec][:template][:spec][:serviceAccountName]).to eq("test-account")
+
+          expect(definition[:spec][:template][:spec][:containers].first[:image]).to eq("test-image")
+        end
+
+        subject.create_deployment_config("test") do |spec|
+          spec[:spec][:template][:spec][:serviceAccount] = "test-account"
+          spec[:spec][:template][:spec][:serviceAccountName] = "test-account"
+
+          spec[:spec][:template][:spec][:containers].first[:image] = "test-image"
+        end
+      end
+
+      it "doesn't raise an exception for an existing object" do
+        error = KubeException.new(500, "deployment config already exists", "")
+        expect(connection_stub).to receive(:create_deployment_config).and_raise(error)
+
+        expect { subject.create_deployment_config("test") }.not_to raise_error
+      end
+    end
+
+    describe "#create_service" do
+      it "creates a service with the given name, port, and edits" do
+        expect(kube_connection_stub).to receive(:create_service) do |definition|
+          expect(definition[:metadata][:name]).to eq("http")
+          expect(definition[:metadata][:namespace]).to eq("manageiq")
+
+          ports = definition[:spec][:ports]
+          expect(ports.first).to eq(:name => "http-80", :port => 80, :targetPort => 80)
+          expect(ports.last).to eq(:name => "https", :port => 443, :targetPort => 5000)
+        end
+
+        subject.create_service("http", 80) do |spec|
+          spec[:spec][:ports] << {:name => "https", :port => 443, :targetPort => 5000}
+        end
+      end
+
+      it "doesn't raise an exception for an existing object" do
+        error = KubeException.new(500, "service already exists", "")
+        expect(kube_connection_stub).to receive(:create_service).and_raise(error)
+
+        expect { subject.create_service("http", 80) }.not_to raise_error
+      end
+    end
+
+    describe "#create_secret" do
+      it "creates a secret with the given name and data" do
+        expect(kube_connection_stub).to receive(:create_secret) do |definition|
+          expect(definition[:metadata][:name]).to eq("mysecret")
+          expect(definition[:metadata][:namespace]).to eq("manageiq")
+
+          expect(definition[:stringData]).to eq(
+            "secret-one" => "very_secret",
+            "secret-two" => "super_secret"
+          )
+        end
+
+        subject.create_secret("mysecret", "secret-one" => "very_secret") do |spec|
+          spec[:stringData]["secret-two"] = "super_secret"
+        end
+      end
+
+      it "doesn't raise an exception for an existing object" do
+        error = KubeException.new(500, "secret mysecret already exists", "")
+        expect(kube_connection_stub).to receive(:create_secret).and_raise(error)
+
+        expect { subject.create_secret("mysecret", {}) }.not_to raise_error
+      end
+    end
+
+    describe "#delete_deployment_config" do
+      it "deletes the replication controller if it exists" do
+        rc = double("ReplicationController", :metadata => double(:name => "rc_name"))
+
+        expect(kube_connection_stub).to receive(:get_replication_controllers)
+          .with(:label_selector => "openshift.io/deployment-config.name=dc_name", :namespace => "manageiq")
+          .and_return([rc])
+
+        expect(connection_stub).to receive(:delete_deployment_config).with("dc_name", "manageiq")
+        expect(kube_connection_stub).to receive(:delete_replication_controller).with("rc_name", "manageiq")
+
+        subject.delete_deployment_config("dc_name")
+      end
+
+      it "doesn't try to delete the replication controler if it doesn't exist" do
+        expect(kube_connection_stub).to receive(:get_replication_controllers)
+          .with(:label_selector => "openshift.io/deployment-config.name=dc_name", :namespace => "manageiq")
+          .and_return([])
+
+        expect(connection_stub).to receive(:delete_deployment_config).with("dc_name", "manageiq")
+        expect(kube_connection_stub).not_to receive(:delete_replication_controller)
+
+        subject.delete_deployment_config("dc_name")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This puts the hash definitions of the API objects into definition methods which expose only a limited amount of customization.

The new create / delete methods on the main ContainerOrchestrator object now yield the definition before issuing the API call to allow for further changes.

This is mostly related to the re-architecture, but won't hurt anything if we merge it now `¯\_(ツ)_/¯`