### PR TITLE
Change in :named_scope to allow chaining

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -576,10 +576,10 @@ module Rbac
 
     def apply_scope(klass, scope)
       klass = klass.all
-      if !scope.kind_of?(Array)
-        send_scope(klass, scope)
-      else
+      if scope.kind_of?(Array)
         scope.inject(klass) { |k, s| send_scope(k, s) }
+      else
+        send_scope(klass, scope)
       end
     end
 

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -147,8 +147,10 @@ module Rbac
     #   - Array<Numeric> list if ids. :class is required. results are returned as ids
     #   - Array<Object> list of objects. results are returned as objects
     # @option options :named_scope   [Symbol|Array<String,Integer>] support for using named scope in search
-    #     Example without args: :named_scope => :in_my_region
-    #     Example with args:    :named_scope => [in_region, 1]
+    #     Example one scope without args:     :named_scope => :in_my_region
+    #     Example one scope with args:        :named_scope => [[:in_region, 1]]
+    #     Example more scopes without args:   :named_scope => [:in_my_region, :active]
+    #     Example more scopes some with args: :named_scope => [[:in_region, 1], :active, [:with_manager, "X"]]
     # @option options :conditions    [Hash|String|Array<String>]
     # @option options :where_clause  []
     # @option options :sub_filter
@@ -181,10 +183,6 @@ module Rbac
       # => list of objects
       # results are returned in the same format as the targets. for empty targets, the default result format is a list of ids.
       targets           = options[:targets]
-
-      # Support for using named_scopes in search. Supports scopes with or without args:
-      # Example without args: :named_scope => :in_my_region
-      # Example with args:    :named_scope => [in_region, 1]
       scope             = options[:named_scope]
 
       klass             = to_class(options[:class])
@@ -563,8 +561,7 @@ module Rbac
       klass.kind_of?(String) || klass.kind_of?(Symbol) ? klass.to_s.constantize : klass
     end
 
-    def apply_scope(klass, scope)
-      klass = klass.all
+    def send_scope(klass, scope)
       scope_name = Array.wrap(scope).first
       if scope_name.nil?
         klass
@@ -574,6 +571,15 @@ module Rbac
                                                                                            :class_name => class_name}
       else
         klass.send(*scope)
+      end
+    end
+
+    def apply_scope(klass, scope)
+      klass = klass.all
+      if !scope.kind_of?(Array)
+        send_scope(klass, scope)
+      else
+        scope.inject(klass) { |k, s| send_scope(k, s) }
       end
     end
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1436,7 +1436,7 @@ describe Rbac::Filterer do
 
           it "works when passing a named_scope" do
             User.with_user(user) do
-              results = described_class.search(:class => "Vm", :named_scope => [:group_scope, 1]).first
+              results = described_class.search(:class => "Vm", :named_scope => [[:group_scope, 1]]).first
               expect(results.length).to eq(1)
             end
           end
@@ -1465,10 +1465,10 @@ describe Rbac::Filterer do
 
           it "works when passing a named_scope" do
             User.with_user(user) do
-              results = described_class.search(:class => "Vm", :named_scope => [:group_scope, 1]).first
+              results = described_class.search(:class => "Vm", :named_scope => [[:group_scope, 1]]).first
               expect(results.length).to eq(1)
 
-              results = described_class.search(:class => "Vm", :named_scope => [:group_scope, 2]).first
+              results = described_class.search(:class => "Vm", :named_scope => [[:group_scope, 2]]).first
               expect(results.length).to eq(0)
             end
           end
@@ -1491,7 +1491,7 @@ describe Rbac::Filterer do
         end
 
         it "works when passing a named_scope" do
-          results = described_class.search(:class => "Vm", :named_scope => [:group_scope, 4]).first
+          results = described_class.search(:class => "Vm", :named_scope => [[:group_scope, 4]]).first
           expect(results.length).to eq(1)
         end
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1393,6 +1393,8 @@ describe Rbac::Filterer do
     end
 
     context "with tagged VMs" do
+      let(:ems) { FactoryGirl.create(:ext_management_system) }
+
       before(:each) do
         [
           FactoryGirl.create(:host, :name => "Host1", :hostname => "host1.local"),
@@ -1407,11 +1409,13 @@ describe Rbac::Filterer do
           vm.host = host
           vm.evm_owner_id = user.id  if i.even?
           vm.miq_group_id = group.id if i.odd?
+          vm.ext_management_system = ems if i.even?
           vm.save
           vm.tag_with(@tags.values.join(" "), :ns => "*") if i > 0
         end
 
-        Vm.scope :group_scope, ->(group_num) { Vm.where("name LIKE ?", "Test Group #{group_num}%") }
+        Vm.scope :group_scope,    ->(group_num) { Vm.where("name LIKE ?", "Test Group #{group_num}%") }
+        Vm.scope :is_on,          ->            { Vm.where(:power_state => "on") }
       end
 
       context ".search" do
@@ -1491,7 +1495,22 @@ describe Rbac::Filterer do
         end
 
         it "works when passing a named_scope" do
+          results = described_class.search(:class => "Vm", :named_scope => :is_on).first
+          expect(results.length).to eq(4)
+        end
+
+        it "works when passing a named_scope with parameterized scope" do
           results = described_class.search(:class => "Vm", :named_scope => [[:group_scope, 4]]).first
+          expect(results.length).to eq(1)
+        end
+
+        it "works when passing a named_scope with multiple scopes" do
+          results = described_class.search(:class => "Vm", :named_scope => [:is_on, :active]).first
+          expect(results.length).to eq(2)
+        end
+
+        it "works when passing a named_scope with multiple mixed scopes" do
+          results = described_class.search(:class => "Vm", :named_scope => [[:group_scope, 3], :active]).first
           expect(results.length).to eq(1)
         end
 


### PR DESCRIPTION
Chaining of scopes is required since we need to combine multiple scopes in stateless report data. When we're able to chain scopes, we can avoid the need of having complex scopes.

Required by: https://github.com/ManageIQ/manageiq/pull/16226
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/2459