### PR TITLE
Max queued targets threshold

### DIFF
--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -1,4 +1,6 @@
 class BinaryBlob < ApplicationRecord
+  include_concern 'Purging'
+
   belongs_to :resource, :polymorphic => true
   has_many :binary_blob_parts, -> { order(:id) }, :dependent => :delete_all
 

--- a/app/models/binary_blob/purging.rb
+++ b/app/models/binary_blob/purging.rb
@@ -1,0 +1,20 @@
+class BinaryBlob < ApplicationRecord
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_timer
+        purge_queue(:scope)
+      end
+
+      def purge_window_size
+        ::Settings.binary_blob.purge_window_size
+      end
+
+      def purge_scope(_older_than = nil)
+        where(:resource => nil)
+      end
+    end
+  end
+end

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -168,7 +168,7 @@ module EmsRefresh
     task_id = nil
 
     # Items will be naturally serialized since there is a dedicated worker.
-    MiqQueue.put_or_update(queue_options) do |msg, item|
+    miq_queue_record = MiqQueue.put_or_update(queue_options) do |msg, item|
       targets = msg.nil? ? targets : msg.data.concat(targets)
 
       # If we are merging with an existing queue item we don't need a new
@@ -193,6 +193,16 @@ module EmsRefresh
         :task_id     => task_id,
         :msg_timeout => queue_timeout
       )
+    end
+
+    if targets.present?
+      # If we are storing data, we want to make sure any BinaryBlob present will be tied back to this MiqQueue record
+      payload_ids = targets.map { |x| x.try(:second).try(:[], :payload_id) }.compact
+      if payload_ids
+        BinaryBlob
+          .where(:id => payload_ids, :resource_id => nil)
+          .update_all(:resource_id => miq_queue_record.id, :resource_type => miq_queue_record.class.base_class)
+      end
     end
 
     task_id

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -197,7 +197,11 @@ module EmsRefresh
 
     if targets.present?
       # If we are storing data, we want to make sure any BinaryBlob present will be tied back to this MiqQueue record
-      payload_ids = targets.map { |x| x.try(:second).try(:[], :payload_id) }.compact
+      payload_ids = targets.map do |type, target_hash|
+        next if type != "ManagerRefresh::Target"
+        target_hash[:payload_id]
+      end.compact
+
       if payload_ids
         BinaryBlob
           .where(:id => payload_ids, :resource_id => nil)

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -166,6 +166,7 @@ module EmsRefresh
     # If this is the only refresh then we will use the task we just created,
     # if we merge with another queue item then we will return its task_id
     task_id = nil
+    new_targets = targets
 
     # Items will be naturally serialized since there is a dedicated worker.
     miq_queue_record = MiqQueue.put_or_update(queue_options) do |msg, item|
@@ -195,9 +196,9 @@ module EmsRefresh
       )
     end
 
-    if targets.present?
+    if new_targets.present?
       # If we are storing data, we want to make sure any BinaryBlob present will be tied back to this MiqQueue record
-      payload_ids = targets.map do |type, target_hash|
+      payload_ids = new_targets.map do |type, target_hash|
         next if type != "ManagerRefresh::Target"
         target_hash[:payload_id]
       end.compact

--- a/app/models/manager_refresh/target.rb
+++ b/app/models/manager_refresh/target.rb
@@ -9,6 +9,7 @@ module ManagerRefresh
     # @param manager [ManageIQ::Providers::BaseManager] The Manager owning the Target
     # @param manager_id [Integer] A primary key of the Manager owning the Target
     # @param event_id [Integer] A primary key of the EmsEvent associated with the Target
+    # @param payload_id [Integer] A primary key of a BinaryBlob containing the target inventory payload
     # @param options [Hash] A free form options hash
     def initialize(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, payload_id: nil, options: {})
       raise "Provide either :manager or :manager_id argument" if manager.nil? && manager_id.nil?

--- a/app/models/manager_refresh/target.rb
+++ b/app/models/manager_refresh/target.rb
@@ -1,6 +1,6 @@
 module ManagerRefresh
   class Target
-    attr_reader :association, :manager_ref, :event_id, :options
+    attr_reader :association, :manager_ref, :event_id, :options, :payload_id
 
     # @param association [Symbol] An existing association on Manager, that lists objects represented by a Target, naming
     #                             should be the same of association of a counterpart InventoryCollection object
@@ -10,7 +10,7 @@ module ManagerRefresh
     # @param manager_id [Integer] A primary key of the Manager owning the Target
     # @param event_id [Integer] A primary key of the EmsEvent associated with the Target
     # @param options [Hash] A free form options hash
-    def initialize(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, options: {})
+    def initialize(association:, manager_ref:, manager: nil, manager_id: nil, event_id: nil, payload_id: nil, options: {})
       raise "Provide either :manager or :manager_id argument" if manager.nil? && manager_id.nil?
 
       @manager     = manager
@@ -18,6 +18,7 @@ module ManagerRefresh
       @association = association
       @manager_ref = manager_ref
       @event_id    = event_id
+      @payload_id  = payload_id
       @options     = options
     end
 
@@ -38,6 +39,7 @@ module ManagerRefresh
         :manager_id  => manager_id,
         :association => association,
         :manager_ref => manager_ref,
+        :payload_id  => payload_id,
         :event_id    => event_id,
         :options     => options
       }
@@ -45,6 +47,15 @@ module ManagerRefresh
 
     alias id dump
     alias name manager_ref
+
+    def payload=(data)
+      payload_blob.try(:destroy)
+      @payload_id = data ? BinaryBlob.create!(:binary => data).id : nil
+    end
+
+    def payload
+      payload_blob.try(:binary)
+    end
 
     # @return [ManageIQ::Providers::BaseManager] The Manager owning the Target
     def manager
@@ -61,6 +72,10 @@ module ManagerRefresh
     # @return [ApplicationRecord] A ManagerRefresh::Target loaded from the database as AR object
     def load_from_db
       manager.public_send(association).find_by(manager_ref)
+    end
+
+    def payload_blob
+      BinaryBlob.find_by(:id => payload_id) if payload_id
     end
   end
 end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -19,6 +19,7 @@ require 'digest'
 #
 class MiqQueue < ApplicationRecord
   belongs_to :handler, :polymorphic => true
+  has_many :binary_blobs, :as => :resource, :dependent => :destroy
 
   attr_accessor :last_exception
 

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -19,7 +19,7 @@ require 'digest'
 #
 class MiqQueue < ApplicationRecord
   belongs_to :handler, :polymorphic => true
-  has_many :binary_blobs, :as => :resource, :dependent => :destroy
+  has_many :binary_blobs, :as => :resource, :dependent => :nullify
 
   attr_accessor :last_exception
 

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -111,6 +111,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "ContainerProject", :method_name => "purge_timer", :zone => nil)
   end
 
+  def binary_blob_purge_timer
+    queue_work(:class_name => "BinaryBlob", :method_name => "purge_timer", :zone => nil)
+  end
+
   def miq_schedule_queue_scheduled_work(schedule_id, rufus_job)
     MiqSchedule.queue_scheduled_work(schedule_id, rufus_job.job_id, rufus_job.next_time.to_i, rufus_job.opts)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -199,6 +199,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:archived_entities_purge_timer)
     end
 
+    every = worker_settings[:binary_blob_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue(:binary_blob_purge_timer)
+    end
+
     # Schedule every 24 hours
     at = worker_settings[:storage_file_collection_time_utc]
     if Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc) < Time.now.utc

--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -92,6 +92,12 @@ module PurgingMixin
       total
     end
 
+    def purge_by_scope(older_than = nil, window = nil, &block)
+      _log.info("Purging #{table_name.humanize}...")
+      total = purge_in_batches(purge_scope(older_than), window || purge_window_size, &block)
+      _log.info("Purging #{table_name.humanize}...Complete - Deleted #{total} records")
+    end
+
     private
 
     # Private:  The ids to purge if we want to keep a fixed number of records

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,8 @@
   :user_type: userprincipalname
   :amazon_key:
   :amazon_secret:
+:binary_blob:
+  :purge_window_size: 100
 :broker_notify_properties:
   :exclude:
     :HostSystem:
@@ -1154,6 +1156,7 @@
         :restart_interval: 6.hours
     :schedule_worker:
       :container_entities_purge_interval: 1.day
+      :binary_blob_purge_interval: 1.hour
       :authentication_check_interval: 1.hour
       :chargeback_generation_interval: 1.day
       :chargeback_generation_time_utc: 01:00:00

--- a/spec/models/manager_refresh/target_collection_spec.rb
+++ b/spec/models/manager_refresh/target_collection_spec.rb
@@ -225,12 +225,14 @@ describe ManagerRefresh::TargetCollection do
               :manager_id  => @ems.id,
               :event_id    => @ems_event.id,
               :association => :vms,
+              :payload_id  => nil,
               :manager_ref => {:ems_ref => @vm_1.ems_ref},
               :options     => {:opt1 => "opt1", :opt2 => "opt2"}
             }, {
               :manager_id  => @ems.id,
               :event_id    => @ems_event.id,
               :association => :vms,
+              :payload_id  => nil,
               :manager_ref => {:ems_ref => @vm_1.ems_ref},
               :options     => {:opt1 => "opt1", :opt2 => "opt2"}
             }

--- a/spec/models/manager_refresh/target_spec.rb
+++ b/spec/models/manager_refresh/target_spec.rb
@@ -55,6 +55,31 @@ describe ManagerRefresh::Target do
       )
     end
 
+    it "intializes correct ManagerRefresh::Target.object with a :payload_id " do
+      expected_payload = "abcd"
+      payload_id = BinaryBlob.create!(:binary => expected_payload.dup).id
+
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :payload_id  => payload_id,
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1).to(
+        have_attributes(
+          :manager     => @ems,
+          :manager_id  => @ems.id,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :payload_id  => payload_id,
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+      )
+      expect(target_1.payload).to eq(expected_payload)
+    end
+
     it "raises exception when manager not provided in any form" do
       data = {
         :association => :vms,
@@ -80,6 +105,7 @@ describe ManagerRefresh::Target do
           :manager_id  => @ems.id,
           :event_id    => nil,
           :association => :vms,
+          :payload_id  => nil,
           :manager_ref => {:ems_ref => @vm_1.ems_ref},
           :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
@@ -99,6 +125,27 @@ describe ManagerRefresh::Target do
           :manager_id  => @ems.id,
           :event_id    => nil,
           :association => :vms,
+          :payload_id  => nil,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+      )
+    end
+
+    it "class method .dump returns the same as an instance method .dump " do
+      target_1 = ManagerRefresh::Target.load(
+        :manager     => @ems,
+        :association => :vms,
+        :manager_ref => {:ems_ref => @vm_1.ems_ref},
+        :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+      )
+
+      expect(target_1.dump).to(
+        eq(
+          :manager_id  => @ems.id,
+          :event_id    => nil,
+          :association => :vms,
+          :payload_id  => nil,
           :manager_ref => {:ems_ref => @vm_1.ems_ref},
           :options     => {:opt1 => "opt1", :opt2 => "opt2"}
         )
@@ -153,6 +200,89 @@ describe ManagerRefresh::Target do
       )
 
       expect(target_1.name).to eq target_1.manager_ref
+    end
+
+    context ".payload" do
+      it "returns the payload from binary_blob" do
+        expected_payload = @vm_1.inspect
+        payload_id = BinaryBlob.create!(:binary => expected_payload.dup)
+
+        target_1 = ManagerRefresh::Target.new(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :payload_id  => payload_id,
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.payload).to eq(expected_payload)
+      end
+
+      it "returns nil if no payload_id" do
+        target_1 = ManagerRefresh::Target.new(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        expect(target_1.payload).to be_nil
+      end
+    end
+
+    context ".payload=" do
+      it "creates a binary blob" do
+        expected_payload = @vm_1.inspect
+
+        target_1 = ManagerRefresh::Target.new(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        target_1.payload = expected_payload.dup
+
+        expect(target_1.payload_id).to_not be_nil
+        expect(BinaryBlob.find(target_1.payload_id).binary).to eq(expected_payload)
+      end
+
+      it "overwrites a binary blob" do
+        first_payload = "abcd"
+        expected_payload = @vm_1.inspect
+
+        target_1 = ManagerRefresh::Target.new(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        target_1.payload = first_payload
+        payload_id = target_1.payload_id
+
+        target_1.payload = expected_payload.dup
+
+        expect(target_1.payload).to eq(expected_payload)
+        expect { BinaryBlob.find(payload_id) }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      it "deletes the binary blob when the payload is cleared" do
+        target_1 = ManagerRefresh::Target.new(
+          :manager     => @ems,
+          :association => :vms,
+          :manager_ref => {:ems_ref => @vm_1.ems_ref},
+          :options     => {:opt1 => "opt1", :opt2 => "opt2"}
+        )
+
+        target_1.payload = "abcd"
+        payload_id = target_1.payload_id
+
+        target_1.payload = nil
+        expect(target_1.payload).to be_nil
+
+        expect { BinaryBlob.find(payload_id) }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end


### PR DESCRIPTION
Add max_queued_targets_threshold, making sure we have a top limit
of max queued items. The current solution can have issues with
a lot of queued targets (big processing time and memory)

Also if the refresh worker goes down (consumer) we want to make sure
the producers will not be queueing targets indefinitelly. Cause in
that case, that would be causing the producers to rise in Memory
and procidessing time would be rising. So we would be forced to
delete the queue item with a lot of targets anyway.

Only last commit is relevant. 

Depends on 
- [ ]  https://github.com/ManageIQ/manageiq/pull/16413