### PR TITLE
Don't allow nil values in embedded_methods

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -3,7 +3,7 @@ require 'manageiq/automation_engine/syntax_checker'
 class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
-  default_value_for :embedded_methods, []
+  default_value_for :embedded_methods, :value => [], :allows_nil => false
 
   belongs_to :ae_class, :class_name => "MiqAeClass", :foreign_key => :class_id
   has_many   :inputs,   -> { order(:priority) }, :class_name => "MiqAeField", :foreign_key => :method_id,


### PR DESCRIPTION
The UI can send embedded_methods set to nil, we are expecting the embedded_methods to be an array.
Fixed the default_value_for call to not allow nil

This PR is an alternative to https://github.com/ManageIQ/manageiq-ui-classic/pull/2480

@h-kataria @gmcculloug 