### PR TITLE
Use simplest EvmSpecHelper miq_server method

### DIFF
--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -25,7 +25,7 @@ describe EmbeddedAnsibleWorker::Runner do
     context "#update_embedded_ansible_provider" do
       let(:api_connection) { double("AnsibleAPIConnection") }
       before do
-        EvmSpecHelper.local_guid_miq_server_zone
+        EvmSpecHelper.local_miq_server
         MiqDatabase.seed
         MiqDatabase.first.set_ansible_admin_authentication(:password => "secret")
 

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -362,7 +362,7 @@ describe MiqProvisionVirtWorkflow do
     let(:local_vmware)  { FactoryGirl.create(:ems_vmware_with_authentication) }
 
     it "only returns records from its region" do
-      EvmSpecHelper.local_guid_miq_server_zone # Because there is no default timezone in settings
+      EvmSpecHelper.local_miq_server # Because there is no default timezone in settings
       FactoryGirl.create(:template_vmware, :ext_management_system => remote_vmware, :id => external_region_id)
       FactoryGirl.create(:template_vmware, :ext_management_system => local_vmware)
 

--- a/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
@@ -15,7 +15,7 @@ describe MiqLdapToSssd::ConfigureApplianceSettings do
   end
 
   describe '#configure' do
-    let!(:miq_server) { EvmSpecHelper.local_guid_miq_server_zone[1] }
+    let!(:miq_server) { EvmSpecHelper.local_miq_server }
     before do
       stub_local_settings(miq_server)
     end


### PR DESCRIPTION
We used to use local_quid_miq_server_zone everywhere
Since then we've been paring it back.
This just fixes 3 references that work better with simpler version
