### PR TITLE
Call super from all the EmbeddedAnsible subclasses' #initialize methods

### DIFF
--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -19,6 +19,7 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   end
 
   def initialize
+    super
     require "linux_admin"
   end
 


### PR DESCRIPTION
This is a nice thing to do so that future devs get expected behavior if we ever define `#initialize` in the base class.