### PR TITLE
Added RBAC rules for the help screen (about, documentation, product)

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3270,9 +3270,19 @@
           :hidden: true
           :identifier: db_refresh
 
+# Documentation
+- :name: Documentation
+  :description: Open the Documentation Page
+  :feature_type: node
+  :identifier: documentation
+# Product
+- :name: Product
+  :description: Open the Product Website
+  :feature_type: node
+  :identifier: product
 # About
 - :name: About
-  :description:
+  :description: Show the About Information
   :feature_type: node
   :identifier: about
 


### PR DESCRIPTION
RBAC rules created for these buttons in the top right menu:
![screenshot from 2017-09-20 20-01-25](https://user-images.githubusercontent.com/649130/30659584-859d790c-9e3e-11e7-9b0b-ef215c61c14d.png)


Pivotal story: https://www.pivotaltracker.com/story/show/150933794

@martinpovolny my copy-paste skills aren't so strong, am I doing this right?