### PR TITLE
Use resources(VMs) also from all subtenants in chargeback reporting

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -129,7 +129,7 @@ class ChargebackVm < Chargeback
             _log.error("Unable to find tenant '#{@options[:tenant_id]}'. Calculating chargeback costs aborted.")
             raise MiqException::Error, "Unable to find tenant '#{@options[:tenant_id]}'"
           end
-          tenant.vms
+          Vm.where(:id => tenant.subtree.map { |t| t.vms.ids }.flatten)
         elsif @options[:service_id]
           service = Service.find(@options[:service_id])
           if service.nil?

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -241,13 +241,14 @@ describe ChargebackVm do
     end
 
     context "Report a chargeback of a tenant" do
-      let(:options_tenant) { base_options.merge(:tenant_id => @tenant.id) }
+      let(:options_tenant) { base_options.merge(:tenant_id => @tenant.id).tap { |t| t.delete(:tag) } }
+
       let(:start_time)  { report_run_time - 17.hours }
       let(:finish_time) { report_run_time - 14.hours }
 
       before do
         @tenant = FactoryGirl.create(:tenant)
-        @tenant_child = FactoryGirl.create(:tenant, :ancestry => @tenant.id)
+        @tenant_child = FactoryGirl.create(:tenant, :parent => @tenant)
         @vm_tenant = FactoryGirl.create(:vm_vmware, :tenant_id => @tenant_child.id,
                                         :name => "test_vm_tenant", :created_on => month_beginning)
 


### PR DESCRIPTION
in chargeback for vms report, in filter tab, when filter by tenant has been selected it did not take VMs from sub tenants for filtering in chargeback report.

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1498027


@miq-bot assign @gtanzillo 