### PR TITLE
Change Failure label by Rollback

### DIFF
--- a/product/charts/miq_reports/vim_perf_daily_middleware_server.yaml
+++ b/product/charts/miq_reports/vim_perf_daily_middleware_server.yaml
@@ -75,9 +75,9 @@ headers:
 - Committed
 - Timed-out
 - Heuristic
-- Application Failure
+- Application Rollback
 - Aborted
-- Resource Failure
+- Resource Rollback
 
 # Condition expression for search filtering
 conditions:

--- a/product/charts/miq_reports/vim_perf_hourly_middleware_server.yaml
+++ b/product/charts/miq_reports/vim_perf_hourly_middleware_server.yaml
@@ -75,9 +75,9 @@ headers:
 - Committed
 - Timed-out
 - Heuristic
-- Application Failure
+- Application Rollback
 - Aborted
-- Resource Failure
+- Resource Rollback
 
 # Condition expression for search filtering
 conditions:

--- a/product/charts/miq_reports/vim_perf_realtime_middleware_server.yaml
+++ b/product/charts/miq_reports/vim_perf_realtime_middleware_server.yaml
@@ -75,9 +75,9 @@ headers:
 - Committed
 - Timed-out
 - Heuristic
-- Application Failure
+- Application Rollback
 - Aborted
-- Resource Failure
+- Resource Rollback
 
 # Condition expression for search filtering
 conditions:


### PR DESCRIPTION
Fix a label name, Rollback instead Failure.

In the current utilization graphs in CloudForms we have Application Failure and Resource Failure. We need to use the same terminology across all the CloudForms UIs.

Wildfly terminology. col_order are **mw_tx_application_rollbacks** and **mw_tx_resource_rollbacks**

![screenshot from 2017-10-07 11-22-00](https://user-images.githubusercontent.com/3019213/31306511-094a886a-ab52-11e7-8ac6-b3e9a044f3c2.png)
