### PR TITLE
Catch exceptions while decrypting object, attribute from Automate Workspace

### DIFF
--- a/app/models/automate_workspace.rb
+++ b/app/models/automate_workspace.rb
@@ -21,6 +21,10 @@ class AutomateWorkspace < ApplicationRecord
 
   def decrypt(object_name, attribute)
     MiqPassword.decrypt(encrypted_value(object_name, attribute))
+  rescue ArgumentError
+    ""
+  rescue MiqPassword::MiqPasswordError
+    ""
   end
 
   def encrypt(object_name, attribute, value)
@@ -35,7 +39,7 @@ class AutomateWorkspace < ApplicationRecord
     value = fetch_value(object_name, attribute)
     raise ArgumentError, "#{object_name} : Attribute #{attribute} not found" unless value
     raise ArgumentError, "#{object_name} : Attribute #{attribute} invalid type" unless value.kind_of?(String)
-    match_data = /password::(.*)/.match(value)
+    match_data = /^password::(.*)/.match(value)
     raise ArgumentError, "Attribute #{attribute} is not a password type" unless match_data
     match_data[1]
   end

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -9,7 +9,13 @@ describe AutomateWorkspace do
     let(:password) { "ca$hc0w" }
     let(:encrypted) { MiqPassword.encrypt(password) }
     let(:input) do
-      { "objects"           => {"root" => { "var1" => "1", "var2" => "password::#{encrypted}"}},
+      { "objects"           => {
+        "root" => {
+          "var1" => "1",
+          "var2" => "password::#{encrypted}",
+          "var3" => "password::v2:{c8qTeiuz6JgbBOiDqp3eiQ==}"
+        }
+      },
         "method_parameters" => {"arg1" => "password::#{encrypted}"} }
     end
 
@@ -42,16 +48,20 @@ describe AutomateWorkspace do
       expect(aw.decrypt('method_parameters', 'arg1')).to eq(password)
     end
 
-    it "#decrypt raises error when object doesn't exist" do
-      expect { aw.decrypt('frooti', 'var2') }.to raise_exception(ArgumentError)
+    it "#decrypt doesn't raise exception when bad encrypted data" do
+      expect(aw.decrypt('root', 'var3')).to eq("")
     end
 
-    it "#decrypt raises error when attribute doesn't exist" do
-      expect { aw.decrypt('root', 'nada') }.to raise_exception(ArgumentError)
+    it "#decrypt doesn't raise exception when object doesn't exist" do
+      expect(aw.decrypt('frooti', 'var2')).to eq("")
+    end
+
+    it "#decrypt doesn't raise exception when attribute doesn't exist" do
+      expect(aw.decrypt('root', 'nada')).to eq("")
     end
 
     it "#decrypt raises error when type is invalid" do
-      expect { aw.decrypt('root', 'var1') }.to raise_exception(ArgumentError)
+      expect(aw.decrypt('root', 'var1')).to eq("")
     end
 
     it "#encrypt" do


### PR DESCRIPTION
During decryption if there is an exception catch the exception and return an empty string.
We catch 
* ArgumentError
* MiqPassword::MiqPasswordError


This change is needed by REST API PR https://github.com/ManageIQ/manageiq-api/pull/124