### PR TITLE
Add Web Metrics reports hourly and every minute

### DIFF
--- a/product/reports/670_Performance by Asset Type - Middleware Servers/160_Web Metrics - hourly over last day.yaml
+++ b/product/reports/670_Performance by Asset Type - Middleware Servers/160_Web Metrics - hourly over last day.yaml
@@ -1,0 +1,68 @@
+---
+where_clause:
+dims:
+reserved:
+title: "EAP Web Metrics - hourly over the last day"
+conditions:
+order: Descending
+graph:
+menu_name: "EAP Web Metrics - hourly over the last day"
+rpt_group: Custom
+priority:
+col_order:
+- id
+- name
+- start_time
+- mw_aggregated_active_web_sessions_max
+- mw_aggregated_active_web_sessions_min
+- mw_aggregated_active_web_sessions_avg
+- mw_aggregated_expired_web_sessions_max
+- mw_aggregated_expired_web_sessions_min
+- mw_aggregated_expired_web_sessions_avg
+- mw_aggregated_rejected_web_sessions_max
+- mw_aggregated_rejected_web_sessions_min
+- mw_aggregated_rejected_web_sessions_avg
+timeline:
+file_mtime:
+categories:
+rpt_type: Custom
+filename:
+db_options:
+  :rpt_type: middleware
+  :options:
+    :interval: hourly
+    :start_offset: 86400
+    :end_offset: 0
+include: {}
+
+db: MiddlewareServerPerformance
+cols:
+- id
+- name
+- start_time
+- mw_aggregated_active_web_sessions_max
+- mw_aggregated_active_web_sessions_min
+- mw_aggregated_active_web_sessions_avg
+- mw_aggregated_expired_web_sessions_max
+- mw_aggregated_expired_web_sessions_min
+- mw_aggregated_expired_web_sessions_avg
+- mw_aggregated_rejected_web_sessions_max
+- mw_aggregated_rejected_web_sessions_min
+- mw_aggregated_rejected_web_sessions_avg
+template_type: report
+group: n
+sortby:
+- id
+headers:
+- Id
+- Name
+- Start
+- Active Web Sessions - max
+- Active Web Sessions - min
+- Active Web Sessions - avg
+- Expired Web Sessions - max
+- Expired Web Sessions - min
+- Expired Web Sessions - avg
+- Rejected Web Sessions - max
+- Rejected Web Sessions - min
+- Rejected Web Sessions - avg

--- a/product/reports/670_Performance by Asset Type - Middleware Servers/170_Web Metrics - every minute over last hour.yaml
+++ b/product/reports/670_Performance by Asset Type - Middleware Servers/170_Web Metrics - every minute over last hour.yaml
@@ -1,0 +1,50 @@
+---
+where_clause:
+dims:
+reserved:
+title: "EAP Web Metrics - every minute over the last hour"
+conditions:
+order: Descending
+graph:
+menu_name: "EAP Web Metrics - every minute over the last hour"
+rpt_group: Custom
+priority:
+col_order:
+- id
+- name
+- start_time
+- mw_aggregated_active_web_sessions_max
+- mw_aggregated_expired_web_sessions_max
+- mw_aggregated_rejected_web_sessions_max
+timeline:
+file_mtime:
+categories:
+rpt_type: Custom
+filename:
+db_options:
+  :rpt_type: middleware
+  :options:
+    :interval: every minute
+    :start_offset: 3600
+    :end_offset: 0
+include: {}
+
+db: MiddlewareServerPerformance
+cols:
+- id
+- name
+- start_time
+- mw_aggregated_active_web_sessions_max
+- mw_aggregated_expired_web_sessions_max
+- mw_aggregated_rejected_web_sessions_max
+template_type: report
+group: n
+sortby:
+- id
+headers:
+- Id
+- Name
+- Start
+- Active Web Sessions
+- Expired Web Sessions
+- Rejected Web Sessions

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 145)
+    include_examples(".seed called multiple times", 147)
   end
 end


### PR DESCRIPTION
This PR add two reports asked in [JMAN4-120](https://issues.jboss.org/browse/JMAN4-120) / [HAWKULAR-1162](https://issues.jboss.org/browse/HAWKULAR-1162).

Example for minute-ranged report:
![reports-1-3](https://user-images.githubusercontent.com/613814/32170352-7ea9a3f0-bd74-11e7-9b7d-b925ff065e0b.png)

Example for hour-ranged report:
![reports-1-4](https://user-images.githubusercontent.com/613814/32170353-7ff9aa5c-bd74-11e7-82ab-b84842f9a962.png)

Reports listed on menu:
![reports-2](https://user-images.githubusercontent.com/613814/32006188-56b58e76-b9a6-11e7-9888-5e5075721131.png)

The reports in this PR are based on metrics which are not enabled by default. In order to do so, you need to open a EAP console and run the following command:
```
/subsystem=undertow/:write-attribute(name=statistics-enabled,value=true)
```
or for EAP6:
```
/subsystem=web/:write-attribute(name=statistics-enabled,value=true)
```

![reports-instruction-1](https://user-images.githubusercontent.com/613814/32006706-c8719f04-b9a7-11e7-815f-690233342d66.png)

This way, the metrics for each deployment are going to be on counting:
![reports-instruction-2](https://user-images.githubusercontent.com/613814/32006835-195d7d8e-b9a8-11e7-9cdf-30e1f5bf0270.png)

Since this report is tracking metrics related to sessions, it is necessary to deploy apps with session management. Here a couple of demo apps:

https://drive.google.com/drive/u/0/folders/0B8K8kT5CYn9MYUZfLWVDdTllcWM

In order to get numbers on sessions metrics, it is only necessary to browse the home page of any of those demo apps. To make it simple, here a JMeter test plan:

https://drive.google.com/a/redhat.com/file/d/0BxCIJ_AbAJBeM2tCOV9jSTJidkk/view?usp=sharing

