### PR TITLE
Use in_my_region during widget content generation

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -385,7 +385,7 @@ class MiqWidget < ApplicationRecord
 
   def grouped_subscribers
     grouped_users   = grouped_users_by_id
-    groups_by_id    = MiqGroup.where(:id => grouped_users.keys).index_by(&:id)
+    groups_by_id    = MiqGroup.in_my_region.where(:id => grouped_users.keys).index_by(&:id)
     users_by_userid = User.in_my_region.where(:userid => grouped_users.values.flatten.uniq).index_by(&:userid)
     grouped_users.each_with_object({}) do |(k, v), h|
       user_objs = users_by_userid.values_at(*v).reject(&:blank?)

--- a/app/models/miq_widget/content_generator.rb
+++ b/app/models/miq_widget/content_generator.rb
@@ -43,7 +43,7 @@ class MiqWidget::ContentGenerator
   end
 
   def find_group_or_raise(group_description, widget)
-    group = MiqGroup.find_by(:description => group_description)
+    group = MiqGroup.in_my_region.find_by(:description => group_description)
     if group.nil?
       error_message = "MiqGroup #{group_description} was not found"
       _log.error("#{widget.log_prefix} #{error_message}")

--- a/spec/models/miq_widget/content_generator_spec.rb
+++ b/spec/models/miq_widget/content_generator_spec.rb
@@ -15,8 +15,9 @@ describe MiqWidget::ContentGenerator do
       before do
         allow(User).to receive(:where).with(:userid => 1).and_return([user1])
         allow(User).to receive(:where).with(:userid => 2).and_return([user2])
-        record = group
-        allow(MiqGroup).to receive(:find_by).with(:description => "description").and_return(record)
+        records = Array(group)
+        allow(MiqGroup).to receive(:in_my_region).and_return(records)
+        allow(records).to receive(:find_by).with(:description => "description").and_return(group)
       end
 
       context "when the group exists" do
@@ -29,6 +30,7 @@ describe MiqWidget::ContentGenerator do
           end
 
           it "returns the result" do
+            expect(MiqGroup).to receive(:in_my_region)
             expect(content_generator.generate(widget, klass, group_description, nil, timezones)).to eq([4, 5])
           end
         end
@@ -63,8 +65,9 @@ describe MiqWidget::ContentGenerator do
       let(:group) { double("MiqGroup") }
 
       before do
-        record = group
-        allow(MiqGroup).to receive(:find_by).with(:description => "EvmGroup-administrator").and_return(record)
+        records = Array(group)
+        allow(MiqGroup).to receive(:in_my_region).and_return(records)
+        allow(records).to receive(:find_by).with(:description => "EvmGroup-administrator").and_return(group)
       end
 
       context "when the resulting length is equal to the expected count" do

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -146,6 +146,13 @@ describe MiqWidget do
           result = @widget_report_vendor_and_guest_os.grouped_subscribers
           expect(result.size).to eq(0)
         end
+
+        it 'only returns groups in the current region' do
+          groups = [@group1, @group2]
+          expect(MiqGroup).to receive(:in_my_region).and_return(groups)
+          allow(groups).to receive(:where).and_return(groups)
+          @widget_report_vendor_and_guest_os.grouped_subscribers
+        end
       end
 
       def add_user(group)


### PR DESCRIPTION
Ensure that when an miq group is looked up by its description during widget content generation that `in_my_region` is used. Currently it is causing an error when generating widget content as it is setting the user in current region with a group in a different region, causing it to be unviewable to the user. 

https://bugzilla.redhat.com/show_bug.cgi?id=1505241

@miq-bot add_label bug, fine/yes
@miq-bot assign @gtanzillo 

cc: @jrafanie @yrudman 