### PR TITLE
Rename the key from workspace to objects

### DIFF
--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -6,8 +6,8 @@ class AutomateWorkspace < ApplicationRecord
   validates :user, :presence => true
 
   def merge_output!(hash)
-    if hash['workspace'].nil? || hash['state_vars'].nil?
-      raise ArgumentError, "No workspace or state_vars specified for edit"
+    if hash['objects'].nil? || hash['state_vars'].nil?
+      raise ArgumentError, "No objects or state_vars specified for edit"
     end
 
     self[:output] = (output || {}).deep_merge(hash)

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -7,9 +7,9 @@ describe AutomateWorkspace do
     end
 
     it "properly merges the hash with the new output" do
-      hash = {'workspace' => {'a' => 1}, 'state_vars' => {'b' => 2}}
-      partial_hash = {'workspace' => {'c' => 1}, 'state_vars' => {} }
-      merged_hash = {'workspace' => {'a' => 1, 'c' => 1}, 'state_vars' => {'b' => 2}}
+      hash = {'objects' => {'root' => {'a' => 1}}, 'state_vars' => {'b' => 2}}
+      partial_hash = {'objects' => {'root' => {'c' => 1}}, 'state_vars' => {} }
+      merged_hash = {'objects' => {'root' => {'a' => 1, 'c' => 1}}, 'state_vars' => {'b' => 2}}
 
       aw.merge_output!(hash)
       aw.reload


### PR DESCRIPTION
In the Input and Output fields of AutomateWorkspace object we store a hash with the following keys

- method_parameters
- current
- workspace
- state_vars

This PR changes the workspace key to objects, since that key stores a hash of objects keyed by name

- method_parameters
- current
- objects
- state_vars

https://github.com/ManageIQ/manageiq-automation_engine/pull/64 This PR shows the nested input and output keys