### PR TITLE
Move oVirt Ruby SDK dependency to the provider repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,6 @@ end
 
 group :ovirt, :manageiq_default do
   manageiq_plugin "manageiq-providers-ovirt"
-  gem "ovirt-engine-sdk",               "~>4.1.4",       :require => false # Required by the oVirt provider
   gem "ovirt_metrics",                  "~>1.4.1",       :require => false
 end
 


### PR DESCRIPTION
This patch removes the dependency on the oVirt Ruby SDK, because that
gem is used only by the oVirt provider, and it has been added explicitly
to that repository in the following pull request:

  Require oVirt Ruby SDK 4.1.9 or newer
  https://github.com/ManageIQ/manageiq-providers-ovirt/pull/107