### PR TITLE
Bump manageiq-smartstate gem to 0.1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,7 +165,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.1.3",       :require => false
+  gem "manageiq-smartstate",            "~>0.1.4",       :require => false
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb


### PR DESCRIPTION
manageiq-smartstate gem has been updated to version 0.1.4 and pushed out to Rubygems.
Change manageiq to use the new version.
This is in support of https://bugzilla.redhat.com/show_bug.cgi?id=1463780

@roliveri @Fryguy @agrare please review and merge

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1463780
