### PR TITLE
Fix has_required_role? for InventoryCollectorWorker

### DIFF
--- a/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
@@ -6,7 +6,8 @@ class ManageIQ::Providers::BaseManager::InventoryCollectorWorker < MiqWorker
   self.required_roles = "ems_inventory"
 
   def self.has_required_role?
-    !worker_settings[:disabled]
+    return false if worker_settings[:disabled]
+    super
   end
 
   def friendly_name


### PR DESCRIPTION
This was skipping the base MiqWorker.has_required_role? code checking
for active roles and instead just looking for the disabled setting.