### PR TITLE
Add metering reports

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -41,6 +41,10 @@ class ChargeableField < ApplicationRecord
      "fixed_storage_2"                   => ['fixed_storage_2', '', 'occurrence']}[metric_index]
   end
 
+  def measure_metering(consumption, options, sub_metric = nil)
+    used? ? consumption.sum(metric) : measure(consumption, options, sub_metric)
+  end
+
   def measure(consumption, options, sub_metric = nil)
     return consumption.consumed_hours_in_interval if metering?
     return 1.0 if fixed?

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -9,8 +9,6 @@ class Chargeback < ActsAsArModel
     :tag_name             => :string,
     :label_name           => :string,
     :fixed_compute_metric => :integer,
-    :metering_used_metric => :integer,
-    :metering_used_cost   => :float
   )
 
   def self.build_results_for_report_chargeback(options)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -145,7 +145,7 @@ class Chargeback < ActsAsArModel
   end
 
   def self.report_cb_model(model)
-    model.gsub(/^Chargeback/, "")
+    model.gsub(/^(Chargeback|Metering)/, "")
   end
 
   def self.db_is_chargeback?(db)

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -47,7 +47,7 @@ class Chargeback
 
     def current_value(metric, _sub_metric) # used for containers allocated metrics
       case metric
-      when 'derived_vm_numvcpu_cores' # Allocated CPU count
+      when 'derived_vm_numvcpu_cores', 'derived_vm_numvcpus_cores' # Allocated CPU count
         resource.try(:limit_cpu_cores).to_f
       when 'derived_memory_available'
         resource.try(:limit_memory_bytes).to_f / 1.megabytes # bytes to megabytes

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -31,6 +31,11 @@ class Chargeback
       @tag_list_with_prefix ||= @rollups.map(&:tag_list_with_prefix).flatten.uniq
     end
 
+    def sum(metric, sub_metric = nil)
+      metric = ChargeableField::VIRTUAL_COL_USES[metric] || metric
+      values(metric, sub_metric).sum
+    end
+
     def max(metric, sub_metric = nil)
       values(metric, sub_metric).max
     end

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -1,0 +1,13 @@
+module Metering
+  def calculate_costs(consumption, _)
+    self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
+
+    relevant_fields.each do |field|
+      next unless self.class.report_col_options.include?(field)
+      group, source, * = field.split('_')
+      chargable_field = ChargeableField.find_by(:group => group, :source => source)
+      value = chargable_field.measure(consumption, @options) if chargable_field
+      self[field] = (value || 0) unless field == 'fixed_compute_metric'
+    end
+  end
+end

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -2,12 +2,13 @@ module Metering
   def calculate_costs(consumption, _)
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
     self.metering_used_metric = fixed_compute_metric
+    self.existence_hours_metric = consumption.consumed_hours_in_interval
 
     relevant_fields.each do |field|
       next unless self.class.report_col_options.include?(field)
       group, source, * = field.split('_')
       chargable_field = ChargeableField.find_by(:group => group, :source => source)
-      next if field == "fixed_compute_metric" || chargable_field && chargable_field.metering?
+      next if field == "existence_hours_metric" || field == "fixed_compute_metric" || chargable_field && chargable_field.metering?
       value = chargable_field.measure_metering(consumption, @options) if chargable_field
       self[field] = (value || 0)
     end

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -1,13 +1,15 @@
 module Metering
   def calculate_costs(consumption, _)
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
+    self.metering_used_metric = fixed_compute_metric
 
     relevant_fields.each do |field|
       next unless self.class.report_col_options.include?(field)
       group, source, * = field.split('_')
       chargable_field = ChargeableField.find_by(:group => group, :source => source)
+      next if field == "fixed_compute_metric" || chargable_field && chargable_field.metering?
       value = chargable_field.measure_metering(consumption, @options) if chargable_field
-      self[field] = (value || 0) unless field == 'fixed_compute_metric'
+      self[field] = (value || 0)
     end
   end
 end

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -7,6 +7,22 @@ module Metering
     relevant_fields.each do |field|
       next unless self.class.report_col_options.include?(field)
       group, source, * = field.split('_')
+
+      if field == 'net_io_used_metric'
+        group = 'net_io'
+        source = 'used'
+      end
+
+      if field == 'disk_io_used_metric'
+        group = 'disk_io'
+        source = 'used'
+      end
+
+      if field == 'cpu_cores_used_metric'
+        group = 'cpu_cores'
+        source = 'used'
+      end
+
       chargable_field = ChargeableField.find_by(:group => group, :source => source)
       next if field == "existence_hours_metric" || field == "fixed_compute_metric" || chargable_field && chargable_field.metering?
       value = chargable_field.measure_metering(consumption, @options) if chargable_field

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -6,7 +6,7 @@ module Metering
       next unless self.class.report_col_options.include?(field)
       group, source, * = field.split('_')
       chargable_field = ChargeableField.find_by(:group => group, :source => source)
-      value = chargable_field.measure(consumption, @options) if chargable_field
+      value = chargable_field.measure_metering(consumption, @options) if chargable_field
       self[field] = (value || 0) unless field == 'fixed_compute_metric'
     end
   end

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -23,6 +23,11 @@ module Metering
         source = 'used'
       end
 
+      if field == 'cpu_cores_allocated_metric'
+        group = 'cpu_cores'
+        source = 'allocated'
+      end
+
       chargable_field = ChargeableField.find_by(:group => group, :source => source)
       next if field == "existence_hours_metric" || field == "fixed_compute_metric" || chargable_field && chargable_field.metering?
       value = chargable_field.measure_metering(consumption, @options) if chargable_field

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -8,11 +8,13 @@ class MeteringContainerImage < ChargebackContainerImage
 
   def self.report_col_options
     {
-      "cpu_cores_used_metric" => {:grouping => [:total]},
-      "fixed_compute_metric"  => {:grouping => [:total]},
-      "memory_used_metric"    => {:grouping => [:total]},
-      "metering_used_metric"  => {:grouping => [:total]},
-      "net_io_used_metric"    => {:grouping => [:total]},
+      "cpu_cores_allocated_metric" => {:grouping => [:total]},
+      "cpu_cores_used_metric"      => {:grouping => [:total]},
+      "fixed_compute_metric"       => {:grouping => [:total]},
+      "memory_allocated_metric"    => {:grouping => [:total]},
+      "memory_used_metric"         => {:grouping => [:total]},
+      "metering_used_metric"       => {:grouping => [:total]},
+      "net_io_used_metric"         => {:grouping => [:total]},
     }
   end
 

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,4 +1,6 @@
 class MeteringContainerImage < ChargebackContainerImage
+  include Metering
+
   def self.report_col_options
     {
       "cpu_cores_used_metric" => {:grouping => [:total]},

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,4 +1,8 @@
 class MeteringContainerImage < ChargebackContainerImage
+  set_columns_hash(
+    :metering_used_metric => :integer,
+  )
+
   include Metering
 
   def self.report_col_options

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,6 +1,7 @@
 class MeteringContainerImage < ChargebackContainerImage
   set_columns_hash(
     :metering_used_metric => :integer,
+    :existence_hours_metric => :interger
   )
 
   include Metering

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,0 +1,15 @@
+class MeteringContainerImage < ChargebackContainerImage
+  def self.report_col_options
+    {
+      "cpu_cores_used_metric" => {:grouping => [:total]},
+      "fixed_compute_metric"  => {:grouping => [:total]},
+      "memory_used_metric"    => {:grouping => [:total]},
+      "metering_used_metric"  => {:grouping => [:total]},
+      "net_io_used_metric"    => {:grouping => [:total]},
+    }
+  end
+
+  def self.build_results_for_report_MeteringContainerImage(options)
+    build_results_for_report_ChargebackContainerImage(options)
+  end
+end

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,7 +1,7 @@
 class MeteringContainerImage < ChargebackContainerImage
   set_columns_hash(
-    :metering_used_metric => :integer,
-    :existence_hours_metric => :interger
+    :metering_used_metric   => :integer,
+    :existence_hours_metric => :integer
   )
 
   include Metering

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,4 +1,6 @@
 class MeteringContainerProject < ChargebackContainerProject
+  include Metering
+
   def self.report_col_options
     {
       "cpu_cores_used_metric" => {:grouping => [:total]},

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,0 +1,15 @@
+class MeteringContainerProject < ChargebackContainerProject
+  def self.report_col_options
+    {
+      "cpu_cores_used_metric" => {:grouping => [:total]},
+      "fixed_compute_metric"  => {:grouping => [:total]},
+      "memory_used_metric"    => {:grouping => [:total]},
+      "metering_used_metric"  => {:grouping => [:total]},
+      "net_io_used_metric"    => {:grouping => [:total]},
+    }
+  end
+
+  def self.build_results_for_report_MeteringContainerProject(options)
+    build_results_for_report_ChargebackContainerProject(options)
+  end
+end

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,7 +1,7 @@
 class MeteringContainerProject < ChargebackContainerProject
   set_columns_hash(
-    :metering_used_metric => :integer,
-    :existence_hours_metric => :interger
+    :metering_used_metric   => :integer,
+    :existence_hours_metric => :integer
   )
 
   include Metering

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,4 +1,8 @@
 class MeteringContainerProject < ChargebackContainerProject
+  set_columns_hash(
+    :metering_used_metric => :integer,
+  )
+
   include Metering
 
   def self.report_col_options

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,6 +1,7 @@
 class MeteringContainerProject < ChargebackContainerProject
   set_columns_hash(
     :metering_used_metric => :integer,
+    :existence_hours_metric => :interger
   )
 
   include Metering

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,4 +1,8 @@
 class MeteringVm < ChargebackVm
+  set_columns_hash( # Fields common to any chargeback type
+    :metering_used_metric => :integer,
+  )
+
   include Metering
 
   def self.report_col_options

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,0 +1,20 @@
+class MeteringVm < ChargebackVm
+  def self.report_col_options
+    {
+      "cpu_allocated_metric"     => {:grouping => [:total]},
+      "cpu_used_metric"          => {:grouping => [:total]},
+      "disk_io_used_metric"      => {:grouping => [:total]},
+      "fixed_compute_metric"     => {:grouping => [:total]},
+      "memory_allocated_metric"  => {:grouping => [:total]},
+      "memory_used_metric"       => {:grouping => [:total]},
+      "metering_used_metric"     => {:grouping => [:total]},
+      "net_io_used_metric"       => {:grouping => [:total]},
+      "storage_allocated_metric" => {:grouping => [:total]},
+      "storage_used_metric"      => {:grouping => [:total]},
+    }
+  end
+
+  def self.build_results_for_report_MeteringVm(options)
+    build_results_for_report_ChargebackVm(options)
+  end
+end

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,4 +1,6 @@
 class MeteringVm < ChargebackVm
+  include Metering
+
   def self.report_col_options
     {
       "cpu_allocated_metric"     => {:grouping => [:total]},

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,6 +1,7 @@
 class MeteringVm < ChargebackVm
   set_columns_hash( # Fields common to any chargeback type
     :metering_used_metric => :integer,
+    :existence_hours_metric => :integer
   )
 
   include Metering

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,6 +1,6 @@
 class MeteringVm < ChargebackVm
-  set_columns_hash( # Fields common to any chargeback type
-    :metering_used_metric => :integer,
+  set_columns_hash(
+    :metering_used_metric   => :integer,
     :existence_hours_metric => :integer
   )
 

--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -61,6 +61,9 @@
 - Switch
 - ManageIQ::Providers::CloudManager::Template
 - ManageIQ::Providers::InfraManager::Template
+- MeteringContainerProject
+- MeteringContainerImage
+- MeteringVm
 - Tenant
 - User
 - VimPerformanceTrend

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -106,16 +106,6 @@
       :finish: Infinity
       :fixed_rate: 0.0
       :variable_rate: 0.0
-  - :description: Metering - Hours Used
-    :metric: metering_used_hours
-    :per_time: hourly
-    :per_unit: hours
-    :type_currency: Dollars
-    :tiers:
-    - :start: 0
-      :finish: Infinity
-      :fixed_rate: 0.0
-      :variable_rate: 1
 - :description: Default
   :guid: 7d7aaf20-5214-11df-a888-001d09066d98
   :rate_type: Storage

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -926,7 +926,9 @@ class MiqExpression
       cb_model = Chargeback.report_cb_model(model)
       model.constantize.try(:refresh_dynamic_metric_columns)
       md = model_details(model, :include_model => false, :include_tags => true).select do |c|
-        c.last.ends_with?(*ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES)
+        allowed_suffixes = ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES
+        allowed_suffixes -= ['_cost'] if model.starts_with?('Metering')
+        c.last.ends_with?(*allowed_suffixes)
       end
       td = if TAG_CLASSES.include?(cb_model)
              tag_details(model, {}) + _custom_details_for(cb_model, {})

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -32,6 +32,9 @@ describe ChargebackContainerImage do
     let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
     before do
+      # TODO: remove metering columns form specs
+      described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
+
       MiqRegion.seed
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -31,6 +31,9 @@ describe ChargebackContainerProject do
     let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
     before do
+      # TODO: remove metering columns form specs
+      described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
+
       MiqRegion.seed
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -29,7 +29,6 @@ describe ChargebackRateDetail do
         fixed_compute_2
         derived_memory_available
         derived_memory_used
-        metering_used_hours
         net_usage_rate_average
       )
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -56,6 +56,9 @@ describe ChargebackVm do
     end
 
     before do
+      # TODO: remove metering columns form specs
+      described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
+
       MiqRegion.seed
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -1,0 +1,62 @@
+describe MeteringContainerImage do
+  include Spec::Support::ChargebackHelper
+  let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }
+  let(:hourly_rate)       { 0.01 }
+  let(:count_hourly_rate) { 1.00 }
+  let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
+  let(:report_run_time) { month_end }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
+  let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:ems) { FactoryGirl.create(:ems_openshift) }
+  let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
+
+  before do
+    # TODO: remove metering columns form specs
+    described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
+
+    MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
+    ChargebackRate.seed
+
+    MiqEnterprise.seed
+
+    EvmSpecHelper.create_guid_miq_server_zone
+    @node = FactoryGirl.create(:container_node, :name => "node")
+    @image = FactoryGirl.create(:container_image, :ext_management_system => ems)
+    @label = FactoryGirl.build(:custom_attribute, :name => "version/1.2/_label-1", :value => "test/1.0.0  rc_2", :section => 'docker_labels')
+    @project = FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems)
+    @group = FactoryGirl.create(:container_group, :ext_management_system => ems, :container_project => @project,
+                                :container_node => @node)
+    @container = FactoryGirl.create(:kubernetes_container, :container_group => @group, :container_image => @image,
+                                    :limit_memory_bytes => 1.megabytes, :limit_cpu_cores => 1.0)
+
+    Timecop.travel(report_run_time)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context "Monthly" do
+    let(:options) { base_options.merge(:interval => 'monthly', :entity_id => @project.id, :tag => nil) }
+
+    before do
+      add_metric_rollups_for(@container, month_beginning...month_end, 12.hours, metric_rollup_params)
+
+      Range.new(month_beginning, month_end, true).step_value(12.hours).each do |time|
+        @container.vim_performance_states << FactoryGirl.create(:vim_performance_state, :timestamp => time, :image_tag_names => "environment/prod")
+      end
+    end
+
+    subject { MeteringContainerImage.build_results_for_report_MeteringContainerImage(options).first.first }
+
+    it "allocated fields" do
+      expect(subject.memory_allocated_metric).to eq(@container.limit_memory_bytes / 1.megabytes)
+      expect(subject.cpu_cores_allocated_metric).to eq(@container.limit_cpu_cores)
+      expect(subject.cpu_cores_allocated_metric).to eq(@container.limit_memory_bytes / 1.megabytes)
+    end
+  end
+end

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -1,0 +1,67 @@
+describe MeteringContainerProject do
+  include Spec::Support::ChargebackHelper
+
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:base_options) do
+    {:interval_size       => 2,
+     :end_interval_offset => 0,
+     :ext_options         => {:tz => 'UTC'},
+     :userid              => admin.userid}
+  end
+
+  let(:cpu_usage_rate_average) { 50.0 }
+  let(:derived_memory_used)    { 100.0 }
+  let(:net_usage_rate_average) { 25.0 }
+
+  let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
+  let(:report_run_time) { month_end }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
+  let(:count_of_metric_rollup) { MetricRollup.where(:timestamp => month_beginning...month_end).count }
+  let(:ems) { FactoryGirl.create(:ems_vmware) }
+  let(:project) { FactoryGirl.create(:container_project, :name => "my project", :ext_management_system => ems, :created_on => month_beginning) }
+  let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576) }
+  let(:host) { FactoryGirl.create(:host, :storages => [storage], :hardware => hardware, :vms => [vm]) }
+  let(:storage) { FactoryGirl.create(:storage_target_vmware) }
+  let(:ems_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => ems, :hosts => [host]) }
+
+  before do
+    MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
+    MiqEnterprise.seed
+    EvmSpecHelper.create_guid_miq_server_zone
+    Timecop.travel(report_run_time)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:metric_rollup_params) do
+    {
+      :parent_ems_id => ems.id,
+      :tag_names     => "",
+    }
+  end
+
+  context 'monthly' do
+    subject { MeteringContainerProject.build_results_for_report_MeteringContainerProject(options).first.first }
+
+    let(:options) { base_options.merge(:interval => 'monthly', :interval_size => 4, :entity_id => project.id) }
+
+    before do
+      add_metric_rollups_for(project, month_beginning...month_end, 12.hours, metric_rollup_params)
+    end
+
+    it 'calculates metering values' do
+      expect(subject.cpu_cores_used_metric).to eq(cpu_usage_rate_average * count_of_metric_rollup)
+      expect(subject.fixed_compute_metric).to eq(count_of_metric_rollup)
+      expect(subject.memory_used_metric).to eq(derived_memory_used * count_of_metric_rollup)
+      expect(subject.metering_used_metric).to eq(count_of_metric_rollup)
+      expect(subject.existence_hours_metric).to eq(month_beginning.end_of_month.day * 24)
+      expect(subject.net_io_used_metric).to eq(net_usage_rate_average * count_of_metric_rollup)
+    end
+  end
+end

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -1,0 +1,81 @@
+describe MeteringVm do
+  include Spec::Support::ChargebackHelper
+
+  let(:admin) { FactoryGirl.create(:user_admin) }
+  let(:base_options) do
+    {:interval_size       => 2,
+     :end_interval_offset => 0,
+     :ext_options         => {:tz => 'UTC'},
+     :userid              => admin.userid}
+  end
+
+  let(:derived_vm_numvcpus)       { 1.0 }
+  let(:derived_memory_available)  { 1000.0 }
+  let(:cpu_usagemhz_rate_average) { 50.0 }
+  let(:disk_usage_rate_average)   { 100.0 }
+  let(:derived_memory_used)   { 100.0 }
+  let(:net_usage_rate_average) { 25.0 }
+  let(:derived_vm_used_disk_storage) { 1.0.gigabytes }
+  let(:derived_vm_allocated_disk_storage) { 4.0.gigabytes }
+
+  let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
+  let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(base_options[:ext_options])) }
+  let(:report_run_time) { month_end }
+  let(:month_beginning) { ts.beginning_of_month.utc }
+  let(:month_end) { ts.end_of_month.utc }
+  let(:hours_in_month) { Time.days_in_month(month_beginning.month, month_beginning.year) * 24 }
+  let(:count_of_metric_rollup) { MetricRollup.where(:timestamp => month_beginning...month_end).count }
+  let(:ems) { FactoryGirl.create(:ems_vmware) }
+  let(:vm) { FactoryGirl.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref", :created_on => month_beginning) }
+  let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576) }
+  let(:host) { FactoryGirl.create(:host, :storages => [storage], :hardware => hardware, :vms => [vm]) }
+  let(:storage) { FactoryGirl.create(:storage_target_vmware) }
+  let(:ems_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => ems, :hosts => [host]) }
+
+  before do
+    MiqRegion.seed
+    ChargebackRateDetailMeasure.seed
+    ChargeableField.seed
+    MiqEnterprise.seed
+    EvmSpecHelper.create_guid_miq_server_zone
+    Timecop.travel(report_run_time)
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:metric_rollup_params) do
+    {
+      :tag_names             => "environment/prod",
+      :parent_host_id        => host.id,
+      :parent_ems_cluster_id => ems_cluster.id,
+      :parent_ems_id         => ems.id,
+      :parent_storage_id     => storage.id,
+    }
+  end
+
+  context 'monthly' do
+    subject { MeteringVm.build_results_for_report_MeteringVm(options).first.first }
+
+    let(:options) { base_options.merge(:interval => 'monthly', :interval_size => 4, :entity_id => vm.id) }
+
+    before do
+      add_metric_rollups_for(vm, month_beginning...month_end, 12.hours, metric_rollup_params)
+    end
+
+    it 'calculates metering values' do
+      expect(subject.cpu_allocated_metric).to eq(derived_vm_numvcpus)
+      expect(subject.cpu_used_metric).to eq(cpu_usagemhz_rate_average * count_of_metric_rollup)
+      expect(subject.disk_io_used_metric).to eq(disk_usage_rate_average * count_of_metric_rollup)
+      expect(subject.fixed_compute_metric).to eq(count_of_metric_rollup)
+      expect(subject.memory_allocated_metric).to eq(derived_memory_available)
+      expect(subject.memory_used_metric).to eq(derived_memory_used * count_of_metric_rollup)
+      expect(subject.metering_used_metric).to eq(count_of_metric_rollup)
+      expect(subject.existence_hours_metric).to eq(month_beginning.end_of_month.day * 24)
+      expect(subject.net_io_used_metric).to eq(net_usage_rate_average * count_of_metric_rollup)
+      expect(subject.storage_allocated_metric).to eq(derived_vm_allocated_disk_storage)
+      expect(subject.storage_used_metric).to eq(derived_vm_used_disk_storage * count_of_metric_rollup)
+    end
+  end
+end


### PR DESCRIPTION
This PR is adding metering reports:
Metering for VM
Metering for ContainerProject
Metering for ContainerImage

also:
- metering used hours moved from chargeback to these reports
- added existence hours column

These reports are most likely like a chargeback reports but without cost.
Difference is also in calculation of used metric - there are used **sums** instead of averages.

<img width="1431" alt="screen shot 2017-10-30 at 12 36 39" src="https://user-images.githubusercontent.com/14937244/32169017-09d89cd4-bd6f-11e7-8eec-4da83e3191a6.png">



@miq-bot assign @gtanzillo 

@miq-bot add_label enhancement, chargeback


## Links

UI: https://github.com/ManageIQ/manageiq-ui-classic/pull/2553