### PR TITLE
Fix issue where new Lan records don't get linked

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -343,6 +343,8 @@ module EmsRefresh::SaveInventoryInfra
     child_keys = [:subnets]
 
     save_inventory_multi(switch.lans, hashes, :use_association, [:uid_ems], child_keys, extra_keys)
+    switch.save! # Needed to get ids back for lan new records
+
     store_ids_for_new_records(switch.lans, hashes, :uid_ems)
 
     child_lans = hashes.select { |h| !h[:id].nil? && !h.fetch_path(:parent, :id).nil? }


### PR DESCRIPTION
When linking up lans to their parents we need the id for the new record.
Without saving the parent association these new ids weren't coming back
after saving.