### PR TITLE
Implement a physical server workflow and request

### DIFF
--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -7,6 +7,7 @@ class MiqDialog < ApplicationRecord
     [_("Configured System Provision"), "MiqProvisionConfiguredSystemWorkflow"],
     [_("Host Provision"),              "MiqHostProvisionWorkflow"],
     [_("VM Migrate"),                  "VmMigrateWorkflow"],
+    [_("Physical Server Provision"),   "PhysicalServerProvisionWorkflow"]
   ].freeze
 
   serialize :content

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -73,6 +73,9 @@ class MiqRequest < ApplicationRecord
       },
       :ServiceReconfigureRequest           => {
         :service_reconfigure => N_("Service Reconfigure")
+      },
+      :PhysicalServerProvisionRequest      => {
+        :provision_physical_server => N_("Physical Server Provision")
       }
     },
     :Infrastructure => {

--- a/app/models/physical_server/operations.rb
+++ b/app/models/physical_server/operations.rb
@@ -3,4 +3,5 @@ module PhysicalServer::Operations
 
   include_concern 'Power'
   include_concern 'Led'
+  include_concern 'ConfigPattern'
 end

--- a/app/models/physical_server/operations/config_pattern.rb
+++ b/app/models/physical_server/operations/config_pattern.rb
@@ -1,0 +1,23 @@
+module PhysicalServer::Operations::ConfigPattern
+  def apply_config_pattern(pattern_id)
+    change_state(:apply_config_pattern, pattern_id)
+  end
+
+  private
+
+  def change_state(verb, pattern_id)
+    unless ext_management_system
+      raise _("A Server #{self} <%{name}> with Id: <%{id}> is not associated \
+with a provider.") % {:name => name, :id => id}
+    end
+
+    _log.info("Apply config pattern with ID: #{pattern_id} to server with UUID: #{ems_ref}")
+
+    options = {:uuid => ems_ref, :id => pattern_id, :etype => "rack", :restart => "immediate"}
+    response = ext_management_system.send(verb, self, options)
+
+    _log.info("Complete #{verb} #{self}")
+
+    response
+  end
+end

--- a/app/models/physical_server/operations/config_pattern.rb
+++ b/app/models/physical_server/operations/config_pattern.rb
@@ -1,22 +1,15 @@
 module PhysicalServer::Operations::ConfigPattern
   def apply_config_pattern(pattern_id)
-    change_state(:apply_config_pattern, pattern_id)
-  end
-
-  private
-
-  def change_state(verb, pattern_id)
     unless ext_management_system
-      raise _("A Server #{self} <%{name}> with Id: <%{id}> is not associated \
-with a provider.") % {:name => name, :id => id}
+      raise _("A Server #{self} <%{name}> with Id: <%{id}> is not associated with a provider.") % {:name => name, :id => id}
     end
 
     _log.info("Apply config pattern with ID: #{pattern_id} to server with UUID: #{ems_ref}")
 
     options = {:uuid => ems_ref, :id => pattern_id, :etype => "rack", :restart => "immediate"}
-    response = ext_management_system.send(verb, self, options)
+    response = ext_management_system.send(:apply_config_pattern, self, options)
 
-    _log.info("Complete #{verb} #{self}")
+    _log.info("Complete apply_config_pattern #{self}")
 
     response
   end

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -1,0 +1,12 @@
+class PhysicalServerProvisionRequest < MiqProvisionConfiguredSystemRequest
+  TASK_DESCRIPTION  = 'Physical Server Provisioning'.freeze
+  SOURCE_CLASS_NAME = 'PhysicalServer'.freeze
+
+  def src_configured_systems
+    PhysicalServer.where(:id => @options[:src_configured_system_ids])
+  end
+
+  def self.request_task_class_from(_attribs)
+    ManageIQ::Providers::Lenovo::PhysicalInfraManager
+  end
+end

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -2,12 +2,16 @@ class PhysicalServerProvisionRequest < MiqProvisionConfiguredSystemRequest
   TASK_DESCRIPTION  = 'Physical Server Provisioning'.freeze
   SOURCE_CLASS_NAME = 'PhysicalServer'.freeze
 
+  def description
+    "Apply configuration pattern"
+  end
+
   def src_configured_systems
     PhysicalServer.where(:id => options[:src_configured_system_ids])
   end
 
   def self.request_task_class_from(_attribs)
-    ManageIQ::Providers::Lenovo::PhysicalInfraManager
+    ManageIQ::Providers::Lenovo::PhysicalInfraManager::ProvisionTask
   end
 
   def event_name(mode)

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -3,7 +3,7 @@ class PhysicalServerProvisionRequest < MiqProvisionConfiguredSystemRequest
   SOURCE_CLASS_NAME = 'PhysicalServer'.freeze
 
   def src_configured_systems
-    PhysicalServer.where(:id => @options[:src_configured_system_ids])
+    PhysicalServer.where(:id => options[:src_configured_system_ids])
   end
 
   def self.request_task_class_from(_attribs)

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -9,4 +9,12 @@ class PhysicalServerProvisionRequest < MiqProvisionConfiguredSystemRequest
   def self.request_task_class_from(_attribs)
     ManageIQ::Providers::Lenovo::PhysicalInfraManager
   end
+
+  def event_name(mode)
+    "physical_server_provision_request_#{mode}"
+  end
+
+  def originating_controller
+    "physical_server"
+  end
 end

--- a/app/models/physical_server_provision_workflow.rb
+++ b/app/models/physical_server_provision_workflow.rb
@@ -39,16 +39,7 @@ class PhysicalServerProvisionWorkflow < MiqProvisionConfiguredSystemWorkflow
   private
 
   def get_customization_scripts
-    customization_scripts = []
-
-    # Retrieve the customization scripts/config patterns associated
-    # with the provider that's associated with each physical server
-    physical_servers = PhysicalServer.where(:id => @values[:src_configured_system_ids])
-    physical_servers.each do |server|
-      script = CustomizationScript.where(:manager_id => server.ems_id)
-      customization_scripts.push(script)
-    end
-
-    customization_scripts.flatten
+    ems_ids = PhysicalServer.where(:id => @values[:src_configured_system_ids]).pluck(:ems_id).uniq
+    CustomizationScript.where(:manager_id => ems_ids)
   end
 end

--- a/app/models/physical_server_provision_workflow.rb
+++ b/app/models/physical_server_provision_workflow.rb
@@ -1,0 +1,54 @@
+class PhysicalServerProvisionWorkflow < MiqProvisionConfiguredSystemWorkflow
+  def self.base_model
+    PhysicalServerProvisionWorkflow
+  end
+
+  def self.automate_dialog_request
+    'UI_PHYSICAL_SERVER_PROVISION_INFO'
+  end
+
+  def self.request_class
+    PhysicalServerProvisionRequest
+  end
+
+  def self.default_dialog_file
+    'physical_server_provision_dialogs'
+  end
+
+  def allowed_configured_systems(_options = {})
+    @allowed_configured_systems ||= begin
+      physical_servers = PhysicalServer.where(:id => @values[:src_configured_system_ids])
+      physical_servers.collect do |configured_system|
+        build_ci_hash_struct(configured_system, ["name"])
+      end
+    end
+  end
+
+  def allowed_configuration_profiles(_options = {})
+    @allowed_configuration_profiles ||= begin
+      config_profiles = get_customization_scripts
+      config_profiles.each_with_object({}) do |config_profile, hash|
+        hash[config_profile.id] = config_profile.name
+      end
+    end
+  end
+
+  def get_source_and_targets(_refresh = false)
+  end
+
+  private
+
+  def get_customization_scripts
+    customization_scripts = []
+
+    # Retrieve the customization scripts/config patterns associated
+    # with the provider that's associated with each physical server
+    physical_servers = PhysicalServer.where(:id => @values[:src_configured_system_ids])
+    physical_servers.each do |server|
+      script = CustomizationScript.where(:manager_id => server.ems_id)
+      customization_scripts.push(script)
+    end
+
+    customization_scripts.flatten
+  end
+end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6376,6 +6376,10 @@
       :description: Edit Instance Tags
       :feature_type: control
       :identifier: physical_server_tag
+    - :name: Provision Physical Server
+      :description: Provision Physical Server
+      :feature_type: control
+      :identifier: physical_server_provision
 
 # Firmwares
 - :name: Firmwares

--- a/product/dialogs/miq_dialogs/physical_server_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/physical_server_provision_dialogs.yaml
@@ -1,0 +1,202 @@
+---
+:name: physical_server_provision_dialogs
+:description: Dialog for provisioning physical servers
+:dialog_type: PhysicalServerProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :tag_ids:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags: []
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :notes: Minimum 8 characters or blank
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :ip_addr:
+          :description: IP Address
+          :required: false
+          :notes: (Enter starting IP address)
+          :display: :edit
+          :data_type: :string
+          :notes_display: :hide
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :src_configured_system_ids:
+          :values_from:
+            :method: :allowed_configured_systems
+          :description: Physical Servers
+          :required: true
+          :notes:
+          :display: :show
+          :data_type: :integer
+          :notes_display: :show
+        :src_configuration_profile_id:
+          :values_from:
+            :method: :allowed_configuration_profiles
+          :description: Configuration Pattern
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :customize
+  - :schedule

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -16,6 +16,7 @@ describe MiqRequest do
         :AutomationRequest                   => {:automation            => "Automation"},
         :ServiceTemplateProvisionRequest     => {:clone_to_service      => "Service Provision"},
         :ServiceReconfigureRequest           => {:service_reconfigure   => "Service Reconfigure"},
+        :PhysicalServerProvisionRequest      => {:provision_physical_server => "Physical Server Provision"}
       }
 
       expect(described_class::REQUEST_TYPES).to eq(expected_request_types)


### PR DESCRIPTION
This PR implements a workflow and request for physical servers to support LXCA config patterns (to provision physical servers). The workflow and request are based on the corresponding MiqProvisionConfiguredSystem classes, so we can reuse the ConfiguredSystem provisioning dialogs.