### PR TITLE
Add MW diagnostic report class so we can use it when generating JDRs in report data table

### DIFF
--- a/app/models/middleware_diagnostic_report.rb
+++ b/app/models/middleware_diagnostic_report.rb
@@ -1,0 +1,3 @@
+class MiddlewareDiagnosticReport < ApplicationRecord
+  belongs_to :middleware_server
+end


### PR DESCRIPTION
### Merge first

When we want to display JDRs we would like to use newer table for them, but that requires changes in from which class our [middleware_diagnostic_report.rb](https://github.com/ManageIQ/manageiq-providers-hawkular/blob/128237e59c2e42f90ba7e8f453b7e70880b487b5/app/models/manageiq/providers/hawkular/middleware_manager/middleware_diagnostic_report.rb) we inherit from.

With inheriting directly from `ApplicationRecord` we are unable to use `paged_view_search` since that requires parent and parent has no connection to `middleware_diagnostic_report`

This is first of series of pull requests, merge this one first pleas