### PR TITLE
Correctly return nil in build_tag_tagging_path() routine

### DIFF
--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -226,7 +226,7 @@ module AssignmentMixin
       obj = Classification.find_by(:id => id)
       if obj.nil?
         _log.warn("Unable to find classification with id [#{id}], skipping assignment")
-        nil
+        return nil
       end
     end
     "#{klass.underscore}/tag#{obj.ns}/#{obj.parent.name}/#{obj.name}"


### PR DESCRIPTION
`build_tag_tagging_path()` was introduced in https://github.com/ManageIQ/manageiq/pull/16401 by splitting part of `assign_to_tags()` into its own routine.

The original routine would skip creation of a tag string in case the `Classification` object doesn't
exist. To retain the same semantics, `build_tag_tagging_path()` needs to return `nil` here, otherwise
an exception would occur few moments later, when creating that

```ruby
"#{klass.underscore}/tag#{obj.ns}/#{obj.parent.name}/#{obj.name}"
```

tag string.