### PR TITLE
Add limit to purge_tool

### DIFF
--- a/tools/purge_metrics.rb
+++ b/tools/purge_metrics.rb
@@ -11,7 +11,8 @@ opts = Trollop.options do
   opt :realtime, "Realtime range", :default => "4.hours"
   opt :hourly,   "Hourly range",   :default => "6.months"
   opt :daily,    "Daily range",    :default => "6.months"
-  opt :window,   "Window of records to delete at once", :default => 1000
+  opt :window,   "Window of records to delete at once", :default => 10000
+  opt :limit,    "Total number of records to delete per method"
 end
 Trollop.die :mode,     "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
 Trollop.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
@@ -43,7 +44,7 @@ require 'ruby-progressbar'
 %w(realtime hourly daily).each do |interval|
   pbar = ProgressBar.create(:title => interval.titleize, :total => counts[interval], :autofinish => false)
   if counts[interval] > 0
-    Metric::Purging.purge(dates[interval], interval, opts[:window]) do |count, _|
+    Metric::Purging.purge(dates[interval], interval, opts[:window], opts[:limit]) do |count, _|
       pbar.progress += count
     end
   end


### PR DESCRIPTION
Customers get confused when purging with the tool `purge_metrics.rb`.
When they notice that it doesn't seem to be working, the tables already have a bunch of records. So it takes hours for the script to complete and for them to get feedback whether it worked or not.

This new option allows them to quickly try and ensure that records are being removed from the database.

/cc @jdeubel
/cc @Fryguy if you were thinking we'd just remove the `total_limit` option (since it doesn't seem to be used that often if ever) then please close this. I can start to work towards that end goal.