### PR TITLE
Log less details about the targets

### DIFF
--- a/app/models/manager_refresh/target_collection.rb
+++ b/app/models/manager_refresh/target_collection.rb
@@ -31,14 +31,14 @@ module ManagerRefresh
                                          :options     => options)
     end
 
-    # @return [String] A String containing a name of each target in the TargetCollection
+    # @return [String] A String containing a summary
     def name
-      "Collection of targets with name: #{targets.collect(&:name)}"
+      "Collection of #{targets.size} targets"
     end
 
     # @return [String] A String containing an id of each target in the TargetCollection
     def id
-      "Collection of targets with id: #{targets.collect(&:id)}"
+      "Collection of targets with id: #{targets.collect(&:manager_ref)}"
     end
 
     # Returns targets in a format:

--- a/spec/models/manager_refresh/target_collection_spec.rb
+++ b/spec/models/manager_refresh/target_collection_spec.rb
@@ -110,7 +110,8 @@ describe ManagerRefresh::TargetCollection do
         :options     => {:opt1 => "opt1", :opt2 => "opt2"}
       )
 
-      expect(target_collection.name).to eq "Collection of targets with name: [{:ems_ref=>\"vm_1\"}, {:ems_ref=>\"vm_2\"}]"
+      expect(target_collection.name).to eq "Collection of 2 targets"
+      expect(target_collection.id).to eq "Collection of targets with id: [{:ems_ref=>\"vm_1\"}, {:ems_ref=>\"vm_2\"}]"
     end
   end
 


### PR DESCRIPTION
Log less details about the targets to prevent queue being bloated by targeted refresh data,
