### PR TITLE
Add physical server to constant support policy

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -17,7 +17,7 @@ class MiqEvent < EventStream
   SUPPORTED_POLICY_AND_ALERT_CLASSES = [Host, VmOrTemplate, Storage, EmsCluster, ResourcePool,
                                         MiqServer, ExtManagementSystem,
                                         ContainerReplicator, ContainerGroup, ContainerNode, ContainerImage,
-                                        MiddlewareServer].freeze
+                                        MiddlewareServer, PhysicalServer].freeze
 
   def self.raise_evm_event(target, raw_event, inputs = {}, options = {})
     # Target may have been deleted if it's a worker

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -28,6 +28,14 @@ describe MiqEvent do
         end
         MiqEvent.raise_evm_job_event(obj, {:type => "scan", :suffix => "complete"}, {})
       end
+
+      it "physical_server" do
+        obj = FactoryGirl.create(:physical_server)
+        expect(MiqEvent).to receive(:raise_evm_event) do |target, raw_event, _inputs|
+          target == obj && raw_event == "physical_server_shutdown"
+        end
+        MiqEvent.raise_evm_job_event(obj, {:type => "shutdown"}, {})
+      end
     end
 
     it "will recognize known events" do


### PR DESCRIPTION
This PR do:
1 - Add the Physical Server to able policies in the automate stuffs.
2 - Test the physical server event (shutdown).