### PR TITLE
Require miq_fault_tolerant_vim in raw_connect

### DIFF
--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -38,6 +38,7 @@ module VimConnectMixin
   module ClassMethods
     def raw_connect(options)
       require 'handsoap'
+      require 'VMwareWebService/miq_fault_tolerant_vim'
 
       options[:pass] = MiqPassword.try_decrypt(options[:pass])
       validate_connection do


### PR DESCRIPTION
Need to require miq_fault_tolerant_vim in raw_connect to validate credentials.

`WARN -- :MIQ(ManageIQ::Providers::Vmware::InfraManager.validate_connection) #<NameError: uninitialized constant VimConnectMixin::ClassMethods::MiqVim>`

https://bugzilla.redhat.com/show_bug.cgi?id=1512019