### PR TITLE
Don't support memcached in containers even if it is installed

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -6,7 +6,7 @@ module MiqEnvironment
 
     def self.supports_memcached?
       return @supports_memcached unless @supports_memcached.nil?
-      @supports_memcached = self.is_linux? && self.is_appliance? && self.supports_command?('memcached') && self.supports_command?('memcached-tool') && self.supports_command?('service')
+      @supports_memcached = is_linux? && is_appliance? && !is_container? && supports_command?('memcached') && supports_command?('memcached-tool') && supports_command?('service')
     end
 
     def self.supports_apache?


### PR DESCRIPTION
In the monolithic image we will start memcached from the entrypoint without using systemd. The MiqMemcached code only uses systemd so that will break when we stop running systemd in the monolithic image.

This will be fine in the other container images as we don't install memcached there.