### PR TITLE
Directly run a playbook

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/inventory.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/inventory.rb
@@ -1,2 +1,12 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Inventory < ManageIQ::Providers::EmbeddedAutomationManager::InventoryRootGroup
+  def self.raw_create_inventory(tower, inventory_name, hosts)
+    miq_org = tower.provider.default_organization
+    tower.with_provider_connection do |connection|
+      connection.api.inventories.create!(:name => inventory_name, :organization => miq_org).tap do |inventory|
+        hosts.split(',').each do |host|
+          connection.api.hosts.create!(:name => host, :inventory => inventory.id)
+        end
+      end
+    end
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -2,4 +2,46 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook <
   ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
 
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
+
+  def run(options, userid = nil)
+    options[:playbook_id] = id
+    options[:userid]      = userid || 'system'
+    options[:name]        = "Playbook: #{name}"
+    miq_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner.create_job(options)
+    miq_job.signal(:start)
+    miq_job.miq_task.id
+  end
+
+  # return provider raw object
+  def raw_create_job_template(options)
+    job_template_klass = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript
+    job_template_klass.raw_create_in_provider(manager, build_parameter_list(options))
+  end
+
+  private
+
+  def build_parameter_list(options)
+    params = {
+      :name                     => options[:template_name] || "#{name}_#{Time.zone.now.to_i}",
+      :description              => options[:description] || '',
+      :project                  => configuration_script_source.manager_ref,
+      :playbook                 => name,
+      :become_enabled           => options[:become_enabled].present?,
+      :verbosity                => options[:verbosity].presence || 0,
+      :ask_variables_on_launch  => true,
+      :ask_limit_on_launch      => true,
+      :ask_inventory_on_launch  => true,
+      :ask_credential_on_launch => true,
+      :limit                    => options[:limit],
+      :inventory                => options[:inventory] || manager.provider.default_inventory,
+      :extra_vars               => options[:extra_vars].try(:to_json)
+    }
+
+    %i(credential cloud_credential network_credential).each do |credential|
+      cred_sym = "#{credential}_id".to_sym
+      params[credential] = Authentication.find(options[cred_sym]).manager_ref if options[cred_sym]
+    end
+
+    params.compact
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -1,0 +1,140 @@
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < ::Job
+  # options are job table columns, including options column which is the playbook context info
+  def self.create_job(options)
+    super(name, options)
+  end
+
+  def start
+    time = Time.zone.now
+    update_attributes(:started_on => time)
+    miq_task.update_attributes(:started_on => time)
+    if options[:inventory]
+      queue_signal(:create_job_template)
+    else
+      queue_signal(:create_inventory)
+    end
+  end
+
+  def create_inventory
+    set_status('creating inventory')
+    tower = playbook.manager
+    hosts = options[:hosts] || options.fetch_path(:extra_vars, :hosts)
+    options[:inventory] =
+      if hosts == 'localhost' || hosts.nil?
+        tower.provider.default_inventory
+      else
+        inventory_name = "#{playbook.name}_#{Time.zone.now.to_i}"
+        ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Inventory.raw_create_inventory(tower, inventory_name, hosts).id
+      end
+    save!
+    queue_signal(:create_job_template)
+  rescue => err
+    _log.log_backtrace(err)
+    queue_signal(:post_ansible_run, err.message, 'error')
+  end
+
+  def create_job_template
+    set_status('creating job template')
+    raw_job_template = playbook.raw_create_job_template(options)
+    options[:job_template_ref] = raw_job_template.id
+    save!
+
+    queue_signal(:launch_ansible_tower_job)
+  rescue => err
+    _log.log_backtrace(err)
+    queue_signal(:post_ansible_run, err.message, 'error')
+  end
+
+  def launch_ansible_tower_job
+    set_status('launching tower job')
+    job_template = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.new(
+      :manager     => playbook.manager,
+      :manager_ref => options[:job_template_ref],
+      :variables   => {}
+    )
+    launch_options = options.slice(:extra_vars, :limit)
+    tower_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create_job(job_template, launch_options)
+    options[:tower_job_id] = tower_job.id
+    self.name = "#{name}, Job ID: #{tower_job.id}"
+    miq_task.update_attributes(:name => name)
+    save!
+
+    queue_signal(:poll_ansible_tower_job_status, 10)
+  rescue => err
+    _log.log_backtrace(err)
+    queue_signal(:post_ansible_run, err.message, 'error')
+  end
+
+  def poll_ansible_tower_job_status(interval)
+    set_status('waiting for tower job to complete')
+
+    tower_job_status = tower_job.raw_status
+    if tower_job_status.completed?
+      tower_job.refresh_ems
+      if tower_job_status.succeeded?
+        queue_signal(:post_ansible_run, 'Playbook ran successfully', 'ok')
+      else
+        queue_signal(:post_ansible_run, 'Ansible engine returned an error for the job', 'error')
+      end
+    else
+      interval = 60 if interval > 60
+      queue_signal(:poll_ansible_tower_job_status, interval * 2, :deliver_on => Time.now.utc + interval)
+    end
+  rescue => err
+    _log.log_backtrace(err)
+    queue_signal(:post_ansible_run, err.message, 'error')
+  end
+
+  def post_ansible_run(*args)
+    # delete inventory, job_template, job?
+    queue_signal(:finish, *args)
+  end
+
+  alias_method :initializing, :dispatch_start
+  alias_method :finish,       :process_finished
+  alias_method :abort_job,    :process_abort
+  alias_method :cancel,       :process_cancel
+  alias_method :error,        :process_error
+
+  private
+
+  def load_transitions
+    self.state ||= 'initialize'
+
+    {
+      :initializing                  => {'initialize'       => 'waiting_to_start'},
+      :start                         => {'waiting_to_start' => 'running'},
+      :create_inventory              => {'running'          => 'inventory'},
+      :create_job_template           => {'inventory'        => 'job_template', 'running' => 'job_template'},
+      :launch_ansible_tower_job      => {'job_template'     => 'ansible_job'},
+      :poll_ansible_tower_job_status => {'ansible_job'      => 'ansible_job'},
+      :post_ansible_run              => {'inventory'        => 'ansible_done', 'job_template' => 'ansible_done', 'ansible_job' => 'ansible_done'},
+      :finish                        => {'*'                => 'finished'},
+      :abort_job                     => {'*'                => 'aborting'},
+      :cancel                        => {'*'                => 'canceling'},
+      :error                         => {'*'                => '*'}
+    }
+  end
+
+  def queue_signal(*args, deliver_on: nil)
+    priority = options[:priority] || MiqQueue::NORMAL_PRIORITY
+
+    MiqQueue.put(
+      :class_name  => self.class.name,
+      :method_name => "signal",
+      :instance_id => id,
+      :priority    => priority,
+      :role        => 'embedded_ansible',
+      :args        => args,
+      :deliver_on  => deliver_on
+    )
+  end
+
+  def playbook
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook.find(options[:playbook_id])
+  end
+
+  def tower_job
+    ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.find(options[:tower_job_id])
+  end
+end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -1,0 +1,257 @@
+describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner do
+  let(:manager)  { FactoryGirl.create(:embedded_automation_manager_ansible) }
+  let(:playbook) { FactoryGirl.create(:embedded_playbook, :manager => manager) }
+  subject { ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner.create_job(options.merge(:playbook_id => playbook.id)) }
+
+  describe '#start' do
+    context 'inventory is given' do
+      let(:options) { {:inventory => '3'} }
+
+      it 'moves on to create_job_template' do
+        expect(subject).to receive(:queue_signal).with(:create_job_template)
+        subject.start
+      end
+    end
+
+    context 'hosts are given' do
+      let(:options) { {:hosts => 'host1,localhost'} }
+
+      it 'moves on to create inventory' do
+        expect(subject).to receive(:queue_signal).with(:create_inventory)
+        subject.start
+      end
+    end
+  end
+
+  describe '#create_inventory' do
+    context 'localhost is used' do
+      let(:options) { {:hosts => 'localhost'} }
+
+      it 'uses default inventory and moves on to create_job_template' do
+        allow(subject).to receive(:playbook).and_return(double(:manager => double(:provider => double(:default_inventory => 'default'))))
+        expect(subject).to receive(:queue_signal).with(:create_job_template)
+        subject.create_inventory
+        expect(subject.options).to have_attributes(:inventory => 'default')
+      end
+    end
+
+    context 'other hosts are used' do
+      let(:options) { {:hosts => 'host1,host2'} }
+
+      it 'creates an inventory and moves on to create_job_template' do
+        expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Inventory).to receive(:raw_create_inventory).and_return(double(:id => 'inv1'))
+        expect(subject).to receive(:queue_signal).with(:create_job_template)
+        subject.create_inventory
+        expect(subject.options[:inventory]).to eq('inv1')
+      end
+    end
+
+    context 'error is raised' do
+      let(:options) { {:hosts => 'host1,host2'} }
+
+      it 'moves on to post_ansible_run' do
+        allow(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Inventory).to receive(:raw_create_inventory).and_raise("can't complete the request")
+        expect(subject).to receive(:queue_signal).with(:post_ansible_run, "can't complete the request", "error")
+        subject.create_inventory
+      end
+    end
+  end
+
+  describe '#create_job_template' do
+    before { allow(subject).to receive(:playbook).and_return(playbook) }
+    let(:options) { {:playbook_id => playbook.id, :inventory => 'inv1'} }
+
+    context 'options are enough to cretate job template' do
+      it 'creates a job template and moves on to launch_ansible_tower_job' do
+        allow(playbook).to receive(:raw_create_job_template).and_return(double(:id => 'jt_ref'))
+        expect(subject).to receive(:queue_signal).with(:launch_ansible_tower_job)
+        subject.create_job_template
+        expect(subject.options).to have_attributes(:job_template_ref => 'jt_ref')
+      end
+    end
+
+    context 'error is raised' do
+      it 'moves on to post_ansible_run' do
+        allow(playbook).to receive(:raw_create_job_template).and_raise("can't complete the request")
+        expect(subject).to receive(:queue_signal).with(:post_ansible_run, "can't complete the request", "error")
+        subject.create_job_template
+      end
+    end
+  end
+
+  describe '#launch_ansible_tower_job' do
+    let(:options) { {:job_template_ref => 'jt1'} }
+
+    context 'job template is ready' do
+      it 'launches a job and moves on to poll_ansible_tower_job_status' do
+        expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job).and_return(double(:id => 'jb1'))
+        expect(subject).to receive(:queue_signal).with(:poll_ansible_tower_job_status, kind_of(Integer))
+        subject.launch_ansible_tower_job
+        expect(subject.options[:tower_job_id]).to eq('jb1')
+      end
+    end
+
+    context 'error is raised' do
+      it 'moves on to post_ansible_run' do
+        allow(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job).and_raise("can't complete the request")
+        expect(subject).to receive(:queue_signal).with(:post_ansible_run, "can't complete the request", "error")
+        subject.launch_ansible_tower_job
+      end
+    end
+  end
+
+  describe '#poll_ansible_tower_job_status' do
+    let(:options) { {:tower_job_id => 'jb1'} }
+
+    context 'tower job is still running' do
+      before { allow(subject).to receive(:tower_job).and_return(double(:raw_status => double(:completed? => false))) }
+
+      it 'requeues for later poll' do
+        expect(subject).to receive(:queue_signal).with(:poll_ansible_tower_job_status, 20, kind_of(Hash))
+        subject.poll_ansible_tower_job_status(10)
+      end
+    end
+
+    context 'tower job finishes normally' do
+      before { allow(subject).to receive(:tower_job).and_return(double(:raw_status => double(:completed? => true, :succeeded? => true), :refresh_ems => nil)) }
+
+      it 'moves on to post_ansible_run with ok status' do
+        expect(subject).to receive(:queue_signal).with(:post_ansible_run, kind_of(String), 'ok')
+        subject.poll_ansible_tower_job_status(10)
+      end
+    end
+
+    context 'tower job fails' do
+      before { allow(subject).to receive(:tower_job).and_return(double(:raw_status => double(:completed? => true, :succeeded? => false), :refresh_ems => nil)) }
+
+      it 'moves on to post_ansible_run with error status' do
+        expect(subject).to receive(:queue_signal).with(:post_ansible_run, kind_of(String), 'error')
+        subject.poll_ansible_tower_job_status(10)
+      end
+    end
+
+    context 'error is raised' do
+      before { allow(subject).to receive(:tower_job).and_raise('internal error') }
+
+      it 'moves on to post_ansible_run with error message' do
+        expect(subject).to receive(:queue_signal).with(:post_ansible_run, 'internal error', 'error')
+        subject.poll_ansible_tower_job_status(10)
+      end
+    end
+  end
+
+  describe 'state transitions' do
+    let(:options) { {} }
+
+    %w(start create_inventory create_job_template launch_ansible_tower_job poll_ansible_tower_job_status post_ansible_run finish abort_job cancel error).each do |signal|
+      shared_examples_for "allows #{signal} signal" do
+        it signal.to_s do
+          expect(subject).to receive(signal.to_sym)
+          subject.signal(signal.to_sym)
+        end
+      end
+    end
+
+    %w(start create_inventory create_job_template launch_ansible_tower_job poll_ansible_tower_job_status post_ansible_run).each do |signal|
+      shared_examples_for "does not allow #{signal} signal" do
+        it signal.to_s do
+          expect { subject.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{subject.state}/)
+        end
+      end
+    end
+
+    context 'in waiting_to_start state' do
+      before { subject.state = 'waiting_to_start' }
+
+      it_behaves_like 'allows start signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'does not allow create_inventory signal'
+      it_behaves_like 'does not allow create_job_template signal'
+      it_behaves_like 'does not allow launch_ansible_tower_job signal'
+      it_behaves_like 'does not allow poll_ansible_tower_job_status signal'
+      it_behaves_like 'does not allow post_ansible_run signal'
+    end
+
+    context 'in running state' do
+      before { subject.state = 'running' }
+
+      it_behaves_like 'allows create_inventory signal'
+      it_behaves_like 'allows create_job_template signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'does not allow start signal'
+      it_behaves_like 'does not allow launch_ansible_tower_job signal'
+      it_behaves_like 'does not allow poll_ansible_tower_job_status signal'
+      it_behaves_like 'does not allow post_ansible_run signal'
+    end
+
+    context 'in inventory state' do
+      before { subject.state = 'inventory' }
+
+      it_behaves_like 'allows create_job_template signal'
+      it_behaves_like 'allows post_ansible_run signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'does not allow start signal'
+      it_behaves_like 'does not allow create_inventory signal'
+      it_behaves_like 'does not allow launch_ansible_tower_job signal'
+      it_behaves_like 'does not allow poll_ansible_tower_job_status signal'
+    end
+
+    context 'in job_template state' do
+      before { subject.state = 'job_template' }
+
+      it_behaves_like 'allows launch_ansible_tower_job signal'
+      it_behaves_like 'allows post_ansible_run signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'does not allow start signal'
+      it_behaves_like 'does not allow create_inventory signal'
+      it_behaves_like 'does not allow create_job_template signal'
+      it_behaves_like 'does not allow poll_ansible_tower_job_status signal'
+    end
+
+    context 'in ansible_job state' do
+      before { subject.state = 'ansible_job' }
+
+      it_behaves_like 'allows poll_ansible_tower_job_status signal'
+      it_behaves_like 'allows post_ansible_run signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'does not allow start signal'
+      it_behaves_like 'does not allow create_inventory signal'
+      it_behaves_like 'does not allow create_job_template signal'
+      it_behaves_like 'does not allow launch_ansible_tower_job signal'
+    end
+
+    context 'in ansible_done state' do
+      before { subject.state = 'ansible_done' }
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'does not allow start signal'
+      it_behaves_like 'does not allow create_inventory signal'
+      it_behaves_like 'does not allow launch_ansible_tower_job signal'
+      it_behaves_like 'does not allow poll_ansible_tower_job_status signal'
+      it_behaves_like 'does not allow post_ansible_run signal'
+    end
+  end
+end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -1,0 +1,30 @@
+describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
+  let(:manager) { FactoryGirl.create(:embedded_automation_manager_ansible) }
+  subject { FactoryGirl.create(:embedded_playbook, :manager => manager) }
+
+  describe '#run' do
+    it 'delegates request to playbook runner' do
+      double_return = double(:signal => nil, :miq_task => double(:id => 'tid'))
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner)
+        .to receive(:create_job).with(hash_including(:playbook_id => subject.id, :userid => 'system')).and_return(double_return)
+      expect(subject.run({})).to eq('tid')
+    end
+  end
+
+  describe '#raw_create_job_template' do
+    it 'delegates request to job template raw creation' do
+      options = {:inventory => 'inv', :extra_vars => {'a' => 'x'} }
+      option_matcher = hash_including(
+        :inventory  => 'inv',
+        :extra_vars => '{"a":"x"}',
+        :playbook   => subject.name,
+        :project    => 'mref'
+      )
+
+      allow(subject).to receive(:configuration_script_source).and_return(double(:manager_ref => 'mref'))
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
+        .to receive(:raw_create_in_provider).with(instance_of(manager.class), option_matcher)
+      subject.raw_create_job_template(options)
+    end
+  end
+end


### PR DESCRIPTION
Replaces #16060
Usage: `ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook#run(options, userid)`
The return is a task id that you can use to track the playbook execution progress. 

Has dependency on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/25