### PR TITLE
Enable alerts definitions for transactions and messaging for Middleware Server

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -511,6 +511,76 @@ class MiqAlert < ApplicationRecord
           {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
           {:name => :value_mw_threshold, :description => _("Max Wait Time in Datasource connection (ms)"), :numeric => true}
         ]},
+      {:name => "mw_ms_topic_delivering_count", :description => _("Messaging - Delivering Message Count"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Delivering Message Count"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_durable_message_count", :description => _("Messaging - Durable Message Count"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Durable Message Count"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_non_durable_message_count", :description => _("Messaging - Non-durable Message Count"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Non-durable Message Count"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_message_count", :description => _("Messaging - Messages Count"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Messages Count"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_message_added", :description => _("Messaging - Messages Added"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Messages Added"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_durable_subscription_count", :description => _("Messaging - Durable Subscribers"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Durable Subscribers"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_non_durable_subscription_count", :description => _("Messaging - Non-durable Subscribers"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Non-durable Subscribers"), :numeric => true}
+        ]},
+      {:name => "mw_ms_topic_subscription_count", :description => _("Messaging - Subscriptions"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Subscriptions"), :numeric => true}
+        ]},
+      {:name => "mw_tx_committed", :description => _("EAP Transactions - Committed"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Comitted Transactions"), :numeric => true, :required => true}
+        ]},
+      {:name => "mw_tx_timeout", :description => _("EAP Transactions - Timed Out"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Timed Out Transactions"), :numeric => true, :required => true}
+        ]},
+      {:name => "mw_tx_heuristics", :description => _("EAP Transactions - Heuristic"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Heuristics"), :numeric => true, :required => true}
+        ]},
+      {:name => "mw_tx_application_rollbacks", :description => _("EAP Transactions - Application Rollbacks"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Application Rollbacks"), :numeric => true, :required => true}
+        ]},
+      {:name => "mw_tx_resource_rollbacks", :description => _("EAP Transactions - Resource Rollbacks"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Resource Rollbacks"), :numeric => true, :required => true}
+        ]},
+      {:name => "mw_tx_aborted", :description => _("EAP Transactions - Aborted"), :db => ["MiddlewareServer"], :responds_to_events => "hawkular_alert",
+        :options => [
+          {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
+          {:name => :value_mw_threshold, :description => _("Number of Aborted Transactions"), :numeric => true, :required => true}
+        ]},
       {:name => "dwh_generic", :description => _("All Datawarehouse alerts"), :db => ["ContainerNode"], :responds_to_events => "datawarehouse_alert",
         :options => [], :always_evaluate => true}
     ]


### PR DESCRIPTION
## Tasks

- [X] EAP Transactions - Committed
- [X] EAP Transactions - Timed Out
- [X] EAP Transactions - Heuristic
- [X] EAP Transactions - Application Rollback
- [X] EAP Transactions - Resource Rollback
- [X] EAP Transactions - Aborted
- [X] Messaging - Delivering Message Count
- [X] Messaging - Durable Message Count
- [X] Messaging - Non-durable Message Count
- [X] Messaging - Messages Count
- [X] Messaging - Messages Added
- [X] Messaging - Durable Subscribers
- [X] Messaging - Non-durable Subscribers
- [X] Messaging - Subscriptions

![screenshot from 2017-10-06 10-07-20](https://user-images.githubusercontent.com/3019213/31268955-d9b35c4a-aa7e-11e7-9198-eb306cf002d0.png)

![screenshot from 2017-10-06 09-40-04](https://user-images.githubusercontent.com/3019213/31268003-bf429a50-aa7a-11e7-852d-9df38fb8312e.png)
**Let use operators <,<=,> and >=**
![screenshot from 2017-10-06 10-07-47](https://user-images.githubusercontent.com/3019213/31268961-db2d9356-aa7e-11e7-839c-576289f81579.png)
## EAP Transactions - Aborted
![screenshot from 2017-10-06 10-07-58](https://user-images.githubusercontent.com/3019213/31268963-dc5d07ac-aa7e-11e7-9e68-f68045746139.png)
## EAP Transactions - Application Rollback
![screenshot from 2017-10-06 10-08-08](https://user-images.githubusercontent.com/3019213/31268973-e0ebda82-aa7e-11e7-9203-56421cc9e96a.png)
## EAP Transactions - Committed
![screenshot from 2017-10-06 10-08-19](https://user-images.githubusercontent.com/3019213/31268974-e2360ec6-aa7e-11e7-8d30-4f0b849a459b.png)
## EAP Transactions - Heuristic
![screenshot from 2017-10-06 10-08-28](https://user-images.githubusercontent.com/3019213/31268976-e361c2f4-aa7e-11e7-81fc-250f00fc4d3c.png)
## EAP Transactions - Resource Rollback
![screenshot from 2017-10-06 10-08-40](https://user-images.githubusercontent.com/3019213/31268977-e4b61df8-aa7e-11e7-998a-65555a7f3e30.png)
## EAP Transactions - Timed Out
![screenshot from 2017-10-06 10-08-52](https://user-images.githubusercontent.com/3019213/31268978-e607021c-aa7e-11e7-8272-debd31721fc0.png)

## Messaging - Delivering Message Count
![screenshot from 2017-10-06 09-40-21](https://user-images.githubusercontent.com/3019213/31268017-d1d622d6-aa7a-11e7-9e20-3db1b2ae337f.png)
## Messaging - Durable Message Count
![screenshot from 2017-10-06 09-40-30](https://user-images.githubusercontent.com/3019213/31268021-d4189768-aa7a-11e7-88ba-c814f8f0e315.png)
## Messaging - Durable Subscribers
![screenshot from 2017-10-06 09-40-41](https://user-images.githubusercontent.com/3019213/31268023-d53cb3e0-aa7a-11e7-9316-d4ff8befd4ef.png)
## Messaging - Messages Added
![screenshot from 2017-10-06 09-41-02](https://user-images.githubusercontent.com/3019213/31268024-d69a4bc6-aa7a-11e7-88e9-29e6e3557cab.png)
## Messaging - Messages Count
![screenshot from 2017-10-06 09-41-16](https://user-images.githubusercontent.com/3019213/31268027-d7a794ba-aa7a-11e7-8b95-6598c93fe244.png)
##  Messaging - Non-durable Message Count
![screenshot from 2017-10-06 09-41-27](https://user-images.githubusercontent.com/3019213/31268030-d8e7f464-aa7a-11e7-8333-fc87498b5b63.png)
## Messaging - Non-durable Subscribers
![screenshot from 2017-10-06 09-41-41](https://user-images.githubusercontent.com/3019213/31268033-d9fc497c-aa7a-11e7-9f65-bc41ccfc8494.png)
## Messaging - Subscriptions
![screenshot from 2017-10-06 09-41-52](https://user-images.githubusercontent.com/3019213/31268036-dae1a9fe-aa7a-11e7-8f10-4bbe036e2d89.png)




https://issues.jboss.org/browse/HAWKULAR-1255