### PR TITLE
Run set_request_values on request update as well as creation

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -86,10 +86,10 @@ class MiqRequestWorkflow
     # Ensure that tags selected in the pre-dialog get applied to the request
     values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).uniq if @values.try(:[], :pre_dialog_vm_tags).present?
 
+    set_request_values(values)
     if request
       MiqRequest.update_request(request, values, @requester)
     else
-      set_request_values(values)
       req = request_class.new(:options => values, :requester => @requester, :request_type => request_type.to_s)
       return req unless req.valid? # TODO: CatalogController#atomic_req_submit is the only one that enumerates over the errors
       values[:__request_type__] = request_type.to_s.presence # Pass this along to MiqRequest#create_request

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -435,13 +435,18 @@ describe MiqRequestWorkflow do
   end
 
   context "#set_request_values" do
-    it "doesn't reset owner_group and requester_group on a second run" do
-      owner = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
-      values = {:owner_email => owner.email}
+    before do
       workflow.set_request_values(values)
+    end
+    let(:values) { {:owner_email => owner.email} }
+    let(:owner)  { FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)]) }
+
+    it 'sets owner_group and requester_group' do
       expect(values[:owner_group]).to eq(owner.current_group.description)
       expect(values[:requester_group]).to eq(workflow.requester.miq_group_description)
+    end
 
+    it 'does not reset owner_group and requester_group on a second run' do
       old_requester = workflow.requester
       new_requester = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
       workflow.requester = new_requester

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -434,6 +434,26 @@ describe MiqRequestWorkflow do
     end
   end
 
+  context "#set_request_values" do
+    it "doesn't reset owner_group and requester_group on a second run" do
+      owner = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
+      values = {:owner_email => owner.email}
+      workflow.set_request_values(values)
+      expect(values[:owner_group]).to eq(owner.current_group.description)
+      expect(values[:requester_group]).to eq(workflow.requester.miq_group_description)
+
+      old_requester = workflow.requester
+      new_requester = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
+      workflow.requester = new_requester
+      new_owner = FactoryGirl.create(:user_with_email, :miq_groups => [FactoryGirl.create(:miq_group)])
+
+      values[:owner_email] = new_owner.email
+      workflow.set_request_values(values)
+      expect(values[:owner_group]).to eq(owner.current_group.description)
+      expect(values[:requester_group]).to eq(old_requester.miq_group_description)
+    end
+  end
+
   context "#respool_to_folder" do
     before do
       resource_pool.ext_management_system = ems


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1500486 by causing `set_request_values` to run when requests are updated, not just created. This allows the Openstack provider-specific `set_request_values` to reparse the volume information out of the form when it is updated.