### PR TITLE
Permanently deleted app/helpers/ui_constants.rb ... end of issue #1661

### DIFF
--- a/spec/support/test_contamination.rb
+++ b/spec/support/test_contamination.rb
@@ -8,7 +8,7 @@ module Spec
       def self.patched_include
         Module.new do
           def include(included)
-            exceptions = ["ActionView::Helpers::NumberHelper", "SNMP::BER", "UiConstants"] # TODO: Why is UiConstants included in `main`??? :(
+            exceptions = ["ActionView::Helpers::NumberHelper", "SNMP::BER"]
             return super if included.to_s.in?(exceptions)
             raise RuntimeError, "Unexpected module '#{included}' included globally, did you mean to include it in a class?", caller
           end


### PR DESCRIPTION
### Closes: #1661 
#### Issue: #1661

#### Needs to be merged together with https://github.com/ManageIQ/manageiq-ui-classic/pull/2165

`UiConstants` were removed permanently.

/cc @mzazrivec