### PR TITLE
Unconditionally seed all standard reports and widgets

### DIFF
--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -62,8 +62,8 @@ module MiqReport::Seeding
       rec = find_by_filename(rpt[:filename])
 
       if rec
-        if rec.filename && (rec.file_mtime.nil? || rec.file_mtime.utc < rpt[:file_mtime])
-          _log.info("#{typ.titleize}: [#{rec.name}] file has been updated on disk, synchronizing with model")
+        if rec.filename
+          _log.info("#{typ.titleize}: [#{rec.name}] file exists, synchronizing with model")
           rec.update_attributes(rpt)
           rec.save
         end

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -472,7 +472,7 @@ class MiqWidget < ApplicationRecord
 
     widget = find_by(:description => attrs["description"])
     if widget
-      if filename && widget.updated_at.utc < File.mtime(filename).utc
+      if filename
         $log.info("Widget: [#{widget.description}] file has been updated on disk, synchronizing with model")
         ["enabled", "visibility"].each { |a| attrs.delete(a) } # Don't updates these because they may have been modofoed by the end user.
         widget.updated_at = Time.now.utc


### PR DESCRIPTION
**Before**: seeding process did not update record in `miq_report` table if timestamp of yaml file in `products/...` directory older than in `miq_report`. (assumption was: newer file are always from later version). 

**Issue**:  files in cfme `build 5.7.4.0` have newer date than in `build 5.8.1.5` and report modified in 5.8.1.5  (in https://github.com/ManageIQ/manageiq/pull/14646) was not seeded when upgrading from 5.7.4.0 to 5.8.1.5

https://bugzilla.redhat.com/show_bug.cgi?id=1494819

**After**: Unconditionally seed all standard reports

\cc @gtanzillo 
