### PR TITLE
Add two new types to MW server factories

### DIFF
--- a/spec/factories/middleware_servers.rb
+++ b/spec/factories/middleware_servers.rb
@@ -9,4 +9,16 @@ FactoryGirl.define do
           :class   => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServer',
           :parent  => :middleware_server do
   end
+
+  factory :hawkular_middleware_server_wildfly,
+          :aliases => ['app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_wildfly'],
+          :class   => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerWildfly',
+          :parent  => :middleware_server do
+  end
+
+  factory :hawkular_middleware_server_eap,
+          :aliases => ['app/models/manageiq/providers/hawkular/middleware_manager/middleware_server_eap'],
+          :class   => 'ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerEap',
+          :parent  => :hawkular_middleware_server_wildfly do
+  end
 end


### PR DESCRIPTION
### Merge first
This PR enables 2 new middleware server types for testing purposes in ui-classic repository.