### PR TITLE
Renaming auth_api to dbus_api service to reflect the new ManageIQ/dbus_api_service

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -137,7 +137,7 @@ module Authenticator
     end
 
     def user_attrs_from_external_directory_via_dbus_api_service(username)
-      require "httpd_dbus_api"
+      require_dependency "httpd_dbus_api"
 
       HttpdDBusApi.new.user_attrs(username, ATTRS_NEEDED)
     end

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -109,7 +109,7 @@ module Authenticator
 
     def user_attrs_from_external_directory(username)
       if MiqEnvironment::Command.is_container?
-        user_attrs_from_external_directory_via_auth_api(username)
+        user_attrs_from_external_directory_via_dbus_api_service(username)
       else
         user_attrs_from_external_directory_via_dbus(username)
       end
@@ -136,8 +136,10 @@ module Authenticator
       ATTRS_NEEDED.each_with_object({}) { |attr, hash| hash[attr] = Array(user_attrs[attr]).first }
     end
 
-    def user_attrs_from_external_directory_via_auth_api(username)
-      HttpdAuthApi.new.user_attrs(username, ATTRS_NEEDED)
+    def user_attrs_from_external_directory_via_dbus_api_service(username)
+      require "httpd_dbus_api"
+
+      HttpdDBusApi.new.user_attrs(username, ATTRS_NEEDED)
     end
   end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -144,7 +144,7 @@ class MiqGroup < ApplicationRecord
   end
 
   def self.get_httpd_groups_by_user_via_dbus_api_service(user)
-    require "httpd_dbus_api"
+    require_dependency "httpd_dbus_api"
 
     groups = HttpdDBusApi.new.user_groups(user)
     strip_group_domains(groups)

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -119,7 +119,7 @@ class MiqGroup < ApplicationRecord
 
   def self.get_httpd_groups_by_user(user)
     if MiqEnvironment::Command.is_container?
-      get_httpd_groups_by_user_via_auth_api(user)
+      get_httpd_groups_by_user_via_dbus_api_service(user)
     else
       get_httpd_groups_by_user_via_dbus(user)
     end
@@ -143,8 +143,10 @@ class MiqGroup < ApplicationRecord
     strip_group_domains(user_groups.first)
   end
 
-  def self.get_httpd_groups_by_user_via_auth_api(user)
-    groups = HttpdAuthApi.new.user_groups(user)
+  def self.get_httpd_groups_by_user_via_dbus_api_service(user)
+    require "httpd_dbus_api"
+
+    groups = HttpdDBusApi.new.user_groups(user)
     strip_group_domains(groups)
   end
 

--- a/lib/httpd_dbus_api.rb
+++ b/lib/httpd_dbus_api.rb
@@ -1,28 +1,28 @@
 require "faraday"
 require "json"
 
-class HttpdAuthApi
+class HttpdDBusApi
   def initialize(options = {})
     @options = options
   end
 
   def user_attrs(userid, attributes = nil)
     if attributes.present?
-      auth_api("/api/user_attrs/#{userid}?attributes=#{attributes.join(',')}")
+      dbus_api("/api/user_attrs/#{userid}?attributes=#{attributes.join(',')}")
     else
-      auth_api("/api/user_attrs/#{userid}")
+      dbus_api("/api/user_attrs/#{userid}")
     end
   end
 
   def user_groups(userid)
-    auth_api("/api/user_groups/#{userid}")
+    dbus_api("/api/user_groups/#{userid}")
   end
 
   private
 
-  def auth_api(request_url)
-    host = ENV["HTTPD_AUTH_API_SERVICE_HOST"]
-    port = ENV["HTTPD_AUTH_API_SERVICE_PORT"]
+  def dbus_api(request_url)
+    host = ENV["HTTPD_DBUS_API_SERVICE_HOST"]
+    port = ENV["HTTPD_DBUS_API_SERVICE_PORT"]
     conn = Faraday.new(:url => "http://#{host}:#{port}") do |faraday|
       faraday.options[:open_timeout] = @options[:open_timeout] || 5  # Net::HTTP open_timeout
       faraday.options[:timeout]      = @options[:timeout]      || 30 # Net::HTTP read_timeout

--- a/spec/lib/httpd_dbus_api_spec.rb
+++ b/spec/lib/httpd_dbus_api_spec.rb
@@ -1,6 +1,7 @@
 require 'webmock/rspec'
+require 'httpd_dbus_api'
 
-RSpec.describe HttpdAuthApi do
+RSpec.describe HttpdDBusApi do
   let(:jdoe_userid) { "jdoe" }
 
   let(:jdoe_user_attrs) do
@@ -20,8 +21,8 @@ RSpec.describe HttpdAuthApi do
   let(:jim_groups_error) { "Unable to get groups for user #{jim_userid} - No such user" }
 
   before do
-    ENV["HTTPD_AUTH_API_SERVICE_HOST"] = "1.2.3.4"
-    ENV["HTTPD_AUTH_API_SERVICE_PORT"] = "3400"
+    ENV["HTTPD_DBUS_API_SERVICE_HOST"] = "1.2.3.4"
+    ENV["HTTPD_DBUS_API_SERVICE_PORT"] = "3400"
 
     stub_request(:get, "http://1.2.3.4:3400/api/user_attrs/#{jdoe_userid}")
       .to_return(:status => 200, :body => { "result" => jdoe_user_attrs }.to_json)


### PR DESCRIPTION
Renaming all auth_api services/classes/environment to dbus_api to reflect the new service and repo ManageIQ/dbus_api_service .