### PR TITLE
Remove Host#acts_as_ems?

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -47,8 +47,6 @@ module EmsRefresh
             t.ext_management_system
           elsif t.respond_to?(:manager) && t.manager
             t.manager
-          elsif t.kind_of?(Host) && t.acts_as_ems?
-            t
           end
 
       h[e] << t unless e.nil?

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -539,11 +539,6 @@ class Host < ApplicationRecord
     ret.include?("unknown") ? nil : ret
   end
 
-  def acts_as_ems?
-    product = vmm_product.to_s.downcase
-    ['hyperv', 'hyper-v'].any? { |p| product.include?(p) }
-  end
-
   def refreshable_status
     if ext_management_system
       return {:show => true, :enabled => true, :message => ""}

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -92,10 +92,6 @@ module PerEmsWorkerMixin
     end
 
     def queue_name_for_ems(ems)
-      # Host objects do not have dedicated refresh workers so request a generic worker which will
-      # be used to make a web-service call to a SmartProxy to initiate inventory collection.
-      return "generic" if ems.kind_of?(Host) && ems.acts_as_ems?
-
       return ems unless ems.kind_of?(ExtManagementSystem)
       ems.queue_name
     end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1600,9 +1600,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def has_active_ems?
-    # If the VM does not have EMS connection see if it is using SmartProxy as the EMS
     return true unless ext_management_system.nil?
-    return true if host && host.acts_as_ems? && host.is_proxy_active?
     false
   end
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -26,11 +26,6 @@ describe EmsRefresh do
       queue_refresh_and_assert_queue_item(target, [target])
     end
 
-    it "with Host acting as an Ems" do
-      target = FactoryGirl.create(:host_microsoft)
-      queue_refresh_and_assert_queue_item(target, [target])
-    end
-
     it "with Vm" do
       target = FactoryGirl.create(:vm_vmware, :ext_management_system => @ems)
       queue_refresh_and_assert_queue_item(target, [target])


### PR DESCRIPTION
I was cleaning up the `PerEmsWorkerMixin.queue_name_for_ems` and found a strange `host.acts_as_ems?` condition.

It looks like we used to use `SmartProxy` to aggregate Hyper-V hosts, possibly before SCVMM.  @Fryguy Is this still a thing we do or do we only support SCVMM now?