### PR TITLE
Move EmsRefresh targets to MiqQueue data

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -357,7 +357,7 @@ class MiqQueue < ApplicationRecord
           end
 
           msg.update_attributes!(save_options)
-          _log.info("#{MiqQueue.format_short_log_msg(msg)} updated with following: #{save_options.inspect}")
+          _log.info("#{MiqQueue.format_short_log_msg(msg)} updated with following: #{save_options.except(:data, :msg_data).inspect}")
           _log.info("#{MiqQueue.format_full_log_msg(msg)}, Requeued")
         end
         break

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -104,7 +104,7 @@ describe EmsRefresh do
   def assert_queue_item(expected_targets)
     q_all = MiqQueue.all
     expect(q_all.length).to eq(1)
-    expect(q_all[0].args).to eq([expected_targets.collect { |t| [t.class.name, t.id] }])
+    expect(q_all[0].data).to eq(expected_targets.collect { |t| [t.class.name, t.id] })
     expect(q_all[0].class_name).to eq(described_class.name)
     expect(q_all[0].method_name).to eq('refresh')
     expect(q_all[0].role).to eq("ems_inventory")

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -231,7 +231,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh")
-          expect(q.args).to eq([[[vm.class.name, vm.id]]])
+          expect(q.data).to eq([[vm.class.name, vm.id]])
         end
 
         it "will handle queued Host updates properly" do
@@ -253,7 +253,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh")
-          expect(q.args).to eq([[[host.class.name, host.id]]])
+          expect(q.data).to eq([[host.class.name, host.id]])
         end
 
         it "will handle create events properly" do
@@ -356,7 +356,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh")
-          expect(q.args).to eq([[[vm2.class.name, vm2.id]]])
+          expect(q.data).to eq([[vm2.class.name, vm2.id]])
         end
 
         it "will reconnect to an EMS" do


### PR DESCRIPTION
Reduce the overhead of put_or_update by moving EmsRefresh targets from
MiqQueue args to data.  Also replace uniquing the targets on put with
`msg.args[0] | targets` with just a simple concat and unique the targets
on the dequeue side.