### PR TITLE
Add belongsto filter for other network models

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -54,6 +54,10 @@ module Rbac
 
     TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User)
 
+    NETWORK_MODELS_FOR_BELONGSTO_FILTER = %w(
+      CloudNetwork
+    ).freeze
+
     BELONGSTO_FILTER_CLASSES = %w(
       VmOrTemplate
       Host
@@ -62,8 +66,7 @@ module Rbac
       EmsCluster
       ResourcePool
       Storage
-      CloudNetwork
-    )
+    ).freeze + NETWORK_MODELS_FOR_BELONGSTO_FILTER
 
     # key: MiqUserRole#name - user's role
     # value:

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -56,6 +56,12 @@ module Rbac
 
     NETWORK_MODELS_FOR_BELONGSTO_FILTER = %w(
       CloudNetwork
+      CloudSubnet
+      FloatingIp
+      LoadBalancer
+      NetworkPort
+      NetworkRouter
+      SecurityGroup
     ).freeze
 
     BELONGSTO_FILTER_CLASSES = %w(
@@ -66,7 +72,7 @@ module Rbac
       EmsCluster
       ResourcePool
       Storage
-    ).freeze + NETWORK_MODELS_FOR_BELONGSTO_FILTER
+    ) + NETWORK_MODELS_FOR_BELONGSTO_FILTER
 
     # key: MiqUserRole#name - user's role
     # value:

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -581,8 +581,8 @@ module Rbac
         # typically, this is the only one we want:
         vcmeta = vcmeta_list.last
 
-        if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) } && klass <= VmOrTemplate ||
-           vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)        && klass <= CloudNetwork
+        if ([ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) } && klass <= VmOrTemplate) ||
+           (vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)        && NETWORK_MODELS_FOR_BELONGSTO_FILTER.any? { |association_class| klass <= association_class.safe_constantize })
           vcmeta.send(association_name).to_a
         else
           vcmeta_list.grep(klass) + vcmeta.descendants.grep(klass)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1199,9 +1199,7 @@ describe Rbac::Filterer do
 
     context 'with cloud network and network manager' do
       let!(:network_manager)   { FactoryGirl.create(:ems_openstack).network_manager }
-      let!(:cloud_network)     { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager) }
       let!(:network_manager_1) { FactoryGirl.create(:ems_openstack).network_manager }
-      let!(:cloud_network_1)   { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager_1) }
 
       context 'with belongs_to_filter' do
         before do
@@ -1254,6 +1252,9 @@ describe Rbac::Filterer do
       end
 
       context 'network manager is tagged' do
+        let!(:cloud_network)     { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager) }
+        let!(:cloud_network_1)   { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager_1) }
+
         before do
           group.entitlement = Entitlement.new
           group.entitlement.set_managed_filters([['/managed/environment/prod']])

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1211,42 +1211,44 @@ describe Rbac::Filterer do
           group.save!
         end
 
-        context 'when records match belognsto filter' do
-          it 'lists cloud networks with network manager according to belongsto filter' do
-            User.with_user(user) do
-              results = described_class.search(:class => CloudNetwork).first
-              expect(results).to match_array([cloud_network])
-              expect(results.first.ext_management_system).to eq(network_manager)
+        describe '.search' do
+          context 'when records match belognsto filter' do
+            it 'lists cloud networks with network manager according to belongsto filter' do
+              User.with_user(user) do
+                results = described_class.search(:class => CloudNetwork).first
+                expect(results).to match_array([cloud_network])
+                expect(results.first.ext_management_system).to eq(network_manager)
+              end
+            end
+
+            it 'lists network manager according to belongsto filter' do
+              User.with_user(user) do
+                results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+                expect(results).to match_array([network_manager])
+              end
             end
           end
 
-          it 'lists network manager according to belongsto filter' do
-            User.with_user(user) do
-              results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
-              expect(results).to match_array([network_manager])
+          context 'when records don\'t match belognsto filter' do
+            before do
+              group.entitlement = Entitlement.new
+              group.entitlement.set_managed_filters([])
+              group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|XXXX"])
+              group.save!
             end
-          end
-        end
 
-        context 'when records don\'t match belognsto filter' do
-          before do
-            group.entitlement = Entitlement.new
-            group.entitlement.set_managed_filters([])
-            group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|XXXX"])
-            group.save!
-          end
-
-          it 'lists no cloud networks' do
-            User.with_user(user) do
-              results = described_class.search(:class => CloudNetwork).first
-              expect(results).to be_empty
+            it 'lists no cloud networks' do
+              User.with_user(user) do
+                results = described_class.search(:class => CloudNetwork).first
+                expect(results).to be_empty
+              end
             end
-          end
 
-          it 'lists no network manager' do
-            User.with_user(user) do
-              results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
-              expect(results).to be_empty
+            it 'lists no network manager' do
+              User.with_user(user) do
+                results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+                expect(results).to be_empty
+              end
             end
           end
         end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1222,11 +1222,21 @@ describe Rbac::Filterer do
 
         NETWORK_MODELS.each do |network_model|
           describe '.search' do
+            let!(:network_object) do
+              return network_manager if network_model == "ManageIQ::Providers::NetworkManager"
+              FactoryGirl.create(network_model.underscore, :ext_management_system => network_manager)
+            end
+
+            let!(:network_object_with_different_network_manager) do
+              return network_manager_1 if network_model == "ManageIQ::Providers::NetworkManager"
+              FactoryGirl.create(network_model.underscore,  :ext_management_system => network_manager_1)
+            end
+
             context 'when records match belognsto filter' do
               it "lists records of #{network_model} manager according to belongsto filter" do
                 User.with_user(user) do
-                  results = described_class.search(:class => CloudNetwork).first
-                  expect(results).to match_array([cloud_network])
+                  results = described_class.search(:class => network_model).first
+                  expect(results).to match_array([network_object])
                   expect(results.first.ext_management_system).to eq(network_manager)
                 end
               end
@@ -1242,7 +1252,7 @@ describe Rbac::Filterer do
 
               it "lists no records of #{network_model}" do
                 User.with_user(user) do
-                  results = described_class.search(:class => CloudNetwork).first
+                  results = described_class.search(:class => network_model).first
                   expect(results).to be_empty
                 end
               end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1197,11 +1197,11 @@ describe Rbac::Filterer do
       end
     end
 
-    context 'with cloud network and network manager' do
+    context "with cloud network and network manager" do
       let!(:network_manager)   { FactoryGirl.create(:ems_openstack).network_manager }
       let!(:network_manager_1) { FactoryGirl.create(:ems_openstack).network_manager }
 
-      context 'with belongs_to_filter' do
+      context "with belongs_to_filter" do
         before do
           group.entitlement = Entitlement.new
           group.entitlement.set_managed_filters([])
@@ -1221,7 +1221,7 @@ describe Rbac::Filterer do
         ).freeze
 
         NETWORK_MODELS.each do |network_model|
-          describe '.search' do
+          describe ".search" do
             let!(:network_object) do
               return network_manager if network_model == "ManageIQ::Providers::NetworkManager"
               FactoryGirl.create(network_model.underscore, :ext_management_system => network_manager)
@@ -1232,7 +1232,7 @@ describe Rbac::Filterer do
               FactoryGirl.create(network_model.underscore,  :ext_management_system => network_manager_1)
             end
 
-            context 'when records match belognsto filter' do
+            context "when records match belogns to filter" do
               it "lists records of #{network_model} manager according to belongsto filter" do
                 User.with_user(user) do
                   results = described_class.search(:class => network_model).first
@@ -1242,7 +1242,7 @@ describe Rbac::Filterer do
               end
             end
 
-            context 'when records don\'t match belognsto filter' do
+            context "when records don't match belogns to filter" do
               before do
                 group.entitlement = Entitlement.new
                 group.entitlement.set_managed_filters([])
@@ -1261,28 +1261,28 @@ describe Rbac::Filterer do
         end
       end
 
-      context 'network manager with/without tagging' do
+      context "network manager with/without tagging" do
         let!(:cloud_network)     { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager) }
         let!(:cloud_network_1)   { FactoryGirl.create(:cloud_network, :ext_management_system => network_manager_1) }
 
-        context 'network manager is tagged' do
+        context "network manager is tagged" do
           before do
             group.entitlement = Entitlement.new
-            group.entitlement.set_managed_filters([['/managed/environment/prod']])
+            group.entitlement.set_managed_filters([["/managed/environment/prod"]])
             group.entitlement.set_belongsto_filters([])
             group.save!
 
-            network_manager.tag_with('/managed/environment/prod', :ns => '*')
+            network_manager.tag_with("/managed/environment/prod", :ns => "*")
           end
 
-          it 'doesn\'t list cloud networks' do
+          it "doesn't list cloud networks" do
             User.with_user(user) do
               results = described_class.search(:class => CloudNetwork).first
               expect(results).to be_empty
             end
           end
 
-          it 'lists only tagged network manager' do
+          it "lists only tagged network manager" do
             User.with_user(user) do
               results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
               expect(results).to match_array([network_manager])
@@ -1290,7 +1290,7 @@ describe Rbac::Filterer do
           end
         end
 
-        context 'network manager not is tagged' do
+        context "network manager not is tagged" do
           before do
             group.entitlement = Entitlement.new
             group.entitlement.set_managed_filters([])
@@ -1298,7 +1298,7 @@ describe Rbac::Filterer do
             group.save!
           end
 
-          it 'lists all cloud networks' do
+          it "lists all cloud networks" do
             User.with_user(user) do
               results = described_class.search(:class => CloudNetwork).first
               expect(results).to match_array(CloudNetwork.all)
@@ -1306,7 +1306,7 @@ describe Rbac::Filterer do
             end
           end
 
-          it 'lists all network managers' do
+          it "lists all network managers" do
             User.with_user(user) do
               results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
               expect(results).to match_array(ManageIQ::Providers::NetworkManager.all)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1225,18 +1225,11 @@ describe Rbac::Filterer do
         NETWORK_MODELS.each do |network_model|
           describe '.search' do
             context 'when records match belognsto filter' do
-              it 'lists cloud networks with network manager according to belongsto filter' do
+              it "lists records of #{network_model} manager according to belongsto filter" do
                 User.with_user(user) do
                   results = described_class.search(:class => CloudNetwork).first
                   expect(results).to match_array([cloud_network])
                   expect(results.first.ext_management_system).to eq(network_manager)
-                end
-              end
-
-              it 'lists network manager according to belongsto filter' do
-                User.with_user(user) do
-                  results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
-                  expect(results).to match_array([network_manager])
                 end
               end
             end
@@ -1249,16 +1242,9 @@ describe Rbac::Filterer do
                 group.save!
               end
 
-              it 'lists no cloud networks' do
+              it "lists no records of #{network_model}" do
                 User.with_user(user) do
                   results = described_class.search(:class => CloudNetwork).first
-                  expect(results).to be_empty
-                end
-              end
-
-              it 'lists no network manager' do
-                User.with_user(user) do
-                  results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
                   expect(results).to be_empty
                 end
               end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1209,26 +1209,15 @@ describe Rbac::Filterer do
           group.save!
         end
 
-        NETWORK_MODELS = %w(
-          CloudNetwork
-          CloudSubnet
-          FloatingIp
-          LoadBalancer
-          NetworkPort
-          NetworkRouter
-          SecurityGroup
-          ManageIQ::Providers::NetworkManager
-        ).freeze
-
-        NETWORK_MODELS.each do |network_model|
+        (described_class::NETWORK_MODELS_FOR_BELONGSTO_FILTER + [ManageIQ::Providers::NetworkManager]).each do |network_model|
           describe ".search" do
             let!(:network_object) do
-              return network_manager if network_model == "ManageIQ::Providers::NetworkManager"
+              return network_manager if network_model == ManageIQ::Providers::NetworkManager
               FactoryGirl.create(network_model.underscore, :ext_management_system => network_manager)
             end
 
             let!(:network_object_with_different_network_manager) do
-              return network_manager_1 if network_model == "ManageIQ::Providers::NetworkManager"
+              return network_manager_1 if network_model == ManageIQ::Providers::NetworkManager
               FactoryGirl.create(network_model.underscore,  :ext_management_system => network_manager_1)
             end
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1250,29 +1250,29 @@ describe Rbac::Filterer do
             end
           end
         end
+      end
 
-        context 'network manager is tagged' do
-          before do
-            group.entitlement = Entitlement.new
-            group.entitlement.set_managed_filters([['/managed/environment/prod']])
-            group.entitlement.set_belongsto_filters([])
-            group.save!
+      context 'network manager is tagged' do
+        before do
+          group.entitlement = Entitlement.new
+          group.entitlement.set_managed_filters([['/managed/environment/prod']])
+          group.entitlement.set_belongsto_filters([])
+          group.save!
 
-            network_manager.tag_with('/managed/environment/prod', :ns => '*')
+          network_manager.tag_with('/managed/environment/prod', :ns => '*')
+        end
+
+        it 'doesn\'t list cloud networks' do
+          User.with_user(user) do
+            results = described_class.search(:class => CloudNetwork).first
+            expect(results).to be_empty
           end
+        end
 
-          it 'doesn\'t list cloud networks' do
-            User.with_user(user) do
-              results = described_class.search(:class => CloudNetwork).first
-              expect(results).to be_empty
-            end
-          end
-
-          it 'lists only tagged network manager' do
-            User.with_user(user) do
-              results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
-              expect(results).to match_array([network_manager])
-            end
+        it 'lists only tagged network manager' do
+          User.with_user(user) do
+            results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+            expect(results).to match_array([network_manager])
           end
         end
       end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1211,43 +1211,56 @@ describe Rbac::Filterer do
           group.save!
         end
 
-        describe '.search' do
-          context 'when records match belognsto filter' do
-            it 'lists cloud networks with network manager according to belongsto filter' do
-              User.with_user(user) do
-                results = described_class.search(:class => CloudNetwork).first
-                expect(results).to match_array([cloud_network])
-                expect(results.first.ext_management_system).to eq(network_manager)
+        NETWORK_MODELS = %w(
+          CloudNetwork
+          CloudSubnet
+          FloatingIp
+          LoadBalancer
+          NetworkPort
+          NetworkRouter
+          SecurityGroup
+          ManageIQ::Providers::NetworkManager
+        ).freeze
+
+        NETWORK_MODELS.each do |network_model|
+          describe '.search' do
+            context 'when records match belognsto filter' do
+              it 'lists cloud networks with network manager according to belongsto filter' do
+                User.with_user(user) do
+                  results = described_class.search(:class => CloudNetwork).first
+                  expect(results).to match_array([cloud_network])
+                  expect(results.first.ext_management_system).to eq(network_manager)
+                end
+              end
+
+              it 'lists network manager according to belongsto filter' do
+                User.with_user(user) do
+                  results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+                  expect(results).to match_array([network_manager])
+                end
               end
             end
 
-            it 'lists network manager according to belongsto filter' do
-              User.with_user(user) do
-                results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
-                expect(results).to match_array([network_manager])
+            context 'when records don\'t match belognsto filter' do
+              before do
+                group.entitlement = Entitlement.new
+                group.entitlement.set_managed_filters([])
+                group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|XXXX"])
+                group.save!
               end
-            end
-          end
 
-          context 'when records don\'t match belognsto filter' do
-            before do
-              group.entitlement = Entitlement.new
-              group.entitlement.set_managed_filters([])
-              group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|XXXX"])
-              group.save!
-            end
-
-            it 'lists no cloud networks' do
-              User.with_user(user) do
-                results = described_class.search(:class => CloudNetwork).first
-                expect(results).to be_empty
+              it 'lists no cloud networks' do
+                User.with_user(user) do
+                  results = described_class.search(:class => CloudNetwork).first
+                  expect(results).to be_empty
+                end
               end
-            end
 
-            it 'lists no network manager' do
-              User.with_user(user) do
-                results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
-                expect(results).to be_empty
+              it 'lists no network manager' do
+                User.with_user(user) do
+                  results = described_class.search(:class => ManageIQ::Providers::NetworkManager).first
+                  expect(results).to be_empty
+                end
               end
             end
           end


### PR DESCRIPTION
same thing as was done in https://github.com/ManageIQ/manageiq/pull/16063
but for other models in Network menu

**belongsto filter** is **H & C tab** in the group setting as is shown on the picture:
![group](https://user-images.githubusercontent.com/14937244/31341758-d7f870b4-ad0a-11e7-8247-34512f7ed8df.png)
**Description of bug:**
We have selected network manager but for some [models](https://github.com/ManageIQ/manageiq/pull/16151/commits/5fa5b38ff41284418ac799a300edd641900fe4d9#diff-8d948055de14ced0e63abf9637a9a788R57) this filter is not applied:
and we have 2 network manager one is openstack and second azure

**before:**
example for CloudSubnet, you can see also CloudSubnet for openstack network manager
<img width="1405" alt="screen shot 2017-10-09 at 16 20 54" src="https://user-images.githubusercontent.com/14937244/31342800-13380560-ad0e-11e7-9804-5d40c4e7afb8.png">

we need to see only Azure's CloudSubnets
so I added this rule other models as we did in https://github.com/ManageIQ/manageiq/pull/16063/
**after:**
<img width="1397" alt="screen shot 2017-10-09 at 16 19 58 1" src="https://user-images.githubusercontent.com/14937244/31342673-cd1da1ac-ad0d-11e7-99c1-416a8ab1ea53.png">

# Links
EUWE BZ:https://bugzilla.redhat.com/show_bug.cgi?id=1465093
FINE BZ:https://bugzilla.redhat.com/show_bug.cgi?id=1463422

@miq-bot add_label blocker, rbac, bug, fine, euwe
@miq-bot assign @gtanzillo 

