### PR TITLE
Give automate workspace factory a default user, tenant

### DIFF
--- a/spec/factories/automate_workspace.rb
+++ b/spec/factories/automate_workspace.rb
@@ -1,4 +1,6 @@
 FactoryGirl.define do
   factory :automate_workspace do
+    user
+    tenant
   end
 end

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -1,11 +1,6 @@
 describe AutomateWorkspace do
   describe "#merge_output!" do
-    let(:user) { FactoryGirl.create(:user_with_group, :userid => "admin") }
-    let(:aw) do
-      FactoryGirl.create(:automate_workspace, :user   => user,
-                                              :tenant => user.current_tenant,
-                                              :input  => input)
-    end
+    let(:aw) { FactoryGirl.create(:automate_workspace, :input => input) }
     let(:password) { "ca$hc0w" }
     let(:encrypted) { MiqPassword.encrypt(password) }
     let(:input) do


### PR DESCRIPTION
It needs these two things to be valid, but these details are not
always relevant to the behavior being tested. They don't appear to be
in the existing tests, so I removed these, letting them fall back on
the default.

@miq-bot assign @gmcculloug 
@miq-bot add-label test, technical debt