### PR TITLE
No need to skip ovirt's - 'ensure_managers' was moved to a separate job

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -153,11 +153,6 @@ FactoryGirl.define do
   end
 
   factory :ems_redhat,
-          :parent => :ems_redhat_with_ensure_managers do
-    after(:build) { |ems_redhat| ems_redhat.define_singleton_method(:ensure_managers) {} }
-  end
-
-  factory :ems_redhat_with_ensure_managers,
           :aliases => ["manageiq/providers/redhat/infra_manager"],
           :class   => "ManageIQ::Providers::Redhat::InfraManager",
           :parent  => :ems_infra do


### PR DESCRIPTION
No need to skip ovirt's - 'ensure_managers' was moved to a separate job