### PR TITLE
Sort array of queue names

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -336,7 +336,7 @@ class MiqWorker < ApplicationRecord
   # This converts it back to a Ruby Array safely.
   def queue_name
     begin
-      JSON.parse(self[:queue_name])
+      JSON.parse(self[:queue_name]).sort
     rescue JSON::ParserError, TypeError
       self[:queue_name]
     end


### PR DESCRIPTION
Queue names can get out of numerical order, this can make it tough
to compare two arrays of queues as sometimes we need to turn those
arrays into Ruby Strings.

For example a queue of `["ems_1", "ems_3", "ems_2"]` from the database
would not equal `["ems_1", "ems_2", "ems_3"]` if both were strings.