### PR TITLE
[WIP] Metrics collector persister split

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker.rb
@@ -1,7 +1,7 @@
-class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqQueueWorkerBase
+class ManageIQ::Providers::BaseManager::MetricsCollectorWorker < MiqWorker
   require_nested :Runner
 
-  include PerEmsTypeWorkerMixin
+  include PerEmsWorkerMixin
 
   self.required_roles = ["ems_metrics_collector"]
 

--- a/app/models/manageiq/providers/base_manager/metrics_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_collector_worker/runner.rb
@@ -1,3 +1,2 @@
-class ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner < ::MiqQueueWorkerBase::Runner
-  self.delay_startup_for_vim_broker = true # NOTE: For ems_metrics_collector role, TODO: only for VMware
+class ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner < ::MiqWorker::Runner
 end

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -95,6 +95,11 @@ module Metric::CiMixin::Processing
     affected_timestamps
   end
 
+  def perf_save_metrics(metrics)
+    _log.info("Saving metrics...")
+    _log.info("Saving metrics...Complete")
+  end
+
   private
 
   def normalize_value(value, counter)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1055,6 +1055,9 @@
       :starting_timeout: 20.minutes
       :poll: 10.seconds
       :memory_threshold: 0.megabytes
+    :ems_metrics_collector_worker:
+      :defaults:
+        :poll: 30.seconds
     :ems_refresh_core_worker:
       :poll: 1.seconds
       :nice_delta: 1
@@ -1089,14 +1092,6 @@
         :memory_threshold: 500.megabytes
         :poll_method: :normal
         :queue_timeout: 10.minutes
-      :ems_metrics_collector_worker:
-        :defaults:
-          :count: 2
-          :memory_threshold: 400.megabytes
-          :nice_delta: 3
-          :poll_method: :escalate
-        :ems_metrics_collector_worker_google: {}
-        :ems_metrics_collector_worker_redhat: {}
       :ems_metrics_processor_worker:
         :count: 2
         :memory_threshold: 600.megabytes


### PR DESCRIPTION
This moves the metrics collector worker to a PerEmsWorker and adds a `perf_save_metrics` method to handle saving metrics sent from the queue