### PR TITLE
Add a Subnet model for SCVMM

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -347,7 +347,14 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_lans_inventory(switch, hashes)
-    save_inventory_multi(switch.lans, hashes, :use_association, [:uid_ems])
+    extra_keys = [:parent]
+    child_keys = [:subnets]
+
+    save_inventory_multi(switch.lans, hashes, :use_association, [:uid_ems], child_keys, extra_keys)
+  end
+
+  def save_subnets_inventory(lan, hashes)
+    save_inventory_multi(lan.subnets, hashes, :use_association, [:ems_ref])
   end
 
   def save_storage_files_inventory(storage, hashes)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -49,6 +49,7 @@ class Host < ApplicationRecord
   has_many                  :host_switches, :dependent => :destroy
   has_many                  :switches, :through => :host_switches
   has_many                  :lans,     :through => :switches
+  has_many                  :subnets,  :through => :lans
   has_many                  :networks, :through => :hardware
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy

--- a/app/models/lan.rb
+++ b/app/models/lan.rb
@@ -1,6 +1,7 @@
 class Lan < ApplicationRecord
   belongs_to :switch
 
+  has_many :subnets, :dependent => :destroy
   has_many :guest_devices
   has_many :vms_and_templates, -> { distinct }, :through => :guest_devices
   has_many :vms,               -> { distinct }, :through => :guest_devices

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -16,6 +16,7 @@ module ManageIQ::Providers
     has_many :operating_systems,          :through => :vms_and_templates
     has_many :switches, -> { distinct },  :through => :hosts
     has_many :lans, -> { distinct },      :through => :hosts
+    has_many :subnets, -> { distinct },   :through => :lans
     has_many :networks,                   :through => :hardwares
     has_many :guest_devices,              :through => :hardwares
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -1,0 +1,7 @@
+class Subnet < ApplicationRecord
+  include NewWithTypeStiMixin
+
+  acts_as_miq_taggable
+
+  belongs_to :lan
+end

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -4,6 +4,7 @@ class Switch < ApplicationRecord
 
   has_many :guest_devices
   has_many :lans, :dependent => :destroy
+  has_many :subnets, :through => :lans
 
   acts_as_miq_taggable
 end


### PR DESCRIPTION
This adds the Subnet model and associations for SCVMM networking
Required for: https://github.com/ManageIQ/manageiq-providers-scvmm/pull/15