### PR TITLE
Fix sporadic failure for tag_details

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -3242,6 +3242,10 @@ describe MiqExpression do
   end
 
   describe ".tag_details" do
+    before do
+      described_class.instance_variable_set(:@classifications, nil)
+    end
+
     it "returns the tags when no path is given" do
       Tenant.seed
       FactoryGirl.create(


### PR DESCRIPTION
other spec could set variable in class
MiqExpression#classifications as it is
set for memoizing result of query
but thanks to that MiqExpression#classification
is not updated as this test is expecting

So, `@classification` is set to nil,
for filling out it properly in 
https://github.com/ManageIQ/manageiq/blob/master/lib/miq_expression.rb#L888

@miq-bot add_label gapridashvili/yes, bug/sporadic test failure 
@miq-bot assign @gtanzillo 


Links 
----------------
* https://travis-ci.org/ManageIQ/manageiq/jobs/298532721 - CI failure