### PR TITLE
Use the built-in OpenShift service environment variables

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -71,7 +71,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     server = MiqServer.my_server(true)
 
     if MiqEnvironment::Command.is_container?
-      host = ENV["ANSIBLE_SERVICE_NAME"]
+      host = ENV["ANSIBLE_SERVICE_HOST"]
       path = "/api/v1"
     else
       host = server.hostname || server.ipaddress

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -74,8 +74,8 @@ class EmbeddedAnsible
 
   def self.api_connection
     if MiqEnvironment::Command.is_container?
-      host = ENV["ANSIBLE_SERVICE_NAME"]
-      port = 80
+      host = ENV["ANSIBLE_SERVICE_HOST"]
+      port = ENV["ANSIBLE_SERVICE_PORT_HTTP"]
     else
       host = "localhost"
       port = HTTP_PORT

--- a/lib/miq_memcached.rb
+++ b/lib/miq_memcached.rb
@@ -3,7 +3,11 @@ require 'linux_admin'
 
 module MiqMemcached
   def self.server_address
-    ENV["MEMCACHED_SERVER"] || ::Settings.session.memcache_server
+    if ENV["MEMCACHED_SERVICE_HOST"] && ENV["MEMCACHED_SERVICE_PORT"]
+      "#{ENV["MEMCACHED_SERVICE_HOST"]}:#{ENV["MEMCACHED_SERVICE_PORT"]}"
+    else
+      ::Settings.session.memcache_server
+    end
   end
 
   class Error < RuntimeError; end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -156,9 +156,11 @@ describe EmbeddedAnsible do
 
     describe ".api_connection" do
       around do |example|
-        ENV["ANSIBLE_SERVICE_NAME"] = "ansible-service"
+        ENV["ANSIBLE_SERVICE_HOST"] = "192.0.2.1"
+        ENV["ANSIBLE_SERVICE_PORT_HTTP"] = "1234"
         example.run
-        ENV.delete("ANSIBLE_SERVICE_NAME")
+        ENV.delete("ANSIBLE_SERVICE_HOST")
+        ENV.delete("ANSIBLE_SERVICE_PORT_HTTP")
       end
 
       it "connects to the ansible service when running in a container" do
@@ -166,7 +168,7 @@ describe EmbeddedAnsible do
         expect(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
 
         expect(AnsibleTowerClient::Connection).to receive(:new).with(
-          :base_url   => "http://ansible-service/api/v1",
+          :base_url   => "http://192.0.2.1:1234/api/v1",
           :username   => "admin",
           :password   => "adminpassword",
           :verify_ssl => 0

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -70,9 +70,9 @@ describe EmbeddedAnsibleWorker::Runner do
         end
 
         around do |example|
-          ENV["ANSIBLE_SERVICE_NAME"] = "ansible-service"
+          ENV["ANSIBLE_SERVICE_HOST"] = "192.0.2.1"
           example.run
-          ENV.delete("ANSIBLE_SERVICE_NAME")
+          ENV.delete("ANSIBLE_SERVICE_HOST")
         end
 
         it "creates the provider with the service name for the URL" do
@@ -84,7 +84,7 @@ describe EmbeddedAnsibleWorker::Runner do
 
           provider = ManageIQ::Providers::EmbeddedAnsible::Provider.first
           expect(provider.zone).to eq(miq_server.zone)
-          expect(provider.default_endpoint.url).to eq("https://ansible-service/api/v1")
+          expect(provider.default_endpoint.url).to eq("https://192.0.2.1/api/v1")
           userid, password = provider.auth_user_pwd
           expect(userid).to eq("admin")
           expect(password).to eq("secret")


### PR DESCRIPTION
Before this change we were providing the memcached and ansible service names as environment variables.

These names are DNS entries that resolve to the already present values in `<SVCNAME>_SERVICE_HOST`. If we just use those directly, we can eliminate some template overhead.

ref: https://docs.openshift.org/latest/dev_guide/environment_variables.html#automatically-added-environment-variables

Thanks @abellotti for showing me that we could make use of these.