### PR TITLE
Populate cloud volume types for new chargeback rates

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -252,6 +252,18 @@ class ChargebackRateDetail < ApplicationRecord
         end
 
         rate_details.push(detail_new)
+
+        if detail_new.chargeable_field.metric == 'derived_vm_allocated_disk_storage'
+          volume_types = CloudVolume.pluck(:volume_type).uniq.compact
+          volume_types.each do |volume_type|
+            storage_detail_new = detail_new.dup
+            storage_detail_new.sub_metric = volume_type
+            detail[:tiers].sort_by { |tier| tier[:start] }.each do |tier|
+              storage_detail_new.chargeback_tiers << ChargebackTier.new(tier.slice(*ChargebackTier::FORM_ATTRIBUTES))
+            end
+            rate_details.push(storage_detail_new)
+          end
+        end
       end
     end
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -69,7 +69,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def sub_metrics
     if metric == 'derived_vm_allocated_disk_storage'
-      volume_types = CloudVolume.pluck(:volume_type).uniq.compact
+      volume_types = CloudVolume.volume_types
       unless volume_types.empty?
         res = {}
         res[_('All')] = ''
@@ -271,7 +271,7 @@ class ChargebackRateDetail < ApplicationRecord
         rate_details.push(detail_new)
 
         if detail_new.chargeable_field.metric == 'derived_vm_allocated_disk_storage'
-          volume_types = CloudVolume.pluck(:volume_type).uniq.compact
+          volume_types = CloudVolume.volume_types
           volume_types.each do |volume_type|
             storage_detail_new = detail_new.dup
             storage_detail_new.sub_metric = volume_type

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -284,6 +284,6 @@ class ChargebackRateDetail < ApplicationRecord
       end
     end
 
-    rate_details.sort_by { |rd| [rd[:group], rd[:description]] }
+    rate_details.sort_by { |rd| [rd.chargeable_field[:group], rd.chargeable_field[:description], rd[:sub_metric].to_s] }
   end
 end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -67,6 +67,23 @@ class ChargebackRateDetail < ApplicationRecord
     showback_rate.save
   end
 
+  def sub_metrics
+    if metric == 'derived_vm_allocated_disk_storage'
+      volume_types = CloudVolume.pluck(:volume_type).uniq.compact
+      unless volume_types.empty?
+        res = {}
+        res[_('All')] = ''
+        volume_types.each { |type| res[type.capitalize] = type }
+        res[_('Other - Unclassified')] = 'unclassified'
+        res
+      end
+    end
+  end
+
+  def sub_metric_human
+    sub_metric.present? ? sub_metric.capitalize : 'All'
+  end
+
   def charge(relevant_fields, consumption, options)
     result = {}
     if (relevant_fields & [metric_key, cost_keys[0]]).present?

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -14,7 +14,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   delegate :metric_key, :cost_keys, :to => :chargeable_field
 
-  FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric chargeable_field_id).freeze
+  FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric chargeable_field_id sub_metric).freeze
   PER_TIME_TYPES = {
     "hourly"  => _("Hourly"),
     "daily"   => _("Daily"),

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -20,6 +20,10 @@ class CloudVolume < ApplicationRecord
 
   acts_as_miq_taggable
 
+  def self.volume_types
+    pluck(:volume_type).uniq.compact
+  end
+
   def self.available
     left_outer_joins(:attachments).where("disks.backing_id" => nil)
   end

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -21,7 +21,7 @@ class CloudVolume < ApplicationRecord
   acts_as_miq_taggable
 
   def self.volume_types
-    pluck(:volume_type).uniq.compact
+    where.not(:volume_type => nil).group(:volume_type).pluck(:volume_type)
   end
 
   def self.available

--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :cloud_volume do
+    sequence(:volume_type) { |n| "volume_type_#{seq_padded_for_sorting(n)}" }
   end
 
   factory :cloud_volume_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume", :parent => :cloud_volume do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -11,6 +11,43 @@ describe ChargebackRateDetail do
     end
   end
 
+  describe "#default_rate_details_for" do
+    before do
+      ChargebackRateDetailMeasure.seed
+      ChargeableField.seed
+    end
+
+    it 'loads chargeback rates from yml for Compute metrics' do
+      rates = ChargebackRateDetail.default_rate_details_for('Compute')
+      expected_metrics = %w(
+        derived_vm_numvcpus
+        cpu_usagemhz_rate_average
+        v_derived_cpu_total_cores_used
+        disk_usage_rate_average
+        fixed_compute_1
+        fixed_compute_2
+        derived_memory_available
+        derived_memory_used
+        metering_used_hours
+        net_usage_rate_average
+      )
+
+      expect(rates.map { |x| x.chargeable_field.metric }).to match_array(expected_metrics)
+    end
+
+    it 'loads chargeback rates from yml for Storage metrics' do
+      rates = ChargebackRateDetail.default_rate_details_for('Storage')
+      expected_metrics = %w(
+        fixed_storage_1
+        fixed_storage_2
+        derived_vm_allocated_disk_storage
+        derived_vm_used_disk_storage
+      )
+
+      expect(rates.map { |x| x.chargeable_field.metric }).to match_array(expected_metrics)
+    end
+  end
+
   describe "#find_rate" do
     let(:cvalue) { {"val1" => 0.0, "val2" => 10.0, "val3" => 20.0, "val4" => 50.0} }
     let(:cbt1) { FactoryGirl.build(:chargeback_tier, :start => 0, :finish => 10, :fixed_rate => 3.0, :variable_rate => 0.3) }

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -46,6 +46,15 @@ describe ChargebackRateDetail do
 
       expect(rates.map { |x| x.chargeable_field.metric }).to match_array(expected_metrics)
     end
+
+    context 'when cloud volumes are present' do
+      let!(:cloud_volumes) { FactoryGirl.create_list(:cloud_volume_openstack, 3) }
+
+      it 'loads chargeback rates with sub metric from CloudVolumes' do
+        rates = ChargebackRateDetail.default_rate_details_for('Storage')
+        expect(rates.map(&:sub_metric).compact).to match_array(cloud_volumes.map(&:volume_type).uniq.compact)
+      end
+    end
   end
 
   describe "#find_rate" do

--- a/spec/models/vim_performance_state_spec.rb
+++ b/spec/models/vim_performance_state_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe VimPerformanceState do
     let(:hdd2_size) { 9_101 }
     let(:ssd_volume) { FactoryGirl.create(:cloud_volume_openstack, :volume_type => 'ssd') }
     let(:ssd_disk) { FactoryGirl.create(:disk, :size => ssd_size, :backing => ssd_volume) }
-    let(:hdd_volume) { FactoryGirl.create(:cloud_volume_openstack) }
+    let(:hdd_volume) { FactoryGirl.create(:cloud_volume_openstack, :volume_type => nil) }
     let(:hdd1_disk) { FactoryGirl.create(:disk, :size => hdd1_size, :backing => hdd_volume) }
     let(:hdd2_disk) { FactoryGirl.create(:disk, :size => hdd2_size) }
     let(:hardware) { FactoryGirl.create(:hardware, :disks => [ssd_disk, hdd1_disk, hdd2_disk]) }


### PR DESCRIPTION
This PR is backend part of UI for adding dynamic sub_metrics. 
Sub metrics now are intended as cloud volume types and only for Storage Allocated Metrics

@miq-bot assign @gtanzillo 