### PR TITLE
Add back listing of custom attributes in chargeback 

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -931,11 +931,11 @@ class MiqExpression
         c.last.ends_with?(*allowed_suffixes)
       end
       td = if TAG_CLASSES.include?(cb_model)
-             tag_details(model, {}) + _custom_details_for(cb_model, {})
+             tag_details(model, {})
            else
              []
            end
-      md + td
+      md + td + _custom_details_for(cb_model, {})
     else
       model_details(model, :include_model => false, :include_tags => true)
     end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1,4 +1,31 @@
 describe MiqExpression do
+  describe '#reporting_available_fields' do
+    let(:vm) { FactoryGirl.create(:vm) }
+    let!(:custom_attribute) { FactoryGirl.create(:custom_attribute, :name => 'my_attribute_1', :resource => vm) }
+    let(:extra_fields) do
+      %w(start_date
+         end_date
+         interval_name
+         display_range
+         entity
+         tag_name
+         label_name
+         id
+         vm_id
+         vm_name)
+    end
+
+    it 'lists custom attributes in ChargebackVm' do
+      displayed_columms = described_class.reporting_available_fields('ChargebackVm').map(&:second)
+      expected_columns = (ChargebackVm.attribute_names - extra_fields).map { |x| "ChargebackVm-#{x}" }
+
+      CustomAttribute.all.each do |custom_attribute|
+        expected_columns.push("#{vm.class}-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}#{custom_attribute.name}")
+      end
+      expect(displayed_columms).to match_array(expected_columns)
+    end
+  end
+
   describe "#valid?" do
     it "returns true for a valid flat expression" do
       expression = described_class.new("=" => {"field" => "Vm-name", "value" => "foo"})


### PR DESCRIPTION
accidently caused by:
https://github.com/ManageIQ/manageiq/pull/15788/commits/931467201828d4a17699765c2ac38907244084fe#diff-e5855dfa8cc9aeeeb9d13acd1525499eR929

method `_custom_details_for(cb_model, {})` is not related to tags as it could looks on first look.

@miq-bot add_label bug, chargeback
@miq-bot assign @gtanzillo 

thanks @zeari 
