### PR TITLE
Handle OpenID-Connect authentication client protocol

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -115,7 +115,7 @@ module Authenticator
                     :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
                     :email     => request.headers['X-REMOTE-USER-EMAIL'],
                     :domain    => request.headers['X-REMOTE-USER-DOMAIN']}
-      [user_attrs, (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:]/)]
+      [user_attrs, (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:,]/)]
     end
 
     def user_attrs_from_external_directory(username)

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -2,7 +2,6 @@ module EvmSettings
   ALLOWED_KEYS = [
     "/authentication/sso_enabled",
     "/authentication/saml_enabled",
-    "/authentication/oidc_enabled",
     "/authentication/local_login_disabled"
   ].freeze
 

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -2,6 +2,7 @@ module EvmSettings
   ALLOWED_KEYS = [
     "/authentication/sso_enabled",
     "/authentication/saml_enabled",
+    "/authentication/oidc_enabled",
     "/authentication/local_login_disabled"
   ].freeze
 

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -476,7 +476,6 @@ describe Authenticator::Httpd do
 
       context "using external authorization" do
         let(:config) { {:httpd_role => true} }
-
         it "records two successful audit entries" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
@@ -489,6 +488,26 @@ describe Authenticator::Httpd do
             :message => "Authentication successful for user testuser",
           )
           expect(AuditEvent).not_to receive(:failure)
+          authenticate
+        end
+      end
+
+      context "using a coma separated group list" do
+        let(:config) { {:httpd_role => true} }
+        let(:headers) do
+          super().merge('X-Remote-User-Groups' => 'wibble@fqdn,bubble@fqdn')
+        end
+        let(:user_attrs) do
+          { :username  => "testuser",
+            :fullname  => "Test User",
+            :firstname => "Alice",
+            :lastname  => "Aardvark",
+            :email     => "testuser@example.com",
+            :domain    => "example.com" }
+        end
+
+        it "handles a comma separated grouplist" do
+          expect(subject).to receive(:find_external_identity).with(username, user_attrs, ["wibble@fqdn", "bubble@fqdn"])
           authenticate
         end
       end

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -492,7 +492,7 @@ describe Authenticator::Httpd do
         end
       end
 
-      context "using a coma separated group list" do
+      context "using a comma separated group list" do
         let(:config) { {:httpd_role => true} }
         let(:headers) do
           super().merge('X-Remote-User-Groups' => 'wibble@fqdn,bubble@fqdn')

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -476,6 +476,7 @@ describe Authenticator::Httpd do
 
       context "using external authorization" do
         let(:config) { {:httpd_role => true} }
+
         it "records two successful audit entries" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/121849185

This changes introduced by this PR will prepare the authentication back end to handle the upcoming support of the OpenID Connect protocol.

This changes introduced by this PR, although reliant on more work for full OpenID Connect support, will not adversarially impact current functionality. 