### PR TITLE
Typo on middleware server live metric

### DIFF
--- a/product/live_metrics/middleware_server.yaml
+++ b/product/live_metrics/middleware_server.yaml
@@ -18,7 +18,7 @@ supported_metrics:
 - WildFly Memory Metrics~NonHeap Used: mw_non_heap_used
 - WildFly Memory Metrics~NonHeap Committed: mw_non_heap_committed
 - WildFly Memory Metrics~Accumulated GC Duration: mw_accumulated_gc_duration
-- WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_agregated_servlet_time
+- WildFly Aggregated Web Metrics~Aggregated Servlet Request Time: mw_aggregated_servlet_time
 - WildFly Aggregated Web Metrics~Aggregated Servlet Request Count: mw_aggregated_servlet_request_count
 - WildFly Aggregated Web Metrics~Aggregated Active Web Sessions: mw_aggregated_active_web_sessions
 - WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions: mw_aggregated_rejected_web_sessions


### PR DESCRIPTION
Fixed typo in a Hawkular live metric `mw_agregated_servlet_time`.

@lucasponce could you please check it out? And could you tell me if this change should imply changes in other repos than core and manageiq-providers-hawkular?