### PR TITLE
[FINE] make test more robust

### DIFF
--- a/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_spec.rb
+++ b/spec/models/manageiq/providers/kubernetes/container_manager/metrics_capture/capture_context_spec.rb
@@ -28,9 +28,11 @@ describe ManageIQ::Providers::Kubernetes::ContainerManager::MetricsCapture::Capt
     VCR.use_cassette("#{described_class.name.underscore}_refresh",
                      :match_requests_on => [:path,]) do # , :record => :new_episodes) do
       EmsRefresh.refresh(@ems)
-      @node = @ems.container_nodes.first
-      pod = @ems.container_groups.first
-      container = @ems.containers.first
+      @ems.reload
+
+      @node = @ems.container_nodes.find_by(:name => "capture.context.com")
+      pod = @ems.container_groups.find_by(:name => "docker-registry-1-51q71")
+      container = pod.containers.find_by(:name => "registry")
 
       @targets = [['node', @node], ['pod', pod], ['container', container]]
     end if @node.nil?


### PR DESCRIPTION
Backport https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/76 from cben/hawkular_capture_context_spec-robust-targets

(cherry picked from https://github.com/ManageIQ/manageiq-providers-kubernetes/commit/05baa39c3be4bd385c263d0a7f38c193fcc5537f adjusted for different VCR)

- [x] Depends on https://github.com/ManageIQ/manageiq/pull/16531 to fix fine — merged.

@miq-bot add-label wip, test