### PR TITLE
Encrypt/Decrypt passwords in Automate Workspace

### DIFF
--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -20,12 +20,12 @@ class AutomateWorkspace < ApplicationRecord
   end
 
   def decrypt(object_name, attribute)
-    MiqAePassword.decrypt(encrypted_value(object_name, attribute))
+    MiqPassword.decrypt(encrypted_value(object_name, attribute))
   end
 
   def encrypt(object_name, attribute, value)
     hash = {'objects' => {}, 'state_vars' => {}}
-    hash.store_path('objects', object_name, attribute, "password::#{MiqAePassword.encrypt(value)}")
+    hash.store_path('objects', object_name, attribute, "password::#{MiqPassword.encrypt(value)}")
     merge_output!(hash)
   end
 

--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -18,4 +18,33 @@ class AutomateWorkspace < ApplicationRecord
     save!
     self
   end
+
+  def decrypt(object_name, attribute)
+    MiqAePassword.decrypt(encrypted_value(object_name, attribute))
+  end
+
+  def encrypt(object_name, attribute, value)
+    self.output ||= {}
+    self.output.store_path('objects', object_name, attribute, "password::#{MiqAePassword.encrypt(value)}")
+    save
+  end
+
+  private
+
+  def encrypted_value(object_name, attribute)
+    value = fetch_value(object_name, attribute)
+    raise ArgumentError, "#{object_name} : Attribute #{attribute} not found" unless value
+    raise ArgumentError, "#{object_name} : Attribute #{attribute} invalid type" unless value.kind_of?(String)
+    match_data = /password::(.*)/.match(value)
+    raise ArgumentError, "Attribute #{attribute} is not a password type" unless match_data
+    match_data[1]
+  end
+
+  def fetch_value(object_name, attribute)
+    if object_name == "method_parameters"
+      input.fetch_path(object_name, attribute)
+    else
+      input.fetch_path('objects', object_name, attribute)
+    end
+  end
 end

--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -24,9 +24,9 @@ class AutomateWorkspace < ApplicationRecord
   end
 
   def encrypt(object_name, attribute, value)
-    self.output ||= {}
-    self.output.store_path('objects', object_name, attribute, "password::#{MiqAePassword.encrypt(value)}")
-    save
+    hash = {'objects' => {}, 'state_vars' => {}}
+    hash.store_path('objects', object_name, attribute, "password::#{MiqAePassword.encrypt(value)}")
+    merge_output!(hash)
   end
 
   private

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -1,7 +1,18 @@
 describe AutomateWorkspace do
   describe "#merge_output!" do
     let(:user) { FactoryGirl.create(:user_with_group, :userid => "admin") }
-    let(:aw) { FactoryGirl.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
+    let(:aw) do
+      FactoryGirl.create(:automate_workspace, :user   => user,
+                                              :tenant => user.current_tenant,
+                                              :input  => input)
+    end
+    let(:password) { "secret" }
+    let(:encrypted) { MiqAePassword.encrypt(password) }
+    let(:input) do
+      { 'objects'           => {'root' => { 'var1' => '1', 'var2' => "password::#{encrypted}"}},
+        'method_parameters' => {'arg1' => "password::#{encrypted}"} }
+    end
+
     it "raises error on invalid hash" do
       expect { aw.merge_output!({}) }.to raise_exception(ArgumentError)
     end
@@ -21,6 +32,32 @@ describe AutomateWorkspace do
 
     it "#href_slug" do
       expect(aw.href_slug).to eq("automate_workspaces/#{aw.guid}")
+    end
+
+    it "#decrypt from object" do
+      expect(aw.decrypt('root', 'var2')).to eq(password)
+    end
+
+    it "#decrypt from method parameters" do
+      expect(aw.decrypt('method_parameters', 'arg1')).to eq(password)
+    end
+
+    it "#decrypt raises error when object doesn't exist" do
+      expect { aw.decrypt('frooti', 'var2') }.to raise_exception(ArgumentError)
+    end
+
+    it "#decrypt raises error when attribute doesn't exist" do
+      expect { aw.decrypt('root', 'nada') }.to raise_exception(ArgumentError)
+    end
+
+    it "#decrypt raises error when type is invalid" do
+      expect { aw.decrypt('root', 'var1') }.to raise_exception(ArgumentError)
+    end
+
+    it "#encrypt" do
+      aw.encrypt('root', 'mypassword', password)
+      aw.reload
+      expect(aw.output.fetch_path('objects', 'root', 'mypassword')).to eq("password::#{encrypted}")
     end
   end
 end

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -6,11 +6,11 @@ describe AutomateWorkspace do
                                               :tenant => user.current_tenant,
                                               :input  => input)
     end
-    let(:password) { "secret" }
+    let(:password) { "ca$hc0w" }
     let(:encrypted) { MiqAePassword.encrypt(password) }
     let(:input) do
-      { 'objects'           => {'root' => { 'var1' => '1', 'var2' => "password::#{encrypted}"}},
-        'method_parameters' => {'arg1' => "password::#{encrypted}"} }
+      { "objects"           => {"root" => { "var1" => "1", "var2" => "password::#{encrypted}"}},
+        "method_parameters" => {"arg1" => "password::#{encrypted}"} }
     end
 
     it "raises error on invalid hash" do

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -7,7 +7,7 @@ describe AutomateWorkspace do
                                               :input  => input)
     end
     let(:password) { "ca$hc0w" }
-    let(:encrypted) { MiqAePassword.encrypt(password) }
+    let(:encrypted) { MiqPassword.encrypt(password) }
     let(:input) do
       { "objects"           => {"root" => { "var1" => "1", "var2" => "password::#{encrypted}"}},
         "method_parameters" => {"arg1" => "password::#{encrypted}"} }


### PR DESCRIPTION
A customer can create encrypted attributes in Automate Model to store passwords. These attributes get stored in the AutomateWorkspace to be accessible via REST API.

This PR adds 2 methods
* decrypt a password given a object name and attribute name. The object name can be one of the objects from the workspace or method_parameters.
* encrypt given a object name, attribute and a clear text string.

This is needed for 4.6 to allow Ansible Playbooks to access customer defined password attributes from their Automate Models. E.g. An ansible playbook connecting to IPAM system might need a password stored in Automate Model.
