### PR TITLE
some production enhancement to pg_inspector

### DIFF
--- a/spec/tools/pg_inspector/active_connections_to_human_spec.rb
+++ b/spec/tools/pg_inspector/active_connections_to_human_spec.rb
@@ -1,0 +1,19 @@
+$LOAD_PATH << Rails.root.join("tools")
+
+require 'pg_inspector'
+
+describe PgInspector::ActiveConnectionsHumanYAML do
+  it "#compress_id" do
+    subject = described_class.new
+    expect(subject.send(:compress_id, 5)).to eq("5")
+    expect(subject.send(:compress_id, 1_000_000_000_005)).to eq("1r5")
+    expect(subject.send(:compress_id, 2_000_000_000_005)).to eq("2r5")
+  end
+
+  it "#uncompress_id" do
+    subject = described_class.new
+    expect(subject.send(:uncompress_id, "5")).to eq(5)
+    expect(subject.send(:uncompress_id, "1r5")).to eq(1_000_000_000_005)
+    expect(subject.send(:uncompress_id, "2r5")).to eq(2_000_000_000_005)
+  end
+end

--- a/tools/pg_inspector/active_connections_to_yaml.rb
+++ b/tools/pg_inspector/active_connections_to_yaml.rb
@@ -107,7 +107,7 @@ SQL
 
       rows_array.each do |row|
         next unless row["application_name"].end_with?('..')
-        error_msg = "The application name for MIQ server/worker: {#app_name} is truncated"
+        error_msg = "The application name for MIQ server/worker: #{row["application_name"]} is truncated"
         if options[:ignore_error]
           $stderr.puts error_msg
         else

--- a/tools/pg_inspector/inspect_pg.rb
+++ b/tools/pg_inspector/inspect_pg.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+## Run pg_inspector using parameters given in local database.yml and v2 key.
+
+if __FILE__ == $PROGRAM_NAME
+  $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(.. .. lib))))
+end
+
+require 'yaml'
+require 'manageiq-gems-pending'
+require 'util/miq-password'
+
+BASE_DIR = __dir__
+LOG_DIR = '/var/www/miq/vmdb/log'.freeze
+DATABASE_YML_FILE_PATH = "#{BASE_DIR}/../../config/database.yml".freeze
+V2_KEY_FILE_PATH = "#{BASE_DIR}/../../certs/v2_key".freeze
+
+production_db = YAML.load_file(DATABASE_YML_FILE_PATH)["production"]
+
+db_user = production_db["username"]
+db_password_encrypt = production_db["password"]
+db_password = MiqPassword.try_decrypt(db_password_encrypt)
+db_host = production_db["host"]
+
+# system "#{BASE_DIR}/../pg_inspector.rb -h"
+ENV['PGPASSWORD'] = db_password
+system("#{BASE_DIR}/../pg_inspector.rb connections -u #{db_user} -s #{db_host} -i")
+if File.exist?(Pathname.new(LOG_DIR).join('pg_inspector_server.yml'))
+  puts("pg_inspector_server.yml already exists, skip generating.")
+else
+  system("#{BASE_DIR}/../pg_inspector.rb servers -u #{db_user} -s #{db_host}")
+end
+system("#{BASE_DIR}/../pg_inspector.rb human")
+success = system("#{BASE_DIR}/../pg_inspector.rb locks")
+unless success
+  exit(1)
+end

--- a/tools/pg_inspector/inspect_pg.sh
+++ b/tools/pg_inspector/inspect_pg.sh
@@ -5,7 +5,6 @@ basedir=$(dirname $0)
 logdir=/var/www/miq/vmdb/log
 logfile=${logdir}/pg_inspector.log
 # default postgresql password: smartvm
-export PGPASSWORD="${PGPASSWORD:-smartvm}"
 
 # show message on screen and also append to log file
 exec > >(tee -ia ${logfile})
@@ -14,9 +13,7 @@ echo ""
 echo "inspect_pg runs on $(date)"
 
 # Run step 1, 3 and 4 in sequence, assume step 2 has done before.
-${basedir}/../pg_inspector.rb connections
-${basedir}/../pg_inspector.rb human
-${basedir}/../pg_inspector.rb locks
+bundle exec ${basedir}/inspect_pg.rb
 
 # remove first only if all steps success
 if [ $? -ne '0' ]; then

--- a/tools/pg_inspector/inspect_pg_server.rb
+++ b/tools/pg_inspector/inspect_pg_server.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+## Run pg_inspector servers using parameters given in local database.yml and v2 key.
+
+if __FILE__ == $PROGRAM_NAME
+  $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(.. .. lib))))
+end
+
+require 'yaml'
+require 'manageiq-gems-pending'
+require 'util/miq-password'
+
+BASE_DIR = __dir__
+LOG_DIR = '/var/www/miq/vmdb/log'.freeze
+DATABASE_YML_FILE_PATH = "#{BASE_DIR}/../../config/database.yml".freeze
+V2_KEY_FILE_PATH = "#{BASE_DIR}/../../certs/v2_key".freeze
+
+production_db = YAML.load_file(DATABASE_YML_FILE_PATH)["production"]
+
+db_user = production_db["username"]
+db_password_encrypt = production_db["password"]
+db_password = MiqPassword.try_decrypt(db_password_encrypt)
+db_host = production_db["host"]
+
+# system "#{BASE_DIR}/../pg_inspector.rb -h"
+ENV['PGPASSWORD'] = db_password
+system("#{BASE_DIR}/../pg_inspector.rb servers -u #{db_user} -s #{db_host}")

--- a/tools/pg_inspector/inspect_pg_server.rb
+++ b/tools/pg_inspector/inspect_pg_server.rb
@@ -1,9 +1,5 @@
 #!/usr/bin/env ruby
-require 'bundler/inline'
-
-gemfile do
-  gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-end
+require 'bundler/setup'
 
 ## Run pg_inspector servers using parameters given in local database.yml and v2 key.
 

--- a/tools/pg_inspector/inspect_pg_server.rb
+++ b/tools/pg_inspector/inspect_pg_server.rb
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+require 'bundler/inline'
+
+gemfile do
+  gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
+end
 
 ## Run pg_inspector servers using parameters given in local database.yml and v2 key.
 


### PR DESCRIPTION
 some production enhancement to pg_inspector

- compatible to current and previous version of miq application name
- output blocked connections to separate file
- use database.yml
- only generate server.yml when not exists
- add a ruby wrap for decrypt password and cron to run pg_inspector_server with database.yml information 

\cc @jrafanie @yrudman @gtanzillo 
@miq-bot add-label wip, tools