### PR TITLE
Passing a class as a value in an Active Record query is deprecated

### DIFF
--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -27,7 +27,7 @@ module CustomAttributeMixin
     end
 
     def self.custom_keys
-      custom_attr_scope = CustomAttribute.where(:resource_type => base_class).where.not(:name => nil).distinct.pluck(:name, :section)
+      custom_attr_scope = CustomAttribute.where(:resource_type => base_class.name).where.not(:name => nil).distinct.pluck(:name, :section)
       custom_attr_scope.map do |x|
         "#{x[0]}#{x[1] ? SECTION_SEPARATOR + x[1] : ''}"
       end


### PR DESCRIPTION
Removed deprecation warning : `[2017-09-21T09:25:12.478212 #13453:3fc1b8f199ec]  WARN -- : DEPRECATION WARNING: Passing a class as a value in an Active Record query is deprecated and will be removed. Pass a string instead. (called from custom_keys at /Users/yrudman/work/rh/manageiq/app/models/mixins/custom_attribute_mixin.rb:30)
`

@miq-bot add-label core