### PR TITLE
Always check for userid as UPN

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -58,7 +58,7 @@ module Authenticator
           else
             # If role_mode == database we will only use the external system for authentication. Also, the user must exist in our database
             # otherwise we will fail authentication
-            user_or_taskid = lookup_by_identity(username)
+            user_or_taskid = lookup_by_identity(username, request)
             user_or_taskid ||= autocreate_user(username)
 
             unless user_or_taskid
@@ -166,7 +166,7 @@ module Authenticator
       [!!result, username]
     end
 
-    def lookup_by_identity(username)
+    def lookup_by_identity(username, *_args)
       case_insensitive_find_by_userid(username)
     end
 

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -70,6 +70,15 @@ module Authenticator
       [upn_username, user]
     end
 
+    def lookup_by_identity(username, request)
+      user_attrs, _membership_list = user_details_from_headers(username, request)
+      upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain]}".downcase
+
+      user =   find_userid_as_upn(upn_username)
+      user ||= find_userid_as_distinguished_name(user_attrs)
+      user ||  case_insensitive_find_by_userid(username)
+    end
+
     private
 
     def find_userid_as_upn(upn_username)


### PR DESCRIPTION
Always check for userid in UPN format, even when "Get User Groups
from External Authentication (httpd)" is not checked

https://bugzilla.redhat.com/show_bug.cgi?id=1496979

The recent changes to the authentication code space to normalize userid to UPN format
resulted in an edge case failure.

A user entry in the database would not be found if the userid is in UPN format when
"Get User Groups from External Authentication (httpd)" is not checked

This PR addresses this edge case.