### PR TITLE
Add dialog field description to list of values updatable by automate

### DIFF
--- a/app/models/dialog_field_check_box.rb
+++ b/app/models/dialog_field_check_box.rb
@@ -1,5 +1,5 @@
 class DialogFieldCheckBox < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(required read_only visible).freeze
+  AUTOMATE_VALUE_FIELDS = %w(required read_only visible description).freeze
 
   def checked?
     value == "t"

--- a/app/models/dialog_field_date_control.rb
+++ b/app/models/dialog_field_date_control.rb
@@ -1,5 +1,5 @@
 class DialogFieldDateControl < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only visible).freeze
+  AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only visible description).freeze
 
   include TimezoneMixin
 

--- a/app/models/dialog_field_date_time_control.rb
+++ b/app/models/dialog_field_date_time_control.rb
@@ -1,5 +1,5 @@
 class DialogFieldDateTimeControl < DialogFieldDateControl
-  AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only visible).freeze
+  AUTOMATE_VALUE_FIELDS = %w(show_past_dates read_only visible description).freeze
 
   def automate_output_value
     return nil if @value.blank?

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -1,5 +1,5 @@
 class DialogFieldSortedItem < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(sort_by sort_order data_type default_value required read_only visible).freeze
+  AUTOMATE_VALUE_FIELDS = %w(sort_by sort_order data_type default_value required read_only visible description).freeze
 
   def initialize_with_values(dialog_values)
     if load_values_on_init?

--- a/app/models/dialog_field_text_area_box.rb
+++ b/app/models/dialog_field_text_area_box.rb
@@ -1,3 +1,3 @@
 class DialogFieldTextAreaBox < DialogFieldTextBox
-  AUTOMATE_VALUE_FIELDS = %w(required read_only visible).freeze
+  AUTOMATE_VALUE_FIELDS = %w(required read_only visible description).freeze
 end

--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -1,5 +1,5 @@
 class DialogFieldTextBox < DialogField
-  AUTOMATE_VALUE_FIELDS = %w(data_type protected required validator_rule validator_type read_only visible).freeze
+  AUTOMATE_VALUE_FIELDS = %w(data_type protected required validator_rule validator_type read_only visible description).freeze
 
   def value
     @value = values_from_automate if dynamic && @value.blank?

--- a/spec/models/dialog_field_check_box_spec.rb
+++ b/spec/models/dialog_field_check_box_spec.rb
@@ -76,9 +76,10 @@ describe DialogFieldCheckBox do
     let(:dialog_field) { described_class.new }
     let(:automate_hash) do
       {
-        "value"     => value,
-        "required"  => true,
-        "read_only" => true
+        "value"       => value,
+        "required"    => true,
+        "read_only"   => true,
+        "description" => "description"
       }
     end
 
@@ -93,6 +94,10 @@ describe DialogFieldCheckBox do
 
       it "sets the read_only" do
         expect(dialog_field.read_only).to be_truthy
+      end
+
+      it "sets the description" do
+        expect(dialog_field.description).to eq("description")
       end
     end
 

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -59,7 +59,8 @@ describe DialogFieldDateControl do
       {
         "value"           => value,
         "show_past_dates" => true,
-        "read_only"       => true
+        "read_only"       => true,
+        "description"     => "description"
       }
     end
 
@@ -78,6 +79,10 @@ describe DialogFieldDateControl do
 
       it "sets the read_only" do
         expect(dialog_field.read_only).to be_truthy
+      end
+
+      it "sets the description" do
+        expect(dialog_field.description).to eq("description")
       end
     end
 

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -302,6 +302,7 @@ describe DialogFieldSortedItem do
         "sort_order"    => "descending",
         "data_type"     => "datatype",
         "default_value" => "default",
+        "description"   => "description",
         "required"      => true,
         "read_only"     => true,
         "values"        => values
@@ -319,6 +320,10 @@ describe DialogFieldSortedItem do
 
       it "sets the sort_order" do
         expect(dialog_field.sort_order).to eq(:descending)
+      end
+
+      it "sets the description" do
+        expect(dialog_field.description).to eq("description")
       end
 
       it "sets the data_type" do

--- a/spec/models/dialog_field_text_area_box_spec.rb
+++ b/spec/models/dialog_field_text_area_box_spec.rb
@@ -7,6 +7,7 @@ describe DialogFieldTextAreaBox do
         "data_type"      => "datatype",
         "value"          => value,
         "protected"      => true,
+        "description"    => "description",
         "required"       => true,
         "read_only"      => true,
         "validator_rule" => "rule",
@@ -33,6 +34,10 @@ describe DialogFieldTextAreaBox do
 
       it "sets the required" do
         expect(dialog_field.required).to be_truthy
+      end
+
+      it "sets the description" do
+        expect(dialog_field.description).to eq("description")
       end
 
       it "sets the read_only" do

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -283,6 +283,7 @@ describe DialogFieldTextBox do
         "data_type"      => "datatype",
         "value"          => value,
         "protected"      => true,
+        "description"    => "description",
         "required"       => true,
         "read_only"      => true,
         "validator_type" => "regex",
@@ -301,6 +302,10 @@ describe DialogFieldTextBox do
 
       it "sets the required" do
         expect(dialog_field.required).to be_truthy
+      end
+
+      it "sets the description" do
+        expect(dialog_field.description).to eq("description")
       end
 
       it "sets the read_only" do


### PR DESCRIPTION
Description field in Dynamic Dialog Element cannot be updated from Automate Method
Some fields of dynamic dialog elements can be updated through Automate methods. Currently, description is not one of these. This PR adds description to the list of automate value fields, allowing it to be updated by an automate method. 

**Links**

- https://bugzilla.redhat.com/show_bug.cgi?id=1494212