### PR TITLE
Fix save_tags_inventory spec: assign the tag, not the catogory

### DIFF
--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -8,7 +8,7 @@ context "save_tags_inventory" do
                                  :category_description => category_name)
     category = mapping.tag.category
     entry = category.add_entry(:name => tag_name, :description => tag_name)
-    category.tag
+    entry.tag
   end
 
   before(:each) do


### PR DESCRIPTION
In #16453, I changed this spec to "realistically" create a tag mapping + category + tag.
But I made a typo/thinko, taking the parent (category) tag to be assigned to the vm.
This caused false failure for #16449 and days of lost work debugging/rewriting it, eventually caused similar failure in the rewrite too :-(

Well, at least now I'll have 2 approaches to choose from :-)

@miq-bot add-label test, bug, gaprindashvili/yes

@agrare Please review