### PR TITLE
Dialog generation for orchestration template

### DIFF
--- a/app/models/dialog/orchestration_template_service_dialog.rb
+++ b/app/models/dialog/orchestration_template_service_dialog.rb
@@ -1,0 +1,133 @@
+class Dialog
+  class OrchestrationTemplateServiceDialog
+    def self.create_dialog(label, template)
+      Dialog::OrchestrationTemplateServiceDialog.new.create_dialog(label, template)
+    end
+
+    def create_dialog(label, template)
+      Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
+        tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
+        add_stack_group(template.deployment_options, tab, 0)
+
+        template.parameter_groups.each_with_index do |parameter_group, index|
+          add_parameter_group(parameter_group, tab, index + 1)
+        end
+        dialog.save!
+      end
+    end
+
+    private
+
+    def add_stack_group(deploy_options, tab, position)
+      tab.dialog_groups.build(
+        :display  => "edit",
+        :label    => "Options",
+        :position => position
+      ).tap do |dialog_group|
+        deploy_options.each_with_index { |opt, index| add_parameter_field(opt, dialog_group, index) }
+      end
+    end
+
+    def add_parameter_group(parameter_group, tab, position)
+      return if parameter_group.parameters.blank?
+
+      tab.dialog_groups.build(
+        :display  => "edit",
+        :label    => parameter_group.label || "Parameter Group#{position}",
+        :position => position
+      ).tap do |dialog_group|
+        parameter_group.parameters.each_with_index { |param, index| add_parameter_field(param, dialog_group, index) }
+      end
+    end
+
+    def add_parameter_field(parameter, group, position)
+      if parameter.constraints
+        dynamic_dropdown = parameter.constraints.detect { |c| c.kind_of?(OrchestrationTemplate::OrchestrationParameterAllowedDynamic) }
+        return create_parameter_dynamic_dropdown_list(parameter, group, position, dynamic_dropdown) if dynamic_dropdown
+
+        dropdown = parameter.constraints.detect { |c| c.kind_of?(OrchestrationTemplate::OrchestrationParameterAllowed) }
+        return create_parameter_dropdown_list(parameter, group, position, dropdown) if dropdown
+
+        checkbox = parameter.constraints.detect { |c| c.kind_of?(OrchestrationTemplate::OrchestrationParameterBoolean) }
+        return create_parameter_checkbox(parameter, group, position) if checkbox
+      end
+
+      create_parameter_textbox(parameter, group, position)
+    end
+
+    def create_parameter_dynamic_dropdown_list(parameter, group, position, dynamic_dropdown)
+      group.dialog_fields.build(
+        :type         => "DialogFieldDropDownList",
+        :name         => "param_#{parameter.name}",
+        :data_type    => "string",
+        :dynamic      => true,
+        :display      => "edit",
+        :required     => false,
+        :label        => parameter.label,
+        :description  => parameter.description,
+        :position     => position,
+        :dialog_group => group
+      ).tap do |dialog_field|
+        dialog_field.resource_action.fqname = dynamic_dropdown.fqname
+      end
+    end
+
+    def create_parameter_dropdown_list(parameter, group, position, dropdown)
+      values = dropdown.allowed_values
+      dropdown_list = values.kind_of?(Hash) ? values.to_a : values.collect { |v| [v, v] }
+      group.dialog_fields.build(
+        :type           => "DialogFieldDropDownList",
+        :name           => "param_#{parameter.name}",
+        :data_type      => "string",
+        :display        => "edit",
+        :required       => true,
+        :values         => dropdown_list,
+        :default_value  => parameter.default_value || dropdown_list.first,
+        :label          => parameter.label,
+        :description    => parameter.description,
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group
+      )
+    end
+
+    def create_parameter_textbox(parameter, group, position)
+      field_type = parameter.data_type == 'json' ? "DialogFieldTextAreaBox" : "DialogFieldTextBox"
+      if parameter.constraints
+        pattern = parameter.constraints.detect { |c| c.kind_of? OrchestrationTemplate::OrchestrationParameterPattern }
+      end
+      group.dialog_fields.build(
+        :type           => field_type,
+        :name           => "param_#{parameter.name}",
+        :data_type      => "string",
+        :display        => "edit",
+        :required       => true,
+        :default_value  => parameter.default_value,
+        :options        => {:protected => parameter.hidden?},
+        :validator_type => pattern ? 'regex' : nil,
+        :validator_rule => pattern.try(:pattern),
+        :label          => parameter.label,
+        :description    => parameter.description,
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group
+      )
+    end
+
+    def create_parameter_checkbox(parameter, group, position)
+      group.dialog_fields.build(
+        :type           => "DialogFieldCheckBox",
+        :name           => "param_#{parameter.name}",
+        :data_type      => "boolean",
+        :display        => "edit",
+        :default_value  => parameter.default_value,
+        :options        => {:protected => parameter.hidden?},
+        :label          => parameter.label,
+        :description    => parameter.description,
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group
+      )
+    end
+  end
+end

--- a/app/models/dialog/orchestration_template_service_dialog.rb
+++ b/app/models/dialog/orchestration_template_service_dialog.rb
@@ -1,7 +1,7 @@
 class Dialog
   class OrchestrationTemplateServiceDialog
     def self.create_dialog(label, template)
-      Dialog::OrchestrationTemplateServiceDialog.new.create_dialog(label, template)
+      new.create_dialog(label, template)
     end
 
     def create_dialog(label, template)
@@ -40,25 +40,25 @@ class Dialog
       end
     end
 
-    def add_field(parameter, group, position, prefix = nil)
+    def add_field(parameter, group, position, name_prefix = nil)
       if parameter.constraints
         dynamic_dropdown = parameter.constraints.detect { |c| c.kind_of?(OrchestrationTemplate::OrchestrationParameterAllowedDynamic) }
-        return create_dynamic_dropdown_list(parameter, group, position, dynamic_dropdown, prefix) if dynamic_dropdown
+        return create_dynamic_dropdown_list(parameter, group, position, dynamic_dropdown, name_prefix) if dynamic_dropdown
 
         dropdown = parameter.constraints.detect { |c| c.kind_of?(OrchestrationTemplate::OrchestrationParameterAllowed) }
-        return create_dropdown_list(parameter, group, position, dropdown, prefix) if dropdown
+        return create_dropdown_list(parameter, group, position, dropdown, name_prefix) if dropdown
 
         checkbox = parameter.constraints.detect { |c| c.kind_of?(OrchestrationTemplate::OrchestrationParameterBoolean) }
-        return create_checkbox(parameter, group, position, prefix) if checkbox
+        return create_checkbox(parameter, group, position, name_prefix) if checkbox
       end
 
-      create_textbox(parameter, group, position, prefix)
+      create_textbox(parameter, group, position, name_prefix)
     end
 
-    def create_dynamic_dropdown_list(parameter, group, position, dynamic_dropdown, prefix)
+    def create_dynamic_dropdown_list(parameter, group, position, dynamic_dropdown, name_prefix)
       group.dialog_fields.build(
         :type         => "DialogFieldDropDownList",
-        :name         => "#{prefix}#{parameter.name}",
+        :name         => "#{name_prefix}#{parameter.name}",
         :data_type    => parameter.data_type || "string",
         :dynamic      => true,
         :display      => "edit",
@@ -72,12 +72,12 @@ class Dialog
       end
     end
 
-    def create_dropdown_list(parameter, group, position, dropdown, prefix)
+    def create_dropdown_list(parameter, group, position, dropdown, name_prefix)
       values = dropdown.allowed_values
       dropdown_list = values.kind_of?(Hash) ? values.to_a : values.collect { |v| [v, v] }
       group.dialog_fields.build(
         :type           => "DialogFieldDropDownList",
-        :name           => "#{prefix}#{parameter.name}",
+        :name           => "#{name_prefix}#{parameter.name}",
         :data_type      => parameter.data_type || "string",
         :display        => "edit",
         :required       => parameter.required,
@@ -91,7 +91,7 @@ class Dialog
       )
     end
 
-    def create_textbox(parameter, group, position, prefix)
+    def create_textbox(parameter, group, position, name_prefix)
       if parameter.data_type == 'string' || parameter.data_type == 'integer'
         data_type = parameter.data_type
         field_type = 'DialogFieldTextBox'
@@ -104,7 +104,7 @@ class Dialog
       end
       group.dialog_fields.build(
         :type           => field_type,
-        :name           => "#{prefix}#{parameter.name}",
+        :name           => "#{name_prefix}#{parameter.name}",
         :data_type      => data_type,
         :display        => "edit",
         :required       => parameter.required,
@@ -120,10 +120,10 @@ class Dialog
       )
     end
 
-    def create_checkbox(parameter, group, position, prefix)
+    def create_checkbox(parameter, group, position, name_prefix)
       group.dialog_fields.build(
         :type           => "DialogFieldCheckBox",
-        :name           => "#{prefix}#{parameter.name}",
+        :name           => "#{name_prefix}#{parameter.name}",
         :data_type      => "boolean",
         :display        => "edit",
         :default_value  => parameter.default_value,

--- a/app/models/dialog/orchestration_template_service_dialog.rb
+++ b/app/models/dialog/orchestration_template_service_dialog.rb
@@ -85,7 +85,7 @@ class Dialog
         :default_value  => parameter.default_value || dropdown_list.first,
         :label          => parameter.label,
         :description    => parameter.description,
-        :reconfigurable => true,
+        :reconfigurable => parameter.reconfigurable,
         :position       => position,
         :dialog_group   => group
       )
@@ -114,7 +114,7 @@ class Dialog
         :validator_rule => pattern.try(:pattern),
         :label          => parameter.label,
         :description    => parameter.description,
-        :reconfigurable => true,
+        :reconfigurable => parameter.reconfigurable,
         :position       => position,
         :dialog_group   => group
       )
@@ -130,7 +130,7 @@ class Dialog
         :options        => {:protected => parameter.hidden?},
         :label          => parameter.label,
         :description    => parameter.description,
-        :reconfigurable => true,
+        :reconfigurable => parameter.reconfigurable,
         :position       => position,
         :dialog_group   => group
       )

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -91,11 +91,12 @@ class OrchestrationTemplate < ApplicationRecord
   # Return array of OrchestrationParameters. (Deployment options are different from parameters, but they use same class)
   def deployment_options(_manager_class = nil)
     tenant_opt = OrchestrationTemplate::OrchestrationParameter.new(
-      :name        => "tenant_name",
-      :label       => "Tenant",
-      :data_type   => "string",
-      :description => "Tenant where the stack will be deployed",
-      :required    => true,
+      :name           => "tenant_name",
+      :label          => "Tenant",
+      :data_type      => "string",
+      :description    => "Tenant where the stack will be deployed",
+      :required       => true,
+      :reconfigurable => false,
       :constraints => [
         OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(
           :fqname => "/Cloud/Orchestration/Operations/Methods/Available_Tenants"
@@ -104,12 +105,13 @@ class OrchestrationTemplate < ApplicationRecord
     )
 
     stack_name_opt = OrchestrationTemplate::OrchestrationParameter.new(
-      :name        => "stack_name",
-      :label       => "Stack Name",
-      :data_type   => "string",
-      :description => "Name of the stack",
-      :required    => true,
-      :constraints => [
+      :name           => "stack_name",
+      :label          => "Stack Name",
+      :data_type      => "string",
+      :description    => "Name of the stack",
+      :required       => true,
+      :reconfigurable => false,
+      :constraints    => [
         OrchestrationTemplate::OrchestrationParameterPattern.new(
           :pattern => '^[A-Za-z][A-Za-z0-9\-]*$'
         )

--- a/app/models/orchestration_template/orchestration_parameter.rb
+++ b/app/models/orchestration_template/orchestration_parameter.rb
@@ -27,9 +27,11 @@ class OrchestrationTemplate
     attr_accessor :default_value
     attr_accessor :hidden
     attr_accessor :required
+    attr_accessor :reconfigurable
     attr_writer   :constraints
 
     def initialize(hash = {})
+      @reconfigurable = true
       hash.each { |key, value| public_send("#{key}=", value) }
     end
 

--- a/spec/models/dialog/orchestration_template_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_service_dialog_spec.rb
@@ -119,6 +119,7 @@ describe Dialog::OrchestrationTemplateServiceDialog do
           :label         => "Drop down",
           :data_type     => "string",
           :default_value => "val1",
+          :required      => true,
           :constraints   => [constraint])
       ])
     ]

--- a/spec/models/dialog/orchestration_template_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_service_dialog_spec.rb
@@ -1,10 +1,10 @@
 describe Dialog::OrchestrationTemplateServiceDialog do
   let(:orchestration_template) { FactoryGirl.create(:orchestration_template) }
 
-  describe "#create_dialog" do
+  describe ".create_dialog" do
     it "creates a dialog from a template without parameters" do
       allow(orchestration_template).to receive(:parameter_groups).and_return([])
-      dialog = subject.create_dialog("test", orchestration_template)
+      dialog = described_class.create_dialog("test", orchestration_template)
 
       expect(dialog).to have_attributes(
         :label   => "test",

--- a/spec/models/dialog/orchestration_template_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_service_dialog_spec.rb
@@ -1,0 +1,126 @@
+describe Dialog::OrchestrationTemplateServiceDialog do
+  let(:orchestration_template) { FactoryGirl.create(:orchestration_template) }
+
+  describe "#create_dialog" do
+    it "creates a dialog from a template without parameters" do
+      allow(orchestration_template).to receive(:parameter_groups).and_return([])
+      dialog = subject.create_dialog("test", orchestration_template)
+
+      expect(dialog).to have_attributes(
+        :label   => "test",
+        :buttons => "submit,cancel"
+      )
+
+      tabs = dialog.dialog_tabs
+      assert_tab_attributes(tabs[0])
+    end
+  end
+
+  describe "creation of dropdown parameter fields" do
+    context "when allowed values are given" do
+      it "creates a dropdown field with pairs of values" do
+        # Create a simple dialog with one dropdown parameter.
+        constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(val1 val2))
+        param_groups = create_dropdown_param(constraint)
+        allow(orchestration_template).to receive(:parameter_groups).and_return(param_groups)
+        dialog = subject.create_dialog("test", orchestration_template)
+
+        # Get the dropdown field
+        field = dropdown_field(dialog)
+        # Ensure the allowed values are properly stored.
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(val1 val1), %w(val2 val2)])
+      end
+    end
+
+    context "when a hash of allowed values is given" do
+      it "creates pairs from hashes" do
+        # Create a simple dialog with one dropdown parameter.
+        constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => {"key1" => "val1", "key2" => "val2"})
+        param_groups = create_dropdown_param(constraint)
+        allow(orchestration_template).to receive(:parameter_groups).and_return(param_groups)
+        dialog = subject.create_dialog("test", orchestration_template)
+
+        # Get the dropdown field
+        field = dropdown_field(dialog)
+        # Ensure the allowed values are properly stored.
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [[nil, "<Choose>"], %w(key1 val1), %w(key2 val2)])
+      end
+    end
+
+    context "when automate method is given" do
+      it "creates a dropdown field requested resource_action" do
+        # Create a simple dialog with one dropdown parameter.
+        constraint = OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(:fqname => "/Path/To/Method")
+        param_groups = create_dropdown_param(constraint)
+        allow(orchestration_template).to receive(:parameter_groups).and_return(param_groups)
+        dialog = subject.create_dialog("test", orchestration_template)
+
+        # Get the dropdown field
+        field = dropdown_field(dialog)
+        # Ensure the field is properly defined with the resource action.
+        expect(field.resource_action.fqname).to eq("/Path/To/Method")
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown")
+      end
+    end
+  end
+
+  def assert_stack_tab(tab)
+    assert_tab_attributes(tab)
+
+    groups = tab.dialog_groups
+    expect(groups.size).to eq(3)
+
+    assert_stack_group(groups[0])
+  end
+
+  def assert_tab_attributes(tab)
+    expect(tab).to have_attributes(
+      :label   => "Basic Information",
+      :display => "edit"
+    )
+  end
+
+  def assert_stack_group(group)
+    expect(group).to have_attributes(
+      :label   => "Options",
+      :display => "edit",
+    )
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(4)
+
+    expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+  end
+
+  def assert_field(field, clss, attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
+  end
+
+  def dropdown_field(dialog)
+    # First ensure that the dialog is properly constructed.
+    tabs = dialog.dialog_tabs
+    expect(tabs.size).to eq(1)
+    expect(tabs[0].dialog_groups.size).to eq(2)
+    expect(tabs[0].dialog_groups[1].dialog_fields.size).to eq(1)
+    fields = tabs[0].dialog_groups[1].dialog_fields
+    # Return the first field; it should be the only field.
+    fields[0]
+  end
+
+  def create_dropdown_param(constraint)
+    [OrchestrationTemplate::OrchestrationParameterGroup.new(
+      :label      => "group",
+      :parameters => [
+        OrchestrationTemplate::OrchestrationParameter.new(
+          :name          => "dropdown",
+          :label         => "Drop down",
+          :data_type     => "string",
+          :default_value => "val1",
+          :constraints   => [constraint])
+      ])
+    ]
+  end
+end

--- a/spec/models/dialog/orchestration_template_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_service_dialog_spec.rb
@@ -28,7 +28,7 @@ describe Dialog::OrchestrationTemplateServiceDialog do
         # Get the dropdown field
         field = dropdown_field(dialog)
         # Ensure the allowed values are properly stored.
-        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(val1 val1), %w(val2 val2)])
+        assert_field(field, DialogFieldDropDownList, :name => "param_dropdown", :default_value => "val1", :values => [%w(val1 val1), %w(val2 val2)], :reconfigurable => true)
       end
     end
 
@@ -90,8 +90,8 @@ describe Dialog::OrchestrationTemplateServiceDialog do
     expect(fields.size).to eq(4)
 
     expect(fields[0].resource_action.fqname).to eq("/Cloud/Orchestration/Operations/Methods/Available_Tenants")
-    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name",     :dynamic => true)
-    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",      :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$')
+    assert_field(fields[0], DialogFieldDropDownList, :name => "tenant_name", :dynamic => true, :reconfigurable => false)
+    assert_field(fields[1], DialogFieldTextBox,      :name => "stack_name",  :validator_rule => '^[A-Za-z][A-Za-z0-9\-]*$', :reconfigurable => false)
   end
 
   def assert_field(field, clss, attributes)
@@ -120,8 +120,9 @@ describe Dialog::OrchestrationTemplateServiceDialog do
           :data_type     => "string",
           :default_value => "val1",
           :required      => true,
-          :constraints   => [constraint])
-      ])
-    ]
+          :constraints   => [constraint]
+        )
+      ]
+    )]
   end
 end


### PR DESCRIPTION
Move service/orchestration_template_dialog_service.rb from classic-ui repo back to main repo as models/dialog/orchestration_template_service_dialog.rb.

The old code generate deployment options per template type. The new code relies on the template to provide deployment options. Template sub-classes in provider repos implement the `deployemnt_options` method.  