### PR TITLE
Alert seeding: allowing fixtures to have its own notification options

### DIFF
--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -938,7 +938,9 @@ class MiqAlert < ApplicationRecord
           alert = create(alert_hash)
           _log.info("Added sample Alert: #{alert.description}")
           if action
-            alert.options = {:notifications => {action.action_type.to_sym => action.options}}
+            alert.options ||= {}
+            alert.options[:notifications] ||= {}
+            alert.options[:notifications][action.action_type.to_sym] = action.options
             alert.save
           end
         end


### PR DESCRIPTION
In the alert seeding process, when a single alert is created out of `db/fixtures/miq_alerts.yml`, properties (like Show on Timeline, placed under `notifications` key) were wrongly skipped and always set to nil. Actually, those properties were overrode by the action descriptor hash.

Now, the action descriptor hash and the yaml attributes are merged. This way, both attributes are saved properly.

Links
----------------
* This is needed to have merged in order to get ManageIQ/manageiq#16314 working.
* An example of an alert with notification attributes included: [Middleware Heap Max > 90%](https://github.com/ManageIQ/manageiq/pull/16314/files#diff-c02beb5ccbe5eda1dc99ad7010ff5b30R325)
