### PR TITLE
[WIP] Remove qpid_proton optional group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :nuage, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.18",        :git => "https://github.com/xlab-si/qpid_proton_gem", :require => false
+  gem "qpid_proton",                    "~>0.18",        :require => false # used by Nuage provider
 end
 
 group :openshift, :manageiq_default do


### PR DESCRIPTION
This group was introduced to move the Nuage provider PRs forward because
the qpid_proton gem 0.18 was previously not released. Now that it has
been, we should be able to use the offical release from RubyGems.