### PR TITLE
Updates model to indicate support for console

### DIFF
--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class PhysicalInfraManager < BaseManager
+    include SupportsFeatureMixin
+
     virtual_total :total_physical_servers,    :physical_servers
     virtual_column :total_hosts,              :type => :integer
     virtual_column :total_vms,                :type => :integer
@@ -32,5 +34,19 @@ module ManageIQ::Providers
     end
 
     alias total_vms count_vms
+
+    supports :console do
+      unless console_supported?
+        unsupported_reason_add(:console, N_("Console not supported"))
+      end
+    end
+
+    def console_supported?
+      false
+    end
+
+    def console_url
+      raise MiqException::Error, _("Console not supported")
+    end
   end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6261,6 +6261,10 @@
       :description: Re-check Authentication Status of Physical Infrastructure Providers
       :feature_type: control
       :identifier: ems_physical_infra_recheck_auth_status
+    - :name: Management Console
+      :description: Open a management console
+      :feature_type: control
+      :identifier: ems_physical_infra_console
   - :name: Modify
     :description: Modify Physical Infrastructure Providers
     :feature_type: admin

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -109,6 +109,7 @@
   - ems_infra_show_list
   - ems_infra_tag
   - ems_infra_timeline
+  - ems_physical_infra_console
   - ems_physical_infra_show
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
@@ -197,6 +198,7 @@
   - ems_infra_show_list
   - ems_infra_tag
   - ems_infra_timeline
+  - ems_physical_infra_console
   - ems_physical_infra_show
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
@@ -347,6 +349,7 @@
   - ems_infra_tag
   - ems_infra_timeline
   - ems_physical_infra_new
+  - ems_physical_infra_console
   - ems_physical_infra_delete
   - ems_physical_infra_discover
   - ems_physical_infra_edit
@@ -541,6 +544,7 @@
   - ems_infra_show_list
   - ems_infra_tag
   - ems_infra_timeline
+  - ems_physical_infra_console
   - ems_physical_infra_show
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
@@ -623,6 +627,7 @@
   - ems_infra_show_list
   - ems_infra_tag
   - ems_infra_timeline
+  - ems_physical_infra_console
   - ems_physical_infra_show
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
@@ -735,6 +740,7 @@
   - all_vm_rules
   - automation_manager
   - embedded_automation_manager
+  - ems_physical_infra_console
   - catalog_items_view
   - compute
   - miq_template_clone

--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -40,4 +40,25 @@ describe ManageIQ::Providers::PhysicalInfraManager do
     pim.physical_servers = [ps]
     expect(pim.total_vms).to be(1)
   end
+
+  it 'will check supports_console returns false' do
+    ps = FactoryGirl.create(:generic_physical_infra,
+                            :name     => "LXCA",
+                            :hostname => "0.0.0.0")
+    expect(ps.supports_console?).to be(false)
+  end
+
+  it 'will return false if console is not supported' do
+    ps = FactoryGirl.create(:generic_physical_infra,
+                            :name     => "LXCA",
+                            :hostname => "0.0.0.0")
+    expect(ps.console_supported?).to be(false)
+  end
+
+  it 'will raise  exception for cnosle url if  console is not supported' do
+    ps = FactoryGirl.create(:generic_physical_infra,
+                            :name     => "LXCA",
+                            :hostname => "0.0.0.0")
+    expect { ps.console_url }.to raise_error(MiqException::Error)
+  end
 end


### PR DESCRIPTION
Adds support to the physical infrastructure manager to indicate that this provider supports a remote console and a method to determine the url of that console. This will enable the user interface to put a remote access link on the provider summary page. Default methods will show this feature as disabled. Sub-classes will need to override to indicate support and to build the target URL for the console.

@miq-bot add_label wip