### PR TITLE
[GAPRINDASHVILI] Remove models that do not have API/UI support for custom actions

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -19,33 +19,17 @@ class CustomButton < ApplicationRecord
   PLAYBOOK_METHOD = "Order_Ansible_Playbook".freeze
 
   BUTTON_CLASSES = [
-    AvailabilityZone,
-    CloudNetwork,
-    CloudObjectStoreContainer,
-    CloudSubnet,
     CloudTenant,
     CloudVolume,
-    ContainerGroup,
-    ContainerImage,
     ContainerNode,
     ContainerProject,
-    ContainerTemplate,
-    ContainerVolume,
     EmsCluster,
     ExtManagementSystem,
     GenericObject,
     Host,
-    LoadBalancer,
-    MiqGroup,
     MiqTemplate,
-    NetworkRouter,
-    OrchestrationStack,
-    SecurityGroup,
     Service,
     Storage,
-    Switch,
-    Tenant,
-    User,
     Vm,
   ].freeze
 


### PR DESCRIPTION
For the initial Gaprindashvili release we agreed to limit the models that are exposed as custom buttons while work continues to expose the required models and actions through the API and enable the ui-components dialog runner for each object.

cc @eclarizio @d-m-u @jntullo