### PR TITLE
[EUWE] Disable VNC console button for VMware 6.5 and later

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1131,6 +1131,10 @@ class ApplicationHelper::ToolbarBuilder
         if @record.current_state != "on"
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
+        type = get_vmdb_config.fetch_path(:server, :remote_console_type)
+        if @record.vendor == 'vmware' && type == 'VNC' && @record.console_supported?(type) && @record.ext_management_system.api_version.to_f > 6
+          return N_("The web-based VNC console is not available on VMware versions 6.5 and above.")
+        end
       when "instance_retire_now"
         return N_("Instance is already retired") if @record.retired
       when "vm_timeline"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1683,6 +1683,21 @@ describe ApplicationHelper do
           allow(@record).to receive_messages(:current_state => 'on', :ipaddresses => '192.168.1.1')
         end
 
+        it "VM on VMware API > 6" do
+          vmdb_config = {
+            :server => {
+              :remote_console_type => 'VNC'
+            }
+          }
+          stub_server_configuration(vmdb_config)
+
+          ems = FactoryGirl.create(:ems_vmware)
+          @record = FactoryGirl.create(:vm_vmware, :ext_management_system => ems, :vendor => 'vmware')
+
+          allow(ems).to receive_messages(:api_version => '6.5')
+          expect(subject).to eq("The web-based VNC console is not available on VMware versions 6.5 and above.")
+        end
+
         it_behaves_like 'vm not powered on', "The web-based VNC console is not available because the VM is not powered on"
         it_behaves_like 'default case'
       end


### PR DESCRIPTION
VMware does not support VNC consoles in v6.5 or later.  This disables the VM Console button for affected VMs on VMware hosts.

https://bugzilla.redhat.com/show_bug.cgi?id=1500995