### PR TITLE
Allow Openstack provider Volumes and Snapshots to be eligible for provisioning.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -16,7 +16,8 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
                             ManageIQ::Providers::Openstack::CloudManager::Template
                             ManageIQ::Providers::Azure::CloudManager::Template
                             ManageIQ::Providers::Google::CloudManager::Template
-                            ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate))
+                            ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate
+                            ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate))
   end
 
   private

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -15,7 +15,8 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     super.where(:type => %w(ManageIQ::Providers::Amazon::CloudManager::Template
                             ManageIQ::Providers::Openstack::CloudManager::Template
                             ManageIQ::Providers::Azure::CloudManager::Template
-                            ManageIQ::Providers::Google::CloudManager::Template))
+                            ManageIQ::Providers::Google::CloudManager::Template
+                            ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate))
   end
 
   private

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -29,5 +29,9 @@ class MiqTemplate < VmOrTemplate
     where(arel_table[:ems_id].not_eq(nil))
   end
 
+  def self.without_volume_templates
+    where.not(:type => "ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate")
+  end
+
   def active?; false; end
 end

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -30,7 +30,8 @@ class MiqTemplate < VmOrTemplate
   end
 
   def self.without_volume_templates
-    where.not(:type => "ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate")
+    where.not(:type => ["ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate",
+                        "ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate"])
   end
 
   def active?; false; end


### PR DESCRIPTION
This patch allows any openstack VolumeTemplates and VolumeSnapshotTemplates to be visible in the provisioning source selection if they are present. These classes are basically proxies for Cloud Volumes and Cloud Volume Snapshots that permit them to be used as provisioning sources without refactoring the provisioning system to support types other than MiqTemplate.

See https://github.com/ManageIQ/manageiq-providers-openstack/pull/104 for more information
https://github.com/ManageIQ/manageiq-ui-classic/pull/2253

@gmcculloug 