### PR TITLE
Add MiqException prefix to vm snapshot exceptions

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -51,7 +51,7 @@ module VmOrTemplate::Operations::Snapshot
     run_command_via_parent(:vm_create_snapshot, :name => name, :desc => desc, :memory => memory)
   rescue => err
     create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "create")
-    raise MiqVmSnapshotError, err.to_s
+    raise MiqException::MiqVmSnapshotError, err.to_s
   end
 
   def create_snapshot(name, desc = nil, memory = false)
@@ -59,14 +59,14 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_snapshot(snapshot_id)
-    raise MiqVmError, unsupported_reason(:remove_snapshot) unless supports_remove_snapshot?
+    raise MiqException::MiqVmError, unsupported_reason(:remove_snapshot) unless supports_remove_snapshot?
     snapshot = snapshots.find_by(:id => snapshot_id)
     raise _("Requested VM snapshot not found, unable to remove snapshot") unless snapshot
     begin
       run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
     rescue => err
       if err.to_s.include?('not found')
-        raise MiqVmSnapshotError, err.to_s
+        raise MiqException::MiqVmSnapshotError, err.to_s
       else
         raise
       end
@@ -115,7 +115,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_snapshot_by_description(description, refresh = false)
-    raise MiqVmError, unsupported_reason(:remove_snapshot_by_description) unless supports_remove_snapshot_by_description?
+    raise MiqException::MiqVmError, unsupported_reason(:remove_snapshot_by_description) unless supports_remove_snapshot_by_description?
     run_command_via_parent(:vm_remove_snapshot_by_description, :description => description, :refresh => refresh)
   end
 
@@ -139,7 +139,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_all_snapshots
-    raise MiqVmError, unsupported_reason(:remove_all_snapshots) unless supports_remove_all_snapshots?
+    raise MiqException::MiqVmError, unsupported_reason(:remove_all_snapshots) unless supports_remove_all_snapshots?
     run_command_via_parent(:vm_remove_all_snapshots)
   end
 
@@ -148,7 +148,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_revert_to_snapshot(snapshot_id)
-    raise MiqVmError, unsupported_reason(:revert_to_snapshot) unless supports_revert_to_snapshot?
+    raise MiqException::MiqVmError, unsupported_reason(:revert_to_snapshot) unless supports_revert_to_snapshot?
     snapshot = snapshots.find_by(:id => snapshot_id)
     raise _("Requested VM snapshot not found, unable to RevertTo snapshot") unless snapshot
     run_command_via_parent(:vm_revert_to_snapshot, :snMor => snapshot.uid_ems)


### PR DESCRIPTION
The MiqVm* exceptions need to be prefixed with MiqException::

```
[----] E, [2017-10-12T12:22:39.387424 #19551:2b22230730d0] ERROR -- : MIQ(MiqQueue#deliver) Message id: [611], Error: [uninitialized constant VmOrTemplate::Operations::Snapshot::MiqVmError]
[----] E, [2017-10-12T12:22:39.387587 #19551:2b22230730d0] ERROR -- : [NameError]: uninitialized constant VmOrTemplate::Operations::Snapshot::MiqVmError  Method:[block in method_missing]
[----] E, [2017-10-12T12:22:39.387650 #19551:2b22230730d0] ERROR -- : /home/agrare/workspace/redhat/manageiq/app/models/vm_or_template/operations/snapshot.rb:62:in `raw_remove_snapshot'
/home/agrare/workspace/redhat/manageiq/app/models/vm_or_template/operations/snapshot.rb:86:in `remove_snapshot'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1501306