### PR TITLE
Prevent replication subscription to the same region as the current region

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -33,6 +33,7 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def save!
+    assert_different_region!
     assert_valid_schemas!
     id ? update_subscription : create_subscription
   end
@@ -226,6 +227,12 @@ class PglogicalSubscription < ActsAsArModel
     with_remote_connection do |conn|
       remote_errors = ManageIQ::Schema::Checker.check_schema(conn)
       raise remote_errors if remote_errors
+    end
+  end
+
+  def assert_different_region!
+    if MiqRegionRemote.region_number_from_sequence == remote_region_number
+      raise "Subscriptions cannot be created to the same region as the current region"
     end
   end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -185,12 +185,14 @@ describe PglogicalSubscription do
     it "raises when the local schema is invalid" do
       with_an_invalid_local_schema
       sub = described_class.new(:host => "some.host.example.com")
+      allow(sub).to receive(:assert_different_region!)
       expect { sub.save! }.to raise_error(RuntimeError, "Different local schema")
     end
 
     it "raises when the remote schema is invalid" do
       with_an_invalid_remote_schema
       sub = described_class.new(:host => "some.host.example.com", :password => "1234")
+      allow(sub).to receive(:assert_different_region!)
       expect { sub.save! }.to raise_error(RuntimeError, "Different remote schema")
     end
 
@@ -199,7 +201,6 @@ describe PglogicalSubscription do
       allow(pglogical).to receive(:enabled?).and_return(true)
       allow(pglogical).to receive(:subscription_show_status).and_return(subscriptions.first)
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
-      with_valid_schemas
 
       sub = described_class.new(:host => "some.host.example.com")
       expect { sub.save! }.to raise_error(RuntimeError, "Subscriptions cannot be created to the same region as the current region")
@@ -241,7 +242,10 @@ describe PglogicalSubscription do
         expect(sync_structure).to be false
       end.and_return(double(:check => nil))
 
-      described_class.new(:host => "test-2.example.com", :user => "root", :password => "1234").save!
+      sub = described_class.new(:host => "test-2.example.com", :user => "root", :password => "1234")
+      allow(sub).to receive(:assert_different_region!)
+
+      sub.save!
     end
 
     it "doesnt create the node when we are already a node" do
@@ -265,8 +269,11 @@ describe PglogicalSubscription do
         expect(sync_structure).to be false
       end.and_return(double(:check => nil))
 
-      ret = described_class.new(:host => "test-2.example.com", :password => "1234", :user => "root").save!
-      expect(ret).to be_an_instance_of(described_class)
+      sub = described_class.new(:host => "test-2.example.com", :password => "1234", :user => "root")
+      allow(sub).to receive(:assert_different_region!)
+
+      sub.save!
+      expect(sub).to be_an_instance_of(described_class)
     end
 
     it "updates the dsn when an existing subscription is saved" do
@@ -278,6 +285,7 @@ describe PglogicalSubscription do
 
       sub = described_class.find(:first)
       sub.host = "other-host.example.com"
+      allow(sub).to receive(:assert_different_region!)
 
       expect(pglogical).to receive(:subscription_disable).with(sub.id)
         .and_return(double(:check => nil))
@@ -303,6 +311,7 @@ describe PglogicalSubscription do
 
       sub = described_class.find(:first)
       sub.host = "other-host.example.com"
+      allow(sub).to receive(:assert_different_region!)
 
       expect(pglogical).to receive(:subscription_disable).with(sub.id)
         .and_return(double(:check => nil))
@@ -346,6 +355,7 @@ describe PglogicalSubscription do
       to_save = []
       to_save << described_class.new(:host => "test-2.example.com", :password => "1234", :user => "root")
       to_save << described_class.new(:host => "test-3.example.com", :password => "1234", :user => "miq")
+      to_save.each { |s| allow(s).to receive(:assert_different_region!) }
 
       described_class.save_all!(to_save)
     end
@@ -376,6 +386,7 @@ describe PglogicalSubscription do
       to_save << described_class.new(:host => "test-2.example.com", :user => "root", :password => "1234")
       to_save << described_class.new(:host => "test-3.example.com", :user => "miq", :password => "1234")
       to_save << described_class.new(:host => "test-4.example.com", :user => "miq", :password => "1234")
+      to_save.each { |s| allow(s).to receive(:assert_different_region!) }
 
       expect { described_class.save_all!(to_save) }.to raise_error("Failed to save subscription " \
         "to test-2.example.com: Error one\nFailed to save subscription to test-4.example.com: Error two")


### PR DESCRIPTION
This change prevents a user from shooting himself in the foot by creating a subscription to the same region as the server he's accessing which means creating a subscription to the same DB and region.

The side effect of doing that is, as part of subscription creation, we do a `MiqRegion.destroy_region(connection, remote_region_number)`. In this case that will destroy the current region. This will prevent that from happening

https://bugzilla.redhat.com/show_bug.cgi?id=1507323

/cc @jrafanie 