### PR TITLE
Remove duplicate metric_rollups not dealing with active relation

### DIFF
--- a/app/models/metric/helper.rb
+++ b/app/models/metric/helper.rb
@@ -121,7 +121,7 @@ module Metric::Helper
 
   def self.remove_duplicate_timestamps(recs)
     if recs.respond_to?(:klass) # active record relation
-      return recs unless recs.klass.kind_of?(Metric) || recs.klass.kind_of?(MetricRollup)
+      return recs unless recs.klass <= Metric || recs.klass <= MetricRollup
     elsif recs.empty? || !recs.all? { |r| r.kind_of?(Metric) || r.kind_of?(MetricRollup) }
       return recs 
     end

--- a/spec/models/metric/helper_spec.rb
+++ b/spec/models/metric/helper_spec.rb
@@ -29,6 +29,11 @@ describe Metric::Helper do
       expect(recs).to match_array([metric_rollup_1, metric_rollup_3])
     end
 
+    it "dedups a given scope" do
+      recs = described_class.remove_duplicate_timestamps(MetricRollup.where(:id => [metric_rollup_1, metric_rollup_2, metric_rollup_3]))
+      expect(recs).to match_array([metric_rollup_1, metric_rollup_3])
+    end
+
     it "returns only unique records and merge values with the same timestamp" do
       metric_rollup_1.cpu_usage_rate_average = nil
       metric_rollup_1.save


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1463165

Duplicated rollup records are still there in reports.

