### PR TITLE
Allow to create OrchestrationTemplate from old types

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -20,6 +20,25 @@ class OrchestrationTemplate < ApplicationRecord
   attr_accessor :remote_proxy
   alias remote_proxy? remote_proxy
 
+  DEPRECATED_TYPES = {
+    'OrchestrationTemplateCfn'   => 'ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate',
+    'OrchestrationTemplateHot'   => 'ManageIQ::Providers::Openstack::CloudManager::OrchestrationTemplate',
+    'OrchestrationTemplateVnfd'  => 'ManageIQ::Providers::Openstack::CloudManager::VnfdTemplate',
+    'OrchestrationTemplateAzure' => 'ManageIQ::Providers::Azure::CloudManager::OrchestrationTemplate',
+  }.freeze
+
+  # Temporarily maintain backward compatibility for API users. Should be removed later.
+  def self.new(*args, &block)
+    if (h = args.first).kind_of?(Hash)
+      old_type = h[:type] || h['type']
+      if (new_type = DEPRECATED_TYPES[old_type]).present?
+        _log.warn("#{old_type} has been renamed to #{new_type}")
+        args.unshift(args.shift.except('type').merge(:type => new_type))
+      end
+    end
+    super(*args, &block)
+  end
+
   # available templates for ordering an orchestration service
   def self.available
     where(:draft => false, :orderable => true)

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -292,6 +292,17 @@ describe OrchestrationTemplate do
     end
   end
 
+  # Temporarily maintain backward compatibility for API users. Should be removed later.
+  describe '.new' do
+    it 'creates new type from old type with key being a symbol' do
+      expect(described_class.new(:type => 'OrchestrationTemplateCfn')).to be_a(ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate)
+    end
+
+    it 'creates new type from old type with key being a string' do
+      expect(described_class.new('type' => 'OrchestrationTemplateCfn')).to be_a(ManageIQ::Providers::Amazon::CloudManager::OrchestrationTemplate)
+    end
+  end
+
   def assert_deployment_option(option, name, constraint_type, required)
     expect(option.name).to eq(name)
     expect(option.required?).to eq(required)


### PR DESCRIPTION
Temporarily maintain backward compatibility for API users. Should be removed later.

Due to our recent work to rename `OrchestrationTemplate` subclasses, existing customers that use API to create template may fail the creation. See comments on https://github.com/ManageIQ/manageiq-api/pull/63.

Our UI users should not have this concern.

@abellotti How do we let API users know that the old types are deprecated?