### PR TITLE
Sysprep files for ovirt

### DIFF
--- a/db/fixtures/customization_templates.yml
+++ b/db/fixtures/customization_templates.yml
@@ -308,3 +308,226 @@
     - nmcli connection up eth0
   :type: CustomizationTemplateCloudInit
   :system: true
+
+- :name: oVirt sysprep win2008 x64
+  :description: This template generates the sysprep configuration supported by oVirt
+  :script: ! "<%\n  # Setting Variables\n  debug                   = false\n  ms_product_key
+    \         = \"XXXXX-XXXXX-XXXXX-XXXXX-XXXXX\"\n  locale                  = \"en-US\"\n
+    \ registered_organization = \"My Company\"\n  registered_owner        = \"My Company\"\n
+    \ timezone                = \"Eastern Standard Time\"\n  organization            =
+    \"My Company\"\n  domain                  = \"mycompany.com\"\n  machine_object_ou
+    \      = \"OU=MemberServers,DC=mycompany,DC=com\"\n  domain_user             = \"User\"\n
+    \ domain_password         = \"password\"\n  admin_password          = \"password\"\n
+    \ \n \n  # Change values if blank\n  evm[:hostname]          = evm[:vm_target_hostname]
+    if evm[:hostname].blank?      # Use vm_target_hostname if hostname in the dialog
+    was blank\n  evm[:addr_mode]         = [\"dhcp\"] if evm[:ip_addr].blank? || evm[:subnet_mask].blank?
+    || evm[:gateway].blank?\n%>\n\n<%= evm.inspect if debug == true %>\n<?xml version=\"1.0\"
+    encoding=\"utf-8\"?>\n<unattend xmlns=\"urn:schemas-microsoft-com:unattend\">\n
+    \   <settings pass=\"specialize\">\n        <component name=\"Microsoft-Windows-Shell-Setup\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n\t    <% unless evm[:hostname].blank?
+    %>\n            <ComputerName><%= evm[:hostname] %></ComputerName>\n            <%
+    end %>\n            <RegisteredOrganization><%= registered_organization %></RegisteredOrganization>\n
+    \           <RegisteredOwner>User</RegisteredOwner>\n        </component>\n        <component
+    name=\"Microsoft-Windows-UnattendedJoin\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\"
+    language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Identification>\n
+    \               <Credentials>\n                    <Domain><%= domain %></Domain>\n
+    \                   <Password><%= domain_user %></Password>\n                    <Username><%=
+    domain_password %></Username>\n                </Credentials>\n                <DebugJoin>true</DebugJoin>\n
+    \               <JoinDomain><%= domain %></JoinDomain>\n                <MachineObjectOU><%=
+    machine_object_ou %></MachineObjectOU>\n            </Identification>\n        </component>\n
+    \   </settings>\n    <settings pass=\"oobeSystem\">\n        <component name=\"Microsoft-Windows-IE-ClientNetworkProtocolImplementation\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <HKLMProxyEnable>false</HKLMProxyEnable>\n
+    \       </component>\n        <component name=\"Microsoft-Windows-International-Core\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <InputLocale><%=
+    locale %></InputLocale>\n            <SystemLocale><%= locale %></SystemLocale>\n
+    \           <UILanguage><%= locale %></UILanguage>\n            <UILanguageFallback>en-us</UILanguageFallback>\n
+    \           <UserLocale><%= locale %></UserLocale>\n        </component>\n        <component
+    name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\"
+    language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Display>\n
+    \               <ColorDepth>32</ColorDepth>\n                <HorizontalResolution>1024</HorizontalResolution>\n
+    \               <RefreshRate>75</RefreshRate>\n                <VerticalResolution>768</VerticalResolution>\n
+    \           </Display>\n            <OOBE>\n                <HideEULAPage>true</HideEULAPage>\n
+    \               <SkipUserOOBE>true</SkipUserOOBE>\n            </OOBE>\n            <UserAccounts>\n
+    \               <AdministratorPassword>\n                    <Value><%= admin_password
+    %></Value>\n                    <PlainText>true</PlainText>\n                </AdministratorPassword>\n
+    \           </UserAccounts>\n            <RegisteredOrganization><%= registered_organization
+    %></RegisteredOrganization>\n            <RegisteredOwner>User</RegisteredOwner>\n
+    \           <TimeZone><%= timezone %></TimeZone>\n        </component>\n    </settings>\n
+    \   <settings pass=\"windowsPE\">\n        <component name=\"Microsoft-Windows-International-Core-WinPE\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <SetupUILanguage>\n
+    \               <UILanguage><%= locale %></UILanguage>\n            </SetupUILanguage>\n
+    \           <InputLocale><%= locale %></InputLocale>\n            <SystemLocale><%=
+    locale %></SystemLocale>\n            <UILanguage><%= locale %></UILanguage>\n            <UILanguageFallback>en-US</UILanguageFallback>\n
+    \           <UserLocale><%= locale %></UserLocale>\n        </component>\n        <component
+    name=\"Microsoft-Windows-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\"
+    language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <UserData>\n
+    \               <ProductKey>\n                    <Key><%= ms_product_key %></Key>\n
+    \                   <WillShowUI>Never</WillShowUI>\n                </ProductKey>\n
+    \               <AcceptEula>true</AcceptEula>\n                <Organization><%=
+    organization %></Organization>\n                <FullName>User</FullName>\n            </UserData>\n
+    \       </component>\n    </settings>\n    <cpi:offlineImage cpi:source=\"wim:c:/osc/sources/install.wim#Windows
+    Longhorn SERVERSTANDARD\" xmlns:cpi=\"urn:schemas-microsoft-com:cpi\" />\n</unattend>"
+  :type: CustomizationTemplateSysprep
+  :system: true
+
+- :name: oVirt sysprep win2010 x64
+  :description: This template generates the sysprep configuration supported by oVirt
+  :script: ! "<%\n  # Setting Variables\n  debug                   = false\n  ms_product_key
+    \         = \"XXXXX-XXXXX-XXXXX-XXXXX-XXXXX\"\n  locale                  = \"en-US\"\n
+    \ registered_organization = \"My Company\"\n  registered_owner        = \"My Company\"\n
+    \ timezone                = \"Eastern Standard Time\"\n  organization            =
+    \"My Company\"\n  domain                  = \"mycompany.com\"\n  machine_object_ou
+    \      = \"OU=MemberServers,DC=mycompany,DC=com\"\n  domain_user             = \"User\"\n
+    \ domain_password         = \"password\"\n  admin_password          = \"password\"\n\n\n
+    \ # Change values if blank\n  evm[:hostname]          = evm[:vm_target_hostname]
+    if evm[:hostname].blank?      # Use vm_target_hostname if hostname in the dialog
+    was blank\n  evm[:addr_mode]         = [\"dhcp\"] if evm[:ip_addr].blank? || evm[:subnet_mask].blank?
+    || evm[:gateway].blank?\n%>\n\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<unattend
+    xmlns=\"urn:schemas-microsoft-com:unattend\">\n    <settings pass=\"windowsPE\">\n
+    \       <component name=\"Microsoft-Windows-Setup\" processorArchitecture=\"amd64\"
+    publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\"
+    xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n
+    \           <UserData>\n                <ProductKey>\n                    <Key><%=
+    ms_product_key %></Key>\n                </ProductKey>\n                <AcceptEula>true</AcceptEula>\n
+    \               <FullName>\"user\"</FullName>\n                <Organization><%=
+    organization %></Organization>\n            </UserData>\n            <ImageInstall>\n
+    \               <OSImage>\n                    <InstallToAvailablePartition>true</InstallToAvailablePartition>\n
+    \               </OSImage>\n            </ImageInstall>\n        </component>\n
+    \       <component name=\"Microsoft-Windows-International-Core-WinPE\" processorArchitecture=\"amd64\"
+    publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\"
+    xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n
+    \           <SetupUILanguage>\n                <UILanguage><%= locale %></UILanguage>\n
+    \           </SetupUILanguage>\n            <InputLocale><%= locale %></InputLocale>\n
+    \           <UILanguage><%= locale %></UILanguage>\n            <SystemLocale><%=
+    locale %></SystemLocale>\n            <UserLocale><%= locale %></UserLocale>\n        </component>\n
+    \   </settings>\n    <settings pass=\"specialize\">\n        <component name=\"Microsoft-Windows-UnattendedJoin\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Identification>\n
+    \               <Credentials>\n                    <Domain><%= domain %></Domain>\n
+    \                   <Password><%= domain_user %></Password>\n                    <Username><%=
+    domain_password %></Username>\n                </Credentials>\n                <JoinDomain><%=
+    domain %></JoinDomain>\n                <MachineObjectOU><%= machine_object_ou %></MachineObjectOU>\n
+    \           </Identification>\n        </component>\n        <component name=\"Microsoft-Windows-Shell-Setup\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Display>\n
+    \               <ColorDepth>32</ColorDepth>\n                <DPI>96</DPI>\n                <HorizontalResolution>1024</HorizontalResolution>\n
+    \               <RefreshRate>75</RefreshRate>\n                <VerticalResolution>768</VerticalResolution>\n
+    \           </Display>\n\t    <% unless evm[:hostname].blank? %>\n            <ComputerName><%=
+    evm[:hostname] %></ComputerName>\n            <% end %>\n            <TimeZone><%=
+    timezone %></TimeZone>\n        </component>\n        <component name=\"Microsoft-Windows-International-Core\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <InputLocale><%=
+    locale %></InputLocale>\n            <UserLocale><%= locale %></UserLocale>\n            <SystemLocale><%=
+    locale %></SystemLocale>\n            <UILanguage><%= locale %></UILanguage>\n        </component>\n
+    \   </settings>\n    <settings pass=\"oobeSystem\">\n        <component name=\"Microsoft-Windows-Shell-Setup\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <UserAccounts>\n
+    \               <AdministratorPassword>\n                    <Value><%= admin_password
+    %></Value>\n                    <PlainText>true</PlainText>\n                </AdministratorPassword>\n
+    \               <LocalAccounts>\n                    <LocalAccount wcm:action=\"add\">\n
+    \                       <Password>\n                            <Value><%= admin_password
+    %></Value>\n                            <PlainText>true</PlainText>\n                        </Password>\n
+    \                       <DisplayName>user</DisplayName>\n                        <Group>administrators</Group>\n
+    \                       <Name>user</Name>\n                    </LocalAccount>\n
+    \               </LocalAccounts>\n            </UserAccounts>\n            <OOBE>\n
+    \               <HideEULAPage>true</HideEULAPage>\n                <NetworkLocation>Work</NetworkLocation>\n
+    \               <ProtectYourPC>2</ProtectYourPC>\n            </OOBE>\n        </component>\n
+    \       <component name=\"Microsoft-Windows-International-Core\" processorArchitecture=\"amd64\"
+    publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\"
+    xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n
+    \           <InputLocale><%= locale %></InputLocale>\n            <UserLocale><%=
+    locale %></UserLocale>\n            <SystemLocale><%= locale %></SystemLocale>\n
+    \           <UILanguage><%= locale %></UILanguage>\n        </component>\n    </settings>\n
+    \   <cpi:offlineImage cpi:source=\"wim:d:/sources/install.wim#Windows 10 ENTERPRISE\"
+    xmlns:cpi=\"urn:schemas-microsoft-com:cpi\"/>\n</unattend>"
+  :type: CustomizationTemplateSysprep
+  :system: true
+
+- :name: oVirt sysprep win2016 x64
+  :description: This template generates the sysprep configuration supported by oVirt
+  :script: ! "<%\n  # Setting Variables\n  debug                   = false\n  ms_product_key
+    \         = \"XXXXX-XXXXX-XXXXX-XXXXX-XXXXX\"\n  locale                  = \"en-US\"\n
+    \ registered_organization = \"My Company\"\n  registered_owner        = \"My Company\"\n
+    \ timezone                = \"Eastern Standard Time\"\n  organization            =
+    \"My Company\"\n  domain                  = \"mycompany.com\"\n  machine_object_ou
+    \      = \"OU=MemberServers,DC=mycompany,DC=com\"\n  domain_user             = \"User\"\n
+    \ domain_password         = \"password\"\n  admin_password          = \"password\"\n\n\n
+    \ # Change values if blank\n  evm[:hostname]          = evm[:vm_target_hostname]
+    if evm[:hostname].blank?      # Use vm_target_hostname if hostname in the dialog
+    was blank\n  evm[:addr_mode]         = [\"dhcp\"] if evm[:ip_addr].blank? || evm[:subnet_mask].blank?
+    || evm[:gateway].blank?\n%>\n\n<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<unattend
+    xmlns=\"urn:schemas-microsoft-com:unattend\">\n    <settings pass=\"specialize\">\n
+    \       <component name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\"
+    publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\"
+    xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n\t
+    \   <% unless evm[:hostname].blank? %>\n            <ComputerName><%= evm[:hostname]
+    %></ComputerName>\n            <% end %>\n            <RegisteredOrganization><%=
+    registered_organization %></RegisteredOrganization>\n            <RegisteredOwner>User</RegisteredOwner>\n
+    \           <ProductKey><%= ms_product_key %></ProductKey>\n        </component>\n
+    \       <component name=\"Microsoft-Windows-UnattendedJoin\" processorArchitecture=\"amd64\"
+    publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\" versionScope=\"nonSxS\"
+    xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n
+    \           <Identification>\n                <Credentials>\n                    <Domain><%=
+    domain %></Domain>\n                    <Password><%= domain_user %></Password>\n
+    \                   <Username><%= domain_password %></Username>\n                </Credentials>\n
+    \               <DebugJoin>true</DebugJoin>\n                <JoinDomain><%= domain
+    %></JoinDomain>\n                <MachineObjectOU><%= machine_object_ou %></MachineObjectOU>\n
+    \           </Identification>\n        </component>\n    </settings>\n    <settings
+    pass=\"oobeSystem\">\n        <component name=\"Microsoft-Windows-IE-ClientNetworkProtocolImplementation\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <HKLMProxyEnable>false</HKLMProxyEnable>\n
+    \       </component>\n        <component name=\"Microsoft-Windows-International-Core\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <InputLocale><%=
+    locale %></InputLocale>\n            <SystemLocale><%= locale %></SystemLocale>\n
+    \           <UILanguage><%= locale %></UILanguage>\n            <UILanguageFallback>en-US</UILanguageFallback>\n
+    \           <UserLocale><%= locale %></UserLocale>\n        </component>\n        <component
+    name=\"Microsoft-Windows-Shell-Setup\" processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\"
+    language=\"neutral\" versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <Display>\n
+    \               <ColorDepth>32</ColorDepth>\n                <HorizontalResolution>1024</HorizontalResolution>\n
+    \               <RefreshRate>75</RefreshRate>\n                <VerticalResolution>768</VerticalResolution>\n
+    \           </Display>\n            <OOBE>\n                <HideEULAPage>true</HideEULAPage>\n
+    \               <SkipUserOOBE>true</SkipUserOOBE>\n            </OOBE>\n            <UserAccounts>\n
+    \               <AdministratorPassword>\n                    <Value><%= admin_password
+    %></Value>\n                    <PlainText>true</PlainText>\n                </AdministratorPassword>\n
+    \           </UserAccounts>\n            <RegisteredOrganization><%= registered_organization
+    %></RegisteredOrganization>\n            <RegisteredOwner>User</RegisteredOwner>\n
+    \           <TimeZone><%= timezone %></TimeZone>\n        </component>\n    </settings>\n
+    \   <settings pass=\"windowsPE\">\n        <component name=\"Microsoft-Windows-International-Core-WinPE\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <SetupUILanguage>\n
+    \               <UILanguage><%= locale %></UILanguage>\n            </SetupUILanguage>\n
+    \           <InputLocale><%= locale %></InputLocale>\n            <UILanguage><%=
+    locale %></UILanguage>\n            <SystemLocale><%= locale %></SystemLocale>\n
+    \           <UILanguageFallback>en-US</UILanguageFallback>\n            <UserLocale><%=
+    locale %></UserLocale>\n        </component>\n        <component name=\"Microsoft-Windows-Setup\"
+    processorArchitecture=\"amd64\" publicKeyToken=\"31bf3856ad364e35\" language=\"neutral\"
+    versionScope=\"nonSxS\" xmlns:wcm=\"http://schemas.microsoft.com/WMIConfig/2002/State\"
+    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n            <UserData>\n
+    \               <ProductKey>\n                    <Key><%= ms_product_key %></Key>\n
+    \                   <WillShowUI>Never</WillShowUI>\n                </ProductKey>\n
+    \               <AcceptEula>true</AcceptEula>\n                <Organization><%=
+    organization %></Organization>\n                <FullName>User</FullName>\n            </UserData>\n
+    \       </component>\n    </settings>\n    <cpi:offlineImage cpi:source=\"catalog://catalogs/windows2012-x86/sources/install_windows
+    longhorn serverenterprise.clg\" xmlns:cpi=\"urn:schemas-microsoft-com:cpi\" />\n</unattend>"
+  :type: CustomizationTemplateSysprep
+  :system: true


### PR DESCRIPTION
Ovirt supports different config values in sysprep file than available in
existing `customization_template` so we introduce new one. We provide
sysprep files for win2k8, win2k10 and win2k16.

Bug-Url:
https://bugzilla.redhat.com/1323289