### PR TITLE
Fixes typo in en.yml

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -990,8 +990,8 @@ en:
       ems_object_storages:         Object Storage Managers
       evm_server:                  EVM Server
       ems_network:                 Network Provider
-      ems_phyical_infra:           Physical Infrastructure Provider
-      ems_phyical_infras:          Physical Infrastructure Providers
+      ems_physical_infra:          Physical Infrastructure Provider
+      ems_physical_infras:         Physical Infrastructure Providers
       ems_storage:                 Storage Manager
       floating_ips:                Floating IP
       load_balancer:               Load Balancer


### PR DESCRIPTION
Fixes typo in locale/en.yml that was having unintended results in the UI presentation of the provider summary page and provider list page.

manageiq-ui-classic is unable to show the appropriate tool tips for these pages due to this missing definition.

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @agrare 