### PR TITLE
Extend InventoryCollectionDefault::NetworkManager with network_groups

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/network_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/network_manager.rb
@@ -243,5 +243,17 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
 
       attributes.merge!(extra_attributes)
     end
+
+    def network_groups(extra_attributes = {})
+      attributes = {
+        :model_class    => ::NetworkGroup,
+        :association    => :network_groups,
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.try(:network_manager).try(:id) || persister.manager.id },
+        }
+      }
+
+      attributes.merge!(extra_attributes)
+    end
   end
 end


### PR DESCRIPTION
With this commit we implement a class function that is needed when implementing graph inventory refresh for NetworkManager that support NetworkGroup inventory object. The new `network_groups` function provides hash of common properties that are needed by persister.

@Ladas I've assigned you since I remember you being in charge of introducing graph refresh. Please let me know if someone else should be assigned instead.

@miq-bot add_label enhancement
@miq-bot assign @Ladas 

/cc @gberginc 