### PR TITLE
Update MiqRequestTask attributes

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -86,14 +86,14 @@ class MiqRequestTask < ApplicationRecord
   end
 
   # This function updates the task attributes
-  # The list of attributes that can be updated are 
+  # The list of attributes that can be updated are
   # 1. options
   # 2. message
   # For now we are only supporting updating the options hash because
   # it contains key provisioning parameters, like ip address etc.
   # Usecase: Allow Ansible playbook to update provisioning parameters
   # via the REST API.
-  # 
+  #
   # TODO : Use strong parameters for validating which parameters can
   #        be updated.
   def update_request_task(values)

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -87,7 +87,6 @@ class MiqRequestTask < ApplicationRecord
 
   def update_request_task(values)
     update_attributes(:options => options.merge(values['options'] || {}))
-    self
   end
 
   def execute_callback(state, message, _result)

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -85,6 +85,17 @@ class MiqRequestTask < ApplicationRecord
     update_and_notify_parent(:state => req_state, :status => req_status, :message => display_message(msg))
   end
 
+  # This function updates the task attributes
+  # The list of attributes that can be updated are 
+  # 1. options
+  # 2. message
+  # For now we are only supporting updating the options hash because
+  # it contains key provisioning parameters, like ip address etc.
+  # Usecase: Allow Ansible playbook to update provisioning parameters
+  # via the REST API.
+  # 
+  # TODO : Use strong parameters for validating which parameters can
+  #        be updated.
   def update_request_task(values)
     update_attributes(:options => options.merge(values['options'] || {}))
   end

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -85,6 +85,11 @@ class MiqRequestTask < ApplicationRecord
     update_and_notify_parent(:state => req_state, :status => req_status, :message => display_message(msg))
   end
 
+  def update_request_task(values)
+    update_attributes(:options => options.merge(values['options'] || {}))
+    self
+  end
+  
   def execute_callback(state, message, _result)
     unless state.to_s.downcase == "ok"
       update_and_notify_parent(:state => "finished", :status => "Error", :message => "Error: #{message}")

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -89,7 +89,7 @@ class MiqRequestTask < ApplicationRecord
     update_attributes(:options => options.merge(values['options'] || {}))
     self
   end
-  
+
   def execute_callback(state, message, _result)
     unless state.to_s.downcase == "ok"
       update_and_notify_parent(:state => "finished", :status => "Error", :message => "Error: #{message}")

--- a/spec/models/miq_request_task_spec.rb
+++ b/spec/models/miq_request_task_spec.rb
@@ -1,24 +1,24 @@
 describe MiqRequestTask do
-  let(:options) { {'a' => 1, 'b' => 2} }
-  let(:update_options) { {'a' => 'one', 'c' => 'three'} }
+  let(:existing_options) { {'a' => 1, 'b' => 2} }
+  let(:new_options) { {'a' => 'one', 'c' => 'three'} }
   let(:miq_request) do
     FactoryGirl.build(:miq_host_provision_request,
                       :requester => user,
-                      :options   => options)
+                      :options   => existing_options)
   end
 
   let(:task) do
     FactoryGirl.create(:miq_request_task,
                        :miq_request => miq_request,
-                       :options     => options)
+                       :options     => existing_options)
   end
   let(:user) { FactoryGirl.build(:user) }
 
   context "#update_request_task" do
     it "updates the option hash" do
-      task.update_request_task('options' => update_options)
+      task.update_request_task('options' => new_options)
 
-      expect(task.options).to have_attributes(options.merge(update_options))
+      expect(task.options).to have_attributes(existing_options.merge(new_options))
     end
   end
 end

--- a/spec/models/miq_request_task_spec.rb
+++ b/spec/models/miq_request_task_spec.rb
@@ -1,0 +1,24 @@
+describe MiqRequestTask do
+  let(:options) { {'a' => 1, 'b' => 2} }
+  let(:update_options) { {'a' => 'one', 'c' => 'three'} }
+  let(:miq_request) do
+    FactoryGirl.build(:miq_host_provision_request,
+                      :requester => user,
+                      :options   => options)
+  end
+
+  let(:task) do
+    FactoryGirl.create(:miq_request_task,
+                       :miq_request => miq_request,
+                       :options     => options)
+  end
+  let(:user) { FactoryGirl.build(:user) }
+
+  context "#update_request_task" do
+    it "updates the option hash" do
+      task.update_request_task('options' => update_options)
+
+      expect(task.options).to have_attributes(options.merge(update_options))
+    end
+  end
+end


### PR DESCRIPTION
Added the update_request_task method for MiqRequestTask, this allows up to update a predefined list of attributes in the MiqRequestTask.

1. options

This function would be called by the REST API to update the task options. 
The use case we have is updating task options from an Ansible Playbook via the REST API.

REST API PR : https://github.com/ManageIQ/manageiq-api/pull/117