### PR TITLE
Add the public/webmks folder to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ public/upload
 public/pictures/
 public/ui/
 /public/packs
+/public/webmks
 
 # tmp/
 tmp/*


### PR DESCRIPTION
Will make the life of the developers who work with consoles easier. Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/2682

@miq-bot add_label developer