### PR TITLE
Revert "Merge pull request #16130 from jrafanie/fork_workers_no_more"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-network_discovery",     "~>0.1.2",       :require => false
 gem "mime-types",                     "~>2.6.1",       :path => "mime-types-redirector"
 gem "more_core_extensions",           "~>3.3"
+gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false
 gem "net-ssh",                        "=3.2.0",        :require => false

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -55,7 +55,7 @@ ENV["BUNDLER_GROUPS"] = MIQ_WORKER_TYPES[worker_class].join(',')
 require File.expand_path("../../../config/environment", __dir__)
 
 worker_class = worker_class.constantize
-worker_class.preload_for_worker_role if worker_class.respond_to?(:preload_for_worker_role)
+worker_class.before_fork
 unless options[:dry_run]
   create_options = {:pid => Process.pid}
   runner_options = {}


### PR DESCRIPTION
Reverting for now since worker_options for spawn were not properly being
passed to the run_single_worker script, specifically the ems_id.

This reverts commit f885db28c163a9b5c21cd72532bc54abd88175d0, reversing
changes made to b7a986d611b350cfb69e41ffaa8092b9dd00cdbc.