### PR TITLE
Enable alerts on ext_management_system from prometheus events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -223,7 +223,7 @@ class EmsEvent < EventStream
     target_type = "src_vm_or_template"  if target_type == "src_vm"
     target_type = "dest_vm_or_template" if target_type == "dest_vm"
     target_type = "middleware_server"   if event.event_type == "hawkular_alert"
-    target_type = "container_node"      if event.event_type == "datawarehouse_alert"
+    target_type = "target"              if event.event_type == "datawarehouse_alert"
 
     event.send(target_type)
   end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -246,6 +246,7 @@ class MiqAlert < ApplicationRecord
     status = miq_alert_statuses.find_or_initialize_by(:resource => target, :event_ems_ref => ems_ref)
     status.result = result
     status.ems_id = target.try(:ems_id)
+    status.ems_id ||= target.id if target.is_a?(ExtManagementSystem)
     status.description = status_description || description
     status.severity = severity
     status.severity = event_severity unless event_severity.blank?
@@ -600,7 +601,7 @@ class MiqAlert < ApplicationRecord
           {:name => :mw_operator, :description => _("Operator"), :values => [">", ">=", "<", "<="]},
           {:name => :value_mw_threshold, :description => _("Number of rejected Web sessions"), :numeric => true, :required => true}
         ]},
-      {:name => "dwh_generic", :description => _("All Datawarehouse alerts"), :db => ["ContainerNode"], :responds_to_events => "datawarehouse_alert",
+      {:name => "dwh_generic", :description => _("External Prometheus Alerts"), :db => ["ContainerNode", "ExtManagementSystem"], :responds_to_events => "datawarehouse_alert",
         :options => [], :always_evaluate => true}
     ]
   end


### PR DESCRIPTION
- Enable creating ext_management_system targeted alerts to be evaluated post catching Prometheus events
- Rename control screens "All Datawarehouse alerts" to the more fitting "External Prometheus Alerts"
(we used to have generic external alerts called datawarehouse alerts, we ended up supporting just the Prometheus Alerts so that name is more fitting)

Part of Prometheus Alert integration:
https://github.com/ManageIQ/manageiq/issues/14238

Related To:
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/140