### PR TITLE
fix broken ovirt tests

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -154,13 +154,13 @@ FactoryGirl.define do
 
   factory :ems_redhat,
           :parent => :ems_redhat_with_ensure_managers do
-    after(:build) { |ems_redhat| ems_redhat.class.skip_callback(:save, :before, :ensure_managers, :raise => false) }
+    after(:build) { |ems_redhat| ems_redhat.define_singleton_method(:ensure_managers) {} }
   end
 
   factory :ems_redhat_with_ensure_managers,
           :aliases => ["manageiq/providers/redhat/infra_manager"],
-          :class => "ManageIQ::Providers::Redhat::InfraManager",
-          :parent => :ems_infra do
+          :class   => "ManageIQ::Providers::Redhat::InfraManager",
+          :parent  => :ems_infra do
   end
 
   factory :ems_redhat_v3,


### PR DESCRIPTION
fix broken ovirt tests

the skip should be for the instance an not the class.