### PR TITLE
Match appliance Ruby version on Travis, add 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
 matrix:
   allow_failures:
   - rvm: 2.4.2
+  exclude:
+  - rvm: 2.4.2
+    env: TEST_SUITE=brakeman
   fast_finish: true
 addons:
   postgresql: '9.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- '2.3.5'
+- 2.3.1
 sudo: false
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - 2.3.1
+- 2.4.2
 sudo: false
 cache:
   bundler: true
@@ -14,6 +15,8 @@ env:
   - TEST_SUITE=vmdb PARALLEL=true
   - TEST_SUITE=brakeman
 matrix:
+  allow_failures:
+  - rvm: 2.4.2
   fast_finish: true
 addons:
   postgresql: '9.5'


### PR DESCRIPTION
This sets the required Travis build to Ruby 2.3.1 to reflect the Ruby version actually shipped on ManageIQ appliances. It also adds the newest version of Ruby that developers of ManageIQ can use as an optional build so the platform team can keep an eye on future regressions.

Closes https://github.com/ManageIQ/manageiq/issues/14446