### PR TITLE
Lazy load ActiveMetrics adapters

### DIFF
--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -71,7 +71,7 @@ module Metric::CiMixin::Processing
         end
       end
 
-      parameters = if ActiveMetrics::Base.connection.kind_of?(ActiveMetrics::ConnectionAdapters::MiqPostgresAdapter)
+      parameters = if ActiveMetrics::Base.connection_config[:adapter] == "miq_postgres"
                      # We can just pass original data to PG, with metrics grouped by timestamps, since that is how
                      # we store to PG now. It will spare quite some memory and time to not convert it to row_per_metric
                      # and than back to original format.

--- a/lib/active_metrics.rb
+++ b/lib/active_metrics.rb
@@ -1,4 +1,1 @@
-require 'active_metrics/connection_adapters/elasticsearch_adapter'
-require 'active_metrics/connection_adapters/hawkular_metrics_adapter'
-require 'active_metrics/connection_adapters/influxdb_adapter'
 require 'active_metrics/base'


### PR DESCRIPTION
This was always intended to be done but I didn't really realize the requires were already in the right spot so we need only remove them from active_metrics.rb

The addition of a `kind_of?` check in the metrics processing made me think of it.