### PR TITLE
Keep full model name when parsing expression with tag

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,6 +1,6 @@
 class MiqExpression::Tag < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:alnum:]]*(::)?)?)
+(?<model_name>([[:alnum:]]*(::)?)*)
 \.?(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,6 +1,6 @@
 class MiqExpression::Tag < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:alnum:]]*(::)?)*)
+(?<model_name>([[:alnum:]]*(::)?){4})
 \.?(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe MiqExpression::Tag do
                                                             :namespace    => "/managed/service_level")
     end
 
+    it "with model-parent::model.managed-in_tag" do
+      tag = "ManageIQ::Providers::CloudManager.managed-service_level"
+      expect(described_class.parse(tag)).to have_attributes(:model        => ManageIQ::Providers::CloudManager,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/service_level")
+    end
+
     it "with model.associations.associations.managed-in_tag" do
       tag = "Vm.service.user.managed-service_level"
       expect(described_class.parse(tag)).to have_attributes(:model        => Vm,

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe MiqExpression::Tag do
       tag = "Vm.managed"
       expect(described_class.parse(tag)).to be_nil
     end
+
+    it "returns nil with invalid case parent-model::model::somethingmanaged-se" do
+      tag = "ManageIQ::Providers::CloudManagermanaged-se'"
+      expect(described_class.parse(tag)).to be_nil
+    end
   end
 
   describe "#to_s" do


### PR DESCRIPTION
**Issue**: 
`MiqExpression::Tag.parse` does not return full model name. Parsing  tag like `ManageIQ::Providers::CloudManager.managed-service_level` will return `CloudManager` and 
`>> "CloudManager".safe_constantize
=> nil
`
https://bugzilla.redhat.com/show_bug.cgi?id=1501333

**Solution**:
 keep full model name when parsing


**Example**: group has assigned filter expression 
![screen shot 2017-10-16 at 4 15 50 pm](https://user-images.githubusercontent.com/6556758/31633502-9bc4620e-b28e-11e7-9035-5654e9e11caf.png)

and tag was assigned to some instances of gce provider
![screen shot 2017-10-16 at 4 26 42 pm](https://user-images.githubusercontent.com/6556758/31633602-f0a7e458-b28e-11e7-8ccc-4f6a3fe218c3.png)


**BEFORE**:

![before](https://user-images.githubusercontent.com/6556758/31634052-2515c95c-b290-11e7-9f67-df690150364c.gif)


**AFTER**:

![after](https://user-images.githubusercontent.com/6556758/31634482-c082874e-b291-11e7-9836-62740d812f59.gif)


@miq-bot add-label bug, core

\cc @gtanzillo @imtayadeway 







