### PR TITLE
Add to inventory collection a method to rehash secondary indexes

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -978,6 +978,20 @@ module ManagerRefresh
       parent.send(association)
     end
 
+    def rehash_secondary_indexes
+      secondary_refs.keys.each { |k| rehash_secondary_index(k) }
+    end
+
+    def rehash_secondary_index(name)
+      return unless secondary_refs.key?(name)
+      keys = secondary_refs[name]
+
+      secondary_indexes[name] = {}
+      data_index.values.each do |inventory_obj|
+        secondary_indexes[name][inventory_obj.id_with_keys(keys)] = inventory_obj
+      end
+    end
+
     private
 
     attr_writer :attributes_blacklist, :attributes_whitelist, :db_data_index


### PR DESCRIPTION
Inventory collection has the capability to define secondary indexes. However, if an inventory object is built using `find_or_build`, the secondary index is not built correctly. Also, if the data in the inventory objects is updated, the secondary indexes become out of sync.

This is adding methods to rebuild/synchronize secondary indexes.
