### PR TITLE
Add custom buttons to generic object.

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -32,6 +32,7 @@ class CustomButton < ApplicationRecord
     ContainerVolume,
     EmsCluster,
     ExtManagementSystem,
+    GenericObject,
     Host,
     LoadBalancer,
     MiqTemplate,

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -9,6 +9,11 @@ class CustomButtonSet < ApplicationRecord
       # for services we need to show custom buttons for a specific Services parent ServiceTemplate and for all Services
       applies_to_instance(class_name, class_id).sort_by(&ordering) +
         applies_to_all_instances("Service").sort_by(&ordering)
+    when "GenericObjectDefinition"
+      # for generic objects we need to show custom buttons for a specific generic object's parent GenericObjectDefinition
+      # and for all Generic Objects
+      applies_to_instance(class_name, class_id).sort_by(&ordering) +
+        applies_to_all_instances("GenericObject").sort_by(&ordering)
     else
       applies_to_all_instances(class_name).sort_by(&ordering)
     end

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -1,6 +1,9 @@
 class GenericObject < ApplicationRecord
   acts_as_miq_taggable
 
+  virtual_has_one :custom_actions
+  virtual_has_one :custom_action_buttons
+
   belongs_to :generic_object_definition
 
   validates :name, :presence => true
@@ -10,6 +13,7 @@ class GenericObject < ApplicationRecord
            :type_cast,
            :property_association_defined?,
            :property_methods, :property_method_defined?,
+           :custom_actions, :custom_action_buttons,
            :to => :generic_object_definition, :allow_nil => true
 
   def initialize(attributes = {})

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -15,6 +15,8 @@ class GenericObjectDefinition < ApplicationRecord
 
   serialize :properties, Hash
 
+  include CustomActionsMixin
+
   has_one   :picture, :dependent => :destroy, :as => :resource
   has_many  :generic_objects
 
@@ -127,6 +129,10 @@ class GenericObjectDefinition < ApplicationRecord
   def delete_property_method(name)
     properties[:methods].delete(name.to_s)
     save!
+  end
+
+  def generic_custom_buttons
+    CustomButton.buttons_for("GenericObject")
   end
 
   private


### PR DESCRIPTION
Add custom buttons to generic object the same way as for service templates.

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement, fine/no