### PR TITLE
Add support for regex matchers in have_attributes

### DIFF
--- a/spec/support/custom_matchers/have_attributes.rb
+++ b/spec/support/custom_matchers/have_attributes.rb
@@ -16,6 +16,8 @@ RSpec::Matchers.define :have_attributes do |attrs|
 
         matcher = if actual.respond_to?(:acts_like_time?) && expected.respond_to?(:acts_like_time?)
                     be_same_time_as(expected)
+                  elsif expected.kind_of?(RSpec::Matchers::BuiltIn::Match)
+                    match(expected.expected)
                   else
                     eq(expected)
                   end


### PR DESCRIPTION
:warning: This is a hack. (but no more of a hack than our custom matcher, so...)

We currently use our own version of the RSpec `have_attributes` matcher, which, as you might expect, doesn't implement half of the goodies RSpec provides. Namely, [composable matchers](https://relishapp.com/rspec/rspec-expectations/docs/composing-matchers).

As an example, here's something that would pass in normal RSpecland but fails in ManageIQland:

```ruby
RSpec.describe "have_attributes composability" do
  it "allows regex in have_attributes" do
    hash = { foo: "Let's party like it's 1999!", bar: "Nope, not now." }

    expect(hash).to have_attributes(bar: "Nope, not now.", foo: match(/party like/))
  end
end
```

The `match` fails as it's trying to equate a string to an RSpec matcher.

Work is currently being done (or rather, been slated to be done for a while) to remove our custom matcher and use RSpec's, **so this is very temporary**, but this adds the ability to be able to use the builtin Match matcher now, which matches on regular expressions. Even after we switch to RSpec's `have_attributes`, this will continue to pass as normal.

TLDR: You can't use crazy meta'd composable matchers like `a_string_starting_with('a')`, but you can get the same effect now with `match(/\Aa/)` if you like.

### Links

* https://github.com/ManageIQ/manageiq-providers-openstack/pull/105
* https://github.com/ManageIQ/manageiq/pull/11474