### PR TITLE
[WIP] Enable Nuage provider by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -908,6 +908,7 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
+  :nuage: true
 :prototype:
   :queue_type: miq_queue
   :artemis:


### PR DESCRIPTION
Until now Nuage provider was not mature enough to have it "turned on" by default. Therefore a setting was introduced:

```
:product:
  :nuage: false/true
```

This setting is currently used to hide the "Add New Manager" button on the Network Managers page on the UI when Nuage is not used:

https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/button/ems_network.rb

However, Nuage provider has recently obtained all the required stuff (graph refresh, targeted refresh, event catching) and it's ready to be turned on by default. Therefore we're setting the setting to `true` from now on.

@miq-bot assign @blomquisg 

/cc @gberginc 




