### PR TITLE
[EUWE] Further improve the /api/service endpoint

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -176,9 +176,15 @@ module Api
         options[:offset], options[:limit] = expand_paginate_params if paginate_params?
         options[:filter] = miq_expression if miq_expression
 
-        res = Rbac.filtered(res, options)
+        res = rbac_filtered(res, options)
         preload_for_expansion!(res, type)
         res
+      end
+
+      # FIXME:  Makes it so it can be overridden in subclasses.  So basically,
+      # this is a HACK.  Should try and make this so it can be re-used.
+      def rbac_filtered(res, options)
+        Rbac.filtered(res, options)
       end
 
       def preload_for_expansion!(resources, type)

--- a/app/controllers/api/services_controller.rb
+++ b/app/controllers/api/services_controller.rb
@@ -162,5 +162,13 @@ module Api
       msg = valid ? "" : "Action #{action} is not available for #{service_ident(svc)}"
       action_result(valid, msg)
     end
+
+    def rbac_filtered(res, options)
+      klass = collection_class(@req.subcollection ? @req.subcollection.to_sym : @req.collection.to_sym)
+      options[:extra_cols] = virtual_attributes_list(klass.new).select do |col|
+                               klass.attribute_supported_by_sql?(col)
+                             end
+      super(res, options)
+    end
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -39,7 +39,6 @@ class Service < ApplicationRecord
   virtual_has_many   :vms
   virtual_has_many   :all_vms
   virtual_has_many   :power_states, :uses => :all_vms
-  virtual_total      :v_total_vms, :vms
 
   virtual_has_one    :custom_actions
   virtual_has_one    :custom_action_buttons, :uses => {:service_template => :custom_action_buttons}
@@ -63,6 +62,9 @@ class Service < ApplicationRecord
 
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'
+
+  virtual_total :v_total_vms, :vms,
+                :arel => aggregate_hardware_arel("v_total_vms", vms_tbl[:id].count, :skip_hardware => true)
 
   virtual_column :has_parent,                               :type => :boolean
   virtual_column :power_state,                              :type => :string

--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -168,8 +168,11 @@ module Service::Aggregation
     def base_service_aggregation_join(arel, services_tbl, options = {})
       arel.join(service_resources_tbl).on(service_resources_tbl[:service_id].eq(services_tbl[:id])
                                   .and(service_resources_tbl[:resource_type].eq(vm_or_template_type)))
-          .join(vms_tbl).on(vm_join_clause(options))
-          .join(hardwares_tbl).on(hardwares_tbl[:vm_or_template_id].eq(vms_tbl[:id]))
+          .join(vms_tbl).on(vm_join_clause(options)).tap do |arel_query|
+            unless options[:skip_hardware]
+              arel_query.join(hardwares_tbl).on(hardwares_tbl[:vm_or_template_id].eq(vms_tbl[:id]))
+            end
+          end
     end
 
     # Generates the following SQL conditional to be used in


### PR DESCRIPTION
Does a few things:

* Turns `v_total_vms` into an `arel` based virtual_total (really messy because we are using a `virtual_has_many` relationship for the ruby implementation for services => vms)
* Moves the `Rbac.filtered` to a `rbac_filtered` method in the `app/controllers/api/base_controller/renderer.rb`, that can be overwritten in the subclass controllers
* Overwrites `rbac_filtered` in the `Api::ServicesController`, and includes the `:extra_cols` option to `Rbac`, with the virtual attributes that are accessible via SQL


Benchmarks
----------

In the example route I was hitting:

```
/api/services?expand=resources&attributes=picture%2Cpicture.image_href%2Cevm_owner.name%2Cv_total_vms&filter[]=service_id%3Dnil
```

the `attributes` included some other `virtual_columns`, but only the `v_total_vms` column was accessible through SQL, and was reducing the number of SQL calls by a significant margin.

The results are with a DB that only has 42 services, and the DB was local in these benchmarks, so DB times will probably be inflated in most production appliance installations due to latency:

**Before:**

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 3283 |     123 |         95 | 1511 |
|  367 |     119 |       50.1 |  223 |
|  364 |     119 |       48.3 |  223 |
|  418 |     119 |       52.0 |  223 |
|  411 |     119 |       53.9 |  223 |

**After:**

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  544 |      39 |         24 | 1445 |
|  265 |      35 |       17.0 |  157 |
|  238 |      35 |       18.3 |  157 |
|  225 |      35 |       16.9 |  157 |
|  234 |      35 |       17.7 |  157 |



Links
-----

* Similar to https://github.com/ManageIQ/manageiq/pull/16426
* Uses features from https://github.com/ManageIQ/manageiq/pull/11502 and https://github.com/ManageIQ/manageiq/pull/13101


Steps for Testing/QA
--------------------

If either @chrisarcand and/or @Fryguy could run through the tests they did for https://github.com/ManageIQ/manageiq/pull/16426, that would be good, but effectively I was doing a `curl` against the following path:

```
/api/services?expand=resources&attributes=picture%2Cpicture.image_href%2Cevm_owner.name%2Cv_total_vms&filter[]=service_id%3Dnil
```

And did it 5 times to make sure any autoloading and caches were warmed.


**UPDATE:**

Got my changes for `manageiq_performance` compiled into a PR ( https://github.com/ManageIQ/manageiq-performance/pull/35 ), which was how I was running the tests.

If you add the following to a local gemfile in `manageiq` and `bundle update`:

```ruby
# bundler.d/Gemfile.dev.rb
gem 'manageiq-performance', :require => [ 'manageiq_performance/railtie/rake_tasks',
                                          'manageiq_performance/railtie/middleware' ],
                            :git     => "https://github.com/ManageIQ/manageiq-performance",
                            :branch  => "api_requestor",
```

You can run the following to run benchmarks against the URL from above:

```console
$ bundle exec miqperf benchmark --api --count=5 "/api/services?expand=resources&attributes=picture%2Cpicture.image_href%2Cevm_owner.name%2Cv_total_vms&filter[]=service_id%3Dnil"
```

And then view the results by running:

```console
$ bundle exec miqperf results --last
/api/services
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  544 |      39 |         24 | 1445 |
|  265 |      35 |       17.0 |  157 |
|  238 |      35 |       18.3 |  157 |
|  225 |      35 |       16.9 |  157 |
|  234 |      35 |       17.7 |  157 |
```

You can also see a summary of the SQL queries made using this shell oneliner:

```console
$ cat $(ls -d tmp/manageiq_performance/run_* | tail -1)/**/*.queries | grep ":sql:" | sort | uniq -c | sort -r
```

Which will sort and display the start of the most common types queries made across all runs.  To view the raw files, run:

```console
$ vim $(ls -d tmp/manageiq_performance/run_* | tail -1)/**/*.queries
```

To view the extended info of the requests you just profiled, swapping `vim` with your editor of choice (milage may vary though depending on how your editor of choice handles opening multiple files through bash expansion).

cc: @kbrock