### PR TITLE
Fix typo in policy event details header

### DIFF
--- a/product/timelines/miq_reports/tl_policy_events_daily.yaml
+++ b/product/timelines/miq_reports/tl_policy_events_daily.yaml
@@ -47,7 +47,7 @@ headers:
 - Miq Event Description
 - Miq Policy Description
 - Result
-- Tagret
+- Target
 
 # Condition(s) string for the SQL query
 conditions:


### PR DESCRIPTION
Fix typo in details of policy event on timeline: s/Tagret/Target/

Fixes [BUG 1515451](https://bugzilla.redhat.com/show_bug.cgi?id=1515451)