### PR TITLE
Print file name on any error from RipperRubyParser, not just SyntaxError

### DIFF
--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -71,7 +71,12 @@ class DescendantLoader
       require 'ripper_ruby_parser'
 
       content = File.read(filename)
-      parsed = RipperRubyParser::Parser.new.parse(content)
+      begin
+        parsed = RipperRubyParser::Parser.new.parse(content)
+      rescue => e
+        puts "\nError parsing classes in #{filename}:\n#{e.class.name}: #{e}\n\n"
+        raise
+      end
 
       classes = collect_classes(parsed)
 
@@ -93,10 +98,6 @@ class DescendantLoader
 
         [search_combos, define_combos, flatten_name(name), flatten_name(sklass)]
       end.compact
-
-    rescue RipperRubyParser::SyntaxError
-      puts "\nSyntax error in #{filename}\n\n"
-      raise
     end
 
     def collect_classes(node, parents = [])

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -72,9 +72,9 @@ class DescendantLoader
 
       content = File.read(filename)
       begin
-        parsed = RipperRubyParser::Parser.new.parse(content)
+        parsed = RipperRubyParser::Parser.new.parse(content, filename)
       rescue => e
-        puts "\nError parsing classes in #{filename}:\n#{e.class.name}: #{e}\n\n"
+        $stderr.puts "\nError parsing classes in #{filename}:\n#{e.class.name}: #{e}\n\n"
         raise
       end
 


### PR DESCRIPTION
RipperRubyParser sometimes throws a non-specific RuntimeError.  E.g.
https://github.com/mvz/ripper_ruby_parser/issues/3,
https://github.com/mvz/ripper_ruby_parser/issues/5
Whether a real syntax error or a bug, to diagnose we need to see file name
(line and column are normally clear from exception).

+ Pass file name to parser.  Don't see it in exceptions though...
+ Change rescue to print file name on any (StandardError) errors from parsing.