### PR TITLE
Fix the lenovo's event_catcher time

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1077,7 +1077,7 @@
       :event_catcher_google:
         :poll: 15.seconds
       :event_catcher_lenovo:
-        :poll: 4.minutes
+        :poll: 15.seconds
       :event_catcher_cinder:
         :poll: 10.seconds
       :event_catcher_swift:


### PR DESCRIPTION
This PR is able to:
- Fix the time's lenovo event_catcher problem that was higher than `heart_timeout`.

Depends on: [PR 83](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/83) `lenovo_provider`