### PR TITLE
Added user_id, group_id, tenant_id

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -404,13 +404,7 @@ class MiqQueue < ApplicationRecord
       begin
         status = STATUS_OK
         message = "Message delivered successfully"
-        result = if user_id
-                   user = User.find(user_id)
-                   user.current_group = MiqGroup.find(group_id) if group_id
-                   User.with_user(user) { dispatch_method(obj, args) }
-                 else
-                   dispatch_method(obj, args)
-                 end
+        result = User.with_user(user_id, group_id) { dispatch_method(obj, args) }
       rescue MiqException::MiqQueueRetryLater => err
         unget(err.options)
         message = "Message not processed.  Retrying #{err.options[:deliver_on] ? "at #{err.options[:deliver_on]}" : 'immediately'}"

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -404,7 +404,7 @@ class MiqQueue < ApplicationRecord
       begin
         status = STATUS_OK
         message = "Message delivered successfully"
-        result = User.with_user(user_id, group_id) { dispatch_method(obj, args) }
+        result = User.with_user_group(user_id, group_id) { dispatch_method(obj, args) }
       rescue MiqException::MiqQueueRetryLater => err
         unget(err.options)
         message = "Message not processed.  Retrying #{err.options[:deliver_on] ? "at #{err.options[:deliver_on]}" : 'immediately'}"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -248,6 +248,18 @@ class User < ApplicationRecord
     Thread.current[:userid] = saved_userid
   end
 
+  def self.with_user_group(user, group, &block)
+    return yield if user.nil?
+    user = User.find(user) unless user.kind_of?(User)
+    if group && group.kind_of?(MiqGroup)
+      user.current_group = group
+    elsif group != user.current_group_id
+      group = MiqGroup.find_by(:id => group)
+      user.current_group = group if group
+    end
+    User.with_user(user, &block)
+  end
+
   def self.current_user=(user)
     Thread.current[:userid] = user.try(:userid)
     Thread.current[:user] = user

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -36,6 +36,28 @@ describe MiqQueue do
     end
   end
 
+  describe "user_context" do
+    it "sets the User.current_user" do
+      user = FactoryGirl.create(:user_with_group, :name => 'Freddy Kreuger')
+      msg = FactoryGirl.create(:miq_queue, :state       => MiqQueue::STATE_DEQUEUE,
+                                           :handler     => @miq_server,
+                                           :class_name  => 'Storage',
+                                           :method_name => 'foobar',
+                                           :user_id     => user.id,
+                                           :args        => [1,2,3],
+                                           :group_id    => user.current_group.id,
+                                           :tenant_id   => user.current_tenant.id)
+      expect(Storage).to receive(:foobar) do |arg|
+        expect(User.current_user.name).to eq(user.name)
+        expect(User.current_user.current_group.id).to eq(user.current_user.current_group.id)
+        expect(User.current_user.current_tenant.id).to eq(user.current_user.current_tenant.id)
+        expect(args).to eq([1,2,3])
+      end
+
+      msg.deliver
+    end
+  end
+
   describe "#check_for_timeout" do
     it "will destroy a dequeued message when it times out" do
       handler = FactoryGirl.create(:miq_ems_refresh_worker)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -44,14 +44,14 @@ describe MiqQueue do
                                            :class_name  => 'Storage',
                                            :method_name => 'foobar',
                                            :user_id     => user.id,
-                                           :args        => [1,2,3],
+                                           :args        => [1, 2, 3],
                                            :group_id    => user.current_group.id,
                                            :tenant_id   => user.current_tenant.id)
-      expect(Storage).to receive(:foobar) do |arg|
+      expect(Storage).to receive(:foobar) do
         expect(User.current_user.name).to eq(user.name)
         expect(User.current_user.current_group.id).to eq(user.current_user.current_group.id)
         expect(User.current_user.current_tenant.id).to eq(user.current_user.current_tenant.id)
-        expect(args).to eq([1,2,3])
+        expect(args).to eq([1, 2, 3])
       end
 
       msg.deliver

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -519,6 +519,25 @@ describe User do
     end
   end
 
+  describe "#with_user_group" do
+    let(:user1) { FactoryGirl.create(:user_with_group) }
+    let(:user2) { FactoryGirl.create(:user_with_group) }
+
+    it "sets the user and group" do
+      User.with_user_group(user1, user2.current_group_id) do
+        expect(User.current_userid).to eq(user1.userid)
+        expect(User.current_user).to eq(user1)
+        expect(User.current_user.current_group).to eq(user2.current_group)
+        User.with_user_group(user2, user1.current_group) do
+          expect(User.current_userid).to eq(user2.userid)
+          expect(User.current_user).to eq(user2)
+        end
+        expect(User.current_userid).to eq(user1.userid)
+        expect(User.current_user).to eq(user1)
+      end
+    end
+  end
+
   context ".super_admin" do
     it "has super_admin" do
       FactoryGirl.create(:miq_group, :role => "super_administrator")


### PR DESCRIPTION
If the User and group ids are passed in we run the method
using User.with_user which sets the User.current_user

When we execute object#methods via the Queue we loose the user context under which the method should run. When we execute methods for Generic Objects we need the user context, this PR would allow the user_id/group_id/tenant_id to be recorded in the Queue and set using User.with_user 


Depends on Schema PR
https://github.com/ManageIQ/manageiq-schema/pull/83

This PR is needed by these other PRs
https://github.com/ManageIQ/manageiq/pull/16077

