### PR TITLE
Fix nil cases of allocated disk types in chargeback reporting

### DIFF
--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -71,7 +71,7 @@ class Chargeback
 
     def sub_metric_rollups(sub_metric)
       q = VimPerformanceState.where(:timestamp => start_time...end_time, :resource => resource, :capture_interval => 3_600)
-      q.map { |x| x.allocated_disk_types[sub_metric] || 0 }
+      q.map { |x| x.state_data.try(:[], :allocated_disk_types).try(:[], sub_metric) || 0 }
     end
 
     def values(metric, sub_metric = nil)

--- a/spec/models/chargeback/consumption_with_rollups_spec.rb
+++ b/spec/models/chargeback/consumption_with_rollups_spec.rb
@@ -1,0 +1,38 @@
+describe Chargeback::ConsumptionWithRollups do
+  let(:vm)          { FactoryGirl.build(:vm_microsoft) }
+  let(:consumption) { described_class.new([metric_rollup], starting_date, starting_date + 1.day) }
+
+  describe '#sub_metric_rollups' do
+    let(:starting_date)        { Time.parse('2012-09-01 23:59:59Z').utc }
+    let(:sub_metric)           { 'ssd' }
+    let(:ssd_volume)           { FactoryGirl.create(:cloud_volume_openstack, :volume_type => sub_metric) }
+    let!(:state)         { FactoryGirl.create(:vim_performance_state, :resource => vm, :state_data => nil, :timestamp => starting_date, :capture_interval => 3_600) }
+    let!(:metric_rollup) { FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => starting_date + 1.hour, :resource => vm) }
+
+    before do
+      Timecop.travel(starting_date)
+    end
+
+    it "doesn't fail when there are no state data about disks" do
+      expect(consumption.send(:values, 'derived_vm_allocated_disk_storage', sub_metric)).to match_array([0])
+    end
+
+    context 'vim performance state contains any state data for storage' do
+      let(:volume_size) { 1_024 }
+
+      before do
+        state.capture
+        state.allocated_disk_types = {sub_metric => volume_size}
+        state.save
+      end
+
+      it 'returns values' do
+        expect(consumption.send(:values, 'derived_vm_allocated_disk_storage', sub_metric)).to match_array([volume_size])
+      end
+    end
+
+    after do
+      Timecop.return
+    end
+  end
+end

--- a/spec/models/vim_performance_state_spec.rb
+++ b/spec/models/vim_performance_state_spec.rb
@@ -59,5 +59,18 @@ RSpec.describe VimPerformanceState do
     subject { vm.perf_capture_state.allocated_disk_types }
 
     it { is_expected.to match('ssd' => ssd_size, 'unclassified' => hdd1_size + hdd2_size) }
+
+    context 'when disk size is nil' do
+      let!(:hdd1_disk) { FactoryGirl.create(:disk, :size => nil, :backing => hdd_volume) }
+
+      it { is_expected.to match('ssd' => ssd_size, 'unclassified' => hdd2_size) }
+
+      context "when all disk's sizes are nil" do
+        let!(:hdd2_disk) { FactoryGirl.create(:disk, :size => nil, :backing => hdd_volume) }
+        let!(:ssd_disk)  { FactoryGirl.create(:disk, :size => nil, :backing => ssd_volume) }
+
+        it { is_expected.to be_empty }
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix nil cases and use 0
VimPerformanceState#allocated_disk_types
is dynamic method, which is only accessing

VimPerformanceState#state_data[:allocated_disk_types]

this fix is handling situation when
VimPerformanceState#state_data is nil
VimPerformanceState#state_data[:allocated_disk_types] is nil
VimPerformanceState#state_data[:allocated_disk_types][sub_metric] is nil

and replacing it by 0


@miq-bot assign @gtanzillo 

@miq-bot add_label gapridashvili/yes, bug, chargeback
