### PR TITLE
Fixes virtual_totals when a default_scope exists

### DIFF
--- a/lib/extensions/virtual_total.rb
+++ b/lib/extensions/virtual_total.rb
@@ -93,30 +93,34 @@ module VirtualTotal
     def virtual_aggregate_arel(reflection, method_name, column)
       return unless reflection && reflection.macro == :has_many && !reflection.options[:through]
       lambda do |t|
+        query = if reflection.scope
+                  reflection.klass.instance_exec(nil, &reflection.scope)
+                else
+                  reflection.klass.all
+                end
+
+        # ordering will probably screw up aggregations, so clear this out from
+        # any calls
+        #
+        # only clear this out if this isn't a `:size` call as well, since doing
+        # a COUNT(*) will allow any ORDER BY to still work properly.  This is
+        # to avoid any possible edge cases by clearing out the order clause.
+        query.order_values = [] if method_name != :size
+
         foreign_table = reflection.klass.arel_table
         # need db access for the keys, so delaying all this lookup until call time
-        local_key = reflection.active_record_primary_key
+        local_key   = reflection.active_record_primary_key
         foreign_key = reflection.foreign_key
+        query       = query.where(t[local_key].eq(foreign_table[foreign_key]))
+
         arel_column = if method_name == :size
                         Arel.star.count
                       else
                         reflection.klass.arel_attribute(column).send(method_name)
                       end
+        query       = query.select(arel_column)
 
-        where_clause = t[local_key].eq(foreign_table[foreign_key])
-
-        # Default relations are expected when applying this arel, so grab the
-        # AST (arel) from the where clause of the scope, and apply it to the
-        # above where_clause.
-        #
-        # I don't think anything besides a where clause would ever be used in a
-        # default scope/relation... heres to hoping...
-        if reflection.scope
-          reflection_scope_arel = reflection.scope_for(reflection.klass).where_clause.ast
-          where_clause = where_clause.and(reflection_scope_arel)
-        end
-
-        t.grouping(foreign_table.project(arel_column).where(where_clause))
+        t.grouping(Arel::Nodes::SqlLiteral.new(query.to_sql))
       end
     end
   end

--- a/spec/lib/extensions/virtual_total_spec.rb
+++ b/spec/lib/extensions/virtual_total_spec.rb
@@ -1,4 +1,309 @@
 describe VirtualTotal do
+  before(:each) do
+    # rubocop:disable Style/SingleLineMethods, Style/EmptyLineBetweenDefs, Style/AccessorMethodName
+    class VitualTotalTestBase < ActiveRecord::Base
+      self.abstract_class = true
+
+      establish_connection :adapter => 'sqlite3', :database => ':memory:'
+
+      include VirtualFields
+
+      # HACK:  not sure the right way to do this
+      def self.id_increment
+        @id_increment ||= 0
+        @id_increment  += 1
+      end
+    end
+
+    ActiveRecord::Schema.define do
+      def self.connection; VitualTotalTestBase.connection; end
+      def self.set_pk_sequence!(*); end
+      self.verbose = false
+
+      create_table :vt_authors do |t|
+        t.string   :name
+      end
+
+      create_table :vt_books do |t|
+        t.integer  :author_id
+        t.string   :name
+        t.boolean  :published, :default => false
+        t.boolean  :special,   :default => false
+        t.integer  :rating
+        t.datetime :created_on
+      end
+    end
+
+    class VtAuthor < VitualTotalTestBase
+      def self.connection; VitualTotalTestBase.connection; end
+
+      has_many :books,                             :class_name => "VtBook", :foreign_key => "author_id"
+      has_many :published_books, -> { published }, :class_name => "VtBook", :foreign_key => "author_id"
+      has_many :wip_books,       -> { wip },       :class_name => "VtBook", :foreign_key => "author_id"
+
+      virtual_total :total_books, :books
+      virtual_total :total_books_published, :published_books
+      virtual_total :total_books_in_progress, :wip_books
+
+      def self.create_with_books(count = 0)
+        create!(:name => "foo", :id => id_increment).tap { |author| author.create_books(count) }
+      end
+
+      def create_books(count, create_attrs = {})
+        count.times do
+          attrs = {
+            :name   => "bar",
+            :author => self,
+            :id     => VtBook.id_increment
+          }.merge(create_attrs)
+          VtBook.create(attrs)
+        end
+      end
+    end
+
+    class VtBook < VitualTotalTestBase
+      def self.connection; VitualTotalTestBase.connection end
+
+      belongs_to :author, :class_name => "VtAuthor"
+      scope :published, -> { where(:published => true)  }
+      scope :wip,       -> { where(:published => false) }
+    end
+    # rubocop:enable Style/SingleLineMethods, Style/EmptyLineBetweenDefs, Style/AccessorMethodName
+  end
+
+  after(:each) do
+    VitualTotalTestBase.remove_connection
+    Object.send(:remove_const, :VtAuthor)
+    Object.send(:remove_const, :VtBook)
+    Object.send(:remove_const, :VitualTotalTestBase)
+  end
+
+  describe ".virtual_total" do
+    context "with a standard has_many" do
+      it "sorts by total" do
+        author2 = VtAuthor.create_with_books(2)
+        author0 = VtAuthor.create_with_books(0)
+        author1 = VtAuthor.create_with_books(1)
+
+        expect(VtAuthor.order(:total_books).pluck(:id))
+          .to eq([author0, author1, author2].map(&:id))
+      end
+
+      it "calculates totals locally" do
+        author0_id = VtAuthor.create_with_books(0).id
+        author2_id = VtAuthor.create_with_books(2).id
+        expect do
+          expect(VtAuthor.find(author0_id).total_books).to eq(0)
+          expect(VtAuthor.find(author2_id).total_books).to eq(2)
+        end.to match_query_limit_of(4)
+      end
+
+      it "can bring back totals in primary query" do
+        author3 = VtAuthor.create_with_books(3)
+        author1 = VtAuthor.create_with_books(1)
+        author2 = VtAuthor.create_with_books(2)
+        expect do
+          author_query = VtAuthor.select(:id, :total_books)
+          expect(author_query).to match_array([author3, author1, author2])
+          expect(author_query.map(&:total_books)).to match_array([3, 1, 2])
+        end.to match_query_limit_of(1)
+      end
+    end
+
+    context "with a has_many that includes a scope" do
+      it "sorts by total" do
+        author2 = VtAuthor.create_with_books(2)
+        author2.create_books(1, :published => true)
+        author0 = VtAuthor.create_with_books(0)
+        author0.create_books(2, :published => true)
+        author1 = VtAuthor.create_with_books(1)
+
+        expect(VtAuthor.order(:total_books_published).pluck(:id))
+          .to eq([author1, author2, author0].map(&:id))
+        expect(VtAuthor.order(:total_books_in_progress).pluck(:id))
+          .to eq([author0, author1, author2].map(&:id))
+      end
+
+      it "calculates totals locally" do
+        author0 = VtAuthor.create_with_books(0)
+        author0.create_books(2, :published => true)
+        author2 = VtAuthor.create_with_books(2)
+        author2.create_books(1, :published => true)
+
+        expect do
+          expect(VtAuthor.find(author0.id).total_books).to eq(2)
+          expect(VtAuthor.find(author0.id).total_books_published).to eq(2)
+          expect(VtAuthor.find(author0.id).total_books_in_progress).to eq(0)
+          expect(VtAuthor.find(author2.id).total_books).to eq(3)
+          expect(VtAuthor.find(author2.id).total_books_published).to eq(1)
+          expect(VtAuthor.find(author2.id).total_books_in_progress).to eq(2)
+        end.to match_query_limit_of(12)
+      end
+
+      it "can bring back totals in primary query" do
+        author3 = VtAuthor.create_with_books(3)
+        author3.create_books(4, :published => true)
+        author1 = VtAuthor.create_with_books(1)
+        author1.create_books(5, :published => true)
+        author2 = VtAuthor.create_with_books(2)
+        author2.create_books(6, :published => true)
+
+        expect do
+          cols = %i(id total_books total_books_published total_books_in_progress)
+          author_query = VtAuthor.select(*cols).to_a
+          expect(author_query).to match_array([author3, author1, author2])
+          expect(author_query.map(&:total_books)).to match_array([7, 6, 8])
+          expect(author_query.map(&:total_books_published)).to match_array([4, 5, 6])
+          expect(author_query.map(&:total_books_in_progress)).to match_array([3, 1, 2])
+        end.to match_query_limit_of(1)
+      end
+    end
+
+    context "with order clauses in the relation" do
+      before(:each) do
+        # Monkey patching VtAuthor for these specs
+        class VtAuthor < VitualTotalTestBase
+          has_many :recently_published_books, -> { published.order(:created_on => :desc) },
+                   :class_name => "VtBook", :foreign_key => "author_id"
+
+          virtual_total :total_recently_published_books, :recently_published_books
+          virtual_aggregate :sum_recently_published_books_rating, :recently_published_books, :sum, :rating
+        end
+      end
+
+      it "sorts by total" do
+        author2 = VtAuthor.create_with_books(2)
+        author2.create_books(1, :published => true, :rating => 5)
+        author0 = VtAuthor.create_with_books(0)
+        author0.create_books(2, :published => true, :rating => 2)
+        author1 = VtAuthor.create_with_books(1)
+
+        expect(VtAuthor.order(:total_recently_published_books).pluck(:id))
+          .to eq([author1, author2, author0].map(&:id))
+        expect(VtAuthor.order(:sum_recently_published_books_rating).pluck(:id))
+          .to eq([author1, author0, author2].map(&:id))
+      end
+
+      it "calculates totals locally" do
+        author0 = VtAuthor.create_with_books(0)
+        author0.create_books(2, :published => true, :rating => 2)
+        author2 = VtAuthor.create_with_books(2)
+        author2.create_books(1, :published => true, :rating => 5)
+
+        expect do
+          expect(VtAuthor.find(author0.id).total_recently_published_books).to eq(2)
+          expect(VtAuthor.find(author0.id).sum_recently_published_books_rating).to eq(4)
+          expect(VtAuthor.find(author2.id).total_recently_published_books).to eq(1)
+          expect(VtAuthor.find(author2.id).sum_recently_published_books_rating).to eq(5)
+        end.to match_query_limit_of(8)
+      end
+
+      it "can bring back totals in primary query" do
+        author3 = VtAuthor.create_with_books(3)
+        author3.create_books(2, :published => true, :rating => 2)
+        author1 = VtAuthor.create_with_books(1)
+        author1.create_books(3, :published => true, :rating => 1)
+        author2 = VtAuthor.create_with_books(2)
+        author2.create_books(1, :published => true, :rating => 5)
+
+        expect do
+          cols = %i(id total_recently_published_books sum_recently_published_books_rating)
+          author_query = VtAuthor.select(*cols).to_a
+          expect(author_query).to match_array([author3, author1, author2])
+          expect(author_query.map(&:total_recently_published_books)).to match_array([2, 3, 1])
+          expect(author_query.map(&:sum_recently_published_books_rating)).to match_array([4, 3, 5])
+        end.to match_query_limit_of(1)
+      end
+    end
+
+    context "with a special books class" do
+      before(:each) do
+        class SpecialVtBook < VtBook
+          default_scope { where(:special => true) }
+
+          self.table_name = 'vt_books'
+        end
+
+        # Monkey patching VtAuthor for these specs
+        class VtAuthor < VitualTotalTestBase
+          has_many :special_books,
+                   :class_name => "SpecialVtBook", :foreign_key => "author_id"
+          has_many :published_special_books, -> { published },
+                   :class_name => "SpecialVtBook", :foreign_key => "author_id"
+
+          virtual_total :total_special_books, :special_books
+          virtual_total :total_special_books_published, :published_special_books
+        end
+      end
+
+      after(:each) do
+        Object.send(:remove_const, :SpecialVtBook)
+      end
+
+      context "with a has_many that includes a scope" do
+        it "sorts by total" do
+          author2 = VtAuthor.create_with_books(2)
+          author2.create_books(5, :special => true)
+          author2.create_books(1, :special => true, :published => true)
+          author0 = VtAuthor.create_with_books(0)
+          author0.create_books(2, :special => true)
+          author0.create_books(2, :special => true, :published => true)
+          author1 = VtAuthor.create_with_books(1)
+
+          expect(VtAuthor.order(:total_special_books).pluck(:id))
+            .to eq([author1, author0, author2].map(&:id))
+          expect(VtAuthor.order(:total_special_books_published).pluck(:id))
+            .to eq([author1, author2, author0].map(&:id))
+        end
+
+        it "calculates totals locally" do
+          author0 = VtAuthor.create_with_books(0)
+          author0.create_books(2, :special => true)
+          author0.create_books(2, :special => true, :published => true)
+          author2 = VtAuthor.create_with_books(2)
+          author2.create_books(5, :special => true)
+          author2.create_books(1, :special => true, :published => true)
+
+          expect do
+            expect(VtAuthor.find(author0.id).total_books).to eq(4)
+            expect(VtAuthor.find(author0.id).total_special_books).to eq(4)
+            expect(VtAuthor.find(author0.id).total_special_books_published).to eq(2)
+            expect(VtAuthor.find(author2.id).total_books).to eq(8)
+            expect(VtAuthor.find(author2.id).total_special_books).to eq(6)
+            expect(VtAuthor.find(author2.id).total_special_books_published).to eq(1)
+          end.to match_query_limit_of(12)
+        end
+
+        it "can bring back totals in primary query" do
+          author3 = VtAuthor.create_with_books(3)
+          author3.create_books(4, :published => true)
+          author1 = VtAuthor.create_with_books(1)
+          author1.create_books(2, :special => true)
+          author1.create_books(2, :special => true, :published => true)
+          author2 = VtAuthor.create_with_books(2)
+          author2.create_books(5, :special => true)
+          author2.create_books(1, :special => true, :published => true)
+
+          expect do
+            cols = %i(
+              id
+              total_books
+              total_books_published
+              total_special_books
+              total_special_books_published
+            )
+            author_query = VtAuthor.select(*cols).to_a
+            expect(author_query).to match_array([author3, author1, author2])
+            expect(author_query.map(&:total_books)).to match_array([7, 5, 8])
+            expect(author_query.map(&:total_books_published)).to match_array([4, 2, 1])
+            expect(author_query.map(&:total_special_books)).to match_array([0, 4, 6])
+            expect(author_query.map(&:total_special_books_published)).to match_array([0, 2, 1])
+          end.to match_query_limit_of(1)
+        end
+      end
+    end
+  end
+
   describe ".virtual_total (with real has_many relation ems#total_vms)" do
     let(:base_model) { ExtManagementSystem }
     it "sorts by total" do
@@ -73,6 +378,40 @@ describe VirtualTotal do
       FactoryGirl.create(:host).tap do |host|
         count.times { host.storages.create(FactoryGirl.attributes_for(:storage)) }
       end.reload
+    end
+  end
+
+  # Duplicated from VmOrTemplateSpec#provisioned_storage since this can't be
+  # simulated in SQLite, since they allow you to have an ORDER BY with a column
+  # that isn't in the SELECT clause...
+  #
+  # Keep this test here to confirm the virtual_aggregate works when an order
+  # exists on the scope, unless this is aggregate is deleted (then feel free to
+  # remove).
+  describe ".virtual_total (with real has_many relation and .order() in scope vm#provisioned_storage)" do
+    context "with no hardware" do
+      let(:base_model) { Vm }
+
+      it "calculates totals locally" do
+        expect(model_with_children(0).provisioned_storage).to eq(0.0)
+        expect(model_with_children(2).provisioned_storage).to eq(20.0)
+      end
+
+      it "uses calculated (inline) attribute" do
+        vm1   = model_with_children(0)
+        vm2   = model_with_children(2)
+        query = ManageIQ::Providers::Vmware::InfraManager::Vm.select(:id, :provisioned_storage).to_a
+        expect do
+          expect(query).to match_array([vm1, vm2])
+          expect(query.map(&:provisioned_storage)).to match_array([0.0, 20.0])
+        end.to match_query_limit_of(0)
+      end
+
+      def model_with_children(count)
+        FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware)).tap do |vm|
+          count.times { vm.hardware.disks.create(FactoryGirl.attributes_for(:disk, :size => 10.0)) }
+        end.reload
+      end
     end
   end
 end

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -12,18 +12,21 @@ describe CloudTenant do
 
   describe '#total_vms' do
     let(:ems)          { FactoryGirl.create(:ems_openstack) }
-    let(:vm)           { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
+    let(:vm1)          { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
+    let(:vm2)          { FactoryGirl.create(:vm_openstack, :ext_management_system => nil) }
+    let(:vms)          { [vm1, vm2] }
     let(:template)     { FactoryGirl.create(:miq_template) }
-    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => ems, :vms => [vm], :miq_templates => [template]) }
+    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => ems, :vms => vms, :miq_templates => [template]) }
 
     it 'counts only vms' do
-      expect(cloud_tenant.vms).to match_array(vm)
+      cloud_tenant.reload
+      expect(cloud_tenant.vms.map(&:id)).to match_array([vm1.id])
       expect(cloud_tenant.total_vms).to eq(1)
 
       total_vms_from_select = CloudTenant.where(:id => cloud_tenant).select(:total_vms).first[:total_vms]
       expect(total_vms_from_select).to eq(1)
       expect(total_vms_from_select).to eq(cloud_tenant.total_vms)
-      expect(cloud_tenant.vms_and_templates.count).to eq(2)
+      expect(cloud_tenant.vms_and_templates.count).to eq(3)
     end
   end
 end

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -9,4 +9,21 @@ describe CloudTenant do
 
     expect(tenant1.all_cloud_networks).to match_array([net1, net2])
   end
+
+  describe '#total_vms' do
+    let(:ems)          { FactoryGirl.create(:ems_openstack) }
+    let(:vm)           { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
+    let(:template)     { FactoryGirl.create(:miq_template) }
+    let(:cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => ems, :vms => [vm], :miq_templates => [template]) }
+
+    it 'counts only vms' do
+      expect(cloud_tenant.vms).to match_array(vm)
+      expect(cloud_tenant.total_vms).to eq(1)
+
+      total_vms_from_select = CloudTenant.where(:id => cloud_tenant).select(:total_vms).first[:total_vms]
+      expect(total_vms_from_select).to eq(1)
+      expect(total_vms_from_select).to eq(cloud_tenant.total_vms)
+      expect(cloud_tenant.vms_and_templates.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
This is an alternative solution from the one provided in https://github.com/ManageIQ/manageiq/pull/16512 .  Borrowed the tests from that PR though (thanks @lpichler !)

When a `has_many` relation of a model that is used in a `virtual_total` and has a default scope, it was not getting applied to the arel query when the `virtual_total` column was being used in the `.select`.  An example in `CloudTenant`:

```ruby
class CloudTenant < ApplicationRecord

  has_many   :vms, -> { active }

  virtual_total :total_vms, :vms

  # ...
end
```

Then with flowing `ActiveRecord` query:

```ruby
CloudTenant.where(:name => 'DEV').select(:total_vms)
```

Would produce:

```sql
SELECT (
  (SELECT COUNT(*)
   FROM "vms"
   WHERE "cloud_tenants"."id" = "vms"."cloud_tenant_id")
  ) AS total_vms
FROM "cloud_tenants"
WHERE "cloud_tenants"."name" = 'DEV'
```

Which doesn't take into account the `active` scope, which will filter out any VM without an `ems_id` (so templates).

With this change, the SQL executed then gets updated to the following:

```sql
SELECT (
  (SELECT COUNT(*)
   FROM "vms"
   WHERE "cloud_tenants"."id" = "vms"."cloud_tenant_id"
     AND "vms"."type" IN ('Vm', 'ManageIQ::Providers::CloudManager::Vm',
                          'ManageIQ::Providers::InfraManager::Vm', 'VmServer',
                          'ManageIQ::Providers::Amazon::CloudManager::Vm',
                          'ManageIQ::Providers::Azure::CloudManager::Vm',
                          'ManageIQ::Providers::Google::CloudManager::Vm',
                          'ManageIQ::Providers::Openstack::CloudManager::Vm',
                          'ManageIQ::Providers::Vmware::CloudManager::Vm', 'VmXen',
                          'ManageIQ::Providers::Redhat::InfraManager::Vm',
                          'ManageIQ::Providers::Microsoft::InfraManager::Vm',
                          'ManageIQ::Providers::Vmware::InfraManager::Vm')
     AND ("vms"."ems_id" IS NOT NULL))
  ) AS total_vms
FROM "cloud_tenants"
WHERE "cloud_tenants"."name" = 'DEV'
```

Which properly includes the default scopes for both the `Vm` model, and the `:vm` relation in `CloudTenant`.


Links
-----
* Alternative to https://github.com/ManageIQ/manageiq/pull/16512
* https://bugzilla.redhat.com/show_bug.cgi?id=1494589