### PR TITLE
Bundler.with_clean_env is deprecated

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -15,7 +15,7 @@ namespace :evm do
       server.update_attributes(:status => "started")
 
       # start the workers using foreman
-      Bundler.with_clean_env { exec("foreman start --port=3000") }
+      exec("foreman start --port=3000")
     end
   end
 


### PR DESCRIPTION
From what I can tell, we don't actually need it here.  I tested without it and everything works fine.