### PR TITLE
Fixed syntax with `orderby` in RSS Feed YAML files

### DIFF
--- a/product/alerts/rss/vmpowerevent.yml
+++ b/product/alerts/rss/vmpowerevent.yml
@@ -29,7 +29,7 @@ search_conditions: "event_type = 'VmPoweredOffEvent' OR event_type = 'VmPoweredO
 limit_to_time:
 limit_to_count:
 orderby:
-  :created_on :desc
+  :created_on: :desc
 
 # tags_include: any or all
 tag_ns:

--- a/product/alerts/rss/vmpoweroff.yml
+++ b/product/alerts/rss/vmpoweroff.yml
@@ -21,7 +21,7 @@ search_conditions: "event_type = 'VmPoweredOffEvent'"
 limit_to_time:
 limit_to_count:
 orderby:
-  :created_on :desc
+  :created_on: :desc
 
 # tags_include: any or all
 tag_ns:


### PR DESCRIPTION
The issue was causing the orderby column and direction to be pulled in as a single symbol instead of a hash causing a SQL error while generating the feed.

SQL before -
`SELECT  "event_streams".* FROM "event_streams" WHERE "event_streams"."type" IN ('EmsEvent') AND (event_type = 'VmPoweredOffEvent') ORDER BY "event_streams"."created_on :desc" ASC LIMIT $1`

After -
`SELECT  "event_streams".* FROM "event_streams" WHERE "event_streams"."type" IN ('EmsEvent') AND (event_type = 'VmPoweredOffEvent') ORDER BY "event_streams"."created_on" DESC LIMIT $1`

https://bugzilla.redhat.com/show_bug.cgi?id=1501265