### PR TITLE
Create embedded ansible deployment on demand

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -71,7 +71,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
   def provider_uri_hash
     if MiqEnvironment::Command.is_container?
-      {:scheme => "https", :host => ENV["ANSIBLE_SERVICE_HOST"], :path => "/api/v1"}
+      {:scheme => "https", :host => ContainerEmbeddedAnsible::ANSIBLE_SERVICE_NAME, :path => "/api/v1"}
     elsif Rails.env.development?
       {:scheme => "http", :host => "localhost", :path => "/api/v1", :port => 54321}
     else

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,6 +106,10 @@
     :rabbitmq_image_tag: 3
     :memcached_image_name: memcached
     :memcached_image_tag: alpine
+  :container:
+    :image_name: manageiq/embedded-ansible
+    :image_tag: latest
+    :service_account: miq-privileged
 :ems:
 # provider specific settings are nested here, but they are in the provider repos
 # e.g.:

--- a/lib/embedded_ansible/container_embedded_ansible.rb
+++ b/lib/embedded_ansible/container_embedded_ansible.rb
@@ -1,5 +1,6 @@
 class ContainerEmbeddedAnsible < EmbeddedAnsible
-  ANSIBLE_DC_NAME = "ansible".freeze
+  ANSIBLE_SERVICE_NAME = "ansible".freeze
+  ANSIBLE_SECRETS_NAME = "ansible-secrets".freeze
 
   def self.available?
     ContainerOrchestrator.available?
@@ -10,8 +11,9 @@ class ContainerEmbeddedAnsible < EmbeddedAnsible
   end
 
   def start
-    miq_database.set_ansible_admin_authentication(:password => ENV["ANSIBLE_ADMIN_PASSWORD"])
-    ContainerOrchestrator.new.scale(ANSIBLE_DC_NAME, 1)
+    create_ansible_secret
+    create_ansible_service
+    create_ansible_deployment_config
 
     loop do
       break if alive?
@@ -22,7 +24,9 @@ class ContainerEmbeddedAnsible < EmbeddedAnsible
   end
 
   def stop
-    ContainerOrchestrator.new.scale(ANSIBLE_DC_NAME, 0)
+    orchestrator.delete_deployment_config(ANSIBLE_SERVICE_NAME)
+    orchestrator.delete_service(ANSIBLE_SERVICE_NAME)
+    orchestrator.delete_secret(ANSIBLE_SECRETS_NAME)
   end
 
   alias disable stop
@@ -36,6 +40,98 @@ class ContainerEmbeddedAnsible < EmbeddedAnsible
   end
 
   def api_connection
-    api_connection_raw(ENV["ANSIBLE_SERVICE_HOST"], ENV["ANSIBLE_SERVICE_PORT_HTTP"])
+    api_connection_raw(ANSIBLE_SERVICE_NAME, 80)
+  end
+
+  private
+
+  def create_ansible_secret
+    # NOTE: These keys have to match the ones in #container_environment
+    secret_data = {
+      "secret-key"        => find_or_create_secret_key,
+      "admin-password"    => find_or_create_admin_authentication.password,
+      "database-password" => find_or_create_database_authentication.password,
+      "rabbit-password"   => find_or_create_rabbitmq_authentication.password
+    }
+
+    orchestrator.create_secret(ANSIBLE_SECRETS_NAME, secret_data)
+  end
+
+  def create_ansible_service
+    orchestrator.create_service(ANSIBLE_SERVICE_NAME, 443) do |service|
+      http_port = {
+        :name       => "#{ANSIBLE_SERVICE_NAME}-80",
+        :port       => 80,
+        :targetPort => 80
+      }
+      service[:spec][:ports] << http_port
+    end
+  end
+
+  def create_ansible_deployment_config
+    orchestrator.create_deployment_config(ANSIBLE_SERVICE_NAME) do |dc|
+      dc[:spec][:serviceName] = ANSIBLE_SERVICE_NAME
+      dc[:spec][:replicas] = 1
+
+      dc[:spec][:template][:spec][:serviceAccount]     = settings.service_account
+      dc[:spec][:template][:spec][:serviceAccountName] = settings.service_account
+
+      container = dc[:spec][:template][:spec][:containers].first
+      container[:ports]          = [{:containerPort => 443}, {:containerPort => 80}]
+      container[:livenessProbe]  = liveness_probe
+      container[:readinessProbe] = readiness_probe
+      container[:env]            = container_environment
+      container[:image]          = image
+
+      container[:securityContext] = {:privileged => true}
+    end
+  end
+
+  def liveness_probe
+    {
+      :tcpSocket           => {:port => 443},
+      :initialDelaySeconds => 480,
+      :timeoutSeconds      => 3
+    }
+  end
+
+  def readiness_probe
+    {
+      :httpGet             => {:path => "/", :port => 443, :scheme => "HTTPS"},
+      :initialDelaySeconds => 200,
+      :timeoutSeconds      => 3
+    }
+  end
+
+  def container_environment
+    rabbit_auth    = find_or_create_rabbitmq_authentication
+    database_auth  = find_or_create_database_authentication
+
+    [
+      {:name => "RABBITMQ_USER_NAME",    :value => rabbit_auth.userid},
+      {:name => "DATABASE_SERVICE_NAME", :value => ENV["POSTGRESQL_SERVICE_HOST"]},
+      {:name => "POSTGRESQL_DATABASE",   :value => "awx"},
+      {:name => "POSTGRESQL_USER",       :value => database_auth.userid},
+      {:name      => "ANSIBLE_SECRET_KEY",
+       :valueFrom => {:secretKeyRef=>{:name => ANSIBLE_SECRETS_NAME, :key => "secret-key"}}},
+      {:name      => "ADMIN_PASSWORD",
+       :valueFrom => {:secretKeyRef=>{:name => ANSIBLE_SECRETS_NAME, :key => "admin-password"}}},
+      {:name      => "POSTGRESQL_PASSWORD",
+       :valueFrom => {:secretKeyRef=>{:name => ANSIBLE_SECRETS_NAME, :key => "database-password"}}},
+      {:name      => "RABBITMQ_PASSWORD",
+       :valueFrom => {:secretKeyRef=>{:name => ANSIBLE_SECRETS_NAME, :key => "rabbit-password"}}}
+    ]
+  end
+
+  def image
+    "#{settings.image_name}:#{settings.image_tag}"
+  end
+
+  def orchestrator
+    @orchestrator ||= ContainerOrchestrator.new
+  end
+
+  def settings
+    ::Settings.embedded_ansible.container
   end
 end

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -106,12 +106,6 @@ describe EmbeddedAnsibleWorker::Runner do
           expect(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
         end
 
-        around do |example|
-          ENV["ANSIBLE_SERVICE_HOST"] = "192.0.2.1"
-          example.run
-          ENV.delete("ANSIBLE_SERVICE_HOST")
-        end
-
         it "creates the provider with the service name for the URL" do
           expect(worker).to receive(:remove_demo_data).with(api_connection)
           expect(worker).to receive(:ensure_initial_objects)
@@ -121,7 +115,7 @@ describe EmbeddedAnsibleWorker::Runner do
 
           provider = ManageIQ::Providers::EmbeddedAnsible::Provider.first
           expect(provider.zone).to eq(miq_server.zone)
-          expect(provider.default_endpoint.url).to eq("https://192.0.2.1/api/v1")
+          expect(provider.default_endpoint.url).to eq("https://ansible/api/v1")
           userid, password = provider.auth_user_pwd
           expect(userid).to eq("admin")
           expect(password).to eq("secret")


### PR DESCRIPTION
Enhance the handling of embedded ansible when running in a container.

Before, we would just scale an existing deployment when we are running in a container but we don't really want to unconditionally create a deployment that we may not use.

After this PR, we will create the deployment and all the other dependent objects required to run containerized embedded ansible when the role is enabled.

This includes moving things like secret and password generation into our app rather than relying on OpenShift generators to create and store them for us.