### PR TITLE
Add awx as an embedded ansible plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "color",                          "~>1.8"
 gem "config",                         "~>1.3.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
 gem "default_value_for",              "~>3.0.3"
+gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -66,17 +66,18 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   private
 
   def provider_url
-    server = MiqServer.my_server(true)
+    URI::Generic.build(provider_uri_hash).to_s
+  end
 
+  def provider_uri_hash
     if MiqEnvironment::Command.is_container?
-      host = ENV["ANSIBLE_SERVICE_HOST"]
-      path = "/api/v1"
+      {:scheme => "https", :host => ENV["ANSIBLE_SERVICE_HOST"], :path => "/api/v1"}
+    elsif Rails.env.development?
+      {:scheme => "http", :host => "localhost", :path => "/api/v1", :port => 54321}
     else
-      host = server.hostname || server.ipaddress
-      path = "/ansibleapi/v1"
+      server = MiqServer.my_server(true)
+      {:scheme => "https", :host => server.hostname || server.ipaddress, :path => "/ansibleapi/v1"}
     end
-
-    URI::HTTPS.build(:host => host, :path => path).to_s
   end
 
   def raise_role_notification(notification_type)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -94,6 +94,16 @@
   :history:
     :keep_drift_states: 6.months
     :purge_window_size: 10000
+:embedded_ansible:
+  :docker:
+    :task_image_name: ansible/awx_task
+    :task_image_tag: latest
+    :web_image_name: ansible/awx_web
+    :web_image_tag: latest
+    :rabbitmq_image_name: rabbitmq
+    :rabbitmq_image_tag: 3
+    :memcached_image_name: memcached
+    :memcached_image_tag: alpine
 :ems:
 # provider specific settings are nested here, but they are in the provider repos
 # e.g.:

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -10,7 +10,7 @@ class EmbeddedAnsible
   end
 
   def self.detect_available_platform
-    subclasses.detect(&:available?) || NullEmbeddedAnsible
+    subclasses.sort.detect(&:available?) || NullEmbeddedAnsible
   end
 
   def self.available?
@@ -19,6 +19,14 @@ class EmbeddedAnsible
 
   def self.enabled?
     MiqServer.my_server(true).has_active_role?(ANSIBLE_ROLE)
+  end
+
+  def self.priority
+    0
+  end
+
+  def self.<=>(other_embedded_ansible)
+    other_embedded_ansible.priority <=> priority
   end
 
   def alive?

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -78,6 +78,10 @@ class EmbeddedAnsible
   def database_connection
     ActiveRecord::Base.connection
   end
+
+  def database_configuration
+    @db_config ||= ActiveRecord::Base.configurations[Rails.env]
+  end
 end
 
 Dir.glob(File.join(File.dirname(__FILE__), "embedded_ansible/*.rb")).each { |f| require_dependency f }

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -43,8 +43,40 @@ class EmbeddedAnsible
     )
   end
 
+  def find_or_create_secret_key
+    miq_database.ansible_secret_key ||= SecureRandom.hex(16)
+  end
+
+  def find_or_create_admin_authentication
+    miq_database.ansible_admin_authentication || miq_database.set_ansible_admin_authentication(:password => generate_password)
+  end
+
+  def find_or_create_rabbitmq_authentication
+    miq_database.ansible_rabbitmq_authentication || miq_database.set_ansible_rabbitmq_authentication(:password => generate_password)
+  end
+
+  def find_or_create_database_authentication
+    auth = miq_database.ansible_database_authentication
+    return auth if auth
+
+    auth = miq_database.set_ansible_database_authentication(:password => generate_password)
+
+    database_connection.select_value("CREATE ROLE #{database_connection.quote_column_name(auth.userid)} WITH LOGIN PASSWORD #{database_connection.quote(auth.password)}")
+    database_connection.select_value("CREATE DATABASE awx OWNER #{database_connection.quote_column_name(auth.userid)} ENCODING 'utf8'")
+
+    auth
+  end
+
+  def generate_password
+    SecureRandom.base64(18).tr("+/", "-_")
+  end
+
   def miq_database
     MiqDatabase.first
+  end
+
+  def database_connection
+    ActiveRecord::Base.connection
   end
 end
 

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -113,12 +113,11 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
 
   def configure_secret_key
     key = miq_database.ansible_secret_key
-    if key.present?
-      File.write(SECRET_KEY_FILE, key)
-    else
-      AwesomeSpawn.run!("/usr/bin/python -c \"import uuid; file('#{SECRET_KEY_FILE}', 'wb').write(uuid.uuid4().hex)\"")
-      miq_database.ansible_secret_key = File.read(SECRET_KEY_FILE)
+    unless key.present?
+      key = SecureRandom.hex(16)
+      miq_database.ansible_secret_key = key
     end
+    File.write(SECRET_KEY_FILE, key)
   end
 
   def update_proxy_settings

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -112,7 +112,7 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   end
 
   def configure_secret_key
-    key = miq_database.ansible_secret_key || generate_secret_key
+    key = find_or_create_secret_key
     File.write(SECRET_KEY_FILE, key)
   end
 
@@ -130,29 +130,10 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
     File.write(SETTINGS_FILE, new_contents)
   end
 
-  def generate_secret_key
-    miq_database.ansible_secret_key = SecureRandom.hex(16)
-  end
-
-  def generate_admin_authentication
-    miq_database.set_ansible_admin_authentication(:password => generate_password)
-  end
-
-  def generate_rabbitmq_authentication
-    miq_database.set_ansible_rabbitmq_authentication(:password => generate_password)
-  end
-
-  def generate_database_authentication
-    auth = miq_database.set_ansible_database_authentication(:password => generate_password)
-    database_connection.select_value("CREATE ROLE #{database_connection.quote_column_name(auth.userid)} WITH LOGIN PASSWORD #{database_connection.quote(auth.password)}")
-    database_connection.select_value("CREATE DATABASE awx OWNER #{database_connection.quote_column_name(auth.userid)} ENCODING 'utf8'")
-    auth
-  end
-
   def inventory_file_contents
-    admin_auth    = miq_database.ansible_admin_authentication || generate_admin_authentication
-    rabbitmq_auth = miq_database.ansible_rabbitmq_authentication || generate_rabbitmq_authentication
-    database_auth = miq_database.ansible_database_authentication || generate_database_authentication
+    admin_auth    = find_or_create_admin_authentication
+    rabbitmq_auth = find_or_create_rabbitmq_authentication
+    database_auth = find_or_create_database_authentication
     db_config     = Rails.configuration.database_configuration[Rails.env]
 
     <<-EOF.strip_heredoc
@@ -179,14 +160,6 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
       rabbitmq_use_long_name=false
       rabbitmq_enable_manager=false
     EOF
-  end
-
-  def generate_password
-    SecureRandom.base64(18).tr("+/", "-_")
-  end
-
-  def database_connection
-    ActiveRecord::Base.connection
   end
 
   def local_tower_version

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -18,6 +18,10 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
     required_rpms.subset?(LinuxAdmin::Rpm.list_installed.keys.to_set)
   end
 
+  def self.priority
+    30
+  end
+
   def initialize
     require "linux_admin"
   end

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -134,7 +134,6 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
     admin_auth    = find_or_create_admin_authentication
     rabbitmq_auth = find_or_create_rabbitmq_authentication
     database_auth = find_or_create_database_authentication
-    db_config     = Rails.configuration.database_configuration[Rails.env]
 
     <<-EOF.strip_heredoc
       [tower]
@@ -145,8 +144,8 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
       [all:vars]
       admin_password='#{admin_auth.password}'
 
-      pg_host='#{db_config["host"] || "localhost"}'
-      pg_port='#{db_config["port"] || "5432"}'
+      pg_host='#{database_configuration["host"] || "localhost"}'
+      pg_port='#{database_configuration["port"] || "5432"}'
 
       pg_database='awx'
       pg_username='#{database_auth.userid}'

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -112,11 +112,7 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   end
 
   def configure_secret_key
-    key = miq_database.ansible_secret_key
-    unless key.present?
-      key = SecureRandom.hex(16)
-      miq_database.ansible_secret_key = key
-    end
+    key = miq_database.ansible_secret_key || generate_secret_key
     File.write(SECRET_KEY_FILE, key)
   end
 
@@ -132,6 +128,10 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
       new_contents << "AWX_TASK_ENV['NO_PROXY'] = '127.0.0.1'\n"
     end
     File.write(SETTINGS_FILE, new_contents)
+  end
+
+  def generate_secret_key
+    miq_database.ansible_secret_key = SecureRandom.hex(16)
   end
 
   def generate_admin_authentication

--- a/lib/embedded_ansible/container_embedded_ansible.rb
+++ b/lib/embedded_ansible/container_embedded_ansible.rb
@@ -5,6 +5,10 @@ class ContainerEmbeddedAnsible < EmbeddedAnsible
     ContainerOrchestrator.available?
   end
 
+  def self.priority
+    20
+  end
+
   def start
     miq_database.set_ansible_admin_authentication(:password => ENV["ANSIBLE_ADMIN_PASSWORD"])
     ContainerOrchestrator.new.scale(ANSIBLE_DC_NAME, 1)

--- a/lib/embedded_ansible/docker_embedded_ansible.rb
+++ b/lib/embedded_ansible/docker_embedded_ansible.rb
@@ -52,6 +52,12 @@ class DockerEmbeddedAnsible < EmbeddedAnsible
     api_connection_raw("localhost", AWX_WEB_PORT)
   end
 
+  def alive?
+    super
+  rescue JSON::ParserError
+    false
+  end
+
   private
 
   def run_rabbitmq_container

--- a/lib/embedded_ansible/docker_embedded_ansible.rb
+++ b/lib/embedded_ansible/docker_embedded_ansible.rb
@@ -1,0 +1,201 @@
+class DockerEmbeddedAnsible < EmbeddedAnsible
+  AWX_WEB_PORT = "54321".freeze
+
+  def self.available?
+    require 'docker'
+    Docker.validate_version!
+  rescue RuntimeError
+    false
+  end
+
+  def initialize
+    super
+    require 'docker'
+  end
+
+  def start
+    run_rabbitmq_container
+    run_memcached_container
+    sleep(15)
+    run_web_container
+    run_task_container
+
+    loop do
+      break if alive?
+
+      _log.info("Waiting for Ansible container to respond")
+      sleep WAIT_FOR_ANSIBLE_SLEEP
+    end
+  rescue RuntimeError
+    stop
+  end
+
+  def stop
+    container_names.each { |c| stop_container(c) }
+  end
+
+  alias disable stop
+
+  def running?
+    container_names.all? { |c| container_running?(c) }
+  end
+
+  def configured?
+    self.class.available?
+  end
+
+  def api_connection
+    api_connection_raw("localhost", AWX_WEB_PORT)
+  end
+
+  private
+
+  def run_rabbitmq_container
+    rabbitmq_auth = find_or_create_rabbitmq_authentication
+    run_container(
+      rabbitmq_image_name,
+      'name'         => rabbitmq_container_name,
+      'ExposedPorts' => {"25672/tcp" => {},
+                         "4369/tcp"  => {},
+                         "5671/tcp"  => {},
+                         "5672/tcp"  => {}},
+      'Env'          => ["RABBITMQ_DEFAULT_VHOST=awx",
+                         "RABBITMQ_DEFAULT_USER=#{rabbitmq_auth.userid}",
+                         "RABBITMQ_DEFAULT_PASS=#{rabbitmq_auth.password}"]
+    )
+  end
+
+  def run_memcached_container
+    run_container(
+      memcached_image_name,
+      'name'         => memcached_container_name,
+      'ExposedPorts' => {"11211/tcp" => {}}
+    )
+  end
+
+  def run_web_container
+    run_container(
+      awx_web_image_name,
+      'name'         => awx_web_container_name,
+      'Env'          => awx_env,
+      'Hostname'     => "awxweb",
+      'User'         => "root",
+      'ExposedPorts' => {"8052/tcp" => {}},
+      'HostConfig'   => {
+        'Links'        => [rabbitmq_container_name, memcached_container_name],
+        'PortBindings' => {
+          '8052/tcp' => [{ 'HostPort' => AWX_WEB_PORT, 'HostIp' => "0.0.0.0" }]
+        }
+      }
+    )
+  end
+
+  def run_task_container
+    run_container(
+      awx_task_image_name,
+      'name'         => awx_task_container_name,
+      'Env'          => awx_env,
+      'Hostname'     => "awx",
+      'User'         => "root",
+      'ExposedPorts' => {"8052/tcp" => {}},
+      'HostConfig'   => {
+        'Links' => [rabbitmq_container_name,
+                    memcached_container_name,
+                    awx_web_container_name]
+      }
+    )
+  end
+
+  def run_container(image, create_params = {})
+    Docker::Image.create('fromImage' => image)
+    container = Docker::Container.create(create_params.merge('Image' => image))
+    container.start
+  end
+
+  def stop_container(name)
+    Docker::Container.get(name).kill.delete
+  rescue Docker::Error::NotFoundError
+    nil
+  end
+
+  def container_running?(name)
+    Docker::Container.get(name)
+    true
+  rescue Docker::Error::NotFoundError
+    false
+  end
+
+  def awx_env
+    admin_auth    = find_or_create_admin_authentication
+    database_auth = find_or_create_database_authentication
+    rabbitmq_auth = find_or_create_rabbitmq_authentication
+
+    [
+      "SECRET_KEY=#{find_or_create_secret_key}",
+      "DATABASE_NAME=awx",
+      "DATABASE_USER=#{database_auth.userid}",
+      "DATABASE_PASSWORD=#{database_auth.password}",
+      "DATABASE_PORT=#{database_configuration["port"] || 5432}",
+      "DATABASE_HOST=#{database_configuration["host"] || docker_bridge_gateway}",
+      "RABBITMQ_USER=#{rabbitmq_auth.userid}",
+      "RABBITMQ_PASSWORD=#{rabbitmq_auth.password}",
+      "RABBITMQ_HOST=#{rabbitmq_container_name}",
+      "RABBITMQ_PORT=5672",
+      "RABBITMQ_VHOST=awx",
+      "MEMCACHED_HOST=#{memcached_container_name}",
+      "MEMCACHED_PORT=11211",
+      "AWX_ADMIN_USER=#{admin_auth.userid}",
+      "AWX_ADMIN_PASSWORD=#{admin_auth.password}"
+    ]
+  end
+
+  def docker_bridge_gateway
+    br = Docker::Network.get("bridge")
+    br.info["IPAM"]["Config"].first["Gateway"]
+  end
+
+  def container_names
+    [
+      awx_task_container_name,
+      awx_web_container_name,
+      memcached_container_name,
+      rabbitmq_container_name
+    ]
+  end
+
+  def awx_task_container_name
+    "awx_task"
+  end
+
+  def awx_task_image_name
+    "#{settings.task_image_name}:#{settings.task_image_tag}"
+  end
+
+  def awx_web_container_name
+    "awx_web"
+  end
+
+  def awx_web_image_name
+    "#{settings.web_image_name}:#{settings.web_image_tag}"
+  end
+
+  def rabbitmq_container_name
+    "rabbitmq"
+  end
+
+  def rabbitmq_image_name
+    "#{settings.rabbitmq_image_name}:#{settings.rabbitmq_image_tag}"
+  end
+
+  def memcached_container_name
+    "memcached"
+  end
+
+  def memcached_image_name
+    "#{settings.memcached_image_name}:#{settings.memcached_image_tag}"
+  end
+
+  def settings
+    ::Settings.embedded_ansible.docker
+  end
+end

--- a/lib/embedded_ansible/docker_embedded_ansible.rb
+++ b/lib/embedded_ansible/docker_embedded_ansible.rb
@@ -130,13 +130,16 @@ class DockerEmbeddedAnsible < EmbeddedAnsible
     database_auth = find_or_create_database_authentication
     rabbitmq_auth = find_or_create_rabbitmq_authentication
 
+    db_host = database_configuration["host"] || docker_bridge_gateway
+    db_host = docker_bridge_gateway if db_host == "localhost"
+
     [
       "SECRET_KEY=#{find_or_create_secret_key}",
       "DATABASE_NAME=awx",
       "DATABASE_USER=#{database_auth.userid}",
       "DATABASE_PASSWORD=#{database_auth.password}",
       "DATABASE_PORT=#{database_configuration["port"] || 5432}",
-      "DATABASE_HOST=#{database_configuration["host"] || docker_bridge_gateway}",
+      "DATABASE_HOST=#{db_host}",
       "RABBITMQ_USER=#{rabbitmq_auth.userid}",
       "RABBITMQ_PASSWORD=#{rabbitmq_auth.password}",
       "RABBITMQ_HOST=#{rabbitmq_container_name}",

--- a/lib/embedded_ansible/docker_embedded_ansible.rb
+++ b/lib/embedded_ansible/docker_embedded_ansible.rb
@@ -8,6 +8,10 @@ class DockerEmbeddedAnsible < EmbeddedAnsible
     false
   end
 
+  def self.priority
+    10
+  end
+
   def initialize
     super
     require 'docker'

--- a/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
@@ -1,10 +1,12 @@
 require 'linux_admin'
+require 'docker'
 require_dependency 'embedded_ansible'
 
 describe ApplianceEmbeddedAnsible do
   before do
     allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
     allow(ContainerOrchestrator).to receive(:available?).and_return(false)
+    allow(Docker).to receive(:validate_version!).and_raise(RuntimeError)
 
     installed_rpms = {
       "ansible-tower-server" => "1.0.1",

--- a/spec/lib/embedded_ansible/container_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/container_embedded_ansible_spec.rb
@@ -1,3 +1,4 @@
+require 'docker'
 require_dependency 'embedded_ansible'
 
 describe ContainerEmbeddedAnsible do
@@ -5,6 +6,8 @@ describe ContainerEmbeddedAnsible do
 
   before do
     allow(ContainerOrchestrator).to receive(:available?).and_return(true)
+    allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)
+    allow(Docker).to receive(:validate_version!).and_raise(RuntimeError)
 
     FactoryGirl.create(:miq_region, :region => ApplicationRecord.my_region_number)
     MiqDatabase.seed

--- a/spec/lib/embedded_ansible/docker_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/docker_embedded_ansible_spec.rb
@@ -19,4 +19,17 @@ describe DockerEmbeddedAnsible do
       expect(described_class.available?).to be true
     end
   end
+
+  describe "#alive?" do
+    let(:connection) { double("APIConnection", :api => api) }
+    let(:api)        { double("AnsibleAPI") }
+
+    it "returns false if the api raises a JSON::ParserError" do
+      expect(subject).to receive(:running?).and_return(true)
+      expect(subject).to receive(:api_connection).and_return(connection)
+      expect(api).to receive(:verify_credentials).and_raise(JSON::ParserError)
+
+      expect(subject.alive?).to be false
+    end
+  end
 end

--- a/spec/lib/embedded_ansible/docker_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/docker_embedded_ansible_spec.rb
@@ -1,0 +1,22 @@
+require 'docker'
+require_dependency 'embedded_ansible'
+
+describe DockerEmbeddedAnsible do
+  before do
+    allow(Docker).to receive(:validate_version!).and_return(true)
+    allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)
+    allow(ContainerOrchestrator).to receive(:available?).and_return(false)
+  end
+
+  describe "subject" do
+    it "is an instance of DockerEmbeddedAnsible" do
+      expect(subject).to be_an_instance_of(described_class)
+    end
+  end
+
+  describe ".available?" do
+    it "returns true when the docker gem is usable" do
+      expect(described_class.available?).to be true
+    end
+  end
+end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -1,6 +1,12 @@
 require 'docker'
 
 describe EmbeddedAnsible do
+  describe ".<=>" do
+    it "allows classes to be sorted by priority" do
+      expect(EmbeddedAnsible.subclasses.sort).to eq([ApplianceEmbeddedAnsible, ContainerEmbeddedAnsible, DockerEmbeddedAnsible, NullEmbeddedAnsible])
+    end
+  end
+
   context "with no available subclass" do
     before do
       expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)


### PR DESCRIPTION
This fixes https://github.com/ManageIQ/manageiq/issues/15975

This PR builds on https://github.com/ManageIQ/manageiq/pull/16168 by adding a new EmbeddedAnsible plugin which handles running AWX.

[AWX](https://github.com/ansible/awx) is the upstream of Ansible Tower and is distributed in a collection of containers rather than rpms.

The `DockerEmbeddedAnsible` class manages these containers using the [docker-api gem](https://github.com/swipely/docker-api).

When the role is enabled on an upstream appliance or on a development machine, we will pull the latest images, and run the containers using the same credential management system as we would in the appliance case.

The class also handles setting up the container environment required. This is mostly a ruby version of the [playbook role that the AWX project uses to install the containers](https://github.com/ansible/awx/blob/devel/installer/local_docker/tasks/main.yml) without all the image build and PG bits.