### PR TITLE
Datastores duplicated after a refresh

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -124,8 +124,10 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
     def storages(extra_attributes = {})
       attributes = {
         :model_class => ::Storage,
-        # TODO: change :manager_ref => [:location],
-        :association => :storages
+        :manager_ref => [:location],
+        :association => :storages,
+        :complete    => false,
+        :arel        => Storage
       }
 
       attributes.merge!(extra_attributes)


### PR DESCRIPTION
There was no way to identify uniquely datastore during a refresh
which resulted in duplications. This PR solves this issue.

Bug-Url:
https://bugzilla.redhat.com/1510053