### PR TITLE
Fixes a stack trace issue (500) during API authentication.

### DIFF
--- a/lib/token_manager.rb
+++ b/lib/token_manager.rb
@@ -37,7 +37,10 @@ class TokenManager
   def token_get_info(token, what = nil)
     return {} unless token_valid?(token)
 
-    what.nil? ? token_store.read(token) : token_store.read(token)[what]
+    token_data = token_store.read(token)
+    return nil if token_data.nil?
+
+    what.nil? ? token_data : token_data[what]
   end
 
   def token_valid?(token)


### PR DESCRIPTION
- seems to happen in a *very* short window where the token is invalidated in the memcached from the time it is checked for and the time we get fields out of the token.
- stumbled into this scenario while attempting to reproduce bugzilla #1512839.

