### PR TITLE
When importing report symbolize keys only in 'db_options:' section

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -27,8 +27,8 @@ module MiqReport::ImportExport
         raise _("Incorrect format, only policy records can be imported.")
       end
 
-      # Ensure that all columns serialized as hashes in the report have keys that are symbols
-      self.column_names.each { |k| report[k].deep_symbolize_keys! if report[k].kind_of?(Hash) }
+      report[:db_options] ||= report["db_options"]
+      report[:db_options].deep_symbolize_keys! if report[:db_options]
 
       user = options[:user] || User.find_by_userid(options[:userid])
       report.merge!("miq_group_id" => user.current_group_id, "user_id" => user.id)

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -7,7 +7,8 @@ describe MiqReport::ImportExport do
                                      :tz         => "Eastern Time (US & Canada)",
                                      :col_order  => ["name", "boot_time", "disks_aligned"],
                                      :cols       => ["name", "boot_time", "disks_aligned"],
-                                     :db_options => {:rpt_type => "ChargebackContainerProject"}
+                                     :db_options => {:rpt_type => "ChargebackContainerProject"},
+                                     "include"   => {"columns" => %w(col1 col2)}
                                     )
   end
 
@@ -40,13 +41,21 @@ describe MiqReport::ImportExport do
         expect(result[:status]).to eq(:add)
         expect(MiqReport.count).to eq(1)
       end
+    end
 
-      it "imports from json and preserves symbolized keys in serialized columns" do
+    context "keys symbolizing" do
+      let(:report) do
         @options[:save] = true
         MiqReport.import_from_hash(@from_json, @options)
+        MiqReport.last
+      end
 
-        report = MiqReport.last
+      it "imports from json and preserves symbolized keys in `db_options` section " do
         expect(report.db_options[:rpt_type]).to_not be_nil
+      end
+
+      it "keeps string keys in 'include:' section" do
+        expect(report["include"]["columns"]).to_not be_nil
       end
     end
 


### PR DESCRIPTION
**Issue**: After importing report columns defined in include section of report were not populated.
https://bugzilla.redhat.com/show_bug.cgi?id=1498471

Report generator expect keys in `include:` section of report to be string.
Importing report  (after https://github.com/ManageIQ/manageiq/pull/15273) change keys to symbols and `include:` section of report was skipped.

**Fix:** Symbolize keys only in `db_options:` section when importing report

\cc @gtanzillo 

@miq-bot add-label bug, core, reporting, euwe/yes, fine/yes

**BEFORE:**

![before](https://user-images.githubusercontent.com/6556758/31294264-3a5a459e-aaa8-11e7-9ef4-d82ef8b42152.gif)

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/31294282-45da724a-aaa8-11e7-92ce-65a56e9ded11.gif)

