### PR TITLE
Fix special characters in dynamic sub metric column of chargeback storage type column

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -609,6 +609,11 @@ class MiqExpression
       column_human = if col
                        if col.starts_with?(CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX)
                          CustomAttributeMixin.to_human(col)
+                       elsif parsed_field.try(:storage_allocated_field?)
+                         uri_parser = URI::RFC2396_Parser.new
+                         dict_col = "#{parsed_field.model}.#{uri_parser.escape(parsed_field.column, /\./)}"
+                         human_value = Dictionary.gettext(dict_col, :type => :column, :notfound => :titleize)
+                         URI::RFC2396_Parser.new.unescape(human_value.gsub('%2 E', '%2E'))
                        else
                          Dictionary.gettext(dict_col, :type => :column, :notfound => :titleize)
                        end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -573,7 +573,10 @@ class MiqExpression
       :include_model => true,
       :include_table => true
     }.merge(options)
-    tables, col = val.split("-")
+
+    parsed_field ||= MiqExpression::ChargeableField.parse(val)
+    tables, col = parsed_field ? [parsed_field.model.to_s, parsed_field.column] : val.split("-")
+
     first = true
     val_is_a_tag = false
     ret = ""

--- a/lib/miq_expression/chargeable_field.rb
+++ b/lib/miq_expression/chargeable_field.rb
@@ -1,9 +1,10 @@
 class MiqExpression::ChargeableField < MiqExpression::Target
   STORAGE_ALLOCATED_PREFIX = 'storage_allocated_'.freeze
+  SPECIAL_CHARACTERS = '_./,;\\-{}()*&^% $#@!+"\''.freeze
 
   REGEX = /
 (?<model_name>([[:alnum:]]*(::)?){4})
--(?<column>#{STORAGE_ALLOCATED_PREFIX}[a-z]+[_\-[:alnum:]]+)
+-(?<column>#{STORAGE_ALLOCATED_PREFIX}[#{SPECIAL_CHARACTERS}[:alnum:]]+)
 /x
 
   def self.parse(field)
@@ -12,5 +13,9 @@ class MiqExpression::ChargeableField < MiqExpression::Target
     parsed_params = parse_params(field) || return
     return unless parsed_params[:model_name]
     new(parsed_params[:model_name], nil, parsed_params[:column])
+  end
+
+  def storage_allocated_field?
+    @column.include?(STORAGE_ALLOCATED_PREFIX)
   end
 end

--- a/lib/miq_expression/chargeable_field.rb
+++ b/lib/miq_expression/chargeable_field.rb
@@ -1,0 +1,16 @@
+class MiqExpression::ChargeableField < MiqExpression::Target
+  STORAGE_ALLOCATED_PREFIX = 'storage_allocated_'.freeze
+
+  REGEX = /
+(?<model_name>([[:alnum:]]*(::)?){4})
+-(?<column>#{STORAGE_ALLOCATED_PREFIX}[a-z]+[_\-[:alnum:]]+)
+/x
+
+  def self.parse(field)
+    return unless field.include?(STORAGE_ALLOCATED_PREFIX)
+
+    parsed_params = parse_params(field) || return
+    return unless parsed_params[:model_name]
+    new(parsed_params[:model_name], nil, parsed_params[:column])
+  end
+end

--- a/spec/lib/miq_expression/chargeable_field_spec.rb
+++ b/spec/lib/miq_expression/chargeable_field_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe MiqExpression::ChargeableField do
+  describe '.parse' do
+    it 'parses chargeable field with sub metric type' do
+      field = 'ChargebackVm-storage_allocated_ceph-sas_cost'
+      expect(described_class.parse(field)).to have_attributes(:model => ChargebackVm, :column => 'storage_allocated_ceph-sas_cost')
+    end
+
+    it 'parses chargeable field' do
+      field = 'ChargebackVm-storage_allocated_cost'
+      expect(described_class.parse(field)).to have_attributes(:model => ChargebackVm, :column => 'storage_allocated_cost')
+      field = 'ChargebackContainerProject-storage_allocated_cost'
+      expect(described_class.parse(field)).to have_attributes(:model => ChargebackContainerProject, :column => 'storage_allocated_cost')
+    end
+
+    it 'doesn\'t parse field model.belongs_to_associations with invalid format' do
+      field = 'Vm.host'
+      expect(described_class.parse(field)).to be_nil
+    end
+
+    it 'doesn\'t parse field with format of MiqExpression::Field::REGEX' do
+      field = 'Vm.host-name'
+      expect(described_class.parse(field)).to be_nil
+    end
+
+    it 'doesn\'t parse field with invalid format' do
+      field = 'sdfsdf.host'
+      expect(described_class.parse(field)).to be_nil
+    end
+  end
+end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -84,6 +84,13 @@ describe MiqExpression do
       human_form = described_class.value2human('ChargebackVm-storage_allocated_ceph-sas_cost')
       expect(human_form).to eq('Chargeback for Vms : Storage Allocated Ceph Sas Cost')
     end
+
+    let(:cloud_volume_other_type) { './,; {}()*&^%$#@!)(+"\'' }
+
+    it 'transforms column with more special characters' do
+      human_form = described_class.value2human("ChargebackVm-storage_allocated_#{cloud_volume_other_type}_cost")
+      expect(human_form).to eq("Chargeback for Vms : Storage Allocated #{cloud_volume_other_type} Cost")
+    end
   end
 
   describe "#valid?" do

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -79,6 +79,13 @@ describe MiqExpression do
     end
   end
 
+  describe '.value2human' do
+    it 'transforms ' do
+      human_form = described_class.value2human('ChargebackVm-storage_allocated_ceph-sas_cost')
+      expect(human_form).to eq('Chargeback for Vms : Storage Allocated Ceph Sas Cost')
+    end
+  end
+
   describe "#valid?" do
     it "returns true for a valid flat expression" do
       expression = described_class.new("=" => {"field" => "Vm-name", "value" => "foo"})


### PR DESCRIPTION
chargeable field with cloud volume type = column used in chargeback report, the column is based on`CloudVolume#type`
example:
`ChargebackVm-storage_allocated_ceph-sas_cost`
The part `ceph-sas` is `CloudVolume#type` and it is from cloud provider and input can be probably whatever as we tried in openstack UI. But I think commonly will be used "-" in the type.

This column is processed in `MiqExpression#value2human` where was used parsing like `.split("-")` and it was causing issues. So I added `MiqExpression::ChargebackField` class with `REGEX` to cover this. And I also used more special characters in MiqExpression::ChargebackField.

Reporting generation is working correctly with such columns.

<img width="1431" alt="screen shot 2018-01-12 at 11 53 32" src="https://user-images.githubusercontent.com/14937244/34871828-4312f42c-f78f-11e7-80c8-20a010021cef.png">

@miq-bot assign @gtanzillo 
@miq-bot add_label chargeback, bug
# Links
https://github.com/ManageIQ/manageiq-ui-classic/pull/2670