### PR TITLE
Add miq_expression setter to MiqAlert

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -68,6 +68,10 @@ class MiqAlert < ApplicationRecord
     miq_expression || hash_expression
   end
 
+  def miq_expression=(exp)
+    super(exp.nil? || exp.kind_of?(MiqExpression) ? exp : MiqExpression.new(exp))
+  end
+
   def evaluation_description
     return "Expression (Custom)" if     miq_expression
     return "None"                unless hash_expression && hash_expression.key?(:eval_method)


### PR DESCRIPTION
Adding type coercion for `miq_expression` column. 
This will allow us to create alerts via API with miq_expression by passing a hash instead of creating the miq expression object on the API side. 
This is part of adding hash_hexpression to the alert definitions API in https://github.com/ManageIQ/manageiq-api/pull/76. 