### PR TITLE
[WIP] Remove using Setting[:new_chargeback] from chargeback specs, fix sporadic failure 

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -29,11 +29,7 @@ class Chargeback < ActsAsArModel
       data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')
 
       # we are getting hash with metrics and costs for metrics defined for chargeback
-      if Settings[:new_chargeback]
-        data[key].new_chargeback_calculate_costs(consumption, rates_to_apply)
-      else
-        data[key].calculate_costs(consumption, rates_to_apply)
-      end
+      data[key].calculate_costs(consumption, rates_to_apply)
     end
     _log.info("Calculating chargeback costs...Complete")
 
@@ -87,46 +83,6 @@ class Chargeback < ActsAsArModel
       'Container'
     when ChargebackContainerImage
       'ContainerImage'
-    end
-  end
-
-  def new_chargeback_calculate_costs(consumption, rates)
-    self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
-
-    rates.each do |rate|
-      plan = ManageIQ::Consumption::ShowbackPricePlan.find_or_create_by(:description => rate.description,
-                                                                        :name        => rate.description,
-                                                                        :resource    => MiqEnterprise.first)
-      
-      data = {}
-      rate.rate_details_relevant_to(relevant_fields).each do |r|
-        r.populate_showback_rate(plan, r, showback_category)
-        measure = r.chargeable_field.showback_measure
-        dimension, _, _ = r.chargeable_field.showback_dimension
-        value = r.chargeable_field.measure(consumption, @options)
-        data[measure] ||= {}
-        data[measure][dimension] = [value, r.showback_unit(ChargeableField::UNITS[r.chargeable_field.metric])]
-      end
-
-      results = plan.calculate_list_of_costs_input(resource_type:  showback_category,
-                                                   data:           data,
-                                                   start_time:     consumption.instance_variable_get("@start_time"),
-                                                   end_time:       consumption.instance_variable_get("@end_time"),
-                                                   cycle_duration: @options.duration_of_report_step)
-
-      results.each do |cost_value, sb_rate|
-        r = ChargebackRateDetail.find(sb_rate.concept)
-        metric = r.chargeable_field.metric
-        metric_index = ChargeableField::VIRTUAL_COL_USES.invert[metric] || metric
-        metric_value = data[r.chargeable_field.group][metric_index]
-        metric_field = [r.chargeable_field.group, r.chargeable_field.source, "metric"].join("_")
-        cost_field = [r.chargeable_field.group, r.chargeable_field.source, "cost"].join("_")
-        _, total_metric_field, total_field = r.chargeable_field.cost_keys
-        self[total_field] = (self[total_field].to_f || 0) + cost_value.to_f
-        self[total_metric_field] = (self[total_metric_field].to_f || 0) + cost_value.to_f
-        self[cost_field] = cost_value.to_f
-        self[metric_field] = metric_value.first.to_f
-      end
     end
   end
 

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -13,6 +13,10 @@ class Chargeback < ActsAsArModel
     :metering_used_cost   => :float
   )
 
+  def self.self_class
+    Settings[:new_chargeback] ? include(Chargeback::New) : self
+  end
+
   def self.build_results_for_report_chargeback(options)
     _log.info("Calculating chargeback costs...")
     @options = options = ReportOptions.new_from_h(options)
@@ -23,7 +27,7 @@ class Chargeback < ActsAsArModel
       rates_to_apply = rates.get(consumption)
 
       key = report_row_key(consumption)
-      data[key] ||= new(options, consumption)
+      data[key] ||= self_class.new(options, consumption)
 
       chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
       data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')

--- a/app/models/chargeback/new.rb
+++ b/app/models/chargeback/new.rb
@@ -1,0 +1,47 @@
+class Chargeback
+  module New
+    def self.included(child)
+      child.class_eval do
+        def calculate_costs(consumption, rates)
+          self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
+
+          rates.each do |rate|
+            plan = ManageIQ::Consumption::ShowbackPricePlan.find_or_create_by(:description => rate.description,
+                                                                              :name        => rate.description,
+                                                                              :resource    => MiqEnterprise.first)
+
+            data = {}
+            rate.rate_details_relevant_to(relevant_fields).each do |r|
+              r.populate_showback_rate(plan, r, showback_category)
+              measure = r.chargeable_field.showback_measure
+              dimension, _, _ = r.chargeable_field.showback_dimension
+              value = r.chargeable_field.measure(consumption, @options)
+              data[measure] ||= {}
+              data[measure][dimension] = [value, r.showback_unit(ChargeableField::UNITS[r.chargeable_field.metric])]
+            end
+
+            results = plan.calculate_list_of_costs_input(resource_type:  showback_category,
+                                                         data:           data,
+                                                         start_time:     consumption.instance_variable_get("@start_time"),
+                                                         end_time:       consumption.instance_variable_get("@end_time"),
+                                                         cycle_duration: @options.duration_of_report_step)
+
+            results.each do |cost_value, sb_rate|
+              r = ChargebackRateDetail.find(sb_rate.concept)
+              metric = r.chargeable_field.metric
+              metric_index = ChargeableField::VIRTUAL_COL_USES.invert[metric] || metric
+              metric_value = data[r.chargeable_field.group][metric_index]
+              metric_field = [r.chargeable_field.group, r.chargeable_field.source, "metric"].join("_")
+              cost_field = [r.chargeable_field.group, r.chargeable_field.source, "cost"].join("_")
+              _, total_metric_field, total_field = r.chargeable_field.cost_keys
+              self[total_field] = (self[total_field].to_f || 0) + cost_value.to_f
+              self[total_metric_field] = (self[total_metric_field].to_f || 0) + cost_value.to_f
+              self[cost_field] = cost_value.to_f
+              self[metric_field] = metric_value.first.to_f
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/chargeback_container_image_new_chargeback_spec.rb
+++ b/spec/models/chargeback_container_image_new_chargeback_spec.rb
@@ -1,3 +1,3 @@
-Settings[:new_chargeback] = '1'
+ChargebackContainerImage.include(Chargeback::New)
 require './spec/models/chargeback_container_image_spec.rb'
 

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -141,8 +141,4 @@ describe ChargebackContainerImage do
       expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
     end
   end
-
-  after(:all) do
-    Settings[:new_chargeback] = nil if Settings[:new_chargeback]
-  end
 end

--- a/spec/models/chargeback_container_project_new_chargeback_spec.rb
+++ b/spec/models/chargeback_container_project_new_chargeback_spec.rb
@@ -1,2 +1,2 @@
-Settings[:new_chargeback] = '1'
+ChargebackContainerImage.include(Chargeback::New)
 require './spec/models/chargeback_container_project_spec.rb'

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -29,7 +29,7 @@ describe ChargebackContainerProject do
 
   let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
-  before(:each) do
+  before do
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -232,8 +232,4 @@ describe ChargebackContainerProject do
       expect(subject.fixed_compute_metric).to eq(@metric_size / 2)
     end
   end
-
-  after(:all) do
-    Settings[:new_chargeback] = nil if Settings[:new_chargeback]
-  end
 end

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -208,7 +208,7 @@ describe ChargebackContainerProject do
 
   context "gets rate from enterprise" do
     let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
-    let(:miq_enterprise) { MiqEnterprise.first || FactoryGirl.create(:miq_enterprise) }
+    let(:miq_enterprise) { MiqEnterprise.first }
 
     before do
       add_metric_rollups_for(@project, month_beginning...month_end, 24.hours, metric_rollup_params)

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -83,6 +83,13 @@ describe ChargebackVm do
   let(:cpu_usage_cost) { cpu_usagemhz * consumed_hours * hourly_rate }
 
   it 'should calculate the same -- no matter the time range (daily/weekly/monthly)' do
+    puts "-------"
+    puts ChargebackVm.include?(Chargeback::New)
+    puts ChargebackContainerImage.include?(Chargeback::New)
+    puts ChargebackContainerProject.include?(Chargeback::New)
+    puts Settings[:new_chargeback]
+    puts "----"
+
     [daily_cb, weekly_cb, monthly_cb].each do |cb|
       expect(cb.start_date).to eq(report_run_time.beginning_of_month)
       expect(cb.fixed_compute_metric).to eq(consumed_hours)

--- a/spec/models/chargeback_vm_new_chargeback_spec.rb
+++ b/spec/models/chargeback_vm_new_chargeback_spec.rb
@@ -1,2 +1,2 @@
-Settings[:new_chargeback] = '1'
+ChargebackVm.include(Chargeback::New)
 require './spec/models/chargeback_vm_spec.rb'

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -630,8 +630,4 @@ describe ChargebackVm do
       end
     end
   end
-
-  after(:all) do
-    Settings[:new_chargeback] = nil if Settings[:new_chargeback]
-  end
 end


### PR DESCRIPTION
this is fixing sporadic failure https://travis-ci.org/ManageIQ/manageiq/jobs/290169994
concretely here:
where the spec `spec/models/chargeback_vm/ongoing_time_period_spec.rb` has been called with `Setting[:new_chargeback] = true`, which was set by other spec.
- in two last commit is small clean up

## Solution
- Removing controlling  of usage new chargeback by Setting[:new_chargeback] in specs
- entry point of new chargeback is moved to module (method is renamed to calculate_costs - same for old chargeback) 
- entry point of new chargeback is used when new module Chargeback::New is included to the Chargeback class
- `Setting[:new_chargeback]` is still used but only from setting for the server

@miq-bot add_label sporadic failure, technical_debt

cc @bdunne @Fryguy @jrafanie 

@miq-bot assign @gtanzillo 

## Links 
clean up after https://github.com/ManageIQ/manageiq/pull/16214
