### PR TITLE
Fix Product Features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6298,7 +6298,7 @@
       :description: Display Individual Physical Server
       :feature_type: view
       :identifier: physical_server_show
-      :name: Timeline
+    - :name: Timeline
       :description: Display Timelines for Physical Servers
       :feature_type: view
       :identifier: physical_server_timeline


### PR DESCRIPTION
This [commit](https://github.com/ManageIQ/manageiq/commit/b435fd566459f8cc56adb330a0aa6760d08b598a) broke the api specs, as it's missing a hyphen at the beginning of a new product feature

related w/ broken specs: https://github.com/ManageIQ/manageiq-api/pull/116

@miq-bot add_label bug
@miq-bot assign @agrare 
