### PR TITLE
Fixing middleware servers alert handling

### DIFF
--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -33,7 +33,8 @@ class MiddlewareServer < ApplicationRecord
     s_start = event.full_data.index("id=\"") + 4
     s_end = event.full_data.index("\"", s_start + 4) - 1
     event_id = event.full_data[s_start..s_end]
-    if event_id.start_with?("MiQ-#{alert_id}") && event.middleware_server_id == id
+    if event.middleware_server_id == id && (
+      event_id.start_with?("MiQ-#{alert_id}") || event_id.start_with?(ext_management_system.miq_id_prefix))
       return true
     end
     false

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -586,7 +586,7 @@ class MiqAlert < ApplicationRecord
   end
 
   def evaluate_internal(target, _inputs = {})
-    if target.class.name == 'MiddlewareServer'
+    if target.kind_of?(::MiddlewareServer)
       method = "evaluate_middleware"
       options = _inputs[:ems_event]
     else


### PR DESCRIPTION
* miq_alert: MiddlewareServers model has STI enabled. It's not enough to test against the class name to detect if target is a mw-server. Using kind_of?.
* middleware_server: The format of the alert ids changed. Testing against the new id format in addition to the old one to check if alert should be handled.

This PR is part of a collection of PRs solving ManageIQ/manageiq#15756.