### PR TITLE
Add severity to alert definitions

### DIFF
--- a/spec/lib/task_helpers/exports/alerts_spec.rb
+++ b/spec/lib/task_helpers/exports/alerts_spec.rb
@@ -13,7 +13,8 @@ describe TaskHelpers::Exports::Alerts do
           "hash_expression"    => nil,
           "responds_to_events" => nil,
           "enabled"            => true,
-          "read_only"          => nil
+          "read_only"          => nil,
+          "severity"           => nil
         }
       }
     ]

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -184,6 +184,26 @@ describe MiqAlert do
         expect(mas.severity).to eq('warning')
       end
 
+      it "miq_alert_status.severity = MiqAlert#severity if ems_event.full_data.severity not present" do
+        @alert.severity = "error"
+        @alert.evaluate(
+          [@vm.class.base_class.name, @vm.id],
+          :ems_event => FactoryGirl.create(:ems_event, :full_data => {})
+        )
+        mas = @alert.miq_alert_statuses.where(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).first
+        expect(mas.severity).to eq('error')
+      end
+
+      it "miq_alert_status.severity = ems_event.full_data.severity  if present and MiqAlert#severity is also present" do
+        @alert.severity = "error"
+        @alert.evaluate(
+          [@vm.class.base_class.name, @vm.id],
+          :ems_event => FactoryGirl.create(:ems_event, :full_data => {:severity => 'info'})
+        )
+        mas = @alert.miq_alert_statuses.where(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).first
+        expect(mas.severity).to eq('info')
+      end
+
       it "miq_alert_status.severity = nil if  ems_event.full_data.severity not present" do
         @alert.evaluate([@vm.class.base_class.name, @vm.id])
         mas = @alert.miq_alert_statuses.where(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id).first


### PR DESCRIPTION
- Add column to miq_alerts
- Allow "info", "warning", "error" or nil for no severity
- Assign severity when alert fires
- Allow severity in incoming event to override serenity in alert definition

Migration in https://github.com/ManageIQ/manageiq-schema/pull/77

https://www.pivotaltracker.com/story/show/151341252
