### PR TITLE
Use forked rufus-scheduler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ group :rest_api, :manageiq_default do
 end
 
 group :scheduler, :manageiq_default do
-  gem "rufus-scheduler",                "~>3.1.3",       :require => false
+  gem "rufus-scheduler", :git => "https://github.com/chrisarcand/rufus-scheduler.git", :branch => "3-1-with-ruby-2-4-support", :require => false
 end
 
 group :seed, :manageiq_default do


### PR DESCRIPTION
Allows for Ruby 2.4 support without updating to the latest rufus-scheduler, which breaks things for us.

See the following commit for more details: https://github.com/chrisarcand/rufus-scheduler/commit/9b349cadc900f02ca73c1a2ce8f5be02ed36af24

