### PR TITLE
Add #raw_stdout_via_worker method

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -7,4 +7,26 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
     update_attributes(:retirement_requester => requester)
     finish_retirement
   end
+
+  # Intend to be called by UI to display stdout. Therefore the error message directly returned
+  # instead of raising an exception.
+  def raw_stdout_via_worker(userid = User.current_user, format = 'txt')
+    unless MiqRegion.my_region.role_active?("embedded_ansible")
+      return "Cannot get standard output of this playbook because the embedded Ansible role is not enabled"
+    end
+
+    options = {:userid => userid, :action => 'ansible_stdout'}
+    queue_options = {:class_name  => self.class,
+                     :method_name => 'raw_stdout',
+                     :instance_id => id,
+                     :args        => [format],
+                     :priority    => MiqQueue::HIGH_PRIORITY,
+                     :role        => 'embedded_ansible'}
+    taskid = MiqTask.generic_action_with_callback(options, queue_options)
+    MiqTask.wait_for_taskid(taskid)
+    miq_task = MiqTask.find(taskid)
+    results = miq_task.task_results || miq_task.message
+    miq_task.destroy
+    results
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -7,4 +7,45 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
     expect(job).to receive(:finish_retirement).once
     job.retire_now
   end
+
+  describe '#raw_stdout_via_worker' do
+    before do
+      EvmSpecHelper.create_guid_miq_server_zone
+      region = MiqRegion.seed
+      allow(region).to receive(:role_active?).with("embedded_ansible").and_return(role_enabled)
+      allow(MiqRegion).to receive(:my_region).and_return(region)
+    end
+
+    context 'when embedded_ansible role is enabled' do
+      let(:role_enabled) { true }
+
+      before do
+        allow(described_class).to receive(:find).and_return(job)
+
+        allow(MiqTask).to receive(:wait_for_taskid) do
+          request = MiqQueue.find_by(:class_name => described_class.name)
+          request.update_attributes(:state => MiqQueue::STATE_DEQUEUE)
+          request.delivered(*request.deliver)
+        end
+      end
+
+      it 'gets stdout from the job' do
+        expect(job).to receive(:raw_stdout).and_return('A stdout from the job')
+        expect(job.raw_stdout_via_worker).to eq('A stdout from the job')
+      end
+
+      it 'returns the error message' do
+        expect(job).to receive(:raw_stdout).and_throw('Failed to get stdout from the job')
+        expect(job.raw_stdout_via_worker).to include('Failed to get stdout from the job')
+      end
+    end
+
+    context 'when embedded_ansible role is disabled' do
+      let(:role_enabled) { false }
+
+      it 'returns an error message' do
+        expect(job.raw_stdout_via_worker).to eq('Cannot get standard output of this playbook because the embedded Ansible role is not enabled')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add `Job#raw_stdout_via_worker` method mainly used by UI to get and display a standard output from an Ansible job. The implementation detects whether the embedded role is enabled and gets the output through the embedded ansible worker.

An error message is returned when it fails to get the stdout, so the caller does not need to rescue an error.

Solves https://github.com/ManageIQ/manageiq-ui-classic/issues/2470