### PR TITLE
Drop Ruby 2.2 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-raise "Ruby versions less than 2.2.2 are unsupported!" if RUBY_VERSION < "2.2.2"
+raise "Ruby versions less than 2.3.1 are unsupported!" if RUBY_VERSION < "2.3.1"
 
 source 'https://rubygems.org'
 


### PR DESCRIPTION
Dockerfiles are already 2.3.1, so no changes needed there.

For https://github.com/ManageIQ/manageiq/pull/16121