### PR TITLE
Make sure we do not pass primary_key to insert query

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -15,7 +15,8 @@ module ManagerRefresh::SaveCollection
         # Cache the connection for the batch
         connection = get_connection
 
-        all_attribute_keys_array = all_attribute_keys.to_a
+        # Make sure we don't send a primary_key for INSERT in any form, it could break PG sequencer
+        all_attribute_keys_array = all_attribute_keys.to_a - [primary_key.to_s, primary_key.to_sym]
         table_name               = inventory_collection.model_class.table_name
         values                   = hashes.map do |hash|
           "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x) }.join(",")})"


### PR DESCRIPTION
Make sure we do not pass primary_key to insert query. Passing
primary key manually can lead to broken sequencer.