### PR TITLE
Refactor #values and #raw_values methods to improve default value setup

### DIFF
--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -4,7 +4,7 @@ class DialogFieldSortedItem < DialogField
   def initialize_with_values(dialog_values)
     if load_values_on_init?
       raw_values
-      @value = value_from_dialog_fields(dialog_values) || default_value
+      @value = value_from_dialog_fields(dialog_values) || default_value_if_included
     else
       @raw_values = initial_values
     end
@@ -32,10 +32,8 @@ class DialogFieldSortedItem < DialogField
     options[:sort_order] = value.to_sym
   end
 
-  # Sort values before sending back
   def values
-    values_data = raw_values
-    sort_data(values_data)
+    raw_values
   end
 
   def get_default_value
@@ -79,6 +77,14 @@ class DialogFieldSortedItem < DialogField
 
   private
 
+  def add_nil_option
+    @raw_values.unshift(nil_option).reject!(&:empty?)
+  end
+
+  def default_value_if_included
+    default_value if default_value_included?(@raw_values)
+  end
+
   def sort_data(data_to_sort)
     return data_to_sort if sort_by == :none
 
@@ -89,12 +95,22 @@ class DialogFieldSortedItem < DialogField
     data_to_sort
   end
 
+  def determine_selected_default_value
+    use_first_value_as_default unless default_value_included?(@raw_values)
+    self.value ||= default_value.nil? && data_type == "integer" ? nil : default_value.send(value_modifier)
+  end
+
   def raw_values
     @raw_values ||= dynamic ? values_from_automate : static_raw_values
-    use_first_value_as_default unless default_value_included?(@raw_values)
-    self.value ||= default_value.send(value_modifier)
-
+    reject_extranneous_nil_values unless dynamic?
+    @raw_values = sort_data(@raw_values)
+    add_nil_option unless dynamic?
+    determine_selected_default_value
     @raw_values
+  end
+
+  def reject_extranneous_nil_values
+    @raw_values = @raw_values.reject { |value| value[0].nil? }
   end
 
   def use_first_value_as_default
@@ -106,7 +122,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def static_raw_values
-    self[:values].to_miq_a.reject { |value| value[0].nil? }.unshift(nil_option).reject(&:empty?)
+    self[:values].to_miq_a.reject { |value| value[0].nil? }.reject(&:empty?)
   end
 
   def initial_values

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -1,62 +1,139 @@
 describe DialogFieldDropDownList do
   context "dialog_field_drop_down_list" do
-    before(:each) do
-      @df = FactoryGirl.create(:dialog_field_sorted_item, :label => 'drop_down_list', :name => 'drop_down_list')
+    let(:data_type) { "string" }
+    let(:sort_by) { :description }
+    let(:sort_order) { :ascending }
+    before do
+      @df = FactoryGirl.create(:dialog_field_sorted_item,
+                               :label      => 'drop_down_list',
+                               :name       => 'drop_down_list',
+                               :data_type  => data_type,
+                               :sort_by    => sort_by,
+                               :sort_order => sort_order)
     end
 
-    it "sort_by" do
-      expect(@df.sort_by).to eq(:description)
-      @df.sort_by = :none
-      expect(@df.sort_by).to eq(:none)
-      @df.sort_by = :value
-      expect(@df.sort_by).to eq(:value)
-      expect { @df.sort_by = :data }.to raise_error(RuntimeError)
-      expect(@df.sort_by).to eq(:value)
+    describe "#sort_by" do
+      it "allows setters and getters" do
+        expect(@df.sort_by).to eq(:description)
+        @df.sort_by = :none
+        expect(@df.sort_by).to eq(:none)
+        @df.sort_by = :value
+        expect(@df.sort_by).to eq(:value)
+        expect { @df.sort_by = :data }.to raise_error(RuntimeError)
+        expect(@df.sort_by).to eq(:value)
+      end
     end
 
-    it "sort_order" do
-      expect(@df.sort_order).to eq(:ascending)
-      @df.sort_order = :descending
-      expect(@df.sort_order).to eq(:descending)
-      expect { @df.sort_order = :mixed }.to raise_error(RuntimeError)
-      expect(@df.sort_order).to eq(:descending)
+    describe "#sort_order" do
+      it "allows setters and getters" do
+        expect(@df.sort_order).to eq(:ascending)
+        @df.sort_order = :descending
+        expect(@df.sort_order).to eq(:descending)
+        expect { @df.sort_order = :mixed }.to raise_error(RuntimeError)
+        expect(@df.sort_order).to eq(:descending)
+      end
     end
 
-    it "return sorted values array as strings" do
-      @df.data_type = "string"
-      @df.values = [%w(2 Y), %w(1 Z), %w(3 X)]
-      expect(@df.values).to eq([[nil, "<None>"], %w(3 X), %w(2 Y), %w(1 Z)])
-      @df.sort_order = :descending
-      expect(@df.values).to eq([%w(1 Z), %w(2 Y), %w(3 X), [nil, "<None>"]])
+    describe "sorting #values" do
+      before do
+        @df.values = [%w(2 Y), %w(1 Z), %w(3 X)]
+      end
 
-      @df.sort_by = :value
-      @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], %w(1 Z), %w(2 Y), %w(3 X)])
-      @df.sort_order = :descending
-      expect(@df.values).to eq([%w(3 X), %w(2 Y), %w(1 Z), [nil, "<None>"]])
+      context "when the data type is a string" do
+        let(:data_type) { "string" }
 
-      @df.sort_by = :none
-      @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
-      @df.sort_order = :descending
-      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
-    end
+        context "when sorting by description" do
+          context "when sorting ascending" do
+            it "returns the sorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(3 X), %w(2 Y), %w(1 Z)])
+            end
+          end
 
-    it "return sorted values array as integers" do
-      @df.data_type = "integer"
-      @df.values = [%w(2 Y), %w(10 Z), %w(3 X)]
+          context "when sorting descending" do
+            let(:sort_order) { :descending }
 
-      @df.sort_by = :value
-      @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(3 X), %w(10 Z)])
-      @df.sort_order = :descending
-      expect(@df.values).to eq([%w(10 Z), %w(3 X), %w(2 Y), [nil, "<None>"]])
+            it "returns the sorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(1 Z), %w(2 Y), %w(3 X)])
+            end
+          end
+        end
 
-      @df.sort_by = :none
-      @df.sort_order = :ascending
-      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(10 Z), %w(3 X)])
-      @df.sort_order = :descending
-      expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(10 Z), %w(3 X)])
+        context "when sorting by value" do
+          let(:sort_by) { :value }
+
+          context "when sorting ascending" do
+            it "returns the sorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(1 Z), %w(2 Y), %w(3 X)])
+            end
+          end
+
+          context "when sorting descending" do
+            let(:sort_order) { :descending }
+
+            it "returns the sorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(3 X), %w(2 Y), %w(1 Z)])
+            end
+          end
+        end
+
+        context "when sorting by none" do
+          let(:sort_by) { :none }
+
+          context "when sorting ascending" do
+            it "returns the unsorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
+            end
+          end
+
+          context "when sorting descending" do
+            let(:sort_order) { :descending }
+
+            it "returns the unsorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
+            end
+          end
+        end
+      end
+
+      context "when the data type is an integer" do
+        let(:data_type) { "integer" }
+
+        context "when sorting by value" do
+          let(:sort_by) { :value }
+
+          context "when sorting ascending" do
+            it "returns the sorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(1 Z), %w(2 Y), %w(3 X)])
+            end
+          end
+
+          context "when sorting descending" do
+            let(:sort_order) { :descending }
+
+            it "returns the sorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(3 X), %w(2 Y), %w(1 Z)])
+            end
+          end
+        end
+
+        context "when sorting by none" do
+          let(:sort_by) { :none }
+
+          context "when sorting ascending" do
+            it "returns the unsorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
+            end
+          end
+
+          context "when sorting descending" do
+            let(:sort_order) { :descending }
+
+            it "returns the unsorted values with a nil option prepended" do
+              expect(@df.values).to eq([[nil, "<None>"], %w(2 Y), %w(1 Z), %w(3 X)])
+            end
+          end
+        end
+      end
     end
 
     context "#initialize_with_values" do
@@ -154,7 +231,7 @@ describe DialogFieldDropDownList do
 
           it "returns the values" do
             expect(dialog_field.refresh_json_value("789")).to eq(
-              :refreshed_values => [["789", 101], ["123", 456], [nil, "<None>"]],
+              :refreshed_values => [[nil, "<None>"], ["789", 101], ["123", 456]],
               :checked_value    => "789",
               :read_only        => true,
               :visible          => true
@@ -190,6 +267,16 @@ describe DialogFieldDropDownList do
 
           it "returns the values from automate" do
             expect(dialog_field.values).to eq(%w(automate values))
+          end
+
+          context "when the values returned contain a nil" do
+            before do
+              allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return([[nil, "Choose something!"]])
+            end
+
+            it "returns the values from automate" do
+              expect(dialog_field.values).to eq([[nil, "Choose something!"]])
+            end
           end
         end
 
@@ -235,11 +322,11 @@ describe DialogFieldDropDownList do
 
       context "when the raw values are already set" do
         before do
-          dialog_field.instance_variable_set(:@raw_values, %w(potato potato))
+          dialog_field.instance_variable_set(:@raw_values, [%w(potato potato)])
         end
 
-        it "returns the raw values" do
-          expect(dialog_field.values).to eq(%w(potato potato))
+        it "returns the raw values with a nil option" do
+          expect(dialog_field.values).to eq([[nil, "<None>"], %w(potato potato)])
         end
       end
 

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -3,13 +3,14 @@ describe DialogFieldSortedItem do
     let(:dialog_field) do
       described_class.new(
         :name                => "potato_name",
-        :default_value       => "test2",
+        :default_value       => default_value,
         :dynamic             => true,
         :load_values_on_init => load_values_on_init,
         :show_refresh_button => show_refresh_button,
         :values              => [%w(test test), %w(test2 test2)]
       )
     end
+    let(:default_value) { "test2" }
 
     context "when show_refresh_button is true" do
       let(:show_refresh_button) { true }


### PR DESCRIPTION
While testing https://bugzilla.redhat.com/show_bug.cgi?id=1496946, QA found an issue where the default value was being set to nil but the code was not actually choosing the nil option in the drop down, and this was causing issues where they were able to submit a dialog with a required field even though that field wasn't actually filled in. Since it had a `data_type` of integer, and a few of the values were all strings, all of them were getting `.to_i`'d into a value of `0`, and ended up causing issues for the default value.

This PR re-arranges the order in which things are done with regards to sorting and determining how to set the `default_value`, so it fixes the issue.

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes, euwe/yes

Related UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/2340, will need this in order to be able to set `default_value` to a nil when a drop down field is also set to required.