### PR TITLE
Move the notifications to include more of the setup

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -8,8 +8,10 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   end
 
   def do_before_work_loop
+    raise_role_notification(:role_activate_start)
     setup_ansible
     update_embedded_ansible_provider
+    raise_role_notification(:role_activate_success)
   rescue => err
     _log.log_backtrace(err)
     do_exit(err.message, 1)
@@ -28,13 +30,9 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   end
 
   def setup_ansible
-    raise_role_notification(:role_activate_start)
-
     _log.info("Starting embedded ansible service ...")
     embedded_ansible.start
     _log.info("Finished starting embedded ansible service.")
-
-    raise_role_notification(:role_activate_success)
   end
 
   def update_embedded_ansible_provider

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -20,11 +20,43 @@ describe EmbeddedAnsibleWorker::Runner do
       r
     }
 
-    it "#do_before_work_loop exits on exceptions" do
-      expect(runner).to receive(:setup_ansible)
-      expect(runner).to receive(:update_embedded_ansible_provider).and_raise(StandardError)
-      expect(runner).to receive(:do_exit)
-      runner.do_before_work_loop
+    context "#do_before_work_loop" do
+      let(:start_notification_id) { NotificationType.find_by(:name => "role_activate_start").id }
+      let(:success_notification_id) { NotificationType.find_by(:name => "role_activate_success").id }
+
+      before do
+        ServerRole.seed
+        NotificationType.seed
+      end
+
+      it "creates a notification to inform the user that the service has started" do
+        expect(runner).to receive(:setup_ansible)
+        expect(runner).to receive(:update_embedded_ansible_provider)
+
+        runner.do_before_work_loop
+
+        note = Notification.find_by(:notification_type_id => success_notification_id)
+        expect(note.options[:role_name]).to eq("Embedded Ansible")
+        expect(note.options.keys).to include(:server_name)
+      end
+
+      it "creates a notification to inform the user that the role has been assigned" do
+        expect(runner).to receive(:setup_ansible)
+        expect(runner).to receive(:update_embedded_ansible_provider)
+
+        runner.do_before_work_loop
+
+        note = Notification.find_by(:notification_type_id => start_notification_id)
+        expect(note.options[:role_name]).to eq("Embedded Ansible")
+        expect(note.options.keys).to include(:server_name)
+      end
+
+      it "exits on exceptions" do
+        expect(runner).to receive(:setup_ansible)
+        expect(runner).to receive(:update_embedded_ansible_provider).and_raise(StandardError)
+        expect(runner).to receive(:do_exit)
+        runner.do_before_work_loop
+      end
     end
 
     context "#update_embedded_ansible_provider" do
@@ -94,36 +126,6 @@ describe EmbeddedAnsibleWorker::Runner do
           expect(userid).to eq("admin")
           expect(password).to eq("secret")
         end
-      end
-    end
-
-    context "#setup_ansible" do
-      let(:start_notification_id) { NotificationType.find_by(:name => "role_activate_start").id }
-      let(:success_notification_id) { NotificationType.find_by(:name => "role_activate_success").id }
-
-      before do
-        ServerRole.seed
-        NotificationType.seed
-      end
-
-      it "creates a notification to inform the user that the service has started" do
-        expect(embedded_ansible_instance).to receive(:start)
-
-        runner.setup_ansible
-
-        note = Notification.find_by(:notification_type_id => success_notification_id)
-        expect(note.options[:role_name]).to eq("Embedded Ansible")
-        expect(note.options.keys).to include(:server_name)
-      end
-
-      it "creates a notification to inform the user that the role has been assigned" do
-        expect(embedded_ansible_instance).to receive(:start)
-
-        runner.setup_ansible
-
-        note = Notification.find_by(:notification_type_id => start_notification_id)
-        expect(note.options[:role_name]).to eq("Embedded Ansible")
-        expect(note.options.keys).to include(:server_name)
       end
     end
   end


### PR DESCRIPTION
Things can go wrong while setting up the default objects and setting up the provider.

We should wait until all of this work is done before creating the notification that says that the role has been successfully enabled.

https://bugzilla.redhat.com/show_bug.cgi?id=1458019