### PR TITLE
Adds support for physical server timeline

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -2,6 +2,9 @@ class PhysicalServer < ApplicationRecord
   include NewWithTypeStiMixin
   include MiqPolicyMixin
   include TenantIdentityMixin
+  include SupportsFeatureMixin
+  include EventMixin
+
   include_concern 'Operations'
 
   acts_as_miq_taggable
@@ -61,5 +64,9 @@ class PhysicalServer < ApplicationRecord
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone
+  end
+
+  def event_where_clause(assoc = :ems_events)
+    ["#{events_table_name(assoc)}.physical_server_id = ?", id]
   end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6298,6 +6298,10 @@
       :description: Display Individual Physical Server
       :feature_type: view
       :identifier: physical_server_show
+      :name: Timeline
+      :description: Display Timelines for Physical Servers
+      :feature_type: view
+      :identifier: physical_server_timeline
   - :name: Modify
     :description: Modify Physical Servers
     :feature_type: admin

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -113,6 +113,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - physical_server_timeline
   - host_show
   - host_show_list
   - host_perf
@@ -200,6 +201,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - physical_server_timeline
   - host_show
   - host_show_list
   - host_perf
@@ -353,6 +355,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - physical_server_timeline
   - host_new
   - host_analyze
   - host_compare
@@ -459,6 +462,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - physical_server_timeline
   - host_show
   - host_show_list
   - host_perf
@@ -541,6 +545,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - physical_server_timeline
   - host_show
   - host_show_list
   - host_perf
@@ -622,6 +627,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - physical_server_timeline
   - host_show
   - host_show_list
   - host_perf


### PR DESCRIPTION
This PR consists in making timelines available for physical servers.

[This PR is in parallel with UI PR 2272](https://github.com/ManageIQ/manageiq-ui-classic/pull/2272)