### PR TITLE
Add agent coordinator worker for amazon ssa support

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1055,6 +1055,9 @@
       :starting_timeout: 20.minutes
       :poll: 10.seconds
       :memory_threshold: 0.megabytes
+    :agent_coordinator_worker:
+      :heartbeat_timeout: 30.minutes
+      :poll: 30.seconds
     :ems_refresh_core_worker:
       :poll: 1.seconds
       :nice_delta: 1

--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -2,6 +2,7 @@
 # global namespace
 
 MIQ_WORKER_TYPES = {
+  "ManageIQ::Providers::Amazon::AgentCoordinatorWorker"                       => %i(manageiq_default),
   "ManageIQ::Providers::Amazon::CloudManager::EventCatcher"                   => %i(manageiq_default),
   "ManageIQ::Providers::Amazon::CloudManager::MetricsCollectorWorker"         => %i(manageiq_default),
   "ManageIQ::Providers::Amazon::CloudManager::RefreshWorker"                  => %i(manageiq_default),
@@ -98,6 +99,7 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
   ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
   ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker
+  ManageIQ::Providers::Amazon::AgentCoordinatorWorker
   ManageIQ::Providers::Google::CloudManager::RefreshWorker
   ManageIQ::Providers::Google::NetworkManager::RefreshWorker
   ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker


### PR DESCRIPTION
Add a new worker call AgentCoordinatorWork for Amazon SSA support. This PR depends on https://github.com/ManageIQ/manageiq-providers-amazon/pull/318
