### PR TITLE
fix containers refresh for when a container has no set image yet

### DIFF
--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -181,7 +181,7 @@ module EmsRefresh::SaveInventoryContainer
 
     hashes.each do |h|
       h[:ems_id] = container_group[:ems_id]
-      h[:container_image_id] = h[:container_image][:id]
+      h[:container_image_id] = h.fetch_path(:container_image, :id)
     end
 
     save_inventory_multi(container_group.containers, hashes, :use_association, [:ems_ref],


### PR DESCRIPTION
This could happen if a pod is just starting and an image has not yet been resolved for one of its containers
@cben Please review
cc @simon3z @moolitayer 


@miq-bot add_label providers/containers, bug 