### PR TITLE
Fix the ems_event add_queue method

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -58,7 +58,7 @@ class EmsEvent < EventStream
     group[:name]
   end
 
-  def self.add_queue(_meth, ems_id, event)
+  def self.add_queue(meth, ems_id, event)
     if Settings.prototype.queue_type == 'artemis'
       MiqQueue.artemis_client('event_handler').publish_topic(
         :service => "events",


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/16073 introduced a new option
for a artemis queue but broke the method handling for the standard
MiqQueue.