### PR TITLE
:vm_import feature in SupportsFeatureMixin

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -51,10 +51,6 @@ module ManageIQ::Providers
       {:available => true, :message => nil}
     end
 
-    def validate_import_vm
-      false
-    end
-
     def clusterless_hosts
       hosts.where(:ems_cluster => nil)
     end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -125,6 +125,7 @@ module SupportsFeatureMixin
     :update_security_group      => 'Security Group Update',
     :block_storage              => 'Block Storage',
     :object_storage             => 'Object Storage',
+    :vm_import                  => 'VM Import',
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.


### PR DESCRIPTION
Added :vm_import feature to SupportsFeatureMixin that replaces
validate_import_vm method.