### PR TITLE
Return used and allocated values in combined_quota results even when no quota defined

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -151,10 +151,12 @@ class Tenant < ApplicationRecord
   end
 
   def combined_quotas
-    tenant_quotas.each_with_object({}) do |q, h|
+    TenantQuota.quota_definitions.each_with_object({}) do |d, h|
+      scope_name, _ = d
+      q = tenant_quotas.send(scope_name).take || tenant_quotas.build(:name => scope_name, :value => 0)
       h[q.name.to_sym] = q.quota_hash
       h[q.name.to_sym][:allocated]   = q.allocated
-      h[q.name.to_sym][:available]   = q.available
+      h[q.name.to_sym][:available]   = q.available unless q.new_record?
       h[q.name.to_sym][:used]        = q.used
     end.reverse_merge(TenantQuota.quota_definitions)
   end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -618,6 +618,7 @@ describe Tenant do
     let(:parent_tenant) { FactoryGirl.create(:tenant, :parent => default_tenant) }
     let(:child_tenant1) { FactoryGirl.create(:tenant, :parent => parent_tenant) }
     let(:child_tenant2) { FactoryGirl.create(:tenant, :parent => parent_tenant) }
+    let(:child_tenant3) { FactoryGirl.create(:tenant, :parent => parent_tenant) }
 
     before do
       parent_tenant.set_quotas(
@@ -702,6 +703,22 @@ describe Tenant do
       expect(combined[:cpu_allocated][:used]).to              eql 2
       expect(combined[:storage_allocated][:used]).to          eql 2
       expect(combined[:templates_allocated][:used]).to        eql 2
+    end
+
+    it "combined quotas get used value when no quotas are defined for tenant" do
+      combined = child_tenant3.combined_quotas
+
+      expect(combined[:vms_allocated][:used]).to              eql 2
+      expect(combined[:mem_allocated][:used]).to              eql 2
+      expect(combined[:cpu_allocated][:used]).to              eql 2
+      expect(combined[:storage_allocated][:used]).to          eql 2
+      expect(combined[:templates_allocated][:used]).to        eql 2
+
+      expect(combined[:vms_allocated][:value]).to             eql 0.0
+      expect(combined[:mem_allocated][:value]).to             eql 0.0
+      expect(combined[:cpu_allocated][:value]).to             eql 0.0
+      expect(combined[:storage_allocated][:value]).to         eql 0.0
+      expect(combined[:templates_allocated][:value]).to       eql 0.0
     end
   end
 


### PR DESCRIPTION
We were not calculating nor displaying used and allocated values for quotas that were not defined. This enhancement enables that.

https://bugzilla.redhat.com/show_bug.cgi?id=1415792