### PR TITLE
Fix the pre-defined Auditor role's permissions.

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -111,6 +111,7 @@
   - ems_physical_infra_console
   - ems_physical_infra_tag
   - ems_physical_infra_view
+  - ems_physical_infra_tag
   - host_show
   - host_show_list
   - host_perf
@@ -181,7 +182,6 @@
   :read_only: true
   :miq_product_feature_identifiers:
   - about
-  - all_vm_rules
   - automation_manager
   - embedded_automation_manager
   - bottlenecks
@@ -192,23 +192,31 @@
   - iso_datastore_view
   - control_explorer
   - dashboard
-  - ems_cluster_show
-  - ems_cluster_show_list
-  - ems_cluster_perf
+  - ems_cluster_view
   - ems_cluster_tag
-  - ems_cluster_timeline
-  - ems_infra_show
-  - ems_infra_show_list
+  - ems_infra_view
   - ems_infra_tag
-  - ems_infra_timeline
+  - ems_infra_check_compliance
   - ems_physical_infra_console
   - ems_physical_infra_tag
   - ems_physical_infra_view
   - host_show
   - host_show_list
   - host_perf
+  - infra_networking_view
+  - infra_networking_tag
+  - instance_view
+  - instance_check_compliance
+  - instance_policy_sim
+  - instance_tag
+  - image_view
+  - image_check_compliance
+  - image_policy_sim
+  - image_tag
+  - iso_datastore_view
+  - host_view
+  - host_check_compliance
   - host_tag
-  - host_timeline
   - miq_task_my_ui
   - my_settings_default_views
   - my_settings_time_profiles
@@ -217,14 +225,11 @@
   - miq_report_saved_reports
   - miq_report_schedules
   - miq_report_view
+  - miq_template_view
   - miq_template_check_compliance
-  - miq_template_perf
   - miq_template_policy_sim
-  - miq_template_show
-  - miq_template_show_list
-  - miq_template_snapshot
+  - miq_template_snapshot_view
   - miq_template_tag
-  - miq_template_timeline
   - physical_infra_topology_view
   - physical_server_view
   - planning
@@ -247,8 +252,11 @@
   - timeline
   - usage
   - utilization
+  - vm_view
   - vm_check_compliance
+  - vm_compare
   - vm_console
+  - vm_drift
   - vm_webmks_console
   - vm_cloud_explorer
   - vm_explorer


### PR DESCRIPTION
Auditor: Able to see virtual infrastructure for auditing purposes. Can view all infrastructure items. Cannot perform actions on them.

http://talk.manageiq.org/t/product-features-and-roles/2855

https://bugzilla.redhat.com/show_bug.cgi?id=1479583

This fixes just the Auditor role. A more systematic check and fix is needed. A detailed review is very welcome.