### PR TITLE
Add Generic Object Definition trait for methods, attributes, associations

### DIFF
--- a/spec/factories/generic_object_definition.rb
+++ b/spec/factories/generic_object_definition.rb
@@ -1,5 +1,15 @@
 FactoryGirl.define do
   factory :generic_object_definition do
     sequence(:name) { |n| "generic_object_definition_#{seq_padded_for_sorting(n)}" }
+
+    trait :with_methods_attributes_associations do
+      properties do
+        {
+          :methods      => %w(add_vms remove_vms),
+          :attributes   => { 'powered_on' => 'boolean', 'widget' => 'string' },
+          :associations => { 'vms' => 'Vm', 'services' => 'Service' }
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
Having a trait to create a fully built out generic object definition will help to clean up some API specs.

@miq-bot add_label test
