### PR TITLE
[WIP] Fix total_vms for VMs in CloudTenant 

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -32,7 +32,7 @@ class CloudTenant < ApplicationRecord
 
   acts_as_tree :order => 'name'
 
-  virtual_total :total_vms, :vms
+  virtual_total :total_vms, :vms, :arel => Vm.vms_arel
 
   def self.class_by_ems(ext_management_system)
     ext_management_system && ext_management_system.class::CloudTenant

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -8,6 +8,25 @@ class Vm < VmOrTemplate
 
   include_concern 'Operations'
 
+  def self.vms_arel
+    lambda do |t|
+      vm_table = Vm.arel_table
+      local_key     = :id
+      foreign_key   = :cloud_tenant_id
+      arel_column   = Arel.star.count
+
+      default_conditions = Vm.default_scopes.inject({}) { |result, scope| result.merge!(scope.call.where_values_hash) }
+
+      empty_arel = nil
+      arel_conditions = default_conditions.inject(empty_arel) do |result, array_condition|
+        condition = vm_table[array_condition.first].in(array_condition.second)
+        result ? result.and(condition) : condition
+      end
+
+      t.grouping(vm_table.project(arel_column).where(t[local_key].eq(vm_table[foreign_key])).where(arel_conditions))
+    end
+  end
+
   def self.base_model
     Vm
   end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -23,6 +23,9 @@ class Vm < VmOrTemplate
         result ? result.and(condition) : condition
       end
 
+      # Vm.active
+      arel_conditions = arel_conditions.and(vm_table[:ems_id].not_eq(nil))
+
       t.grouping(vm_table.project(arel_column).where(t[local_key].eq(vm_table[foreign_key])).where(arel_conditions))
     end
   end

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -9,4 +9,21 @@ describe CloudTenant do
 
     expect(tenant1.all_cloud_networks).to match_array([net1, net2])
   end
+
+  describe '#total_vms' do
+    let(:ems)          { FactoryGirl.create(:ems_openstack) }
+    let(:vm)           { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
+    let(:template)     { FactoryGirl.create(:miq_template) }
+    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => ems, :vms => [vm], :miq_templates => [template]) }
+
+    it 'counts only vms' do
+      expect(cloud_tenant.vms).to match_array(vm)
+      expect(cloud_tenant.total_vms).to eq(1)
+
+      total_vms_from_select = CloudTenant.where(:id => cloud_tenant).select(:total_vms).first[:total_vms]
+      expect(total_vms_from_select).to eq(1)
+      expect(total_vms_from_select).to eq(cloud_tenant.total_vms)
+      expect(cloud_tenant.vms_and_templates.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Issue
This call is using `default_scopes` of VM and as well scope from https://github.com/ManageIQ/manageiq/blob/master/app/models/cloud_tenant.rb#L16

` CloudTenant.where(:name => 'DEV’).first.total_vms`

but instead of case with using `select`

`CloudTenant.where(:name => 'DEV’).select(:total_vms)`
it is not including default_scopes because it is building aggregation query 
https://github.com/ManageIQ/manageiq/blob/master/lib/extensions/virtual_total.rb#L93 (without needed condition)

## How it pertain reports ?
It pertains `extra_cols` and RBAC.
`extra_cols` are used for processing virtual columns from report in RBAC(https://github.com/ManageIQ/manageiq/blob/master/lib/rbac/filterer.rb#L587) in report generator (https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_report/generator.rb#L276)


## Solution
not sure if this possible to fix in `ar_virtual/total.rb`(Not sure how) but I created AR as class method on VM,
to use it in `virtual_total` columns thru :arel parameter.


cc @NickLaMuro 

@miq-bot assign @gtanzillo 

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1494589