### PR TITLE
Adds vm_snapshot_success NotificationType

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -154,6 +154,11 @@
   :expires_in: 24.hours
   :level: :error
   :audience: global
+- :name: vm_snapshot_success
+  :message: 'The operation %{snapshot_op} on snapshot of %{subject} completed successfully.'
+  :expires_in: 24.hours
+  :level: :warning
+  :audience: global
 - :name: vm_snapshot_failure
   :message: 'Failed to %{snapshot_op} snapshot of %{subject}: %{error}'
   :expires_in: 24.hours


### PR DESCRIPTION
Adds `vm_snapshot_success` NotificationType so we can create notification when snapshot operation succeeds. This is used in https://github.com/ManageIQ/manageiq-providers-openstack/pull/128

Partially solves https://bugzilla.redhat.com/show_bug.cgi?id=1429313
