### PR TITLE
Allow to schedule disconnected container entities for perf capture

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -87,8 +87,9 @@ class ContainerGroup < ApplicationRecord
     self.container_services = []
     self.container_replicator_id = nil
     self.container_build_pod_id = nil
+    # Keeping old_container_project_id for backwards compatibility, we will need a migration that is putting it back to
+    # container_project_id
     self.old_container_project_id = self.container_project_id
-    self.container_project_id = nil
     self.deleted_on = Time.now.utc
     save
   end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -84,7 +84,6 @@ class ContainerGroup < ApplicationRecord
     return if archived?
     _log.info("Disconnecting Pod [#{name}] id [#{id}] from EMS [#{ext_management_system.name}] id [#{ext_management_system.id}]")
     self.containers.each(&:disconnect_inv)
-    self.container_node_id = nil
     self.container_services = []
     self.container_replicator_id = nil
     self.container_build_pod_id = nil

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -13,7 +13,7 @@ class ContainerNode < ApplicationRecord
 
   # :name, :uid, :creation_timestamp, :resource_version
   belongs_to :ext_management_system, :foreign_key => "ems_id"
-  has_many   :container_groups
+  has_many   :container_groups, -> { active }
   has_many   :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
   has_many   :containers, :through => :container_groups
   has_many   :container_images, -> { distinct }, :through => :container_groups

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -4,7 +4,7 @@ class ContainerProject < ApplicationRecord
   include ArchivedMixin
   include_concern 'Purging'
   belongs_to :ext_management_system, :foreign_key => "ems_id"
-  has_many :container_groups
+  has_many :container_groups, -> { active }
   has_many :container_routes
   has_many :container_replicators
   has_many :container_services

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -21,7 +21,8 @@ module Metric::Capture
   end
 
   def self.targets_archived_from
-    Settings.performance.targets.archived_for.to_i_with_method.seconds.ago.utc
+    archived_for_setting = Settings.performance.targets.archived_for
+    archived_for_setting.to_i_with_method.seconds.ago.utc
   end
 
   def self.concurrent_requests(interval_name)

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -20,6 +20,10 @@ module Metric::Capture
     historical_days.days.ago.utc.beginning_of_day
   end
 
+  def self.targets_archived_from
+    Settings.performance.targets.archived_for.to_i_with_method.seconds.ago.utc
+  end
+
   def self.concurrent_requests(interval_name)
     requests = ::Settings.performance.concurrent_requests[interval_name]
     requests = 20 if requests < 20 && interval_name == 'realtime'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -903,6 +903,8 @@
   :host_overhead:
     :memory: 2.01.percent
     :cpu: 0.15.percent
+  :targets:
+    :archived_for: 8.hours
   :vim_cache_ttl: 1.hour
 :policy_events:
   :history:


### PR DESCRIPTION
Collect metrics for archived Container entities. We need this
for shortlived entities (e.g. pods), to make sure the entity
is not discovered and archived before the metrics capture
was planned. The amount of time for looking back for archived
items is configurable and by default is 8h.


Partially fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1506671