### PR TITLE
Update Ruby to 2.3.5 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- '2.3.1'
+- '2.3.5'
 sudo: false
 cache:
   bundler: true


### PR DESCRIPTION
Updates the Ruby version we test against on Travis. This is still 2.3.x as it's the oldest version we support on appliances in Fine.