### PR TITLE
Bump ripper_ruby_parser to latest ~>1.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "rails",                          "~>5.0.2"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
-gem "ripper_ruby_parser",             "~>1.0.0",       :require => false
+gem "ripper_ruby_parser",             "~>1.1.2",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.1",       :require => false
 gem "rugged",                         "~>0.25.0",      :require => false


### PR DESCRIPTION
Was held at 1.0 (#16081) when 1.1.0 could not parse our source,
after 2 quick fixes by author it works for us again. :bow:
(https://github.com/mvz/ripper_ruby_parser/issues/5)

Can this PR break plugin repos?
-------------------------------

Shouldn't, this parses `app/**.rb` from all plugins at once.
AFAIU, no additional parsing happens as more code is loaded.

I also tested a couple other repos against this locally.

Links
-----

- #16112 improves diagnostics if similar problem happens in future.
  (independent, can be merged in either order)