### PR TITLE
Replace custom have_attributes with `include`

### DIFF
--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -72,7 +72,7 @@ describe GitWorktree do
 
     it "#read_file that exists" do
       fname = 'A/File1.YamL'
-      expect(YAML.load(@ae_db.read_file(fname))).to have_attributes(@default_hash.merge(:fname => fname))
+      expect(YAML.load(@ae_db.read_file(fname))).to include(@default_hash.merge(:fname => fname))
     end
 
     it "#file_attributes" do

--- a/spec/lib/vmdb/loggers/container_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/container_logger_spec.rb
@@ -1,10 +1,16 @@
 describe Vmdb::Loggers::ContainerLogger::Formatter do
+  let(:hostname) { "testhostname" }
+
+  before do
+    allow(ENV).to receive(:[]).with('HOSTNAME').and_return(hostname)
+  end
+
   it "stuff" do
     time = Time.now
     result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")
-    expect(JSON.parse(result)).to have_attributes(
+    expect(JSON.parse(result)).to include(
       "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N "),
-      "hostname"   => ENV["HOSTNAME"],
+      "hostname"   => hostname,
       "level"      => "info",
       "message"    => "testing 1, 2, 3",
       "pid"        => $PROCESS_ID,

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -119,7 +119,7 @@ describe AutomationRequest do
         "approval_state" => "approved",
         "userid"         => admin.userid.to_s,
       )
-      expect(ar.options).to have_attributes(
+      expect(ar.options).to include(
         :namespace  => "SYSTEM",
         :class_name => "PROCESS",
         :user_id    => admin.id
@@ -129,7 +129,7 @@ describe AutomationRequest do
     it "allows /System/Process to be passed in" do
       uri_parts = @uri_parts.merge(:namespace => "/System", :class_name => "Process")
       ar = AutomationRequest.create_from_scheduled_task(admin, uri_parts, @parameters)
-      expect(ar.options).to have_attributes(
+      expect(ar.options).to include(
         :namespace  => "SYSTEM",
         :class_name => "PROCESS"
       )
@@ -138,7 +138,7 @@ describe AutomationRequest do
     it "locks scheduled tasks to /System/Process when other namespaces and class_names are passed in" do
       uri_parts = @uri_parts.merge(:namespace => "/Test", :class_name => "TestClass")
       ar = AutomationRequest.create_from_scheduled_task(admin, uri_parts, @parameters)
-      expect(ar.options).to have_attributes(
+      expect(ar.options).to include(
         :namespace  => "SYSTEM",
         :class_name => "PROCESS"
       )
@@ -147,7 +147,7 @@ describe AutomationRequest do
     it "locks class_name to Process when something else is passed in" do
       uri_parts = @uri_parts.merge(:class_name => "TestClass")
       ar = AutomationRequest.create_from_scheduled_task(admin, uri_parts, @parameters)
-      expect(ar.options).to have_attributes(
+      expect(ar.options).to include(
         :class_name => "PROCESS"
       )
     end
@@ -155,7 +155,7 @@ describe AutomationRequest do
     it "locks namespace to System when something else is passed in" do
       uri_parts = @uri_parts.merge(:namespace => "/Test")
       ar = AutomationRequest.create_from_scheduled_task(admin, uri_parts, @parameters)
-      expect(ar.options).to have_attributes(
+      expect(ar.options).to include(
         :namespace  => "SYSTEM"
       )
     end

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -175,7 +175,7 @@ describe Compliance do
     inputs = objects.extract_options!
     objects.each do |obj|
       expect(MiqQueue).to receive(:put) do |args|
-        expect(args).to have_attributes(
+        expect(args).to include(
           :method_name => "check_compliance",
           :class_name  => "Compliance",
           :args        => [[obj.class.name, obj.id], inputs]
@@ -188,7 +188,7 @@ describe Compliance do
     inputs = objects.extract_options!
     objects.each do |obj|
       expect(MiqQueue).to receive(:put) do |args|
-        expect(args).to have_attributes(
+        expect(args).to include(
           :method_name => "scan_and_check_compliance",
           :class_name  => "Compliance",
           :task_id     => 'vc-refresher',

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -51,7 +51,7 @@ describe MiqWebServerWorkerMixin do
 
   it "#rails_server_options" do
     w = FactoryGirl.create(:miq_ui_worker, :uri => "http://127.0.0.1:3000")
-    expect(w.rails_server_options).to have_attributes(
+    expect(w.rails_server_options).to include(
       :Port        => 3000,
       :Host        => w.class.binding_address,
       :environment => Rails.env.to_s,

--- a/spec/models/resource_action_serializer_spec.rb
+++ b/spec/models/resource_action_serializer_spec.rb
@@ -15,7 +15,7 @@ describe ResourceActionSerializer do
 
     it "serializes the resource_action" do
       serialized = resource_action_serializer.serialize(resource_action)
-      expect(serialized).to have_attributes(expected_serialized_values)
+      expect(serialized).to include(expected_serialized_values)
       expect(serialized.keys).to include("action", "ae_attributes", "ae_message")
       expect(serialized.keys).not_to include(*described_class::EXCLUDED_ATTRIBUTES)
     end

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -82,7 +82,7 @@ describe(ServiceAnsiblePlaybook) do
         expect(basic_service).to receive(:create_inventory_with_hosts).with(action, hosts).and_return(double(:id => 10))
         basic_service.preprocess(action)
         service.reload
-        expect(basic_service.options[:provision_job_options]).to have_attributes(:inventory => 10)
+        expect(basic_service.options[:provision_job_options]).to include(:inventory => 10)
       end
     end
 
@@ -92,7 +92,7 @@ describe(ServiceAnsiblePlaybook) do
         expect(service).to receive(:create_inventory_with_hosts).with(action, hosts).and_return(double(:id => 20))
         service.preprocess(action)
         service.reload
-        expect(service.options[:provision_job_options]).to have_attributes(
+        expect(service.options[:provision_job_options]).to include(
           :inventory  => 20,
           :credential => credential_1.manager_ref,
           :extra_vars => {'var1' => 'value1', 'var2' => 'value2', 'var3' => 'default_val3', 'pswd' => encrypted_val}
@@ -113,7 +113,7 @@ describe(ServiceAnsiblePlaybook) do
           expect(service).to receive(:create_inventory_with_hosts).with(action, hosts).and_return(double(:id => 20))
           service.preprocess(action)
           service.reload
-          expect(service.options[:retirement_job_options]).to have_attributes(
+          expect(service.options[:retirement_job_options]).to include(
             :inventory  => 20,
             :credential => nil,
             :extra_vars => {'var1' => 'default_val1', 'var2' => 'default_val2', 'var3' => 'default_val3'}
@@ -128,7 +128,7 @@ describe(ServiceAnsiblePlaybook) do
         expect(service).to receive(:create_inventory_with_hosts).with(action, hosts).and_return(double(:id => 30))
         service.preprocess(action, override_options)
         service.reload
-        expect(service.options[:provision_job_options]).to have_attributes(
+        expect(service.options[:provision_job_options]).to include(
           :inventory  => 30,
           :credential => credential_2.manager_ref,
           :extra_vars => {'var1' => 'new_val1', 'var2' => 'value2', 'var3' => 'default_val3', 'pswd' => encrypted_val2}

--- a/spec/models/service_container_template_spec.rb
+++ b/spec/models/service_container_template_spec.rb
@@ -95,7 +95,7 @@ describe(ServiceContainerTemplate) do
     it 'prepares job options from dialog' do
       expect(ems).not_to receive(:create_project)
       service.preprocess(action)
-      expect(service.options[:provision_options]).to have_attributes(
+      expect(service.options[:provision_options]).to include(
         :container_project_name => 'old_project',
         :parameters             => {"var1" => "value1", "var2" => "value2"}
       )
@@ -104,7 +104,7 @@ describe(ServiceContainerTemplate) do
     it 'honors new project name more than existing project name' do
       expect(ems).to receive(:create_project)
       service_with_new_project.preprocess(action)
-      expect(service_with_new_project.options[:provision_options]).to have_attributes(
+      expect(service_with_new_project.options[:provision_options]).to include(
         :container_project_name => 'new_project',
         :parameters             => {"var1" => "value1", "var2" => "value2"}
       )
@@ -113,7 +113,7 @@ describe(ServiceContainerTemplate) do
     it 'prepares job options combined from dialog and overrides' do
       expect(ems).to receive(:create_project)
       service_with_new_project.preprocess(action, override_options)
-      expect(service_with_new_project.options[:provision_options]).to have_attributes(
+      expect(service_with_new_project.options[:provision_options]).to include(
         :container_project_name => 'override_project',
         :parameters             => {'var1' => 'new_val1', 'var2' => 'value2'}
       )

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -436,9 +436,9 @@ describe Service do
     describe "#queue_chargeback_report_generation" do
       it "queue request to generate chargeback report" do
         expect(MiqQueue).to receive(:put) do |args|
-          expect(args).to have_attributes(:class_name  => described_class.name,
-                                          :method_name => "generate_chargeback_report",
-                                          :args        => {:report_source => "Test Run"})
+          expect(args).to include(:class_name  => described_class.name,
+                                  :method_name => "generate_chargeback_report",
+                                  :args        => {:report_source => "Test Run"})
         end
         @service.queue_chargeback_report_generation(:report_source => "Test Run")
       end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -128,7 +128,7 @@ describe ServiceTemplateAnsiblePlaybook do
                                                     catalog_extra_vars[:description],
                                                     catalog_extra_vars[:config_info][:provision])
 
-      expect(params).to have_attributes(
+      expect(params).to include(
         :name               => name,
         :description        => description,
         :become_enabled     => true,
@@ -139,7 +139,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(params.keys).to_not include(:extra_vars, :cloud_credentials)
       expect(params_two.keys).to include(:extra_vars)
-      expect(JSON.parse(params_two[:extra_vars])).to have_attributes(
+      expect(JSON.parse(params_two[:extra_vars])).to include(
         'key1' => 'val1',
         'key2' => 'val2'
       )
@@ -218,11 +218,11 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.name).to eq(catalog_item_options_three[:name])
       expect(service_template.description).to eq(catalog_item_options_three[:description])
-      expect(service_template.options.fetch_path(:config_info, :provision, :extra_vars)).to have_attributes(
+      expect(service_template.options.fetch_path(:config_info, :provision, :extra_vars)).to include(
         'key1' => {:default => 'updated_val1'},
         'key2' => {:default => 'updated_val2'}
       )
-      expect(service_template.options.fetch_path(:config_info, :provision)).to have_attributes(
+      expect(service_template.options.fetch_path(:config_info, :provision)).to include(
         :become_enabled => false,
         :verbosity      => 0
       )

--- a/spec/support/custom_matchers/be_same_time_as.rb
+++ b/spec/support/custom_matchers/be_same_time_as.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define :be_same_time_as do |expected|
     regexp = /(.*_spec\.rb:\d+)/
     called_from = caller.detect { |line| line =~ regexp }
     puts <<-MESSAGE
-\rWARNING: The `be_same_time_as` matcher is deprecated and will be removed shortly.
+\nWARNING: The `be_same_time_as` matcher is deprecated and will be removed shortly.
 Use the `be_within` matcher instead: `be_same_time_as(expected_time).precision(1) == be_within(0.1).of(expected_time)`
 #{"Called from " + called_from if called_from}
     MESSAGE

--- a/spec/support/custom_matchers/be_same_time_as.rb
+++ b/spec/support/custom_matchers/be_same_time_as.rb
@@ -1,5 +1,13 @@
 RSpec::Matchers.define :be_same_time_as do |expected|
   match do |actual|
+    regexp = /(.*_spec\.rb:\d+)/
+    called_from = caller.detect { |line| line =~ regexp }
+    puts <<-MESSAGE
+\rWARNING: The `be_same_time_as` matcher is deprecated and will be removed shortly.
+Use the `be_within` matcher instead: `be_same_time_as(expected_time).precision(1) == be_within(0.1).of(expected_time)`
+#{"Called from " + called_from if called_from}
+    MESSAGE
+
     actual.round(precision) == expected.round(precision)
   end
 

--- a/spec/support/custom_matchers/have_attributes.rb
+++ b/spec/support/custom_matchers/have_attributes.rb
@@ -37,7 +37,7 @@ RSpec::Matchers.define :have_attributes do |attrs|
 
     if @array_access_used
       puts <<-MESSAGE
-\rWARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
+\nWARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
 If you're matching attributes in hashes, use appropriate hash matchers instead (`include`, `eq`).
 #{"Called from " + called_from if called_from}
       MESSAGE


### PR DESCRIPTION
**Depends on #16191, merge that first**

These specs depend on our custom have_attributes matcher which really does exactly what `include` from RSpec is intended for. We're removing our custom stuff and using RSpec's, so these need to change to the appropriate matcher.

Note these aren't all the have_attributes cases, just the ones where array access (:[]) is used.