### PR TITLE
Fixed named scope regression in MiqSchedule.with_prod_default_not_in

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -22,7 +22,7 @@ class MiqSchedule < ApplicationRecord
   }
 
   scope :filter_matches_with,      ->(exp)    { where(:filter => exp) }
-  scope :with_prod_default_not_in, ->(prod)   { where.not(:prod_default => [prod, nil]) }
+  scope :with_prod_default_not_in, ->(prod)   { where.not(:prod_default => prod).or(where(:prod_default => nil)) }
   scope :without_adhoc,            ->         { where(:adhoc => nil) }
   scope :with_towhat,              ->(towhat) { where(:towhat => towhat) }
   scope :with_userid,              ->(userid) { where(:userid => userid) }


### PR DESCRIPTION
According to the [TreeBuilder](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/presenters/tree_builder_ops_settings.rb#L47) the query should be `(prod_default != 'system' or prod_default is null)` and not `(prod_default != 'system' or prod_default is not null)`. 

To test this you'll need both https://github.com/ManageIQ/manageiq/pull/16348 and https://github.com/ManageIQ/manageiq-ui-classic/pull/2564

**Before:**
![screenshot from 2017-10-30 19-17-56](https://user-images.githubusercontent.com/649130/32188065-0ff3d808-bda7-11e7-8b43-d8e9818e8158.png)

**After:**
![screenshot from 2017-10-30 19-15-00](https://user-images.githubusercontent.com/649130/32188053-07afc4c2-bda7-11e7-8eec-83fe58b8d340.png)
