### PR TITLE
Remove fault_tolerant from vim_connect

### DIFF
--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -5,7 +5,7 @@ module VimConnectMixin
     options[:auth_type] ||= :ws
     raise _("no credentials defined") if missing_credentials?(options[:auth_type])
 
-    options[:use_broker] = (self.class.respond_to?(:use_vim_broker?) ? self.class.use_vim_broker? : ManageIQ::Providers::Vmware::InfraManager.use_vim_broker?) if options[:fault_tolerant] && !options.key?(:use_broker)
+    options[:use_broker] = (self.class.respond_to?(:use_vim_broker?) ? self.class.use_vim_broker? : ManageIQ::Providers::Vmware::InfraManager.use_vim_broker?) unless options.key?(:use_broker)
     if options[:use_broker] && !MiqVimBrokerWorker.available?
       msg = "Broker Worker is not available"
       _log.error(msg)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/16379 removed the
fault_tolerant option from vim_connect_mixin but it was still being
checked when setting options[:use_broker].  This caused
options[:use_broker] to be always true and console/simulate_queue_worker
connections and refreshes fail.