### PR TITLE
Improves v_total_vms

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -42,7 +42,6 @@ class Service < ApplicationRecord
   virtual_has_many   :power_states, :uses => :all_vms
   virtual_has_many   :orchestration_stacks
   virtual_has_many   :generic_objects
-  virtual_total      :v_total_vms, :vms
 
   virtual_has_one    :custom_actions
   virtual_has_one    :custom_action_buttons
@@ -70,6 +69,9 @@ class Service < ApplicationRecord
   include_concern 'RetirementManagement'
   include_concern 'Aggregation'
   include_concern 'ResourceLinking'
+
+  virtual_total :v_total_vms, :vms,
+                :arel => aggregate_hardware_arel("v_total_vms", vms_tbl[:id].count, :skip_hardware => true)
 
   virtual_column :has_parent,                               :type => :boolean
   virtual_column :power_state,                              :type => :string

--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -168,8 +168,11 @@ module Service::Aggregation
     def base_service_aggregation_join(arel, services_tbl, options = {})
       arel.join(service_resources_tbl).on(service_resources_tbl[:service_id].eq(services_tbl[:id])
                                   .and(service_resources_tbl[:resource_type].eq(vm_or_template_type)))
-          .join(vms_tbl).on(vm_join_clause(options))
-          .join(hardwares_tbl).on(hardwares_tbl[:vm_or_template_id].eq(vms_tbl[:id]))
+          .join(vms_tbl).on(vm_join_clause(options)).tap do |arel_query|
+            unless options[:skip_hardware]
+              arel_query.join(hardwares_tbl).on(hardwares_tbl[:vm_or_template_id].eq(vms_tbl[:id]))
+            end
+          end
     end
 
     # Generates the following SQL conditional to be used in

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -207,6 +207,19 @@ describe Service do
       expect(@service.all_vms).to    match_array [@vm, @vm1, @vm1, @vm2]
     end
 
+    it "#v_total_vms" do
+      expect(@service.v_total_vms).to eq 4
+      expect(@service.attribute_present?(:v_total_vms)).to eq false
+    end
+
+    it "#v_total_vms with arel" do
+      service = Service.select(:id, :v_total_vms)
+                       .where(:id => @service.id)
+                       .first
+      expect(service.v_total_vms).to eq 4
+      expect(service.attribute_present?(:v_total_vms)).to eq true
+    end
+
     it "#direct_service" do
       expect(@vm.direct_service).to eq(@service)
       expect(@vm1.direct_service).to eq(@service_c1)


### PR DESCRIPTION
Model code from https://github.com/ManageIQ/manageiq/pull/16438, updated to work in master (no difference in code, just different states of the code around it causing different diffs).  Performance info can be found in that PR.

Effectively this allows you to make a single query to services and get the info necessary to determine the `v_total_vms`.  So running:

```ruby
Service.select(Service.arel_table[Arel.star], :v_total_vms).first.v_total_vms
```

And have only 1 query executed, looking like the following:

```sql
SELECT 'services'.*, (
  SELECT COUNT("vms"."id")
  FROM "services" "v_total_vms_services"
  INNER JOIN "service_resources" ON "service_resources"."service_id" = "v_total_vms_services"."id"
         AND "service_resources"."resource_type" = 'VmOrTemplate'
  INNER JOIN "vms" ON "vms"."id" = "service_resources"."resource_id"
  WHERE (("v_total_vms_services"."id" = "services"."id" OR "v_total_vms_services"."ancestry" ILIKE CONCAT("services"."id", '/%'))
          OR "v_total_vms_services"."ancestry" = CAST("services"."id" AS VARCHAR))
) v_total_vms
FROM "services" ORDER BY "services"."id"
ASC LIMIT 1
```

In the previous implementation, it would have look more like this:

```
irb> Service.first.v_total_vms
Service Load (0.3ms) SELECT  "services".* FROM "services" ORDER BY "services"."id" ASC LIMIT $1  [["LIMIT", 1]]
Service Inst Including Associations (0.2ms - 1rows)
Service Load (0.6ms)  SELECT "services".* FROM "services" WHERE (("services"."ancestry" LIKE '20000000000001/%' ...
ServiceResource Inst Including Associations (0.0ms - 0rows)
VmOrTemplate Load (0.5ms)  SELECT "vms".* FROM "vms" WHERE "vms"."id" = XXXXXX
VmOrTemplate Inst Including Associations (0.0ms - 0rows)
ServiceResource Load (0.2ms)  SELECT "service_resources".* FROM "service_resources" WHERE...
ServiceResource Inst Including Associations (0.0ms - 0rows)
VmOrTemplate Load (0.5ms)  SELECT "vms".* FROM "vms" WHERE "vms"."id" = XXXXXX
VmOrTemplate Inst Including Associations (0.0ms - 0rows)
...
```

As noted in the PRs that implemented the base code for these features to work (#11502 and #13101), the nested SQL that get's generated because of these methods is a double edged sword.  When used with one record, the query is effectively harmless, but if used against the entirety of a large table, this could overload a DB as nested selects have to be evaluated against each record in the main query.  This is still quicker than the alternative, but too many of these types of virtual attributes in a select can be a problem.


Links
-----
* https://github.com/ManageIQ/manageiq/pull/16438
* Uses features from #11502 and #13101


Steps for Testing/QA
--------------------

Best to be tested in IRB with this change, as it isn't hooked up to the UI in most cases.

```ruby
irb> Service.select(Service.arel_table[Arel.star], :v_total_vms).map(&:v_total_vms)
```

With the above, you should only see one query (you might need to enable `toggle_console_sql_logging` if running in production mode).  Testing with a DB that has a large number of services would also be a good idea, as this has the potential to cause a lot of work on the DB, and ideally would be used in index based actions on the API.