### PR TITLE
Change error notification level from success to error

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -152,7 +152,7 @@
 - :name: tower_op_failure
   :message: 'The operation %{op_name} %{op_arg} on %{tower} has failed to complete. Please check the logs for further details.'
   :expires_in: 24.hours
-  :level: :success
+  :level: :error
   :audience: global
 - :name: vm_snapshot_failure
   :message: 'Failed to %{snapshot_op} snapshot of %{subject}: %{error}'


### PR DESCRIPTION
Ansible Tower failure notification had wrong level. Changed from `success` to `error` so the notification displays red cross instead of green checkmark. Introduced by https://github.com/ManageIQ/manageiq/pull/14625 .

@miq-bot add_label  bug, providers/ansible_tower, fine/yes

@jameswnl Please review. Thanks :)

https://bugzilla.redhat.com/show_bug.cgi?id=1471868