### PR TITLE
Change with_adhoc scope to without_adhoc

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -23,7 +23,7 @@ class MiqSchedule < ApplicationRecord
 
   scope :filter_matches_with,      ->(exp)    { where(:filter => exp) }
   scope :with_prod_default_not_in, ->(prod)   { where.not(:prod_default => [prod, nil]) }
-  scope :with_adhoc,               ->(adhoc)  { where(:adhoc => adhoc) }
+  scope :without_adhoc,            ->         { where(:adhoc => nil) }
   scope :with_towhat,              ->(towhat) { where(:towhat => towhat) }
   scope :with_userid,              ->(userid) { where(:userid => userid) }
 


### PR DESCRIPTION
Fix `with_adhoc` scope to process nil values only.

![image](https://user-images.githubusercontent.com/7453394/32186735-31db779a-bda3-11e7-99f4-38826fd26a45.png)

Required by: https://github.com/ManageIQ/manageiq-ui-classic/pull/2564