### PR TITLE
[WIP] Fix sporadic spec about custom attributes

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -20,8 +20,9 @@ describe MiqExpression do
       expected_columns = (ChargebackVm.attribute_names - extra_fields).map { |x| "ChargebackVm-#{x}" }
 
       expected_columns.push(*displayed_columms.select { |x| x.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX) })
+      expected_columns.push("#{vm.class}-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}#{custom_attribute.name}")
 
-      expect(displayed_columms).to match_array(expected_columns)
+      expect(displayed_columms).to match_array(expected_columns.uniq)
     end
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -19,9 +19,8 @@ describe MiqExpression do
       displayed_columms = described_class.reporting_available_fields('ChargebackVm').map(&:second)
       expected_columns = (ChargebackVm.attribute_names - extra_fields).map { |x| "ChargebackVm-#{x}" }
 
-      CustomAttribute.all.each do |custom_attribute|
-        expected_columns.push("#{vm.class}-#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}#{custom_attribute.name}")
-      end
+      expected_columns.push(*displayed_columms.select { |x| x.include?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX) })
+
       expect(displayed_columms).to match_array(expected_columns)
     end
   end


### PR DESCRIPTION
Issue
----------------
There are added some attributes to `ChargebackVm` class by other spec during this test between, line
```ruby
# reporting_available_fields added some attributes to class ChargebackVm :
displayed_columms = described_class.reporting_available_fields('ChargebackVm').map(&:second)

...
# other specs add some custom attributes 
...

but CustomAttribute.all is different count that as was loaded by described_class.reporting_available_fields
```

So I update spec to avoid this behaviour.

Links
----------------

* https://travis-ci.org/ManageIQ/manageiq/jobs/298928343

cc @gtanzillo 
@miq-bot assign @chrisarcand 

@miq-bot add_label bug/sporadic test failure, test