### PR TITLE
Prefix container object ems_ref with class name

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -130,9 +130,8 @@ class EmsEvent < EventStream
 
   def self.process_container_entities_in_event!(event, _options = {})
     [ContainerNode, ContainerGroup, ContainerReplicator].each do |entity|
-      process_object_in_event!(entity, event, :ems_ref_key => :ems_ref)
+      process_object_in_event!(entity, event)
     end
-    event.except!(:ems_ref)
   end
 
   def self.process_middleware_entities_in_event!(event, _options = {})


### PR DESCRIPTION
Use the class name as a prefix for ems_ref removing a collision with the
real ems_ref column

Depends on ManageIQ/manageiq-providers-kubernetes#123
Fixes #16074