### PR TITLE
Fixed to add "delete" support for cloud_object_store_object object

### DIFF
--- a/app/models/cloud_object_store_object.rb
+++ b/app/models/cloud_object_store_object.rb
@@ -15,7 +15,7 @@ class CloudObjectStoreObject < ApplicationRecord
 
   alias_attribute :name, :key
 
-  supports_not :delete, :reason => N_("Delete operation is not supported.")
+  supports :delete
 
   def disconnect_inv
     # This is for bypassing a weird Rails behaviour. If we do a ems.cloud_object_store_objects.delete(objects) and a


### PR DESCRIPTION
supports_not for delete was added for these objects in https://github.com/ManageIQ/manageiq/pull/14080 however same PR added "Delete" roles feature. "Delete" button was added to UI counterpart of this PR in https://github.com/ManageIQ/manageiq-ui-classic/pull/497, so in my opinion adding supports_not for delete was incorrect

https://bugzilla.redhat.com/show_bug.cgi?id=1497113

cc @miha-plesko 
