### PR TITLE
Use version 2.0.0 of the pg-pglogical gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,7 +149,7 @@ group :automate, :seed, :manageiq_default do
 end
 
 group :replication, :manageiq_default do
-  gem "pg-pglogical",                   "~>1.1.0",       :require => false
+  gem "pg-pglogical",                   "~>2.0.0",       :require => false
 end
 
 group :rest_api, :manageiq_default do


### PR DESCRIPTION
This allows us to work with version 2.0.1 of the pglogical package

Should be merged with https://github.com/ManageIQ/manageiq-appliance-build/pull/230