### PR TITLE
[WIP] Add dependency to qpid_proton gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,7 @@ end
 
 group :nuage, :manageiq_default do
   manageiq_plugin "manageiq-providers-nuage"
+  gem "qpid_proton",                    "~>0.17.0.2", :git => "https://github.com/gberginc/qpid_proton_gem"
 end
 
 group :openshift, :manageiq_default do


### PR DESCRIPTION
The Gem is required by Nuage network provider. However, because of a bug
in the published version of qpid_proton gem (0.17), the gem cannot be
used to succesfully authenticate with Nuage ActiveMQ. Because the bug
has been resolved, we temporarily propose addition of a custom Gem
version with that patch applied so that changes to Nuage provider can be
merged.

This dependency will be removed as soon as 0.18 release of qpid_proton
gem is available.