### PR TITLE
Revert containers related change to miq_shortcuts to fix UI specs.

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -217,7 +217,7 @@
 - :name: containers
   :description: Compute / Containers / Containers
   :url: /container/show_list
-  :rbac_feature_name: container_show_list
+  :rbac_feature_name: container
   :startup: true
 - :name: container_nodes
   :description: Compute / Containers / Container Nodes


### PR DESCRIPTION
Broken in #15935.

ping @zakiva, @mzazrivec, @imtayadeway 

Replacement for https://github.com/ManageIQ/manageiq-ui-classic/pull/2493

To go together with (or before) https://github.com/ManageIQ/manageiq-ui-classic/pull/2498