### PR TITLE
Fixes custom button method for things with subclasses

### DIFF
--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -48,6 +48,6 @@ module CustomActionsMixin
   end
 
   def generic_custom_buttons
-    CustomButton.buttons_for(self.class.name)
+    CustomButton.buttons_for(self.class.base_model.name)
   end
 end


### PR DESCRIPTION
Anything that's a subclass needs the base_name for custom buttons