### PR TITLE
[WIP] Containers old refresh: create/resolve mapped tags in separate pass

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -56,7 +56,9 @@ class ContainerLabelTagMapping < ApplicationRecord
   end
   private_class_method :map_name_type_value
 
-  # Given a hash built by `map_*` methods, returns a Tag (creating if needed).
+  # Given a hash built by `map_*` methods, sets tag_hash[:tag_id] (creating if needed),
+  # and returns the Tag object.
+  # TODO: remove this compatibility method?
   def self.find_or_create_tag(tag_hash)
     if tag_hash[:tag_id]
       Tag.find(tag_hash[:tag_id])
@@ -75,6 +77,13 @@ class ContainerLabelTagMapping < ApplicationRecord
         end
       end
       entry.tag
+    end
+  end
+
+  # Sets h[:tag_id] in each hash (creating if nedeed).
+  def self.find_or_create_tags(tag_hashes)
+    tag_hashes.each do |h|
+      find_or_create_tag(h)
     end
   end
 

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -1,5 +1,6 @@
 module EmsRefresh::SaveInventoryContainer
   def save_ems_container_inventory(ems, hashes, _target = nil)
+    ContainerLabelTagMapping.find_or_create_tags(hashes[:tags_to_resolve].to_a)
 
     child_keys = [:container_projects, :container_quotas, :container_limits, :container_nodes,
                   :container_builds, :container_build_pods, :persistent_volume_claims, :persistent_volumes,


### PR DESCRIPTION
Overview issue: https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/126

- [ ] Depends on https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/117
 which makes parser emit `:tags_to_resolve`, each hash there potentially used
 in multiple entities' `:tags`.

This does not yet do batch Tag queries.  Still O(tags).
I expect *will* give a small performance boost from parser reusing same tag for multiple entities, which will allow saving to query the tag id only once.
(That's why it now sets `tag_hash[:tag_id]` as side effect.)
And `retag_entity` remains an O(entities) bottleneck.

My main goal here is exposing ability to resolve tag hashes to tag ids in one pass and reassign them later, which I'll leverage later to implement tag mapping for containers graph refresh.

@miq-bot add-label enhancement

@Ladas @agrare @zgalor @moolitayer Please review.

