### PR TITLE
TopologicalSort: use graphviz format in exceptions

### DIFF
--- a/app/models/manager_refresh/graph/topological_sort.rb
+++ b/app/models/manager_refresh/graph/topological_sort.rb
@@ -8,25 +8,12 @@ module ManagerRefresh
         @graph = graph
       end
 
-      # Sorts the graph into layers of InventoryCollection objects processable in parallel
-      #
-      # @return [Array<Array>] Array of arrays(layers) of InventoryCollection objects
-      def topological_sort
-        make_topological_sort(graph.nodes, graph.edges)
-      end
-
-      private
-
-      # (see #topological_sort)
-      #
-      # @param original_nodes [Array<ManagerRefresh::InventoryCollection>] List of nodes, where node is
-      #        InventoryCollection object
-      # @param edges [Array<Array>] List of edges, where edge is defined as [InventoryCollection, InventoryCollection]
-      # @return [Array<Array>] Array of arrays(layers) of InventoryCollection objects
-      def make_topological_sort(original_nodes, edges)
         ################################################################################################################
         # Topological sort of the graph of the DTO collections to find the right order of saving DTO collections and
         # identify what DTO collections can be saved in parallel.
+        # Does not mutate graph.
+        #
+        # @return [Array<Array>] Array of arrays(layers) of InventoryCollection objects
         ################################################################################################################
         # The expected input here is the directed acyclic Graph G (inventory_collections), consisting of Vertices(Nodes) V and
         # Edges E:
@@ -45,8 +32,9 @@ module ManagerRefresh
         # Then each Si can have their Vertices(DTO collections) processed in parallel. This algorithm cannot
         # identify independent sub-graphs inside of the layers Si, so we can make the processing even more effective.
         ################################################################################################################
-
-        nodes          = original_nodes.dup
+      def topological_sort
+        nodes          = graph.nodes.dup
+        edges          = graph.edges
         sets           = []
         i              = 0
         sets[0], nodes = nodes.partition { |v| !edges.detect { |e| e.second == v } }
@@ -56,14 +44,16 @@ module ManagerRefresh
           i         += 1
           max_depth -= 1
           if max_depth <= 0
-            raise "Max depth reached while doing topological sort of nodes #{original_nodes} and edges #{edges}, your "\
-                  "graph probably contains a cycle"
+            message = "Max depth reached while doing topological sort, your graph probably contains a cycle"
+            $log.error("#{message}:\n#{graph.to_graphviz}")
+            raise "#{message} (see log)"
           end
 
           set, nodes = nodes.partition { |v| edges.select { |e| e.second == v }.all? { |e| sets.flatten.include?(e.first) } }
           if set.blank?
-            raise "Blank dependency set while doing topological sort of nodes #{original_nodes} and edges #{edges}, "\
-                  "your graph probably contains a cycle"
+            message = "Blank dependency set while doing topological sort, your graph probably contains a cycle"
+            $log.error("#{message}:\n#{graph.to_graphviz}")
+            raise "#{message} (see log)"
           end
 
           sets[i] = set


### PR DESCRIPTION
TLDR: I encountered this exception, and wanted it to look prettier.
I axed the private `make_topological_sort(nodes, edges)` helper as I needed access to the graph object.

### *A Fairly long Tale,*
#### *of purely entertaining value, in lieu of which the indifferent reader is advised to just peruse the diff*

:question: Long was I stuck on my quest, doing something wrong :man_facepalming: , 
when I received from the wise Lady Topo a logical sort of hint, spoken thusly:  :older_woman: :speech_balloon: 

```
RuntimeError:
  Blank dependency set while doing topological sort of nodes [InventoryCollection:<ContainerProject>, InventoryCollection:<ContainerQuota>, blacklist: [namespace], InventoryCollection:<ContainerQuotaItem>, InventoryCollection:<ContainerLimit>, blacklist: [namespace], InventoryCollection:<ContainerLimitItem>, InventoryCollection:<ContainerNode>, InventoryCollection:<ContainerCondition>, InventoryCollection:<ComputerSystem>, InventoryCollection:<Hardware>, InventoryCollection:<OperatingSystem>, InventoryCollection:<ContainerImageRegistry>, InventoryCollection:<ContainerImage>, InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<ContainerCondition>, InventoryCollection:<ContainerVolume>, InventoryCollection:<Container>, InventoryCollection:<ContainerPortConfig>, InventoryCollection:<ContainerEnvVar>, InventoryCollection:<SecurityContext>, InventoryCollection:<ContainerReplicator>, blacklist: [namespace], InventoryCollection:<ContainerService>, blacklist: [namespace], InventoryCollection:<ContainerServicePortConfig>, InventoryCollection:<ContainerRoute>, blacklist: [namespace, tags], InventoryCollection:<ContainerTemplate>, blacklist: [namespace], InventoryCollection:<ContainerTemplateParameter>, InventoryCollection:<ContainerBuild>, blacklist: [tags], InventoryCollection:<ContainerBuildPod>, InventoryCollection:<PersistentVolume>, InventoryCollection:<PersistentVolumeClaim>, blacklist: [namespace], InventoryCollection:<CustomAttribute>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>, InventoryCollection:<CustomAttribute>, InventoryCollection:<Tagging>] and edges [[InventoryCollection:<ContainerProject>, InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerProject>, InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerProject>, InventoryCollection:<Tagging>], [InventoryCollection:<ContainerProject>, InventoryCollection:<ContainerQuota>, blacklist: [namespace]], [InventoryCollection:<ContainerQuota>, blacklist: [namespace], InventoryCollection:<ContainerQuotaItem>], [InventoryCollection:<ContainerProject>, InventoryCollection:<ContainerLimit>, blacklist: [namespace]], [InventoryCollection:<ContainerLimit>, blacklist: [namespace], InventoryCollection:<ContainerLimitItem>], [InventoryCollection:<ContainerNode>, InventoryCollection:<ContainerCondition>], [InventoryCollection:<ContainerNode>, InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerNode>, InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerNode>, InventoryCollection:<Tagging>], [InventoryCollection:<ContainerNode>, InventoryCollection:<ComputerSystem>], [InventoryCollection:<ComputerSystem>, InventoryCollection:<Hardware>], [InventoryCollection:<ComputerSystem>, InventoryCollection:<OperatingSystem>], [InventoryCollection:<ContainerImageRegistry>, InventoryCollection:<ContainerImage>], [InventoryCollection:<ContainerProject>, InventoryCollection:<ContainerGroup>, blacklist: [namespace]], [InventoryCollection:<ContainerNode>, InventoryCollection:<ContainerGroup>, blacklist: [namespace]], [InventoryCollection:<ContainerReplicator>, blacklist: [namespace], InventoryCollection:<ContainerGroup>, blacklist: [namespace]], [InventoryCollection:<ContainerBuildPod>, InventoryCollection:<ContainerGroup>, blacklist: [namespace]], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<ContainerCondition>], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<Tagging>], [InventoryCollection:<Tag>, InventoryCollection:<Tagging>], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<ContainerVolume>], [InventoryCollection:<ContainerImage>, InventoryCollection:<Container>], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<Container>], [InventoryCollection:<Container>, InventoryCollection:<ContainerPortConfig>], [InventoryCollection:<Container>, InventoryCollection:<ContainerEnvVar>], [InventoryCollection:<ContainerProject>, InventoryCollection:<ContainerReplicator>, blacklist: [namespace]], [InventoryCollection:<ContainerReplicator>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerReplicator>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerReplicator>, blacklist: [namespace], InventoryCollection:<Tagging>], [InventoryCollection:<Tag>, InventoryCollection:<Tagging>], [InventoryCollection:<ContainerProject>, InventoryCollection:<ContainerService>, blacklist: [namespace]], [InventoryCollection:<ContainerImageRegistry>, InventoryCollection:<ContainerService>, blacklist: [namespace]], [InventoryCollection:<ContainerGroup>, blacklist: [namespace], InventoryCollection:<ContainerService>, blacklist: [namespace]], [InventoryCollection:<ContainerService>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerService>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerService>, blacklist: [namespace], InventoryCollection:<Tagging>], [InventoryCollection:<Tag>, InventoryCollection:<Tagging>], [InventoryCollection:<ContainerService>, blacklist: [namespace], InventoryCollection:<ContainerServicePortConfig>], [InventoryCollection:<ContainerRoute>, blacklist: [namespace, tags], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerRoute>, blacklist: [namespace, tags], InventoryCollection:<Tagging>], [InventoryCollection:<ContainerTemplate>, blacklist: [namespace], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerTemplate>, blacklist: [namespace], InventoryCollection:<Tagging>], [InventoryCollection:<ContainerBuild>, blacklist: [tags], InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerBuild>, blacklist: [tags], InventoryCollection:<Tagging>], [InventoryCollection:<ContainerBuildPod>, InventoryCollection:<CustomAttribute>], [InventoryCollection:<ContainerBuildPod>, InventoryCollection:<Tagging>]], your graph probably contains a cycle
```

This led me on a side quest to decipher her wise but cryptic words... :world_map: :game_die:

Rummaging in the inventory I've collected, I was relieved I still have the `to_graphviz` spell of +1 clarity I'd obtained previously. :crystal_ball:
Casting it left me with the following scroll, already pretty lucid: :scroll:
```
RuntimeError:
  Blank dependency set while doing topological sort, your graph probably contains a cycle:
  digraph {
      container_projects; 	// InventoryCollection:<ContainerProject>
      container_quotas; 	// InventoryCollection:<ContainerQuota>, blacklist: [namespace]
      container_quota_items; 	// InventoryCollection:<ContainerQuotaItem>
      container_limits; 	// InventoryCollection:<ContainerLimit>, blacklist: [namespace]
      container_limit_items; 	// InventoryCollection:<ContainerLimitItem>
      container_nodes; 	// InventoryCollection:<ContainerNode>
      container_conditions_for_container_nodes; 	// InventoryCollection:<ContainerCondition>
      computer_systems; 	// InventoryCollection:<ComputerSystem>
      computer_system_hardwares; 	// InventoryCollection:<Hardware>
      computer_system_operating_systems; 	// InventoryCollection:<OperatingSystem>
      container_image_registries; 	// InventoryCollection:<ContainerImageRegistry>
      container_images; 	// InventoryCollection:<ContainerImage>
      container_groups; 	// InventoryCollection:<ContainerGroup>, blacklist: [namespace]
      container_conditions_for_container_groups; 	// InventoryCollection:<ContainerCondition>
      container_volumes; 	// InventoryCollection:<ContainerVolume>
      containers; 	// InventoryCollection:<Container>
      container_port_configs; 	// InventoryCollection:<ContainerPortConfig>
      container_env_vars; 	// InventoryCollection:<ContainerEnvVar>
      security_contexts; 	// InventoryCollection:<SecurityContext>
      container_replicators; 	// InventoryCollection:<ContainerReplicator>, blacklist: [namespace]
      container_services; 	// InventoryCollection:<ContainerService>, blacklist: [namespace]
      container_service_port_configs; 	// InventoryCollection:<ContainerServicePortConfig>
      container_routes; 	// InventoryCollection:<ContainerRoute>, blacklist: [namespace, tags]
      container_templates; 	// InventoryCollection:<ContainerTemplate>, blacklist: [namespace]
      container_template_parameters; 	// InventoryCollection:<ContainerTemplateParameter>
      container_builds; 	// InventoryCollection:<ContainerBuild>, blacklist: [tags]
      container_build_pods; 	// InventoryCollection:<ContainerBuildPod>
      persistent_volumes; 	// InventoryCollection:<PersistentVolume>
      persistent_volume_claims; 	// InventoryCollection:<PersistentVolumeClaim>, blacklist: [namespace]
      custom_attributes_for_container_projects_labels; 	// InventoryCollection:<CustomAttribute>
      custom_attributes_for_container_projects_additional_attributes; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_projects; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_nodes_labels; 	// InventoryCollection:<CustomAttribute>
      custom_attributes_for_container_nodes_additional_attributes; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_nodes; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_groups_labels; 	// InventoryCollection:<CustomAttribute>
      custom_attributes_for_container_groups_node_selectors; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_groups; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_replicators_labels; 	// InventoryCollection:<CustomAttribute>
      custom_attributes_for_container_replicators_selectors; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_replicators; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_services_labels; 	// InventoryCollection:<CustomAttribute>
      custom_attributes_for_container_services_selectors; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_services; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_routes_labels; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_routes; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_templates_labels; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_templates; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_builds_labels; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_builds; 	// InventoryCollection:<Tagging>
      custom_attributes_for_container_build_pods_labels; 	// InventoryCollection:<CustomAttribute>
      taggings_for_container_build_pods; 	// InventoryCollection:<Tagging>
    // edges:
    container_projects -> custom_attributes_for_container_projects_labels;
    container_projects -> custom_attributes_for_container_projects_additional_attributes;
    container_projects -> taggings_for_container_projects;
    container_projects -> container_quotas;
    container_quotas -> container_quota_items;
    container_projects -> container_limits;
    container_limits -> container_limit_items;
    container_nodes -> container_conditions_for_container_nodes;
    container_nodes -> custom_attributes_for_container_nodes_labels;
    container_nodes -> custom_attributes_for_container_nodes_additional_attributes;
    container_nodes -> taggings_for_container_nodes;
    container_nodes -> computer_systems;
    computer_systems -> computer_system_hardwares;
    computer_systems -> computer_system_operating_systems;
    container_image_registries -> container_images;
    container_projects -> container_groups;
    container_nodes -> container_groups;
    container_replicators -> container_groups;
    container_build_pods -> container_groups;
    container_groups -> container_conditions_for_container_groups;
    container_groups -> custom_attributes_for_container_groups_labels;
    container_groups -> custom_attributes_for_container_groups_node_selectors;
    container_groups -> taggings_for_container_groups;
     -> taggings_for_container_groups;
    container_groups -> container_volumes;
    persistent_volume_claims -> container_volumes;
    container_images -> containers;
    container_groups -> containers;
    containers -> container_port_configs;
    containers -> container_env_vars;
    containers -> security_contexts;
    container_projects -> container_replicators;
    container_replicators -> custom_attributes_for_container_replicators_labels;
    container_replicators -> custom_attributes_for_container_replicators_selectors;
    container_replicators -> taggings_for_container_replicators;
     -> taggings_for_container_replicators;
    container_projects -> container_services;
    container_image_registries -> container_services;
    container_groups -> container_services;
    container_services -> custom_attributes_for_container_services_labels;
    container_services -> custom_attributes_for_container_services_selectors;
    container_services -> taggings_for_container_services;
     -> taggings_for_container_services;
    container_services -> container_service_port_configs;
    container_routes -> custom_attributes_for_container_routes_labels;
    container_routes -> taggings_for_container_routes;
    container_templates -> custom_attributes_for_container_templates_labels;
    container_templates -> taggings_for_container_templates;
    container_builds -> custom_attributes_for_container_builds_labels;
    container_builds -> taggings_for_container_builds;
    container_build_pods -> custom_attributes_for_container_build_pods_labels;
    container_build_pods -> taggings_for_container_build_pods;
    persistent_volume_claims -> persistent_volumes;
    container_projects -> persistent_volume_claims;
  }
```

This I took to Graf Vizen dot Parsi, the famous calligrapher :man_with_turban: :black_nib:  :notebook_with_decorative_cover:,
hoping he'd illustrate it for me — but he refused to help, saying it is "improper" and mumbling about "sin taxes" being high in this kingdom.

### *The end*

----

Never the less, this has helped me on my quest!  :v:
I debugged those `-> taggings_for_container_services;` lines on the scroll and discovered I have edge endpoints not among the nodes — I actually knew I'm yet to add some collections to the persister, and should have expected all kinds of trouble, but forgot about it...
I'm sending another PR to add some sanity checks on graph construction => #16389

I'll soon return to my regularly scheduled programming.