### PR TITLE
Default name to description for MiqAlertSet and MiqPolicySet

### DIFF
--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -1,7 +1,7 @@
 class MiqAlertSet < ApplicationRecord
   acts_as_miq_set
 
-  before_validation :default_name_to_guid, :on => :create
+  before_validation :default_name_to_description, :on => :create
 
   include AssignmentMixin
 
@@ -47,5 +47,11 @@ class MiqAlertSet < ApplicationRecord
     fixture_file = File.join(FIXTURE_DIR, "miq_alert_sets.yml")
     return unless File.exist?(fixture_file)
     File.open(fixture_file) { |fd| MiqAlertSet.import_from_yaml(fd, :save => true) }
+  end
+
+  private
+
+  def default_name_to_description
+    self.name ||= description
   end
 end

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -1,7 +1,7 @@
 class MiqPolicySet < ApplicationRecord
   acts_as_miq_set
 
-  before_validation :default_name_to_guid, :on => :create
+  before_validation :default_name_to_description, :on => :create
   before_destroy    :destroy_policy_tags
 
   attr_accessor :reserved
@@ -83,5 +83,11 @@ class MiqPolicySet < ApplicationRecord
         ps.update_attribute(:mode, "control")
       end
     end
+  end
+
+  private
+
+  def default_name_to_description
+    self.name ||= description
   end
 end # class MiqPolicySet

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -6,11 +6,11 @@ describe MiqPolicy do
     # calling conditions.
 
     before(:each) do
-      @ps = FactoryGirl.create(:miq_policy_set)
+      @ps = FactoryGirl.create(:miq_policy_set, :name => "ps")
       @p  = FactoryGirl.create(:miq_policy)
       @ps.add_member(@p)
 
-      @ps2 = FactoryGirl.create(:miq_policy_set)
+      @ps2 = FactoryGirl.create(:miq_policy_set, :name => "ps2")
       @p2  = FactoryGirl.create(:miq_policy)
     end
 
@@ -159,8 +159,8 @@ describe MiqPolicy do
 
     let(:profiles) do
       [
-        FactoryGirl.create(:miq_policy_set).tap { |pf| pf.add_member(policies[0]) },
-        FactoryGirl.create(:miq_policy_set).tap { |pf| pf.add_member(policies[1]) },
+        FactoryGirl.create(:miq_policy_set, :name => "ps3").tap { |pf| pf.add_member(policies[0]) },
+        FactoryGirl.create(:miq_policy_set, :name => "ps4").tap { |pf| pf.add_member(policies[1]) },
       ]
     end
 


### PR DESCRIPTION
Before this PR, the "name" filed for Policy Profiles and Alert Profiles defaulted to a generated guid. The UI doesn't use the "name" field, only "description".

at the moment, "description" is not enforced to be unique, but "name" is.

When developing the ansible module for Alert Profiles, I've realized we need a human-readable unique identifier for the profiles, and that it doesn't make much sense to allow UI users to create multiple profiles with the same description - it's confusing and inconsistent with alerts/policies whose description *does* have to be unique.

This PR fixes this by changing the default behavior, without impact to existing profiles.