### PR TITLE
Move ems refresh targets to miq queue data

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -82,10 +82,14 @@ module EmsRefresh
     # Handle targets passed as a single class/id pair, an array of class/id pairs, or an array of references
     targets = get_target_objects(target, id).uniq
 
+    # Store manager records to avoid n+1 queries
+    manager_by_manager_id = {}
+
     # Split the targets into refresher groups
     groups = targets.group_by do |t|
       ems = case
             when t.respond_to?(:ext_management_system) then t.ext_management_system
+            when t.respond_to?(:manager_id)            then manager_by_manager_id[t.manager_id] ||= t.manager
             when t.respond_to?(:manager)               then t.manager
             else                                            t
             end

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -36,18 +36,23 @@ module ManageIQ
         self.targets_by_ems_id = Hash.new { |h, k| h[k] = [] }
 
         targets.each do |t|
-          ems = case
-                when t.respond_to?(:ext_management_system) then t.ext_management_system
-                when t.respond_to?(:manager)               then t.manager
-                else                                            t
-                end
-          if ems.nil?
-            _log.warn("Unable to perform refresh for #{t.class} [#{t.name}] id [#{t.id}], since it is not on an EMS.")
-            next
-          end
+          if t.kind_of?(ManagerRefresh::Target)
+            ems_by_ems_id[t.manager_id] ||= t.manager
+            targets_by_ems_id[t.manager_id] << t
+          else
+            ems = case
+                  when t.respond_to?(:ext_management_system) then t.ext_management_system
+                  when t.respond_to?(:manager)               then t.manager
+                  else                                            t
+                  end
+            if ems.nil?
+              _log.warn("Unable to perform refresh for #{t.class} [#{t.name}] id [#{t.id}], since it is not on an EMS.")
+              next
+            end
 
-          ems_by_ems_id[ems.id] ||= ems
-          targets_by_ems_id[ems.id] << t
+            ems_by_ems_id[ems.id] ||= ems
+            targets_by_ems_id[ems.id] << t
+          end
         end
       end
 

--- a/app/models/manager_refresh/target_collection.rb
+++ b/app/models/manager_refresh/target_collection.rb
@@ -31,14 +31,14 @@ module ManagerRefresh
                                          :options     => options)
     end
 
-    # @return [String] A String containing a name of each target in the TargetCollection
+    # @return [String] A String containing a summary
     def name
-      "Collection of targets with name: #{targets.collect(&:name)}"
+      "Collection of #{targets.size} targets"
     end
 
     # @return [String] A String containing an id of each target in the TargetCollection
     def id
-      "Collection of targets with id: #{targets.collect(&:id)}"
+      "Collection of targets with id: #{targets.collect(&:manager_ref)}"
     end
 
     # Returns targets in a format:

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -360,7 +360,7 @@ class MiqQueue < ApplicationRecord
           end
 
           msg.update_attributes!(save_options)
-          _log.info("#{MiqQueue.format_short_log_msg(msg)} updated with following: #{save_options.inspect}")
+          _log.info("#{MiqQueue.format_short_log_msg(msg)} updated with following: #{save_options.except(:data, :msg_data).inspect}")
           _log.info("#{MiqQueue.format_full_log_msg(msg)}, Requeued")
         end
         break

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -104,7 +104,7 @@ describe EmsRefresh do
   def assert_queue_item(expected_targets)
     q_all = MiqQueue.all
     expect(q_all.length).to eq(1)
-    expect(q_all[0].args).to eq([expected_targets.collect { |t| [t.class.name, t.id] }])
+    expect(q_all[0].data).to eq(expected_targets.collect { |t| [t.class.name, t.id] })
     expect(q_all[0].class_name).to eq(described_class.name)
     expect(q_all[0].method_name).to eq('refresh')
     expect(q_all[0].role).to eq("ems_inventory")

--- a/spec/models/manager_refresh/target_collection_spec.rb
+++ b/spec/models/manager_refresh/target_collection_spec.rb
@@ -110,7 +110,8 @@ describe ManagerRefresh::TargetCollection do
         :options     => {:opt1 => "opt1", :opt2 => "opt2"}
       )
 
-      expect(target_collection.name).to eq "Collection of targets with name: [{:ems_ref=>\"vm_1\"}, {:ems_ref=>\"vm_2\"}]"
+      expect(target_collection.name).to eq "Collection of 2 targets"
+      expect(target_collection.id).to eq "Collection of targets with id: [{:ems_ref=>\"vm_1\"}, {:ems_ref=>\"vm_2\"}]"
     end
   end
 

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -231,7 +231,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh")
-          expect(q.args).to eq([[[vm.class.name, vm.id]]])
+          expect(q.data).to eq([[vm.class.name, vm.id]])
         end
 
         it "will handle queued Host updates properly" do
@@ -253,7 +253,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh")
-          expect(q.args).to eq([[[host.class.name, host.id]]])
+          expect(q.data).to eq([[host.class.name, host.id]])
         end
 
         it "will handle create events properly" do
@@ -356,7 +356,7 @@ describe MiqVimBrokerWorker::Runner do
           q = MiqQueue.first
           expect(q.class_name).to eq("EmsRefresh")
           expect(q.method_name).to eq("refresh")
-          expect(q.args).to eq([[[vm2.class.name, vm2.id]]])
+          expect(q.data).to eq([[vm2.class.name, vm2.id]])
         end
 
         it "will reconnect to an EMS" do


### PR DESCRIPTION
Reduce the overhead of put_or_update by moving EmsRefresh targets from
MiqQueue args to data. Also replace uniquing the targets on put with
msg.args[0] | targets with just a simple concat and unique the targets
on the dequeue side.