### PR TITLE
Update default_value_for

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
-gem "default_value_for",              "~>3.0.2"
+gem "default_value_for",              "~>3.0.3"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"


### PR DESCRIPTION
[default_value_for 3.0.3 has been released](https://github.com/FooBarWidget/default_value_for/issues/71#issuecomment-333662970) with support for Rails 5.1

Part of #14446 and https://github.com/ManageIQ/manageiq/issues/15036