### PR TITLE
Get rid of the condition modifier.

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -331,13 +331,9 @@ class MiqPolicy < ApplicationRecord
   end
 
   def self.eval_condition(c, rec, inputs = {})
-    possible_results = c['modifier'] == 'allow' ? %w(allow deny) : %w(deny allow)
-    begin
-      index = Condition.evaluate(c, rec, inputs) ? 0 : 1
-      possible_results[index]
-    rescue => err
-      logger.log_backtrace(err)
-    end
+    Condition.evaluate(c, rec, inputs) ? 'allow' : 'deny'
+  rescue => err
+    logger.log_backtrace(err)
   end
   private_class_method :eval_condition
 

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -63,7 +63,6 @@ class MiqPolicy < ApplicationRecord
             :name        => policy.attributes["name"],
             :description => policy.attributes["description"],
             :expression  => MiqExpression.new(policy.condition),
-            :modifier    => policy.modifier,
             :towhat      => "Vm"
           )]
         else

--- a/db/fixtures/miq_policy_sets.yml
+++ b/db/fixtures/miq_policy_sets.yml
@@ -72,18 +72,18 @@
       Condition:
       - name: if container image has high severity openscap rule results
         description: Has high severity OpenSCAP rule results
-        modifier: deny
         expression: !ruby/object:MiqExpression
           exp:
-            FIND:
-              search:
-                "=":
-                  field: ContainerImage.openscap_rule_results-result
-                  value: fail
-              checkany:
-                "=":
-                  field: ContainerImage.openscap_rule_results-severity
-                  value: High
+            not:
+              FIND:
+                search:
+                  "=":
+                    field: ContainerImage.openscap_rule_results-result
+                    value: fail
+                checkany:
+                  "=":
+                    field: ContainerImage.openscap_rule_results-severity
+                    value: High
           context_type:
         towhat: ContainerImage
         file_mtime:
@@ -123,12 +123,12 @@
       Condition:
       - name: "Do not scan image-inspector's image"
         description: "Don't scan image-inspector's image"
-        modifier: deny
         expression: !ruby/object:MiqExpression
           exp:
-            ENDS WITH:
-              field: ContainerImage-name
-              value: "/image-inspector"
+            not:
+              ENDS WITH:
+                field: ContainerImage-name
+                value: "/image-inspector"
           context_type:
         towhat: ContainerImage
         file_mtime:

--- a/product/policy/built_in_policies.yml
+++ b/product/policy/built_in_policies.yml
@@ -13,7 +13,6 @@
     - "=":
         field: Vm-power_state
         value: 'on'
-  :modifier: deny
   :mode: control
   :action: vm_stop
 - :name: Prevent Retired VM from Starting
@@ -26,7 +25,6 @@
     "=":
       field: Vm-retired
       value: true
-  :modifier: deny
   :mode: control
   :action: prevent
 - :name: Prevent Retired Instance from Starting
@@ -39,7 +37,6 @@
     "=":
       field: Vm-retired
       value: true
-  :modifier: deny
   :mode: control
   :action: vm_suspend
 - :name: Stop Retired VM
@@ -52,6 +49,5 @@
     "=":
       field: Vm-retired
       value: true
-  :modifier: deny
   :mode: control
   :action: vm_stop

--- a/spec/factories/condition.rb
+++ b/spec/factories/condition.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :condition do
     sequence(:name)        { |num| "condition_#{seq_padded_for_sorting(num)}" }
     sequence(:description) { |num| "Condition #{seq_padded_for_sorting(num)}" }
-    modifier               "allow"
     towhat                 "Vm"
     expression             { MiqExpression.new(">=" => {"field" => "Vm-num_cpu", "value" => "2"}) }
   end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -151,4 +151,17 @@ describe Condition do
       expect(Condition.subst_matches?(expr, vm1)).not_to be_truthy
     end
   end
+
+  describe ".import_from_hash" do
+    it "removes condition modifier" do
+      cond_hash = {
+        "description" => "test condition",
+        "expression"  => MiqExpression.new(">" => {"field" => "Vm-cpu_num", "value" => 2}),
+        "modifier"    => 'deny',
+        "towhat"      => "Vm"
+      }
+      condition, _s = Condition.import_from_hash(cond_hash)
+      expect(condition.expression.exp).to eq("not" => {">" => {"field" => "Vm-cpu_num", "value" => 2}})
+    end
+  end
 end


### PR DESCRIPTION
Get rid of the condition modifier which is confusing and not necessary.

Control and compliance policy actions can be set basing on condition success, failure or both.

However, the action for [built in policies](https://github.com/ManageIQ/manageiq/blob/master/product/policy/built_in_policies.yml) is defined only for a true condition and is executed when condition is met. But the old logic would invoke actions only upon false condition result. So the old logic uses condition modifier 'deny' to force a true condition result into false and vice versa. 
This flipping around seems not necessary and should be avoid to make a simple person's life easier and happier.

If a control policy has condition modifier set as 'deny', the actions for false condition would be invoked when the condition is actually met and vice versa. 

There is no way to specify the condition modifier when adding a policy via UI. It can be done only via yaml file.

I won't be surprised if you find this confusing :)

Depends on https://github.com/ManageIQ/manageiq-schema/pull/95

cc @gtanzillo @moolitayer 
@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1499161