### PR TITLE
Deprecate be_same_time_as and custom have_attributes matchers

### DIFF
--- a/spec/support/custom_matchers/be_same_time_as.rb
+++ b/spec/support/custom_matchers/be_same_time_as.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define :be_same_time_as do |expected|
     regexp = /(.*_spec\.rb:\d+)/
     called_from = caller.detect { |line| line =~ regexp }
     puts <<-MESSAGE
-\rWARNING: The `be_same_time_as` matcher is deprecated and will be removed shortly.
+\nWARNING: The `be_same_time_as` matcher is deprecated and will be removed shortly.
 Use the `be_within` matcher instead: `be_same_time_as(expected_time).precision(1) == be_within(0.1).of(expected_time)`
 #{"Called from " + called_from if called_from}
     MESSAGE

--- a/spec/support/custom_matchers/be_same_time_as.rb
+++ b/spec/support/custom_matchers/be_same_time_as.rb
@@ -1,5 +1,13 @@
 RSpec::Matchers.define :be_same_time_as do |expected|
   match do |actual|
+    regexp = /(.*_spec\.rb:\d+)/
+    called_from = caller.detect { |line| line =~ regexp }
+    puts <<-MESSAGE
+\rWARNING: The `be_same_time_as` matcher is deprecated and will be removed shortly.
+Use the `be_within` matcher instead: `be_same_time_as(expected_time).precision(1) == be_within(0.1).of(expected_time)`
+#{"Called from " + called_from if called_from}
+    MESSAGE
+
     actual.round(precision) == expected.round(precision)
   end
 

--- a/spec/support/custom_matchers/have_attributes.rb
+++ b/spec/support/custom_matchers/have_attributes.rb
@@ -37,7 +37,7 @@ RSpec::Matchers.define :have_attributes do |attrs|
 
     if @array_access_used
       puts <<-MESSAGE
-\rWARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
+\nWARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
 If you're matching attributes in hashes, use appropriate hash matchers instead (`include`, `eq`).
 #{"Called from " + called_from if called_from}
       MESSAGE


### PR DESCRIPTION
For `have_attributes`, see https://github.com/ManageIQ/manageiq/pull/11474 and other places where we've wasted time trying to figure out why RSpec's composable matchers don't work here.

For `be_same_time_as`, as don't need it now that we no longer support SQL Server. The original reasoning for this matcher was to coordinate varying precision between Ruby, Postgres, SQL Server. Now we don't support SQL Server so it really doesn't matter. 

```ruby
expect(time_value_under_test).to be_within(0.1).of(expected_time_value)
expect(time_value_under_test.to be_same_time_as(expected_time_value.precision(1)

expect(a_thing).to receive(:a_method_with_start_time).with(a_value_within(0.1).of(start_time))
expect(a_thing).to receive(:a_method_with_start_time).with(be_same_time_as(start_time.precision(1))
```