### PR TITLE
Fix normal if statement

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -534,10 +534,12 @@ class MiqRequestWorkflow
 
   def tags
     vm_tags = @values[:vm_tags]
+    return unless vm_tags.kind_of?(Array)
+
     vm_tags.each do |tag_id|
       tag = Classification.find(tag_id)
       yield(tag.name, tag.parent.name)  unless tag.nil?    # yield the tag's name and category
-    end if vm_tags.kind_of?(Array)
+    end
   end
 
   def get_tags

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -538,7 +538,7 @@ class MiqRequestWorkflow
 
     vm_tags.each do |tag_id|
       tag = Classification.find(tag_id)
-      yield(tag.name, tag.parent.name)  unless tag.nil?    # yield the tag's name and category
+      yield(tag.name, tag.parent.name) # yield the tag's name and category
     end
   end
 


### PR DESCRIPTION
Fixes Code Climate:
- Favor a normal if-statement over a modifier clause in a multiline statement. 

Also:
- Return early if `vm_tags` is not an Array
- Drop unnecessary conditional