### PR TITLE
[EUWE] Automate - Calculate quota using service dialogs overrides.

### DIFF
--- a/spec/automation/unit/method_validation/calculate_requested_spec.rb
+++ b/spec/automation/unit/method_validation/calculate_requested_spec.rb
@@ -45,6 +45,89 @@ describe "Quota Validation" do
     end
   end
 
+  shared_examples_for "requested" do
+    it "check" do
+      setup_model("vmware")
+      build_small_environment
+      build_vmware_service_item
+      @service_request.options[:dialog] = result_dialog
+      @service_request.save
+      expect(@service_request.options[:dialog]).to include(result_dialog)
+      ws = run_automate_method(service_attrs)
+      expect(ws.root['quota_requested']).to include(result_counts_hash)
+    end
+  end
+
+  context "vmware service item with dialog override number_of_sockets = 3" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 6, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_sockets" => "3"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override cores_per_socket = 4" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 8, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_cores_per_socket" => "4"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override sockets = 3 and cores = 4 = 12" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 12, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_sockets" => "3", "dialog_option_0_cores_per_socket" => "4"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override number_of_cpus = 5" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 5, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_cpus" => "5"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override vm_memory = 2147483648" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 4, :vms => 1, :memory => 2.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_vm_memory" => "2147483648"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override number_of_vms = 5" do
+    let(:result_counts_hash) do
+      {:storage => 512.megabytes, :cpu => 4, :vms => 5, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_number_of_vms" => "5"}
+    end
+    it_behaves_like "requested"
+  end
+
+  context "vmware service item with dialog override storage = 2147483648" do
+    let(:result_counts_hash) do
+      {:storage => 2.gigabytes, :cpu => 4, :vms => 1, :memory => 1.gigabytes}
+    end
+    let(:result_dialog) do
+      {"dialog_option_0_storage" => "2147483648"}
+    end
+    it_behaves_like "requested"
+  end
+
   context "Service Bundle provisioning quota" do
     it "Bundle of 2, google and vmware" do
       create_service_bundle([google_template, vmware_template])


### PR DESCRIPTION
Changed requested method to use dialog overrides in quota calculations.

Modified requested method to calculate quota based on dialog values for:
number_of_sockets, cores_per_socket, number_of_cpus, vm_memory and storage.

This can be tested by using service dialogs using these values.

Testing

Create a service using service dialog overrides values for the above values.
You can use one or more override values.
Order the service, change some values and run.

Note: We are honoring number_of_vms in a service dialog but not using number_of_vms in quota calculations.   Doing quota calculations for number_of_vms in a service dialog will be in
 a followup PR.

I am including screenshots of a dialog using some values.

<img width="903" alt="test_dialog 1" src="https://user-images.githubusercontent.com/11841651/31558337-71c6f578-b01a-11e7-9f23-d5f4bc4f8d9b.png">

<img width="1098" alt="test_dialog 2" src="https://user-images.githubusercontent.com/11841651/31558353-8b4d945c-b01a-11e7-9b98-809e43302d34.png">






