### PR TITLE
Seed MiqAlerts used for Prometheus Alerts

### DIFF
--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -35,11 +35,17 @@ class MiqAlertSet < ApplicationRecord
     ContentImporter.import_from_hash(MiqAlertSet, MiqAlert, alert_profile, options)
   end
 
-  def self.import_from_yaml(fd)
+  def self.import_from_yaml(fd, options = {})
     input = YAML.load(fd)
     input.collect do |e|
-      _a, stat = import_from_hash(e["MiqAlertSet"])
+      _a, stat = import_from_hash(e["MiqAlertSet"], options)
       stat
     end
+  end
+
+  def self.seed
+    fixture_file = File.join(FIXTURE_DIR, "miq_alert_sets.yml")
+    return unless File.exist?(fixture_file)
+    File.open(fixture_file) { |fd| MiqAlertSet.import_from_yaml(fd, :save => true) }
   end
 end

--- a/db/fixtures/miq_alert_sets.yml
+++ b/db/fixtures/miq_alert_sets.yml
@@ -1,0 +1,45 @@
+---
+- MiqAlertSet:
+    name: prometheus provider profile
+    description: Prometheus Provider Profile
+    set_type: MiqAlertSet
+    guid: a16fcf51-e2ae-492d-af37-19de881476ad
+    mode: ExtManagementSystem
+    MiqAlert:
+    - description: External Prometheus - Providers
+      options:
+        :notifications:
+          :delay_next_evaluation: 0
+          :evm_event: {}
+      guid: ea3acd49-9516-4fde-b828-bf68d254c0cf
+      db: ExtManagementSystem
+      responds_to_events: datawarehouse_alert
+      miq_expression:
+      enabled: true
+      read_only:
+      hash_expression:
+        :eval_method: dwh_generic
+        :mode: internal
+        :options: {}
+- MiqAlertSet:
+    name: prometheus node profile
+    description: Prometheus node Profile
+    set_type: MiqAlertSet
+    guid: ff0fb114-be03-4685-bebb-b6ae8f13d7ad
+    mode: ContainerNode
+    MiqAlert:
+    - description: External Prometheus - Nodes
+      options:
+        :notifications:
+          :delay_next_evaluation: 0
+          :evm_event: {}
+      guid: efe9d4f0-9c6f-4c67-80b1-05cd83223349
+      db: ContainerNode
+      responds_to_events: datawarehouse_alert
+      miq_expression:
+      enabled: true
+      read_only:
+      hash_expression:
+        :eval_method: dwh_generic
+        :mode: internal
+        :options: {}

--- a/spec/models/miq_alert_set_spec.rb
+++ b/spec/models/miq_alert_set_spec.rb
@@ -1,0 +1,45 @@
+describe MiqAlertSet do
+  context ".seed" do
+    it "should create the prometheus profiles" do
+      expect(MiqAlertSet.count).to eq(0)
+      described_class.seed
+      expect(MiqAlertSet.count).to eq(2)
+      provider_profile = MiqAlertSet.find_by(:guid => "a16fcf51-e2ae-492d-af37-19de881476ad")
+      expect(provider_profile).to have_attributes(:mode => "ExtManagementSystem")
+      expect(provider_profile.miq_alerts.count).to eq(1)
+      expect(provider_profile.miq_alerts.first).to have_attributes(
+        :guid               => "ea3acd49-9516-4fde-b828-bf68d254c0cf",
+        :db                 => "ExtManagementSystem",
+        :responds_to_events => "datawarehouse_alert",
+      )
+      node_profile = MiqAlertSet.find_by(:guid => "ff0fb114-be03-4685-bebb-b6ae8f13d7ad")
+      expect(node_profile).to have_attributes(:mode => "ContainerNode")
+      expect(node_profile.miq_alerts.count).to eq(1)
+      expect(node_profile.miq_alerts.first).to have_attributes(
+        :guid               => "efe9d4f0-9c6f-4c67-80b1-05cd83223349",
+        :db                 => "ContainerNode",
+        :responds_to_events => "datawarehouse_alert",
+      )
+    end
+
+    it "should not explode if the seed file is missing" do
+      fixture_file = ApplicationRecord::FIXTURE_DIR.join("miq_alert_sets.yml")
+      expect { without_file(fixture_file) { described_class.seed } }.to_not raise_exception
+    end
+  end
+
+  def without_file(fname)
+    # Note: can the file you are moving cause sporadic failures in other threads?
+    raise _("no block given") unless block_given?
+    raise _("fname is blank") if fname.blank?
+    tempf = Tempfile.new("temporary_backup")
+    begin
+      FileUtils.mv(fname, tempf.path)
+      yield
+    ensure
+      FileUtils.mv(tempf.path, fname) if File.exist?(tempf.path)
+      tempf.close
+      tempf.unlink
+    end
+  end
+end


### PR DESCRIPTION
These two alerts profiles are used for the [Prometheus Alerts Integration](  https://github.com/ManageIQ/manageiq/issues/14238) Seeding them would make setup a little easier.

![alert_profiles_seed](https://user-images.githubusercontent.com/3010449/32847546-f1a22984-ca32-11e7-8729-688d69b986ec.png)
