### PR TITLE
ExtManagementSystem - use supports_not :admin_ui; use supports_not

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -263,10 +263,22 @@ class ExtManagementSystem < ApplicationRecord
 
   # UI methods for determining availability of fields
   supports_not :admin_ui
-  supports_not :api_version
-  supports_not :port
-  supports_not :provider_id
-  supports_not :security_protocol
+
+  def supports_api_version?
+    false
+  end
+
+  def supports_port?
+    false
+  end
+
+  def supports_provider_id?
+    false
+  end
+
+  def supports_security_protocol?
+    false
+  end
 
   def supports_authentication?(authtype)
     authtype.to_s == "default"

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -262,21 +262,11 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   # UI methods for determining availability of fields
-  def supports_port?
-    false
-  end
-
-  def supports_api_version?
-    false
-  end
-
-  def supports_security_protocol?
-    false
-  end
-
-  def supports_provider_id?
-    false
-  end
+  supports_not :admin_ui
+  supports_not :api_version
+  supports_not :port
+  supports_not :provider_id
+  supports_not :security_protocol
 
   def supports_authentication?(authtype)
     authtype.to_s == "default"


### PR DESCRIPTION
Displaying a toolbar button to open the admin ui tries to call the supports method, and when not there, falls back to the old availability code, which fails with missing `validate_admin_ui` method.

This is because since https://github.com/ManageIQ/manageiq-providers-ovirt/pull/133, `RedHat::InfraManager` supports :admin_ui, but the `supports_not` call was not added to the ancestor class.

Adding, and taking the opportunity to use `supports_not` for all the `def supports_foo? ; false ; end` methods.

Cc @borod108 , @vojtechszocs , @martinpovolny 