### PR TITLE
bug 1494442: fix attach/detach disks automate methods

### DIFF
--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -92,7 +92,7 @@ module VmOrTemplate::Operations::Configuration
 
   def raw_attach_volume(volume_id, device = nil)
     raise _("VM has no EMS, unable to attach volume") unless ext_management_system
-    run_command_via_parent(:vm_attach_volume, :volume_id, :device)
+    run_command_via_parent(:vm_attach_volume, :volume_id => volume_id, :device => device)
   end
 
   def attach_volume(volume_id, device = nil)
@@ -101,7 +101,7 @@ module VmOrTemplate::Operations::Configuration
 
   def raw_detach_volume(volume_id)
     raise _("VM has no EMS, unable to detach volume") unless ext_management_system
-    run_command_via_parent(:vm_detach_volume, :volume_id)
+    run_command_via_parent(:vm_detach_volume, :volume_id => volume_id)
   end
 
   def detach_volume(volume_id, device = nil)


### PR DESCRIPTION
Fix for bug 1494442 - symbol conversion error while detaching disks
  from an openstack instance

https://bugzilla.redhat.com/show_bug.cgi?id=1494442

This depends on OpenStack provider pull request: https://github.com/ManageIQ/manageiq-providers-openstack/pull/112