### PR TITLE
Fix VmOrTemplate#registered? and add scope forms

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -194,6 +194,14 @@ class VmOrTemplate < ApplicationRecord
   scope :orphaned,  ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
   scope :with_ems,  ->       { where.not(:ems_id => nil) }
 
+  # The SQL form of `#registered?`, with it's inverse as well.
+  # TODO: Vmware Specific (copied (old) TODO from #registered?)
+  scope :registered, (lambda do
+    where(arel_table[:template].eq(false).or(arel_table[:ems_id].not_eq(nil)).and(arel_table[:host_id].not_eq(nil)))
+  end)
+  scope :unregistered, (lambda do
+    where(arel_table[:template].eq(true).and(arel_table[:ems_id].eq(nil)).or(arel_table[:host_id].eq(nil)))
+  end)
 
   alias_method :datastores, :storages    # Used by web-services to return datastores as the property name
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -301,7 +301,7 @@ class VmOrTemplate < ApplicationRecord
   # Determines if the VM is on an EMS or Host
   def registered?
     # TODO: Vmware specific
-    return false if self.template? && ext_management_system_id.nil?
+    return false if template? && ems_id.nil?
     host_id.present?
   end
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -5,57 +5,80 @@ describe VmOrTemplate do
   let(:ems)     { FactoryGirl.create(:ext_management_system) }
   let(:storage) { FactoryGirl.create(:storage) }
 
-  # Basically these specs are a truth table for the #registered? method
+  # Basically these specs are a truth table for the #registered? method, but
+  # need it to verify functionality when converting these to scopes
   describe "being registered" do
     subject                { FactoryGirl.create(:vm_or_template, attrs) }
     let(:host)             { FactoryGirl.create(:host) }
+    let(:registered_vms)   { described_class.registered.to_a }
+    let(:unregistered_vms) { described_class.unregistered.to_a }
+
+    # Preloads subject so that the registered_vms and unregistered_vms specs
+    # have it available to query against.
+    before { subject }
 
     context "with attrs of template => false, ems_id => nil, host_id => nil" do
       let(:attrs) { { :template => false, :ems_id => nil, :host_id => nil } }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
+      it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
+      it("is in unregistered_vms")     { expect(unregistered_vms).to include subject }
     end
 
     context "with attrs template => false, ems_id => nil, host_id => [ID]" do
       let(:attrs) { { :template => false, :ems_id => nil, :host_id => host.id } }
 
       it("is #registered?")            { expect(subject.registered?).to be true }
+      it("is in registered_vms")       { expect(registered_vms).to include subject }
+      it("is not in unregistered_vms") { expect(unregistered_vms).to_not include subject }
     end
 
     context "with attrs template => false, ems_id => [ID], host_id => nil" do
       let(:attrs) { { :template => false, :ems_id => ems.id, :host_id => nil } }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
+      it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
+      it("is in unregistered_vms")     { expect(unregistered_vms).to include subject }
     end
 
     context "with attrs template => false, ems_id => [ID], host_id => [ID]" do
       let(:attrs) { { :template => false, :ems_id => ems.id, :host_id => host.id } }
 
       it("is #registered?")            { expect(subject.registered?).to be true }
+      it("is in registered_vms")       { expect(registered_vms).to include subject }
+      it("is not in unregistered_vms") { expect(unregistered_vms).to_not include subject }
     end
 
     context "with attrs template => true, ems_id => nil, host_id => nil" do
       let(:attrs) { { :template => true, :ems_id => nil, :host_id => nil } }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
+      it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
+      it("is in unregistered_vms")     { expect(unregistered_vms).to include subject }
     end
 
     context "with attrs if template => true, ems_id => nil, host_id => [ID]" do
       let(:attrs) { { :template => true, :ems_id => nil, :host_id => host.id } }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
+      it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
+      it("is in unregistered_vms")     { expect(unregistered_vms).to include subject }
     end
 
     context "with attrs if template => true, ems_id => [ID], host_id => nil" do
       let(:attrs) { { :template => true, :ems_id => ems.id, :host_id => nil } }
 
       it("is not #registered?")        { expect(subject.registered?).to be false }
+      it("is not in registered_vms")   { expect(registered_vms).to_not include subject }
+      it("is in unregistered_vms")     { expect(unregistered_vms).to include subject }
     end
 
     context "with attrs if template => true, ems_id => [ID], host_id => [ID]" do
       let(:attrs) { { :template => true, :ems_id => ems.id, :host_id => host.id } }
 
       it("is #registered?")            { expect(subject.registered?).to be true }
+      it("is in registered_vms")       { expect(registered_vms).to include subject }
+      it("is not in unregistered_vms") { expect(unregistered_vms).to_not include subject }
     end
   end
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -5,6 +5,60 @@ describe VmOrTemplate do
   let(:ems)     { FactoryGirl.create(:ext_management_system) }
   let(:storage) { FactoryGirl.create(:storage) }
 
+  # Basically these specs are a truth table for the #registered? method
+  describe "being registered" do
+    subject                { FactoryGirl.create(:vm_or_template, attrs) }
+    let(:host)             { FactoryGirl.create(:host) }
+
+    context "with attrs of template => false, ems_id => nil, host_id => nil" do
+      let(:attrs) { { :template => false, :ems_id => nil, :host_id => nil } }
+
+      it("is not #registered?")        { expect(subject.registered?).to be false }
+    end
+
+    context "with attrs template => false, ems_id => nil, host_id => [ID]" do
+      let(:attrs) { { :template => false, :ems_id => nil, :host_id => host.id } }
+
+      it("is #registered?")            { expect(subject.registered?).to be true }
+    end
+
+    context "with attrs template => false, ems_id => [ID], host_id => nil" do
+      let(:attrs) { { :template => false, :ems_id => ems.id, :host_id => nil } }
+
+      it("is not #registered?")        { expect(subject.registered?).to be false }
+    end
+
+    context "with attrs template => false, ems_id => [ID], host_id => [ID]" do
+      let(:attrs) { { :template => false, :ems_id => ems.id, :host_id => host.id } }
+
+      it("is #registered?")            { expect(subject.registered?).to be true }
+    end
+
+    context "with attrs template => true, ems_id => nil, host_id => nil" do
+      let(:attrs) { { :template => true, :ems_id => nil, :host_id => nil } }
+
+      it("is not #registered?")        { expect(subject.registered?).to be false }
+    end
+
+    context "with attrs if template => true, ems_id => nil, host_id => [ID]" do
+      let(:attrs) { { :template => true, :ems_id => nil, :host_id => host.id } }
+
+      it("is not #registered?")        { expect(subject.registered?).to be false }
+    end
+
+    context "with attrs if template => true, ems_id => [ID], host_id => nil" do
+      let(:attrs) { { :template => true, :ems_id => ems.id, :host_id => nil } }
+
+      it("is not #registered?")        { expect(subject.registered?).to be false }
+    end
+
+    context "with attrs if template => true, ems_id => [ID], host_id => [ID]" do
+      let(:attrs) { { :template => true, :ems_id => ems.id, :host_id => host.id } }
+
+      it("is #registered?")            { expect(subject.registered?).to be true }
+    end
+  end
+
   context ".event_by_property" do
     context "should add an EMS event" do
       before(:each) do


### PR DESCRIPTION
`ext_management_system_id` is a method/column that has never existed, but was added as part of a commit to switch this to not make full calls to `#host` and `#ext_management_system`, but the `#ext_management_system` relation uses `:ems_id` as the column, not the common convention of `:ext_management_system_id`.  Hence the mistake.

In most cases, this doesn't show up since `#template?` call short circuits the `if`, and this is almost always called from a `Vm` class (from `Storage`), so `#template?` will always be `false`.

_**Note about added scopes**: The scopes added are meant to be used in a future performance fix, but added as part of this PR since they required the specs for validation anyway, and also helped design the specs in the fashion they are written.  The last commit can be omitted for now if desired and added with the performance fix, but the context seemed like it would be helpful for understanding why the specs were written in the way they were._


Links
-----
* Offending commit:  https://github.com/ManageIQ/manageiq/commit/866b5db
    - part of https://github.com/ManageIQ/manageiq/pull/8364