### PR TITLE
Workers can run log_status so ask for the right pid

### DIFF
--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -21,7 +21,7 @@ module MiqServer::StatusManagement
 
   def process_status
     require 'miq-process'
-    pinfo = MiqProcess.processInfo
+    pinfo = MiqProcess.processInfo(pid)
     # Ensure the hash only contains the values we want to store in the table
     pinfo.keep_if { |k, _v| MiqWorker::PROCESS_INFO_FIELDS.include?(k) }
     pinfo[:os_priority] = pinfo.delete(:priority)


### PR DESCRIPTION
If no argument is provided, processInfo will get the current process'
memory information, which when run from a queue worker, will not be the
server's pid.

When run on an appliance with a bloated MiqServer process:

Before (uses the current Process's memory information):
```
irb(main):001:0> MiqServer.my_server.process_status
=> {:memory_usage=>148525056, :memory_size=>439468032, :percent_memory=>0.89, :cpu_time=>779, :percent_cpu=>0.0, :proportional_set_size=>139434000, :os_priority=>20}
```

After:
```
irb(main):001:0> MiqServer.my_server.process_status
=> {:memory_usage=>3902767104, :memory_size=>4303794176, :percent_memory=>23.44, :cpu_time=>15366516, :percent_cpu=>9.78, :proportional_set_size=>1431006000, :os_priority=>20}
```

@dmetzger57 @NickLaMuro don't trust any MiqServer.log_status log lines, they're most likely wrong.