### PR TITLE
Create a virtual column for `picture_url_path`

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -37,6 +37,9 @@ class GenericObjectDefinition < ApplicationRecord
   delegate :count, :to => :generic_objects, :prefix => true, :allow_nil => false
   virtual_column :generic_objects_count, :type => :integer
 
+  delegate :url_path, :to => :picture, :prefix => true, :allow_nil => true
+  virtual_column :picture_url_path, :type => :string
+
   FEATURES.each do |feature|
     define_method("property_#{feature}s") do
       return errors[:properties] if properties_changed? && !valid?


### PR DESCRIPTION
The virtual column for `picture_url_path` will assist in fetching the url path for the Picture associated with a `Generic Object Definition` record using the following `GET` API -

```
GET /api/generic_object_definitions/<id>?attributes=picture_url_path
```

https://www.pivotaltracker.com/n/projects/1613907/stories/151742686