### PR TITLE
Metrics Worker capture_timer more ems centric

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -132,14 +132,15 @@ module Metric::Capture
   # 1. Only calculate rollups for Hosts
   # 2. Some Hosts have an EmsCluster as a parent, others have none.
   # 3. Only Hosts with a parent are rolled up.
-  #
+  # @param [Array<Host|VmOrTemplate|Storage>] @targets The nodes to rollup
+  # @option options :force Force capture if this node is a host
   # @returns Hash<String,Array<Host>>
   #   e.g.: {"EmsCluster:4"=>[Host:4], "EmsCluster:5"=>[Host:1, Host:2]}
-  def self.calc_targets_by_rollup_parent(targets)
+  def self.calc_targets_by_rollup_parent(targets, options = {})
     realtime_targets = targets.select do |target|
       target.kind_of?(Host) &&
         perf_target_to_interval_name(target) == "realtime" &&
-        perf_capture_now?(target)
+        (options[:force] || perf_capture_now?(target))
     end
     realtime_targets.each_with_object({}) do |target, h|
       target.perf_rollup_parents("realtime").to_a.compact.each do |parent|
@@ -148,7 +149,6 @@ module Metric::Capture
       end
     end
   end
-  private_class_method :calc_targets_by_rollup_parent
 
   # Determine queue options for each target
   # Is only generating options for Vmware Hosts, which have a task for rollups.

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -8,9 +8,9 @@ module Metric::Targets
     MiqRegion.my_region.perf_capture_always = options
   end
 
-  def self.capture_infra_targets(zone, options)
-    load_infra_targets_data(zone, options)
-    all_hosts = capture_host_targets(zone)
+  def self.capture_infra_targets(emses, options)
+    load_infra_targets_data(emses, options)
+    all_hosts = capture_host_targets(emses)
     targets = enabled_hosts = only_enabled(all_hosts)
     targets += capture_storage_targets(all_hosts) unless options[:exclude_storages]
     targets += capture_vm_targets(enabled_hosts) unless options[:exclude_vms]
@@ -31,26 +31,26 @@ module Metric::Targets
   # @return vms under all availability zones
   #         and vms under no availability zone
   # NOTE: some stacks (e.g. nova) default to no availability zone
-  def self.capture_cloud_targets(zone, options = {})
+  def self.capture_cloud_targets(emses, options = {})
     return [] if options[:exclude_vms]
 
-    MiqPreloader.preload(zone.ems_clouds, :vms => [{:availability_zone => :tags}, :ext_management_system])
+    MiqPreloader.preload(emses, :vms => [{:availability_zone => :tags}, :ext_management_system])
 
-    zone.ems_clouds.flat_map(&:vms).select do |vm|
+    emses.flat_map(&:vms).select do |vm|
       vm.state == 'on' && (vm.availability_zone.nil? || vm.availability_zone.perf_capture_enabled?)
     end
   end
 
-  def self.capture_container_targets(zone, _options)
+  def self.capture_container_targets(emses, _options)
     includes = {
       :container_nodes  => :tags,
       :container_groups => [:tags, :containers => :tags],
     }
 
-    MiqPreloader.preload(zone.ems_containers, includes)
+    MiqPreloader.preload(emses, includes)
 
     targets = []
-    zone.ems_containers.each do |ems|
+    emses.each do |ems|
       targets += ems.container_nodes
       targets += ems.container_groups
       targets += ems.containers
@@ -59,21 +59,21 @@ module Metric::Targets
     targets
   end
 
-  # preload zone with relations that will be used in cap&u
+  # preload emses with relations that will be used in cap&u
   #
   # tags are needed for determining if it is enabled.
   # ems is needed for determining queue name
   # cluster is used for hierarchies
-  def self.load_infra_targets_data(zone, options)
-    MiqPreloader.preload(zone, preload_hash_infra_targets_data(options))
-    postload_infra_targets_data(zone, options)
+  def self.load_infra_targets_data(emses, options)
+    MiqPreloader.preload(emses, preload_hash_infra_targets_data(options))
+    postload_infra_targets_data(emses, options)
   end
 
   def self.preload_hash_infra_targets_data(options)
     # Preload all of the objects we are going to be inspecting.
-    includes = {:ext_management_systems => {:hosts => {:ems_cluster => :tags, :tags => {}}}}
-    includes[:ext_management_systems][:hosts][:storages] = :tags unless options[:exclude_storages]
-    includes[:ext_management_systems][:hosts][:vms] = {} unless options[:exclude_vms]
+    includes = {:hosts => {:ems_cluster => :tags, :tags => {}}}
+    includes[:hosts][:storages] = :tags unless options[:exclude_storages]
+    includes[:hosts][:vms] = {} unless options[:exclude_vms]
     includes
   end
 
@@ -86,9 +86,9 @@ module Metric::Targets
   # and since we also rely upon tags and clusters, this causes unnecessary data to be downloaded
   #
   # so we have introduced this to work around preload not working (and inverse_of)
-  def self.postload_infra_targets_data(zone, options)
+  def self.postload_infra_targets_data(emses, options)
     # populate ems (with tags / clusters)
-    zone.ext_management_systems.each do |ems|
+    emses.each do |ems|
       ems.hosts.each do |host|
         host.ems_cluster.association(:ext_management_system).target = ems if host.ems_cluster_id
         unless options[:exclude_vms]
@@ -106,10 +106,10 @@ module Metric::Targets
     end
   end
 
-  def self.capture_host_targets(zone)
+  def self.capture_host_targets(emses)
     # NOTE: if capture_storage_targets takes only enabled hosts
     # merge only_enabled into this method
-    zone.ext_management_systems.flat_map(&:hosts)
+    emses.flat_map(&:hosts)
   end
 
   # @param [Host] all hosts that have an ems
@@ -132,8 +132,8 @@ module Metric::Targets
   def self.capture_targets(zone = nil, options = {})
     zone = MiqServer.my_server.zone if zone.nil?
     zone = Zone.find(zone) if zone.kind_of?(Integer)
-    capture_infra_targets(zone, options) + \
-      capture_cloud_targets(zone, options) + \
-      capture_container_targets(zone, options)
+    capture_infra_targets(zone.ext_management_systems, options) + \
+      capture_cloud_targets(zone.ems_clouds, options) + \
+      capture_container_targets(zone.ems_containers, options)
   end
 end


### PR DESCRIPTION
High Level
-----------

We are changing capacity & utilization:

 **before:**
`determine zone.vms --queue--> (collect and persist)`

 **after:**
`(determine ems.vms and collect) --queue--> persist`

This change puts less load on the `queue`. Additionally going from a `zone` centric flow to an `ems` centric flow allows us to optimize the way we call `collect` the `vms`, `hosts`, and `storage`.

This PR
--------

The current PR is focused on `determine vms`, affectionately known as `perf_capture_timer`. It changes 10 helper methods to allow the `vms` to be from a `zone` centric nature to `ems` centric. This allows the new `MetricsCaptureWorker`, which is ems centric, to reuse these methods.

Numbers
---------

For verification I benchmarked `perf_capture_timer`, forcing alert detection on all objects, and triggering 'collection' for all objects.

|       ms |   bytes | objects |query | query ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  2,269.5 | 43,837,717* | 1,217,624 |1,059 |   709.1 |    1,357 |`before-2`
|  2,253.5 | 44,915,145* | 1,217,642 |1,059 |   707.5 |    1,357 |`after-3`

\* Memory usage does not reflect 2,277 freed objects

TL;DR: nothing changed