### PR TITLE
[WIP] Reconnect events for container entities

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -94,4 +94,18 @@ class ContainerGroup < ApplicationRecord
     self.deleted_on = Time.now.utc
     save
   end
+
+  def self.post_refresh_ems(ems_id, _ems_refresh_start_time)
+    self.reconnect_events(ems_id)
+  end
+
+  def self.reconnect_events(ems_id)
+    events = EmsEvent.where(:ems_id => ems_id, :container_group_id => nil).where.not(:container_group_name => nil)
+    events.each do |event|
+      event_data = event.full_data
+      next unless event_data[:kind] == "Pod"
+      event.container_group = ContainerGroup.where(:ems_ref => event_data[:uid]).last
+      event.save if event.container_group_id.present?
+    end
+  end
 end

--- a/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -179,7 +179,7 @@ module EmsRefresh
 
       def post_process_refresh_classes
         # Return the list of classes that need post processing
-        []
+        [ContainerGroup]
       end
 
       def post_refresh(ems, ems_refresh_start_time)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1496179

Try to connect newly discovered entities with events that were collected when the entities werent discovered yet. Currently works for `ContainerGroups` only but its needed for `ContainerNode` and `ContainerReplicator`.


@blomquisg Im leveraging some ancient code here. Is there a more up-to-date way to implement this?

@cben @moolitayer 
cc @simon3z
@miq-bot add_label wip, providers/containers
