### PR TITLE
Enable compliance check for MW server 

### DIFF
--- a/app/models/middleware_server.rb
+++ b/app/models/middleware_server.rb
@@ -1,4 +1,6 @@
 class MiddlewareServer < ApplicationRecord
+  include MiqPolicyMixin
+  include ComplianceMixin
   include NewWithTypeStiMixin
   include LiveMetricsMixin
 

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -86,6 +86,9 @@ middleware_jdbc_ok,EAP JDBC Driver Deploy Succeeded,Default,middleware_operation
 middleware_jdbc_error,EAP JDBC Driver Deploy Failed,Default,middleware_operations
 middleware_jdbc_remove_ok,EAP JDBC Driver Undeploy Succeeded,Default,middleware_operations
 middleware_jdbc_remove_error,EAP JDBC Driver Undeploy Failed,Default,middleware_operations
+middlewareserver_compliance_check,Middleware Server Compliance Check,Default,compliance
+middlewareserver_compliance_passed,Middleware Server Compliance Passed,Default,compliance
+middlewareserver_compliance_failed,Middleware Server Compliance Failed,Default,compliance
 
 #
 # Company tags

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3832,6 +3832,10 @@
       :description: Edit Tags of Middleware Servers
       :feature_type: control
       :identifier: middleware_server_tag
+    - :name: Check Compliance
+      :description: Check Compliance of Last Known Configuration
+      :feature_type: control
+      :identifier: middleware_server_check_compliance
     - :name: Reload middleware server
       :description: Trigger reload operation for Middleware Server
       :feature_type: admin

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -123,6 +123,7 @@
   - my_settings_default_views
   - my_settings_time_profiles
   - my_settings_visuals
+  - middleware_server_check_compliance
   - miq_report_run
   - miq_report_saved_reports
   - miq_report_schedules
@@ -213,6 +214,7 @@
   - my_settings_default_views
   - my_settings_time_profiles
   - my_settings_visuals
+  - middleware_server_check_compliance
   - miq_report_run
   - miq_report_saved_reports
   - miq_report_schedules
@@ -374,6 +376,7 @@
   - my_settings_default_views
   - my_settings_time_profiles
   - my_settings_visuals
+  - middleware_server_check_compliance
   - miq_report_run
   - miq_report_saved_reports
   - miq_report_schedules
@@ -474,6 +477,7 @@
   - my_settings_default_views
   - my_settings_time_profiles
   - my_settings_visuals
+  - middleware_server_check_compliance
   - miq_report_run
   - miq_report_saved_reports
   - miq_report_schedules
@@ -559,6 +563,7 @@
   - my_settings_default_views
   - my_settings_time_profiles
   - my_settings_visuals
+  - middleware_server_check_compliance
   - miq_report_run
   - miq_report_saved_reports
   - miq_report_schedules
@@ -642,6 +647,7 @@
   - my_settings_default_views
   - my_settings_time_profiles
   - my_settings_visuals
+  - middleware_server_check_compliance
   - miq_report_run
   - miq_report_saved_reports
   - miq_report_schedules
@@ -809,6 +815,7 @@
   - automation_manager
   - embedded_automation_manager
   - compute
+  - middleware_server_check_compliance
   - miq_request_admin
   - miq_request_view
   - miq_template_analyze


### PR DESCRIPTION
### This PR:
 * enables to add button in toolbar for starting simulation of policy for MW server and 
 * enables Compliance and Policy for MW server
 * creates new events for compliance checks on MW server

#### Enabled button in toolbar
![screenshot from 2017-11-02 14-32-39](https://user-images.githubusercontent.com/3439771/32328832-7a0e4986-bfdb-11e7-8f7d-e7c77c90cc6c.png)

#### Merge first
This PR is from set of PRs - https://github.com/ManageIQ/manageiq-ui-classic/pull/2594