### PR TITLE
PostgresAdmin now expects the backup file to exist

### DIFF
--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -1,3 +1,4 @@
+require 'util/runcmd'
 describe EvmDatabaseOps do
   context "#backup" do
     before(:each) do
@@ -7,6 +8,7 @@ describe EvmDatabaseOps do
       allow_any_instance_of(MiqSmbSession).to receive(:settings_mount_point).and_return(Rails.root.join("tmp"))
       allow(MiqUtil).to receive(:runcmd)
       allow(PostgresAdmin).to receive(:runcmd_with_logging)
+      allow(FileUtils).to receive(:mv).and_return(true)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(200.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(100.megabytes)
     end
@@ -52,6 +54,7 @@ describe EvmDatabaseOps do
       allow(MiqSmbSession).to receive(:raw_disconnect)
       allow_any_instance_of(MiqSmbSession).to receive(:settings_mount_point).and_return(Rails.root.join("tmp"))
       allow(PostgresAdmin).to receive(:runcmd_with_logging)
+      allow(PostgresAdmin).to receive(:pg_dump_file?).and_return(true)
     end
 
     it "from local backup" do


### PR DESCRIPTION
Starting with this PR: https://github.com/ManageIQ/manageiq-gems-pending/pull/302
PostgresAdmin added file existence and file moves in the backup and
restore code.  We need to mock these for now until we find a cleaner way
to test this.