### PR TITLE
[WIP] Do not discard worker options - fixes fork removal PR

### DIFF
--- a/Procfile.example
+++ b/Procfile.example
@@ -45,9 +45,9 @@
 # These workers subscribe to a queue named based on the particular EMS they connect to
 # The "<id>" tag in these lines should be replaced by the id of the manager instance these workers apply to
 
-# vmware_refresh_<id>:      env QUEUE=ems_<id> ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
-# vmware_event_<id>:        env QUEUE=ems_<id> ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::EventCatcher
-# vmware_refresh_core_<id>: env QUEUE=ems_<id> ruby lib/workers/bin/run_single_worker.rb MiqEmsRefreshCoreWorker
+# vmware_refresh_<id>:      env EMS_ID=<id> ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
+# vmware_event_<id>:        env EMS_ID=<id> ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::EventCatcher
+# vmware_refresh_core_<id>: env EMS_ID=<id> ruby lib/workers/bin/run_single_worker.rb MiqEmsRefreshCoreWorker
 
 # Logs
 #

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -43,8 +43,6 @@ class MiqWorker::Runner
 
   def initialize(cfg = {})
     @cfg = cfg
-    @cfg[:guid] ||= ENV['MIQ_GUID']
-
     $log ||= Rails.logger
 
     @server = MiqServer.my_server(true)

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -133,7 +133,6 @@ module MiqWebServerWorkerMixin
 
   def start
     delete_pid_file
-    ENV['MIQ_GUID'] = guid
     super
   end
 

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -1,7 +1,7 @@
 module Vmdb
   module Initializer
     def self.init
-      _log.info("- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['MIQ_GUID']: #{ENV['MIQ_GUID']}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}")
+      _log.info("- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}")
 
       # UiWorker called in Development Mode
       #   * command line(rails server)

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -23,10 +23,6 @@ opt_parser = OptionParser.new do |opts|
     options[:dry_run] = val
   end
 
-  opts.on("-g=GUID", "--guid=GUID", "Find an existing worker record instead of creating") do |val|
-    options[:guid] = val
-  end
-
   opts.on("-h", "--help", "Displays this help") do
     puts opts
     exit

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -60,13 +60,13 @@ unless options[:dry_run]
   create_options = {:pid => Process.pid}
   runner_options = {}
 
-  if ENV["QUEUE"]
-    create_options[:queue_name] = ENV["QUEUE"]
-    runner_options[:ems_id] = worker_class.ems_id_from_queue_name(ENV["QUEUE"]) if worker_class.respond_to?(:ems_id_from_queue_name)
+  if ENV["EMS_ID"].to_i > 0
+    create_options[:queue_name] = "ems_#{ENV['EMS_ID']}"
+    runner_options[:ems_id]     = ENV["EMS_ID"].to_i
   end
 
-  worker = if options[:guid]
-             worker_class.find_by!(:guid => options[:guid]).tap do |wrkr|
+  worker = if ENV["GUID"]
+             worker_class.find_by!(:guid => ENV["GUID"]).tap do |wrkr|
                wrkr.update_attributes(:pid => Process.pid)
              end
            else

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -29,32 +29,6 @@ describe MiqWorker do
     expect(result.command_line).to eq "renice -n 5 -p 123"
   end
 
-  context ".build_command_line" do
-    before do
-      allow(MiqGenericWorker).to receive(:nice_increment).and_return("+10")
-    end
-
-    it "with ENV['APPLIANCE']" do
-      begin
-        old_env = ENV.delete('DATABASE_URL')
-        ENV['APPLIANCE'] = 'true'
-        w = FactoryGirl.build(:miq_generic_worker)
-        cmd = w.class.build_command_line(:guid => 123)
-        expect(cmd).to start_with("nice +10")
-        expect(cmd).to end_with("MiqGenericWorker")
-      ensure
-        # ENV['x'] = nil deletes the key because ENV accepts only string values
-        ENV['APPLIANCE'] = old_env
-      end
-    end
-
-    it "without ENV['APPLIANCE']" do
-      w = FactoryGirl.build(:miq_generic_worker)
-      cmd = w.class.build_command_line(:guid => 123)
-      expect(cmd).to_not start_with("nice +10")
-    end
-  end
-
   context ".has_required_role?" do
     def check_has_required_role(worker_role_names, expected_result)
       allow(described_class).to receive(:required_roles).and_return(worker_role_names)
@@ -374,19 +348,32 @@ describe MiqWorker do
     context "#command_line" do
       it "with nil worker_options" do
         allow(@worker).to receive(:worker_options).and_return(nil)
-        expect {@worker.command_line}.to raise_error(ArgumentError)
+        expect { @worker.command_line }.to raise_error(ArgumentError)
       end
 
       it "without guid in worker_options" do
         allow(@worker).to receive(:worker_options).and_return({})
-        expect {@worker.command_line}.to raise_error(ArgumentError)
+        expect { @worker.command_line }.to raise_error(ArgumentError)
       end
 
-      it "with provider worker_options" do
-        allow(@worker).to receive(:worker_options).and_return({:ems_id => 1234, :guid => @worker.guid})
-        cmd = @worker.command_line
-        expect(cmd).to include("GUID=#{@worker.guid} ")
-        expect(cmd).to include("EMS_ID=1234 ")
+      it "without ENV['APPLIANCE']" do
+        allow(@worker).to receive(:worker_options).and_return(:ems_id => 1234, :guid => @worker.guid)
+        expect(@worker.command_line).to_not include("nice")
+      end
+
+      it "with ENV['APPLIANCE']" do
+        begin
+          allow(MiqWorker).to receive(:nice_increment).and_return("+10")
+          allow(@worker).to receive(:worker_options).and_return(:ems_id => 1234, :guid => @worker.guid)
+          old_env = ENV.delete('APPLIANCE')
+          ENV['APPLIANCE'] = 'true'
+          cmd = @worker.command_line
+          expect(cmd).to start_with("EMS_ID\\=1234\\ GUID\\=#{@worker.guid}\\ nice\\ \\+10")
+          expect(cmd).to end_with("MiqWorker")
+        ensure
+          # ENV['x'] = nil deletes the key because ENV accepts only string values
+          ENV['APPLIANCE'] = old_env
+        end
       end
     end
 


### PR DESCRIPTION
* Pass worker_options as env vars to the runner
Fixes a bug introduced by #16130
* We're using ENV variables to pass the guid.
* Remove now unused MIQ_GUID environment variable.
* Workers now expect EMS_ID, not QUEUE