### PR TITLE
Adding default filters configuration to physical servers

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -48,6 +48,7 @@
 - MiqWorker
 - OrchestrationStack
 - OrchestrationTemplate
+- PhysicalServer
 - PolicyEvent
 - ResourcePool
 - SecurityGroup

--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -1284,9 +1284,6 @@
           value: "waiting"
     search_type: default
     db: Container
-
-# Physical Servers default filters (Testados)
-
 - attributes:
     name: default_Over Sized
     description: Over Sized
@@ -1335,5 +1332,38 @@
             value: ""
     search_type: default
     db: PhysicalServer
-
-# Physical Servers default filters (Testando)
+- attributes:
+    name: default_Under Allocated
+    description: Under Allocated
+    filter: !ruby/object:MiqExpression
+      exp:
+        and:
+        - "<=":
+            field: PhysicalServer.hardware-v_pct_free_disk_space
+            value: 35
+        - IS NOT EMPTY:
+            field: PhysicalServer.hardware-v_pct_free_disk_space
+            value: ""
+    search_type: default
+    db: PhysicalServer
+- attributes:
+    name: default_Guest OS / Windows
+    description: Guest OS / Windows
+    filter: !ruby/object:MiqExpression
+      exp:
+        INCLUDES:
+          field: PhysicalServer.computer_system.operating_system-product_name
+          value: Win
+    search_type: default
+    db: PhysicalServer
+- attributes:
+    name: default_Guest OS / Linux
+    description: Guest OS / Linux
+    filter: !ruby/object:MiqExpression
+      exp:
+        not:
+          INCLUDES:
+            field: PhysicalServer.computer_system.operating_system-product_name
+            value: Win
+    search_type: default
+    db: PhysicalServer

--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -1319,6 +1319,17 @@
     search_type: default
     db: PhysicalServer
 - attributes:
+    name: default_Status / Stopped
+    description: Status / Stopped
+    filter: !ruby/object:MiqExpression
+      exp:
+        not:
+          INCLUDES:
+            field: PhysicalServer-power_state
+            value: "on"
+    search_type: default
+    db: PhysicalServer
+- attributes:
     name: default_Over Allocated
     description: Over Allocated
     filter: !ruby/object:MiqExpression

--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -1284,3 +1284,56 @@
           value: "waiting"
     search_type: default
     db: Container
+
+# Physical Servers default filters (Testados)
+
+- attributes:
+    name: default_Over Sized
+    description: Over Sized
+    filter: !ruby/object:MiqExpression
+      exp:
+        and:
+        - ">=":
+            field: PhysicalServer.hardware-disk_capacity
+            value: 50039280896
+        - IS NOT EMPTY:
+            field: PhysicalServer.hardware-v_pct_free_disk_space
+            value: ""
+    search_type: default
+    db: PhysicalServer
+- attributes:
+    name: default_Platform / Lenovo
+    description: Platform / Lenovo
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: PhysicalServer-type
+          value: ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer
+    search_type: default
+    db: PhysicalServer
+- attributes:
+    name: default_Status / Running
+    description: Status / Running
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: PhysicalServer-power_state
+          value: "on"
+    search_type: default
+    db: PhysicalServer
+- attributes:
+    name: default_Over Allocated
+    description: Over Allocated
+    filter: !ruby/object:MiqExpression
+      exp:
+        and:
+        - ">=":
+            field: PhysicalServer.hardware-v_pct_free_disk_space
+            value: 50
+        - IS NOT EMPTY:
+            field: PhysicalServer.hardware-v_pct_free_disk_space
+            value: ""
+    search_type: default
+    db: PhysicalServer
+
+# Physical Servers default filters (Testando)


### PR DESCRIPTION
**Requisites**

run `bundle exec rake db:seed`

**It is dependency for**

https://github.com/ManageIQ/manageiq-ui-classic/pull/2338

This PR is able to:

- Add some searches for the physical servers filters.