### PR TITLE
Don't include full file paths into gettext catalogs

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -43,6 +43,8 @@ namespace :locale do
   desc "Extract strings from various yaml files and store them in a ruby file for gettext:find"
   task :extract_yaml_strings => :environment do
     def update_output(string, file, output)
+      file.gsub!(pwd + '/', "")
+      file.gsub!(ManageIQ::UI::Classic::Engine.root.to_s + '/', "")
       return if string.nil? || string.empty?
       if output.key?(string)
         output[string].append(file)


### PR DESCRIPTION
For convenience, we've been including string source locations into our gettext catalogs.

Commit  34e1cfa8375b18efb0a864b613e046bb1bbcdce3 is causing our i18n rake task
to include full (absolute) file paths into the catalogs. We want only the relative part.

This fix should also land in gaprindashvili branch, should we want to update the catalogs
for translation in the future.