### PR TITLE
Remove the manageiq from the ansible deployment config name

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -13,7 +13,7 @@ class EmbeddedAnsible
   HTTPS_PORT             = 54_322
   WAIT_FOR_ANSIBLE_SLEEP = 1.second
   TOWER_VERSION_FILE     = "/var/lib/awx/.tower_version".freeze
-  ANSIBLE_DC_NAME        = "manageiq-ansible".freeze
+  ANSIBLE_DC_NAME        = "ansible".freeze
 
   def self.available?
     return true if MiqEnvironment::Command.is_container?

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -422,7 +422,7 @@ describe EmbeddedAnsible do
           orch = double("ContainerOrchestrator")
           expect(ContainerOrchestrator).to receive(:new).and_return(orch)
 
-          expect(orch).to receive(:scale).with("manageiq-ansible", 0)
+          expect(orch).to receive(:scale).with("ansible", 0)
 
           described_class.stop
         end
@@ -433,7 +433,7 @@ describe EmbeddedAnsible do
           orch = double("ContainerOrchestrator")
           expect(ContainerOrchestrator).to receive(:new).and_return(orch)
 
-          expect(orch).to receive(:scale).with("manageiq-ansible", 0)
+          expect(orch).to receive(:scale).with("ansible", 0)
 
           described_class.disable
         end
@@ -450,7 +450,7 @@ describe EmbeddedAnsible do
           orch = double("ContainerOrchestrator")
           expect(ContainerOrchestrator).to receive(:new).and_return(orch)
 
-          expect(orch).to receive(:scale).with("manageiq-ansible", 1)
+          expect(orch).to receive(:scale).with("ansible", 1)
           expect(described_class).to receive(:alive?).and_return(true)
 
           described_class.start


### PR DESCRIPTION
It doesn't really need to be there and it makes things easier to productize

Requires https://github.com/ManageIQ/manageiq-pods/pull/219

cc @simaishi 