### PR TITLE
Drop C&U :exclude_vms option

### DIFF
--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -43,16 +43,6 @@ describe Metric do
           targets = Metric::Targets.capture_targets(nil, :exclude_storages => true)
           assert_infra_targets_enabled targets, %w(ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host)
         end
-
-        it "should find enabled targets excluding vms" do
-          targets = Metric::Targets.capture_targets(nil, :exclude_vms => true)
-          assert_infra_targets_enabled targets, %w(ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host Storage)
-        end
-
-        it "should find enabled targets excluding vms and storages" do
-          targets = Metric::Targets.capture_targets(nil, :exclude_storages => true, :exclude_vms => true)
-          assert_infra_targets_enabled targets, %w(ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host)
-        end
       end
 
       context "executing perf_capture_timer" do
@@ -1024,11 +1014,6 @@ describe Metric do
         it "should find enabled targets" do
           targets = Metric::Targets.capture_targets
           assert_cloud_targets_enabled targets, %w(ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm)
-        end
-
-        it "should find no enabled targets excluding vms" do
-          targets = Metric::Targets.capture_targets(nil, :exclude_vms => true)
-          assert_cloud_targets_enabled targets, %w()
         end
       end
 


### PR DESCRIPTION
Currently reworking the code. Removing an unused option to simplify the code.
(It is currently not hurting anyone)

The option was added to improve performance along with `:exclude_storages`
sha: af566a9d6025162f38932529c2405ea6022c7938

Use of `:exclude_vms` option was then removed (but storages option kept)
sha: 56a9bdd9d7c265d8292f9eb92783ec0a8b1b405a

@Fryguy The commit with the removal looked like it fixed some minor things, but the comments don't tell me too much.