### PR TITLE
Update generic object property method normalization

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -162,7 +162,7 @@ class GenericObjectDefinition < ApplicationRecord
 
   def normalize_property_methods
     props = properties.symbolize_keys
-    properties[:methods] = props[:methods].collect(&:to_s)
+    properties[:methods] = props[:methods].flatten.collect(&:to_s)
   end
 
   def validate_property_attributes


### PR DESCRIPTION
Currently, when custom buttons are added to a generic object, they show up in property methods as an array. This is causing an [\"invalid method name: [[\\\"button1\\\"]]\"] error during property method name validation. By flattening the array, calling custom actions can proceed as normal.

I discovered this while working on custom action button calling in the API. It was returning them just fine, but causing problems when trying to call the custom action.

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @gmcculloug 