### PR TITLE
Optionally return "id" columns MiqExpression.model_details

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -160,8 +160,6 @@
 - win32_services
 - zones
 :exclude_columns:
-- "^.*_id$"
-- "^id$"
 - "^min_derived_storage.*$"
 - "^max_derived_storage.*$"
 - assoc_ids
@@ -191,10 +189,13 @@
 - password
 - policy_settings
 - "^reserved$"
-- resource_id
 - settings
 - tag_names
 - v_qualified_desc
+:exclude_id_columns:
+- "^.*_id$"
+- "^id$"
+- resource_id
 :exclude_exceptions:
 - capacity_profile_1_memory_per_vm_with_min_max
 - capacity_profile_1_vcpu_per_vm_with_min_max

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -7,6 +7,7 @@ class MiqExpression
   BASE_TABLES = config[:base_tables]
   INCLUDE_TABLES = config[:include_tables]
   EXCLUDE_COLUMNS = config[:exclude_columns]
+  EXCLUDE_ID_COLUMNS = config[:exclude_id_columns]
   EXCLUDE_EXCEPTIONS = config[:exclude_exceptions]
   TAG_CLASSES = config[:tag_classes]
   EXCLUDE_FROM_RELATS = config[:exclude_from_relats]
@@ -795,7 +796,7 @@ class MiqExpression
     BASE_TABLES
   end
 
-  def self.model_details(model, opts = {:typ => "all", :include_model => true, :include_tags => false, :include_my_tags => false})
+  def self.model_details(model, opts = {:typ => "all", :include_model => true, :include_tags => false, :include_my_tags => false, :include_id_columns => false})
     @classifications = nil
     model = model.to_s
 
@@ -998,7 +999,9 @@ class MiqExpression
     include_model = opts[:include_model]
     base_model = class_path.split(".").first
 
-    excludes = EXCLUDE_COLUMNS
+    excludes  = EXCLUDE_COLUMNS
+    excludes += EXCLUDE_ID_COLUMNS unless opts[:include_id_columns]
+
     # special case for C&U ad-hoc reporting
     if opts[:interval] && opts[:interval] != "daily" && base_model.ends_with?("Performance") && !class_path.include?(".")
       excludes += ["^min_.*$", "^max_.*$", "^.*derived_storage_.*$", "created_on"]

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2510,6 +2510,13 @@ describe MiqExpression do
         expect(result.map(&:first)[0]).to eq(" CPU Total Cost")
       end
     end
+
+    context "with :include_id_columns" do
+      it "Vm" do
+        result = described_class.model_details("Vm", :include_id_columns => true)
+        expect(result.map(&:second)).to include("Vm-id", "Vm-host_id", "Vm.host-id")
+      end
+    end
   end
 
   context ".build_relats" do


### PR DESCRIPTION
- This is necessary for building expressions for automate because the workspaces reference objects by id.
- Id columns are not returned by default (preserves the current behavior)
- Passing `:include_id_columns => true` will return id columns

/cc @gmcculloug, @mkanoor 
