### PR TITLE
Postgres version check - only raise in production

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -1,8 +1,13 @@
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   def initialize(*args)
     super
-    if postgresql_version < 90400 || postgresql_version >= 90600
-      msg = "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")}"
+
+    if postgresql_version < 90400
+      raise "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")} (9.4+ required)"
+    end
+
+    if postgresql_version >= 90600
+      msg = "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")} (9.6+ is not supported yet)"
 
       raise msg if Rails.env.production?
       $stderr.puts msg

--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -2,7 +2,10 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   def initialize(*args)
     super
     if postgresql_version < 90400 || postgresql_version >= 90600
-      raise "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")}"
+      msg = "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")}"
+
+      raise msg if Rails.env.production?
+      $stderr.puts msg
     end
   end
 }


### PR DESCRIPTION
The feature (https://github.com/ManageIQ/manageiq/pull/16171) is [meant](https://github.com/ManageIQ/manageiq/issues/16145) to protect users from using a wrong version of external DB.

But it also breaks devel setups for anybody using PG9.6+.

Thus, changing to only raise in production.
Development mode will warn to stderr (not sure about loggers in initializers), but not raise an exception.

Cc @chrisarcand, @carbonin, @Fryguy 

@miq-bot add_label core, fine/no