### PR TITLE
Remove blueprint_id before applying attributes

### DIFF
--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -19,6 +19,7 @@ class DialogImportService
 
     begin
       dialogs.each do |dialog|
+        dialog.except!(:blueprint_id, 'blueprint_id') # blueprint_id might appear in some old dialogs, but no longer exists
         if dialog_with_label?(dialog["label"])
           yield dialog if block_given?
         else
@@ -117,6 +118,7 @@ class DialogImportService
   def import_from_dialogs(dialogs)
     raise ParsedNonDialogYamlError if dialogs.empty?
     dialogs.each do |dialog|
+      dialog.except!(:blueprint_id, 'blueprint_id') # blueprint_id might appear in some old dialogs, but no longer exists
       new_or_existing_dialog = Dialog.where(:label => dialog["label"]).first_or_create
       dialog['id'] = new_or_existing_dialog.id
       associations_to_be_created = build_association_list(dialog)

--- a/spec/lib/services/dialog_import_service_spec.rb
+++ b/spec/lib/services/dialog_import_service_spec.rb
@@ -22,7 +22,7 @@ describe DialogImportService do
 
     let(:dialogs) do
       [{"label" => "Test", "dialog_tabs" => dialog_tabs},
-       {"label" => "Test2", "dialog_tabs" => dialog_tabs, "description" => "potato"}]
+       {"label" => "Test2", "dialog_tabs" => dialog_tabs, "description" => "potato", "blueprint_id" => "456"}]
     end
 
     let(:not_dialogs) { [{"this is not" => "a dialog"}] }


### PR DESCRIPTION
For historical reason some old dialogs may have blueprint_id which no longer exist. The fix is a safety check in case someone needs to import a dialog yaml file from an earlier exporting.
