### PR TITLE
Apply dialog tags to VMs created during orchestration provisioning

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -1,6 +1,7 @@
 class ServiceOrchestration < Service
   include ServiceOrchestrationMixin
   include ServiceOrchestrationOptionsMixin
+  include_concern 'ProvisionTagging'
 
   # read from DB or parse from dialog
   def stack_name
@@ -81,6 +82,7 @@ class ServiceOrchestration < Service
     add_stack_to_resource
     link_orchestration_template
     assign_vms_owner
+    apply_provisioning_tags
   end
 
   def my_zone

--- a/app/models/service_orchestration/provision_tagging.rb
+++ b/app/models/service_orchestration/provision_tagging.rb
@@ -1,0 +1,32 @@
+module ServiceOrchestration::ProvisionTagging
+  DIALOG_TAG_KEY_REGEX = /^Array::dialog_tag_(?<sequence>\d*)_(?<option_key>.*)/i
+  DIALOG_TAG_VALUE_REGEX = /Classification::(\d*)/
+
+  private
+
+  def apply_provisioning_tags
+    tag_ids = provisioning_tag_ids
+    return if tag_ids.empty?
+
+    vm_ids = all_vms.collect(&:id)
+    return if vm_ids.empty?
+
+    Classification.bulk_reassignment(
+      :model      => 'Vm',
+      :object_ids => vm_ids,
+      :add_ids    => tag_ids
+    )
+  end
+
+  def provisioning_tag_ids
+    provision_sequence = miq_request_task.provision_priority + 1
+    dialog_options = root_service.options[:dialog] || {}
+
+    dialog_options.flat_map do |key_name, value|
+      if (match = DIALOG_TAG_KEY_REGEX.match(key_name))
+        tag_sequence = match[:sequence].to_i
+        value.scan(DIALOG_TAG_VALUE_REGEX).flatten if tag_sequence.zero? || tag_sequence == provision_sequence
+      end
+    end.compact
+  end
+end

--- a/spec/models/service_orchestration/provision_tagging_spec.rb
+++ b/spec/models/service_orchestration/provision_tagging_spec.rb
@@ -1,0 +1,83 @@
+describe ServiceOrchestration::ProvisionTagging do
+  shared_examples_for 'service_orchestration VM tagging' do
+    it 'assign tags' do
+      expect(miq_request_task).to receive(:provision_priority).and_return(provision_priority)
+      expect(Classification).to receive(:bulk_reassignment).with(
+        :model      => 'Vm',
+        :object_ids => [vm.id],
+        :add_ids    => tag_ids
+      )
+
+      service.post_provision_configure
+    end
+  end
+
+  describe '#apply_provisioning_tags' do
+    before { expect(service).to receive(:assign_vms_owner) }
+
+    let(:miq_request_task) { FactoryGirl.create(:service_template_provision_task) }
+    let(:vm) { FactoryGirl.create(:vm) }
+    let(:service) { FactoryGirl.build(:service_orchestration, :miq_request_task => miq_request_task) }
+    let(:dialog_tag_options) do
+      { :dialog => {
+        'Array::dialog_tag_0_env'     => 'Classification::1',
+        'Array::dialog_tag_1_network' => 'Classification::11',
+        'Array::dialog_tag_2_dept'    => 'Classification::21,Classification::22,Classification::23'
+      }}
+    end
+
+    context 'without service dialog tag options' do
+      it 'does not apply tags' do
+        expect(Classification).to receive(:bulk_reassignment).never
+
+        service.post_provision_configure
+      end
+    end
+
+    context 'with a vm' do
+      before { expect(service).to receive(:all_vms).and_return([vm]) }
+
+      context 'with a single service and dialog tag options' do
+        before { service[:options] = dialog_tag_options }
+
+        context 'Calls Classification.bulk_reassignment with VM and tag IDs for provision_priority 0' do
+          let(:provision_priority) { 0 }
+          let(:tag_ids) { %w(1 11) }
+
+          it_behaves_like 'service_orchestration VM tagging'
+        end
+      end
+
+      context 'with a bundle service and dialog tag data' do
+        before do
+          parent_service[:options] = dialog_tag_options
+          service.add_to_service(parent_service)
+        end
+
+        let(:parent_service) { FactoryGirl.create(:service, :name => 'parent_service') }
+        let(:service) { FactoryGirl.build(:service_orchestration, :miq_request_task => miq_request_task) }
+
+        context 'Calls Classification.bulk_reassignment with VM and tag IDs for provision_priority 0' do
+          let(:provision_priority) { 0 }
+          let(:tag_ids) { %w(1 11) }
+
+          it_behaves_like 'service_orchestration VM tagging'
+        end
+
+        context 'Call Classification.bulk_reassignment with VM and tag IDs for provision_priority 1' do
+          let(:provision_priority) { 1 }
+          let(:tag_ids) { %w(1 21 22 23) }
+
+          it_behaves_like 'service_orchestration VM tagging'
+        end
+
+        context 'Call Classification.bulk_reassignment with VM and tag IDs for provision_priority 2' do
+          let(:provision_priority) { 2 }
+          let(:tag_ids) { %w(1) }
+
+          it_behaves_like 'service_orchestration VM tagging'
+        end
+      end
+    end
+  end
+end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -258,6 +258,8 @@ describe ServiceOrchestration do
       allow(ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack).to receive(
         :raw_create_stack).and_return("ems_ref")
       @resulting_stack = service.deploy_orchestration_stack
+
+      service.miq_request_task = FactoryGirl.create(:service_template_provision_task)
     end
 
     it 'sets owners for all vms included in the stack' do


### PR DESCRIPTION
VM Lifecycle provisioning (and associated service provisioning) allow users to select tags and those tags are automatically applied to the resulting VMs.  Orchestration provisioning supports tag select, through service dialogs, but the resulting VMs do not have the tags applied as part of the post provisioning steps.

This PR uses the standard dialog field naming scheme (dialog_tag_<sequence>_<name>) to determine which tags are applied to the created VMs.  

For example:
* Field `dialog_tag_0_env` would apply the selected tag (or tags for multi-select tag categories) to all VMs created for a single service or bundle service provision request.
* Field `dialog_tag_1_env` tags would apply to VMs created during a single service provision or a service provisioned in a bundle with a provisioning order of 1.
* Field `dialog_tag_2_env` tags would only be applied to VMs that belong to a service that is part of a bundle and have a provisioning order of 2.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1493996
