### PR TITLE
Fix customization_scripts relation after ManageIQ/manageiq-schema#85

### DIFF
--- a/app/models/manageiq/providers/provisioning_manager.rb
+++ b/app/models/manageiq/providers/provisioning_manager.rb
@@ -1,8 +1,8 @@
 class ManageIQ::Providers::ProvisioningManager < ManageIQ::Providers::BaseManager
   has_many :operating_system_flavors, :dependent => :destroy
-  has_many :customization_scripts,    :dependent => :destroy
-  has_many :customization_script_ptables
-  has_many :customization_script_media
+  has_many :customization_scripts,          :foreign_key => :manager_id, :dependent => :destroy
+  has_many :customization_script_ptables,   :foreign_key => :manager_id
+  has_many :customization_script_media,     :foreign_key => :manager_id
   has_many :configuration_tags,             :foreign_key => :manager_id, :dependent => :destroy
   has_many :configuration_architectures,    :foreign_key => :manager_id
   has_many :configuration_compute_profiles, :foreign_key => :manager_id


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1507593

This fixes the red master on manageiq-providers-foreman.  ManageIQ/manageiq-schema#85 renamed the column, but this model was not updated.  It is a base model for the models in that repo.

@blomquisg Please review.