### PR TITLE
use commit time of latest commit for BUILD date

### DIFF
--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -113,9 +113,8 @@ module Vmdb
       if File.exist?(build_file)
         build = File.read(build_file).strip.split("-").last
       else
-        date  = Time.now.strftime("%Y%m%d%H%M%S")
         sha   = `git rev-parse --short HEAD`.chomp
-        build = "#{date}_#{sha}"
+        build = "unknown_#{sha}"
       end
 
       build


### PR DESCRIPTION
in case a BUILD file is missing we used the current time for
the build time - which can be really confusing

Not using Time.zone on purpose - because we want UTC

This did cost us quite some time in debugging https://bugzilla.redhat.com/show_bug.cgi?id=1491768

The posted build date master.20170914082537_bf64a63 suggested that https://github.com/ManageIQ/manageiq/pull/15590 which would fix the issue is *not* on the appliance - but the sha bf64a63 appended to the build version was commited on 2017-08-29 09:54:25  

@miq-bot assign @Fryguy  