### PR TITLE
Require handsoap in VimConnectMixin

### DIFF
--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -47,6 +47,8 @@ module VimConnectMixin
 
   module ClassMethods
     def raw_connect(options)
+      require 'handsoap'
+
       options[:pass] = MiqPassword.try_decrypt(options[:pass])
       validate_connection do
         if options[:fault_tolerant]


### PR DESCRIPTION
Explicitly require handsoap in VimConnectMixin.raw_connect so that we
can catch a Handsoap::Fault exception.

```
[----] E, [2017-11-10T11:26:47.521471 #13497:10d3134] ERROR -- : MIQ(MiqQueue#deliver) Message id: [1000000000113], Error: [uninitialized constant VimConnectMixin::ClassMethods::Handsoap]
[----] E, [2017-11-10T11:26:47.521689 #13497:10d3134] ERROR -- : [NameError]: uninitialized constant VimConnectMixin::ClassMethods::Handsoap  Method:[block in method_missing]
[----] E, [2017-11-10T11:26:47.521758 #13497:10d3134] ERROR -- : /var/www/miq/vmdb/app/models/mixins/vim_connect_mixin.rb:65:in `rescue in validate_connection'
/var/www/miq/vmdb/app/models/mixins/vim_connect_mixin.rb:61:in `validate_connection'
/var/www/miq/vmdb/app/models/mixins/vim_connect_mixin.rb:51:in `raw_connect'
/var/www/miq/vmdb/app/models/miq_queue.rb:449:in `block in dispatch_method'
```

https://bugzilla.redhat.com/show_bug.cgi?id=1512019