### PR TITLE
Move rule for network manager to belonsto filter

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -84,8 +84,7 @@ module Rbac
       "VmOrTemplate::EmsFolder"                => :parent_blue_folders,
       "VmOrTemplate::ResourcePool"             => :resource_pool,
       "ConfiguredSystem::ExtManagementSystem"  => :ext_management_system,
-      "ConfiguredSystem::ConfigurationProfile" => [:id, :configuration_profile_id],
-      "ExtManagementSystem::CloudNetwork"      => [:ems_id, :id]
+      "ConfiguredSystem::ConfigurationProfile" => [:id, :configuration_profile_id]
     }
 
     # These classes should accept any of the relationship_mixin methods including:

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -62,6 +62,7 @@ module Rbac
       EmsCluster
       ResourcePool
       Storage
+      CloudNetwork
     )
 
     # key: MiqUserRole#name - user's role

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -578,7 +578,8 @@ module Rbac
         # typically, this is the only one we want:
         vcmeta = vcmeta_list.last
 
-        if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) } && klass <= VmOrTemplate
+        if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) } && klass <= VmOrTemplate ||
+           vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)        && klass <= CloudNetwork
           vcmeta.send(association_name).to_a
         else
           vcmeta_list.grep(klass) + vcmeta.descendants.grep(klass)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1197,6 +1197,77 @@ describe Rbac::Filterer do
       end
     end
 
+    context 'with cloud network and network manager' do
+      let!(:network_manager)   { FactoryGirl.create(:ems_openstack).network_manager }
+      let!(:cloud_network)     { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager) }
+      let!(:network_manager_1) { FactoryGirl.create(:ems_openstack).network_manager }
+      let!(:cloud_network_1)   { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager_1) }
+
+      context 'with belongs_to_filter' do
+        before do
+          group.entitlement = Entitlement.new
+          group.entitlement.set_managed_filters([])
+          group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|#{network_manager.name}"])
+          group.save!
+        end
+
+        context 'when records match belognsto filter' do
+          it 'lists cloud networks with network manager according to belongsto filter' do
+            User.with_user(user) do
+              results = described_class.search(:class => CloudNetwork).first
+              expect(results).to match_array([cloud_network])
+              expect(results.first.ext_management_system).to eq(network_manager)
+            end
+          end
+
+          it 'lists network manager according to belongsto filter' do
+            User.with_user(user) do
+              results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+              expect(results).to match_array([network_manager])
+            end
+          end
+        end
+
+        context 'when records don\'t match belognsto filter' do
+          before do
+            group.entitlement = Entitlement.new
+            group.entitlement.set_managed_filters([])
+            group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|XXXX"])
+            group.save!
+          end
+
+          it 'lists no cloud networks' do
+            User.with_user(user) do
+              results = described_class.search(:class => CloudNetwork).first
+              expect(results).to be_empty
+            end
+          end
+
+          it 'lists no network manager' do
+            User.with_user(user) do
+              results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+              expect(results).to be_empty
+            end
+          end
+        end
+      end
+
+      it 'lists all cloud networks' do
+        User.with_user(user) do
+          results = described_class.search(:class => CloudNetwork).first
+          expect(results).to match_array(CloudNetwork.all)
+          expect(results.first.ext_management_system).to eq(network_manager)
+        end
+      end
+
+      it 'lists all network managers' do
+        User.with_user(user) do
+          results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+          expect(results).to match_array(ManageIQ::Providers::NetworkManager.all)
+        end
+      end
+    end
+
     context 'with network models' do
       NETWORK_MODELS = %w(
         CloudNetwork

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1250,6 +1250,31 @@ describe Rbac::Filterer do
             end
           end
         end
+
+        context 'network manager is tagged' do
+          before do
+            group.entitlement = Entitlement.new
+            group.entitlement.set_managed_filters([['/managed/environment/prod']])
+            group.entitlement.set_belongsto_filters([])
+            group.save!
+
+            network_manager.tag_with('/managed/environment/prod', :ns => '*')
+          end
+
+          it 'doesn\'t list cloud networks' do
+            User.with_user(user) do
+              results = described_class.search(:class => CloudNetwork).first
+              expect(results).to be_empty
+            end
+          end
+
+          it 'lists only tagged network manager' do
+            User.with_user(user) do
+              results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+              expect(results).to match_array([network_manager])
+            end
+          end
+        end
       end
 
       it 'lists all cloud networks' do


### PR DESCRIPTION
- we need to filter list in CloudNetwork controller according to the network provider in  belongsto filter
replacement of https://github.com/ManageIQ/manageiq/pull/15271 and https://github.com/ManageIQ/manageiq-ui-classic/pull/1474
## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1487179
https://github.com/ManageIQ/manageiq-ui-classic/pull/2266 - removing old way - not needed for this PR

@miq-bot assign @gtanzillo 