### PR TITLE
Only allow one service order in cart state per user, tenant

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -11,7 +11,7 @@ class ServiceOrder < ApplicationRecord
   has_many :miq_requests, :dependent => :nullify
 
   validates :state, :inclusion => {:in => [STATE_WISH, STATE_CART, STATE_ORDERED]}
-  validates :state, :presence => true
+  validates :state, :uniqueness => { :scope => [:user_id, :tenant_id] }, :if => :cart?
   validates :name, :presence => true, :on => :update
 
   before_create :assign_user
@@ -37,6 +37,10 @@ class ServiceOrder < ApplicationRecord
 
   def ordered?
     state == STATE_ORDERED
+  end
+
+  def cart?
+    state == STATE_CART
   end
 
   def checkout

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -98,6 +98,13 @@ describe ServiceOrder do
     expect { ServiceOrder.remove_from_cart(request, user) }.to raise_error(RuntimeError, error_message)
   end
 
+  it "only allows one cart per user, tenant" do
+    service_order
+    expect do
+      ServiceOrder.create!(:state => ServiceOrder::STATE_CART, :user => user, :tenant => tenant)
+    end.to raise_error(ActiveRecord::RecordInvalid, /State has already been taken/)
+  end
+
   context '#deep_copy' do
     before do
       service_order.update_attributes(:state => ServiceOrder::STATE_ORDERED)


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-api/pull/123

@miq-bot assign @gmcculloug 
cc: @abellotti 
