### PR TITLE
Don't require application_helper anymore

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,6 @@ end
 
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
-require 'application_helper'
-
 require 'rspec/rails'
 require 'vcr'
 require 'cgi'


### PR DESCRIPTION
Some of the helper specs required application_helper as of baf3a89933b.
Because these tests were moved to ui-classic and ui-classic requires
application_helper in it's spec_helper, this main repo does not need
to require application_helper, a file from the ui-classic repo.

Removing this allows us to run the tests locally without access to the
manageiq-ui-classic repo via BUNDLER_GROUPS=manageiq_default.

Pull apart that :spaghetti: one change at a time.