### PR TITLE
inventory cloud_manager module

### DIFF
--- a/app/models/manager_refresh/inventory/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory/cloud_manager.rb
@@ -1,0 +1,16 @@
+module ManagerRefresh::Inventory::CloudManager
+  extend ActiveSupport::Concern
+  include ::ManagerRefresh::Inventory::Core
+
+  class_methods do
+    def has_cloud_manager_vms(options = {})
+      has_vms({
+        :model_class    => provider_module::CloudManager::Vm,
+        :association    => :vms,
+        :builder_params => {
+          :ext_management_system => ->(persister) { persister.manager }
+        },
+      }.merge(options))
+    end
+  end
+end

--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -60,7 +60,7 @@ module ManagerRefresh::Inventory::Core
       has_inventory({
         :model_class                 => ::Vm,
         :manager_ref                 => [:uid_ems],
-        :inventory_object_attributes => %i(),
+        :inventory_object_attributes => %i(location name vendor),
       }.merge(options))
     end
   end


### PR DESCRIPTION
helpers for graph refresh inventory.

to be used like [this](https://github.com/jameswnl/manageiq-providers-dummy_provider/blob/1d9c3091d0f8a26a8b96ee6beb70b6064fd6fbae/app/models/manageiq/providers/dummy_pro/inventory/persister/cloud_manager.rb#L4)


@miq-bot assign @agrare 
@miq-bot add_label enhancement

cc @Ladas 