### PR TITLE
Enhance `resolve_view_path` to check for other possible yaml required for reporting

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -11,10 +11,15 @@ module MiqReport::ImportExport
       )
     end
 
-    def resolve_view_path(file_name)
+    def resolve_view_path(file_name, file_name_no_suffix = nil)
       view_paths.each do |path|
         full_path = File.join(path, file_name)
         return full_path if File.exist?(full_path)
+
+        if file_name_no_suffix
+          full_path_no_suffix = File.join(path, file_name_no_suffix)
+          return full_path_no_suffix if File.exist?(full_path_no_suffix)
+        end
       end
       nil
     end
@@ -103,7 +108,7 @@ module MiqReport::ImportExport
 
       suffix = suffix ? "-#{suffix}" : ''
 
-      viewfile = resolve_view_path("#{db}#{suffix}.yaml")
+      viewfile = resolve_view_path("#{db}#{suffix}.yaml", "#{db}.yaml")
       viewfilebyrole = resolve_view_path("#{db}#{suffix}-#{role}.yaml")
 
       viewfilerestricted || viewfilebyrole || viewfile


### PR DESCRIPTION
This fix gets rid of the`options[:associations]=nil` exception in the GTL code which is preventing a GTL refactor.
Related discussion here -  https://github.com/ManageIQ/manageiq-ui-classic/pull/2378