### PR TITLE
Fix Firmware-Hardware relationship

### DIFF
--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -3,6 +3,6 @@ class Firmware < ApplicationRecord
 
   acts_as_miq_taggable
 
-  belongs_to :hardware, :polymorphic => true
+  belongs_to :resource, :polymorphic => true
   belongs_to :guest_device
 end


### PR DESCRIPTION
The firmware-hardware relationship seems broken (in that direction):

```ruby
Firmware.create(:hardware => Hardware.create) # => ActiveModel::MissingAttributeError: can't write unknown attribute `hardware_id`

```

EDIT:

~~This fixes that by declaring what the foreign key/type is -
`resource`, and not `hardware`, as is the default.~~

This fixes that by making the association `:resource` (as it is in the
inverse of this relationship in `Hardware`, etc..)

@miq-bot add-label bug
@miq-bot assign @agrare 

/cc @juliancheal @rodneyhbrown7 

:heart: :heart: :heart: