### PR TITLE
Fix typo Metering Used Hours

### DIFF
--- a/db/fixtures/chargeable_fields.yml
+++ b/db/fixtures/chargeable_fields.yml
@@ -58,7 +58,7 @@
   :group: fixed
   :source: storage_2
   :description: Fixed Storage Cost 2
-- :metric: user_metering_hours
+- :metric: metering_used_hours
   :group: metering
   :source: used
   :description: Metering - Hours Used

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -97,7 +97,7 @@
       :fixed_rate: 0.0
       :variable_rate: 0.0
   - :description: Metering - Hours Used
-    :metric: user_metering_hours
+    :metric: metering_used_hours
     :per_time: hourly
     :per_unit: hours
     :type_currency: Dollars


### PR DESCRIPTION
there is the typo in yamls, introduced in
https://github.com/ManageIQ/manageiq/pull/15908

this typo in metric don't affect functionality because we are not using metric column to for asking metric rollups to get metric value.

but typo slightly "affects"(just on naming level - not to be confused about names) integration with chargio where mapping of names of metrics is happening 

@miq-bot assign @gtanzillo 

@miq-bot add_label chargeback, technical_debt
