### PR TITLE
Add tag to container_label_tag_mapping factory

### DIFF
--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :container_label_tag_mapping do
     label_name 'name'
+    tag { FactoryGirl.create(:managed_kubernetes_tag) }
 
     trait :only_nodes do
       labeled_resource_type 'ContainerNode'

--- a/spec/factories/tag.rb
+++ b/spec/factories/tag.rb
@@ -2,4 +2,8 @@ FactoryGirl.define do
   factory :tag do
     sequence(:name) { |n| "/namespace/cat/tag_#{seq_padded_for_sorting(n)}" }
   end
+
+  factory :managed_kubernetes_tag, :parent => :tag do
+    sequence(:name) { |n| "/managed/kubernetes:tag_#{seq_padded_for_sorting(n)}" }
+  end
 end


### PR DESCRIPTION
ContainerLabelTagMapping assumes it belongs_to a tag so add this to the
factory.

Introduced by https://github.com/ManageIQ/manageiq/pull/16501