### PR TITLE
Add pronto-rubocop gem to development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -210,6 +210,7 @@ unless ENV["APPLIANCE"]
     gem "rubocop",          "~>0.47.0", :require => false
     gem "scss_lint",        "~>0.48.0", :require => false
     gem "yard"
+    gem "pronto-rubocop"
   end
 
   group :test do


### PR DESCRIPTION
This gem enables us to run rubocop inspections on changed code only like this:

```
$ bundle exec pronto run -c=upstream/master
```

This will filter out only lines modified on our local branch compared to upstream/master and only report rubocop issues there. For more docs please visit: https://github.com/prontolabs/pronto#local-changes. I think having this in development environment by default would be awesome!

@miq-bot add_label developer
@miq-bot assign @blomquisg