### PR TITLE
Fail the CI if there are no factories for each locally defined model

### DIFF
--- a/spec/factories/advanced_setting.rb
+++ b/spec/factories/advanced_setting.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :advanced_setting
+end

--- a/spec/factories/application_record.rb
+++ b/spec/factories/application_record.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :application_record
+end

--- a/spec/factories/asset_tag_import.rb
+++ b/spec/factories/asset_tag_import.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :asset_tag_import
+end

--- a/spec/factories/audit_event.rb
+++ b/spec/factories/audit_event.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :audit_event
 end

--- a/spec/factories/auth_private_key.rb
+++ b/spec/factories/auth_private_key.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :auth_private_key
+end

--- a/spec/factories/auth_token.rb
+++ b/spec/factories/auth_token.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :auth_token
 end

--- a/spec/factories/auth_userid_password.rb
+++ b/spec/factories/auth_userid_password.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :auth_userid_password
+end

--- a/spec/factories/authentication_configuration_script_base.rb
+++ b/spec/factories/authentication_configuration_script_base.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :authentication_configuration_script_base
+end

--- a/spec/factories/authentication_orchestration_stack.rb
+++ b/spec/factories/authentication_orchestration_stack.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :authentication_orchestration_stack
+end

--- a/spec/factories/authentication_rhsm.rb
+++ b/spec/factories/authentication_rhsm.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :authentication_rhsm
+end

--- a/spec/factories/authenticator.rb
+++ b/spec/factories/authenticator.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :authenticator
 end

--- a/spec/factories/chargeback.rb
+++ b/spec/factories/chargeback.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :chargeback
 end

--- a/spec/factories/chargeback_container_image.rb
+++ b/spec/factories/chargeback_container_image.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :chargeback_container_image
+end

--- a/spec/factories/chargeback_container_project.rb
+++ b/spec/factories/chargeback_container_project.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :chargeback_container_project
+end

--- a/spec/factories/chargeback_vm.rb
+++ b/spec/factories/chargeback_vm.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :chargeback_vm
 end

--- a/spec/factories/classification_import.rb
+++ b/spec/factories/classification_import.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :classification_import
+end

--- a/spec/factories/cloud_database.rb
+++ b/spec/factories/cloud_database.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :cloud_database
 end

--- a/spec/factories/cloud_database_flavor.rb
+++ b/spec/factories/cloud_database_flavor.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :cloud_database_flavor
+end

--- a/spec/factories/cloud_resource_quota.rb
+++ b/spec/factories/cloud_resource_quota.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :cloud_resource_quota
+end

--- a/spec/factories/compute_node.rb
+++ b/spec/factories/compute_node.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :compute_node
 end

--- a/spec/factories/condition_set.rb
+++ b/spec/factories/condition_set.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :condition_set
 end

--- a/spec/factories/configuration_compute_profile.rb
+++ b/spec/factories/configuration_compute_profile.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :configuration_compute_profile
+end

--- a/spec/factories/configuration_domain.rb
+++ b/spec/factories/configuration_domain.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :configuration_domain
+end

--- a/spec/factories/configuration_environment.rb
+++ b/spec/factories/configuration_environment.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :configuration_environment
+end

--- a/spec/factories/configuration_realm.rb
+++ b/spec/factories/configuration_realm.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :configuration_realm
+end

--- a/spec/factories/configuration_tag.rb
+++ b/spec/factories/configuration_tag.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :configuration_tag
+end

--- a/spec/factories/container_build.rb
+++ b/spec/factories/container_build.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_build
+end

--- a/spec/factories/container_build_pod.rb
+++ b/spec/factories/container_build_pod.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_build_pod
+end

--- a/spec/factories/container_condition.rb
+++ b/spec/factories/container_condition.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_condition
+end

--- a/spec/factories/container_env_var.rb
+++ b/spec/factories/container_env_var.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_env_var
+end

--- a/spec/factories/container_group_performance.rb
+++ b/spec/factories/container_group_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_group_performance
+end

--- a/spec/factories/container_groups_container_services.rb
+++ b/spec/factories/container_groups_container_services.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_groups_container_services
+end

--- a/spec/factories/container_limit.rb
+++ b/spec/factories/container_limit.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_limit
+end

--- a/spec/factories/container_limit_item.rb
+++ b/spec/factories/container_limit_item.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_limit_item
+end

--- a/spec/factories/container_node_performance.rb
+++ b/spec/factories/container_node_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_node_performance
+end

--- a/spec/factories/container_performance.rb
+++ b/spec/factories/container_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_performance
+end

--- a/spec/factories/container_port_config.rb
+++ b/spec/factories/container_port_config.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_port_config
+end

--- a/spec/factories/container_project_performance.rb
+++ b/spec/factories/container_project_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_project_performance
+end

--- a/spec/factories/container_quota.rb
+++ b/spec/factories/container_quota.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_quota
+end

--- a/spec/factories/container_quota_item.rb
+++ b/spec/factories/container_quota_item.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_quota_item
+end

--- a/spec/factories/container_service_port_config.rb
+++ b/spec/factories/container_service_port_config.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_service_port_config
+end

--- a/spec/factories/container_volume_kubernetes.rb
+++ b/spec/factories/container_volume_kubernetes.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :container_volume_kubernetes
+end

--- a/spec/factories/customization_script_medium.rb
+++ b/spec/factories/customization_script_medium.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :customization_script_medium
+end

--- a/spec/factories/customization_script_ptable.rb
+++ b/spec/factories/customization_script_ptable.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :customization_script_ptable
+end

--- a/spec/factories/dialog_field_association.rb
+++ b/spec/factories/dialog_field_association.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_association
+end

--- a/spec/factories/dialog_field_association_validator.rb
+++ b/spec/factories/dialog_field_association_validator.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_association_validator
+end

--- a/spec/factories/dialog_field_check_box.rb
+++ b/spec/factories/dialog_field_check_box.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_check_box
+end

--- a/spec/factories/dialog_field_date_control.rb
+++ b/spec/factories/dialog_field_date_control.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_date_control
+end

--- a/spec/factories/dialog_field_date_time_control.rb
+++ b/spec/factories/dialog_field_date_time_control.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_date_time_control
+end

--- a/spec/factories/dialog_field_importer.rb
+++ b/spec/factories/dialog_field_importer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_importer
+end

--- a/spec/factories/dialog_field_radio_button.rb
+++ b/spec/factories/dialog_field_radio_button.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_radio_button
+end

--- a/spec/factories/dialog_field_serializer.rb
+++ b/spec/factories/dialog_field_serializer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_serializer
+end

--- a/spec/factories/dialog_field_text_area_box.rb
+++ b/spec/factories/dialog_field_text_area_box.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_field_text_area_box
+end

--- a/spec/factories/dialog_group_serializer.rb
+++ b/spec/factories/dialog_group_serializer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_group_serializer
+end

--- a/spec/factories/dialog_import_validator.rb
+++ b/spec/factories/dialog_import_validator.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_import_validator
+end

--- a/spec/factories/dialog_serializer.rb
+++ b/spec/factories/dialog_serializer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_serializer
+end

--- a/spec/factories/dialog_tab_serializer.rb
+++ b/spec/factories/dialog_tab_serializer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_tab_serializer
+end

--- a/spec/factories/dialog_yaml_serializer.rb
+++ b/spec/factories/dialog_yaml_serializer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dialog_yaml_serializer
+end

--- a/spec/factories/dictionary.rb
+++ b/spec/factories/dictionary.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :dictionary
 end

--- a/spec/factories/dynamic_dialog_field_value_processor.rb
+++ b/spec/factories/dynamic_dialog_field_value_processor.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :dynamic_dialog_field_value_processor
+end

--- a/spec/factories/ems_cluster_performance.rb
+++ b/spec/factories/ems_cluster_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :ems_cluster_performance
+end

--- a/spec/factories/ems_refresh.rb
+++ b/spec/factories/ems_refresh.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :ems_refresh
 end

--- a/spec/factories/event_log.rb
+++ b/spec/factories/event_log.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :event_log
 end

--- a/spec/factories/event_stream.rb
+++ b/spec/factories/event_stream.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :event_stream
 end

--- a/spec/factories/ext_management_system_performance.rb
+++ b/spec/factories/ext_management_system_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :ext_management_system_performance
+end

--- a/spec/factories/file_depot_ftp_anonymous.rb
+++ b/spec/factories/file_depot_ftp_anonymous.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :file_depot_ftp_anonymous
+end

--- a/spec/factories/file_depot_nfs.rb
+++ b/spec/factories/file_depot_nfs.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :file_depot_nfs
 end

--- a/spec/factories/file_depot_smb.rb
+++ b/spec/factories/file_depot_smb.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :file_depot_smb
 end

--- a/spec/factories/host_aggregate_host.rb
+++ b/spec/factories/host_aggregate_host.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :host_aggregate_host
+end

--- a/spec/factories/host_metric.rb
+++ b/spec/factories/host_metric.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :host_metric
 end

--- a/spec/factories/host_performance.rb
+++ b/spec/factories/host_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :host_performance
+end

--- a/spec/factories/host_storage.rb
+++ b/spec/factories/host_storage.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :host_storage
 end

--- a/spec/factories/host_switch.rb
+++ b/spec/factories/host_switch.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :host_switch
 end

--- a/spec/factories/job.rb
+++ b/spec/factories/job.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :job
 end

--- a/spec/factories/job_proxy_dispatcher.rb
+++ b/spec/factories/job_proxy_dispatcher.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :job_proxy_dispatcher
+end

--- a/spec/factories/ldap_management.rb
+++ b/spec/factories/ldap_management.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :ldap_management
+end

--- a/spec/factories/lifecycle_event.rb
+++ b/spec/factories/lifecycle_event.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :lifecycle_event
+end

--- a/spec/factories/live_metric.rb
+++ b/spec/factories/live_metric.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :live_metric
 end

--- a/spec/factories/metering.rb
+++ b/spec/factories/metering.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :metering
 end

--- a/spec/factories/metering_container_image.rb
+++ b/spec/factories/metering_container_image.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :metering_container_image
+end

--- a/spec/factories/metering_container_project.rb
+++ b/spec/factories/metering_container_project.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :metering_container_project
+end

--- a/spec/factories/metering_vm.rb
+++ b/spec/factories/metering_vm.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :metering_vm
 end

--- a/spec/factories/middleware_datasource_performance.rb
+++ b/spec/factories/middleware_datasource_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :middleware_datasource_performance
+end

--- a/spec/factories/middleware_diagnostic_report.rb
+++ b/spec/factories/middleware_diagnostic_report.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :middleware_diagnostic_report
+end

--- a/spec/factories/middleware_performance.rb
+++ b/spec/factories/middleware_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :middleware_performance
+end

--- a/spec/factories/middleware_server_performance.rb
+++ b/spec/factories/middleware_server_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :middleware_server_performance
+end

--- a/spec/factories/miq_action_set.rb
+++ b/spec/factories/miq_action_set.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_action_set
 end

--- a/spec/factories/miq_ae_workspace.rb
+++ b/spec/factories/miq_ae_workspace.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_ae_workspace
+end

--- a/spec/factories/miq_automate.rb
+++ b/spec/factories/miq_automate.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_automate
 end

--- a/spec/factories/miq_bulk_import.rb
+++ b/spec/factories/miq_bulk_import.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_bulk_import
+end

--- a/spec/factories/miq_cockpit_ws_worker.rb
+++ b/spec/factories/miq_cockpit_ws_worker.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_cockpit_ws_worker
+end

--- a/spec/factories/miq_event_definition_set.rb
+++ b/spec/factories/miq_event_definition_set.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_event_definition_set
+end

--- a/spec/factories/miq_event_handler.rb
+++ b/spec/factories/miq_event_handler.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_event_handler
+end

--- a/spec/factories/miq_filter.rb
+++ b/spec/factories/miq_filter.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_filter
 end

--- a/spec/factories/miq_host_provision_workflow.rb
+++ b/spec/factories/miq_host_provision_workflow.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_host_provision_workflow
+end

--- a/spec/factories/miq_priority_worker.rb
+++ b/spec/factories/miq_priority_worker.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_priority_worker
+end

--- a/spec/factories/miq_product_features_share.rb
+++ b/spec/factories/miq_product_features_share.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_product_features_share
+end

--- a/spec/factories/miq_provision_configured_system_request.rb
+++ b/spec/factories/miq_provision_configured_system_request.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_provision_configured_system_request
+end

--- a/spec/factories/miq_provision_configured_system_workflow.rb
+++ b/spec/factories/miq_provision_configured_system_workflow.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_provision_configured_system_workflow
+end

--- a/spec/factories/miq_queue_worker_base.rb
+++ b/spec/factories/miq_queue_worker_base.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_queue_worker_base
+end

--- a/spec/factories/miq_region_remote.rb
+++ b/spec/factories/miq_region_remote.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_region_remote
+end

--- a/spec/factories/miq_reportable.rb
+++ b/spec/factories/miq_reportable.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_reportable
 end

--- a/spec/factories/miq_reporting_worker.rb
+++ b/spec/factories/miq_reporting_worker.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_reporting_worker
+end

--- a/spec/factories/miq_shortcut.rb
+++ b/spec/factories/miq_shortcut.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_shortcut
 end

--- a/spec/factories/miq_smart_proxy_worker.rb
+++ b/spec/factories/miq_smart_proxy_worker.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_smart_proxy_worker
+end

--- a/spec/factories/miq_snmp.rb
+++ b/spec/factories/miq_snmp.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_snmp
 end

--- a/spec/factories/miq_user_scope.rb
+++ b/spec/factories/miq_user_scope.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :miq_user_scope
 end

--- a/spec/factories/miq_web_service_worker.rb
+++ b/spec/factories/miq_web_service_worker.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_web_service_worker
+end

--- a/spec/factories/miq_widget_shortcut.rb
+++ b/spec/factories/miq_widget_shortcut.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :miq_widget_shortcut
+end

--- a/spec/factories/network_group.rb
+++ b/spec/factories/network_group.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :network_group
 end

--- a/spec/factories/notification_recipient.rb
+++ b/spec/factories/notification_recipient.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :notification_recipient
+end

--- a/spec/factories/orchestration_stack_parameter.rb
+++ b/spec/factories/orchestration_stack_parameter.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :orchestration_stack_parameter
+end

--- a/spec/factories/os_process.rb
+++ b/spec/factories/os_process.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :os_process
 end

--- a/spec/factories/patch.rb
+++ b/spec/factories/patch.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :patch
 end

--- a/spec/factories/pglogical_subscription.rb
+++ b/spec/factories/pglogical_subscription.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :pglogical_subscription
+end

--- a/spec/factories/physical_server_provision_request.rb
+++ b/spec/factories/physical_server_provision_request.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :physical_server_provision_request
+end

--- a/spec/factories/physical_server_provision_workflow.rb
+++ b/spec/factories/physical_server_provision_workflow.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :physical_server_provision_workflow
+end

--- a/spec/factories/policy_event_content.rb
+++ b/spec/factories/policy_event_content.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :policy_event_content
+end

--- a/spec/factories/registration_system.rb
+++ b/spec/factories/registration_system.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :registration_system
+end

--- a/spec/factories/resource_action_serializer.rb
+++ b/spec/factories/resource_action_serializer.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :resource_action_serializer
+end

--- a/spec/factories/resource_action_workflow.rb
+++ b/spec/factories/resource_action_workflow.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :resource_action_workflow
+end

--- a/spec/factories/retirement_manager.rb
+++ b/spec/factories/retirement_manager.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :retirement_manager
+end

--- a/spec/factories/scan_history.rb
+++ b/spec/factories/scan_history.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :scan_history
 end

--- a/spec/factories/scan_result.rb
+++ b/spec/factories/scan_result.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :scan_result
 end

--- a/spec/factories/scanning_operations.rb
+++ b/spec/factories/scanning_operations.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :scanning_operations
+end

--- a/spec/factories/schema_migration.rb
+++ b/spec/factories/schema_migration.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :schema_migration
+end

--- a/spec/factories/security_context.rb
+++ b/spec/factories/security_context.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :security_context
+end

--- a/spec/factories/serializer.rb
+++ b/spec/factories/serializer.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :serializer
 end

--- a/spec/factories/service_generic.rb
+++ b/spec/factories/service_generic.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :service_generic
+end

--- a/spec/factories/service_template_generic.rb
+++ b/spec/factories/service_template_generic.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :service_template_generic
+end

--- a/spec/factories/storage_performance.rb
+++ b/spec/factories/storage_performance.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :storage_performance
+end

--- a/spec/factories/storage_profile_storage.rb
+++ b/spec/factories/storage_profile_storage.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :storage_profile_storage
+end

--- a/spec/factories/subnet.rb
+++ b/spec/factories/subnet.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :subnet
 end

--- a/spec/factories/sysprep_file.rb
+++ b/spec/factories/sysprep_file.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :sysprep_file
 end

--- a/spec/factories/tagging.rb
+++ b/spec/factories/tagging.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :tagging
 end

--- a/spec/factories/vim_performance_analysis.rb
+++ b/spec/factories/vim_performance_analysis.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_analysis
+end

--- a/spec/factories/vim_performance_daily.rb
+++ b/spec/factories/vim_performance_daily.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_daily
+end

--- a/spec/factories/vim_performance_operating_range.rb
+++ b/spec/factories/vim_performance_operating_range.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_operating_range
+end

--- a/spec/factories/vim_performance_planning.rb
+++ b/spec/factories/vim_performance_planning.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_planning
+end

--- a/spec/factories/vim_performance_tag.rb
+++ b/spec/factories/vim_performance_tag.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_tag
+end

--- a/spec/factories/vim_performance_tag_daily.rb
+++ b/spec/factories/vim_performance_tag_daily.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_tag_daily
+end

--- a/spec/factories/vim_performance_tag_value.rb
+++ b/spec/factories/vim_performance_tag_value.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_tag_value
+end

--- a/spec/factories/vim_performance_trend.rb
+++ b/spec/factories/vim_performance_trend.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vim_performance_trend
+end

--- a/spec/factories/vm_cloud_reconfigure_request.rb
+++ b/spec/factories/vm_cloud_reconfigure_request.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vm_cloud_reconfigure_request
+end

--- a/spec/factories/vm_cloud_reconfigure_task.rb
+++ b/spec/factories/vm_cloud_reconfigure_task.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vm_cloud_reconfigure_task
+end

--- a/spec/factories/vm_metric.rb
+++ b/spec/factories/vm_metric.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :vm_metric
 end

--- a/spec/factories/vm_migrate_workflow.rb
+++ b/spec/factories/vm_migrate_workflow.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vm_migrate_workflow
+end

--- a/spec/factories/vm_reconfigure_task.rb
+++ b/spec/factories/vm_reconfigure_task.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vm_reconfigure_task
+end

--- a/spec/factories/vm_scan.rb
+++ b/spec/factories/vm_scan.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :vm_scan
 end

--- a/spec/factories/vmdb_database_connection.rb
+++ b/spec/factories/vmdb_database_connection.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vmdb_database_connection
+end

--- a/spec/factories/vmdb_database_lock.rb
+++ b/spec/factories/vmdb_database_lock.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vmdb_database_lock
+end

--- a/spec/factories/vmdb_database_setting.rb
+++ b/spec/factories/vmdb_database_setting.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :vmdb_database_setting
+end

--- a/spec/factories/volume.rb
+++ b/spec/factories/volume.rb
@@ -1,3 +1,3 @@
 FactoryGirl.define do
-  factory :share
+  factory :volume
 end

--- a/spec/factories/widget_import_validator.rb
+++ b/spec/factories/widget_import_validator.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :widget_import_validator
+end

--- a/spec/models/factory_girl_spec.rb
+++ b/spec/models/factory_girl_spec.rb
@@ -1,0 +1,7 @@
+describe 'FactoryGirl' do
+  let(:local_models) { Dir.glob('app/models/*.rb').map { |file| File.basename(file, '.rb').to_sym } }
+
+  it 'All models have a factory defined' do
+    expect(FactoryGirl.factories.map { |x| x.name.to_sym } & local_models).to match_array(local_models)
+  end
+end


### PR DESCRIPTION
**This PR is intentionally making Travis fail to demonstrate how it will react to missing/bad factories.**

The factories defined in this repo are being used elsewhere, [for example](https://github.com/ManageIQ/manageiq-ui-classic/pull/2613#discussion_r148969692) in the UI. However, it might happen that a model has no factory defined. In such case when writing tests it's necessary to create a core PR first. We were discussing with @martinpovolny how to ease this process and my proposal would be to **have at least an empty factory for each model defined in the core repo.**

This simple test checks all the direct descendants of `ApplicationRecord`, skipping all the models that aren't defined in the core repo. A test fails if there is no factory specified, and as a secondary feature, it will report a `pending` notification if the factory couldn't be built because of some other error. These errors are usually happening because the factory requires some extra arguments or a context.

The [first run](https://travis-ci.org/ManageIQ/manageiq/jobs/298189058) of Travis on this build will produce missing factory errors. The second build will run with a commit that adds the missing factories.