### PR TITLE
Add virtual columns for GenericObject and GenericObjectDefinition

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -17,6 +17,9 @@ class GenericObject < ApplicationRecord
            :custom_actions, :custom_action_buttons,
            :to => :generic_object_definition, :allow_nil => true
 
+  delegate :name, :to => :generic_object_definition, :prefix => true, :allow_nil => false
+  virtual_column :generic_object_definition_name, :type => :string
+
   def initialize(attributes = {})
     # generic_object_definition will be set first since hash iteration is based on the order of key insertion
     attributes = (attributes || {}).symbolize_keys

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -34,6 +34,9 @@ class GenericObjectDefinition < ApplicationRecord
 
   before_destroy    :check_not_in_use
 
+  delegate :count, :to => :generic_objects, :prefix => true, :allow_nil => false
+  virtual_column :generic_objects_count, :type => :integer
+
   FEATURES.each do |feature|
     define_method("property_#{feature}s") do
       return errors[:properties] if properties_changed? && !valid?


### PR DESCRIPTION
- Add Generic Object Definition Name virtual column in GenericObject
- Add Generic Object Instances count virtual column in GenericObjectDefinition

UI PR - https://github.com/ManageIQ/manageiq-ui-classic/pull/2209