### PR TITLE
Scope Tenant#name validation to the current region

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -42,7 +42,9 @@ class Tenant < ApplicationRecord
   validate  :validate_only_one_root
   validates :description, :presence => true
   validates :name, :presence => true, :unless => :use_config_for_attributes?
-  validates :name, :uniqueness => {:scope => :ancestry, :message => "should be unique per parent"}
+  validates :name, :uniqueness => {:scope      => :ancestry,
+                                   :conditions => -> { in_my_region },
+                                   :message    => "should be unique per parent"}
   validate :validate_default_tenant, :on => :update, :if => :default_miq_group_id_changed?
 
   scope :all_tenants,  -> { where(:divisible => true) }

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -227,6 +227,15 @@ describe Tenant do
     end
   end
 
+  context "validate multi region" do
+    let(:other_region_id) { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
+
+    it "allows same name as tenant in a different region" do
+      described_class.create(:name => "GT", :description => "GT Tenant in other region", :id => other_region_id)
+      expect(described_class.new(:name => "GT", :description => "GT Tenant in this region").valid?).to be_truthy
+    end
+  end
+
   context "#ensure_can_be_destroyed" do
     let(:tenant)       { FactoryGirl.create(:tenant) }
     let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant) }


### PR DESCRIPTION
Allow admins in the global region to create tenants named the same as tenants replicated from remote regions.

https://bugzilla.redhat.com/show_bug.cgi?id=1422901
