### PR TITLE
Adding the option to set default vlan

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -155,6 +155,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
         f[:notes] = vm_description
       when :vlan
         get_field(:vlan)
+        vlan ||= @values[fn].first
         set_value_from_list(fn, f, vlan, allowed_vlans)
       end
     end

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -418,9 +418,10 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: vLan
+          :description: Network
           :required: true
           :display: :edit
+          :default: <Template>
           :data_type: :string
         :mac_address:
           :description: MAC Address

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -440,8 +440,9 @@
               :vlans: true
             :method: :allowed_vlans
           :description: Network
-          :required: false
+          :required: true
           :display: :edit
+          :default: <Template>
           :data_type: :string
         :mac_address:
           :description: MAC Address


### PR DESCRIPTION
Adding the option to set default vlan

This change is needed by ManageIQ/manageiq-providers-ovirt#150.
PR ManageIQ/manageiq-providers-ovirt#150 is automatically setting a default 'vlan' on a vm provision. It is done by overriding 'miq_provison_workflow.set_default_vlan' method, introduced in this PR.
Since a default vlan is set, there is no need for the 'vlan' field to be required.


