### PR TITLE
Missing cascade delete for host_storages

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -44,7 +44,7 @@ class Host < ApplicationRecord
   has_many                  :vms_and_templates, :dependent => :nullify
   has_many                  :vms, :inverse_of => :host
   has_many                  :miq_templates, :inverse_of => :host
-  has_many                  :host_storages
+  has_many                  :host_storages, :dependent => :destroy
   has_many                  :storages, :through => :host_storages
   has_many                  :host_switches, :dependent => :destroy
   has_many                  :switches, :through => :host_switches

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -2,7 +2,7 @@ class Storage < ApplicationRecord
   has_many :vms_and_templates, :foreign_key => :storage_id, :dependent => :nullify, :class_name => "VmOrTemplate"
   has_many :miq_templates,     :foreign_key => :storage_id
   has_many :vms,               :foreign_key => :storage_id
-  has_many :host_storages
+  has_many :host_storages,     :dependent => :destroy
   has_many :hosts,             :through => :host_storages
   has_many :storage_profile_storages,   :dependent  => :destroy
   has_many :storage_profiles,           :through    => :storage_profile_storages


### PR DESCRIPTION
Missing cascade delete for host_storages, leading to orphaned
records.

Fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1508910
