### PR TITLE
add quickstart docs

### DIFF
--- a/Procfile.example
+++ b/Procfile.example
@@ -2,7 +2,7 @@
 #
 # * copy Procfile.example to Procfile
 # * uncomment needed processes
-# * bin/rake evm:foreman:start to start the processes!
+# * `bin/rake evm:foreman:start` to start the processes!
 #   This task will configure the local server to look started and then start the processes in the Procfile.
 #
 # See documentation at http://manageiq.org/docs/guides/developer_setup/foreman

--- a/Procfile.example
+++ b/Procfile.example
@@ -1,3 +1,12 @@
+# QUICKSTART
+#
+# * copy Procfile.example to Procfile
+# * uncomment needed processes
+# * bin/rake evm:foreman:start to start the processes!
+#   This task will configure the local server to look started and then start the processes in the Procfile.
+#
+# See documentation at http://manageiq.org/docs/guides/developer_setup/foreman
+#
 # Web server workers
 # The $PORT variable is set automatically by foreman for particular workers
 # We tell foreman to start at 3000, it then increments by 1 per instance of a worker type


### PR DESCRIPTION
I wasnt aware of http://manageiq.org/docs/guides/developer_setup/foreman and the rake task.
Because I'm lazy and read docs after failure 🐶 

This adds some essential info and a pointer to the docs

@miq-bot assign @carbonin 
@miq-bot add_label documentation