### PR TITLE
Fix ManagerRefresh::Target spec contexts

### DIFF
--- a/spec/models/manager_refresh/target_spec.rb
+++ b/spec/models/manager_refresh/target_spec.rb
@@ -64,95 +64,95 @@ describe ManagerRefresh::Target do
 
       expect { ManagerRefresh::Target.load(data) }.to raise_error("Provide either :manager or :manager_id argument")
     end
+  end
 
-    context ".dump" do
-      it "intializes correct ManagerRefresh::Target.object with a :manager_id" do
-        target_1 = ManagerRefresh::Target.load(
+  context ".dump" do
+    it "intializes correct ManagerRefresh::Target.object with a :manager_id" do
+      target_1 = ManagerRefresh::Target.load(
+        :manager_id  => @ems.id,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1.dump).to(
+        eq(
           :manager_id  => @ems.id,
+          :event_id    => nil,
           :association => :vms,
           :manager_ref => {:ems_ref => @vm_1.ems_ref},
           :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
-
-        expect(target_1.dump).to(
-          eq(
-            :manager_id  => @ems.id,
-            :event_id    => nil,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          )
-        )
-      end
-
-      it "intializes correct ManagerRefresh::Target.object with a :manager " do
-        target_1 = ManagerRefresh::Target.load(
-          :manager     => @ems,
-          :association => :vms,
-          :manager_ref => {:ems_ref => @vm_1.ems_ref},
-          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-        )
-
-        expect(target_1.dump).to(
-          eq(
-            :manager_id  => @ems.id,
-            :event_id    => nil,
-            :association => :vms,
-            :manager_ref => {:ems_ref => @vm_1.ems_ref},
-            :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-          )
-        )
-      end
-
-      it "class method .dump returns the same as an instance method .dump " do
-        target_1 = ManagerRefresh::Target.load(
-          :manager     => @ems,
-          :association => :vms,
-          :manager_ref => {:ems_ref => @vm_1.ems_ref},
-          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-        )
-
-        expect(target_1.dump).to eq ManagerRefresh::Target.dump(target_1)
-      end
+      )
     end
 
-    context ".load_from_db" do
-      it "loads ManagerRefresh::Target from the db" do
-        target_1 = ManagerRefresh::Target.load(
-          :manager     => @ems,
+    it "intializes correct ManagerRefresh::Target.object with a :manager " do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1.dump).to(
+        eq(
+          :manager_id  => @ems.id,
+          :event_id    => nil,
           :association => :vms,
           :manager_ref => {:ems_ref => @vm_1.ems_ref},
           :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
-
-        expect(target_1.load_from_db).to eq @vm_1
-      end
+      )
     end
 
-    context ".id" do
-      it "checks that .id is an alias for .dump" do
-        target_1 = ManagerRefresh::Target.load(
-          :manager     => @ems,
-          :association => :vms,
-          :manager_ref => {:ems_ref => @vm_1.ems_ref},
-          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-        )
+    it "class method .dump returns the same as an instance method .dump " do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
 
-        expect(target_1.dump).to eq target_1.id
-      end
+      expect(target_1.dump).to eq ManagerRefresh::Target.dump(target_1)
     end
+  end
 
-    context ".name" do
-      it "checks that .name is an alias for .association" do
-        target_1 = ManagerRefresh::Target.load(
-          :manager     => @ems,
-          :association => :vms,
-          :manager_ref => {:ems_ref => @vm_1.ems_ref},
-          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
-        )
+  context ".load_from_db" do
+    it "loads ManagerRefresh::Target from the db" do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
 
-        expect(target_1.name).to eq target_1.manager_ref
-      end
+      expect(target_1.load_from_db).to eq @vm_1
+    end
+  end
+
+  context ".id" do
+    it "checks that .id is an alias for .dump" do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1.dump).to eq target_1.id
+    end
+  end
+
+  context ".name" do
+    it "checks that .name is an alias for .association" do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1.name).to eq target_1.manager_ref
     end
   end
 end


### PR DESCRIPTION
The .load context included the .dump, .load_from_db, .id, and .name (all
of the contexts below it.  I suspect this was an accident and these are
indented to be defined at the same level as the .load context, @Ladas?