### PR TITLE
Update activerecord-session_store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-id_regions",        "~>0.2.0"
-gem "activerecord-session_store",     "~>1.0.0"
+gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.1.0" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>2.2.1",       :require => false
 gem "bundler",                        ">=1.11.1",      :require => false


### PR DESCRIPTION
This release adds support for Ruby 2.4 / Rails 5.1

Also, allow minor release updates.

Required for https://github.com/ManageIQ/manageiq/issues/14446