### PR TITLE
Remove support for compressed ids in dialogs

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -127,7 +127,7 @@ class Dialog < ApplicationRecord
       updated_tabs = []
       tabs.each do |dialog_tab|
         if dialog_tab.key?('id')
-          DialogTab.find(self.class.uncompress_id(dialog_tab['id'])).tap do |tab|
+          DialogTab.find(dialog_tab['id']).tap do |tab|
             tab.update_attributes(dialog_tab.except('id', 'href', 'dialog_id', 'dialog_groups'))
             tab.update_dialog_groups(dialog_tab['dialog_groups'])
             updated_tabs << tab

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -140,7 +140,7 @@ class DialogField < ApplicationRecord
   private
 
   def available_dialog_field_responders(id_list)
-    DialogField.find(id_list.collect { |id| self.class.uncompress_id(id) })
+    DialogField.find(id_list)
   end
 
   def default_resource_action

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -19,7 +19,7 @@ class DialogGroup < ApplicationRecord
     fields.each do |field|
       field['options'].try(:symbolize_keys!)
       if field.key?('id')
-        DialogField.find(self.class.uncompress_id(field['id'])).tap do |dialog_field|
+        DialogField.find(field['id']).tap do |dialog_field|
           resource_action_fields = field.delete('resource_action') || {}
           update_resource_fields(resource_action_fields, dialog_field)
           dialog_field.update_attributes(field.except('id', 'href', 'dialog_group_id', 'dialog_field_responders'))

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -34,7 +34,7 @@ class DialogTab < ApplicationRecord
     updated_groups = []
     groups.each do |group|
       if group.key?('id')
-        DialogGroup.find(self.class.uncompress_id(group['id'])).tap do |dialog_group|
+        DialogGroup.find(group['id']).tap do |dialog_group|
           dialog_group.update_attributes(group.except('id', 'href', 'dialog_tab_id', 'dialog_fields'))
           dialog_group.update_dialog_fields(group['dialog_fields'])
           updated_groups << dialog_group

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -189,8 +189,8 @@ describe DialogField do
     end
 
     context "when the given list is not empty" do
-      it "rebuilds the responder list based on the compressed IDs" do
-        dialog_field.update_dialog_field_responders([dialog_field2.compressed_id])
+      it "rebuilds the responder list based on the IDs" do
+        dialog_field.update_dialog_field_responders([dialog_field2.id])
         expect(dialog_field.dialog_field_responders).to eq([dialog_field2])
       end
     end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -284,15 +284,15 @@ describe Dialog do
     let(:updated_content) do
       [
         {
-          'id'            => dialog_tab.first.compressed_id,
+          'id'            => dialog_tab.first.id,
           'label'         => 'updated_label',
           'dialog_groups' => [
-            { 'id'            => dialog_group.first.compressed_id,
-              'dialog_tab_id' => dialog_tab.first.compressed_id,
+            { 'id'            => dialog_group.first.id,
+              'dialog_tab_id' => dialog_tab.first.id,
               'dialog_fields' =>
                                  [{
                                    'id'              => dialog_field.first.id,
-                                   'dialog_group_id' => dialog_group.first.compressed_id
+                                   'dialog_group_id' => dialog_group.first.id
                                  }] },
             {
               'label'         => 'group 2',
@@ -347,37 +347,6 @@ describe Dialog do
         expect do
           dialog.update_tabs(updated_content)
         end.to change(dialog.reload.dialog_tabs, :count).by(-1)
-      end
-    end
-
-    context 'compresssed ids' do
-      let(:updated_content) do
-        [
-          {
-            'id'            => dialog_tab.first.id,
-            'label'         => 'updated_label_foo',
-            'dialog_groups' => [
-              { 'id'            => dialog_group.first.compressed_id,
-                'label'         => 'updated_label_bar',
-                'dialog_fields' =>
-                                   [{'id' => dialog_field.first.compressed_id, 'label' => 'updated_label_baz'}]}
-            ]
-          }
-        ]
-      end
-
-      before do
-        dialog.dialog_tabs << FactoryGirl.create(:dialog_tab)
-      end
-
-      it 'updates the content' do
-        dialog.update_tabs(updated_content)
-
-        tab = dialog.dialog_tabs.first
-        group = tab.dialog_groups.first
-        expect(tab.label).to eq('updated_label_foo')
-        expect(group.label).to eq('updated_label_bar')
-        expect(group.dialog_fields.first.label).to eq('updated_label_baz')
       end
     end
   end


### PR DESCRIPTION
Since we deprecated the use of compressed ids in the API in
https://github.com/ManageIQ/manageiq-api/pull/59, we no longer need to
support them here.