### PR TITLE
Check for existing source tenant of cloud tenant before attempting to create a new one

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -140,6 +140,12 @@ class CloudTenant < ApplicationRecord
     end
   end
 
+  def update_source_tenant(tenant_params)
+    _log.info("CloudTenant #{name} has tenant #{source_tenant.name}")
+    _log.info("Updating Tenant #{source_tenant.name} with parameters: #{tenant_params.inspect}")
+    source_tenant.update(tenant_params)
+  end
+
   def self.with_ext_management_system(ems_id)
     where(:ext_management_system => ems_id)
   end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -92,9 +92,17 @@ module ManageIQ::Providers
           _log.info("and with parent #{tenant_parent.name}")
           tenant_params[:parent] = tenant_parent
           tenant_params[:source] = cloud_tenant
-          cloud_tenant.source_tenant = Tenant.descendants_of(tenant_parent).find_by(:name => tenant_params[:name]) ||
-              Tenant.new(tenant_params)
-          _log.info("New Tenant #{cloud_tenant.source_tenant.name} created")
+          existing_source_tenant = Tenant.descendants_of(tenant_parent).find_by(:name => tenant_params[:name])
+          if existing_source_tenant
+            cloud_tenant.source_tenant = existing_source_tenant
+            _log.info("CloudTenant #{cloud_tenant.name} has orphaned tenant #{existing_source_tenant.name}")
+            _log.info("Updating Tenant #{cloud_tenant.source_tenant.name} with parameters: #{tenant_params.inspect}")
+            cloud_tenant.source_tenant.update(tenant_params)
+          else
+            cloud_tenant.source_tenant = Tenant.new(tenant_params)
+            _log.info("New Tenant #{cloud_tenant.source_tenant.name} created")
+            _log.info("New Tenant #{cloud_tenant.source_tenant.name} created")
+          end
         end
 
         cloud_tenant.update_source_tenant_associations

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -92,7 +92,8 @@ module ManageIQ::Providers
           _log.info("and with parent #{tenant_parent.name}")
           tenant_params[:parent] = tenant_parent
           tenant_params[:source] = cloud_tenant
-          cloud_tenant.source_tenant = Tenant.new(tenant_params)
+          cloud_tenant.source_tenant = Tenant.descendants_of(tenant_parent).find_by(:name => tenant_params[:name]) ||
+              Tenant.new(tenant_params)
           _log.info("New Tenant #{cloud_tenant.source_tenant.name} created")
         end
 

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -233,6 +233,23 @@ describe EmsCloud do
           expect(tenant_ct_4.vm_or_templates).to match_array([vm_3, vm_4, vm_5])
         end
 
+        it "finds and updates existing tenant with orphaned source cloud tenant" do
+          ems_cloud.sync_cloud_tenants_with_tenants
+          expect_created_tenant_tree
+
+          tenant_ct_4.source = nil
+          tenant_ct_4.save!
+
+          ems_cloud.sync_cloud_tenants_with_tenants
+          tenant_ct_4.reload
+
+          expect(tenant_ct_4.name).to eq(ct_4.name)
+          expect(tenant_ct_4.description).to eq(ct_4.description)
+          expect(tenant_ct_4.parent.name).to eq(ct_2.name)
+          expect(tenant_ct_4.parent.description).to eq(ct_2.description)
+          expect(tenant_ct_4.vm_or_templates).to match_array([vm_3, vm_4])
+        end
+
         it "sets description to CloudTenant#name when CloudTenant#description is empty" do
           ct_4.description = ""
           ct_4.save

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -237,6 +237,9 @@ describe EmsCloud do
           ems_cloud.sync_cloud_tenants_with_tenants
           expect_created_tenant_tree
 
+          ct_4.description = "New description"
+          ct_4.save
+
           tenant_ct_4.source = nil
           tenant_ct_4.save!
 


### PR DESCRIPTION
The intent of this PR is to handle a case where we fail to create the source tenant of an OpenStack cloud tenant because one already exists with the same name and ancestry.

We've seen this happen before but have not been able to identify the root cause.

This change will try to find an existing, orphaned tenant and assign that tenant, if it exists, as the source tenant before attempting to create a new one. 

https://bugzilla.redhat.com/show_bug.cgi?id=1496486