### PR TITLE
Use pg 9.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 matrix:
   fast_finish: true
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 before_install:
 - source ${TRAVIS_BUILD_DIR}/tools/ci/before_install.sh
 before_script:


### PR DESCRIPTION
It looks like Postgres 9.5 finally has support on container based Travis builds using Trusty, which we already do: https://github.com/travis-ci/travis-ci/issues/4264

![](http://screenshots.chrisarcand.com/1pdqo.jpg)