### PR TITLE
[EUWE] Add decorator for VNC Console

### DIFF
--- a/app/decorators/vm_or_template_decorator.rb
+++ b/app/decorators/vm_or_template_decorator.rb
@@ -13,6 +13,10 @@ class VmOrTemplateDecorator < Draper::Decorator
     console_supported?('spice') || console_supported?('vnc')
   end
 
+  def supports_vnc_console?
+    console_supported?('vnc')
+  end
+
   def supports_cockpit?
     supports_launch_cockpit?
   end


### PR DESCRIPTION
SUI requires a check on VNC console because the existing decorators lead to a false positive about console enablement for VMWare consoles.

https://bugzilla.redhat.com/show_bug.cgi?id=1505546

Related: 
https://github.com/ManageIQ/manageiq-api/pull/167
https://github.com/ManageIQ/manageiq-ui-service/pull/1195

@miq-bot add_label bug, euwe/yes
@miq-bot assign @simaishi 
cc: @AllenBW 