### PR TITLE
Change provision daialog "vLan" to "Virtual Network"

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs.yaml
@@ -659,7 +659,7 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: vLan
+          :description: Virtual Network
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_dialogs_pre_sample.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_dialogs_pre_sample.yaml
@@ -63,7 +63,7 @@
 
       :display: :hide
     :network:
-      :description: vLan
+      :description: Virtual Network
       :fields: {}
 
       :display: :hide

--- a/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -420,7 +420,7 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: vLan
+          :description: Virtual Network
           :required: false
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_template.yaml
@@ -626,7 +626,7 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: vLan
+          :description: Virtual Network
           :required: true
           :display: :edit
           :data_type: :string

--- a/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_vmware_dialogs_clone_to_vm.yaml
@@ -635,7 +635,7 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: vLan
+          :description: Virtual Network
           :required: true
           :display: :edit
           :data_type: :string


### PR DESCRIPTION
Update Infra dialogs to use the same vLan field description of "Virtual Network".

Excludes RHV dialogs which currently uses the description "Network"   @oourfali 