### PR TITLE
Enable mwPolicies

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -70,6 +70,8 @@
 - ManageIQ::Providers::InfraManager::Vm
 - VmPerformance
 - Zone
+- ManageIQ::Providers::MiddlewareManager
+- MiddlewareServer
 :include_tables:
 - advanced_settings
 - archived_container_groups
@@ -236,6 +238,8 @@
   ContainerService: container_service
   ContainerTemplate: container_template
   PersistentVolume: persistent_volume
+  ManageIQ::Providers::MiddlewareManager: ext_management_system
+  MiddlewareServer: middleware_server
 :exclude_from_relats:
   ManageIQ::Providers::CloudManager:
   - hosts


### PR DESCRIPTION
### Related PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2436
Enables to search for policies which are assigned to any MW servers - Wildfly and EAP currently.