### PR TITLE
[FINE] Improve tag mapping tests

### DIFF
--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -6,4 +6,21 @@ FactoryGirl.define do
       labeled_resource_type 'ContainerNode'
     end
   end
+
+  # Mapping for <All> entities, as created in UI.
+  factory :tag_mapping_with_category, :parent => :container_label_tag_mapping do
+    transient do
+      category_name { "kubernetes::" + Classification.sanitize_name(label_name.tr("/", ":")) }
+      category_description { "Mapped #{label_name}" }
+    end
+
+    tag do
+      category = FactoryGirl.create(:classification,
+                                    :name         => category_name,
+                                    :description  => category_description,
+                                    :single_value => true,
+                                    :read_only    => true)
+      category.tag
+    end
+  end
 end

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,4 +1,12 @@
 context "save_tags_inventory" do
+  # @return [Tag] for a category linked to a mapping.
+  def mapped_cat(category_name)
+    mapping = FactoryGirl.create(:tag_mapping_with_category,
+                                 :category_name        => category_name,
+                                 :category_description => category_name)
+    mapping.tag.classification
+  end
+
   before(:each) do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
@@ -6,50 +14,82 @@ context "save_tags_inventory" do
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
     @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
-    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner')
-    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff')
-    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:foo') # All
-
-    @cat1 = FactoryGirl.create(:category, :description => 'amazon_vm_owner', :tag => @tag1)
-    @cat2 = FactoryGirl.create(:category, :description => 'department', :tag => @tag2)
-    @cat3 = FactoryGirl.create(:category, :description => 'location', :tag => @tag3)
+    @cat1 = mapped_cat('amazon:vm:owner')
+    @cat2 = mapped_cat('kubernetes:container_node:stuff')
+    @cat3 = mapped_cat('kubernetes::foo') # All entities
   end
 
   # This is what ContainerLabelTagMapping.map_labels(cache, 'Type', labels) would
   # return in the refresh parser. Note that we don't explicitly test the mapping
   # creation here, the assumption is that these were the generated mappings.
   #
+  let(:tag1_hash) do
+    {
+      :category_tag_id   => @cat1.tag_id,
+      :entry_name        => 'owner',
+      :entry_description => 'Daniel'
+    }
+  end
+  let(:tag2_hash) do
+    {
+      :category_tag_id   => @cat2.tag_id,
+      :entry_name        => 'stuff',
+      :entry_description => 'Ladas'
+    }
+  end
+  let(:tag3_hash) do
+    {
+      :category_tag_id   => @cat3.tag_id,
+      :entry_name        => 'foo',
+      :entry_description => 'Bronagh'
+    }
+  end
+
   let(:data) do
     {
       :tags => [
-        {
-          :category_tag_id   => @cat1.tag_id,
-          :entry_name        => 'owner',
-          :entry_description => 'Daniel'
-        },
-        {
-          :category_tag_id   => @cat2.tag_id,
-          :entry_name        => 'stuff',
-          :entry_description => 'Ladas'
-        },
-        {
-          :category_tag_id   => @cat3.tag_id,
-          :entry_name        => 'foo',
-          :entry_description => 'Bronagh'
-        }
+        tag1_hash,
+        tag2_hash,
+        tag3_hash
       ]
     }
+  end
+  let(:data2) do
+    {
+      :tags => [
+        tag2_hash
+      ]
+    }
+  end
+  let(:data_empty) do
+    {
+      :tags => []
+    }
+  end
+  let(:data_empty_array) do
+    []
   end
 
   # Note that in these tests we're explicitly passing the object, so that's
   # why the object type may not match what you would expect from the tag
   # name type above.
 
-  it "creates the expected number of taggings" do
+  it "creates/deletes the expected number of taggings" do
     EmsRefresh.save_tags_inventory(@vm, data)
-    taggings = Tagging.all
-    expect(taggings.size).to eql(3)
-    expect(@vm.tags.size).to eql(3)
+    expect(Tagging.count).to eql(3)
+    expect(@vm.reload.tags.size).to eql(3)
+
+    EmsRefresh.save_tags_inventory(@vm, data_empty)
+    expect(Tagging.count).to eql(0)
+    expect(@vm.reload.tags.size).to eql(0)
+
+    EmsRefresh.save_tags_inventory(@vm, data2)
+    expect(Tagging.count).to eql(1)
+    expect(@vm.reload.tags.size).to eql(1)
+
+    EmsRefresh.save_tags_inventory(@vm, data_empty_array)
+    expect(Tagging.count).to eql(0)
+    expect(@vm.reload.tags.size).to eql(0)
   end
 
   it "creates the expected taggings for a VM" do


### PR DESCRIPTION
fine backport for #16453

Cherry-picked from 66a5465d7360474aaae1315fd9f66e93484b34f4,
edited for older ContainerLabelTagMapping that worked with hashes not InventoryObject.
(with the edits, does not need #16499 fix)

@miq-bot add-label providers/inventory, test

https://bugzilla.redhat.com/show_bug.cgi?id=1508437 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1510095 (gaprindashvili)
**https://bugzilla.redhat.com/show_bug.cgi?id=1510096 (fine)**