### PR TITLE
Find peaks/troughs of memory usage during rollup

### DIFF
--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -173,6 +173,7 @@ module Metric::Rollup
     :cpu_usagemhz_rate_average,
     :disk_usage_rate_average,
     :mem_usage_absolute_average,
+    :derived_memory_used,
     :net_usage_rate_average
   ]
   BURST_TYPES = ['min', 'max']
@@ -239,13 +240,14 @@ module Metric::Rollup
         new_perf_counts[col] ||= 0
 
         value = rt.send(col)
-
-        if obj.kind_of?(VmOrTemplate) && BURST_COLS.include?(col)
-          new_perf[:min_max] ||= {}
-          rollup_burst(col, new_perf[:min_max], rt.timestamp, value)
-        end
-
         Metric::Aggregation::Aggregate.column(col, nil, new_perf, new_perf_counts, value)
+      end
+
+      next unless obj.kind_of?(VmOrTemplate)
+      new_perf[:min_max] ||= {}
+      BURST_COLS.each do |col|
+        value = rt.send(col)
+        rollup_burst(col, new_perf[:min_max], rt.timestamp, value)
       end
     end
 

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -168,16 +168,8 @@ module VmOrTemplate::RightSizing
   end
 
   def derived_memory_used_max_over_time_period
-    if has_attribute?("derived_memory_used_max_over_time_period")
-      self["derived_memory_used_max_over_time_period"]
-    else
-      opts = {
-        :end_date => Time.now.utc,
-        :days     => Metric::LongTermAverages::AVG_DAYS
-      }
-      VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", opts)
-                            .maximum(:derived_memory_used)
-    end
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
+    perfs.collect(&:abs_max_derived_memory_used_value).compact.max
   end
 
   private

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -721,21 +721,30 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :time_profile_id => tp_id,
-                         :resource_id     => vm.id
+                         :resource_id     => vm.id,
+                         :min_max         => {
+                           :abs_max_derived_memory_used_value => 100.00
+                         }
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :derived_memory_used => 10.0,
                          :time_profile_id     => tp_id,
-                         :resource_id         => vm.id
+                         :resource_id         => vm.id,
+                         :min_max             => {
+                           :abs_max_derived_memory_used_value => 500.00
+                         }
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :derived_memory_used => 1000.0,
                          :time_profile_id     => tp_id,
-                         :resource_id         => vm.id
+                         :resource_id         => vm.id,
+                         :min_max             => {
+                           :abs_max_derived_memory_used_value => 200.00
+                         }
     end
 
     it "calculates in ruby" do
-      expect(vm.derived_memory_used_max_over_time_period).to eq(1000.0)
+      expect(vm.derived_memory_used_max_over_time_period).to eq(500.0)
     end
 
     it "calculates in the database" do


### PR DESCRIPTION
Part of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1468634.

This PR covers the memory usage.

(#16195 covers CPU)
