### PR TITLE
Hold ripper_ruby_parser at 1.0.0 because 1.1.0 can't parse manageiq source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "rails",                          "~>5.0.2"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
-gem "ripper_ruby_parser",                              :require => false
+gem "ripper_ruby_parser",             "~>1.0.0",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.1",       :require => false
 gem "rugged",                         "~>0.25.0",      :require => false


### PR DESCRIPTION
1.1.0 can't do:
```
RipperRubyParser::Parser.new.parse('*rels, _col = col.split(".")')
```
which occurs in https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report/generator.rb#L91
This makes it impossible to db:seed and generally run manageiq.

(observed under MRI 2.3.4)

Opened upstream issue: https://github.com/mvz/ripper_ruby_parser/issues/3