### PR TITLE
REST API URL for Dev environment

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -243,6 +243,10 @@ class MiqRegion < ApplicationRecord
   end
 
   def remote_ws_url
+    svr = remote_ws_miq_server
+    remote_url_override = svr.settings_for_resource.webservices.url if svr
+    return remote_url_override if remote_url_override
+
     hostname = remote_ws_address
     hostname && URI::HTTPS.build(:host => hostname).to_s
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1044,6 +1044,7 @@
   :timeout: 120
   :use_vim_broker: true
   :authentication_timeout: 30.seconds
+  :url:
 :workers:
   :worker_base:
     :defaults:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,5 @@
 ---
 :log:
   :level_rails: debug
+:webservices:
+  :url: http://localhost:4000

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -189,4 +189,24 @@ describe MiqRegion do
       expect(region.vms_and_templates).to match_array [vm, t]
     end
   end
+
+  describe "#remote_ws_url" do
+    let(:ip) { "1.1.1.94" }
+    let(:hostname) { "www.manageiq.org" }
+    let(:url) { "https://www.manageiq.org" }
+    let!(:web_server) do
+      FactoryGirl.create(:miq_server, :has_active_webservices => true,
+                                      :hostname               => hostname,
+                                      :ipaddress              => ip)
+    end
+
+    it "fetches the url from server" do
+      expect(region.remote_ws_url).to eq("https://#{ip}")
+    end
+
+    it "fetches the url from the setting" do
+      Vmdb::Settings.save!(web_server, :webservices => {:url => url})
+      expect(region.remote_ws_url).to eq(url)
+    end
+  end
 end

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -172,7 +172,7 @@ describe InterRegionApiMethodRelay do
       let(:region_auth_token) { double("MiqRegion API auth token") }
 
       before do
-        expect(MiqRegion).to receive(:find_by).with(:region => region_number).and_return(region)
+        allow(MiqRegion).to receive(:find_by).with(:region => region_number).and_return(region)
       end
 
       it "opens an api connection to that address when the server has an ip address" do


### PR DESCRIPTION
In a development environment when doing integration testing
the REST API URL needs to be localhost and not be the one from appliance.
The one from the appliance requires Apache and listens on port 443.

In a dev enviornment we use the default value from
**config/environments/development.rb** 
api_url                             http://localhost:3000
