### PR TITLE
Find absolute max/min of CPU usage in mhz during rollup

### DIFF
--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -170,6 +170,7 @@ module Metric::Rollup
   ].freeze
   BURST_COLS = [
     :cpu_usage_rate_average,
+    :cpu_usagemhz_rate_average,
     :disk_usage_rate_average,
     :mem_usage_absolute_average,
     :net_usage_rate_average

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -163,16 +163,8 @@ module VmOrTemplate::RightSizing
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    if has_attribute?("cpu_usagemhz_rate_average_max_over_time_period")
-      self["cpu_usagemhz_rate_average_max_over_time_period"]
-    else
-      opts = {
-        :end_date => Time.now.utc,
-        :days     => Metric::LongTermAverages::AVG_DAYS
-      }
-      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
-                            .maximum(:cpu_usagemhz_rate_average)
-    end
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
+    perfs.collect(&:abs_max_cpu_usagemhz_rate_average_value).compact.max
   end
 
   def derived_memory_used_max_over_time_period

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -675,21 +675,31 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :time_profile_id => tp_id,
-                         :resource_id     => vm.id
+                         :resource_id     => vm.id,
+                         :min_max         => {
+                           :abs_max_cpu_usagemhz_rate_average_value => 100.00
+                         }
+
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :cpu_usagemhz_rate_average => 10.0,
                          :time_profile_id           => tp_id,
-                         :resource_id               => vm.id
+                         :resource_id               => vm.id,
+                         :min_max                   => {
+                           :abs_max_cpu_usagemhz_rate_average_value => 900.00
+                         }
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :cpu_usagemhz_rate_average => 100.0,
                          :time_profile_id           => tp_id,
-                         :resource_id               => vm.id
+                         :resource_id               => vm.id,
+                         :min_max                   => {
+                           :abs_max_cpu_usagemhz_rate_average_value => 500.00
+                         }
     end
 
     it "calculates in ruby" do
-      expect(vm.cpu_usagemhz_rate_average_max_over_time_period).to eq(100.0)
+      expect(vm.cpu_usagemhz_rate_average_max_over_time_period).to eq(900.00)
     end
 
     it "calculates in the database" do


### PR DESCRIPTION

https://bugzilla.redhat.com/show_bug.cgi?id=1468634

@miq-bot add_labels wip, providers/metrics