### PR TITLE
Bump manageiq-smartstate gem to 0.1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,7 +165,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.1.4",       :require => false
+  gem "manageiq-smartstate",            "~>0.1.5",       :require => false
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb


### PR DESCRIPTION
By way of https://github.com/ManageIQ/manageiq-smartstate/pull/30, as
part of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1475540,
The manageiq-smartstate gem was bumped to 0.1.5.  The fixes in question
have all been backported to FINE, but since manageiq-smartstate code
actually lives in manageiq-gems-pending in FINE, this change is not
needed in FINE.  It is upstream only.

Links [Optional]
----------------

* https://github.com/ManageIQ/manageiq-smartstate/pull/30
* https://bugzilla.redhat.com/show_bug.cgi?id=147554

@roliveri please review and merge.  Thanks.  This should be the very last PR having anything to do with the above PR but does not affect 5.8.2 or any hot fix generated by @simaishi.