### PR TITLE
Add a connection to the pool if there is only one for embedded ansible

### DIFF
--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -136,12 +136,25 @@ describe EmbeddedAnsibleWorker do
     end
 
     describe "#start_monitor_thread" do
-      it "sets worker class and id in thread object" do
+      let(:pool) { double("ConnectionPool") }
+
+      before do
         allow(Thread).to receive(:new).and_return({})
         allow(described_class::Runner).to receive(:start_worker)
+      end
+
+      it "sets worker class and id in thread object" do
         thread = subject.start_monitor_thread
         expect(thread[:worker_class]).to eq subject.class.name
         expect(thread[:worker_id]).to    eq subject.id
+      end
+
+      it "adds a connection to the pool if there is only one" do
+        allow(ActiveRecord::Base).to receive(:connection_pool).and_return(pool)
+
+        expect(pool).to receive(:instance_variable_get).with(:@size).and_return(1)
+        expect(pool).to receive(:instance_variable_set).with(:@size, 2)
+        subject.start_monitor_thread
       end
     end
 


### PR DESCRIPTION
Before https://github.com/ManageIQ/manageiq/pull/6786 we used to have one connection specified in the connection pool in database.yml

Installations which have been upgraded from before this change still have that one connection pool in place.

The EmbeddedAnsible worker uses a thread rather than a new process so it shares the connection pool with the server. When the pool is set to only contain one connection, the EmbeddedAnsible worker will not be able to start.

This commit adds a connection to the pool in the same way that we do for workers which specify a specific connection pool size in their settings: https://github.com/ManageIQ/manageiq/blob/f6f7120749d16fd7825f83001dfd875cdecb903c/app/models/miq_worker/runner.rb#L71-L78

https://bugzilla.redhat.com/show_bug.cgi?id=1484150