### PR TITLE
Revert "Replace ContainerLabelTagMapping.controls_tag? with Tag.controlled_by_mapping scope"

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -21,9 +21,6 @@
 class ContainerLabelTagMapping < ApplicationRecord
   belongs_to :tag
 
-  scope :any_value,      -> { where(:label_value => nil) }
-  scope :specific_value, -> { where.not(:label_value => nil) }
-
   require_nested :Mapper
 
   # Return ContainerLabelTagMapping::Mapper instance that holds all current mappings,
@@ -34,21 +31,24 @@ class ContainerLabelTagMapping < ApplicationRecord
 
   # Assigning/unassigning should be possible without Mapper instance, perhaps in another process.
 
-  # Checks whether a Tag record is under mapping control. TODO: Remove? Only used by tests.
+  # Checks whether a Tag record is under mapping control.
+  # TODO: expensive.
   def self.controls_tag?(tag)
-    Tag.controlled_by_mapping.where(:id => tag.id).exists?
+    return false unless tag.classification.try(:read_only) # never touch user-assignable tags.
+    tag_ids = [tag.id, tag.category.tag_id].uniq
+    where(:tag_id => tag_ids).any?
   end
 
   # Assign/unassign mapping-controlled tags, preserving user-assigned tags.
   # All tag references must have been resolved first by Mapper#find_or_create_tags.
   def self.retag_entity(entity, tag_references)
     mapped_tags = Mapper.references_to_tags(tag_references)
-    existing_tags = entity.tags.controlled_by_mapping
+    existing_tags = entity.tags
     Tagging.transaction do
       (mapped_tags - existing_tags).each do |tag|
         Tagging.create!(:taggable => entity, :tag => tag)
       end
-      (existing_tags - mapped_tags).tap do |tags|
+      (existing_tags - mapped_tags).select { |tag| controls_tag?(tag) }.tap do |tags|
         Tagging.where(:taggable => entity, :tag => tags.collect(&:id)).destroy_all
       end
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -4,14 +4,9 @@ class Tag < ApplicationRecord
   virtual_has_one :category,       :class_name => "Classification"
   virtual_has_one :categorization, :class_name => "Hash"
 
-  has_many :container_label_tag_mappings # see also controlled_by_mapping scope
+  has_many :container_label_tag_mappings
 
   before_destroy :remove_from_managed_filters
-
-  # Note those scopes exclude Tags that don't have a Classification.
-  scope :visible,   -> { joins(:classification).merge(Classification.visible) }
-  scope :read_only, -> { joins(:classification).merge(Classification.read_only) }
-  scope :writable,  -> { joins(:classification).merge(Classification.writable) }
 
   def self.list(object, options = {})
     ns = get_namespace(options)
@@ -155,24 +150,6 @@ class Tag < ApplicationRecord
           "display_name" => "#{category.description}: #{classification.description}"
         }
       end
-  end
-
-  # @return [ActiveRecord::Relation] Scope for tags controlled by ContainerLabelTagMapping.
-  #   May include not only "entry" tags but also some parent "category" tags.
-  def self.controlled_by_mapping
-    # TODO: complex query, can we simply select by prefixes e.g. '/managed/kubernetes:%'?
-    # User can create categories with such prefix, but they won't be read_only.
-
-    # Entry tags from specific value->tag mappings.
-
-    mapped_specific_tags = read_only.where(:id => ContainerLabelTagMapping.specific_value.pluck(:tag_id))
-
-    # Entry tags for name->category mappings.
-    mapped_categories = Classification.where(:tag => ContainerLabelTagMapping.any_value.pluck(:tag_id))
-    mapped_entries = Classification.where(:parent => mapped_categories)
-    mapped_child_tags = read_only.where(:id => mapped_entries.select(:tag_id))
-
-    mapped_specific_tags.or(mapped_child_tags)
   end
 
   private


### PR DESCRIPTION
Alternative option to #16461 — fully reverts ManageIQ/manageiq#16449

It broke save_tags_inventory_spec https://travis-ci.org/ManageIQ/manageiq/jobs/301542779#L1054
It seems `Tag.controlled_by_mapping` works right but `entity.tags.controlled_by_mapping` doesn't (?)
Will debug more tomorrow.

cc @agrare My laptop battery is running out, so leaving choice to you :)