### PR TITLE
Collect allocated storage for container projects

### DIFF
--- a/app/models/metric/container_storage.rb
+++ b/app/models/metric/container_storage.rb
@@ -1,0 +1,13 @@
+module Metric::ContainerStorage
+  def self.fill_allocated_container_storage(obj)
+    return {} unless obj.kind_of?(ContainerProject)
+
+    sum_storage = obj.persistent_volume_claims.inject(0) do |sum, volume|
+      sum + volume.capacity[:storage] if volume.capacity.present?
+    end
+
+    {
+      :derived_vm_allocated_disk_storage => sum_storage
+    }
+  end
+end

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -205,6 +205,7 @@ module Metric::Rollup
     new_perf.reverse_merge!(orig_perf)
     new_perf.merge!(Metric::Processing.process_derived_columns(obj, new_perf, hour)) unless DERIVED_COLS_EXCLUDED_CLASSES.include?(obj.class.base_class.name)
     new_perf.merge!(Metric::Statistic.calculate_stat_columns(obj, hour))
+    new_perf.merge!(Metric::ContainerStorage.fill_allocated_container_storage(obj))
 
     new_perf
   end

--- a/spec/models/metric/container_storage_spec.rb
+++ b/spec/models/metric/container_storage_spec.rb
@@ -1,0 +1,28 @@
+describe Metric::ContainerStorage do
+  context ".fill_allocated_container_storage" do
+    let(:project1) { FactoryGirl.create(:container_project, :name => 'project1') }
+    let(:project2) { FactoryGirl.create(:container_project, :name => 'project2') }
+    let(:project3) { FactoryGirl.create(:container_project, :name => 'project3') }
+
+    let(:pvc1) { FactoryGirl.create(:persistent_volume_claim, :capacity => {:storage => 10.gigabytes}) }
+    let(:pvc2) { FactoryGirl.create(:persistent_volume_claim, :capacity => {:storage => 1.gigabytes}) }
+    let(:pvc3) { FactoryGirl.create(:persistent_volume_claim, :capacity => {:storage => 3.gigabytes}) }
+
+    it "calculates container storage out of persistent volume claims" do
+      # single pvc
+      project1.persistent_volume_claims << pvc1
+      derived_columns = described_class.fill_allocated_container_storage(project1)
+      expect(derived_columns[:derived_vm_allocated_disk_storage]).to eq(pvc1.capacity[:storage])
+
+      # multiple pvc's
+      project2.persistent_volume_claims << [pvc2, pvc3]
+      derived_columns = described_class.fill_allocated_container_storage(project2)
+      expect(derived_columns[:derived_vm_allocated_disk_storage]).to eq(pvc2.capacity[:storage] + pvc3.capacity[:storage])
+    end
+
+    it "calculates container storage when having zero persistent volume claims" do
+      derived_columns = described_class.fill_allocated_container_storage(project3)
+      expect(derived_columns[:derived_vm_allocated_disk_storage]).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Fill in `derived_vm_allocated_disk_storage` in hourly `MetricRollups` for container groups and container projects.


@cben  @moolitayer @zakiva please review.
cc @simon3z 
@miq-bot add_label providers/containers, wip,  enhancement, providers/metrics 


Edit: Storage for pods was removed from this PR since in the case of many pods using the same pvc, no one specific pod was allocated the entire storage capacity. 