### PR TITLE
Label->tag mapper: produce InventoryCollection<Tag>

### DIFF
--- a/app/models/container_label_tag_mapping/mapper.rb
+++ b/app/models/container_label_tag_mapping/mapper.rb
@@ -3,12 +3,38 @@ class ContainerLabelTagMapping
   # Performs most of the work of ContainerLabelTagMapping - holds current mappings,
   # computes applicable tags, and creates/finds Tag records - except actually [un]assigning.
   class Mapper
+    # @return [InventoryCollection<Tag>] a collection saving which will find/create (never delete) all
+    #   tags referenced by #map_labels whose id is not yet known.
+    attr_reader :tags_to_resolve_collection
+    # @return [InventoryCollection<Tag>] represents tags whose id is already known.
+    #   Doesn't require saving, not really interesting.
+    attr_reader :specific_tags_collection
+
     # @param mappings [Array<ContainerLabelTagMapping>] Mapping records to use
     def initialize(mappings)
       # {[name, type, value] => [tag_id, ...]}
       @mappings = mappings.group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
                           .transform_values { |ms| ms.collect(&:tag_id) }
-      @tags_to_resolve = []
+
+      @tags_to_resolve_collection = ::ManagerRefresh::InventoryCollection.new(
+        :name              => :mapped_tags_to_resolve,
+        :model_class       => Tag,
+        # more than needed to identify, doesn't matter much as we use custom save
+        :manager_ref       => [:category_tag_id, :entry_name, :entry_description],
+        #:arel            => Tag.all,
+        :custom_save_block => lambda do |_ems, inv_collection|
+          # TODO: O(N) queries, optimize.
+          inv_collection.each do |inv_object|
+            inv_object.id ||= find_or_create_tag(inv_object.attributes)
+          end
+        end
+      )
+
+      @specific_tags_collection = ::ManagerRefresh::InventoryCollection.new(
+        :name        => :mapped_specific_tags,
+        :model_class => Tag,
+        :manager_ref => [:id],
+      )
     end
 
     # Compute desired tags, in intermediate form to be resolved later.
@@ -16,30 +42,19 @@ class ContainerLabelTagMapping
     # @param type [String] Matched against `labeled_resource_type` in mappings.
     #   May be `resource_type` of an actual label, but doesn't have to; can be fake string such as 'Vm'.
     # @param labels [Array] array of {:name, :value} hashes.
-    # @return [Array] opaque "tag references" representing desired tags.
-    #   (Currently {:tag_id} or {:category_tag_id, :entry_name, :entry_description} hashes but will change.)
+    # @return [Array<InventoryObject>] representing desired tags.
     def map_labels(type, labels)
       labels.collect_concat { |label| map_label(type, label) }.uniq
     end
 
-    # Resolves/creates all "tag references" built by `map_labels` method of same Mapper.
-    # The references are mutated to contain a Tag id.
-    # @return [void]
-    def find_or_create_tags
-      # TODO: O(N) queries, optimize.
-      @tags_to_resolve.each do |h|
-        find_or_create_tag(h)
-      end
-    end
-
     # Convert "tag references" to actual Tag objects.  Must have been resolved to known id first.
-    # @param tag_references [Array]
+    # @param tag_references [Array<InventoryObject>]
     # @return [Array<Tag>]
     def self.references_to_tags(tag_references)
-      ref_without_id = tag_references.detect { |ref| ref[:tag_id].nil? }
-      raise "Unresolved tag reference #{ref_without_id}, must call find_or_create_tags first" if ref_without_id
+      ref_without_id = tag_references.detect { |ref| ref.id.nil? }
+      raise "Unresolved tag reference #{ref_without_id}, must save tags_to_resolve_collection first" if ref_without_id
 
-      Tag.find(tag_references.collect { |ref| ref[:tag_id] })
+      Tag.find(tag_references.collect(&:id))
     end
 
     private
@@ -54,7 +69,7 @@ class ContainerLabelTagMapping
       specific_value = @mappings[[name, type, value]] || []
       any_value      = @mappings[[name, type, nil]]   || []
       if !specific_value.empty?
-        specific_value.map { |tag_id| {:tag_id => tag_id} }
+        specific_value.map { |tag_id| emit_specific_reference(tag_id) }
       else
         if value.empty?
           [] # Don't map empty value to any tag.
@@ -73,14 +88,18 @@ class ContainerLabelTagMapping
     end
 
     def emit_tag_reference(h)
-      @tags_to_resolve << h
-      h
+      tags_to_resolve_collection.find_or_build_by(h)
     end
 
+    def emit_specific_reference(tag_id)
+      inv_object = specific_tags_collection.find_or_build_by(:id => tag_id)
+      inv_object.id = tag_id
+      inv_object
+    end
+
+    # @return [Integer] Tag id
     # Mutate the hash to contain :tag_id.
     def find_or_create_tag(tag_hash)
-      return if tag_hash[:tag_id]
-
       category = Tag.find(tag_hash[:category_tag_id]).classification
       entry = category.find_entry_by_name(tag_hash[:entry_name])
       unless entry
@@ -94,7 +113,7 @@ class ContainerLabelTagMapping
           end
         end
       end
-      tag_hash[:tag_id] = entry.tag_id
+      entry.tag_id
     end
   end
 end

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -45,7 +45,9 @@ module EmsRefresh::SaveInventoryCloud
       _log.debug("#{log_header} hashes:\n#{YAML.dump(hashes)}")
     end
 
-    hashes[:tag_mapper].find_or_create_tags if hashes[:tag_mapper]
+    if hashes[:tag_mapper]
+      ManagerRefresh::SaveInventory.save_inventory(ems, [hashes[:tag_mapper].tags_to_resolve_collection])
+    end
 
     child_keys = [
       :resource_groups,

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -1,6 +1,6 @@
 module EmsRefresh::SaveInventoryContainer
   def save_ems_container_inventory(ems, hashes, _target = nil)
-    hashes[:tag_mapper].find_or_create_tags
+    ManagerRefresh::SaveInventory.save_inventory(ems, [hashes[:tag_mapper].tags_to_resolve_collection])
 
     child_keys = [:container_projects, :container_quotas, :container_limits, :container_nodes,
                   :container_builds, :container_build_pods, :persistent_volume_claims, :persistent_volumes,

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -11,6 +11,7 @@ describe ContainerLabelTagMapping do
     cat = FactoryGirl.create(:classification, :read_only => true)
     cat.add_entry(:name => 'unrelated', :description => 'Unrelated tag').tag
   end
+  let(:ems) { FactoryGirl.build(:ext_management_system) }
 
   def labels(kv)
     kv.map do |name, value|
@@ -26,7 +27,7 @@ describe ContainerLabelTagMapping do
   # All-in-one
   def map_to_tags(mapper, model_name, labels_kv)
     tag_refs = mapper.map_labels(model_name, labels(labels_kv))
-    mapper.find_or_create_tags
+    ManagerRefresh::SaveInventory.save_inventory(ems, [mapper.tags_to_resolve_collection])
     ContainerLabelTagMapping::Mapper.references_to_tags(tag_refs)
   end
 
@@ -218,7 +219,7 @@ describe ContainerLabelTagMapping do
     let(:node) { FactoryGirl.create(:container_node) }
 
     def ref_to_tag(tag)
-      {:tag_id => tag.id}
+      instance_double(ManagerRefresh::InventoryObject, :id => tag.id)
     end
 
     before(:each) do

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,3 +1,5 @@
+require 'manager_refresh/inventory_object'
+
 context "save_tags_inventory" do
   before(:each) do
     @zone = FactoryGirl.create(:zone)
@@ -12,15 +14,15 @@ context "save_tags_inventory" do
     @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes::foo/bar') # All
   end
 
-  # This is what ContainerLabelTagMapping::Mapper.map_labels(cache, 'Type', labels) would
-  # return in the refresh parser. Note that we don't explicitly test the mapping
+  # Simulate what ContainerLabelTagMapping::Mapper.map_labels(...) would return, after resolving to tag ids.
+  # Note that we don't explicitly test the mapping
   # creation here, the assumption is that these were the generated mappings.
   let(:data) do
     {
       :tags => [
-        {:tag_id => @tag1.id},
-        {:tag_id => @tag2.id},
-        {:tag_id => @tag3.id},
+        instance_double(ManagerRefresh::InventoryObject, :id => @tag1.id),
+        instance_double(ManagerRefresh::InventoryObject, :id => @tag2.id),
+        instance_double(ManagerRefresh::InventoryObject, :id => @tag3.id),
       ]
     }
   end


### PR DESCRIPTION
This works same as last PR #16098 for save_inventory mode but also exposes a more concrete interface that I'll be able to use in graph refresh:

- Creation of missing tags: The `tags_to_resolve_collection` can just be added to graph refresh.

- Reassigning tags: each `map_labels` returns individual InventoryObject<Tag> - those can used to build
  InventoryCollection<Tagging> that will work similar to `retag_entity`.

  (We originally planned to do reassignment using original code in post-refresh.
  I'm postponing the move to post-refresh ;-) because we it was motivated by a new feature (going through policy) that is less critical than getting tagging working as now;
  and IIUC I'd need to express desired taggings in some form for post-refresh anyway.

(PRs for both of the above that upcoming, WIP building right query similar to retag_entity and adding tests...)

Overview issue: https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/126

@miq-bot add-label enhancement

@Ladas @zgalor @moolitayer @djberg96 please review.