### PR TITLE
Cancel before_destroy  callback chain for MiqServer by throwing 'abort'

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -227,10 +227,9 @@ class MiqServer < ApplicationRecord
 
   def validate_is_deleteable
     unless self.is_deleteable?
-      msg = @error_message
+      _log.error(@error_message)
       @error_message = nil
-      _log.error(msg)
-      raise _(msg)
+      throw :abort
     end
   end
 


### PR DESCRIPTION
Recommended way to halt callback chain in Rails 5 is `throw :abort`

\cc @gtanzillo 

@miq-bot add-label core