### PR TITLE
Store the event initiator in MiqEvent object.

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -79,7 +79,16 @@ class MiqEvent < EventStream
   end
 
   def self.build_evm_event(event, target)
-    MiqEvent.create(:event_type => event, :target => target, :source => 'POLICY', :timestamp => Time.now.utc)
+    user = User.current_user
+    MiqEvent.create(
+      :event_type => event,
+      :target     => target,
+      :source     => 'POLICY',
+      :timestamp  => Time.now.utc,
+      :user_id    => user.try(:id),
+      :group_id   => user.try(:current_group).try(:id),
+      :tenant_id  => user.try(:current_tenant).try(:id)
+    )
   end
 
   def update_with_policy_result(result = {})

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -427,6 +427,7 @@ class VmOrTemplate < ApplicationRecord
 
   # override
   def self.invoke_task_local(task, vm, options, args)
+    user = User.current_user
     cb = nil
     if task
       cb =
@@ -454,6 +455,9 @@ class VmOrTemplate < ApplicationRecord
         :method_name  => options[:task],
         :args         => args,
         :miq_callback => cb,
+        :user_id      => user.id,
+        :group_id     => user.current_group.id,
+        :tenant_id    => user.current_tenant.id
       )
     else
       MiqQueue.submit_job(
@@ -464,6 +468,9 @@ class VmOrTemplate < ApplicationRecord
         :method_name  => options[:task],
         :args         => args,
         :miq_callback => cb,
+        :user_id      => user.id,
+        :group_id     => user.current_group.id,
+        :tenant_id    => user.current_tenant.id
       )
     end
   end

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -102,6 +102,20 @@ describe MiqEvent do
         expect(MiqAeEvent).not_to receive(:raise_evm_event)
         MiqEvent.raise_evm_event(@miq_server, "evm_server_start")
       end
+
+      it "will create miq_event object with username" do
+        user = FactoryGirl.create(:user_with_group, :userid => "test")
+        vm = FactoryGirl.create(:vm_vmware)
+        event = 'request_vm_start'
+        FactoryGirl.create(:miq_event_definition, :name => event)
+
+        User.with_user(user) do
+          event_obj = MiqEvent.raise_evm_event(vm, event)
+          expect(event_obj.user_id).to eq(user.id)
+          expect(event_obj.group_id).to eq(user.current_group.id)
+          expect(event_obj.tenant_id).to eq(user.current_tenant.id)
+        end
+      end
     end
 
     context "#process_evm_event" do

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -28,6 +28,7 @@ describe ProcessTasksMixin do
 
     it "queues a message for the specified task" do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
       test_class.process_tasks(:task => "test_method", :ids => [5], :userid => "admin")
 
       message = MiqQueue.first
@@ -42,6 +43,7 @@ describe ProcessTasksMixin do
 
     it "defaults the userid to system in the queue message" do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
       test_class.process_tasks(:task => "test_method", :ids => [5])
 
       message = MiqQueue.first
@@ -50,7 +52,7 @@ describe ProcessTasksMixin do
       message.args.each do |h|
         expect(h[:task]).to eq("test_method")
         expect(h[:ids]).to eq([5])
-        expect(h[:userid]).to eq("system")
+        expect(h[:userid]).to eq("admin")
       end
     end
 
@@ -98,6 +100,7 @@ describe ProcessTasksMixin do
       end
 
       it "requeues invoke_tasks_remote when invoke_api_tasks fails" do
+        allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
         expect(InterRegionApiMethodRelay).to receive(:api_client_connection_for_region)
         expect(test_class).to receive(:invoke_api_tasks).and_raise(RuntimeError)
         test_class.invoke_tasks_remote(test_options)
@@ -118,6 +121,7 @@ describe ProcessTasksMixin do
     end
 
     it "requeues if the server does not have an address" do
+      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
       test_class.invoke_tasks_remote(test_options)
 
       expect(MiqQueue.first).to have_attributes(

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -117,6 +117,7 @@ describe Vm do
       EvmSpecHelper.create_guid_miq_server_zone
       @host = FactoryGirl.create(:host)
       @vm = FactoryGirl.create(:vm_vmware, :host => @host)
+      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "Freddy"))
     end
 
     it "sets up standard callback for non Power Operations" do


### PR DESCRIPTION
To keep the info about the event initiator in the MiqEvent object.

Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/86.
Depends on https://github.com/ManageIQ/manageiq-schema/pull/94.

https://bugzilla.redhat.com/show_bug.cgi?id=1487749

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement