### PR TITLE
Added a Maintenance key to the hash struct

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -978,7 +978,7 @@ class MiqRequestWorkflow
   end
 
   def host_to_hash_struct(ci)
-    build_ci_hash_struct(ci, [:name, :vmm_product, :vmm_version, :state, :v_total_vms])
+    build_ci_hash_struct(ci, [:name, :vmm_product, :vmm_version, :state, :v_total_vms, :maintenance])
   end
 
   def vm_or_template_to_hash_struct(ci)


### PR DESCRIPTION
Added the `maintenance` key our hash_struct for use in the UI

Allows us to view if a `host` is in Maintenance mode.

<img width="773" alt="screen shot 2017-11-13 at 3 28 56 pm" src="https://user-images.githubusercontent.com/697347/32747646-6855bf6c-c887-11e7-97f2-66cd4023df99.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1506268

