### PR TITLE
Remove .try().try from vmware prototype settings

### DIFF
--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -6,7 +6,7 @@ class MiqEmsRefreshCoreWorker < MiqWorker
   self.required_roles = ["ems_inventory"]
 
   def self.has_required_role?
-    return false if Settings.prototype.try(:ems_vmware).try(:update_driven_refresh)
+    return false if Settings.prototype.ems_vmware.update_driven_refresh
     super
   end
 

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -8,7 +8,7 @@ class MiqVimBrokerWorker < MiqWorker
       smartproxy
       smartstate
     ).tap do |roles|
-      roles << 'ems_inventory' unless Settings.prototype.try(:ems_vmware).try(:update_driven_refresh)
+      roles << 'ems_inventory' unless Settings.prototype.ems_vmware.update_driven_refresh
     end
   }
 

--- a/app/models/miq_vim_broker_worker/runner.rb
+++ b/app/models/miq_vim_broker_worker/runner.rb
@@ -46,7 +46,7 @@ class MiqVimBrokerWorker::Runner < MiqWorker::Runner
   end
 
   def has_ems_inventory_role?
-    @active_roles.include?("ems_inventory") && !Settings.prototype.try(:ems_vmware).try(:update_driven_refresh)
+    @active_roles.include?("ems_inventory") && !Settings.prototype.ems_vmware.update_driven_refresh
   end
 
   def reset_broker_update_notification


### PR DESCRIPTION
Now that the ems_vmware prototype is in we can get rid of the try from
the broker and core worker.

Ref: https://github.com/ManageIQ/manageiq-providers-vmware/pull/76#issuecomment-319410206
> Can you also change app/models/miq_ems_refresh_core_worker.rb to get rid of the .try.try.try?