### PR TITLE
Adds field unique validator check to dialog

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -61,6 +61,11 @@ class Dialog < ApplicationRecord
       errors.add(:base, _("Dialog %{dialog_label} must have at least one Tab") % {:dialog_label => label})
     end
 
+    duplicate_field_names = dialog_fields.collect(&:name).duplicates
+    if duplicate_field_names.present?
+      errors.add(:base, _("Dialog field name cannot be duplicated on a dialog: %{duplicates}") % {:duplicates => duplicate_field_names.join(', ')})
+    end
+
     dialog_tabs.each do |dt|
       next if dt.valid?
       dt.errors.full_messages.each do |err_msg|


### PR DESCRIPTION
This adds a uniqueness check on dialog field names (from this bz: https://bugzilla.redhat.com/show_bug.cgi?id=1491790) so we don't end up with dialogs with two equal field names which goes kaput.

Linked PR adds back in flash messages on dialog edit screen that went kaput when new dialog editor came online. Without it, this check fails silently and is yuck. 

## Will be a terrible experience unless this gets in soon too: ( 🎉 )
https://github.com/ManageIQ/manageiq-ui-classic/pull/2772


(and by soon I mean basically at the same time)