### PR TITLE
Service add to service

### DIFF
--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -31,10 +31,10 @@ module ServiceMixin
       if circular_reference?(rsc)
         raise MiqException::MiqServiceCircularReferenceError,
               _("Adding resource <%{resource_name}> to Service <%{name}> will create a circular reference") %
-                {:resource_name => rsc.name, :name => name}
+              {:resource_name => rsc.name, :name => name}
       else
-        sr = service_resources.new(nh.merge(:resource => rsc))
-        set_service_type if self.respond_to?(:set_service_type)
+        service_resources.new(nh.merge(:resource => rsc))
+        set_service_type if respond_to?(:set_service_type)
         # Create link between services
         rsc.update_attributes(:parent => self) if self.class == Service && rsc.kind_of?(Service)
       end
@@ -47,14 +47,11 @@ module ServiceMixin
   end
 
   def add_resource!(rsc, options = {})
-    sr = add_resource(rsc, options)
-    self.save!
-    sr
+    add_resource(rsc, options).tap { save! }
   end
 
   def remove_resource(rsc)
-    sr = service_resources.find_by(:resource_type => rsc.class.base_class.name, :resource_id => rsc.id)
-    sr.try(:destroy)
+    service_resources.find_by(:resource_type => rsc.class.base_class.name, :resource_id => rsc.id).try(:destroy)
   end
 
   def remove_all_resources
@@ -116,7 +113,7 @@ module ServiceMixin
 
     (current_idx + direction).send(method, target) do |i|
       next if i == current_idx
-      return(i) if self.group_has_resources?(i)
+      return(i) if group_has_resources?(i)
     end
 
     nil

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -17,29 +17,12 @@ module ServiceMixin
     rsc_type = rsc.class.base_class.name.tableize
     raise _("Cannot connect service with nil ID.") if rsc.id.nil? && rsc_type == "service_templates"
 
-    # fetch the corresponding service resource
-    # may want to use a query for this
-    sr = service_resources.detect { |sr| sr.resource_type == rsc.class.base_class.name && sr.resource_id == rsc.id }
-    if sr.nil?
-      if options.kind_of?(ServiceResource)
-        nh = options.attributes.dup
-        %w(id created_at updated_at service_template_id ancestry).each { |key| nh.delete(key) }
-      else
-        nh = options
-      end
+    enforce_single_service_parent(rsc)
 
-      if circular_reference?(rsc)
-        raise MiqException::MiqServiceCircularReferenceError,
-              _("Adding resource <%{resource_name}> to Service <%{name}> will create a circular reference") %
-              {:resource_name => rsc.name, :name => name}
-      else
-        service_resources.new(nh.merge(:resource => rsc))
-        set_service_type if respond_to?(:set_service_type)
-        # Create link between services
-        rsc.update_attributes(:parent => self) if self.class == Service && rsc.kind_of?(Service)
-      end
-    end
-    sr
+    sr = service_resources.detect { |r| r.resource_type == rsc.class.base_class.name && r.resource_id == rsc.id }
+    return sr unless sr.nil?
+
+    create_service_resource(rsc, options) if sr.nil?
   end
 
   def <<(*args)
@@ -119,6 +102,37 @@ module ServiceMixin
     nil
   end
 
+  def parent_services(svc = self)
+    return svc.ancestors if svc.kind_of?(Service)
+    srs = ServiceResource.where(:resource => svc)
+    srs.collect { |sr| sr.public_send(sr.resource_type.underscore) }.compact
+  end
+
+  private
+
+  def enforce_single_service_parent(resource)
+    if resource.try(:enforce_single_service_parent?) == true && resource.service
+      raise MiqException::Error, _("<%{class_name}> <%{id}>:<%{name}> is already connected to a service.") %
+                                 {:class_name => resource.class.name, :id => resource.id, :name => resource.name}
+    end
+  end
+
+  def create_service_resource(rsc, options)
+    if circular_reference?(rsc)
+      raise MiqException::MiqServiceCircularReferenceError,
+            _("Adding resource <%{resource_name}> to Service <%{name}> will create a circular reference") %
+            {:resource_name => rsc.name, :name => name}
+    else
+      nh = if options.kind_of?(ServiceResource)
+             options.attributes.except('id', 'created_at', 'updated_at', 'service_template_id', 'ancestry')
+           else
+             options
+           end
+
+      service_resources.new(nh.merge(:resource => rsc))
+    end
+  end
+
   def circular_reference?(child_svc)
     return true if child_svc == self
     if child_svc.kind_of?(Service)
@@ -137,11 +151,5 @@ module ServiceMixin
       return(result) unless result.nil?
     end
     nil
-  end
-
-  def parent_services(svc = self)
-    return svc.ancestors if svc.kind_of?(Service)
-    srs = ServiceResource.where(:resource => svc)
-    srs.collect { |sr| sr.public_send(sr.resource_type.underscore) }.compact
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -413,4 +413,13 @@ class Service < ApplicationRecord
   def enforce_single_service_parent?
     true
   end
+
+  def add_to_service(parenent_service)
+    parenent_service.add_resource!(self)
+  end
+
+  def remove_from_service(parenent_service)
+    update(:parent => nil)
+    parenent_service.remove_resource(self)
+  end
 end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -393,6 +393,11 @@ class ServiceTemplate < ApplicationRecord
     end
   end
 
+  def add_resource(rsc, options = {})
+    super
+    set_service_type
+  end
+
   private
 
   def update_service_resources(config_info, auth_user = nil)

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -37,6 +37,10 @@ class Vm < VmOrTemplate
     service.add_resource!(self)
   end
 
+  def enforce_single_service_parent?
+    true
+  end
+
   def self.find_all_by_mac_address_and_hostname_and_ipaddress(mac_address, hostname, ipaddress)
     return [] if mac_address.blank? && hostname.blank? && ipaddress.blank?
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -732,6 +732,37 @@ describe Service do
     end
   end
 
+  describe '#add_to_service' do
+    let(:service) { FactoryGirl.create(:service) }
+    let(:child_service) { FactoryGirl.create(:service) }
+
+    it 'associates a child_service to the service' do
+      child_service.add_to_service(service)
+
+      expect(service.reload.services).to include(child_service)
+    end
+
+    it 'raise an error if the child_service is already part of a service' do
+      child_service.add_to_service(service)
+
+      expect { child_service.add_to_service(service) }.to raise_error MiqException::Error
+    end
+  end
+
+  describe '#remove_from_service' do
+    let(:service) { FactoryGirl.create(:service) }
+    let(:child_service) { FactoryGirl.create(:service) }
+
+    it 'removes child_service from the service' do
+      child_service.add_to_service(service)
+      expect(service.services).to include(child_service)
+
+      child_service.remove_from_service(service)
+      expect(service.services).to be_blank
+      expect(child_service.service).to be_nil
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -263,13 +263,21 @@ describe Vm do
     expect(console.url_secret).to be
   end
 
-  it '#add_to_service' do
-    vm = FactoryGirl.create(:vm_vmware)
-    service = FactoryGirl.create(:service)
+  describe '#add_to_service' do
+    let(:vm) { FactoryGirl.create(:vm_vmware) }
+    let(:service) { FactoryGirl.create(:service) }
 
-    vm.add_to_service(service)
-    service.reload
-    expect(service.vms.count).to eq(1)
+    it 'associates the vm to the service' do
+      vm.add_to_service(service)
+
+      expect(service.reload.vms).to include(vm)
+    end
+
+    it 'raise an error if the vm is already part of a service' do
+      vm.add_to_service(service)
+
+      expect { vm.add_to_service(service) }.to raise_error MiqException::Error
+    end
   end
 
   context "#cockpit_url" do


### PR DESCRIPTION
Refactor `add_resource` logic in service_mixin to make it easier to create `add_to_service` methods on target resources, like Service, VM and eventually GenericObject.

Also adds `add_to_service` and `remove_from_service` to Service model.

Links
----------------
Replaces `add_to_service` logic in PR #14876 
https://bugzilla.redhat.com/show_bug.cgi?id=1441412

cc @abellotti 