### PR TITLE
Get rid of ui_lookup() with static string argument

### DIFF
--- a/app/models/cloud_subnet/operations.rb
+++ b/app/models/cloud_subnet/operations.rb
@@ -25,9 +25,7 @@ module CloudSubnet::Operations
       if ext_management_system.nil?
         return {
           :available => false,
-          :message   => _("The Subnet is not connected to an active %{table}") % {
-            :table => ui_lookup(:table => "ext_management_systems")
-          }
+          :message   => _("The Subnet is not connected to an active Provider")
         }
       end
       {:available => true, :message => nil}

--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -86,8 +86,7 @@ module CloudVolume::Operations
     def validate_volume(ext_management_system)
       if ext_management_system.nil?
         return {:available => false,
-                :message   => _("The Volume is not connected to an active %{table}") %
-                  {:table => ui_lookup(:table => "ext_management_systems")}}
+                :message   => _("The Volume is not connected to an active Provider")}
       end
       {:available => true, :message => nil}
     end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -197,7 +197,7 @@ class ExtManagementSystem < ApplicationRecord
         :zone_id   => MiqServer.my_server.zone.id
       )
 
-      _log.info("#{ui_lookup(:table => "ext_management_systems")} #{ems.name} created")
+      _log.info("Provider #{ems.name} created")
       AuditEvent.success(
         :event        => "ems_created",
         :target_id    => ems.id,
@@ -407,10 +407,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def refresh_ems(opts = {})
     if missing_credentials?
-      raise _("no %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("no Provider credentials defined")
     end
     unless authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Provider failed last authentication check")
     end
     EmsRefresh.queue_refresh(self, nil, opts)
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -299,7 +299,7 @@ class Host < ApplicationRecord
 
   def validate_esx_host_connected_to_vc
     # Check the basic require to interact with a VM.
-    return {:available => false, :message => "The Host is not connected to an active #{ui_lookup(:table => "ext_management_systems")}"} unless has_active_ems?
+    return {:available => false, :message => "The Host is not connected to an active Provider"} unless has_active_ems?
     return {:available => false, :message => "The Host is not VMware ESX"} unless is_vmware_esx?
     nil
   end
@@ -587,13 +587,13 @@ class Host < ApplicationRecord
 
   def refresh_ems
     unless ext_management_system
-      raise _("No %{table} defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Providers defined")
     end
     unless ext_management_system.has_credentials?
-      raise _("No %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider credentials defined")
     end
     unless ext_management_system.authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Provider failed last authentication check")
     end
     EmsRefresh.queue_refresh(self)
   end

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -39,8 +39,8 @@ class JobProxyDispatcher
 
         jobs_to_dispatch.each do |job|
           if concurrent_vm_scans_limit > 0 && active_vm_scans_by_zone[@zone] >= concurrent_vm_scans_limit
-            _log.warn("SKIPPING remaining %s jobs in dispatch since there are [%d] active scans in the zone [%s]" %
-                      [ui_lookup(:table => VmOrTemplate.name), active_vm_scans_by_zone[@zone], @zone])
+            _log.warn("SKIPPING remaining Vm Or Template jobs in dispatch since there are [%d] active scans in the zone [%s]" %
+                      [active_vm_scans_by_zone[@zone], @zone])
             break
           end
           @vm = @vms_for_dispatch_jobs.detect { |v| v.id == job.target_id }
@@ -111,10 +111,8 @@ class JobProxyDispatcher
       active_ems_scans = active_container_scans_by_zone_and_ems[@zone][ems_id]
       if concurrent_ems_limit > 0 && active_ems_scans >= concurrent_ems_limit
         _log.warn(
-          "SKIPPING remaining %s scan jobs for %s [%s] in dispatch since there are [%d] active scans in zone [%s]" %
+          "SKIPPING remaining Container Image scan jobs for Provider [%s] in dispatch since there are [%d] active scans in zone [%s]" %
             [
-              ui_lookup(:table => ContainerImage.name),
-              ui_lookup(:table => ExtManagementSystem.name),
               ems_id,
               active_ems_scans,
               @zone

--- a/app/models/manageiq/providers/base_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher.rb
@@ -11,8 +11,7 @@ class ManageIQ::Providers::BaseManager::EventCatcher < MiqWorker
       if ems.nil?
         queue_name.titleize
       else
-        _("Event Monitor for %{table}: %{name}") % {:table => ui_lookup(:table => "ext_management_systems"),
-                                                    :name  => ems.name}
+        _("Event Monitor for Provider: %{name}") % {:name => ems.name}
       end
     end
   end

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -11,8 +11,7 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
       if ems.nil?
         queue_name.kind_of?(Array) ? queue_name.collect(&:titleize).join(", ") : queue_name.titleize
       else
-        _("Refresh Worker for %{table}: %{name}") % {:table => ui_lookup(:table => "ext_management_systems"),
-                                                     :name  => ems.name}
+        _("Refresh Worker for Provider: %{name}") % {:name => ems.name}
       end
     end
   end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -693,7 +693,7 @@ class MiqAction < ApplicationRecord
 
   def action_ems_refresh(action, rec, inputs)
     unless rec.respond_to?(:ext_management_system) && !rec.ext_management_system.nil?
-      MiqPolicy.logger.error("MIQ(action_ems_refresh): Unable to perform action [#{action.description}], object [#{rec.inspect}] does not have a #{ui_lookup(:table => "ext_management_systems")}")
+      MiqPolicy.logger.error("MIQ(action_ems_refresh): Unable to perform action [#{action.description}], object [#{rec.inspect}] does not have a Provider")
       return
     end
 
@@ -785,7 +785,7 @@ class MiqAction < ApplicationRecord
 
   def action_cancel_task(action, rec, inputs)
     unless rec.respond_to?(:ext_management_system) && !rec.ext_management_system.nil?
-      MiqPolicy.logger.error("MIQ(action_cancel_task): Unable to perform action [#{action.description}], object [#{rec.inspect}] does not have a #{ui_lookup(:table => "ext_management_systems")}")
+      MiqPolicy.logger.error("MIQ(action_cancel_task): Unable to perform action [#{action.description}], object [#{rec.inspect}] does not have a Provider")
       return
     end
 

--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -17,7 +17,7 @@ class MiqEmsRefreshCoreWorker < MiqWorker
   def friendly_name
     @friendly_name ||= begin
       ems = ext_management_system
-      ems.nil? ? queue_name.titleize : "Core Refresh Worker for #{ui_lookup(:table => "ext_management_systems")}: #{ems.name}"
+      ems.nil? ? queue_name.titleize : "Core Refresh Worker for Provider: #{ems.name}"
     end
   end
 end

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -39,7 +39,7 @@ module MiqFilter
   def self.object2belongsto(obj)
     # /belongsto/ExtManagementSystem|<name>/EmsCluster|<name>/EmsFolder|<name>
     unless obj.root_id[0] == "ExtManagementSystem"
-      raise _("Folder Root is not a %{table}") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Folder Root is not a Provider")
     end
 
     tag = obj.ancestry(

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -127,8 +127,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       show_dialog(:customize, :show, "disabled")
     else
       if vm.ext_management_system.nil?
-        raise _("Source VM [%{name}] does not belong to a %{table}") %
-                {:name => vm.name, :table => ui_lookup(:table => "ext_management_systems")}
+        raise _("Source VM [%{name}] does not belong to a Provider") % {:name => vm.name}
       end
       set_or_default_hardware_field_values(vm)
 

--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -71,7 +71,7 @@ module VimConnectMixin
       raise $!.message
     rescue Exception
       _log.warn($!.inspect)
-      raise "Unexpected response returned from #{ui_lookup(:table => "ext_management_systems")}, see log for details"
+      raise "Unexpected response returned from Provider, see log for details"
     end
   end
 end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -148,13 +148,13 @@ class OrchestrationStack < ApplicationRecord
     manager = ExtManagementSystem.find_by(:id => manager_id)
 
     unless manager
-      raise _("No %{table} defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider defined")
     end
     unless manager.has_credentials?
-      raise _("No %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider credentials defined")
     end
     unless manager.authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Provider failed last authentication check")
     end
 
     manager_settings = Settings.ems_refresh[manager.class.ems_type]

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -139,7 +139,7 @@ class OrchestrationTemplate < ApplicationRecord
     test_managers.each do |mgr|
       return mgr.orchestration_template_validate(self) rescue nil
     end
-    "No #{ui_lookup(:model => 'ExtManagementSystem').downcase} is capable to validate the template"
+    "No provider is capable to validate the template"
   end
 
   def validate_format

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -56,10 +56,10 @@ class Provider < ApplicationRecord
 
   def refresh_ems(opts = {})
     if missing_credentials?
-      raise _("no %{table} credentials defined") % {:table => ui_lookup(:table => "provider")}
+      raise _("no Provider credentials defined")
     end
     unless authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "provider")}
+      raise _("Provider failed last authentication check")
     end
     managers.flat_map { |manager| EmsRefresh.queue_refresh(manager, nil, opts) }
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -359,15 +359,15 @@ class Storage < ApplicationRecord
   def scan(userid = "system", _role = "ems_operations")
     unless SUPPORTED_STORAGE_TYPES.include?(store_type.upcase)
       raise(MiqException::MiqUnsupportedStorage,
-            _("Action not supported for %{table} type [%{store_type}], [%{name}] with id: [%{id}]") %
-              {:table => ui_lookup(:table => "storages"), :store_type => store_type, :name => name, :id => id})
+            _("Action not supported for Datastore type [%{store_type}], [%{name}] with id: [%{id}]") %
+              {:store_type => store_type, :name => name, :id => id})
     end
 
     hosts = active_hosts_with_authentication_status_ok
     if hosts.empty?
       raise(MiqException::MiqStorageError,
-            _("Check that a Host is running and has valid credentials for %{table} [%{name}] with id: [%{id}]") %
-              {:table => ui_lookup(:tables => "storage"), :name => name, :id => id})
+            _("Check that a Host is running and has valid credentials for Datastore [%{name}] with id: [%{id}]") %
+              {:name => name, :id => id})
     end
     task_name = "SmartState Analysis for [#{name}]"
     self.class.create_scan_task(task_name, userid, [self])

--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -13,8 +13,7 @@ module Vm::Operations::Guest
 
   def raw_shutdown_guest
     unless has_active_ems?
-      raise _("VM has no %{table}, unable to shutdown guest OS") %
-              {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("VM has no Provider, unable to shutdown guest OS")
     end
     run_command_via_parent(:vm_shutdown_guest)
   end
@@ -25,8 +24,7 @@ module Vm::Operations::Guest
 
   def raw_standby_guest
     unless has_active_ems?
-      raise _("VM has no %{table}, unable to standby guest OS") %
-              {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("VM has no Provider, unable to standby guest OS")
     end
     run_command_via_parent(:vm_standby_guest)
   end
@@ -37,8 +35,7 @@ module Vm::Operations::Guest
 
   def raw_reboot_guest
     unless has_active_ems?
-      raise _("VM has no %{table}, unable to reboot guest OS") %
-              {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("VM has no Provider, unable to reboot guest OS")
     end
     run_command_via_parent(:vm_reboot_guest)
   end
@@ -49,7 +46,7 @@ module Vm::Operations::Guest
 
   def raw_reset
     unless has_active_ems?
-      raise _("VM has no %{table}, unable to reset VM") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("VM has no Provider, unable to reset VM")
     end
     run_command_via_parent(:vm_reset)
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -362,7 +362,7 @@ class VmOrTemplate < ApplicationRecord
 
     # VM has no host or storage affiliation
     if vm.storage.nil?
-      task.error("#{vm.name}: There is no owning Host or #{ui_lookup(:table => "storages")} for this VM, "\
+      task.error("#{vm.name}: There is no owning Host or Datastore for this VM, "\
                  "'#{options[:task]}' is not allowed")
       return false
     end
@@ -706,7 +706,7 @@ class VmOrTemplate < ApplicationRecord
 
   def connect_storage(s)
     unless storage == s
-      _log.debug("Connecting Vm [#{name}] id [#{id}] to #{ui_lookup(:table => "storages")} [#{s.name}] id [#{s.id}]")
+      _log.debug("Connecting Vm [#{name}] id [#{id}] to Datastore [#{s.name}] id [#{s.id}]")
       self.storage = s
       save
     end
@@ -715,7 +715,7 @@ class VmOrTemplate < ApplicationRecord
   def disconnect_storage(s = nil)
     if s.nil? || storage == s || storages.include?(s)
       stores = s.nil? ? ([storage] + storages).compact.uniq : [s]
-      log_text = stores.collect { |x| "#{ui_lookup(:table => "storages")} [#{x.name}] id [#{x.id}]" }.join(", ")
+      log_text = stores.collect { |x| "Datastore [#{x.name}] id [#{x.id}]" }.join(", ")
       _log.info("Disconnecting Vm [#{name}] id [#{id}] from #{log_text}")
 
       if s.nil?
@@ -911,7 +911,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def log_proxies_vm_config
-    msg = "[#{log_proxies_format_instance(self)}] on host [#{log_proxies_format_instance(host)}] #{ui_lookup(:table => "storages").downcase} "
+    msg = "[#{log_proxies_format_instance(self)}] on host [#{log_proxies_format_instance(host)}] datastore "
     msg << (storage ? "[#{storage.name}-#{storage.store_type}]" : "No storage")
   end
 
@@ -1052,13 +1052,13 @@ class VmOrTemplate < ApplicationRecord
 
   def refresh_ems
     unless ext_management_system
-      raise _("No %{table} defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider defined")
     end
     unless ext_management_system.has_credentials?
-      raise _("No %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider credentials defined")
     end
     unless ext_management_system.authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Provider failed last authentication check")
     end
     EmsRefresh.queue_refresh(self)
   end
@@ -1071,13 +1071,13 @@ class VmOrTemplate < ApplicationRecord
 
   def refresh_ems_sync
     unless ext_management_system
-      raise _("No %{table} defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider defined")
     end
     unless ext_management_system.has_credentials?
-      raise _("No %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider credentials defined")
     end
     unless ext_management_system.authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Provider failed last authentication check")
     end
     EmsRefresh.refresh(self)
   end

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -44,7 +44,7 @@ module VmOrTemplate::Operations
 
   def raw_unregister
     unless ext_management_system
-      raise _("VM has no %{table}, unable to unregister VM") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("VM has no Provider, unable to unregister VM")
     end
     run_command_via_parent(:vm_unregister)
   end
@@ -55,7 +55,7 @@ module VmOrTemplate::Operations
 
   def raw_destroy
     unless ext_management_system
-      raise _("VM has no %{table}, unable to destroy VM") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("VM has no Provider, unable to destroy VM")
     end
     run_command_via_parent(:vm_destroy)
   end

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -263,8 +263,8 @@ class VmScan < Job
           set_status("Snapshot deleted: reference: [#{mor}]")
         end
       else
-        _log.error("Deleting snapshot: reference: [#{mor}], No #{ui_lookup(:table => "ext_management_systems")} available to delete snapshot")
-        set_status("No #{ui_lookup(:table => "ext_management_systems")} available to delete snapshot, skipping", "error")
+        _log.error("Deleting snapshot: reference: [#{mor}], No Providers available to delete snapshot")
+        set_status("No Providers available to delete snapshot, skipping", "error")
       end
     else
       set_status("Snapshot was not taken, delete not required") if options[:snapshot] == :skipped
@@ -396,8 +396,7 @@ class VmScan < Job
             vm.ext_management_system.vm_remove_snapshot(vm, :snMor => mor, :user_event => user_event)
           end
         else
-          raise _("No %{table} available to delete snapshot") %
-                  {:table => ui_lookup(:table => "ext_management_systems")}
+          raise _("No Providers available to delete snapshot")
         end
       rescue => err
         _log.error(err.message)
@@ -584,7 +583,7 @@ class VmScan < Job
       options[:use_existing_snapshot] = true
       return true
     else
-      signal(:abort, "No #{ui_lookup(:table => "ext_management_systems")} available to create snapshot, skipping", "error")
+      signal(:abort, "No Providers available to create snapshot, skipping", "error")
       return false
     end
   end

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -359,7 +359,7 @@ describe VmScan do
         allow(@vm).to receive(:ext_management_system).and_return(false)
         expect(@job).not_to receive(:delete_snapshot)
         @job.call_snapshot_delete
-        expect(@job.message).to eq "No #{ui_lookup(:table => "ext_management_systems")} available to delete snapshot, skipping"
+        expect(@job.message).to eq "No Providers available to delete snapshot, skipping"
       end
 
       it "calls 'delete_snapshot'" do


### PR DESCRIPTION
Main purpose of this change is to have strings in our application, that would make more
sense for translators.