### PR TITLE
Refresh new target do not run post_refresh

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -109,7 +109,7 @@ module EmsRefresh
     end
 
     ems.refresher.refresh(get_target_objects(target))
-
+    target.post_create_actions_queue if target.respond_to?(:post_create_actions_queue)
     target
   end
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -184,7 +184,10 @@ describe EmsRefresh do
   end
 
   context '.refresh_new_target' do
-    let(:ems) { FactoryGirl.create(:ems_vmware) }
+    let(:ems) do
+      _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
+      FactoryGirl.create(:ems_vmware, :zone => zone)
+    end
 
     context 'targeting a new vm' do
       let(:vm_hash) do


### PR DESCRIPTION
In case when we run refresh_new_target a vm is created before the
refresh was run so we need to make sure it is picked up by post_refresh.

Bug-Url:
https://bugzilla.redhat.com/1510459