### PR TITLE
Introduce $nuage_log that logs into log/nuage.log

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -25,6 +25,7 @@ GlobalVars:
   - $vcloud_log
   - $vim_log
   - $websocket_log
+  - $nuage_log
 Rails/Exit:
   Exclude:
   - lib/workers/bin/*

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -881,6 +881,7 @@
   :level_vim: warn
   :level_websocket: info
   :level_vcloud: info
+  :level_nuage: info
 :ntp:
   :server:
   - 0.pool.ntp.org

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -99,6 +99,7 @@ module Vmdb
       apply_config_value(config, $lenovo_log,        :level_lenovo)
       apply_config_value(config, $websocket_log,     :level_websocket)
       apply_config_value(config, $vcloud_log,        :level_vcloud)
+      apply_config_value(config, $nuage_log,         :level_nuage)
     end
 
     def self.create_loggers
@@ -124,6 +125,7 @@ module Vmdb
       $websocket_log     = create_multicast_logger(path_dir.join("websocket.log"))
       $miq_ae_logger     = create_multicast_logger(path_dir.join("automation.log"))
       $vcloud_log        = create_multicast_logger(path_dir.join("vcloud.log"))
+      $nuage_log         = create_multicast_logger(path_dir.join("nuage.log"))
 
       configure_external_loggers
     end


### PR DESCRIPTION
With this commit we introduce yet another global logger that is to be used by Nuage provider. We're having quite some logs there and it's better to log them into its own file.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1534449
@miq-bot add_label enhancement
@miq-bot assign @blomquisg

/cc @gberginc 