### PR TITLE
Changes dialog name duplication error message to make sense

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -11,8 +11,8 @@ class Dialog < ApplicationRecord
   has_many :resource_actions
   virtual_has_one :content, :class_name => "Hash"
 
-  before_destroy          :reject_if_has_resource_actions
-  validates :label, :unique_within_region => true
+  before_destroy :reject_if_has_resource_actions
+  validates      :name, :unique_within_region => true
 
   alias_attribute  :name, :label
 

--- a/spec/lib/services/dialog_import_service_spec.rb
+++ b/spec/lib/services/dialog_import_service_spec.rb
@@ -459,7 +459,7 @@ describe DialogImportService do
 
       expect do
         dialog_import_service.import(dialogs.first)
-      end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Label is not unique within region/)
+      end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Name is not unique within region/)
     end
   end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -38,7 +38,7 @@ describe Dialog do
     it "with same label" do
       expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }.to_not raise_error
       expect { @dialog = FactoryGirl.create(:dialog, :label => 'dialog') }
-        .to raise_error(ActiveRecord::RecordInvalid, /Label is not unique within region/)
+        .to raise_error(ActiveRecord::RecordInvalid, /Name is not unique within region/)
     end
 
     it "with different labels" do


### PR DESCRIPTION
"Label is not unique within region" is not much help as the part that's being validated is listed in the UI as the name, not the label. The uniqueness validator had to change because rails won't let me just put in a custom message without one of the specialized validators. 

## related to this mess: 
https://github.com/ManageIQ/manageiq-schema/pull/142
https://github.com/ManageIQ/manageiq/pull/16600

(merged:)
~~https://github.com/ManageIQ/manageiq-ui-classic/pull/2772~~
~~https://github.com/ManageIQ/manageiq/pull/16487~~