### PR TITLE
Bump qpid-proton version to 0.18.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :nuage, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.18",        :git => "https://github.com/xlab-si/qpid_proton_gem", :require => false
+  gem "qpid_proton",                    "~>0.18.1",      :require => false
 end
 
 group :openshift, :manageiq_default do


### PR DESCRIPTION
This will bump the version of qpid-proton to 0.18.1. Change is only in .gemfile.

Addresses https://github.com/ManageIQ/manageiq-providers-nuage/issues/42

@miq-bot assign @gberginc 
@miq-bot add_label enhancement

/cc @gberginc 
/cc @miha-plesko 