### PR TITLE
Add scope :without_configuration_profile_id needed by Foreman explorer UI

### DIFF
--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -44,6 +44,7 @@ class ConfiguredSystem < ApplicationRecord
   scope :with_inventory_root_group,     ->(group_id)   { where(:inventory_root_group_id => group_id) }
   scope :with_manager,                  ->(manager_id) { where(:manager_id => manager_id) }
   scope :with_configuration_profile_id, ->(profile_id) { where(:configuration_profile_id => profile_id) }
+  scope :without_configuration_profile_id,          -> { where(:configuration_profile_id => nil) }
 
   def configuration_architecture
     tag_hash[ConfigurationArchitecture]


### PR DESCRIPTION
This is needed in https://github.com/ManageIQ/manageiq-ui-classic/pull/2694