### PR TITLE
[WIP] Adds #save_inventory_with_thin_association

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -33,6 +33,23 @@ module EmsRefresh::SaveInventoryHelper
     end
   end
 
+  # instead of storing records, only store ids
+  class IdTypedIndex < TypedIndex
+    def initialize(ids, find_key, model)
+      @key_attribute_types = find_key.map { |k| model.type_for_attribute(k) }
+
+      # find the records keys for the given records
+      records = model.where(model.primary_key => ids).pluck(*find_key, model.primary_key)
+
+      # Index the records by the values from the find_key
+      @record_index = records.each_with_object({}) do |keys_and_val, h|
+        h.store_path(*keys_and_val)
+      end
+
+      @find_key = find_key
+    end
+  end
+
   def save_inventory_multi(association, hashes, deletes, find_key, child_keys = [], extra_keys = [], disconnect = false)
     association.reset
 


### PR DESCRIPTION
`EmsRefresh::SaveInventoryHelper#save_inventory_with_thin_association` is similar to `#save_inventory_multi`, but prevents attaching the saved records to the parent object that is passed in.  At scale, this can be very expensive since the entire collection of a given association has to be kept in memory for the duration of the refresh, and with large providers with 10k+ records for a given type, this is usually Gigs of memory required to do so.

The `#save_inventory_with_thin_association` method does two main things differently, when compared to `#save_inventory_multi`, to make this less memory intensive:

* Moves the database transaction to be around each top level object, instead of the entire collection of associated objects (allows them to be garbage collected sooner.
* Only uses the association of the parent object to determine the extra attributes (foreign keys), to be applied to the record when saved, but doesn't actually attach it to the object in memory.

These changes makes it so the memory remains nearly constant in large environments.

This also takes the concept of `#store_ids_for_new_records`, and calls out to a new method `#store_ids_for_record_ids`, since it is almost always after `#save_inventory_multi`. The method `#store_ids_for_record_ids` is similar to `#store_ids_for_record_ids`, but uses just ids we have collected instead of accessing ids from full `ActiveRecord` objects. Again, keeping track of just the ids allows us to garbage collect the `ActiveRecord` objects after committing them to the DB instead of waiting until the method is completed to do so.

Also, `#save_inventory_with_findkey` was also updated to support this new way of saving.  The old functionality remains, but the changes allow the method to work with #save_inventory_with_thin_association.


Links
-----
* Original "fine" PR:  https://github.com/ManageIQ/manageiq/pull/15942


TODO
----
* [ ] Get some before/after query metrics for refresh
* [ ] Test batching some of the saves
* [ ] Remove the need for `store_ids_for_record_ids ` [[ref]](https://github.com/ManageIQ/manageiq/pull/15989/files#r139717370)
* [ ] Check into potential issue with [STI Models](https://github.com/ManageIQ/manageiq/pull/15989/files#r139719290) (I think this is a non-issue and already covered by the rails methods I am using, but doesn't hurt)
* [ ] Look into possibly optimizing some `.find` N+1's (might not happen in this PR)


Steps for Testing/QA
--------------------

This PR does not implement the `#save_inventory_with_thin_association` code anywhere, and will be done in followup PRs (allowing it to be slowly integrated without breaking the build).  This also allows us to pick and choose what portions of the full integration of this code we decide to backport to older releases, but doesn't prevent us otherwise from backporting all of it.

Assuming the tests pass, this should be fine, though it might not hurt to make sure the refresh tests in some of the provider repos still work with this code in place before merging (specific regarding the tweaks around `#save_inventory_with_findkey`, since that had to be modified)