### PR TITLE
Fix chargeback specs formatting

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -50,7 +50,7 @@ class ChargebackVm < Chargeback
   end
 
   def self.refresh_dynamic_metric_columns
-    set_columns_hash(dynamic_columns_for(:integer))
+    set_columns_hash(dynamic_columns_for(:float))
   end
 
   def self.build_results_for_report_ChargebackVm(options)

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -22,6 +22,7 @@ describe MiqReport::Formats do
       let(:columns) { Chargeback.descendants.collect(&:virtual_attributes_to_define).inject({}, &:merge) }
       it 'works' do
         columns.each do |name, datatype|
+          name = ChargebackVm.default_column_for_format(name)
           subj = described_class.default_format_for(name.to_sym, name.to_sym, datatype.first)
           if name.ends_with?('_cost')
             expect(subj).to eq(:currency_precision_2)

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -19,6 +19,12 @@ describe MiqReport::Formats do
 
   describe '.default_format_for' do
     context 'for chargebacks' do
+      let!(:cloud_volume) { FactoryGirl.create(:cloud_volume_openstack) }
+
+      before do
+        ChargebackVm.refresh_dynamic_metric_columns
+      end
+
       let(:columns) { Chargeback.descendants.collect(&:virtual_attributes_to_define).inject({}, &:merge) }
       it 'works' do
         columns.each do |name, datatype|


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/manageiq/pull/16321.

Sub Metric Attributes are added to ChargebackVm class(by different spec) but for 
this Sub Metric Attributes is used format from their metric attribute by replacing 
dynamic column to static, like:
`storage_allocated_ssd_cost`
to
`storage_allocated_cost`
and then `storage_allocated_cost ` is stated in yml - https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_report_formats.yml#L53 with formats so it can find proper format.
Selection of format depend on type - so I need change type to `float`. (Integer was not proper here)

Fixing sporadic failure:
https://travis-ci.org/ManageIQ/manageiq/jobs/293681171


cc @jrafanie 
@miq-bot assign @gtanzillo 
@miq-bot add_label bug, bug/sporadic test failure
