### PR TITLE
Remove obsolete chart types

### DIFF
--- a/product/reports/100_Configuration Management - Virtual Machines/005_VMs with Free Space _ 50% by Department.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/005_VMs with Free Space _ 50% by Department.yaml
@@ -17,7 +17,7 @@ conditions: !ruby/object:MiqExpression
 updated_on: 2009-05-08 23:53:31.651481 Z
 order: Descending
 graph:
-  :type: PieThreed
+  :type: Pie
   :count: "8"
   :other: false
 menu_name: "VMs with Free Space > 50% by Department"

--- a/product/reports/100_Configuration Management - Virtual Machines/006_VMs w_Free Space _ 75% by Function.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/006_VMs w_Free Space _ 75% by Function.yaml
@@ -18,7 +18,7 @@ updated_on: 2009-10-19 22:10:21.430000 Z
 order: Descending
 graph:
   :other: false
-  :type: PieThreed
+  :type: Pie
   :count: "8"
 menu_name: "VMs w/Free Space > 75% by Function"
 rpt_group: Custom

--- a/product/reports/100_Configuration Management - Virtual Machines/007_VMs w_Free Space _ 75% by LOB.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/007_VMs w_Free Space _ 75% by LOB.yaml
@@ -18,7 +18,7 @@ updated_on: 2009-10-19 22:17:09.677000 Z
 order: Descending
 graph:
   :other: false
-  :type: PieThreed
+  :type: Pie
   :count: "8"
 menu_name: "VMs w/Free Space > 75% by LOB"
 rpt_group: Custom

--- a/product/reports/100_Configuration Management - Virtual Machines/059_Guest OS Information (any OS).yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/059_Guest OS Information (any OS).yaml
@@ -6,7 +6,7 @@ conditions:
 updated_on: 2008-08-14 15:18:19.546191 Z
 order: Ascending
 graph:
-  :type: PieThreed
+  :type: Pie
   :count: 10
   :other: true
 menu_name: "Guest OS Information - any OS"

--- a/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
+++ b/product/reports/170_Configuration Management - Containers/050_Number of Nodes per CPU Cores.yaml
@@ -24,7 +24,7 @@ sortby:
 - computer_system.hardware.cpu_total_cores
 group:
 graph:
-  :type: ColumnThreed
+  :type: Column
   :count: 10
   :other: true
 dims: 1

--- a/product/reports/170_Configuration Management - Containers/060_Pods per Ready Status.yaml
+++ b/product/reports/170_Configuration Management - Containers/060_Pods per Ready Status.yaml
@@ -24,7 +24,7 @@ sortby:
 - ready_condition_status
 group:
 graph:
-  :type: PieThreed
+  :type: Pie
   :count: 10
   :other: true
 dims: 1

--- a/product/reports/421_Operations - Events/VC Snapshot Events by User.yaml
+++ b/product/reports/421_Operations - Events/VC Snapshot Events by User.yaml
@@ -14,7 +14,7 @@ updated_on: 2009-11-12 22:51:43.435616 Z
 order: Ascending
 graph:
   :other: true
-  :type: PieThreed
+  :type: Pie
   :count: 10
 generate_rows:
 menu_name: "VC Snapshot Events by User"

--- a/product/reports/425_VM Sprawl - Candidates/052_VMs with Volume Free Space -= 75%.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/052_VMs with Volume Free Space -= 75%.yaml
@@ -19,7 +19,7 @@ updated_on: 2009-11-10 20:10:42.138343 Z
 order: Descending
 graph:
   :other: true
-  :type: PieThreed
+  :type: Pie
   :count: 10
 generate_rows:
 menu_name: "VMs with Volume Free Space >= 75%"

--- a/product/reports/425_VM Sprawl - Candidates/059_Summary of VM Create and Deletes.yaml
+++ b/product/reports/425_VM Sprawl - Candidates/059_Summary of VM Create and Deletes.yaml
@@ -18,7 +18,7 @@ updated_on: 2009-11-10 21:28:30.163529 Z
 order: Ascending
 graph:
   :other: true
-  :type: PieThreed
+  :type: Pie
   :count: 10
 generate_rows:
 menu_name: "Summary of VM Create and Deletes"


### PR DESCRIPTION
Remove obsolete chart types from report definitions. It is a part of BZ issue. 


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1491629
https://github.com/ManageIQ/manageiq-ui-classic/pull/2291
Each one of PRs should be enough to fix it.

Steps for Testing/QA [Optional]
-------------------------------
