### PR TITLE
[FINE] container image catch KubeExceptions from annotations

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -7,6 +7,8 @@ class ContainerImage < ApplicationRecord
   include ArchivedMixin
   include_concern 'Purging'
 
+  require 'kubeclient'
+
   DOCKER_IMAGE_PREFIX = "docker://"
   DOCKER_PULLABLE_PREFIX = "docker-pullable://".freeze
   DOCKER_PREFIXES = [DOCKER_IMAGE_PREFIX, DOCKER_PULLABLE_PREFIX].freeze
@@ -95,6 +97,9 @@ class ContainerImage < ApplicationRecord
       "security.manageiq.org/failed-policy" => causing_policy,
       "images.openshift.io/deny-execution"  => "true"
     )
+  rescue KubeException => e
+    _log.warn("#{__method__} #{e.message}")
+    raise unless e.error_code == 404
   end
 
   def openscap_failed_rules_summary


### PR DESCRIPTION
When images that are not represented in Openshift are being checked for compliance and then chosen to be annotated the annotation will fail. This will cause the whole compliance operation to fail and the image not to be marked at all.
This PR will allow the `annotate_deny_execution` function to rescue KubeException with 404 and allow the compliance check to complete even if the annotation failed due to the image not existing. This will ensure that the image compliance status is marked correctly in ManageIQ.

This is a Fine-only fix as in later versions the container images were subclassed to have `Openshift::ContainerImage` which can be sure to be on Openshift (If the annotation on them will fail we assume we want to raise the exception)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1488409