### PR TITLE
Fix Expression builder argument error by reverting #5506

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -181,10 +181,6 @@ class Host < ApplicationRecord
     end
   end
 
-  def self.include_descendant_classes_in_expressions?
-    true
-  end
-
   def self.non_clustered
     where(:ems_cluster_id => nil)
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -12,10 +12,6 @@ class Vm < VmOrTemplate
     Vm
   end
 
-  def self.include_descendant_classes_in_expressions?
-    true
-  end
-
   def self.corresponding_model
     if self == Vm
       MiqTemplate

--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -155,6 +155,7 @@
 - storage_files
 - switches
 - tenant_quotas
+- tenants
 - users
 - vms
 - volumes

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -949,12 +949,7 @@ class MiqExpression
     result = {:columns => model.attribute_names, :parent => parent}
     result[:reflections] = {}
 
-    refs = model.reflections_with_virtual
-    if model.try(:include_descendant_classes_in_expressions?)
-      model.descendants.each { |desc| refs.reverse_merge!(desc.reflections_with_virtual) }
-    end
-
-    refs.each do |assoc, ref|
+    model.reflections_with_virtual.each do |assoc, ref|
       next unless INCLUDE_TABLES.include?(assoc.to_s.pluralize)
       next if     assoc.to_s.pluralize == "event_logs" && parent[:root] == "Host" && !proto?
       next if     assoc.to_s.pluralize == "processes" && parent[:root] == "Host" # Process data not available yet for Host

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2085,23 +2085,6 @@ describe MiqExpression do
     end
   end
 
-  context ".build_relats" do
-    it "includes reflections from descendant classes of Vm" do
-      relats = MiqExpression.get_relats(Vm)
-      expect(relats[:reflections][:cloud_tenant]).not_to be_blank
-    end
-
-    it "includes reflections from descendant classes of Host" do
-      relats = MiqExpression.get_relats(Host)
-      expect(relats[:reflections][:cloud_networks]).not_to be_blank
-    end
-
-    it "excludes reflections from descendant classes of VmOrTemplate " do
-      relats = MiqExpression.get_relats(VmOrTemplate)
-      expect(relats[:reflections][:cloud_tenant]).to be_blank
-    end
-  end
-
   describe "#to_human" do
     it "generates a human readable string for a 'FIELD' expression" do
       exp = MiqExpression.new(">" => {"field" => "Vm-allocated_disk_storage", "value" => "5.megabytes"})


### PR DESCRIPTION
This attempts to fix old bug https://bugzilla.redhat.com/show_bug.cgi?id=1236001 by reverting https://github.com/ManageIQ/manageiq/pull/5506 (the original solution) and adding `tenants` to the list of inclusion tables.

I'm struggling to understand the original bug, which complained about "Tenant" not being available in Vm or Instance conditions. The solution was to add cloud tenants instead, which is the thing that breaks the bug below. As I understand it, this solution fixes both these bugs. But I'm sure there are some things I'm missing, so I'd like to discuss before proceeding.

/cc @gtanzillo @yrudman 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1491620

@miq-bot add-label bug
@miq-bot assign @gtanzillo 