### PR TITLE
[WIP] Delay VmdbDatabase seed

### DIFF
--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -2,7 +2,7 @@ module VmdbDatabase::Seeding
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def seed
+    def refresh
       db = seed_self
       db.seed
       db

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -14,7 +14,6 @@ class EvmDatabase
     MiqGroup
     User
     MiqReport
-    VmdbDatabase
   )
 
   ORDERED_CLASSES = %w(


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/2402

This PR is the start of removing VmdbDatabase from the seeding path.  We will still need to do a seed on boot, but I'd like to delay it.  In fact, I'd like to rename "seed" for this class to "refresh" and treat it like inventory.  Since the "inventory" of the database only changes on migrate, it makes sense to do it only once, but I'm not sure when.  I was thinking we would put a refresh on the queue perhaps on evm_server start?  Eventually a generic would pick it up and just do a one-time inventory update.

@jrafanie @kbrock @bdunne  Would like your thoughts here.  And no, we can't just delete it. :smile: