### PR TITLE
Remove broken factory for orchestration stack

### DIFF
--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -13,10 +13,6 @@ FactoryGirl.define do
   factory :orchestration_stack_amazon, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
   end
 
-  factory :orchestration_stack_amazon_with_non_orderable_template, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack" do
-    orchestration_template { FactoryGirl.create(:orchestration_template_cfn, :orderable => false) }
-  end
-
   factory :orchestration_stack_azure, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Azure::CloudManager::OrchestrationStack" do
   end
 


### PR DESCRIPTION
Remove `orchestration_stack_amazon_with_non_orderable_template` that requires no longer existing factory `orchestration_stack_cfn`. It was only used by classic-ui spec. The non orderable template can be generated in the spec test.