### PR TITLE
Allow forcing the provision task placement_auto method to true.

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -53,7 +53,7 @@ class MiqProvision < MiqProvisionTask
   end
 
   def placement_auto
-    get_option(:placement_auto)
+    get_option(:force_placement_auto) || get_option(:placement_auto)
   end
 
   def after_request_task_create

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -155,4 +155,44 @@ describe MiqProvision do
       prov.eligible_resources(:hosts)
     end
   end
+
+  describe "#placement_auto" do
+    let(:miq_provision) { FactoryGirl.build(:miq_provision, :options => {:placement_auto => placement_option}) }
+
+    context "when option[:placement_auto] is true" do
+      let(:placement_option) { [true, 1] }
+
+      it "without force_placement_auto" do
+        expect(miq_provision.placement_auto).to eq(true)
+      end
+
+      it "with force_placement_auto set to false" do
+        miq_provision.options[:force_placement_auto] = false
+        expect(miq_provision.placement_auto).to eq(true)
+      end
+
+      it "with force_placement_auto set to true" do
+        miq_provision.options[:force_placement_auto] = true
+        expect(miq_provision.placement_auto).to eq(true)
+      end
+    end
+
+    context "when option[:placement_auto] is false" do
+      let(:placement_option) { [false, 0] }
+
+      it "without force_placement_auto" do
+        expect(miq_provision.placement_auto).to eq(false)
+      end
+
+      it "with force_placement_auto set to false" do
+        miq_provision.options[:force_placement_auto] = false
+        expect(miq_provision.placement_auto).to eq(false)
+      end
+
+      it "with force_placement_auto set to true" do
+        miq_provision.options[:force_placement_auto] = true
+        expect(miq_provision.placement_auto).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Supports dialogs where the user has access to limited environment tab placement fields, such
as folder or cluster, and auto-placement is still required to select the remaining fields.

Links
----------------
Required by PR #15951 
https://bugzilla.redhat.com/show_bug.cgi?id=1483636
https://bugzilla.redhat.com/show_bug.cgi?id=1484024


Steps for Testing/QA
-------------------------------
The dialogs provided in PR #15951 only exposed limited Environment tab placement fields.  This change allows the auto-placement logic of the automate state-machine to run even when the user has not selected the "Choose Automatically" option.  Running auto-placement logic is required in this scenario to populate the mandatory placement fields for the provider.

cc @tinaafitz @billfitzgerald0120 