### PR TITLE
Add Tasks start page URL to shortcuts yaml file

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -484,3 +484,8 @@
   :url: /alerts_most_recent
   :rbac_feature_name: monitor_alerts_most_recent
   :startup: true
+- :name: miq_proxy_tasks
+  :description: Settings / Tasks
+  :url: /miq_task/index?jobs_tab=tasks
+  :rbac_feature_name: tasks
+  :startup: true


### PR DESCRIPTION
NOTE: This code change requires MiqShortcut.seed to run first.

Regression code change issue after extensive MIQ shortcuts Start At clean up in prior PR. Adding back Settings / Tasks start page URL to the shortcuts yaml file. 

https://bugzilla.redhat.com/show_bug.cgi?id=1492155

Minimal permissions prior to code fix not working:
=======================================
![bz1492155_user_cfme_minimal_permissions_webui](https://user-images.githubusercontent.com/552686/30938815-392da6ee-a390-11e7-87d4-7ad884424afb.png)


Logging in as Settings only user, after code fix:
=======================================
<img width="1643" alt="bz1492155_logged in as newly created user" src="https://user-images.githubusercontent.com/552686/30939064-124e8632-a391-11e7-8171-76f42865b3a1.png">


