### PR TITLE
Add scopes to substitute `:where_clause`s

### DIFF
--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -41,6 +41,8 @@ class ConfigurationProfile < ApplicationRecord
   virtual_column  :customization_script_ptable_name,   :type => :string
   virtual_column  :operating_system_flavor_name,       :type => :string
 
+  scope :with_manager, ->(manager_id) { where(:manager_id => manager_id) }
+
   def configuration_architecture
     tag_hash[ConfigurationArchitecture]
   end

--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -19,5 +19,7 @@ class ConfigurationScriptBase < ApplicationRecord
   has_many   :authentications,
              :through => :authentication_configuration_script_bases
 
+  scope :with_manager, ->(manager_id) { where(:manager_id => manager_id) }
+
   include ProviderObjectMixin
 end

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -41,6 +41,10 @@ class ConfiguredSystem < ApplicationRecord
   virtual_column  :customization_script_medium_name,   :type => :string
   virtual_column  :customization_script_ptable_name,   :type => :string
 
+  scope :with_inventory_root_group,     ->(group_id)   { where(:inventory_root_group_id => group_id) }
+  scope :with_manager,                  ->(manager_id) { where(:manager_id => manager_id) }
+  scope :with_configuration_profile_id, ->(profile_id) { where(:configuration_profile_id => profile_id) }
+
   def configuration_architecture
     tag_hash[ConfigurationArchitecture]
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -75,6 +75,8 @@ class ExtManagementSystem < ApplicationRecord
   validates :hostname, :presence => true, :if => :hostname_required?
   validate :hostname_uniqueness_valid?, :if => :hostname_required?
 
+  scope :with_eligible_manager_types, ->(eligible_types) { where(:type => eligible_types) }
+
   serialize :options
 
   def hostname_uniqueness_valid?

--- a/app/models/manageiq/providers/automation_manager/inventory_root_group.rb
+++ b/app/models/manageiq/providers/automation_manager/inventory_root_group.rb
@@ -4,6 +4,8 @@ class ManageIQ::Providers::AutomationManager::InventoryRootGroup < ManageIQ::Pro
 
   virtual_column :total_configured_systems, :type => :integer
 
+  scope :with_provider, ->(ems_id) { where(:ems_id => ems_id) }
+
   def total_configured_systems
     Rbac.filtered(configured_systems).count
   end

--- a/app/models/manageiq/providers/cloud_manager/vm_or_template.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm_or_template.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::CloudManager::VmOrTemplate < ActsAsArScope
   class << self
-    delegate :all_orphaned, :all_archived, :to => :aar_scope
+    delegate :orphaned, :archived, :to => :aar_scope
     delegate :klass, :to => :aar_scope, :prefix => true
   end
 

--- a/app/models/manageiq/providers/infra_manager/vm_or_template.rb
+++ b/app/models/manageiq/providers/infra_manager/vm_or_template.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::InfraManager::VmOrTemplate < ActsAsArScope
   class << self
-    delegate :all_orphaned, :all_archived, :to => :aar_scope
+    delegate :orphaned, :archived, :to => :aar_scope
     delegate :klass, :to => :aar_scope, :prefix => true
   end
 

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -26,6 +26,8 @@ class MiqWidget < ApplicationRecord
   serialize :visibility
   serialize :options
 
+  scope :with_content_type, ->(type) { where(:content_type => type) }
+
   include_concern 'ImportExport'
   include UuidMixin
   include YAMLImportExportMixin

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -43,6 +43,8 @@ class OrchestrationStack < ApplicationRecord
 
   virtual_column :stdout, :type => :string
 
+  scope :without_type, ->(type) { where.not(:type => type) }
+
   alias_method :orchestration_stack_parameters, :parameters
   alias_method :orchestration_stack_outputs,    :outputs
   alias_method :orchestration_stack_resources,  :resources

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -15,6 +15,8 @@ class OrchestrationTemplate < ApplicationRecord
             :if         => :unique_md5?
   validates_presence_of :name
 
+  scope :orderable, -> { where(:orderable => true) }
+
   before_destroy :check_not_in_use
 
   attr_accessor :remote_proxy
@@ -122,7 +124,7 @@ class OrchestrationTemplate < ApplicationRecord
 
   # List managers that may be able to deploy this template
   def self.eligible_managers
-    Rbac::Filterer.filtered(ExtManagementSystem, :where_clause => {:type => eligible_manager_types})
+    Rbac::Filterer.filtered(ExtManagementSystem, :named_scope => [[:with_eligible_manager_types, eligible_manager_types]])
   end
 
   delegate :eligible_managers, :to => :class

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -24,6 +24,8 @@ class PhysicalServer < ApplicationRecord
   has_one :host, :inverse_of => :physical_server
   has_one :asset_details, :as => :resource, :dependent => :destroy
 
+  scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
+
   def name_with_details
     details % {
       :name => name,

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -83,6 +83,9 @@ class Service < ApplicationRecord
   validates :display, :inclusion => { :in => [true, false] }
   validates :retired, :inclusion => { :in => [true, false] }
 
+  scope :displayed, ->              { where(:display => true) }
+  scope :retired,   ->(bool = true) { where(:retired => bool) }
+
   supports :reconfigure do
     unsupported_reason_add(:reconfigure, _("Reconfigure unsupported")) unless validate_reconfigure
   end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -65,6 +65,10 @@ class ServiceTemplate < ApplicationRecord
 
   virtual_has_one :config_info, :class_name => "Hash"
 
+  scope :with_service_template_catalog_id,          ->(cat_id) { where(:service_template_catalog_id => cat_id) }
+  scope :with_existent_service_template_catalog_id, ->         { where.not(:service_template_catalog_id => nil) }
+  scope :displayed,                                 ->         { where(:display => true) }
+
   def self.create_catalog_item(options, auth_user)
     transaction do
       create_from_options(options).tap do |service_template|

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -6,5 +6,8 @@ class Switch < ApplicationRecord
   has_many :lans, :dependent => :destroy
   has_many :subnets, :through => :lans
 
+  scope :shareable, ->     { where(:shared => true) }
+  scope :with_id,   ->(id) { where(:id => id) }
+
   acts_as_miq_taggable
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -188,7 +188,12 @@ class VmOrTemplate < ApplicationRecord
   before_validation :set_tenant_from_group
   after_save :save_genealogy_information
 
-  scope :active, -> { where.not(:ems_id => nil) }
+  scope :active,    ->       { where.not(:ems_id => nil) }
+  scope :with_type, ->(type) { where(:type => type) }
+  scope :archived,  ->       { where(:ems_id => nil, :storage_id => nil) }
+  scope :orphaned,  ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
+  scope :with_ems,  ->       { where.not(:ems_id => nil) }
+
 
   alias_method :datastores, :storages    # Used by web-services to return datastores as the property name
 
@@ -1676,24 +1681,6 @@ class VmOrTemplate < ApplicationRecord
 
   def console_supported?(_type)
     false
-  end
-
-  # Return all archived VMs
-  ARCHIVED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NULL".freeze
-  def self.all_archived
-    where(ARCHIVED_CONDITIONS)
-  end
-
-  # Return all orphaned VMs
-  ORPHANED_CONDITIONS = "vms.ems_id IS NULL AND vms.storage_id IS NOT NULL".freeze
-  def self.all_orphaned
-    where(ORPHANED_CONDITIONS)
-  end
-
-  # where.not(ORPHANED_CONDITIONS).where.not(ARCHIVED_CONDITIONS)
-  NOT_ARCHIVED_NOR_OPRHANED_CONDITIONS = "vms.ems_id IS NOT NULL".freeze
-  def self.not_archived_nor_orphaned
-    where.not(:ems_id => nil)
   end
 
   # Stop certain charts from showing unless the subclass allows

--- a/spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::CloudManager::VmOrTemplate do
       FactoryGirl.create(:vm_vmware)
       FactoryGirl.create(:template_vmware)
 
-      expect(described_class.all_archived).to match_array([vm, t])
+      expect(described_class.archived).to match_array([vm, t])
     end
   end
 end

--- a/spec/models/manageiq/providers/infra_manager/vm_or_template_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/vm_or_template_spec.rb
@@ -22,7 +22,7 @@ describe ManageIQ::Providers::InfraManager::VmOrTemplate do
       FactoryGirl.create(:vm_openstack)
       FactoryGirl.create(:template_openstack)
 
-      expect(described_class.all_archived).to match_array([vm, t])
+      expect(described_class.archived).to match_array([vm, t])
     end
   end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -963,7 +963,7 @@ describe VmOrTemplate do
       arch = FactoryGirl.create(:vm_or_template)
       FactoryGirl.create(:vm_or_template, :storage => FactoryGirl.create(:storage))
 
-      expect(VmOrTemplate.all_archived).to eq([arch])
+      expect(VmOrTemplate.archived).to eq([arch])
     end
   end
 
@@ -973,7 +973,7 @@ describe VmOrTemplate do
       FactoryGirl.create(:vm_or_template)
       orph = FactoryGirl.create(:vm_or_template, :storage => FactoryGirl.create(:storage))
 
-      expect(VmOrTemplate.all_orphaned).to eq([orph])
+      expect(VmOrTemplate.orphaned).to eq([orph])
     end
   end
 
@@ -983,7 +983,7 @@ describe VmOrTemplate do
       FactoryGirl.create(:vm_or_template)
       FactoryGirl.create(:vm_or_template, :storage => FactoryGirl.create(:storage))
 
-      expect(VmOrTemplate.not_archived_nor_orphaned).to eq([vm])
+      expect(VmOrTemplate.with_ems).to eq([vm])
     end
   end
 

--- a/tools/purge_archived_vms.rb
+++ b/tools/purge_archived_vms.rb
@@ -14,14 +14,14 @@ query = Vm.where("updated_on < ? or updated_on IS NULL", ARCHIVE_CUTOFF)
 archived = 0
 
 $log.info("Searching for archived VMs older than #{ARCHIVE_CUTOFF} UTC.")
-$log.info("Expecting to prune #{query.all_archived.count} of the #{query.count} older vms")
+$log.info("Expecting to prune #{query.archived.count} of the #{query.count} older vms")
 if REPORT_ONLY
   $log.info("Reporting only; no rows will be deleted.")
 else
   $log.warn("Will delete any matching records.")
 end
 
-query.all_archived.find_in_batches do |vms|
+query.archived.find_in_batches do |vms|
   vms.each do |vm|
     begin
       archived += 1


### PR DESCRIPTION
In order to remove `:where_clause` from `get_view` params in UI, we need
to have scopes which can replace them.

Depends on: https://github.com/ManageIQ/manageiq/pull/16236
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/2435