### PR TITLE
Name service during provisioning from dialog input

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -23,7 +23,7 @@ class Service < ApplicationRecord
   has_ancestry :orphan_strategy => :destroy
 
   belongs_to :tenant
-  belongs_to :service_template               # Template this service was cloned from
+  belongs_to :service_template # Template this service was cloned from
 
   has_many :dialogs, -> { distinct }, :through => :service_template
   has_many :metrics, :as => :resource
@@ -74,7 +74,7 @@ class Service < ApplicationRecord
   virtual_column :power_state,                              :type => :string
   virtual_column :power_status,                             :type => :string
 
-  validates_presence_of :name
+  validates :name, :presence => true
 
   default_value_for :display, false
   default_value_for :retired, false
@@ -253,7 +253,7 @@ class Service < ApplicationRecord
       begin
         rsc = svc_rsc.resource
         rsc_action = service_action(action, svc_rsc)
-        rsc_name =  "#{rsc.class.name}:#{rsc.id}" + (rsc.respond_to?(:name) ? ":#{rsc.name}" : "")
+        rsc_name = "#{rsc.class.name}:#{rsc.id}" + (rsc.respond_to?(:name) ? ":#{rsc.name}" : "")
         if rsc_action.nil?
           _log.info("Not Processing action for Service:<#{name}:#{id}>, RSC:<#{rsc_name}}> in Group Idx:<#{group_idx}>")
         elsif rsc.respond_to?(rsc_action)
@@ -378,7 +378,7 @@ class Service < ApplicationRecord
   end
 
   def chargeback_yaml
-    yaml = YAML.load_file(File.join(Rails.root, "product/chargeback/chargeback_vm_monthly.yaml"))
+    yaml = YAML.load_file(Rails.root.join('product', 'chargeback', 'chargeback_vm_monthly.yaml'))
     yaml["db_options"][:options][:service_id] = id
     yaml["title"] = chargeback_report_name
     yaml

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -52,6 +52,7 @@ class Service < ApplicationRecord
   virtual_has_one    :configuration_script
 
   before_validation :set_tenant_from_group
+  before_create     :apply_dialog_settings
 
   delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
   delegate :provision_dialog, :to => :miq_request, :allow_nil => true
@@ -426,5 +427,19 @@ class Service < ApplicationRecord
   def remove_from_service(parenent_service)
     update(:parent => nil)
     parenent_service.remove_resource(self)
+  end
+
+  private
+
+  def apply_dialog_settings
+    dialog_options = options[:dialog] || {}
+
+    %w(dialog_service_name).each do |field_name|
+      send(field_name, dialog_options[field_name]) if dialog_options.key?(field_name)
+    end
+  end
+
+  def dialog_service_name(value)
+    self.name = value if value.present?
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -434,12 +434,16 @@ class Service < ApplicationRecord
   def apply_dialog_settings
     dialog_options = options[:dialog] || {}
 
-    %w(dialog_service_name).each do |field_name|
+    %w(dialog_service_name dialog_service_description).each do |field_name|
       send(field_name, dialog_options[field_name]) if dialog_options.key?(field_name)
     end
   end
 
   def dialog_service_name(value)
     self.name = value if value.present?
+  end
+
+  def dialog_service_description(value)
+    self.description = value if value.present?
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -763,6 +763,21 @@ describe Service do
     end
   end
 
+  context 'service naming' do
+    it 'without empty options hash' do
+      expect(Service.create(:name => 'test').name).to eq('test')
+    end
+
+    it 'with empty dialog options' do
+      expect(Service.create(:name => 'test', :options => {:dialog => {}}).name).to eq('test')
+    end
+
+    it 'with dialog option dialog_service_name' do
+      expect(Service.create(:name => 'test', :options => {:dialog => {'dialog_service_name' => 'name from dialog'}}).name)
+        .to eq('name from dialog')
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -778,6 +778,28 @@ describe Service do
     end
   end
 
+  context 'service description' do
+    it 'without empty options hash' do
+      expect(Service.create(:name => 'test').description).to be_blank
+    end
+
+    it 'with empty dialog options' do
+      expect(Service.create(:name        => 'test',
+                            :description => 'test description',
+                            :options     => {:dialog => {}}).description)
+        .to eq('test description')
+    end
+
+    it 'with dialog option dialog_service_description' do
+      expect(Service.create(:name        => 'test',
+                            :description => 'test description',
+                            :options     => {
+                              :dialog => {'dialog_service_description' => 'test description from dialog'}
+                            }).description)
+        .to eq('test description from dialog')
+    end
+  end
+
   def create_deep_tree
     @service      = FactoryGirl.create(:service)
     @service_c1   = FactoryGirl.create(:service, :service => @service)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -72,17 +72,17 @@ describe Service do
     before do
       @zone1 = FactoryGirl.create(:small_environment)
       allow(MiqServer).to receive(:my_server).and_return(@zone1.miq_servers.first)
-      @vm          = FactoryGirl.create(:vm_vmware)
-      @vm_1        = FactoryGirl.create(:vm_vmware)
-      @vm_2        = FactoryGirl.create(:vm_vmware)
+      @vm  = FactoryGirl.create(:vm_vmware)
+      @vm1 = FactoryGirl.create(:vm_vmware)
+      @vm2 = FactoryGirl.create(:vm_vmware)
 
-      @service     = FactoryGirl.create(:service)
-      @service_c1  = FactoryGirl.create(:service, :service => @service)
-      @service_c2  = FactoryGirl.create(:service, :service => @service_c1)
+      @service    = FactoryGirl.create(:service)
+      @service_c1 = FactoryGirl.create(:service, :service => @service)
+      @service_c2 = FactoryGirl.create(:service, :service => @service_c1)
       @service << @vm
-      @service_c1 << @vm_1
-      @service_c2 << @vm_1
-      @service_c2 << @vm_2
+      @service_c1 << @vm1
+      @service_c2 << @vm1
+      @service_c2 << @vm2
       @service.service_resources.first.start_action = "Power On"
       @service.service_resources.first.stop_action = "Power Off"
       @service.save
@@ -198,23 +198,23 @@ describe Service do
     end
 
     it "#direct_vms" do
-      expect(@service_c1.direct_vms).to match_array [@vm_1]
+      expect(@service_c1.direct_vms).to match_array [@vm1]
       expect(@service.direct_vms).to    match_array [@vm]
     end
 
     it "#all_vms" do
-      expect(@service_c1.all_vms).to match_array [@vm_1, @vm_1, @vm_2]
-      expect(@service.all_vms).to    match_array [@vm, @vm_1, @vm_1, @vm_2]
+      expect(@service_c1.all_vms).to match_array [@vm1, @vm1, @vm2]
+      expect(@service.all_vms).to    match_array [@vm, @vm1, @vm1, @vm2]
     end
 
     it "#direct_service" do
       expect(@vm.direct_service).to eq(@service)
-      expect(@vm_1.direct_service).to eq(@service_c1)
+      expect(@vm1.direct_service).to eq(@service_c1)
     end
 
     it "#service" do
       expect(@vm.service).to eq(@service)
-      expect(@vm_1.service).to eq(@service)
+      expect(@vm1.service).to eq(@service)
     end
   end
 
@@ -408,7 +408,7 @@ describe Service do
   context "Chargeback report generation" do
     before do
       @vm = FactoryGirl.create(:vm_vmware)
-      @vm_1 = FactoryGirl.create(:vm_vmware)
+      @vm1 = FactoryGirl.create(:vm_vmware)
       @service = FactoryGirl.create(:service)
       @service.name = "Test_Service_1"
       @service << @vm
@@ -419,7 +419,7 @@ describe Service do
       it "queue request to generate chargeback report for each service" do
         @service_c1 = FactoryGirl.create(:service, :service => @service)
         @service_c1.name = "Test_Service_2"
-        @service_c1 << @vm_1
+        @service_c1 << @vm1
         @service_c1.save
 
         expect(MiqQueue).to receive(:put).twice


### PR DESCRIPTION
Services by default are named the same as the service_template they were created through at provisioning time (Service Ordering).  This means that ordering the same service template multiple times leads to the same named service created for a user and it becomes difficult to tell them apart.

The ability to update the name during provisioning was added to the `CatalogItemInitialization` method in automate to address this issue.  However, that logic, while the default for many service provisioning state-machines, is not used in ever case and the default state machine can be changed to one that does not call `CatalogItemInitialization`.

This change moves the service naming (and description) logic into the model at service creation time.  The same service dialog naming conversion that `CatalogItemInitialization` uses is also used here.

Things to note:

1. The logic runs as part of the model creating the service instance.  Any automate logic, including `CatalogItemInitialization` that wants to rename the service will run after and therefore still be honored.
1. The method logic here is setup to support other dialog properties we may want to configure at service creation time.  For example, setting a retirement date on a service.
1. This backend change is not trying to implementing the exact same logic as `CatalogItemInitialization`.  For example, `CatalogItemInitialization` will add a timestamp onto the service name if no override is given.  That level of customization will be left to the automate method to provide, allowing users to easily change that functionality if desired.
1. Reviewers: Will be easier to review by each commit as one is just a rubocop cleanup.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1505929
* [override_service_name method in automate model: ManageIQ/Service/Provisioning/StateMachines/Methods/CatalogItemInitialization](https://github.com/ManageIQ/manageiq-content/blob/078ef3b06226fd80f91fa1b183d3b453c3171348/content/automate/ManageIQ/Service/Provisioning/StateMachines/Methods.class/__methods__/catalogiteminitialization.rb#L40-L48)

Steps for Testing/QA [Optional]
-------------------------------
* Create or modify a service dialog and add a dialog field named `service_name`. (or `service_description`)
* Use the dialog for a catalog item and order the service.  You will want to do one or more of the following to ensure the backend logic is the only logic performing the service rename:
  * Use an Embedded Ansible catalog item type
  * Modify a service provisioning state machine so it does not use `CatalogItemInitialization`
  * Override the `CatalogItemInitialization` method and comment out the `override_service_name` and `override_service_description` methods.
* After ordering the service valid that the name matches the value specified in the dialog field at order time.
* If no dialog field value is provided the service will use the name of the service_template.

cc @billfitzgerald0120 