### PR TITLE
Store the event initiator in MiqEvent object when user info is available.

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -79,16 +79,15 @@ class MiqEvent < EventStream
   end
 
   def self.build_evm_event(event, target)
-    user = User.current_user
-    MiqEvent.create(
+    options = {
       :event_type => event,
       :target     => target,
       :source     => 'POLICY',
-      :timestamp  => Time.now.utc,
-      :user_id    => user.try(:id),
-      :group_id   => user.try(:current_group).try(:id),
-      :tenant_id  => user.try(:current_tenant).try(:id)
-    )
+      :timestamp  => Time.now.utc
+    }
+    user = User.current_user
+    options.merge!(:user_id => user.id, :group_id => user.current_group.id, :tenant_id => user.current_tenant.id) if user
+    MiqEvent.create(options)
   end
 
   def update_with_policy_result(result = {})

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -28,7 +28,6 @@ describe ProcessTasksMixin do
 
     it "queues a message for the specified task" do
       EvmSpecHelper.create_guid_miq_server_zone
-      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
       test_class.process_tasks(:task => "test_method", :ids => [5], :userid => "admin")
 
       message = MiqQueue.first
@@ -43,7 +42,6 @@ describe ProcessTasksMixin do
 
     it "defaults the userid to system in the queue message" do
       EvmSpecHelper.create_guid_miq_server_zone
-      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
       test_class.process_tasks(:task => "test_method", :ids => [5])
 
       message = MiqQueue.first
@@ -52,7 +50,7 @@ describe ProcessTasksMixin do
       message.args.each do |h|
         expect(h[:task]).to eq("test_method")
         expect(h[:ids]).to eq([5])
-        expect(h[:userid]).to eq("admin")
+        expect(h[:userid]).to eq("system")
       end
     end
 
@@ -100,7 +98,6 @@ describe ProcessTasksMixin do
       end
 
       it "requeues invoke_tasks_remote when invoke_api_tasks fails" do
-        allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
         expect(InterRegionApiMethodRelay).to receive(:api_client_connection_for_region)
         expect(test_class).to receive(:invoke_api_tasks).and_raise(RuntimeError)
         test_class.invoke_tasks_remote(test_options)
@@ -121,7 +118,6 @@ describe ProcessTasksMixin do
     end
 
     it "requeues if the server does not have an address" do
-      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "admin"))
       test_class.invoke_tasks_remote(test_options)
 
       expect(MiqQueue.first).to have_attributes(

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -117,7 +117,6 @@ describe Vm do
       EvmSpecHelper.create_guid_miq_server_zone
       @host = FactoryGirl.create(:host)
       @vm = FactoryGirl.create(:vm_vmware, :host => @host)
-      allow(User).to receive(:current_user).and_return(FactoryGirl.create(:user_with_group, :userid => "Freddy"))
     end
 
     it "sets up standard callback for non Power Operations" do


### PR DESCRIPTION
Store the event initiator in MiqEvent object when user info is available.

Follow up of PR https://github.com/ManageIQ/manageiq/pull/16179.

https://bugzilla.redhat.com/show_bug.cgi?id=1487749

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement