### PR TITLE
Unique EmsRefresh.refresh targets if there are over 1,000 targets

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -170,6 +170,7 @@ module EmsRefresh
     # Items will be naturally serialized since there is a dedicated worker.
     MiqQueue.put_or_update(queue_options) do |msg, item|
       targets = msg.nil? ? targets : msg.data.concat(targets)
+      targets.uniq! if targets.size > 1_000
 
       # If we are merging with an existing queue item we don't need a new
       # task, just use the original one


### PR DESCRIPTION
RFC on if we should put back the unique check for ems_refresh targets

cc @Fryguy @Ladas 

https://bugzilla.redhat.com/show_bug.cgi?id=1516401