### PR TITLE
Service dialog generation rely only on OrchestrationParameterConstraint

### DIFF
--- a/app/models/orchestration_template/orchestration_parameter_allowed.rb
+++ b/app/models/orchestration_template/orchestration_parameter_allowed.rb
@@ -1,5 +1,6 @@
 class OrchestrationTemplate
   class OrchestrationParameterAllowed < OrchestrationParameterConstraint
     attr_accessor :allowed_values
+    attr_accessor :allow_multiple
   end
 end

--- a/app/models/orchestration_template/orchestration_parameter_multiline.rb
+++ b/app/models/orchestration_template/orchestration_parameter_multiline.rb
@@ -1,0 +1,4 @@
+class OrchestrationTemplate
+  class OrchestrationParameterMultiline < OrchestrationParameterConstraint
+  end
+end


### PR DESCRIPTION
Before we tried to determine the dialog field type, specifically text box or text area, by `OrchestrationParameter#data_type`. It turned out it is not reliable because every provider has its own data types.

With this work `OrchestrationParameterConstraintMultiline` is introduced for selecting text area. We will need to enhance each provider's template parsing code to utilize this new constraint. More PRs to follow.

Spec test has been enhanced to share code.

Also enable multiple selection of a dropdown. 

https://bugzilla.redhat.com/show_bug.cgi?id=1489908