### PR TITLE
Fix Zone creation

### DIFF
--- a/lib/vmdb/settings/database_source.rb
+++ b/lib/vmdb/settings/database_source.rb
@@ -36,7 +36,9 @@ module Vmdb
       end
 
       def resource
-        @resource_instance == :my_server ? my_server : @resource_instance.reload
+        return my_server if @resource_instance == :my_server
+        @resource_instance.reload if @resource_instance.persisted?
+        @resource_instance
       end
 
       def load

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -355,7 +355,7 @@ describe Vmdb::Settings do
       expect(settings.api.token_ttl).to eq "3.hour"
     end
 
-    it "applied settings from hierarchy Region -> Zone -> Server" do
+    it "applies settings from up the hierarchy: Region -> Zone -> Server" do
       MiqRegion.seed
 
       described_class.save!(server.zone.miq_region, :api => {:token_ttl => "3.hour"})
@@ -369,6 +369,9 @@ describe Vmdb::Settings do
       described_class.save!(server, :api => {:token_ttl => "5.hour"})
       settings = Vmdb::Settings.for_resource(server)
       expect(settings.api.token_ttl).to eq "5.hour"
+
+      settings = Vmdb::Settings.for_resource(MiqServer.new(:zone => server.zone))
+      expect(settings.api.token_ttl).to eq "4.hour"
     end
   end
 


### PR DESCRIPTION
`settings_for_resource` shouldn't blow up if the instance isn't saved yet

It should return the settings from the parent resource instead.
Only attempt to reload the record if the record is persisted

https://bugzilla.redhat.com/show_bug.cgi?id=1509172

@bdunne @Fryguy