### PR TITLE
Pass extra options into miq_adv_search_lists

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -913,8 +913,8 @@ class MiqExpression
     when :exp_available_fields then
       options.merge!(:typ => "field", :disallow_loading_virtual_custom_attributes => false)
       @miq_adv_search_lists[model.to_s][:exp_available_fields] ||= MiqExpression.model_details(model, options)
-    when :exp_available_counts then @miq_adv_search_lists[model.to_s][:exp_available_counts] ||= MiqExpression.model_details(model, options.merge!(:typ => "count"))
-    when :exp_available_finds  then @miq_adv_search_lists[model.to_s][:exp_available_finds]  ||= MiqExpression.model_details(model, options.merge!(:typ => "find"))
+    when :exp_available_counts then @miq_adv_search_lists[model.to_s][:exp_available_counts] ||= MiqExpression.model_details(model, options.merge(:typ => "count"))
+    when :exp_available_finds  then @miq_adv_search_lists[model.to_s][:exp_available_finds]  ||= MiqExpression.model_details(model, options.merge(:typ => "find"))
     end
   end
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -911,8 +911,7 @@ class MiqExpression
 
     case what.to_sym
     when :exp_available_fields then
-      options.merge!(:typ => "field", :disallow_loading_virtual_custom_attributes => false)
-      @miq_adv_search_lists[model.to_s][:exp_available_fields] ||= MiqExpression.model_details(model, options)
+      @miq_adv_search_lists[model.to_s][:exp_available_fields] ||= MiqExpression.model_details(model, options.merge(:typ => "field", :disallow_loading_virtual_custom_attributes => false))
     when :exp_available_counts then @miq_adv_search_lists[model.to_s][:exp_available_counts] ||= MiqExpression.model_details(model, options.merge(:typ => "count"))
     when :exp_available_finds  then @miq_adv_search_lists[model.to_s][:exp_available_finds]  ||= MiqExpression.model_details(model, options.merge(:typ => "find"))
     end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -904,16 +904,17 @@ class MiqExpression
     @model_relats[model] ||= build_relats(model)
   end
 
-  def self.miq_adv_search_lists(model, what)
+  def self.miq_adv_search_lists(model, what, extra_options = {})
     @miq_adv_search_lists ||= {}
     @miq_adv_search_lists[model.to_s] ||= {}
+    options = {:include_model => true}.merge(extra_options)
 
     case what.to_sym
     when :exp_available_fields then
-      options = {:typ => "field", :include_model => true, :disallow_loading_virtual_custom_attributes => false}
+      options.merge!(:typ => "field", :disallow_loading_virtual_custom_attributes => false)
       @miq_adv_search_lists[model.to_s][:exp_available_fields] ||= MiqExpression.model_details(model, options)
-    when :exp_available_counts then @miq_adv_search_lists[model.to_s][:exp_available_counts] ||= MiqExpression.model_details(model, :typ => "count", :include_model => true)
-    when :exp_available_finds  then @miq_adv_search_lists[model.to_s][:exp_available_finds]  ||= MiqExpression.model_details(model, :typ => "find",  :include_model => true)
+    when :exp_available_counts then @miq_adv_search_lists[model.to_s][:exp_available_counts] ||= MiqExpression.model_details(model, options.merge!(:typ => "count"))
+    when :exp_available_finds  then @miq_adv_search_lists[model.to_s][:exp_available_finds]  ||= MiqExpression.model_details(model, options.merge!(:typ => "find"))
     end
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -3254,4 +3254,35 @@ describe MiqExpression do
       expect(actual).to eq([["My Company Tags : Environment", "managed-env"]])
     end
   end
+
+  describe "miq_adv_search_lists" do
+    it ":exp_available_fields" do
+      options = {:include_model                              => true,
+                 :typ                                        => 'field',
+                 :disallow_loading_virtual_custom_attributes => false}
+      expect(described_class).to receive(:model_details).with(Vm, options)
+      described_class.miq_adv_search_lists(Vm, :exp_available_fields)
+    end
+
+    it ":exp_available_counts" do
+      options = {:include_model => true, :typ => 'count'}
+      expect(described_class).to receive(:model_details).with(Vm, options)
+      described_class.miq_adv_search_lists(Vm, :exp_available_counts)
+    end
+
+    it ":exp_available_finds" do
+      options = {:include_model => true, :typ => 'find'}
+      expect(described_class).to receive(:model_details).with(Vm, options)
+      described_class.miq_adv_search_lists(Vm, :exp_available_finds)
+    end
+
+    it ":exp_available_fields with include_id_columns" do
+      options = {:include_model                              => true,
+                 :typ                                        => 'field',
+                 :include_id_columns                         => true,
+                 :disallow_loading_virtual_custom_attributes => false}
+      expect(described_class).to receive(:model_details).with(Vm, options)
+      described_class.miq_adv_search_lists(Vm, :exp_available_fields, :include_id_columns => true)
+    end
+  end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -3256,33 +3256,22 @@ describe MiqExpression do
   end
 
   describe "miq_adv_search_lists" do
-    it ":exp_available_fields" do
-      options = {:include_model                              => true,
-                 :typ                                        => 'field',
-                 :disallow_loading_virtual_custom_attributes => false}
-      expect(described_class).to receive(:model_details).with(Vm, options)
-      described_class.miq_adv_search_lists(Vm, :exp_available_fields)
-    end
-
     it ":exp_available_counts" do
-      options = {:include_model => true, :typ => 'count'}
-      expect(described_class).to receive(:model_details).with(Vm, options)
-      described_class.miq_adv_search_lists(Vm, :exp_available_counts)
+      result = described_class.miq_adv_search_lists(Vm, :exp_available_counts)
+
+      expect(result.map(&:first)).to include(" VM and Instance.Users")
     end
 
     it ":exp_available_finds" do
-      options = {:include_model => true, :typ => 'find'}
-      expect(described_class).to receive(:model_details).with(Vm, options)
-      described_class.miq_adv_search_lists(Vm, :exp_available_finds)
+      result = described_class.miq_adv_search_lists(Vm, :exp_available_finds)
+
+      expect(result.map(&:first)).to include("VM and Instance.Provisioned VMs : Href Slug")
+      expect(result.map(&:first)).not_to include("VM and Instance : Id")
     end
 
     it ":exp_available_fields with include_id_columns" do
-      options = {:include_model                              => true,
-                 :typ                                        => 'field',
-                 :include_id_columns                         => true,
-                 :disallow_loading_virtual_custom_attributes => false}
-      expect(described_class).to receive(:model_details).with(Vm, options)
-      described_class.miq_adv_search_lists(Vm, :exp_available_fields, :include_id_columns => true)
+      result = described_class.miq_adv_search_lists(Vm, :exp_available_fields, :include_id_columns => true)
+      expect(result.map(&:first)).to include("VM and Instance : Id")
     end
   end
 end


### PR DESCRIPTION
The Expression Editor is used to build Advanced Search Filters and Automate Expression Methods.
When using it as an Automate Expression Method we need to compare object ids since custom dialogs for drop down items use ID to uniquely identify objects.

This PR allows for the miq_adv_search_lists to expect an extra argument from the UI which can pass in 
:include_id_columns => true implemented in PR https://github.com/ManageIQ/manageiq/pull/16204