### PR TITLE
Separate has_required_role from should_start_worker

### DIFF
--- a/app/models/miq_cockpit_ws_worker.rb
+++ b/app/models/miq_cockpit_ws_worker.rb
@@ -14,8 +14,7 @@ class MiqCockpitWsWorker < MiqWorker
   end
 
   def self.should_start_worker?
-    return false unless has_required_role?
-    can_start_cockpit_ws?
+    super && can_start_cockpit_ws?
   end
 
   def self.sync_workers

--- a/app/models/miq_ems_refresh_core_worker.rb
+++ b/app/models/miq_ems_refresh_core_worker.rb
@@ -5,9 +5,8 @@ class MiqEmsRefreshCoreWorker < MiqWorker
 
   self.required_roles = ["ems_inventory"]
 
-  def self.has_required_role?
-    return false if Settings.prototype.ems_vmware.update_driven_refresh
-    super
+  def self.should_start_worker?
+    super && !Settings.prototype.ems_vmware.update_driven_refresh
   end
 
   def self.ems_class

--- a/app/models/miq_vim_broker_worker.rb
+++ b/app/models/miq_vim_broker_worker.rb
@@ -19,9 +19,12 @@ class MiqVimBrokerWorker < MiqWorker
     return 1
   }
 
-  def self.has_required_role?
-    return false if emses_to_monitor.empty?
-    super
+  def self.should_start_worker?
+    super && emses_to_monitor?
+  end
+
+  def self.emses_to_monitor?
+    !emses_to_monitor.empty?
   end
 
   def self.emses_to_monitor

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -55,7 +55,7 @@ module MiqWebServerWorkerMixin
 
       workers = find_current_or_starting
       current = workers.length
-      desired = self.has_required_role? ? self.workers : 0
+      desired = should_start_worker? ? workers : 0
       result  = {:adds => [], :deletes => []}
       ports = all_ports_in_use
 

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -29,7 +29,7 @@ module PerEmsWorkerMixin
     def sync_workers
       ws      = find_current_or_starting
       current = ws.collect(&:queue_name).sort
-      desired = self.has_required_role? ? desired_queue_names.sort : []
+      desired = should_start_worker? ? desired_queue_names.sort : []
       result  = {:adds => [], :deletes => []}
 
       unless compare_queues(current, desired)
@@ -57,7 +57,7 @@ module PerEmsWorkerMixin
     end
 
     def start_workers
-      return unless self.has_required_role?
+      return unless should_start_worker?
       all_valid_ems_in_zone.each do |ems|
         start_worker_for_ems(ems)
       end

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -121,7 +121,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def remove_snapshot_by_description(description, refresh = false, retry_time = nil)
-    if (ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager) && ManageIQ::Providers::Vmware::InfraManager.use_vim_broker? && MiqVimBrokerWorker.available?) || host.nil? || host.state == "on"
+    if host.nil? || host.state == "on" || (ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager) && ManageIQ::Providers::Vmware::InfraManager.use_vim_broker? && MiqVimBrokerWorker.available?)
       raw_remove_snapshot_by_description(description, refresh)
     else
       if retry_time.nil?

--- a/spec/models/miq_ems_refresh_core_worker_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker_spec.rb
@@ -1,17 +1,43 @@
 describe MiqEmsRefreshCoreWorker do
-  context "update_driven_refresh" do
-    before do
-      stub_settings_merge(
-        :prototype => {
-          :ems_vmware => {
-            :update_driven_refresh => true
-          }
-        }
-      )
-    end
+  # enable role "ems_inventory" ( .has_role_enabled? == true)
+  before do
+    FactoryGirl.create(:server_role, :name => 'ems_inventory')
+    my_server = EvmSpecHelper.local_miq_server
+    my_server.update_attributes(:role => "ems_inventory")
+    my_server.activate_roles("ems_inventory")
+  end
 
-    it ".has_required_role?" do
-      expect(described_class.has_required_role?).to be_falsy
+  context ".should_start_worker?" do
+    context "with update_driven_refresh" do
+      before do
+        stub_settings_merge(
+          :prototype => {
+            :ems_vmware => {
+              :update_driven_refresh => true
+            }
+          }
+        )
+      end
+
+      it "should not start the worker" do
+        expect(described_class.should_start_worker?).to be_falsy
+      end
+    end
+    context "without update_driven_refresh" do
+      before do
+        stub_settings_merge(
+          :prototype => {
+            :ems_vmware => {
+              :update_driven_refresh => false
+            }
+          }
+        )
+      end
+
+      it "should not start the worker" do
+        described_class.should_start_worker?
+        expect(described_class.should_start_worker?).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
There are 2 concepts in determining if the manager `should_start_worker`:

1. Does the worker `has_required_role?`
2. Are external circumstances setup to run the worker?

This change takes a queue from `miq_cockpit_ws_worker#should_start_worker`. 

In most places of the code, the caller wants to know if it is configured to run the worker rather than if there are other necessary resources available.

### before

In C&U, `perf_capture` calls `connect` for every object - yes way too often. Fixing that is out of scope for this conversation.

Every `connect` uses `has_required_role?` [[here]](https://github.com/ManageIQ/manageiq-providers-vmware/blob/master/app/models/manageiq/providers/vmware/infra_manager.rb#L78) to determine if it will use the broker or not.
While `has_required_role?` looks at configuration, it also determines if there is an ems configured in this zone that has a password and needs a broker.
Amusingly, `perf_capture` would not be called if there were not an ems in this zone. So removing this unneeded check removes 2 queries and speeds up `perf_capture` a little bit - but since there are many calls, it ends up being a lot.

~~Also, we lookup the worker record to see that it is there, and then look up the worker record when we actually need it.~~

### after

Every `connect` still uses `has_reqired_role` but only the configuration is accessed. Password checks others are performed in calls outside `has_required_role`

~~Only lookup the worker record when we need it.~~ another PR

numbers
-------

```
[Vm.count, Vm.all.select {|vm| vm.state == "on"}.count, Host.count, Storage.count]
[1000, 500, 50, 61]  
```

Single and multi runs:

|       ms |      bytes |   objects |query |  qry ms |     rows | comments
|      ---:|        ---:|       ---:|  ---:|     ---:|      ---:| ---
|    609.5 | 18,242,863 |   264,925 |   41 |    84.2 |       16 | capture-1-before
|    536.1 | 18,009,533 |   261,852 |   39 |    86.1 |       14 | capture-1-after
|     12%  |         1% |        1% |   5% |    ?    |      13% | diff

|       ms |      bytes |   objects |query |  qry ms |     rows | comments
|      ---:|        ---:|       ---:|  ---:|     ---:|      ---:| ---
|  2,154.2 | 38,541,310 | 1,468,828 |  322 |   384.7 |      140 | capture-10-before
|  2,136.4 | 36,689,155 | 1,442,646 |  302 |   382.0 |      120 | capture-10-after
|      1%  |         5% |        2% |   6% |     1%  |      14% | diff

Queries removed:

|     ms |query | qry ms |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|    0.7 |    1 |   0.5 |        1 |`.SELECT "ext_management_systems".*  -- [195]` first commit
|    0.9 |    1 |   0.5 |        2 |`.SELECT "authentications".*  -- [155]` first commit
|    0.8 |    1 |   0.6 |        1 |`.SELECT  "miq_workers".*  -- [239]` second commit

note: most of the time is spent fetching from metrics (twice) and writing >50 records to metrics.
With smaller environments, the total ms is closer to 200ms, so the savings is more profound.
