### PR TITLE
Fix string interpolations

### DIFF
--- a/app/models/physical_server/operations/config_pattern.rb
+++ b/app/models/physical_server/operations/config_pattern.rb
@@ -1,7 +1,8 @@
 module PhysicalServer::Operations::ConfigPattern
   def apply_config_pattern(pattern_id)
     unless ext_management_system
-      raise _("A Server #{self} <%{name}> with Id: <%{id}> is not associated with a provider.") % {:name => name, :id => id}
+      raise _("A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
+            {:server => self, :name => name, :id => id}
     end
 
     _log.info("Apply config pattern with ID: #{pattern_id} to server with UUID: #{ems_ref}")

--- a/app/models/physical_server/operations/led.rb
+++ b/app/models/physical_server/operations/led.rb
@@ -15,8 +15,8 @@ module PhysicalServer::Operations::Led
 
   def change_state(verb)
     unless ext_management_system
-      raise _("A Server #{self} <%{name}> with Id: <%{id}> is not associated \
-with a provider.") % {:name => name, :id => id}
+      raise _("A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
+            {:server => self, :name => name, :id => id}
     end
 
     options = {:uuid => ems_ref}

--- a/app/models/physical_server/operations/power.rb
+++ b/app/models/physical_server/operations/power.rb
@@ -31,8 +31,8 @@ module PhysicalServer::Operations::Power
 
   def change_state(verb)
     unless ext_management_system
-      raise _(" A Server #{self} <%{name}> with Id: <%{id}>
-      is not associated with a provider.") % {:name => name, :id => id}
+      raise _(" A Server %{server} <%{name}> with Id: <%{id}> is not associated with a provider.") %
+            {:server => self, :name => name, :id => id}
     end
     options = {:uuid => ems_ref}
     _log.info("Begin #{verb} server: #{name}  with UUID: #{ems_ref}")


### PR DESCRIPTION
String interpolations aren't allowed in a gettext string. This fix also needs to land in gaprindashvili.

Fixes https://github.com/ManageIQ/manageiq/issues/16459