### PR TITLE
Add ems_infra_admin_ui feature

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -86,6 +86,7 @@ module SupportsFeatureMixin
     :discovery                  => 'Discovery of Managers for a Provider',
     :evacuate                   => 'Evacuation',
     :launch_cockpit             => 'Launch Cockpit UI',
+    :admin_ui                   => 'Open Admin UI for a Provider',
     :live_migrate               => 'Live Migration',
     :migrate                    => 'Migration',
     :capture                    => 'Capture of Capacity & Utilization Metrics',

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -970,6 +970,10 @@
       :description: Import Virtual Machine from other Infrastructure Provider
       :feature_type: admin
       :identifier: ems_infra_import_vm
+    - :name: Admin UI
+      :description: Open Admin UI for Infrastructure Providers
+      :feature_type: control
+      :identifier: ems_infra_admin_ui
   - :name: Modify
     :description: Modify Infrastructure Providers
     :feature_type: admin

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -350,6 +350,7 @@
   - ems_infra_show_list
   - ems_infra_tag
   - ems_infra_timeline
+  - ems_infra_admin_ui
   - ems_physical_infra_new
   - ems_physical_infra_console
   - ems_physical_infra_delete


### PR DESCRIPTION
This PR is part of the following series:
- **[Add ems_infra_admin_ui feature](https://github.com/ManageIQ/manageiq/pull/16403) (manageiq)**
- [Add ems_infra_admin_ui feature support](https://github.com/ManageIQ/manageiq-ui-classic/pull/2644) (manageiq-ui-classic)
- [Add admin_ui feature support to InfraManager](https://github.com/ManageIQ/manageiq-providers-ovirt/pull/133) (manageiq-providers-ovirt)

The `ems_infra_admin_ui` product feature represents Infrastructure Provider's capability to link to its own (provider-specific) administration UI.

This feature is currently associated with `EvmRole-operator` (just like `ems_infra_refresh`).

Inspired by @jhernand (see original PR [here](https://github.com/ManageIQ/manageiq/pull/16261)).