### PR TITLE
ContainerLabelTagMapping::Mapper class, separate tag creation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,4 @@
 app/models/mixins/supports_feature_mixin.rb
 app/models/manager_refresh
+app/models/container_label_tag_mapping.rb
+app/models/container_label_tag_mapping

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -1,22 +1,29 @@
+# A mapping matches labels on `resource_type` (NULL means any), `name` (required),
+# and `value` (NULL means any).
+#
+# Note: `labeled_resource_type` doesn't really need to match the actual label's `resource_type`;
+# it's simply matched against the type argument to Mapper#map_labels,
+# and sometimes is a fake string like 'Vm' or 'Image' instead of a model name.
+#
+# Different labels might map to same tag, and one label might map to multiple tags.
+#
+# There are 2 kinds of rows:
+# - When `label_value` is specified, we map only this value to a specific `tag`.
+#   TODO: drop this.  This was never exposed in UI and is dead code to maintain.
+#
+# - When `label_value` is NULL, we map this name with any value to per-value tags.
+#   In this case, `tag` specifies the category under which to create
+#   the value-specific tag (and classification) on demand.
+#
+# All involved tags must also have a Classification.
+#
+# TODO: rename, no longer specific to containers.
 class ContainerLabelTagMapping < ApplicationRecord
-  # A mapping matches labels on `resource_type` (NULL means any), `name` (required),
-  # and `value` (NULL means any).
-  #
-  # Different labels might map to same tag, and one label might map to multiple tags.
-  #
-  # There are 2 kinds of rows:
-  # - When `label_value` is specified, we map only this value to a specific `tag`.
-  # - When `label_value` is NULL, we map this name with any value to per-value tags.
-  #   In this case, `tag` specifies the category under which to create
-  #   the value-specific tag (and classification) on demand.
-  #
-  # All involved tags must also have a Classification.
-
   belongs_to :tag
 
   require_nested :Mapper
 
-  # Return ContainerLabelTagMapping::Mapper instance that holds current mappings,
+  # Return ContainerLabelTagMapping::Mapper instance that holds all current mappings,
   # can compute applicable tags, and create/find Tag records.
   def self.mapper
     ContainerLabelTagMapping::Mapper.new(in_my_region.all)

--- a/app/models/container_label_tag_mapping/mapper.rb
+++ b/app/models/container_label_tag_mapping/mapper.rb
@@ -1,0 +1,90 @@
+class ContainerLabelTagMapping
+  # Performs most of the work of ContainerLabelTagMapping - holds current mappings,
+  # computes applicable tags, and creates/finds Tag records - except actually [un]assigning.
+  class Mapper
+    # Loads all mappings from DB.
+    def initialize(mappings)
+      # {[name, type, value] => [tag_id, ...]}
+      @mappings = mappings.group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
+                          .transform_values { |ms| ms.collect(&:tag_id) }
+      @tags_to_resolve = []
+    end
+
+    # labels should be array of {:name, :value} hashes.
+    # Returns array of opaque "tag references".
+    # (Currently {:tag_id} or {:category_tag_id, :entry_name, :entry_description} hashes but will change.)
+    def map_labels(type, labels)
+      labels.collect_concat { |label| map_label(type, label) }.uniq
+    end
+
+    # Resolves/creates all "tag references" built by `map_labels` method of same Mapper.
+    # The references are mutated to contain a Tag id.
+    def find_or_create_tags
+      # TODO: O(N) queries, optimize.
+      @tags_to_resolve.each do |h|
+        find_or_create_tag(h)
+      end
+    end
+
+    def self.references_to_tags(tag_references)
+      ref_without_id = tag_references.detect { |ref| ref[:tag_id].nil? }
+      raise "Unresolved tag reference #{ref_without_id}, must call find_or_create_tags first" if ref_without_id
+
+      Tag.find(tag_references.collect { |ref| ref[:tag_id] })
+    end
+
+    private
+
+    def map_label(type, label)
+      # Apply both specific-type and any-type, independently.
+      (map_name_type_value(label[:name], type, label[:value]) +
+       map_name_type_value(label[:name], nil,  label[:value]))
+    end
+
+    def map_name_type_value(name, type, value)
+      specific_value = @mappings[[name, type, value]] || []
+      any_value      = @mappings[[name, type, nil]]   || []
+      if !specific_value.empty?
+        specific_value.map { |tag_id| {:tag_id => tag_id} }
+      else
+        if value.empty?
+          [] # Don't map empty value to any tag.
+        else
+          # Note: if the way we compute `entry_name` changes,
+          # consider what will happen to previously created tags.
+          any_value.map do |tag_id|
+            emit_tag_reference(
+              :category_tag_id   => tag_id,
+              :entry_name        => Classification.sanitize_name(value),
+              :entry_description => value,
+            )
+          end
+        end
+      end
+    end
+
+    def emit_tag_reference(h)
+      @tags_to_resolve << h
+      h
+    end
+
+    def find_or_create_tag(tag_hash)
+      return if tag_hash[:tag_id]
+
+      category = Tag.find(tag_hash[:category_tag_id]).classification
+      entry = category.find_entry_by_name(tag_hash[:entry_name])
+      unless entry
+        category.lock(:exclusive) do
+          begin
+            entry = category.add_entry(:name        => tag_hash[:entry_name],
+                                       :description => tag_hash[:entry_description])
+            entry.save!
+          rescue ActiveRecord::RecordInvalid
+            entry = category.find_entry_by_name(tag_hash[:entry_name])
+          end
+        end
+      end
+      tag_hash[:tag_id] = entry.tag_id
+    end
+  end
+end

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -189,14 +189,12 @@ module EmsRefresh::SaveInventory
   end
 
   # Convert all mapped hashes into actual tags and associate them with the object.
-  # The collection or collection[:tags] object should be an array of hashes, probably
-  # created by the ContainerLabelTagMapping.map_labels method. Each hash in the array
-  # should have the following basic structure:
-  #
-  # {:category_tag_id=>139, :entry_name=>"foo", :entry_description=>"bar"}
+  # The collection or collection[:tags] object should be an array of values
+  # created by the ContainerLabelTagMapping::Mapper#map_labels method
+  # that should already have ids set by `Mapper#find_or_create_tags` method.
   #
   # The +collection+ argument can either be a Hash, in which case the argument
-  # should have a single :tags key, or a simple Array of hashes.
+  # should have a single :tags key, or a simple Array.
   #
   def save_tags_inventory(object, collection, _target = nil)
     return if collection.blank?

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -45,6 +45,8 @@ module EmsRefresh::SaveInventoryCloud
       _log.debug("#{log_header} hashes:\n#{YAML.dump(hashes)}")
     end
 
+    hashes[:tag_mapper].find_or_create_tags if hashes[:tag_mapper]
+
     child_keys = [
       :resource_groups,
       :cloud_tenants,

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -1,5 +1,6 @@
 module EmsRefresh::SaveInventoryContainer
   def save_ems_container_inventory(ems, hashes, _target = nil)
+    hashes[:tag_mapper].find_or_create_tags
 
     child_keys = [:container_projects, :container_quotas, :container_limits, :container_nodes,
                   :container_builds, :container_build_pods, :persistent_volume_claims, :persistent_volumes,

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -6,37 +6,21 @@ context "save_tags_inventory" do
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
     @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
-    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner')
-    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff')
-    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:foo') # All
-
-    @cat1 = FactoryGirl.create(:category, :description => 'amazon_vm_owner', :tag => @tag1)
-    @cat2 = FactoryGirl.create(:category, :description => 'department', :tag => @tag2)
-    @cat3 = FactoryGirl.create(:category, :description => 'location', :tag => @tag3)
+    # These might not pass the ContainerLabelTagMapping.controls_tag? criteria, doesn't matter if only adding.
+    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner/alice')
+    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff/jabberwocky')
+    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes::foo/bar') # All
   end
 
-  # This is what ContainerLabelTagMapping.map_labels(cache, 'Type', labels) would
+  # This is what ContainerLabelTagMapping::Mapper.map_labels(cache, 'Type', labels) would
   # return in the refresh parser. Note that we don't explicitly test the mapping
   # creation here, the assumption is that these were the generated mappings.
-  #
   let(:data) do
     {
       :tags => [
-        {
-          :category_tag_id   => @cat1.tag_id,
-          :entry_name        => 'owner',
-          :entry_description => 'Daniel'
-        },
-        {
-          :category_tag_id   => @cat2.tag_id,
-          :entry_name        => 'stuff',
-          :entry_description => 'Ladas'
-        },
-        {
-          :category_tag_id   => @cat3.tag_id,
-          :entry_name        => 'foo',
-          :entry_description => 'Bronagh'
-        }
+        {:tag_id => @tag1.id},
+        {:tag_id => @tag2.id},
+        {:tag_id => @tag3.id},
       ]
     }
   end


### PR DESCRIPTION
Overview/plan issue: https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/126

To be merged **simultaneously** with https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/130 & https://github.com/ManageIQ/manageiq-providers-amazon/pull/316.

A refactoring and first step towards tag mapping with graph refresh.

The functional change besides extracting code to a Mapper class is making Mapper responsible for keeping track of mapped tags, and a batch API to find/create all of them.

Currently it has just array and calls find_or_create_tag for each, but in future PR that will turn into an InventoryCollection<Tag> (with some custom logic) that will be usable as part of graph refresh.

`retag_entity` kept outside Mapper class because it may be used later / in separate process
(soon in post refresh, possibly queued; later collector/persistor split might also require this).