### PR TITLE
Bump manageiq-smartstate gem to 0.1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -165,7 +165,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.1.5",       :require => false
+  gem "manageiq-smartstate",            "~>0.1.6",       :require => false
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb


### PR DESCRIPTION
This picks up changes for Azure Managed Disk Images.

The BZ for this change was https://bugzilla.redhat.com/show_bug.cgi?id=1496523.
@roliveri please review and merge.  Thanks.

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1496523