### PR TITLE
Refactors custom action mixin method 

### DIFF
--- a/app/models/availability_zone.rb
+++ b/app/models/availability_zone.rb
@@ -4,6 +4,7 @@ class AvailabilityZone < ApplicationRecord
   include Metric::CiMixin
   include EventMixin
   include ProviderObjectMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -2,6 +2,7 @@ class CloudNetwork < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -10,6 +10,7 @@ class CloudObjectStoreContainer < ApplicationRecord
   include NewWithTypeStiMixin
   include ProcessTasksMixin
   include SupportsFeatureMixin
+  include CustomActionsMixin
 
   include_concern 'Operations'
 

--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -2,6 +2,7 @@ class CloudSubnet < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -3,6 +3,7 @@ class CloudTenant < ApplicationRecord
   TENANT_MAPPING_ASSOCIATIONS = %i(vms_and_templates).freeze
 
   include NewWithTypeStiMixin
+  include CustomActionsMixin
   extend ActsAsTree::TreeWalker
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -7,6 +7,7 @@ class CloudVolume < ApplicationRecord
   include AvailabilityMixin
   include SupportsFeatureMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
   belongs_to :availability_zone

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -6,6 +6,7 @@ class ContainerGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include TenantIdentityMixin
   include ArchivedMixin
+  include CustomActionsMixin
   include_concern 'Purging'
 
   # :name, :uid, :creation_timestamp, :resource_version, :namespace

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -6,6 +6,7 @@ class ContainerImage < ApplicationRecord
   include CustomAttributeMixin
   include ArchivedMixin
   include NewWithTypeStiMixin
+  include CustomActionsMixin
   include_concern 'Purging'
 
   DOCKER_IMAGE_PREFIX = "docker://"

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -7,6 +7,7 @@ class ContainerNode < ApplicationRecord
   include SupportsFeatureMixin
   include ArchivedMixin
   include CockpitMixin
+  include CustomActionsMixin
   include_concern 'Purging'
 
   EXTERNAL_LOGGING_PATH = "/#/discover?_g=()&_a=(columns:!(hostname,level,kubernetes.pod_name,message),filters:!((meta:(disabled:!f,index:'%{index}',key:hostname,negate:!f),%{query})),index:'%{index}',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'*')),sort:!(time,desc))".freeze

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -2,6 +2,7 @@ class ContainerProject < ApplicationRecord
   include SupportsFeatureMixin
   include CustomAttributeMixin
   include ArchivedMixin
+  include CustomActionsMixin
   include_concern 'Purging'
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many :container_groups, -> { active }

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -1,5 +1,6 @@
 class ContainerTemplate < ApplicationRecord
   include CustomAttributeMixin
+  include CustomActionsMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project

--- a/app/models/container_volume.rb
+++ b/app/models/container_volume.rb
@@ -1,4 +1,5 @@
 class ContainerVolume < ApplicationRecord
+  include CustomActionsMixin
   acts_as_miq_taggable
   belongs_to :parent, :polymorphic => true
   belongs_to :persistent_volume_claim, :dependent => :destroy

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -4,6 +4,7 @@ class EmsCluster < ApplicationRecord
   include_concern 'CapacityPlanning'
   include EventMixin
   include TenantIdentityMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -1,4 +1,6 @@
 class ExtManagementSystem < ApplicationRecord
+  include CustomActionsMixin
+
   def self.types
     leaf_subclasses.collect(&:ems_type)
   end

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -1,6 +1,4 @@
 class GenericObject < ApplicationRecord
-  include CustomActionsMixin
-
   acts_as_miq_taggable
 
   virtual_has_one :custom_actions

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -1,4 +1,6 @@
 class GenericObject < ApplicationRecord
+  include CustomActionsMixin
+
   acts_as_miq_taggable
 
   virtual_has_one :custom_actions

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -11,6 +11,7 @@ class Host < ApplicationRecord
   include NewWithTypeStiMixin
   include TenantIdentityMixin
   include DeprecationMixin
+  include CustomActionsMixin
 
   VENDOR_TYPES = {
     # DB            Displayed

--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -5,6 +5,7 @@ class LoadBalancer < ApplicationRecord
   include RetirementMixin
   include TenantIdentityMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -36,6 +36,7 @@ class MiqGroup < ApplicationRecord
   include ActiveVmAggregationMixin
   include TimezoneMixin
   include TenancyMixin
+  include CustomActionsMixin
 
   alias_method :current_tenant, :tenant
 

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -1,4 +1,6 @@
 class MiqTemplate < VmOrTemplate
+  include CustomActionsMixin
+
   default_scope { where(:template => true) }
 
   include_concern 'Operations'

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -48,6 +48,6 @@ module CustomActionsMixin
   end
 
   def generic_custom_buttons
-    raise "called abstract method generic_custom_buttons"
+    CustomButton.buttons_for(self.class.name)
   end
 end

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -2,6 +2,7 @@ class NetworkRouter < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -7,6 +7,7 @@ class OrchestrationStack < ApplicationRecord
   include ProcessTasksMixin
   include RetirementMixin
   include TenantIdentityMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -2,6 +2,7 @@ class SecurityGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include SupportsFeatureMixin
   include CloudTenancyMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -65,6 +65,7 @@ class Service < ApplicationRecord
   include TenancyMixin
   include SupportsFeatureMixin
   include Metric::CiMixin
+  include CustomActionsMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -65,7 +65,6 @@ class Service < ApplicationRecord
   include TenancyMixin
   include SupportsFeatureMixin
   include Metric::CiMixin
-  include CustomActionsMixin
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -41,6 +41,7 @@ class Storage < ApplicationRecord
   include AsyncDeleteMixin
   include AvailabilityMixin
   include TenantIdentityMixin
+  include CustomActionsMixin
 
   virtual_column :v_used_space,                   :type => :integer
   virtual_column :v_used_space_percent_of_total,  :type => :integer

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -1,4 +1,6 @@
 class Switch < ApplicationRecord
+  include CustomActionsMixin
+
   has_many :host_switches, :dependent => :destroy
   has_many :hosts, :through => :host_switches
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -6,6 +6,7 @@ class Tenant < ApplicationRecord
   DEFAULT_URL = nil
 
   include ActiveVmAggregationMixin
+  include CustomActionsMixin
 
   acts_as_miq_taggable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   include CustomAttributeMixin
   include ActiveVmAggregationMixin
   include TimezoneMixin
+  include CustomActionsMixin
 
   has_many   :miq_approvals, :as => :approver
   has_many   :miq_approval_stamps,  :class_name => "MiqApproval", :foreign_key => :stamper_id

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -112,8 +112,4 @@ class Vm < VmOrTemplate
     )
     console.id
   end
-
-  def generic_custom_buttons
-    CustomButton.buttons_for("Vm")
-  end
 end


### PR DESCRIPTION
We have a bunch of models that need the generic_custom_buttons method and it makes more sense to have that code in the mixin rather than duplicating it in all the models. This's 30 lines vs the almost four hundred, almost identical lines that the comparable PR requires. 

Adds the custom actions mixin to all models in https://docs.google.com/spreadsheets/d/11YAR-k40xCactWx8vKYU7udKtryGLMDuLQwK5d9kAnI/edit?ts=59f8c205#gid=0 and changes mixin method to do something.

wip because needs UI components

**Related to:**
(Host: 
https://github.com/eclarizio/manageiq/commit/8ca58580d4ef1175d68e5871cd7d80678cec1ca0) [unnecessary if we're using this rather than https://github.com/ManageIQ/manageiq/pull/16369 because this includes the mixin and doesn't need the method or tests found in Erik's host PR]
https://github.com/eclarizio/manageiq-ui-classic/commit/f7d05b4ad8a47951e9781e84234a728953159688
https://github.com/eclarizio/manageiq-api/commit/e6376161bd8db90ba46d6bb6d414e93b7ca9ba2d

Everything else:
https://github.com/ManageIQ/manageiq-api/pull/163