### PR TITLE
Bumps net-ssh version from 3.2 to 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "more_core_extensions",           "~>3.3"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false
-gem "net-ssh",                        "=3.2.0",        :require => false
+gem "net-ssh",                        "~>4.2.0",        :require => false
 gem "openscap",                       "~>0.4.3",       :require => false
 gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.0.2"


### PR DESCRIPTION
This is needed b/c net-ssh 3.2 does not work correctly with Ruby 2.4.
See https://github.com/net-ssh/net-ssh/issues/535

Bumping it for linux_admin gem too at https://github.com/ManageIQ/linux_admin/pull/195

Steps for Testing/QA
-------------------------------
1. Start ManageIQ using Ruby 2.4 with OpenStack Infra provider present.
2. Go to Edit page for that model, go to tab for ssh keypair credentials.
3. Fill in correct username and correct key if not already present.
4. Click on Validate button.

Actual result:
Validation fails with `NoMethodError: undefined method `p=' for #<OpenSSL::PKey::DH:0x....>` in evm.log.

Expected result:
Validation pass (if correct username and ssh key)
