### PR TITLE
Add dependency to qpid_proton gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,10 @@ group :nuage, :manageiq_default do
   manageiq_plugin "manageiq-providers-nuage"
 end
 
+group :qpid_proton, :optional => true do
+  gem "qpid_proton",                    "~>0.18",        :git => "https://github.com/xlab-si/qpid_proton_gem", :require => false
+end
+
 group :openshift, :manageiq_default do
   manageiq_plugin "manageiq-providers-openshift"
   gem "htauth",                         "2.0.0",         :require => false # used by container deployment


### PR DESCRIPTION
The Gem is required by Nuage network provider. However, because of a bug
in the published version of qpid_proton gem (0.17), the gem cannot be
used to succesfully authenticate with Nuage ActiveMQ. Because the bug
has been resolved, we temporarily propose addition of a custom Gem
version with that patch applied so that changes to Nuage provider can be
merged.

This dependency will be removed as soon as 0.18 release of qpid_proton
gem is available.