### PR TITLE
Override the href_slug method to use GUID instead of id

### DIFF
--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -5,6 +5,10 @@ class AutomateWorkspace < ApplicationRecord
   validates :tenant, :presence => true
   validates :user, :presence => true
 
+  def href_slug
+    Api::Utils.build_href_slug(self.class, guid)
+  end
+
   def merge_output!(hash)
     if hash['objects'].nil? || hash['state_vars'].nil?
       raise ArgumentError, "No objects or state_vars specified for edit"

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -18,5 +18,9 @@ describe AutomateWorkspace do
 
       expect(aw.output).to eq(merged_hash)
     end
+
+    it "#href_slug" do
+      expect(aw.href_slug).to eq("automate_workspaces/#{aw.guid}")
+    end
   end
 end


### PR DESCRIPTION
Automate Workspaces can only be accessed using GUIDs and not ID's. This PR overrides the href_slug method