### PR TITLE
Add a Yamllint config and fix remaining violations

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+---
+ignore: |
+  /locale/**
+  /spec/tools/openstack_data/**
+  /vendor/**
+
+extends: relaxed
+
+rules:
+  indentation:
+    indent-sequences: false
+  line-length:
+    max: 1000

--- a/db/fixtures/chargeable_fields.yml
+++ b/db/fixtures/chargeable_fields.yml
@@ -66,4 +66,3 @@
   :group: metering
   :source: used
   :description: Metering - Hours Used
-

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6530,7 +6530,7 @@
     - :name: Switch Language
       :description: Display Language options
       :feature_type: view
-      :identifier: sui_language 
+      :identifier: sui_language
     - :name: Notifications
       :description: Display notifications
       :feature_type: view
@@ -6540,10 +6540,10 @@
     :feature_type: node
     :identifier: sui_dashboard
     :children:
-     - :name: Monthly Charge view
-       :description: Display monthly charges
-       :feature_type: view
-       :identifier: sui_dashboard_monthly_charge_view
+    - :name: Monthly Charge view
+      :description: Display monthly charges
+      :feature_type: view
+      :identifier: sui_dashboard_monthly_charge_view
   - :name: My Services
     :description: My Services features
     :feature_type: node
@@ -6672,7 +6672,7 @@
       :description: View Orders
       :feature_type: node
       :identifier: sui_orders_display
-      :children:  
+      :children:
       - :name: Show
         :description: Display Orders
         :feature_type: view
@@ -6699,7 +6699,7 @@
     :description: Service Catalog features
     :feature_type: node
     :identifier: sui_svc_catalog
-    :children:   
+    :children:
     - :name: View
       :description: Display Service Catalog
       :feature_type: node
@@ -6713,7 +6713,7 @@
       :description: Catalog operations
       :feature_type: node
       :identifier: sui_svc_catalog_operations
-      :children:  
+      :children:
       - :name: Add to Shopping Cart
         :description: Add to Shopping Cart
         :feature_type: control
@@ -6736,7 +6736,7 @@
       :description: Shopping Cart operations
       :feature_type: node
       :identifier: sui_cart_operations
-      :children:    
+      :children:
       - :name: Clear
         :description: Clear cart
         :feature_type: control

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -484,7 +484,6 @@
     :sub_types:
     - :hours
     :function:
-    :function:
       :name: number_with_delimiter
       :delimiter: ","
       :suffix: ! ' Hours'

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_template.yaml
@@ -100,7 +100,7 @@
         :owner_email:
           :description: E-Mail
           :required_method: :validate_regex
-          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/physical_server_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/physical_server_provision_dialogs.yaml
@@ -100,7 +100,7 @@
         :owner_email:
           :description: E-Mail
           :required_method: :validate_regex
-          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i 
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
           :required: true
           :display: :edit
           :data_type: :string


### PR DESCRIPTION
With the supplied config and the changes here, and using the newly released 1.9.0 version of yamllint (which contains a bug fix for false positives I found in our repo), the report is now squeaky-clean:

```
yamllint . -f parsable

Compilation finished at Tue Oct 24 10:19:09
```
