### PR TITLE
[WIP] Add new JVM Middleware alerts on miq fresh start 

### DIFF
--- a/db/fixtures/miq_alerts.yml
+++ b/db/fixtures/miq_alerts.yml
@@ -321,3 +321,45 @@
             value: prod
   :db: Vm
   :guid: 89db0be8-c240-11de-a3be-000c290de4f9
+- description: Middleware Heap Max > 90%
+  options:
+    :notifications:
+      :delay_next_evaluation: 600
+      :evm_event: {}
+  db: MiddlewareServer
+  responds_to_events: hawkular_alert
+  hash_expression:
+    :eval_method: mw_heap_used
+    :mode: internal
+    :options:
+      :value_mw_greater_than: '90'
+      :value_mw_less_than: '0'
+  guid: 017f8cbf-fb9b-4417-9b0a-c0fc02d8e0a2
+- description: Middleware Non Heap > 90%
+  options:
+    :notifications:
+      :delay_next_evaluation: 600
+      :evm_event: {}
+  db: MiddlewareServer
+  responds_to_events: hawkular_alert
+  hash_expression:
+    :eval_method: mw_non_heap_used
+    :mode: internal
+    :options:
+      :value_mw_greater_than: '90'
+      :value_mw_less_than: '0'
+  guid: b6fa8fb2-97fd-4c95-8374-bf374fc7ab6f
+- description: Middleware GC > 10 sec/minute
+  options:
+    :notifications:
+      :evm_event: {}
+      :delay_next_evaluation: 600
+  db: MiddlewareServer
+  responds_to_events: hawkular_alert
+  hash_expression:
+    :eval_method: mw_accumulated_gc_duration
+    :mode: internal
+    :options:
+      :mw_operator: ">"
+      :value_mw_garbage_collector: '10000'
+  guid: 4dca61d2-767e-4e6c-ab88-a8d309ad4d23


### PR DESCRIPTION
This task is following the [JMAN4-233](https://issues.jboss.org/browse/JMAN4-233).
It adds the following 3 new middleware alerts:

1. Middleware GC > 10 sec/minute
2. Middleware Heap Max > 90%
3. Middleware Non Heap Max > 90%

![alerts-looks-like](https://user-images.githubusercontent.com/613814/32218634-e0c50b80-be2b-11e7-976a-7ba78751b181.png)

It is added in the seed process in order to have it right after MIQ setup.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1510421 Need to be fixed
* ManageIQ/manageiq#16485 Need to be merged.