### PR TITLE
[WIP] Added ANSIBLE_JOB_TEMPLATE_SYMBOLS

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -20,7 +20,8 @@ class MiqAeMethod < ApplicationRecord
                                   :network_credential_id,
                                   :cloud_credential_id,
                                   :verbosity,
-                                  :become_enabled].freeze
+                                  :become_enabled,
+                                  :extra_vars].freeze
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -14,6 +14,14 @@ class MiqAeMethod < ApplicationRecord
   validates_format_of     :name, :with    => /\A[\w]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ characters")
 
+  ANSIBLE_JOB_TEMPLATE_SYMBOLS = [:repository_id,
+                                  :playbook_id,
+                                  :credential_id,
+                                  :network_credential_id,
+                                  :cloud_credential_id,
+                                  :verbosity,
+                                  :become_enabled].freeze
+
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES
   AVAILABLE_LOCATIONS = %w(builtin inline uri expression playbook).freeze


### PR DESCRIPTION
Constant Needed by Automation Engine and UI

This can then be used in YAML.safe_load by UI and Automate Engine
https://github.com/ManageIQ/manageiq-ui-classic/blob/664a447174fb3ff23b5c9b5efa6382a0d05b417b/app/controllers/miq_ae_class_controller.rb#L986