### PR TITLE
[WIP] [Don't merge] Make spawn pass options again

### DIFF
--- a/Procfile.example
+++ b/Procfile.example
@@ -45,9 +45,9 @@
 # These workers subscribe to a queue named based on the particular EMS they connect to
 # The "<id>" tag in these lines should be replaced by the id of the manager instance these workers apply to
 
-# vmware_refresh_<id>:      env QUEUE=ems_<id> ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
-# vmware_event_<id>:        env QUEUE=ems_<id> ruby lib/workers/bin/run_single_worker.rb ManageIQ::Providers::Vmware::InfraManager::EventCatcher
-# vmware_refresh_core_<id>: env QUEUE=ems_<id> ruby lib/workers/bin/run_single_worker.rb MiqEmsRefreshCoreWorker
+# vmware_refresh_<id>:      ruby lib/workers/bin/run_single_worker.rb --ems-id <id> ManageIQ::Providers::Vmware::InfraManager::RefreshWorker
+# vmware_event_<id>:        ruby lib/workers/bin/run_single_worker.rb --ems-id <id> ManageIQ::Providers::Vmware::InfraManager::EventCatcher
+# vmware_refresh_core_<id>: ruby lib/workers/bin/run_single_worker.rb --ems-id <id> MiqEmsRefreshCoreWorker
 
 # Logs
 #

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -367,7 +367,9 @@ class MiqWorker < ApplicationRecord
     cmd = "nice #{nice_increment} #{cmd}" if ENV["APPLIANCE"]
 
     options = {:guid => guid, :heartbeat => nil}
-    options[:ems_id] = ems_id if ems_id
+    if ems_id
+      options[:ems_id] = ems_id.kind_of?(Array) ? ems_id.join(",") : ems_id
+    end
     "#{AwesomeSpawn::CommandLineBuilder.new.build(cmd, options)} #{name}"
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -43,8 +43,6 @@ class MiqWorker::Runner
 
   def initialize(cfg = {})
     @cfg = cfg
-    @cfg[:guid] ||= ENV['MIQ_GUID']
-
     $log ||= Rails.logger
 
     @server = MiqServer.my_server(true)

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -133,7 +133,6 @@ module MiqWebServerWorkerMixin
 
   def start
     delete_pid_file
-    ENV['MIQ_GUID'] = guid
     super
   end
 

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -1,7 +1,7 @@
 module Vmdb
   module Initializer
     def self.init
-      _log.info("- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['MIQ_GUID']: #{ENV['MIQ_GUID']}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}")
+      _log.info("- Program Name: #{$PROGRAM_NAME}, PID: #{Process.pid}, ENV['EVMSERVER']: #{ENV['EVMSERVER']}")
 
       # UiWorker called in Development Mode
       #   * command line(rails server)

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -27,7 +27,7 @@ opt_parser = OptionParser.new do |opts|
     options[:guid] = val
   end
 
-  opts.on("-e=ems_id", "--ems-id=ems_id", "Provide an ems id to a provider worker.") do |val|
+  opts.on("-e=ems_id", "--ems-id=ems_id,ems_id", Array, "Provide a list of ems ids (without spaces) to a provider worker. This requires, at least one argument.") do |val|
     options[:ems_id] = val
   end
 
@@ -46,7 +46,6 @@ if options[:list]
   exit
 end
 opt_parser.abort(opt_parser.help) unless worker_class
-
 unless ::MIQ_WORKER_TYPES.keys.include?(worker_class)
   puts "ERR:  `#{worker_class}` WORKER CLASS NOT FOUND!  Please run with `-l` to see possible worker class names."
   exit 1
@@ -65,7 +64,7 @@ unless options[:dry_run]
   runner_options = {}
 
   if options[:ems_id]
-    create_options[:queue_name] = "ems_#{options[:ems_id]}"
+    create_options[:queue_name] = options[:ems_id].length == 1 ? "ems_#{options[:ems_id].first}" : options[:ems_id].collect { |id| "ems_#{id}" }
     runner_options[:ems_id]     = options[:ems_id]
   end
 

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -65,7 +65,7 @@ unless options[:dry_run]
 
   if options[:ems_id]
     create_options[:queue_name] = options[:ems_id].length == 1 ? "ems_#{options[:ems_id].first}" : options[:ems_id].collect { |id| "ems_#{id}" }
-    runner_options[:ems_id]     = options[:ems_id]
+    runner_options[:ems_id]     = options[:ems_id].length == 1 ? options[:ems_id].first : options[:ems_id].collect { |id| id }
   end
 
   worker = if options[:guid]

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -27,6 +27,10 @@ opt_parser = OptionParser.new do |opts|
     options[:guid] = val
   end
 
+  opts.on("-e=ems_id", "--ems-id=ems_id", "Provide an ems id to a provider worker.") do |val|
+    options[:ems_id] = val
+  end
+
   opts.on("-h", "--help", "Displays this help") do
     puts opts
     exit
@@ -60,9 +64,9 @@ unless options[:dry_run]
   create_options = {:pid => Process.pid}
   runner_options = {}
 
-  if ENV["QUEUE"]
-    create_options[:queue_name] = ENV["QUEUE"]
-    runner_options[:ems_id] = worker_class.ems_id_from_queue_name(ENV["QUEUE"]) if worker_class.respond_to?(:ems_id_from_queue_name)
+  if options[:ems_id]
+    create_options[:queue_name] = "ems_#{options[:ems_id]}"
+    runner_options[:ems_id]     = options[:ems_id]
   end
 
   worker = if options[:guid]

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -46,6 +46,7 @@ if options[:list]
   exit
 end
 opt_parser.abort(opt_parser.help) unless worker_class
+
 unless ::MIQ_WORKER_TYPES.keys.include?(worker_class)
   puts "ERR:  `#{worker_class}` WORKER CLASS NOT FOUND!  Please run with `-l` to see possible worker class names."
   exit 1

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -346,11 +346,6 @@ describe MiqWorker do
     end
 
     context "#command_line" do
-      it "with nil worker_options" do
-        allow(@worker).to receive(:worker_options).and_return(nil)
-        expect { @worker.command_line }.to raise_error(ArgumentError)
-      end
-
       it "without guid in worker_options" do
         allow(@worker).to receive(:worker_options).and_return({})
         expect { @worker.command_line }.to raise_error(ArgumentError)
@@ -369,7 +364,10 @@ describe MiqWorker do
           ENV['APPLIANCE'] = 'true'
           cmd = @worker.command_line
           expect(cmd).to start_with("nice +10")
-          expect(cmd).to end_with("--ems-id 1234 --guid #{@worker.guid} --heartbeat MiqWorker")
+          expect(cmd).to include("--ems-id 1234")
+          expect(cmd).to include("--guid #{@worker.guid}")
+          expect(cmd).to include("--heartbeat")
+          expect(cmd).to end_with("MiqWorker")
         ensure
           # ENV['x'] = nil deletes the key because ENV accepts only string values
           ENV['APPLIANCE'] = old_env

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -29,32 +29,6 @@ describe MiqWorker do
     expect(result.command_line).to eq "renice -n 5 -p 123"
   end
 
-  context ".build_command_line" do
-    before do
-      allow(MiqGenericWorker).to receive(:nice_increment).and_return("+10")
-    end
-
-    it "with ENV['APPLIANCE']" do
-      begin
-        old_env = ENV.delete('DATABASE_URL')
-        ENV['APPLIANCE'] = 'true'
-        w = FactoryGirl.build(:miq_generic_worker)
-        cmd = w.class.build_command_line(123)
-        expect(cmd).to start_with("nice +10")
-        expect(cmd).to end_with("MiqGenericWorker")
-      ensure
-        # ENV['x'] = nil deletes the key because ENV accepts only string values
-        ENV['APPLIANCE'] = old_env
-      end
-    end
-
-    it "without ENV['APPLIANCE']" do
-      w = FactoryGirl.build(:miq_generic_worker)
-      cmd = w.class.build_command_line(123)
-      expect(cmd).to_not start_with("nice +10")
-    end
-  end
-
   context ".has_required_role?" do
     def check_has_required_role(worker_role_names, expected_result)
       allow(described_class).to receive(:required_roles).and_return(worker_role_names)
@@ -369,6 +343,38 @@ describe MiqWorker do
 
     it "#worker_options" do
       expect(@worker.worker_options).to eq(:guid => @worker.guid)
+    end
+
+    context "#command_line" do
+      it "with nil worker_options" do
+        allow(@worker).to receive(:worker_options).and_return(nil)
+        expect { @worker.command_line }.to raise_error(ArgumentError)
+      end
+
+      it "without guid in worker_options" do
+        allow(@worker).to receive(:worker_options).and_return({})
+        expect { @worker.command_line }.to raise_error(ArgumentError)
+      end
+
+      it "without ENV['APPLIANCE']" do
+        allow(@worker).to receive(:worker_options).and_return(:ems_id => 1234, :guid => @worker.guid)
+        expect(@worker.command_line).to_not include("nice")
+      end
+
+      it "with ENV['APPLIANCE']" do
+        begin
+          allow(MiqWorker).to receive(:nice_increment).and_return("+10")
+          allow(@worker).to receive(:worker_options).and_return(:ems_id => 1234, :guid => @worker.guid)
+          old_env = ENV.delete('APPLIANCE')
+          ENV['APPLIANCE'] = 'true'
+          cmd = @worker.command_line
+          expect(cmd).to start_with("nice +10")
+          expect(cmd).to end_with("--ems-id 1234 --guid #{@worker.guid} --heartbeat MiqWorker")
+        ensure
+          # ENV['x'] = nil deletes the key because ENV accepts only string values
+          ENV['APPLIANCE'] = old_env
+        end
+      end
     end
 
     describe "#stopping_for_too_long?" do


### PR DESCRIPTION
@jrafanie 

 This change allows spawn to be passed multiple ids (or just one id) in the format 1,2,3,4 with no spaces.
    
The queue_name is then generated from the ids to look like either `ems_1` or `["ems_1", "ems_2", "ems_3"]`

I have tested this on the command line with:

```
ruby lib/workers/bin/run_single_worker.rb --ems-id 17,19,18 ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
```

And run MIQ Server using `MIQ_SPAWN_WORKERS=true`