### PR TITLE
Bump the version of pg-pglogical to 2.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,7 @@ group :automate, :seed, :manageiq_default do
 end
 
 group :replication, :manageiq_default do
-  gem "pg-pglogical",                   "~>2.0.0",       :require => false
+  gem "pg-pglogical",                   "~>2.1.1",       :require => false
 end
 
 group :rest_api, :manageiq_default do


### PR DESCRIPTION
This version allows for drop_table to remove the table from the replication set before trying to drop it.

https://bugzilla.redhat.com/show_bug.cgi?id=1508402