### PR TITLE
Override AutomateWorkspace#to_param

### DIFF
--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -33,6 +33,10 @@ class AutomateWorkspace < ApplicationRecord
     merge_output!(hash)
   end
 
+  def to_param
+    guid
+  end
+
   private
 
   def encrypted_value(object_name, attribute)


### PR DESCRIPTION
These objects are now referenced in the API through their
guid. Overriding this method is the Rails Way :tm: to handle this and
will enable us to simplify some code in the API repo.

See: https://apidock.com/rails/ActiveRecord/Base/to_param

@miq-bot add-label technical debt
@miq-bot assign @Fryguy 