### PR TITLE
Remove redis client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,7 +182,6 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
-  gem "redis",                          "~>3.0"
   gem "websocket-driver",               "~>0.6.3"
 end
 


### PR DESCRIPTION
Reverts #15912

We are not really prepared to support a clustered or single redis instance across the region so this won't work for now

cc @skateman @bdunne @jrafanie 