### PR TITLE
Replace ContainerLabelTagMapping.controls_tag? with a prefix-based scope

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -32,6 +32,9 @@ class Classification < ApplicationRecord
   scope :read_only,  -> { where(:read_only => true) }
   scope :writeable,  -> { where(:read_only => false) }
 
+  scope :is_category, -> { where(:parent_id => 0) }
+  scope :is_entry,    -> { where.not(:parent_id => 0) }
+
   DEFAULT_NAMESPACE = "/managed"
 
   default_value_for :read_only,    false

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -23,6 +23,9 @@ class ContainerLabelTagMapping < ApplicationRecord
 
   require_nested :Mapper
 
+  TAG_PREFIXES = ['/managed/amazon:', '/managed/kubernetes:'].freeze
+  validate :validate_tag_prefix
+
   # Return ContainerLabelTagMapping::Mapper instance that holds all current mappings,
   # can compute applicable tags, and create/find Tag records.
   def self.mapper
@@ -53,5 +56,11 @@ class ContainerLabelTagMapping < ApplicationRecord
       end
     end
     entity.tags.reset
+  end
+
+  def validate_tag_prefix
+    unless TAG_PREFIXES.any? { |prefix| tag.name.start_with?(prefix) }
+      errors.add(:tag_id, "tag category name #{tag.name} doesn't start with any of #{TAG_PREFIXES}")
+    end
   end
 end


### PR DESCRIPTION
- [x] Depends on #16499 to avoid a false failure.

This rewrite was all done to avoid that save_tags_inventory_spec failure, but eventually I bumped into it here too, and finally figured it out!
Now we have 2 options: revive #16449 (revert the revert) or this.

@agrare @moolitayer @bazulay @djberg96 Please review/help choose.
(Much of the spec changes here could also be combined with #16449.)

Overview/plan: ManageIQ/manageiq-providers-kubernetes#126


A scope is needed for tag mapping in graph refresh (https://bugzilla.redhat.com/show_bug.cgi?id=1470021), and may improve
performance.

This version no longer cares if there exists a ContainerLabelTagMapping linked to the category, only that it's name starts with `kubernetes:` / `amazon:`.  This can happen to user-created categories too, so we also check it's read_only.

Query for a specific `vm.tags.controlled_by_mapping`:

```
SELECT "tags".* FROM "tags"
INNER JOIN "classifications" ON "classifications"."tag_id" = "tags"."id"
INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id"
WHERE (   "taggings"."taggable_id" = 347 AND "taggings"."taggable_type" = 'VmOrTemplate' AND (name LIKE '/managed/amazon:%')
       OR "taggings"."taggable_id" = 347 AND "taggings"."taggable_type" = 'VmOrTemplate' AND (name LIKE '/managed/kubernetes:%'))
  AND "classifications"."read_only" = 't'
  AND ("classifications"."parent_id" != 0)
```

@miq-bot add-label performance, providers/inventory, gaprindashvili/yes