### PR TITLE
Allow group settings with string keys

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -43,6 +43,10 @@ class MiqGroup < ApplicationRecord
     description
   end
 
+  def settings
+    super && super.with_indifferent_access
+  end
+
   def self.with_allowed_roles_for(user_or_group)
     includes(:miq_user_role).where.not({:miq_user_roles => {:name => user_or_group.disallowed_roles}})
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -312,6 +312,15 @@ describe MiqGroup do
       ws3 = FactoryGirl.create(:miq_widget_set, :name => 'B2', :owner => group)
       expect(group.ordered_widget_sets).to eq([ws1, ws3, ws2])
     end
+
+    it "works when settings use strings" do
+      ws1 = FactoryGirl.create(:miq_widget_set, :name => 'A1', :owner => group)
+      _ws2 = FactoryGirl.create(:miq_widget_set, :name => 'C3', :owner => group)
+      ws3 = FactoryGirl.create(:miq_widget_set, :name => 'B2', :owner => group)
+      group.update_attributes(:settings => {"dashboard_order" => [ws3.id.to_s, ws1.id.to_s]})
+
+      expect(group.ordered_widget_sets).to eq([ws3, ws1])
+    end
   end
 
   context ".sort_by_desc" do


### PR DESCRIPTION
This fixes an issue where settings are created/updated in the JSON
API, which has no notion of symbols as implemented by
Ruby. Consequently, these settings get ignored when looked up by
symbol. My solution was to override the `settings` method to return a
`HashWithIndifferentAccess`.

I am personally not a fan of `HashWithIndifferentAccess`, but
considered this the best of several options. Alternatives considered:

* update everywhere that we might be sending hashes with string keys,
  convert them to symbols
* override the setter to accept hashes with symbols or strings, but
  convert them to all symbols prior to writing.

I could be talked into one of these alternatives (or one I hadn't considered) if you have strong opinions :tm: about it.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1424842

@miq-bot add-label bug
@miq-bot assign @gtanzillo 