### PR TITLE
Silence puts during test of the server_settings_replicator

### DIFF
--- a/spec/tools/server_settings_replicator/server_settings_replicator_spec.rb
+++ b/spec/tools/server_settings_replicator/server_settings_replicator_spec.rb
@@ -4,15 +4,13 @@ require "server_settings_replicator/server_settings_replicator"
 
 describe ServerSettingsReplicator do
   let(:miq_server) { EvmSpecHelper.local_miq_server }
-  let!(:miq_server_remote) { EvmSpecHelper.remote_miq_server }
+  let(:miq_server_remote) { EvmSpecHelper.remote_miq_server }
   let(:settings) { {:k1 => {:k2 => {:k3 => 'v3'}}} }
 
-  describe "#replicate" do
-    it "targets only other servers" do
-      miq_server.add_settings_for_resource(settings)
-      expect(described_class).to receive(:copy_to).with([miq_server_remote], settings)
-      described_class.replicate(miq_server, 'k1/k2')
-    end
+  it "replicates" do
+    miq_server.add_settings_for_resource(settings)
+    expect(described_class).to receive(:copy_to).with([miq_server_remote], settings)
+    described_class.replicate(miq_server, 'k1/k2', [miq_server_remote])
   end
 
   describe "#construct_setting_tree" do

--- a/tools/replicate_server_settings.rb
+++ b/tools/replicate_server_settings.rb
@@ -17,4 +17,9 @@ puts opts.inspect
 Trollop.die :path, "is required" unless opts[:path_given]
 
 server = opts[:serverid] ? MiqServer.find(opts[:serverid]) : MiqServer.my_server
-ServerSettingsReplicator.replicate(server, opts[:path], opts[:dry_run])
+
+# all servers except source
+target_servers = MiqServer.where.not(:id => server.id)
+puts "Replicating from server id=#{server.id}, path=#{opts[:path]} to #{target_servers.count} servers"
+ServerSettingsReplicator.replicate(server, opts[:path], target_servers, opts[:dry_run])
+puts "Done"

--- a/tools/server_settings_replicator/server_settings_replicator.rb
+++ b/tools/server_settings_replicator/server_settings_replicator.rb
@@ -1,20 +1,12 @@
 class ServerSettingsReplicator
-  def self.replicate(server, path_string, dry_run = false)
+  def self.replicate(server, path_string, target_servers, dry_run = false)
     path = path_string.split("/").map(&:to_sym)
-
-    # all servers except source
-    target_servers = MiqServer.where.not(:id => server.id)
     settings = construct_setting_tree(path, server.settings_for_resource.fetch_path(path).to_h)
-
-    puts "Replicating from server id=#{server.id}, path=#{path_string} to #{target_servers.count} servers"
-    puts "Settings: #{settings}"
-
     if dry_run
       puts "Dry run, no updates have been made"
     else
       copy_to(target_servers, settings)
     end
-    puts "Done"
   end
 
   def self.construct_setting_tree(path, values)
@@ -23,6 +15,7 @@ class ServerSettingsReplicator
   end
 
   def self.copy_to(target_servers, target_settings)
+    puts "Settings: #{target_settings}"
     target_servers.each do |target|
       puts " - replicating to server id=#{target.id}..."
       target.add_settings_for_resource(target_settings)


### PR DESCRIPTION
To silent the stdout emitted during test of `tools/server_settings_replicator/server_settings_replicator.rb`

