### PR TITLE
Increase Timeouts and Worker Memory for Azure SSA

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -178,6 +178,9 @@ class Job < ApplicationRecord
     if target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
        target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
       timeout_adjustment = 4
+    elsif target.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) ||
+          target.kind_of?(ManageIQ::Providers::Azure::CloudManager::Template)
+      timeout_adjustment = 4
     end
     timeout_adjustment
   end

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -82,6 +82,9 @@ module MiqServer::ServerSmartProxy
         if target.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm) ||
            target.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Template)
           timeout_adj = 4
+        elsif target.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) ||
+              target.kind_of?(ManageIQ::Providers::Azure::CloudManager::Template)
+          timeout_adj = 4
         elsif target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
               target.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Template)
           timeout_adj = 8

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1137,9 +1137,9 @@
         :nice_delta: 7
       :smart_proxy_worker:
         :count: 2
-        :memory_threshold: 600.megabytes
+        :memory_threshold: 2.gigabytes
         :queue_timeout: 20.minutes
-        :restart_interval: 2.hours
+        :restart_interval: 6.hours
     :schedule_worker:
       :container_entities_purge_interval: 1.day
       :authentication_check_interval: 1.hour


### PR DESCRIPTION
In support of high priority BZ https://bugzilla.redhat.com/show_bug.cgi?id=1488967
we need to increase various timeouts to allow the Azure SSA job to succeed.
1) Increase the Job timeout specific to Azure SSA similar to how it has been
   done for SCVMM previously.
2) Increase the SmartProxyWorker MiqQueue msg_timeout value similar to how it has
   been done for both SCVMM and OpenStack previously.
3) Increase the memory_threshold and restart_interval for all SmartProxyWorker jobs.
   The memory_threshold issue has been seen running SSA on other providers as well as
   Azure so the overall default change here is appropriate.

Other PRs  are related to the BZ as well but this PR may be merged in any order as there 
are no prerequisites for it.

This PR should be back ported to FINE.

Please note that we should probably refactor the timeout code in items 1 and 2 above to distribute it to the Providers in question rather than have it live in the ManageIQ repo but that is an item for another day.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1488967

Steps for Testing/QA [Optional]
-------------------------------

Run SSA on various providers including Azure - especially with Managed Disks.  along with other required PRs referenced in the BZ above the scan should complete.

@roliveri @jrafanie please review and merge as soon as possible to allow us to get this BZ addressed.