### PR TITLE
delegate name attribute to parent_manager

### DIFF
--- a/app/models/manageiq/providers/monitoring_manager.rb
+++ b/app/models/manageiq/providers/monitoring_manager.rb
@@ -7,5 +7,9 @@ module ManageIQ::Providers
     def self.description
       "Monitoring Manager".freeze
     end
+
+    def name
+      "#{parent_manager.try(:name)} Monitoring Manager"
+    end
   end
 end

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -82,5 +82,9 @@ module ManageIQ::Providers
         end
       end
     end
+
+    def name
+      "#{parent_manager.try(:name)} Network Manager"
+    end
   end
 end

--- a/app/models/manageiq/providers/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager.rb
@@ -52,6 +52,10 @@ class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::
     @description ||= "Cinder ".freeze
   end
 
+  def name
+    "#{parent_manager.try(:name)} Cinder Manager"
+  end
+
   def supports_api_version?
     true
   end

--- a/app/models/manageiq/providers/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager.rb
@@ -48,6 +48,10 @@ class ManageIQ::Providers::StorageManager::SwiftManager < ManageIQ::Providers::S
     @description ||= "Swift ".freeze
   end
 
+  def name
+    "#{parent_manager.try(:name)} Swift Manager"
+  end
+
   def supports_api_version?
     true
   end


### PR DESCRIPTION
when changing the name of a parent_manager, the name of the child manager is not updated.
because child_manager are mostly read-only, we just delegate the name display to the parent_manager

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1464529


@hsong-rh could you 👍 the change on the storage manager?
@moolitayer could you 👍 the change on the monitoring manager?

@miq-bot assign @agrare 
@miq-bot add_label bug
