### PR TITLE
Add scopes to substitute `:conditions`s

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -25,6 +25,8 @@ class ChargebackRate < ApplicationRecord
 
   delegate :symbol, :to => :currency, :prefix => true, :allow_nil => true
 
+  scope :with_rate_type, ->(rate_type) { where(:rate_type => rate_type) }
+
   VALID_CB_RATE_TYPES = ["Compute", "Storage"]
 
   def rate_details_relevant_to(report_cols)

--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -7,6 +7,9 @@ class CustomizationTemplate < ApplicationRecord
   validates :pxe_image_type, :presence => true, :unless => :system?
   validates :name,           :uniqueness => { :scope => :pxe_image_type }, :unique_within_region => true
 
+  scope :with_pxe_image_type_id, ->(pxe_image_type_id) { where(:pxe_image_type_id => pxe_image_type_id) }
+  scope :with_system,            ->(bool = true)       { where(:system => bool) }
+
   def self.seed_file_name
     @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")
   end

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -2,6 +2,8 @@ class MiqDialog < ApplicationRecord
   validates :name, :description, :presence => true
   validates :name, :uniqueness => { :scope => :dialog_type, :case_sensitive => false }
 
+  scope :with_dialog_type, ->(dialog_type) { where(:dialog_type => dialog_type) }
+
   DIALOG_TYPES = [
     [_("VM Provision"),                "MiqProvisionWorkflow"],
     [_("Configured System Provision"), "MiqProvisionConfiguredSystemWorkflow"],

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -30,6 +30,9 @@ class MiqPolicy < ApplicationRecord
   validates_uniqueness_of   :name, :description, :guid
   validates :mode, :inclusion => { :in => %w(compliance control) }
 
+  scope :with_mode,   ->(mode)   { where(:mode => mode) }
+  scope :with_towhat, ->(towhat) { where(:towhat => towhat) }
+
   serialize :expression
 
   @@associations_to_get_policies = [:parent_enterprise, :ext_management_system, :parent_datacenter, :ems_cluster, :parent_resource_pool, :host]

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -29,6 +29,8 @@ class MiqProvision < MiqProvisionTask
   virtual_column     :placement_auto, :type => :boolean
   virtual_column     :provision_type, :type => :string  # Legacy provisioning support
 
+  scope :with_miq_request_id, ->(request_id) { where(:miq_request_id => request_id) }
+
   CLONE_SYNCHRONOUS     = false
   CLONE_TIME_LIMIT      = 4.hours
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -21,7 +21,11 @@ class MiqSchedule < ApplicationRecord
     where("updated_at > ?", time)
   }
 
-  scope :filter_matches_with, -> (exp) { where(:filter => exp) }
+  scope :filter_matches_with,      ->(exp)    { where(:filter => exp) }
+  scope :with_prod_default_not_in, ->(prod)   { where.not(:prod_default => [prod, nil]) }
+  scope :with_adhoc,               ->(adhoc)  { where(:adhoc => adhoc) }
+  scope :with_towhat,              ->(towhat) { where(:towhat => towhat) }
+  scope :with_userid,              ->(userid) { where(:userid => userid) }
 
   serialize :sched_action
   serialize :filter

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -31,6 +31,8 @@ class MiqServer < ApplicationRecord
 
   virtual_column :zone_description, :type => :string
 
+  scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
+
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze
   STATUS_RESTARTING     = 'restarting'.freeze

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -14,6 +14,9 @@ class MiqWorker < ApplicationRecord
   virtual_column :friendly_name, :type => :string
   virtual_column :uri_or_queue_name, :type => :string
 
+  scope :with_miq_server_id, ->(server_id) { where(:miq_server_id => server_id) }
+  scope :with_status,        ->(status)    { where(:status => status) }
+
   STATUS_CREATING = 'creating'.freeze
   STATUS_STARTING = 'starting'.freeze
   STATUS_STARTED  = 'started'.freeze


### PR DESCRIPTION
In order to remove `:conditions` from get_view params in UI, we need to have scopes which can replace them.

Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/2513
Should help with: https://github.com/ManageIQ/manageiq-ui-classic/pull/2383