### PR TITLE
Don`t queue email sending when notifier is off

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -285,6 +285,8 @@ class MiqAction < ApplicationRecord
   end
 
   def action_email(action, rec, inputs)
+    return unless MiqRegion.my_region.role_assigned?('notifier')
+
     action.options[:from] = ::Settings.smtp.from if action.options[:from].blank?
 
     email_options = {

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -388,6 +388,20 @@ describe MiqAction do
     end
 
     let(:miq_server) { EvmSpecHelper.local_miq_server }
+    let(:action) { MiqAction.new }
+    let(:inputs) { { :policy => nil, :synchronous => false } }
+
+    let(:q_options) do
+      {
+        :class_name  => "MiqAction",
+        :method_name => "queue_email",
+        :instance_id => nil,
+        :args        => [{:to => nil, :from => "cfadmin@cfserver.com"}],
+        :role        => "notifier",
+        :priority    => 20,
+        :zone        => nil
+      }
+    end
 
     context 'when notifier role is on' do
       before do
@@ -396,22 +410,6 @@ describe MiqAction do
       end
 
       it 'should generate a MiqAction invoking action_email' do
-        action = MiqAction.new
-        inputs = {
-          :policy      => nil,
-          :synchronous => false
-        }
-
-        q_options = {
-          :class_name  => "MiqAction",
-          :method_name => "queue_email",
-          :instance_id => nil,
-          :args        => [{:to => nil, :from => "cfadmin@cfserver.com"}],
-          :role        => "notifier",
-          :priority    => 20,
-          :zone        => nil
-        }
-
         expect(MiqQueue).to receive(:put).with(q_options).once
         action.action_email(action, nil, inputs)
       end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -382,23 +382,39 @@ describe MiqAction do
   end
 
   context 'validate action email should have correct type' do
-    it 'should generate a MiqAction invoking action_email' do
-      action = MiqAction.new
-      inputs = {
-        :policy      => nil,
-        :synchronous => false
-      }
-      q_options = {
-        :class_name  => "MiqAction",
-        :method_name => "queue_email",
-        :instance_id => nil,
-        :args        => [{:to => nil, :from => "cfadmin@cfserver.com"}],
-        :role        => "notifier",
-        :priority    => 20,
-        :zone        => nil
-      }
-      expect(MiqQueue).to receive(:put).with(q_options).once
-      action.action_email(action, nil, inputs)
+    before do
+      MiqRegion.seed
+      ServerRole.seed
+    end
+
+    let(:miq_server) { EvmSpecHelper.local_miq_server }
+
+    context 'when notifier role is on' do
+      before do
+        miq_server.server_roles << ServerRole.where(:name => 'notifier')
+        miq_server.save!
+      end
+
+      it 'should generate a MiqAction invoking action_email' do
+        action = MiqAction.new
+        inputs = {
+          :policy      => nil,
+          :synchronous => false
+        }
+
+        q_options = {
+          :class_name  => "MiqAction",
+          :method_name => "queue_email",
+          :instance_id => nil,
+          :args        => [{:to => nil, :from => "cfadmin@cfserver.com"}],
+          :role        => "notifier",
+          :priority    => 20,
+          :zone        => nil
+        }
+
+        expect(MiqQueue).to receive(:put).with(q_options).once
+        action.action_email(action, nil, inputs)
+      end
     end
   end
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -403,6 +403,13 @@ describe MiqAction do
       }
     end
 
+    context 'when notifier role is off' do
+      it 'is not generating a MiqAction invoking action_email' do
+        expect(MiqQueue).not_to receive(:put).with(q_options)
+        action.action_email(action, nil, inputs)
+      end
+    end
+
     context 'when notifier role is on' do
       before do
         miq_server.server_roles << ServerRole.where(:name => 'notifier')


### PR DESCRIPTION
continuation of https://github.com/ManageIQ/manageiq/pull/14801

# Issue
when is press check compliance (point 11 in BZ) it start lot of queuing, doing work.
first it is starting by raising event https://github.com/ManageIQ/manageiq/blob/master/app/models/compliance.rb#L89
and it is process by automate engine, he will plan other work in MiqQueue,...

one this planning is about putting to MiqQueue item which is saying `send an email`.  So I put guard condition here because previously it was putting this messages to queue  and when notifier role have been turned on, that it was doing these messages for send emailing.
so I think we shouldn't queue in this place.

but guard condition here is also ok https://github.com/ManageIQ/manageiq/pull/14801 because
user can plan events when notifier is on, but after it somebody can turn off role and in this case it should not also send emails.

@miq-bot assign @gtanzillo 
@miq-bot add_label bug

Links
----
https://bugzilla.redhat.com/show_bug.cgi?id=1399157
first part https://github.com/ManageIQ/manageiq/pull/14801
