### PR TITLE
[EUWE] Revert ruby 2.3.5 upgrade on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- '2.3.5'
+- '2.3.1'
 sudo: false
 cache:
   bundler: true


### PR DESCRIPTION
This reverts commit 4b4ff11704e55fd32529ac7ed8d71672250454b9.

Reverting https://github.com/ManageIQ/manageiq/pull/15993 for now, we keep having our travis builds on euwe hang on ruby versions > 2.3.1 (such as 2.3.5 or even 2.4.2).  Perhaps it's due to 
the fix in 2.3.2 for the timer threads with drb:

First fixed in:
https://github.com/ruby/ruby/commit/e143a741913fd970e27eb83e3d809d9694038f9f#diff-4b0b8a13c2d5172da441205f2e57f610

Then, it was changed to use a finalizer in:
https://github.com/ruby/ruby/commit/021e8ead5c4296792db030e62ab4190c9d6617be#diff-4b0b8a13c2d5172da441205f2e57f610