### PR TITLE
Do unassign tags when mapped tags list becomes empty

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -197,7 +197,7 @@ module EmsRefresh::SaveInventory
   # should have a single :tags key, or a simple Array.
   #
   def save_tags_inventory(object, collection, _target = nil)
-    return if collection.blank?
+    return if collection.nil?
     tags = collection.kind_of?(Hash) ? collection[:tags] : collection
     ContainerLabelTagMapping.retag_entity(object, tags)
   rescue => err


### PR DESCRIPTION
.blank? check was a bug, it also skipped retagging given empty array.

Fixes
https://bugzilla.redhat.com/show_bug.cgi?id=1508437

@miq-bot add-label bug, fine/yes, gaprindashvili/yes

@djberg96 @agrare Tiny but important fix, please review.