### PR TITLE
Rename mks to webmks

### DIFF
--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -116,7 +116,7 @@ class Vm < VmOrTemplate
       :spice   => spice_support,
       :vnc     => vnc_support,
       :vmrc    => vmrc_support,
-      :mks     => mks_support,
+      :webmks  => webmks_support,
       :cockpit => cockpit_support
     }
   end
@@ -131,7 +131,7 @@ class Vm < VmOrTemplate
     }
   end
 
-  def mks_support
+  def webmks_support
     {
       :visible => supports_mks_console?,
       :enabled => supports_launch_mks_console?,

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -311,7 +311,7 @@ describe Vm do
   context "#supported_consoles" do
     it 'returns all of the console types' do
       vm = FactoryGirl.create(:vm)
-      expect(vm.supported_consoles.keys).to match_array([:spice, :vnc, :vmrc, :mks, :cockpit])
+      expect(vm.supported_consoles.keys).to match_array([:spice, :vnc, :vmrc, :webmks, :cockpit])
     end
   end
 end


### PR DESCRIPTION
As requested by @bmclaughlin, renaming `mks` to `webmks ` as a follow up to https://github.com/ManageIQ/manageiq/pull/16519

@miq-bot add_label gaprindashvili/yes, fine/yes, euwe/yes 
@miq-bot assign @gtanzillo 