### PR TITLE
Finish simplifying NTP configuration using Settings

### DIFF
--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -7,11 +7,6 @@ module MiqServer::NtpManagement
     get_config("vmdb").config[:ntp]
   end
 
-  def server_ntp_settings_blank?(ntp)
-    # verify the ntp settings are like this and not blank:  {:ntp => {:server => ['blah'], :timeout => 5}}
-    ntp.values.flatten.compact.blank? rescue true
-  end
-
   # Called when zone ntp settings changed... run by the appropriate server
   # Also, called in start of miq_server and on a configuration change for the server
   def ntp_reload(ntp_settings = ntp_config)

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -28,15 +28,6 @@ module MiqServer::NtpManagement
       return
     end
 
-    if ntp_settings.delete(:source) != :server && !server_ntp_settings_blank?(ntp_config)
-      _log.info("Skipping reload of ntp settings from zone since this server is configured with it's own ntp settings")
-      return
-    end
-
-    if ntp_settings[:server].nil?
-      _log.warn("No ntp server settings to synchronize")
-      return
-    end
     _log.info("Synchronizing ntp settings: #{ntp_settings.inspect}")
     apply_ntp_server_settings(ntp_settings)
     @ntp_settings = ntp_settings

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -3,17 +3,6 @@ require 'linux_admin'
 module MiqServer::NtpManagement
   extend ActiveSupport::Concern
 
-  def server_ntp_settings
-    # Get the ntp servers from the vmdb.yml first, zone second, else use some defaults
-    ntp = ntp_config
-    if server_ntp_settings_blank?(ntp)
-      zone.ntp_settings
-    else
-      ntp[:source] = :server
-      ntp
-    end
-  end
-
   def ntp_config
     get_config("vmdb").config[:ntp]
   end
@@ -25,7 +14,7 @@ module MiqServer::NtpManagement
 
   # Called when zone ntp settings changed... run by the appropriate server
   # Also, called in start of miq_server and on a configuration change for the server
-  def ntp_reload(ntp_settings = server_ntp_settings)
+  def ntp_reload(ntp_settings = ntp_config)
     # matches ntp_reload_queue's guard clause
     return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_container?
 

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -3,15 +3,13 @@ require 'linux_admin'
 module MiqServer::NtpManagement
   extend ActiveSupport::Concern
 
-  def ntp_config
-    get_config("vmdb").config[:ntp]
-  end
-
   # Called when zone ntp settings changed... run by the appropriate server
   # Also, called in start of miq_server and on a configuration change for the server
-  def ntp_reload(ntp_settings = ntp_config)
+  def ntp_reload
     # matches ntp_reload_queue's guard clause
     return if !MiqEnvironment::Command.is_appliance? || MiqEnvironment::Command.is_container?
+
+    ntp_settings = get_config("vmdb").config[:ntp]
 
     if @ntp_settings && @ntp_settings == ntp_settings
       _log.info("Skipping reload of ntp settings since they are unchanged")

--- a/app/models/miq_server/queue_management.rb
+++ b/app/models/miq_server/queue_management.rb
@@ -64,7 +64,6 @@ module MiqServer::QueueManagement
       :method_name => "ntp_reload",
       :server_guid => guid,
       :priority    => MiqQueue::HIGH_PRIORITY,
-      :args => [server_ntp_settings],
       :zone        => my_zone
     )
   end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -211,7 +211,6 @@ class Zone < ApplicationRecord
         :class_name  => "MiqServer",
         :instance_id => s.id,
         :method_name => "ntp_reload",
-        :args        => [ntp_settings],
         :server_guid => s.guid,
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => name

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -54,8 +54,7 @@ class Zone < ApplicationRecord
   end
 
   def ntp_settings
-    # Return ntp settings if populated otherwise return the defaults
-    settings.fetch_path(:ntp, :server).present? ? settings[:ntp] : settings_for_resource.ntp.to_h
+    settings_for_resource.ntp.to_h
   end
 
   def assigned_roles
@@ -200,8 +199,6 @@ class Zone < ApplicationRecord
   private
 
   def queue_ntp_reload_if_changed
-    return if settings_was[:ntp] == ntp_settings
-
     servers = active_miq_servers
     return if servers.blank?
     _log.info("Zone: [#{name}], Queueing ntp_reload for [#{servers.length}] active_miq_servers, ids: #{servers.collect(&:id)}")

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -22,7 +22,6 @@ class Zone < ApplicationRecord
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
 
   before_destroy :check_zone_in_use_on_destroy
-  after_update   :queue_ntp_reload_if_changed
 
   include AuthenticationMixin
 
@@ -51,10 +50,6 @@ class Zone < ApplicationRecord
 
   def miq_region
     MiqRegion.find_by(:region => region_id)
-  end
-
-  def ntp_settings
-    settings_for_resource.ntp.to_h
   end
 
   def assigned_roles
@@ -189,29 +184,18 @@ class Zone < ApplicationRecord
     miq_servers.any?(&:started?)
   end
 
+  def ntp_reload_queue
+    servers = active_miq_servers
+    return if servers.blank?
+    _log.info("Zone: [#{name}], Queueing ntp_reload for [#{servers.length}] active_miq_servers, ids: #{servers.collect(&:id)}")
+
+    servers.each(&:ntp_reload_queue)
+  end
+
   protected
 
   def check_zone_in_use_on_destroy
     raise _("cannot delete default zone") if name == "default"
     raise _("zone name '%{name}' is used by a server") % {:name => name} unless miq_servers.blank?
-  end
-
-  private
-
-  def queue_ntp_reload_if_changed
-    servers = active_miq_servers
-    return if servers.blank?
-    _log.info("Zone: [#{name}], Queueing ntp_reload for [#{servers.length}] active_miq_servers, ids: #{servers.collect(&:id)}")
-
-    servers.each do |s|
-      MiqQueue.put_deprecated(
-        :class_name  => "MiqServer",
-        :instance_id => s.id,
-        :method_name => "ntp_reload",
-        :server_guid => s.guid,
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :zone        => name
-      )
-    end
   end
 end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -174,29 +174,7 @@ describe MiqServer do
           @miq_server.ntp_reload
         end
 
-        it "syncs with server settings with zone and server configured" do
-          @zone.update_attribute(:settings, :ntp => zone_ntp)
-          stub_settings(:ntp => server_ntp)
-
-          expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
-          expect(chrony).to receive(:clear_servers)
-          expect(chrony).to receive(:add_servers).with(*server_ntp[:server])
-          @miq_server.ntp_reload
-        end
-
-        it "syncs with zone settings if server not configured" do
-          @zone.update_attribute(:settings, :ntp => zone_ntp)
-          stub_settings({})
-
-          expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
-          expect(chrony).to receive(:clear_servers)
-          expect(chrony).to receive(:add_servers).with(*zone_ntp[:server])
-          @miq_server.ntp_reload
-        end
-
-        it "syncs with default zone settings if server and zone not configured" do
-          @zone.update_attribute(:settings, {})
-
+        it "syncs the settings" do
           expect(LinuxAdmin::Chrony).to receive(:new).and_return(chrony)
           expect(chrony).to receive(:clear_servers)
           expect(chrony).to receive(:add_servers).with("0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org")

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -180,6 +180,13 @@ describe MiqServer do
           expect(chrony).to receive(:add_servers).with("0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org")
           @miq_server.ntp_reload
         end
+
+        it "only changes the config file if there are changes" do
+          expect(@miq_server).to receive(:apply_ntp_server_settings).once
+
+          @miq_server.ntp_reload
+          @miq_server.ntp_reload
+        end
       end
 
       context "when not on an appliance" do


### PR DESCRIPTION
Leverage `Settings` to simplify getting the NTP configuration from the Server / Zone / Region / Defaults

https://bugzilla.redhat.com/show_bug.cgi?id=1476365