### PR TITLE
Charge volume types

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -58,8 +58,8 @@ class ChargeableField < ApplicationRecord
     UNITS[metric] ? detail_measure.adjust(target_unit, UNITS[metric]) : 1
   end
 
-  def metric_key
-    "#{rate_name}_metric" # metric value (e.g. Storage [Used|Allocated|Fixed])
+  def metric_key(sub_metric = nil)
+    "#{rate_name}_#{sub_metric ? sub_metric + '_' : ''}metric" # metric value (e.g. Storage [Used|Allocated|Fixed])
   end
 
   def cost_keys

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -62,10 +62,11 @@ class ChargeableField < ApplicationRecord
     "#{rate_name}_#{sub_metric ? sub_metric + '_' : ''}metric" # metric value (e.g. Storage [Used|Allocated|Fixed])
   end
 
-  def cost_keys
-    ["#{rate_name}_cost",   # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
-     "#{group}_cost",       # cost associated with metric's group (e.g. Storage Total Cost)
-     'total_cost']
+  def cost_keys(sub_metric = nil)
+    keys = ["#{rate_name}_#{sub_metric ? sub_metric + '_' : ''}cost", # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
+            'total_cost']
+
+    sub_metric ? keys : keys + ["#{group}_cost"] # cost associated with metric's group (e.g. Storage Total Cost)
   end
 
   def metering?

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -41,11 +41,11 @@ class ChargeableField < ApplicationRecord
      "fixed_storage_2"                   => ['fixed_storage_2', '', 'occurrence']}[metric_index]
   end
 
-  def measure(consumption, options)
+  def measure(consumption, options, sub_metric = nil)
     return consumption.consumed_hours_in_interval if metering?
     return 1.0 if fixed?
     return 0 if consumption.none?(metric)
-    return consumption.send(options.method_for_allocated_metrics, metric) if allocated?
+    return consumption.send(options.method_for_allocated_metrics, metric, sub_metric) if allocated?
     return consumption.avg(metric) if used?
   end
 

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -211,6 +211,14 @@ class Chargeback < ActsAsArModel
     end
   end
 
+  def self.default_column_for_format(col)
+    if col.start_with?('storage_allocated')
+      col.ends_with?('cost') ? 'storage_allocated_cost' : 'storage_allocated_metric'
+    else
+      col
+    end
+  end
+
   private
 
   def relevant_fields

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -132,6 +132,7 @@ class Chargeback < ActsAsArModel
 
   def calculate_costs(consumption, rates)
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
+    self.class.try(:refresh_dynamic_metric_columns)
 
     rates.each do |rate|
       rate.rate_details_relevant_to(relevant_fields).each do |r|

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -29,12 +29,12 @@ class Chargeback
       @tag_list_with_prefix ||= @rollups.map(&:tag_list_with_prefix).flatten.uniq
     end
 
-    def max(metric)
-      values(metric).max
+    def max(metric, sub_metric = nil)
+      values(metric, sub_metric).max
     end
 
-    def avg(metric)
-      metric_sum = values(metric).sum
+    def avg(metric, sub_metric = nil)
+      metric_sum = values(metric, sub_metric).sum
       metric_sum / consumed_hours_in_interval
     end
 
@@ -53,7 +53,7 @@ class Chargeback
       [super, first_metric_rollup_record.timestamp].compact.min
     end
 
-    def values(metric)
+    def values(metric, sub_metric = nil)
       @values ||= {}
       @values[metric] ||= @rollups.collect(&metric.to_sym).compact
     end

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -4,6 +4,8 @@ class Chargeback
              :parents_determining_rate,
              :to => :first_metric_rollup_record
 
+    attr_accessor :start_time, :end_time
+
     def initialize(metric_rollup_records, start_time, end_time)
       super(start_time, end_time)
       @rollups = metric_rollup_records
@@ -53,9 +55,14 @@ class Chargeback
       [super, first_metric_rollup_record.timestamp].compact.min
     end
 
+    def sub_metric_rollups(sub_metric)
+      q = VimPerformanceState.where(:timestamp => start_time...end_time, :resource => resource, :capture_interval => 3_600)
+      q.map { |x| x.allocated_disk_types[sub_metric] || 0 }
+    end
+
     def values(metric, sub_metric = nil)
       @values ||= {}
-      @values[metric] ||= @rollups.collect(&metric.to_sym).compact
+      @values["#{metric}#{sub_metric}"] ||= sub_metric ? sub_metric_rollups(sub_metric) : @rollups.collect(&metric.to_sym).compact
     end
 
     def first_metric_rollup_record

--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -41,7 +41,7 @@ class Chargeback
       1 # Yes, charge this interval as fixed_compute_*_*
     end
 
-    def current_value(metric)
+    def current_value(metric, _sub_metric = nil)
       # Return the last seen allocation for charging purposes.
       @value ||= {}
       @value[metric] ||= case metric

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -271,7 +271,8 @@ class ChargebackRateDetail < ApplicationRecord
         rate_details.push(detail_new)
 
         if detail_new.chargeable_field.metric == 'derived_vm_allocated_disk_storage'
-          volume_types = CloudVolume.volume_types + ['unclassified']
+          volume_types = CloudVolume.volume_types
+          volume_types.push('unclassified') if volume_types.present?
           volume_types.each do |volume_type|
             storage_detail_new = detail_new.dup
             storage_detail_new.sub_metric = volume_type

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -271,7 +271,7 @@ class ChargebackRateDetail < ApplicationRecord
         rate_details.push(detail_new)
 
         if detail_new.chargeable_field.metric == 'derived_vm_allocated_disk_storage'
-          volume_types = CloudVolume.volume_types
+          volume_types = CloudVolume.volume_types + ['unclassified']
           volume_types.each do |volume_type|
             storage_detail_new = detail_new.dup
             storage_detail_new.sub_metric = volume_type

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -91,8 +91,8 @@ class ChargebackRateDetail < ApplicationRecord
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0
       end
-      result[metric_key] = metric_value
       cost_keys.each { |field| result[field] = cost }
+      result[metric_key(sub_metric)] = metric_value
     end
     result
   end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -224,7 +224,7 @@ class ChargebackRateDetail < ApplicationRecord
   end
 
   def metric_and_cost_by(consumption, options)
-    metric_value = chargeable_field.measure(consumption, options)
+    metric_value = chargeable_field.measure(consumption, options, sub_metric)
     hourly_cost = hourly_cost(metric_value, consumption)
     cost = chargeable_field.metering? ? hourly_cost : hourly_cost * consumption.consumed_hours_in_interval
     [metric_value, cost]

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -91,8 +91,8 @@ class ChargebackRateDetail < ApplicationRecord
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0
       end
-      cost_keys.each { |field| result[field] = cost }
       result[metric_key(sub_metric)] = metric_value
+      cost_keys(sub_metric).each { |field| result[field] = cost }
     end
     result
   end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -48,7 +48,7 @@ class ChargebackVm < Chargeback
   end
 
   def self.refresh_dynamic_metric_columns
-    set_columns_hash(dynamic_columns(:integer))
+    set_columns_hash(dynamic_columns_for(:integer))
   end
 
   def self.build_results_for_report_ChargebackVm(options)
@@ -86,6 +86,10 @@ class ChargebackVm < Chargeback
     %w(vm_name)
   end
 
+  def self.sub_metric_columns
+    dynamic_columns_for(:grouping => [:total])
+  end
+
   def self.report_col_options
     {
       "cpu_allocated_cost"       => {:grouping => [:total]},
@@ -116,7 +120,7 @@ class ChargebackVm < Chargeback
       "storage_used_cost"        => {:grouping => [:total]},
       "storage_used_metric"      => {:grouping => [:total]},
       "total_cost"               => {:grouping => [:total]}
-    }
+    }.merge(sub_metric_columns)
   end
 
   def self.vm_owner(consumption)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -40,7 +40,7 @@ class ChargebackVm < Chargeback
   #   'storage_allocated_volume_type1_cost'   => {:group => [:total]},
   # }
   def self.dynamic_columns_for(column_type)
-    CloudVolume.volume_types.each_with_object({}) do |volume_type, result|
+    (CloudVolume.volume_types + [nil]).each_with_object({}) do |volume_type, result|
       [:metric, :cost].collect do |type|
         result["storage_allocated_#{volume_type || 'unclassified'}_#{type}"] = column_type
       end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -33,13 +33,15 @@ class ChargebackVm < Chargeback
     :total_cost               => :float,
   )
 
-  def self.refresh_dynamic_metric_columns
-    dynamic_columns = CloudVolume.volume_types.each_with_object({}) do |volume_type, result|
+  def self.dynamic_columns
+    CloudVolume.volume_types.each_with_object({}) do |volume_type, result|
       [:metric, :cost].collect do |type|
         result["storage_allocated_#{volume_type || 'unclassified'}_#{type}"] = :integer
       end
     end
+  end
 
+  def self.refresh_dynamic_metric_columns
     set_columns_hash(dynamic_columns)
   end
 

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -40,7 +40,9 @@ class ChargebackVm < Chargeback
   #   'storage_allocated_volume_type1_cost'   => {:group => [:total]},
   # }
   def self.dynamic_columns_for(column_type)
-    (CloudVolume.volume_types + [nil]).each_with_object({}) do |volume_type, result|
+    volume_types = CloudVolume.volume_types
+    volume_types.push(nil) if volume_types.present?
+    volume_types.each_with_object({}) do |volume_type, result|
       [:metric, :cost].collect do |type|
         result["storage_allocated_#{volume_type || 'unclassified'}_#{type}"] = column_type
       end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -33,16 +33,22 @@ class ChargebackVm < Chargeback
     :total_cost               => :float,
   )
 
-  def self.dynamic_columns
+  # example:
+  #  dynamic_columns_for(:group => [:total])
+  #  returns:
+  # { 'storage_allocated_volume_type1_metric' => {:group => [:total]},
+  #   'storage_allocated_volume_type1_cost'   => {:group => [:total]},
+  # }
+  def self.dynamic_columns_for(column_type)
     CloudVolume.volume_types.each_with_object({}) do |volume_type, result|
       [:metric, :cost].collect do |type|
-        result["storage_allocated_#{volume_type || 'unclassified'}_#{type}"] = :integer
+        result["storage_allocated_#{volume_type || 'unclassified'}_#{type}"] = column_type
       end
     end
   end
 
   def self.refresh_dynamic_metric_columns
-    set_columns_hash(dynamic_columns)
+    set_columns_hash(dynamic_columns(:integer))
   end
 
   def self.build_results_for_report_ChargebackVm(options)

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -36,6 +36,9 @@ module MiqReport::Formatting
         options[:format] = :cores
       end
     end
+
+    col = Chargeback.default_column_for_format(col.to_s) if Chargeback.db_is_chargeback?(db)
+
     format = options.delete(:format)
     return "" if value.nil?
     return value.to_s if format == :_none_ # Raw value was requested, do not attempt to format

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -52,8 +52,13 @@ describe ChargebackRateDetail do
 
       it 'loads chargeback rates with sub metric from CloudVolumes' do
         rates = ChargebackRateDetail.default_rate_details_for('Storage')
-        expect(rates.map(&:sub_metric).compact).to match_array(cloud_volumes.map(&:volume_type).uniq.compact)
+        expect(rates.map(&:sub_metric).compact).to match_array(cloud_volumes.map(&:volume_type) + ['unclassified'].uniq.compact)
       end
+    end
+
+    it 'doesnt load chargeback rates any sub metric if cloud volumes are empty' do
+      rates = ChargebackRateDetail.default_rate_details_for('Storage')
+      expect(rates.map(&:sub_metric).compact).to be_empty
     end
   end
 

--- a/spec/support/chargeback_helper.rb
+++ b/spec/support/chargeback_helper.rb
@@ -23,6 +23,18 @@ module Spec
           end
         end
       end
+
+      def add_vim_performance_state_for(resources, range, step, state_data)
+        range.step_value(step).each do |time|
+          Array(resources).each do |resource|
+            FactoryGirl.create(:vim_performance_state,
+                               :timestamp        => time,
+                               :resource         => resource,
+                               :state_data       => state_data,
+                               :capture_interval => 1.hour)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is last part for charging volume types
included:

- first 3 commits are related to storing dynamic columns for totals in report 
- fourth commit is adding support to unclassified volume type
https://github.com/ManageIQ/manageiq/commit/2126d63cbcc523d90a3c852c7959852521a2d9ae
- calculation starts from fifth commit  https://github.com/ManageIQ/manageiq/commit/efe65e46cc96c3f21cc04295a3be7769d526f422
- basically, it is about to get sub metric value from VimPerformanceState for calculation reasons
- formating is inherited from storage_allocated

Example of report:
<img width="1413" alt="screen shot 2017-10-27 at 12 05 33" src="https://user-images.githubusercontent.com/14937244/32099122-5c88e95a-bb0f-11e7-8f4f-68b80d40b45c.png">




@miq-bot assign @gtanzillo 
@miq-bot add_label enhancement, chargeback


# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1375506