### PR TITLE
Add ems_ref to filter duplicate events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -239,6 +239,7 @@ class EmsEvent < EventStream
       :ems_id      => event[:ems_id],
       :target_id   => event[:target_id],
       :target_type => event[:target_type],
+      :ems_ref     => event[:ems_ref],
     )
     new_event.handle_event if new_event
     new_event


### PR DESCRIPTION
This PR add `ems_ref` when MIQ create the event to filter events with same `ems_ref`.