### PR TITLE
update_spid! on timeout, not on each message

### DIFF
--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -83,7 +83,6 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
   end
 
   def get_message
-    @worker.update_spid!
     if dequeue_method_via_drb? && @worker_monitor_drb
       get_message_via_drb
     else
@@ -108,6 +107,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
         begin
           _log.info("#{log_prefix} Reconnecting to DB after timeout error during queue deliver")
           ActiveRecord::Base.connection.reconnect!
+          @worker.update_spid!
         rescue => err
           do_exit("Exiting worker due to timeout error that could not be recovered from...error: #{err.class.name}: #{err.message}", 1)
         end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1508989

We were issuing many redundant queries per minute per queue worker
process because the spid will not change that often.

It was originally added a long time ago in:
commit fbf3233daefe45c97f18bb486bfdade55ab371f3
Date:   Fri May 11 23:49:33 2012 +0000
BugzID:14803

We can eliminate these queries and only do it when we actually
reconnect! following a timeout.