### PR TITLE
Add PostgreSQL version restriction

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -1,0 +1,8 @@
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
+  def initialize(*args)
+    super
+    if postgresql_version < 90400 || postgresql_version >= 90600
+      raise "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")}"
+    end
+  end
+}


### PR DESCRIPTION
Fixes #16145

ManageIQ is only compatible with PostgreSQL 9.4 or 9.5, and many odd errors take a while to find when it's a simple version problem that could be found immediately.

This adds a restriction to the AR adapter to maintain lazy-loading the connection as expected.

Tests are knowingly omitted because any such test really doesn't tell us anything in the future as stubbing the underlying adapter methods would render it moot and actually bothering setting up the adapter being loaded/unloaded isn't worth the trouble given the previous point.