### PR TITLE
Handle deprecated attributes (aliased) in VirtualArel.arel_attribute method

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -31,7 +31,7 @@ module VirtualArel
   module ClassMethods
     def arel_attribute(column_name, arel_table = self.arel_table)
       load_schema
-      if virtual_attribute?(column_name)
+      if virtual_attribute?(column_name) && !attribute_alias?(column_name)
         col = _virtual_arel[column_name.to_s]
         col.call(arel_table) if col
       else


### PR DESCRIPTION
This fixes an MiqExpression bug where an error is raised attempting to get the `arel_attribute` of an aliased column. In the case of the bug, the column was aliased due to deprecation like this in the `Host` model -

`deprecate_attribute :address, :hostname`

The change adds an additional check for whether the column is an alias before attempting to look it up the field in the `_virtual_arel` hash which would result in nil. It instead falls into the else and calls super on it where it will get the name of the column it was aliased to.


https://bugzilla.redhat.com/show_bug.cgi?id=1507047