### PR TITLE
Add allocated storage columns to ChargebackContainerProject

### DIFF
--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -1,21 +1,23 @@
 class ChargebackContainerProject < Chargeback
   set_columns_hash(
-    :project_name          => :string,
-    :project_uid           => :string,
-    :provider_name         => :string,
-    :provider_uid          => :string,
-    :archived              => :string,
-    :cpu_cores_used_cost   => :float,
-    :cpu_cores_used_metric => :float,
-    :fixed_compute_1_cost  => :float,
-    :fixed_compute_2_cost  => :float,
-    :fixed_2_cost          => :float,
-    :fixed_cost            => :float,
-    :memory_used_cost      => :float,
-    :memory_used_metric    => :float,
-    :net_io_used_cost      => :float,
-    :net_io_used_metric    => :float,
-    :total_cost            => :float,
+    :project_name             => :string,
+    :project_uid              => :string,
+    :provider_name            => :string,
+    :provider_uid             => :string,
+    :archived                 => :string,
+    :cpu_cores_used_cost      => :float,
+    :cpu_cores_used_metric    => :float,
+    :fixed_compute_1_cost     => :float,
+    :fixed_compute_2_cost     => :float,
+    :fixed_2_cost             => :float,
+    :fixed_cost               => :float,
+    :memory_used_cost         => :float,
+    :memory_used_metric       => :float,
+    :net_io_used_cost         => :float,
+    :net_io_used_metric       => :float,
+    :storage_allocated_cost   => :float,
+    :storage_allocated_metric => :float,
+    :total_cost               => :float,
   )
 
   def self.build_results_for_report_ChargebackContainerProject(options)
@@ -56,19 +58,21 @@ class ChargebackContainerProject < Chargeback
 
   def self.report_col_options
     {
-      "cpu_cores_used_cost"   => {:grouping => [:total]},
-      "cpu_cores_used_metric" => {:grouping => [:total]},
-      "fixed_compute_metric"  => {:grouping => [:total]},
-      "fixed_compute_1_cost"  => {:grouping => [:total]},
-      "fixed_compute_2_cost"  => {:grouping => [:total]},
-      "fixed_cost"            => {:grouping => [:total]},
-      "memory_used_cost"      => {:grouping => [:total]},
-      "memory_used_metric"    => {:grouping => [:total]},
-      "metering_used_metric"  => {:grouping => [:total]},
-      "metering_used_cost"    => {:grouping => [:total]},
-      "net_io_used_cost"      => {:grouping => [:total]},
-      "net_io_used_metric"    => {:grouping => [:total]},
-      "total_cost"            => {:grouping => [:total]}
+      "cpu_cores_used_cost"      => {:grouping => [:total]},
+      "cpu_cores_used_metric"    => {:grouping => [:total]},
+      "fixed_compute_metric"     => {:grouping => [:total]},
+      "fixed_compute_1_cost"     => {:grouping => [:total]},
+      "fixed_compute_2_cost"     => {:grouping => [:total]},
+      "fixed_cost"               => {:grouping => [:total]},
+      "memory_used_cost"         => {:grouping => [:total]},
+      "memory_used_metric"       => {:grouping => [:total]},
+      "metering_used_metric"     => {:grouping => [:total]},
+      "metering_used_cost"       => {:grouping => [:total]},
+      "net_io_used_cost"         => {:grouping => [:total]},
+      "net_io_used_metric"       => {:grouping => [:total]},
+      "storage_allocated_cost"   => {:grouping => [:total]},
+      "storage_allocated_metric" => {:grouping => [:total]},
+      "total_cost"               => {:grouping => [:total]}
     }
   end
 

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -20,7 +20,8 @@ describe ChargebackContainerProject do
           :chargeback_rate_detail_cpu_cores_used     => {:tiers => [hourly_variable_tier_rate]},
           :chargeback_rate_detail_net_io_used        => {:tiers => [hourly_variable_tier_rate]},
           :chargeback_rate_detail_memory_used        => {:tiers => [hourly_variable_tier_rate]},
-          :chargeback_rate_detail_metering_used      => {:tiers => [hourly_variable_tier_rate]}
+          :chargeback_rate_detail_metering_used      => {:tiers => [hourly_variable_tier_rate]},
+          :chargeback_rate_detail_storage_allocated  => {:tiers => [hourly_variable_tier_rate]}
       }
     end
 
@@ -108,6 +109,13 @@ describe ChargebackContainerProject do
         expect(subject.metering_used_metric).to eq(hours_in_day)
         expect(subject.metering_used_cost).to eq(hours_in_day * hourly_rate)
       end
+
+      it "storage" do
+        skip('this feature needs to be added to new chargeback rating') if Settings.new_chargeback
+        storage_allocated_metric = allocated_max_for(:derived_vm_allocated_disk_storage, @project)
+        expect(subject.storage_allocated_metric).to eq(storage_allocated_metric)
+        expect(subject.storage_allocated_cost).to eq(storage_allocated_metric / 1.gigabyte * hourly_rate * hours_in_day)
+      end
     end
 
     context "Monthly" do
@@ -146,6 +154,13 @@ describe ChargebackContainerProject do
       it 'calculates metering used hours and cost' do
         expect(subject.metering_used_metric).to eq(hours_in_month)
         expect(subject.metering_used_cost).to eq(hours_in_month * hourly_rate)
+      end
+
+      it "storage" do
+        skip('this feature needs to be added to new chargeback rating') if Settings.new_chargeback
+        storage_allocated_metric = allocated_max_for(:derived_vm_allocated_disk_storage, @project)
+        expect(subject.storage_allocated_metric).to eq(storage_allocated_metric)
+        expect(subject.storage_allocated_cost).to eq(storage_allocated_metric / 1.gigabyte * hourly_rate * hours_in_month)
       end
     end
 

--- a/spec/support/chargeback_helper.rb
+++ b/spec/support/chargeback_helper.rb
@@ -12,6 +12,10 @@ module Spec
         resource.metric_rollups.sum(&metric) / hours_in_interval
       end
 
+      def allocated_max_for(metric, resource)
+        resource.metric_rollups.collect(&metric.to_sym).compact.max
+      end
+
       def add_metric_rollups_for(resources, range, step, metric_rollup_params, trait = :with_data)
         range.step_value(step).each do |time|
           Array(resources).each do |resource|


### PR DESCRIPTION
Add `storage allocated` cost and metric columns for ChargebackContainerProject.
Depends on: https://github.com/ManageIQ/manageiq/pull/15973 - nothing errors out if this isnt merged first but the values will always be zero in the report

cc @simon3z 
@miq-bot add_label chargeback, providers/containers