### PR TITLE
Turn options into indifferent access

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < ::Job
   # options are job table columns, including options column which is the playbook context info
   def self.create_job(options)
-    super(name, options)
+    super(name, options.with_indifferent_access)
   end
 
   def start

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -36,7 +36,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
     end
 
     context 'other hosts are used' do
-      let(:options) { {:hosts => 'host1,host2'} }
+      # Use string key to also test the indifferent accessibility
+      let(:options) { {'hosts' => 'host1,host2'} }
 
       it 'creates an inventory and moves on to create_job_template' do
         expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Inventory).to receive(:raw_create_inventory).and_return(double(:id => 'inv1'))


### PR DESCRIPTION
The existing code expects all options keys are symbols. We discovered symbols keys can cause troubles for serializing and deserializing. With the simple fix we now accept either symbol or string.