### PR TITLE
Fix some (not all) deprecated `have_attributes` usage warnings

### DIFF
--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -175,7 +175,7 @@ describe Compliance do
     inputs = objects.extract_options!
     objects.each do |obj|
       expect(MiqQueue).to receive(:put) do |args|
-        expect(args).to have_attributes(
+        expect(args).to include(
           :method_name => "check_compliance",
           :class_name  => "Compliance",
           :args        => [[obj.class.name, obj.id], inputs]
@@ -188,7 +188,7 @@ describe Compliance do
     inputs = objects.extract_options!
     objects.each do |obj|
       expect(MiqQueue).to receive(:put) do |args|
-        expect(args).to have_attributes(
+        expect(args).to include(
           :method_name => "scan_and_check_compliance",
           :class_name  => "Compliance",
           :task_id     => 'vc-refresher',

--- a/spec/models/service_container_template_spec.rb
+++ b/spec/models/service_container_template_spec.rb
@@ -95,7 +95,7 @@ describe(ServiceContainerTemplate) do
     it 'prepares job options from dialog' do
       expect(ems).not_to receive(:create_project)
       service.preprocess(action)
-      expect(service.options[:provision_options]).to have_attributes(
+      expect(service.options[:provision_options]).to include(
         :container_project_name => 'old_project',
         :parameters             => {"var1" => "value1", "var2" => "value2"}
       )
@@ -104,7 +104,7 @@ describe(ServiceContainerTemplate) do
     it 'honors new project name more than existing project name' do
       expect(ems).to receive(:create_project)
       service_with_new_project.preprocess(action)
-      expect(service_with_new_project.options[:provision_options]).to have_attributes(
+      expect(service_with_new_project.options[:provision_options]).to include(
         :container_project_name => 'new_project',
         :parameters             => {"var1" => "value1", "var2" => "value2"}
       )
@@ -113,7 +113,7 @@ describe(ServiceContainerTemplate) do
     it 'prepares job options combined from dialog and overrides' do
       expect(ems).to receive(:create_project)
       service_with_new_project.preprocess(action, override_options)
-      expect(service_with_new_project.options[:provision_options]).to have_attributes(
+      expect(service_with_new_project.options[:provision_options]).to include(
         :container_project_name => 'override_project',
         :parameters             => {'var1' => 'new_val1', 'var2' => 'value2'}
       )

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -436,9 +436,9 @@ describe Service do
     describe "#queue_chargeback_report_generation" do
       it "queue request to generate chargeback report" do
         expect(MiqQueue).to receive(:put) do |args|
-          expect(args).to have_attributes(:class_name  => described_class.name,
-                                          :method_name => "generate_chargeback_report",
-                                          :args        => {:report_source => "Test Run"})
+          expect(args).to include(:class_name  => described_class.name,
+                                  :method_name => "generate_chargeback_report",
+                                  :args        => {:report_source => "Test Run"})
         end
         @service.queue_chargeback_report_generation(:report_source => "Test Run")
       end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -128,7 +128,7 @@ describe ServiceTemplateAnsiblePlaybook do
                                                     catalog_extra_vars[:description],
                                                     catalog_extra_vars[:config_info][:provision])
 
-      expect(params).to have_attributes(
+      expect(params).to include(
         :name               => name,
         :description        => description,
         :become_enabled     => true,
@@ -139,7 +139,7 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(params.keys).to_not include(:extra_vars, :cloud_credentials)
       expect(params_two.keys).to include(:extra_vars)
-      expect(JSON.parse(params_two[:extra_vars])).to have_attributes(
+      expect(JSON.parse(params_two[:extra_vars])).to include(
         'key1' => 'val1',
         'key2' => 'val2'
       )
@@ -218,11 +218,11 @@ describe ServiceTemplateAnsiblePlaybook do
 
       expect(service_template.name).to eq(catalog_item_options_three[:name])
       expect(service_template.description).to eq(catalog_item_options_three[:description])
-      expect(service_template.options.fetch_path(:config_info, :provision, :extra_vars)).to have_attributes(
+      expect(service_template.options.fetch_path(:config_info, :provision, :extra_vars)).to include(
         'key1' => {:default => 'updated_val1'},
         'key2' => {:default => 'updated_val2'}
       )
-      expect(service_template.options.fetch_path(:config_info, :provision)).to have_attributes(
+      expect(service_template.options.fetch_path(:config_info, :provision)).to include(
         :become_enabled => false,
         :verbosity      => 0
       )


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/pull/16188.
ManageIQ has its own `have_attributes` which has diverged from upstream rspec's. It'll go away at some point.

@chrisarcand please review.  Don't have time to do all but figured I'll contribute a little.

@miq-bot add-label test, technical debt