### PR TITLE
Ensure that `base_class` of first target is used for RBAC scope

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -218,6 +218,7 @@ module Rbac
           target_ids  = targets.collect(&:id)
           klass       = targets.first.class
           klass       = base_class if !klass.respond_to?(:find) && (base_class = rbac_base_class(klass))
+          klass       = safe_base_class(klass) if is_sti?(klass) # always scope to base class if model is STI
         end
         scope = apply_scope(klass, scope)
         scope = apply_select(klass, scope, options[:extra_cols]) if options[:extra_cols]
@@ -277,6 +278,10 @@ module Rbac
       attrs[:auth_count] = auth_count unless options[:skip_counts]
 
       return targets, attrs
+    end
+
+    def is_sti?(klass)
+      klass.respond_to?(:finder_needs_type_condition?) ? klass.finder_needs_type_condition? : false
     end
 
     def include_references(scope, klass, include_for_find, exp_includes)


### PR DESCRIPTION
When targets are passed and the instances are of different subclasses through STI, the base class needs to be used for building the scope to prevent ActiveRecord from also scoping to the subclass and limiting the results to only instances of that class.

For example - lets say that targets were passed in as instances of these classes that derive from `ExtManagementSystem`

```
["ManageIQ::Providers::Redhat::InfraManager",
 "ManageIQ::Providers::Google::CloudManager",
 "ManageIQ::Providers::StorageManager::CinderManager",
 "ManageIQ::Providers::Vmware::InfraManager",
 "ManageIQ::Providers::Openstack::NetworkManager"]
```
Without this change RBAC would only return the targets of the first class `ManageIQ::Providers::Redhat::InfraManager` in the results

https://bugzilla.redhat.com/show_bug.cgi?id=1480812
https://bugzilla.redhat.com/show_bug.cgi?id=1467756

/cc @jrafanie, @yrudman 