### PR TITLE
Update model to use the customization_scripts table for LXCA config patterns

### DIFF
--- a/app/models/configuration_template.rb
+++ b/app/models/configuration_template.rb
@@ -1,3 +1,0 @@
-class ConfigurationTemplate < ApplicationRecord
-  belongs_to :ext_management_system, :foreign_key => "ems_id"
-end

--- a/app/models/customization_script.rb
+++ b/app/models/customization_script.rb
@@ -2,5 +2,5 @@ class CustomizationScript < ApplicationRecord
   include NewWithTypeStiMixin
 
   acts_as_miq_taggable
-  belongs_to :ext_management_system, :foreign_key => "manager_id"
+  belongs_to :provisioning_manager
 end

--- a/app/models/customization_script.rb
+++ b/app/models/customization_script.rb
@@ -2,6 +2,5 @@ class CustomizationScript < ApplicationRecord
   include NewWithTypeStiMixin
 
   acts_as_miq_taggable
-  belongs_to :provisioning_manager
   belongs_to :ext_management_system, :foreign_key => "manager_id"
 end

--- a/app/models/customization_script.rb
+++ b/app/models/customization_script.rb
@@ -3,4 +3,5 @@ class CustomizationScript < ApplicationRecord
 
   acts_as_miq_taggable
   belongs_to :provisioning_manager
+  belongs_to :ext_management_system, :foreign_key => "manager_id"
 end

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -52,7 +52,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
   end
 
-  def save_customization_scripts(ems, hashes, target = nil)
+  def save_customization_scripts_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
     ems.customization_scripts.reset

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -23,7 +23,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
 
     child_keys = [
       :physical_servers,
-      :configuration_templates
+      :customization_scripts
     ]
 
     # Save and link other subsections
@@ -52,18 +52,18 @@ module EmsRefresh::SaveInventoryPhysicalInfra
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
   end
 
-  def save_configuration_templates_inventory(ems, hashes, target = nil)
+  def save_customization_scripts(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.configuration_templates.reset
+    ems.customization_scripts.reset
     deletes = if target == ems
                 :use_association
               else
                 []
               end
 
-    save_inventory_multi(ems.configuration_templates, hashes, deletes, [:ems_ref])
-    store_ids_for_new_records(ems.configuration_templates, hashes, :ems_ref)
+    save_inventory_multi(ems.customization_scripts, hashes, deletes, [:manager_ref])
+    store_ids_for_new_records(ems.customization_scripts, hashes, :manager_ref)
   end
 
   #

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -59,7 +59,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :customization_specs, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :storage_profiles,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :physical_servers,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
-  has_many :configuration_templates, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :customization_scripts, :foreign_key => "manager_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6401,25 +6401,25 @@
       :feature_type: view
       :identifier: guest_device_show
 
-# Configuration Templates
-- :name: Configuration Templates
-  :description: Everything under Configuration Templates
+# Customization Scripts
+- :name: Customization Scripts
+  :description: Everything under Customization Scripts
   :feature_type: node
-  :identifier: configuration_template
+  :identifier: customization_script
   :children:
   - :name: View
-    :description: View Configuration Template
+    :description: View Customization Script
     :feature_type: view
-    :identifier: configuration_template_view
+    :identifier: customization_script_view
     :children:
     - :name: List
-      :description: Display Lists of Configuration Templates
+      :description: Display Lists of Customization Scripts
       :feature_type: view
-      :identifier: configuration_template_show_list
+      :identifier: customization_script_show_list
     - :name: Show
-      :description: Display Individual Configuration Templates
+      :description: Display Individual Customization Scripts
       :feature_type: view
-      :identifier: configuration_template_show
+      :identifier: customization_script_show
 
 # Physical Infrastructure Topology
 - :name: Physical Infra Topology


### PR DESCRIPTION
Recently, a new table named _configuration_templates_ was created to hold data related to configuration patterns. Based on feedback received from Red Hat, this PR updates the model to use an existing table, _customization_scripts_, to hold configuration pattern data instead.