### PR TITLE
Parse the serial number during refresh

### DIFF
--- a/product/reports/110_Configuration Management - Hosts/030_Hardware.yaml
+++ b/product/reports/110_Configuration Management - Hosts/030_Hardware.yaml
@@ -20,6 +20,7 @@ col_order:
 - hardware.cpu_cores_per_socket
 - hardware.memory_mb
 - hardware.number_of_nics
+- hardware.serial_number
 timeline:
 id: 70
 file_mtime:
@@ -37,6 +38,7 @@ include:
     - cpu_cores_per_socket
     - memory_mb
     - number_of_nics
+    - serial_number
 db: Host
 cols:
 - name
@@ -55,3 +57,4 @@ headers:
 - Hardware Cores Per Socket
 - Hardware RAM
 - Hardware Number Of Nics
+- Serial Number


### PR DESCRIPTION
Parse the serial number of host during refresh.
This is required for:
https://bugzilla.redhat.com/show_bug.cgi?id=1410183

This is dependent on:
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/97