### PR TITLE
Fix resize approval to work for editing requests

### DIFF
--- a/app/models/vm_cloud_reconfigure_request.rb
+++ b/app/models/vm_cloud_reconfigure_request.rb
@@ -7,6 +7,10 @@ class VmCloudReconfigureRequest < MiqRequest
                                             :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"}
   validate  :must_have_user
 
+  def vms
+    Vm.find(options[:src_ids])
+  end
+
   def self.make_request(request, values, requester, auto_approve = false)
     values[:request_type] = :vm_cloud_reconfigure
 


### PR DESCRIPTION
The initial "resize approval workflow" feature work is missing some follow-on work needed to allow admin editing of resize/reconfigure requests before approval.

Most of the work is in the associated manageiq-ui-classic PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2598