### PR TITLE
Use event ems_ref

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -245,8 +245,6 @@ class EmsEvent < EventStream
       :timestamp   => event[:timestamp],
       :chain_id    => event[:chain_id],
       :ems_id      => event[:ems_id],
-      :target_id   => event[:target_id],
-      :target_type => event[:target_type],
       :ems_ref     => event[:ems_ref],
     )
     new_event.handle_event if new_event

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -186,7 +186,6 @@ class EmsEvent < EventStream
       event_type == "datawarehouse_alert" ? message : nil,
       data[:severity],
       data[:url],
-      data[:ems_ref],
       data[:resolved],
     ]
   end

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -243,7 +243,8 @@ class MiqAlert < ApplicationRecord
 
   def add_status_post_evaluate(target, result, event)
     status_description, event_severity, url, resolved = event.try(:parse_event_metadata)
-    status = miq_alert_statuses.find_or_initialize_by(:resource => target, :event_ems_ref => event.ems_ref)
+    ems_ref = event.try(:ems_ref)
+    status = miq_alert_statuses.find_or_initialize_by(:resource => target, :event_ems_ref => ems_ref)
     status.result = result
     status.ems_id = target.try(:ems_id)
     status.ems_id ||= target.id if target.is_a?(ExtManagementSystem)

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -242,8 +242,8 @@ class MiqAlert < ApplicationRecord
   end
 
   def add_status_post_evaluate(target, result, event)
-    status_description, event_severity, url, ems_ref, resolved = event.try(:parse_event_metadata)
-    status = miq_alert_statuses.find_or_initialize_by(:resource => target, :event_ems_ref => ems_ref)
+    status_description, event_severity, url, resolved = event.try(:parse_event_metadata)
+    status = miq_alert_statuses.find_or_initialize_by(:resource => target, :event_ems_ref => event.ems_ref)
     status.result = result
     status.ems_id = target.try(:ems_id)
     status.ems_id ||= target.id if target.is_a?(ExtManagementSystem)

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -232,6 +232,7 @@ describe EmsEvent do
           :event_type  => "event_with_availability_zone",
           :target_type => @vm.class.name,
           :target_id   => @vm.id,
+          :ems_ref     => "first",
           :vm_ems_ref  => @vm.ems_ref,
           :timestamp   => Time.now,
           :ems_id      => @ems.id
@@ -267,18 +268,18 @@ describe EmsEvent do
         it "should reject duplicates" do
           ems_event = EmsEvent.add(@ems.id, @event_hash)
           expect(
-            EmsEvent.where(@event_hash.except(:target_id)).count
+            EmsEvent.where(@event_hash.except(:ems_ref)).count
           ).to eq(1)
           expect(ems_event).to be_nil
         end
 
-        it "should add an identical event if it is for a different target" do
+        it "should add a new event if it has a different ems_ref" do
           ems_event = EmsEvent.add(
             @ems.id,
-            @event_hash.merge(:target_id => FactoryGirl.build(:vm_openstack).id)
+            @event_hash.merge(:ems_ref => "second")
           )
           expect(
-            EmsEvent.where(@event_hash.except(:target_id)).count
+            EmsEvent.where(@event_hash.except(:ems_ref)).count
           ).to eq(2)
           expect(ems_event).to_not be_nil
         end

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -122,30 +122,30 @@ describe MiqAlert do
         end
       end
 
-      it "should update the existing status if event metadata has the same ems_ref" do
+      it "should update the existing status if event has the same ems_ref" do
         @alert.evaluate(
           [@vm.class.base_class.name, @vm.id],
-          :ems_event => FactoryGirl.create(:ems_event, :full_data => {:ems_ref => 'same'})
+          :ems_event => FactoryGirl.create(:ems_event, :ems_ref => 'same')
         )
         Timecop.travel 10.minutes do
           @alert.evaluate(
             [@vm.class.base_class.name, @vm.id],
-            :ems_event => FactoryGirl.create(:ems_event, :full_data => {:ems_ref => 'same'})
+            :ems_event => FactoryGirl.create(:ems_event, :ems_ref => 'same')
           )
           statuses = @alert.miq_alert_statuses.where(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id)
           expect(statuses.length).to eq(1)
         end
       end
 
-      it "should create a new status if event metadata has a different ems_ref" do
+      it "should create a new status if event has a different ems_ref" do
         @alert.evaluate(
           [@vm.class.base_class.name, @vm.id],
-          :ems_event => FactoryGirl.create(:ems_event, :full_data => {:ems_ref => 'same'})
+          :ems_event => FactoryGirl.create(:ems_event, :ems_ref => 'same')
         )
         Timecop.travel 10.minutes do
           @alert.evaluate(
             [@vm.class.base_class.name, @vm.id],
-            :ems_event => FactoryGirl.create(:ems_event, :full_data => {:ems_ref => 'different'})
+            :ems_event => FactoryGirl.create(:ems_event, :ems_ref => 'different')
           )
           statuses = @alert.miq_alert_statuses.where(:resource_type => @vm.class.base_class.name, :resource_id => @vm.id)
           expect(statuses.length).to eq(2)


### PR DESCRIPTION
After the recent addition of `ems_ref` to `event_streams`[1] and it's  addition to the primary key[2] this clean up is needed.

- Use the new ems_ref in alert resolving
- Remove target from ems_event pkey added recently[3]


[1] https://github.com/ManageIQ/manageiq/pull/16104
[2] https://github.com/ManageIQ/manageiq-schema/pull/70
[3] https://github.com/ManageIQ/manageiq/pull/15719