### PR TITLE
Add the `picture` association to Generic Objects via `generic_object_definition`

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -5,6 +5,7 @@ class GenericObject < ApplicationRecord
   virtual_has_one :custom_action_buttons
 
   belongs_to :generic_object_definition
+  has_one :picture, :through => :generic_object_definition
 
   validates :name, :presence => true
 


### PR DESCRIPTION
Added the `picture` association to Generic Objects, so that custom images can be displayed in the list view

Classic UI PR is - https://github.com/ManageIQ/manageiq-ui-classic/pull/2188, that needs this association.