### PR TITLE
Address CVE-2017-8418 by upgrading Rubocop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -207,7 +207,7 @@ unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
     gem "haml_lint",        "~>0.20.0", :require => false
-    gem "rubocop",          "~>0.47.0", :require => false
+    gem "rubocop",          "~>0.49.0", :require => false
     gem "scss_lint",        "~>0.48.0", :require => false
     gem "yard"
   end


### PR DESCRIPTION
Address [CVE-2017-8418](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418) by upgrading Rubocop gem.