### PR TITLE
Enable help menu items by default in the config/settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -797,6 +797,13 @@
     - MoveIntoResourcePool
     :VmSuspendedEvent:
     - SuspendVM_Task
+:help_menu:
+  :documentation:
+    :enabled: true
+  :product:
+    :enabled: true
+  :about:
+    :enabled: true
 :host_delete:
   :queue_timeout: 20.minutes
 :host_introspect:


### PR DESCRIPTION
UX asked for a global enable/disable feature for each menu item in the help section. We'd like to have the default value as true, so it is necessary to explicitly set them here.

See https://github.com/ManageIQ/manageiq-ui-classic/pull/2238 and https://www.pivotaltracker.com/story/show/150933794