### PR TITLE
Dictionary.gettext should not break on empty string

### DIFF
--- a/app/models/dictionary.rb
+++ b/app/models/dictionary.rb
@@ -1,5 +1,7 @@
 class Dictionary
   def self.gettext(text, opts = {})
+    return "" if text.blank?
+
     opts[:type] ||= :column
     opts[:plural] = false if opts[:plural].nil?
     opts[:translate] = true if opts[:translate].nil?

--- a/spec/models/dictionary_spec.rb
+++ b/spec/models/dictionary_spec.rb
@@ -1,5 +1,13 @@
 describe Dictionary do
   context ".gettext" do
+    context "with empty text" do
+      it("returns an empty string") { expect(described_class.gettext("")).to eq("") }
+    end
+
+    context "with nil" do
+      it("returns an empty string") { expect(described_class.gettext(nil)).to eq("") }
+    end
+
     context "with text only" do
       it("and not found")         { expect(described_class.gettext("abc")).to                         eq("abc") }
       it("as a column entry")     { expect(described_class.gettext("active")).to                      eq("Active") }


### PR DESCRIPTION
**Description**

Currently `Dictionary.gettext` will fail with `NoMethodError` if called with empty string.
A "gettext" method should handle empty strings without failing.

**Examples**
Bug:
```
pry(main)> Dictionary.gettext("")
=> NoMethodError: undefined method `start_with?' for #<Hash:0x0055e4a865d2a8>
```
Fix:
```
pry(main)> Dictionary.gettext("")
=> ""
```
