### PR TITLE
Move graph refresh internals logging to debug

### DIFF
--- a/app/models/manager_refresh/save_collection/base.rb
+++ b/app/models/manager_refresh/save_collection/base.rb
@@ -2,16 +2,16 @@ module ManagerRefresh::SaveCollection
   class Base
     class << self
       def save_inventory_object_inventory(ems, inventory_collection)
-        _log.info("SYNCHRONIZING collection #{inventory_collection} of size #{inventory_collection.size} to"\
-                  " the database, for the manager: '#{ems.name}'")
+        _log.debug("Saving collection #{inventory_collection} of size #{inventory_collection.size} to"\
+                   " the database, for the manager: '#{ems.name}'...")
 
         if inventory_collection.custom_save_block.present?
-          _log.info("SYNCHRONIZING collection #{inventory_collection} using a custom save block")
+          _log.debug("Saving collection #{inventory_collection} using a custom save block")
           inventory_collection.custom_save_block.call(ems, inventory_collection)
         else
           save_inventory(inventory_collection)
         end
-        _log.info("SYNCHRONIZED collection #{inventory_collection}, for the manager: '#{ems.name}'")
+        _log.debug("Saving collection #{inventory_collection}, for the manager: '#{ems.name}'...Complete")
         inventory_collection.saved = true
       end
 

--- a/app/models/manager_refresh/save_collection/recursive.rb
+++ b/app/models/manager_refresh/save_collection/recursive.rb
@@ -31,7 +31,7 @@ module ManagerRefresh::SaveCollection
           end
         end
 
-        _log.info("Saving #{inventory_collection} of size #{inventory_collection.size}")
+        _log.debug("Saving #{inventory_collection} of size #{inventory_collection.size}")
         save_inventory_object_inventory(ems, inventory_collection)
       end
     end

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -84,7 +84,7 @@ module ManagerRefresh::SaveCollection
           inventory_objects_index[index] = inventory_object
         end
 
-        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection.size} *************")
+        _log.debug("Processing #{inventory_collection} of size #{inventory_collection.size}...")
         # Records that are in the DB, we will be updating or deleting them.
         ActiveRecord::Base.transaction do
           association.find_each do |record|
@@ -121,10 +121,10 @@ module ManagerRefresh::SaveCollection
             end
           end
         end
-        _log.info("*************** PROCESSED #{inventory_collection}, "\
-                  "created=#{inventory_collection.created_records.count}, "\
-                  "updated=#{inventory_collection.updated_records.count}, "\
-                  "deleted=#{inventory_collection.deleted_records.count} *************")
+        _log.debug("Processing #{inventory_collection}, "\
+                   "created=#{inventory_collection.created_records.count}, "\
+                   "updated=#{inventory_collection.updated_records.count}, "\
+                   "deleted=#{inventory_collection.deleted_records.count}...Complete")
       rescue => e
         _log.error("Error when saving #{inventory_collection} with #{inventory_collection_details}. Message: #{e.message}")
         raise e
@@ -143,8 +143,8 @@ module ManagerRefresh::SaveCollection
 
         all_manager_uuids_size = inventory_collection.all_manager_uuids.size
 
-        _log.info("*************** PROCESSING :delete_complement of #{inventory_collection} of size "\
-                  "#{all_manager_uuids_size} *************")
+        _log.debug("Processing :delete_complement of #{inventory_collection} of size "\
+                   "#{all_manager_uuids_size}...")
         deleted_counter = 0
 
         inventory_collection.db_collection_for_comparison_for_complement_of(
@@ -158,8 +158,8 @@ module ManagerRefresh::SaveCollection
           end
         end
 
-        _log.info("*************** PROCESSED :delete_complement of #{inventory_collection} of size "\
-                  "#{all_manager_uuids_size}, deleted=#{deleted_counter} *************")
+        _log.debug("Processing :delete_complement of #{inventory_collection} of size "\
+                   "#{all_manager_uuids_size}, deleted=#{deleted_counter}...Complete")
       end
 
       def delete_record!(record)

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -65,7 +65,7 @@ module ManagerRefresh::SaveCollection
         all_attribute_keys << :created_on if supports_created_on?
         all_attribute_keys << :updated_on if supports_updated_on?
 
-        _log.info("*************** PROCESSING #{inventory_collection} of size #{inventory_collection.size} *************")
+        _log.debug("Processing #{inventory_collection} of size #{inventory_collection.size}...")
 
         update_or_destroy_records!(batch_iterator(association), inventory_objects_index, attributes_index, all_attribute_keys)
 
@@ -80,10 +80,10 @@ module ManagerRefresh::SaveCollection
             create_records!(all_attribute_keys, batch, attributes_index)
           end
         end
-        _log.info("*************** PROCESSED #{inventory_collection}, "\
-                  "created=#{inventory_collection.created_records.count}, "\
-                  "updated=#{inventory_collection.updated_records.count}, "\
-                  "deleted=#{inventory_collection.deleted_records.count} *************")
+        _log.debug("Processing #{inventory_collection}, "\
+                   "created=#{inventory_collection.created_records.count}, "\
+                   "updated=#{inventory_collection.updated_records.count}, "\
+                   "deleted=#{inventory_collection.deleted_records.count}...Complete")
       rescue => e
         _log.error("Error when saving #{inventory_collection} with #{inventory_collection_details}. Message: #{e.message}")
         raise e

--- a/app/models/manager_refresh/save_collection/topological_sort.rb
+++ b/app/models/manager_refresh/save_collection/topological_sort.rb
@@ -7,19 +7,21 @@ module ManagerRefresh::SaveCollection
 
         layers = ManagerRefresh::Graph::TopologicalSort.new(graph).topological_sort
 
+        _log.debug("Saving manager #{ems.name}...")
+
         sorted_graph_log = "Topological sorting of manager #{ems.name} resulted in these layers processable in parallel:\n"
         sorted_graph_log += graph.to_graphviz(:layers => layers)
-        _log.info(sorted_graph_log)
+        _log.debug(sorted_graph_log)
 
         layers.each_with_index do |layer, index|
-          _log.info("Saving manager #{ems.name} | Layer #{index}")
+          _log.debug("Saving manager #{ems.name} | Layer #{index}")
           layer.each do |inventory_collection|
             save_inventory_object_inventory(ems, inventory_collection) unless inventory_collection.saved?
           end
-          _log.info("Saved manager #{ems.name} | Layer #{index}")
+          _log.debug("Saved manager #{ems.name} | Layer #{index}")
         end
 
-        _log.info("All layers of manager #{ems.name} saved!")
+        _log.debug("Saving manager #{ems.name}...Complete")
       end
     end
   end

--- a/app/models/manager_refresh/save_inventory.rb
+++ b/app/models/manager_refresh/save_inventory.rb
@@ -2,11 +2,11 @@ module ManagerRefresh
   class SaveInventory
     class << self
       def save_inventory(ems, inventory_collections)
-        _log.info("#{log_header(ems)} Scanning Inventory Collections...Start")
+        _log.debug("#{log_header(ems)} Scanning Inventory Collections...Start")
         ManagerRefresh::InventoryCollection::Scanner.scan!(inventory_collections)
-        _log.info("#{log_header(ems)} Scanning Inventory Collections...Complete")
+        _log.debug("#{log_header(ems)} Scanning Inventory Collections...Complete")
 
-        _log.info("#{log_header(ems)} Saving EMS Inventory...Start")
+        _log.info("#{log_header(ems)} Saving EMS Inventory...")
 
         inventory_object_saving_strategy = Settings.ems_refresh[ems.class.ems_type].try(:[], :inventory_object_saving_strategy)
         if inventory_object_saving_strategy == :recursive


### PR DESCRIPTION
Move all logging except for the top level Saving... messages to debug.

When loglevel is info this is what will be logged from ManagerRefresh:
```
INFO -- : MIQ(ManagerRefresh::SaveInventory.save_inventory) EMS: [fsimonce-ocp], id: [1] Saving EMS Inventory...
INFO -- : MIQ(ManagerRefresh::SaveInventory.save_inventory) EMS: [fsimonce-ocp], id: [1] Saving EMS Inventory...Complete
```

Fixes: https://github.com/ManageIQ/manageiq/issues/16374