### PR TITLE
[EUWE] - available_vms method is not available on EUWE

### DIFF
--- a/app/controllers/cloud_volume_controller.rb
+++ b/app/controllers/cloud_volume_controller.rb
@@ -158,7 +158,7 @@ class CloudVolumeController < ApplicationController
     assert_privileges("cloud_volume_attach")
     @vm_choices = {}
     @volume = find_record_with_rbac(CloudVolume, params[:id])
-    @volume.available_vms.each { |vm| @vm_choices[vm.name] = vm.id }
+    @volume.cloud_tenant.vms.each { |vm| @vm_choices[vm.name] = vm.id }
 
     @in_a_form = true
     drop_breadcrumb(


### PR DESCRIPTION
this line was accidentally backported to EUWE in https://github.com/ManageIQ/manageiq/pull/15310 commit e066db4c6a9c89ee9270691d6e93aafae422b687

https://bugzilla.redhat.com/show_bug.cgi?id=1517712

@dclarizio please review.