### PR TITLE
Add an inventory_collector_worker base class

### DIFF
--- a/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
@@ -5,6 +5,10 @@ class ManageIQ::Providers::BaseManager::InventoryCollectorWorker < MiqWorker
 
   self.required_roles = "ems_inventory"
 
+  def self.has_required_role?
+    !worker_settings[:disabled]
+  end
+
   def friendly_name
     @friendly_name ||= begin
       ems = ext_management_system

--- a/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
@@ -1,0 +1,27 @@
+class ManageIQ::Providers::BaseManager::InventoryCollectorWorker < MiqWorker
+  require_nested :Runner
+
+  include PerEmsWorkerMixin
+
+  self.required_roles = "ems_inventory"
+
+  def friendly_name
+    @friendly_name ||= begin
+      ems = ext_management_system
+      if ems.nil?
+        queue_name.titleize
+      else
+        _("Inventory Collector for %{table}: %{name}") % {:table => ui_lookup(:table => "ext_management_systems"),
+                                                          :name  => ems.name}
+      end
+    end
+  end
+
+  def self.ems_class
+    parent
+  end
+
+  def self.normalized_type
+    @normalized_type ||= "ems_inventory_collector_worker"
+  end
+end

--- a/app/models/manageiq/providers/base_manager/inventory_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/inventory_collector_worker/runner.rb
@@ -1,0 +1,13 @@
+require 'thread'
+
+class ManageIQ::Providers::BaseManager::InventoryCollectorWorker::Runner < ::MiqWorker::Runner
+  OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
+    [:ems_id, 'EMS Instance ID', String],
+  ]
+
+  def after_initialize
+    @ems = ExtManagementSystem.find(@cfg[:ems_id])
+    do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?
+    do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
+  end
+end

--- a/app/models/manageiq/providers/base_manager/inventory_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/inventory_collector_worker/runner.rb
@@ -10,4 +10,7 @@ class ManageIQ::Providers::BaseManager::InventoryCollectorWorker::Runner < ::Miq
     do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?
     do_exit("EMS ID [#{@cfg[:ems_id]}] failed authentication check.", 1) unless @ems.authentication_check.first
   end
+
+  attr_reader :ems
+  private :ems
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1059,6 +1059,7 @@
       :heartbeat_timeout: 30.minutes
       :poll: 30.seconds
     :ems_inventory_collector_worker:
+      :disabled: true
       :nice_delta: 1
       :poll: 5.seconds
     :ems_refresh_core_worker:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1058,6 +1058,9 @@
     :agent_coordinator_worker:
       :heartbeat_timeout: 30.minutes
       :poll: 30.seconds
+    :ems_inventory_collector_worker:
+      :nice_delta: 1
+      :poll: 5.seconds
     :ems_refresh_core_worker:
       :poll: 1.seconds
       :nice_delta: 1


### PR DESCRIPTION
Add a basic inventory collector worker which can be used for sending update-driven inventory payloads to a RefreshWorker for saving.

The goal here is to use the Kubernetes watch_pods() API to ensure that we never miss a pod if it is created and deleted while a refresh is running (already real world issue with customers).

Required for https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/129 and https://github.com/ManageIQ/manageiq-providers-openshift/pull/52