### PR TITLE
Adds Notification when vm_snapshot_remove failed

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -65,6 +65,7 @@ module VmOrTemplate::Operations::Snapshot
     begin
       run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
     rescue => err
+      create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "remove")
       if err.to_s.include?('not found')
         raise MiqException::MiqVmSnapshotError, err.to_s
       else


### PR DESCRIPTION
Notification for failure when removing VM snapshot was missing.

Partially solves https://bugzilla.redhat.com/show_bug.cgi?id=1429313