### PR TITLE
Allow unassignment of specific tags/objects in assignment_mixin

### DIFF
--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -111,6 +111,20 @@ module ActsAsTaggable
     end
   end
 
+  def tag_remove(list, options = {})
+    ns = Tag.get_namespace(options)
+
+    # Remove tags
+    Tag.transaction do
+      Tag.parse(list).each do |name|
+        name = File.join(ns, name)
+        tag = Tag.find_by(:name => name)
+        next if tag.nil?
+        tag.taggings.where(:taggable => self).destroy_all
+      end
+    end
+  end
+
   def tagged_with(options = {})
     tagging = Tagging.arel_table
     query = Tag.includes(:taggings).references(:taggings)

--- a/spec/lib/extensions/ar_taggable_spec.rb
+++ b/spec/lib/extensions/ar_taggable_spec.rb
@@ -102,6 +102,24 @@ describe ActsAsTaggable do
     expect(Vm.find_tagged_with(:all => "red blue yellow abc", :ns => "/test/tags")).to eq([@vm1])
   end
 
+  context "#tag_remove" do
+    it "works" do
+      vm = Vm.find_by(:name => "VM1")
+      vm.tag_add("foo1", :ns => "/test/tags")
+      vm.tag_add("foo2", :ns => "/test/tags")
+      expect(vm.tag_remove("foo1", :ns => "/test/tags")).to eq(["foo1"])
+      expect(Vm.find_tagged_with(:all => "foo2", :ns => "/test/tags")).to eq([@vm1])
+      expect(Vm.find_tagged_with(:all => "foo1", :ns => "/test/tags")).to be_empty
+    end
+
+    it "does nothing if tag doesn't exist" do
+      vm = Vm.find_by(:name => "VM1")
+      vm.tag_remove("foo3", :ns => "/test/tags")
+      expect(Tag.find_by(:name => "/test/tags/foo3")).to be_nil
+      expect(Vm.find_tagged_with(:all => "foo3", :ns => "/test/tags")).to be_empty
+    end
+  end
+
   context "#is_tagged_with?" do
     it "works" do
       vm = Vm.find_by(:name => "VM1")

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -23,6 +23,38 @@ describe AssignmentMixin do
         "vm/tag/managed/environment/staging" => [alert_set2],
       )
     end
+
+    it "unassigns one tag from alert_set" do
+      ct1 = ctag("environment", "test1")
+      ct2 = ctag("environment", "staging1")
+      alert_set = FactoryGirl.create(:miq_alert_set_vm)
+      alert_set.assign_to_tags([ct1, ct2], "vm")
+      alert_set.reload # reload ensures the tag is set
+
+      alert_set.unassign_tags([ct1], "vm")
+      alert_set.reload # reload ensures the tag is unset
+
+      expect(test_class.assignments).to eq(
+        "vm/tag/managed/environment/staging1" => [alert_set]
+      )
+    end
+
+    it "unassigns object from alert_set" do
+      enterprise = FactoryGirl.create(:miq_enterprise)
+      enterprise2 = FactoryGirl.create(:miq_enterprise)
+      alert_set = FactoryGirl.create(:miq_alert_set_vm)
+
+      alert_set.assign_to_objects([enterprise, enterprise2])
+      alert_set.reload
+
+      alert_set.unassign_objects([enterprise2])
+      alert_set.reload
+
+      assignments = alert_set.get_assigned_tos
+
+      expect(assignments[:objects]).to include(enterprise)
+      expect(assignments[:objects]).not_to include(enterprise2)
+    end
   end
 
   describe ".all_assignments" do


### PR DESCRIPTION
At the moment, `assignment_mixin` does not allow unassignment of individual tags/objects, only removal of *all* assigned items.

This PR adds support for unassignment of specific tags or objects. It is required for https://github.com/ManageIQ/manageiq-api/pull/177