### PR TITLE
Add prometheus metrics timeout settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1215,3 +1215,6 @@
       :count: 1
 :hawkular_tenant_labels:
   :_hawkular_admin: Hawkular Admin
+:prometheus_metrics:
+  :open_timeout: 5
+  :request_timeout: 30


### PR DESCRIPTION
**Description**

Metrics collection from OCP 3.7 using Prometheus may hit timeout while collecting metrics.

a. the default timeouts are too small
b. users can not set new timeout values to fit their system

This PR adds the settings needed to adjust the timeouts.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1511341