### PR TITLE
Add hawkular admin tenant label to settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1197,3 +1197,5 @@
       :nice_delta: 1
     :cockpit_ws_worker:
       :count: 1
+:hawkular_tenant_labels:
+  :_hawkular_admin: Hawkular Admin


### PR DESCRIPTION
**Description**
Compute -> Containers -> Providers -> Choose provider -> Monitoring -> Ad-hoc metrics

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1503541

https://github.com/ManageIQ/manageiq-ui-classic/pull/2497

Add hawkular admin tenant label to settings, which together with https://github.com/ManageIQ/manageiq-ui-classic/pull/2497 makes it look good in the UI.

Users of OpenShift can create custom tenants in the Hawkular database. The ad-hoc metrics page can handle some pre-defined names, but users can choose to define new ones. This PR adds an example of such setting, and the one in manageiq-ui-classic adds the code to support this kind of setting.

**Before**

![hawkular_admin_before](https://user-images.githubusercontent.com/498903/31939576-99a38cd0-b8c3-11e7-97b2-8d157d1bf81c.png)

**After**

![hawkular_admin_after](https://user-images.githubusercontent.com/498903/31939591-a570cfaa-b8c3-11e7-9c1e-126b9b0aa75d.png)

**Settings**

![hawkular_settings](https://user-images.githubusercontent.com/498903/31939612-c0bf13c0-b8c3-11e7-9f8b-e1b7c0c20864.png)

