### PR TITLE
Use VMDB::Appliance.PRODUCT_NAME not i18n method.

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -84,7 +84,7 @@ class ContainerOrchestrator
     end
 
     def app_name
-      I18n.t("product.name").downcase
+      Vmdb::Appliance.PRODUCT_NAME.downcase
     end
   end
 end


### PR DESCRIPTION
Since PR https://github.com/ManageIQ/manageiq/pull/16409
we now have a method for product name.