### PR TITLE
Move default NTP server settings from constant to Settings

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,6 +1,4 @@
 class Zone < ApplicationRecord
-  DEFAULT_NTP_SERVERS = {:server => %w(0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org)}.freeze
-
   validates_presence_of   :name, :description
   validates_uniqueness_of :name
 
@@ -56,10 +54,8 @@ class Zone < ApplicationRecord
   end
 
   def ntp_settings
-    # Return ntp settings if populated otherwise return the defaults  {:ntp => {:server => ['blah'], :timeout => 5}}
-    return settings[:ntp] if settings.fetch_path(:ntp, :server).present?
-
-    Zone::DEFAULT_NTP_SERVERS.dup
+    # Return ntp settings if populated otherwise return the defaults
+    settings.fetch_path(:ntp, :server).present? ? settings[:ntp] : settings_for_resource.ntp.to_h
   end
 
   def assigned_roles

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -870,6 +870,11 @@
   :level_scvmm: info
   :level_vim: warn
   :level_websocket: info
+:ntp:
+  :server:
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
 :performance:
   :capture_threshold:
     :default: 10.minutes

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -196,11 +196,10 @@ describe MiqServer do
 
         it "syncs with default zone settings if server and zone not configured" do
           @zone.update_attribute(:settings, {})
-          stub_settings({})
 
           expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
           expect(chrony).to receive(:clear_servers)
-          expect(chrony).to receive(:add_servers).with(*Zone::DEFAULT_NTP_SERVERS[:server])
+          expect(chrony).to receive(:add_servers).with("0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org")
           @miq_server.ntp_reload
         end
       end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -140,9 +140,11 @@ describe Zone do
   end
 
   context "#ntp_settings" do
-    let(:zone) { described_class.new }
+    let(:zone) { described_class.new(:name => "test", :description => "test description") }
 
     it "no settings returns default NTP settings" do
+      zone.save!
+
       expect(zone.ntp_settings).to eq(:server => ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"])
     end
 


### PR DESCRIPTION
Part of:
https://bugzilla.redhat.com/show_bug.cgi?id=1476365

This doesn't complete the fix for the BZ, but it seems like a small chunk of work that could be merged independently.  The idea is to move all of the logic out of the local settings column in favor of Settings.

@carbonin / @Fryguy Let me know if you want me to do all of it in one PR (and don't merge yet if that is the case).