### PR TITLE
Require cluster for RVH VM provision

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -204,7 +204,9 @@
             :method: :allowed_clusters
           :auto_select_single: true
           :description: Name
-          :required: false
+          :required: true
+          :required_method: :validate_placement
+          :required_description: Cluster Name
           :display: :show
           :data_type: :integer
         :cluster_filter:


### PR DESCRIPTION
In order to provision VM on RHV, when not selecting the auto-placement,
user should specify the destination cluster as well.

The PR enforces the selection of the destination cluster.

Bug-Url:
https://bugzilla.redhat.com/show_bug.cgi?id=1469364
