### PR TITLE
Provider Generator to generate a dummy provider

### DIFF
--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager.rb
@@ -1,0 +1,46 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager < ManageIQ::Providers::CloudManager
+  require_nested :MetricsCapture
+  require_nested :MetricsCollectorWorker
+  require_nested :Refresher
+  require_nested :RefreshWorker
+  require_nested :Vm
+
+  def verify_credentials(auth_type = nil, options = {})
+    begin
+      connect
+    rescue => err
+      raise MiqException::MiqInvalidCredentialsError, err.message
+    end
+
+    true
+  end
+
+  def connect(options = {})
+    raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(options[:auth_type])
+
+    auth_token = authentication_token(options[:auth_type])
+    self.class.raw_connect(project, auth_token, options, options[:proxy_uri] || http_proxy_uri)
+  end
+
+  def self.validate_authentication_args(params)
+    # return args to be used in raw_connect
+    return [params[:default_userid], MiqPassword.encrypt(params[:default_password])]
+  end
+
+  def self.hostname_required?
+    # TODO: ExtManagementSystem is validating this
+    false
+  end
+
+  def self.raw_connect(*args)
+    true
+  end
+
+  def self.ems_type
+    @ems_type ||= "<%= provider_name %>".freeze
+  end
+
+  def self.description
+    @description ||= "<%= provider_name.split('_').map(&:capitalize).join(' ') %>".freeze
+  end
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
+  require_nested :Runner
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher/runner.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher/runner.rb
@@ -1,0 +1,43 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::EventCatcher::Runner < ManageIQ::Providers::BaseManager::EventCatcher::Runner
+  def stop_event_monitor
+    event_monitor_handle.stop
+  end
+
+  def monitor_events
+    event_monitor_handle.start
+    event_monitor_running
+    event_monitor_handle.poll do |event|
+      @queue.enq event
+    end
+  ensure
+    stop_event_monitor
+  end
+
+  def queue_event(event)
+    _log.info "#{log_prefix} Caught event [#{event[:id]}]"
+    event_hash = event_to_hash(event, @cfg[:ems_id])
+    EmsEvent.add_queue('add', @cfg[:ems_id], event_hash)
+  end
+
+  private
+
+  def event_to_hash(event, ems_id)
+    {
+      :event_type => "DUMMY_PROVIDER_#{event[:name]}",
+      :source     => 'DUMMY_PROVIDER',
+      :timestamp  => event[:timestamp],
+      :vm_ems_ref => event[:vm_ems_ref],
+      :full_data  => event,
+      :ems_id     => ems_id
+    }
+  end
+
+  def event_monitor_handle
+    @event_monitor_handle ||= begin
+      self.class.parent::Stream.new(
+        @ems,
+        :poll_sleep => worker_settings[:poll]
+      )
+    end
+  end
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher/stream.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher/stream.rb
@@ -1,0 +1,50 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::EventCatcher::Stream
+  class ProviderUnreachable < ManageIQ::Providers::BaseManager::EventCatcher::Runner::TemporaryFailure
+  end
+
+  def initialize(ems, options = {})
+    @ems = ems
+    @last_activity = nil
+    @stop_polling = false
+    @poll_sleep = options[:poll_sleep] || 20.seconds
+  end
+
+  def start
+    @stop_polling = false
+  end
+
+  def stop
+    @stop_polling = true
+  end
+
+  def fake_events
+    [
+      OpenStruct.new(:name       => %w(instance_power_on instance_power_off).sample,
+                     :id         => Time.zone.now.to_i,
+                     :timestamp  => Time.zone.now,
+                     :vm_ems_ref => [1,2].sample),
+      OpenStruct.new(:name       => %w(instance_power_on instance_power_off).sample,
+                     :id         => Time.zone.now.to_i + 1,
+                     :timestamp  => Time.zone.now,
+                     :vm_ems_ref => [1,2].sample),
+    ]
+  end
+
+  def poll
+    @ems.with_provider_connection do |connection|
+      catch(:stop_polling) do
+        begin
+          loop do
+            fake_events.each do |activity|
+              throw :stop_polling if @stop_polling
+              yield activity.to_h
+            end
+            sleep @poll_sleep
+          end
+        rescue => exception
+          raise ProviderUnreachable, exception.message
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/metrics_capture.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/metrics_capture.rb
@@ -1,0 +1,82 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+
+  VIM_STYLE_COUNTERS = {
+    "cpu_usage_rate_average"  => {
+      :counter_key           => "cpu_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "percent",
+      :capture_interval_name => "realtime"
+    },
+
+    "disk_usage_rate_average" => {
+      :counter_key           => "disk_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 2,
+      :rollup                => "average",
+      :unit_key              => "kilobytespersecond",
+      :capture_interval_name => "realtime"
+    },
+    "mem_usage_absolute_average" => {
+      :counter_key           => "mem_usage_absolute_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 1,
+      :rollup                => "average",
+      :unit_key              => "percent",
+      :capture_interval_name => "realtime"
+    },
+    "net_usage_rate_average"  => {
+      :counter_key           => "net_usage_rate_average",
+      :instance              => "",
+      :capture_interval      => "20",
+      :precision             => 2,
+      :rollup                => "average",
+      :unit_key              => "kilobytespersecond",
+      :capture_interval_name => "realtime"
+    }
+  }
+
+  def perf_collect_metrics(interval_name, start_time = nil, end_time = nil)
+    raise "No EMS defined" if target.ext_management_system.nil?
+
+    log_header = "[#{interval_name}] for: [#{target.class.name}], [#{target.id}], [#{target.name}]"
+
+    end_time ||= Time.now
+    end_time     = end_time.utc
+    start_time ||= end_time - 4.hours # 4 hours for symmetry with VIM
+    start_time   = start_time.utc
+
+    begin
+      target.ext_management_system.with_provider_connection do |connection|
+        [{target.ems_ref => VIM_STYLE_COUNTERS},
+         {target.ems_ref => fake_metrics(start_time, end_time)}]
+      end
+    rescue Exception => err
+      _log.error("#{log_header} Unhandled exception during perf data collection: [#{err}], class: [#{err.class}]")
+      _log.error("#{log_header}   Timings at time of error: #{Benchmark.current_realtime.inspect}")
+      _log.log_backtrace(err)
+      raise
+    end
+  end
+
+  private
+
+  def fake_metrics(start_time, end_time)
+    timestamp = start_time
+    metrics = {}
+    while (timestamp < end_time)
+      metrics[timestamp] = {
+        'cpu_usage_rate_average'  => rand(100).to_f,
+        'disk_usage_rate_average' => rand(100).to_f,
+        'mem_usage_rate_average'  => rand(100).to_f,
+        'net_usage_rate_average'  => rand(100).to_f,
+      }
+      timestamp += 20.seconds
+    end
+    metrics
+  end
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/metrics_collector_worker.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/metrics_collector_worker.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
+  require_nested :Runner
+
+  self.default_queue_name = "<%= provider_name %>"
+
+  def friendly_name
+    @friendly_name ||= "C&U Metrics Collector for <%= class_name %>"
+  end
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/metrics_collector_worker/runner.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/metrics_collector_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::MetricsCollectorWorker::Runner < ManageIQ::Providers::BaseManager::MetricsCollectorWorker::Runner
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresh_worker.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresh_worker.rb
@@ -1,0 +1,8 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::RefreshWorker < MiqEmsRefreshWorker
+  require_nested :Runner
+
+  def self.ems_class
+    parent
+  end
+
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresh_worker/runner.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresh_worker/runner.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::RefreshWorker::Runner < ManageIQ::Providers::BaseManager::RefreshWorker::Runner
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresher.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresher.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
+  include ::EmsRefresh::Refreshers::EmsRefresherMixin
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/vm.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/vm.rb
@@ -1,0 +1,41 @@
+class ManageIQ::Providers::<%= class_name %>::CloudManager::Vm < ManageIQ::Providers::CloudManager::Vm
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    # find vm instance via connection and return it
+    # connection.find_instance(ems_ref)
+    # but we return just an object for now
+    OpenStruct.new
+  end
+
+  def raw_start
+    with_provider_object(&:start)
+    # Temporarily update state for quick UI response until refresh comes along
+    update_attributes!(:raw_power_state => "on")
+  end
+
+  def raw_stop
+    with_provider_object(&:stop)
+    # Temporarily update state for quick UI response until refresh comes along
+    update_attributes!(:raw_power_state => "off")
+  end
+
+  def raw_pause
+    with_provider_object(&:pause)
+    # Temporarily update state for quick UI response until refresh comes along
+    update_attributes!(:raw_power_state => "paused")
+  end
+
+  def raw_suspend
+    with_provider_object(&:suspend)
+    # Temporarily update state for quick UI response until refresh comes along
+    update_attributes!(:raw_power_state => "suspended")
+  end
+
+  # TODO: this method could be the default in a baseclass
+  def self.calculate_power_state(raw_power_state)
+    # do some mapping on powerstates
+    # POWER_STATES[raw_power_state.to_s] || "terminated"
+    raw_power_state
+  end
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/inventory/collector/cloud_manager.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/inventory/collector/cloud_manager.rb
@@ -1,0 +1,13 @@
+class ManageIQ::Providers::<%= class_name %>::Inventory::Collector::CloudManager < ManagerRefresh::Inventory::Collector
+  def connection
+    @connection ||= manager.connect
+  end
+
+  def vms
+    [
+      OpenStruct.new(:id => '1', :name => 'funky', :location => 'dc-1', :vendor => 'unknown'),
+      OpenStruct.new(:id => '2', :name => 'bunch', :location => 'dc-1', :vendor => 'unknown')
+    ]
+  end
+
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/inventory/parser/cloud_manager.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/inventory/parser/cloud_manager.rb
@@ -1,0 +1,15 @@
+class ManageIQ::Providers::<%= class_name %>::Inventory::Parser::CloudManager < ManagerRefresh::Inventory::Parser
+  def parse
+    vms
+  end
+
+  def vms
+    collector.vms.each do |inventory|
+      inventory_object = persister.vms.find_or_build(inventory.id.to_s)
+      inventory_object.name = inventory.name
+      inventory_object.location = inventory.location
+      inventory_object.vendor = inventory.vendor
+    end
+  end
+
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/inventory/persister/cloud_manager.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/inventory/persister/cloud_manager.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::<%= class_name %>::Inventory::Persister::CloudManager < ManagerRefresh::Inventory::Persister
+  include ManagerRefresh::Inventory::CloudManager
+
+  has_cloud_manager_vms
+end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/cloud_manager.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/cloud_manager.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::<%= class_name %>::CloudManager < ManageIQ::Providers::CloudManager
-end

--- a/lib/generators/provider/templates/config/settings.yml
+++ b/lib/generators/provider/templates/config/settings.yml
@@ -4,9 +4,27 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+<% if options[:dummy] %>
+        :power:
+          :critical:
+            - <%= provider_name.upcase %>_instance_power_on
+            - <%= provider_name.upcase %>_instance_power_off
+<% end %>
 :http_proxy:
   :<%= provider_name %>:
     :host:
     :password:
     :port:
     :user:
+<% if options[:dummy] %>
+:workers:
+  :worker_base:
+    :event_catcher:
+      :event_catcher_<%= provider_name %>:
+        :poll: 20.seconds
+    :queue_worker_base:
+      :ems_metrics_collector_worker:
+        :ems_metrics_collector_worker_<%= provider_name %>: {}
+      :ems_refresh_worker:
+        :ems_refresh_worker_<%= provider_name %>: {}
+<% end %>


### PR DESCRIPTION
Add dummy options to generate a dummy provider with cloud manager which has dummy implementations of the following workers
1. refresh worker
2. metric collector
3. event catcher
===
```
Usage:
  rails generate provider NAME [options]

Options:
  [--path=PATH]            # Create provider at given path
                           # Default: plugins
  [--vcr], [--no-vcr]      # Enable VCR cassettes (default off)
  [--dummy], [--no-dummy]  # Generate dummy implementations (default off)

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Create or update provider

Example:
    rails generate provider VendorName
```