### PR TITLE
Allow dot in event names

### DIFF
--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -3,8 +3,8 @@ class MiqEventDefinition < ApplicationRecord
 
   validates_presence_of     :name
   validates_uniqueness_of   :name
-  validates_format_of       :name, :with => /\A[a-z0-9_\-]+\z/i,
-    :allow_nil => true, :message => "must only contain alpha-numeric, underscore and hyphen characters without spaces"
+  validates_format_of       :name, :with => /\A[a-z0-9_\-.]+\z/i,
+    :allow_nil => true, :message => "must only contain alpha-numeric, underscore, hyphen and dot characters without spaces"
   validates_presence_of     :description
 
   acts_as_miq_set_member


### PR DESCRIPTION
Allow a dot in event names when parsing them from the `miq_event_definition.csv`.

For Hawkular-ManageIQ event integration we need to be able to push Hawkular events into here. Unfortunately the event name includes a dot, e.g. `hawkular_datasource.ok` or `hawkular_datasource_remove.error`.

Required by https://github.com/ManageIQ/manageiq/pull/16134