### PR TITLE
Fix for add_to_service refactoring

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -402,12 +402,13 @@ class Service < ApplicationRecord
   end
 
   def add_resource(rsc, options = {})
-    service_resource = super
-    return if service_resource.nil?
+    super.tap do |service_resource|
+      break if service_resource.nil?
 
-    # Create ancestry link between services
-    resource = service_resource.resource
-    resource.update_attributes(:parent => self) if resource.kind_of?(Service)
+      # Create ancestry link between services
+      resource = service_resource.resource
+      resource.update_attributes(:parent => self) if resource.kind_of?(Service)
+    end
   end
 
   def enforce_single_service_parent?

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -737,7 +737,7 @@ describe Service do
     let(:child_service) { FactoryGirl.create(:service) }
 
     it 'associates a child_service to the service' do
-      child_service.add_to_service(service)
+      expect(child_service.add_to_service(service)).to be_kind_of(ServiceResource)
 
       expect(service.reload.services).to include(child_service)
     end


### PR DESCRIPTION
The add_to_service method should return a join-table instance (ServiceResource)

Caused test failures in 
[ManageIQ/manageiq-automation_engine/spec/service_models/miq_ae_service_vm_spec.rb#L76](https://github.com/ManageIQ/manageiq-automation_engine/blob/d943d2c0d416e0968f46a5f24eb2674f74403309/spec/service_models/miq_ae_service_vm_spec.rb#L76)

Links
----------------

* Followup PR to refactoring https://github.com/ManageIQ/manageiq/pull/15991
* Needed in https://bugzilla.redhat.com/show_bug.cgi?id=1441412
