### PR TITLE
Allow the request_update to update user_message

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -486,11 +486,8 @@ class MiqRequest < ApplicationRecord
 
   def update_request(values, requester)
     update_attributes(:options => options.merge(values))
-    if values[:user_message].present? && values.keys.length == 1
-      self.user_message = values[:user_message]
-    else
-      after_update_options(requester)
-    end
+    self.user_message = values[:user_message] if values[:user_message].present?
+    after_update_options(requester) unless values.keys == [:user_message]
     self
   end
   api_relay_method(:update_request, :edit) do |values, requester|

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -430,17 +430,32 @@ describe MiqRequest do
   end
 
   context "#update_request" do
-    let(:msg) { "Yabba Dabba Doo" }
-    it "user_message" do
+    before do
       allow(MiqServer).to receive(:my_zone).and_return("New York")
-      request = FactoryGirl.create(:miq_provision_request,
-                                   :requester => fred,
-                                   :options   => {:a => "1"})
+    end
+
+    let(:request) do
+      FactoryGirl.create(:miq_provision_request,
+                         :requester => fred,
+                         :options   => {:a => "1"})
+    end
+
+    it "user_message" do
+      msg = "Yabba Dabba Doo"
       request.update_request({:user_message => msg}, fred)
 
       request.reload
       expect(request.options[:user_message]).to eq(msg)
       expect(request.message).to eq(msg)
+    end
+
+    it "truncates long messages" do
+      msg = "Yabba Dabba Doo" * 30
+      request.update_request({:user_message => msg}, fred)
+
+      request.reload
+      expect(request.options[:user_message].length).to eq(255)
+      expect(request.message.length).to eq(255)
     end
   end
 end

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -428,4 +428,19 @@ describe MiqRequest do
       expect(request.get_user.current_group).to eq(group1)
     end
   end
+
+  context "#update_request" do
+    let(:msg) { "Yabba Dabba Doo" }
+    it "user_message" do
+      allow(MiqServer).to receive(:my_zone).and_return("New York")
+      request = FactoryGirl.create(:miq_provision_request,
+                                   :requester => fred,
+                                   :options   => {:a => "1"})
+      request.update_request({:user_message => msg}, fred)
+
+      request.reload
+      expect(request.options[:user_message]).to eq(msg)
+      expect(request.message).to eq(msg)
+    end
+  end
 end

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -442,6 +442,7 @@ describe MiqRequest do
 
     it "user_message" do
       msg = "Yabba Dabba Doo"
+      expect(request).not_to receive(:after_update_options)
       request.update_request({:user_message => msg}, fred)
 
       request.reload
@@ -451,11 +452,19 @@ describe MiqRequest do
 
     it "truncates long messages" do
       msg = "Yabba Dabba Doo" * 30
+      expect(request).not_to receive(:after_update_options)
       request.update_request({:user_message => msg}, fred)
 
       request.reload
       expect(request.options[:user_message].length).to eq(255)
       expect(request.message.length).to eq(255)
+    end
+
+    it "non user_message should call after_update_options" do
+      expect(request).to receive(:after_update_options)
+      request.update_request({:abc => 1}, fred)
+
+      expect(request.options[:abc]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
This PR allows the caller to update the user_message options hash and the message attribute in the MiqRequest object.

This allows us to update the user_message from the REST API by passing in the options[:user_message].

Needed for Ansible Playbook to update the user_message which is displayed in our UI.