### PR TITLE
Truncate name of refresh task to 255

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -202,7 +202,7 @@ module EmsRefresh
 
   def self.create_refresh_task(ems, targets)
     task_options = {
-      :action => "EmsRefresh(#{ems.name}) [#{targets}]",
+      :action => "EmsRefresh(#{ems.name}) [#{targets}]".truncate(255),
       :userid => "system"
     }
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -94,6 +94,16 @@ describe EmsRefresh do
         expect(task_ids.length).to eq(2)
       end
     end
+
+    describe ".create_refresh_task" do
+      it "create refresh task and trancates task name to 255 symbols" do
+        vm = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => @ems)
+        targets = Array.new(500) { vm }
+        task_name = described_class.send(:create_refresh_task, @ems, targets).name
+        expect(task_name.include?(@ems.name)).to eq true
+        expect(task_name.length).to eq 255
+      end
+    end
   end
 
   def queue_refresh_and_assert_queue_item(target, expected_targets)


### PR DESCRIPTION
After migrating older DB datatype `t.string`  would have maximum length of 255.
See https://github.com/ManageIQ/manageiq-schema/pull/125 for more details.

https://bugzilla.redhat.com/show_bug.cgi?id=1510605

This PR truncate length of string to 255 when attempting to create record in `miq_tasks`

@miq-bot add-label bug
@miq-bot assign @agrare 

\cc @Fryguy 


