### PR TITLE
External auth lookup_by_identity should handle missing request parameter

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -70,12 +70,14 @@ module Authenticator
       [upn_username, user]
     end
 
-    def lookup_by_identity(username, request)
-      user_attrs, _membership_list = user_details_from_headers(username, request)
-      upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain]}".downcase
+    def lookup_by_identity(username, request=nil)
+      unless request.nil?
+        user_attrs, _membership_list = user_details_from_headers(username, request)
+        upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain]}".downcase
 
-      user =   find_userid_as_upn(upn_username)
-      user ||= find_userid_as_distinguished_name(user_attrs)
+        user =   find_userid_as_upn(upn_username)
+        user ||= find_userid_as_distinguished_name(user_attrs)
+      end
       user ||  case_insensitive_find_by_userid(username)
     end
 

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -70,15 +70,15 @@ module Authenticator
       [upn_username, user]
     end
 
-    def lookup_by_identity(username, request=nil)
-      unless request.nil?
+    def lookup_by_identity(username, request = nil)
+      if request
         user_attrs, _membership_list = user_details_from_headers(username, request)
         upn_username = "#{user_attrs[:username]}@#{user_attrs[:domain]}".downcase
 
         user =   find_userid_as_upn(upn_username)
         user ||= find_userid_as_distinguished_name(user_attrs)
       end
-      user ||  case_insensitive_find_by_userid(username)
+      user || case_insensitive_find_by_userid(username)
     end
 
     private

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -62,6 +62,10 @@ describe Authenticator::Httpd do
 
     let(:username) { 'cheshire' }
 
+    it "Handles missing request parameter" do
+      expect(subject.lookup_by_identity('alice')).to eq(alice)
+    end
+
     it "finds existing users as username" do
       expect(subject.lookup_by_identity('alice', request)).to eq(alice)
     end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1505922

Method Httpd#lookup_by_identity has been updated to take an optional parameter but
was not properly handling if the parameter was not provided.

This PR ensures Httpd#lookup_by_identity does the correct thing when the optional request parameter is and is not provided.


* http://documentation.for/library/that/I/am/adding
* [PR relevant issue or pull_request](#123)

Steps for Testing/QA [Optional]
-------------------------------

Setup MiQ for External Auth
Log into classic UI, with valid user.

Ensure the error pop-up: "400 /auth/api error message" (see screenshot in BZ) does not appear
and there are not tracebacks in the api.log
