### PR TITLE
format_by_(class|column) aren't used :fire:

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -911,14 +911,6 @@
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes
 :reporting:
-  :format_by_class:
-    :Integer:
-      :function:
-        :name: number_with_delimiter
-    :Float:
-      :function:
-        :name: number_with_delimiter
-  :format_by_column: {}
   :history:
     :keep_reports: 6.months
     :purge_window_size: 100


### PR DESCRIPTION
Many years ago their usage was removed from the generic server settings and migrated in a way to each report's settings...

```
commit 73ac8da10e3bc0eed2abc471ca89adce222f0700
Author: <REDACTED>
Date:   Wed Dec 16 21:20:47 2009 +0000

    -Changed args in format method to take an options hash instead of format as the last arg to allow passing additional options such as time zone.
    -Updated callers of format method.
    -Support for passing in :_default_ as format value to force default lookup of format and not look in report object.
    -Added support for date, time and datetime formats.
    BugzID: 7453

    git-svn-id: http://miq-ubuntusub.manageiq.com/svn/svnrepos/Manageiq/trunk@17795 3c68ef56-dcc3-11dc-9475-a42b84ecc76f
```

Seen when reviewing: https://github.com/ManageIQ/manageiq/pull/15987