### PR TITLE
[FINE] Add decorator for VNC Console

### DIFF
--- a/app/controllers/api/subcollections/vms.rb
+++ b/app/controllers/api/subcollections/vms.rb
@@ -47,6 +47,9 @@ module Api
         if vm_decorators.include? 'supports_cockpit?'
           hash['supports_cockpit?'] = vm.supports_launch_cockpit?
         end
+        if vm_decorators.include?('supports_vnc_console?')
+          hash['supports_vnc_console?'] = vm.console_supported?('VNC')
+        end
         hash
       end
     end

--- a/spec/requests/api/services_spec.rb
+++ b/spec/requests/api/services_spec.rb
@@ -472,11 +472,15 @@ describe "Services API" do
     end
 
     it "can query vms as subcollection via decorators with additional decorators" do
-      run_get services_url(svc1.id), :expand => "vms", :attributes => "", :decorators => "vms.supports_console?"
+      run_get(services_url(svc1.id), :expand => "vms", :decorators => "vms.supports_console?,vms.supports_cockpit?,vms.supports_vnc_console?")
 
-      expect_svc_with_vms
-      expect_results_to_match_hash("vms", [{"id" => vm1.id, "supports_console?" => true},
-                                           {"id" => vm2.id, "supports_console?" => true}])
+      expected = {
+        "vms" => [
+          a_hash_including("id" => vm1.id, "supports_console?" => true, "supports_cockpit?" => anything, "supports_vnc_console?" => anything),
+          a_hash_including("id" => vm2.id, "supports_console?" => true, "supports_cockpit?" => anything, "supports_vnc_console?" => anything)
+        ]
+      }
+      expect(response.parsed_body).to include(expected)
     end
 
     it "cannot query vms via both virtual attribute and subcollection" do


### PR DESCRIPTION
SUI requires a check on VNC console because the existing decorators lead to a false positive about console enablement for VMWare consoles.

https://bugzilla.redhat.com/show_bug.cgi?id=1505546

Fine version of https://github.com/ManageIQ/manageiq-api/pull/167

@miq-bot assign @simaishi 