### PR TITLE
Add Middleware Server EAP/Wildfly translation

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -846,6 +846,8 @@ en:
       ManageIQ::Providers::Vmware::InfraManager::Host:                      Host (Vmware)
       ManageIQ::Providers::Vmware::InfraManager::HostEsx:                   Host (Vmware)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer:    Physical Server (Lenovo)
+      ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerEap:     Middleware Server (EAP)
+      ManageIQ::Providers::Hawkular::MiddlewareManager::MiddlewareServerWildfly: Middleware Server (WildFly)
       MiddlewareDatasource:     Middleware Datasource
       MiddlewareDomain:         Middleware Domain
       MiddlewareMessaging:      Middleware Messaging


### PR DESCRIPTION
Add Translation for Middleware servers so they appear correct in Alert profile listings.

Attempt to do the https://github.com/ManageIQ/manageiq/pull/16483 correctly.

Fixes: [BUG 1511653](https://bugzilla.redhat.com/show_bug.cgi?id=1511653)

Before:
![image](https://user-images.githubusercontent.com/7453394/32890837-b4b49fe0-cad0-11e7-9267-a0d996cd5f96.png)

After:
![image](https://user-images.githubusercontent.com/7453394/32891008-5c40d6e8-cad1-11e7-9710-9cc8b48a07fa.png)

cc @abonas, @mzazrivec