### PR TITLE
Changed Friendly_name to accept Arrays of queue_names

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -9,7 +9,7 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
     @friendly_name ||= begin
       ems = ext_management_system
       if ems.nil?
-        queue_name.titleize
+        queue_name.kind_of?(Array) ? queue_name.collect(&:titleize).join(", ") : queue_name.titleize
       else
         _("Refresh Worker for %{table}: %{name}") % {:table => ui_lookup(:table => "ext_management_systems"),
                                                      :name  => ems.name}


### PR DESCRIPTION
As Amazon is now a single worker with multiple queues, queue_names
can be arrays.
