### PR TITLE
Improve tag mapping tests

### DIFF
--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -6,4 +6,21 @@ FactoryGirl.define do
       labeled_resource_type 'ContainerNode'
     end
   end
+
+  # Mapping for <All> entities, as created in UI.
+  factory :tag_mapping_with_category, :parent => :container_label_tag_mapping do
+    transient do
+      category_name { "kubernetes::" + Classification.sanitize_name(label_name.tr("/", ":")) }
+      category_description { "Mapped #{label_name}" }
+    end
+
+    tag do
+      category = FactoryGirl.create(:classification,
+                                    :name         => category_name,
+                                    :description  => category_description,
+                                    :single_value => true,
+                                    :read_only    => true)
+      category.tag
+    end
+  end
 end

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,6 +1,16 @@
 require 'manager_refresh/inventory_object'
 
 context "save_tags_inventory" do
+  # @return [Tag] a tag in a category linked to a mapping.
+  def mapped_tag(category_name, tag_name)
+    mapping = FactoryGirl.create(:tag_mapping_with_category,
+                                 :category_name        => category_name,
+                                 :category_description => category_name)
+    category = mapping.tag.category
+    entry = category.add_entry(:name => tag_name, :description => tag_name)
+    category.tag
+  end
+
   before(:each) do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
@@ -8,10 +18,9 @@ context "save_tags_inventory" do
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
     @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
-    # These might not pass the ContainerLabelTagMapping.controls_tag? criteria, doesn't matter if only adding.
-    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner/alice')
-    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff/jabberwocky')
-    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes::foo/bar') # All
+    @tag1 = mapped_tag('amazon:vm:owner', 'alice')
+    @tag2 = mapped_tag('kubernetes:container_node:stuff', 'jabberwocky')
+    @tag3 = mapped_tag('kubernetes::foo', 'bar') # All entities
   end
 
   # Simulate what ContainerLabelTagMapping::Mapper.map_labels(...) would return, after resolving to tag ids.
@@ -26,16 +35,42 @@ context "save_tags_inventory" do
       ]
     }
   end
+  let(:data2) do
+    {
+      :tags => [
+        instance_double(ManagerRefresh::InventoryObject, :id => @tag2.id),
+      ]
+    }
+  end
+  let(:data_empty) do
+    {
+      :tags => []
+    }
+  end
+  let(:data_empty_array) do
+    []
+  end
 
   # Note that in these tests we're explicitly passing the object, so that's
   # why the object type may not match what you would expect from the tag
   # name type above.
 
-  it "creates the expected number of taggings" do
+  it "creates/deletes the expected number of taggings" do
     EmsRefresh.save_tags_inventory(@vm, data)
-    taggings = Tagging.all
-    expect(taggings.size).to eql(3)
-    expect(@vm.tags.size).to eql(3)
+    expect(Tagging.count).to eql(3)
+    expect(@vm.reload.tags.size).to eql(3)
+
+    EmsRefresh.save_tags_inventory(@vm, data_empty)
+    expect(Tagging.count).to eql(0)
+    expect(@vm.reload.tags.size).to eql(0)
+
+    EmsRefresh.save_tags_inventory(@vm, data2)
+    expect(Tagging.count).to eql(1)
+    expect(@vm.reload.tags.size).to eql(1)
+
+    EmsRefresh.save_tags_inventory(@vm, data_empty_array)
+    expect(Tagging.count).to eql(0)
+    expect(@vm.reload.tags.size).to eql(0)
   end
 
   it "creates the expected taggings for a VM" do


### PR DESCRIPTION
- Add factory `:tag_mapping_with_category`.
  There are tests in many places approximating this, not all correctly...
- With the factory I was able to add promised test for #16370
- Going to rely on this in several other tag mapping PRs.

@miq-bot add-label test, gaprindashvili/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1508437 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1510096 (gaprindashvili)

@Ladas @agrare Please review this first, unblocks other PRs to not have circular deps...