### PR TITLE
Add the help menu to the permissions template yaml file

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -9,6 +9,7 @@
 - :compute
 - :con
 - :conf
+- :help
 - :inf
 - :mdl
 - :monitor


### PR DESCRIPTION
Seems like `permissions.tmpl.yml` is not being used in a development setup at all, so the issue can be reproduced in an appliance only where it is copied as `permissions.yml`. Adding this will display the help menu properly.

https://bugzilla.redhat.com/show_bug.cgi?id=1497093