### PR TITLE
Allow proxying WebMKS consoles using the WebsocketWorker

### DIFF
--- a/lib/websocket_proxy.rb
+++ b/lib/websocket_proxy.rb
@@ -17,7 +17,8 @@ class WebsocketProxy
       @ws = env['rack.hijack'].call
       # Set up the socket client for the proxy
       @sock = TCPSocket.open(@console.host_name, @console.port)
-      init_ssl if @console.ssl
+      adapter = @console.ssl ? WebsocketSSLSocket : WebsocketSocket
+      @right = adapter.new(@sock, @console)
     rescue => ex
       @logger.error(ex)
       @error = true
@@ -25,9 +26,7 @@ class WebsocketProxy
 
     @driver.on(:open) { @console.update(:opened => true) }
 
-    @driver.on(:message) do |msg|
-      @ssl ? @ssl.syswrite(msg.data.pack('C*')) : @sock.write(msg.data.pack('C*'))
-    end
+    @driver.on(:message) { |msg| @right.issue(msg.data.pack('C*')) }
 
     @driver.on(:close) { cleanup }
   end
@@ -44,8 +43,9 @@ class WebsocketProxy
       data = @ws.recv_nonblock(64.kilobytes)
       @driver.parse(data)
     else
-      data = @ssl ? @ssl.sysread(64.kilobytes) : @sock.recv_nonblock(64.kilobytes)
-      @driver.binary(data)
+      @right.fetch(64.kilobytes) do |data|
+        @driver.binary(data)
+      end
     end
   end
 
@@ -68,18 +68,5 @@ class WebsocketProxy
 
   def vm_id
     @console ? @console.vm_id : 'unknown'
-  end
-
-  private
-
-  def init_ssl
-    context = OpenSSL::SSL::SSLContext.new
-    context.cert = OpenSSL::X509::Certificate.new(File.open('certs/server.cer'))
-    context.key = OpenSSL::PKey::RSA.new(File.open('certs/server.cer.key'))
-    context.ssl_version = :SSLv23
-    context.verify_depth = OpenSSL::SSL::VERIFY_NONE
-    @ssl = OpenSSL::SSL::SSLSocket.new(@sock, context)
-    @ssl.sync_close = true
-    @ssl.connect
   end
 end

--- a/lib/websocket_proxy.rb
+++ b/lib/websocket_proxy.rb
@@ -17,7 +17,14 @@ class WebsocketProxy
       @ws = env['rack.hijack'].call
       # Set up the socket client for the proxy
       @sock = TCPSocket.open(@console.host_name, @console.port)
-      adapter = @console.ssl ? WebsocketSSLSocket : WebsocketSocket
+      adapter = case @console.protocol
+                when 'vnc'
+                  WebsocketSocket
+                when 'spice'
+                  @console.ssl ? WebsocketSSLSocket : WebsocketSocket
+                when 'webmks'
+                  WebsocketWebmks
+                end
       @right = adapter.new(@sock, @console)
     rescue => ex
       @logger.error(ex)

--- a/lib/websocket_right.rb
+++ b/lib/websocket_right.rb
@@ -1,0 +1,14 @@
+class WebsocketRight
+  def initialize(socket, model)
+    @sock = socket
+    @model = model
+  end
+
+  def fetch(*)
+    raise NotImplementedError, 'This should be defined in a subclass'
+  end
+
+  def issue(*)
+    raise NotImplementedError, 'This should be defined in a subclass'
+  end
+end

--- a/lib/websocket_socket.rb
+++ b/lib/websocket_socket.rb
@@ -1,0 +1,9 @@
+class WebsocketSocket < WebsocketRight
+  def fetch(length)
+    yield(@sock.recv_nonblock(length))
+  end
+
+  def issue(data)
+    @sock.write(data)
+  end
+end

--- a/lib/websocket_ssl_socket.rb
+++ b/lib/websocket_ssl_socket.rb
@@ -1,0 +1,22 @@
+class WebsocketSSLSocket < WebsocketRight
+  def initialize(socket, model)
+    super(socket, model)
+
+    context = OpenSSL::SSL::SSLContext.new
+    context.cert = OpenSSL::X509::Certificate.new(File.open('certs/server.cer'))
+    context.key = OpenSSL::PKey::RSA.new(File.open('certs/server.cer.key'))
+    context.ssl_version = :SSLv23
+    context.verify_depth = OpenSSL::SSL::VERIFY_NONE
+    @ssl = OpenSSL::SSL::SSLSocket.new(@sock, context)
+    @ssl.sync_close = true
+    @ssl.connect
+  end
+
+  def fetch(length)
+    yield(@ssl.sysread(length))
+  end
+
+  def issue(data)
+    @ssl.syswrite(data)
+  end
+end

--- a/lib/websocket_webmks.rb
+++ b/lib/websocket_webmks.rb
@@ -1,0 +1,30 @@
+class WebsocketWebmks < WebsocketSSLSocket
+  attr_accessor :url
+
+  def initialize(socket, model)
+    super(socket, model)
+    @url = URI::Generic.build(:scheme => 'wss',
+                              :host   => @model.host_name,
+                              :port   => @model.port,
+                              :path   => "/ticket/#{@model.secret}").to_s
+    @driver = WebSocket::Driver.client(self, :protocols => ['binary'])
+    @driver.on(:close) { socket.close unless socket.closed? }
+    @driver.start
+  end
+
+  def fetch(length)
+    # WebSocket::Driver requires an event handler that should be registered only once
+    @driver.on(:message) { |msg| yield(msg.data) } if @driver.listeners(:message).length.zero?
+
+    data = @ssl.sysread(length)
+    @driver.parse(data)
+  end
+
+  def issue(data)
+    @driver.binary(data)
+  end
+
+  def write(data)
+    @ssl.syswrite(data)
+  end
+end

--- a/spec/lib/websocket_proxy_spec.rb
+++ b/spec/lib/websocket_proxy_spec.rb
@@ -45,14 +45,18 @@ describe WebsocketProxy do
     let(:ws) { double }
     let(:sock) { double }
 
+    before do
+      subject.instance_variable_set(:@driver, driver)
+      subject.instance_variable_set(:@ws, ws)
+      subject.instance_variable_set(:@sock, sock)
+      right = subject.instance_variable_get(:@right)
+      right.instance_variable_set(:@sock, sock)
+    end
+
     context 'websocket to socket' do
       let(:is_ws) { true }
 
       it 'reads from the websocket and parses the result' do
-        subject.instance_variable_set(:@driver, driver)
-        subject.instance_variable_set(:@ws, ws)
-        subject.instance_variable_set(:@sock, sock)
-
         expect(ws).to receive(:recv_nonblock).and_return(123)
         expect(driver).to receive(:parse).with(123)
 
@@ -64,10 +68,6 @@ describe WebsocketProxy do
       let(:is_ws) { false }
 
       it 'reads from the socket and sends the result to the driver' do
-        subject.instance_variable_set(:@driver, driver)
-        subject.instance_variable_set(:@ws, ws)
-        subject.instance_variable_set(:@sock, sock)
-
         expect(sock).to receive(:recv_nonblock).and_return(123)
         expect(driver).to receive(:binary).with(123)
 


### PR DESCRIPTION
The `WebsocketWorker` provides us a *websocket-to-socket* proxying that powers our browser based VNC/SPICE remote consoles. Thanks to this it's not necessary for the client to have a route to the hypervisor nor the VMs and the (internal) SSL certificate validation is also eliminated. Since VMware removed the support for VNC consoles since 6.5 and their only browser-based remote console technology is WebMKS, it also should be proxied.

As WebMKS runs on top of WebSocket, the worker needs to be rewritten to a *websocket-to-** proxy. I introduced a new generic `WebsocketRight` class to ease the implementation of new protocol types on the right side of the proxy. All inherited classes should define a `fetch(length)` and an `issue(data)` methods for reading and writing on the right side of the proxy. The naming of these methods is intentional as the [`websocket-driver`](https://github.com/faye/websocket-driver-ruby) we're using reserves the `write` method.

Provider PR: https://github.com/ManageIQ/manageiq-providers-vmware/pull/140
Classic UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/2768

https://bugzilla.redhat.com/show_bug.cgi?id=1504299