### PR TITLE
target new refresh fails

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -77,7 +77,7 @@ module EmsRefresh::SaveInventoryInfra
     _log.info("#{log_header} Saving EMS Inventory...Complete")
 
     new_relats = hashes_relats(hashes)
-    link_ems_inventory(ems, target, prev_relats, new_relats)
+    link_ems_inventory(ems, target, prev_relats, new_relats, disconnect)
     remove_obsolete_switches
 
     ems


### PR DESCRIPTION
When running publish vm workflow flow I saw:

[NoMethodError]: undefined method `base_class' for NilClass:Class  Method:[block in method_missing]
relationship_mixin.rb:621:in `block in remove_children'

and it is triggered from `save_ems_inventory_no_disconnect`. It means that `link_invenotry` do not
respects disconnect flag which is fixed by this patch.