### PR TITLE
Set default values for help menu link target types in settings.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -799,11 +799,11 @@
     - SuspendVM_Task
 :help_menu:
   :documentation:
-    :enabled: true
+    :type: default
   :product:
-    :enabled: true
+    :type: new_window
   :about:
-    :enabled: true
+    :type: modal
 :host_delete:
   :queue_timeout: 20.minutes
 :host_introspect:


### PR DESCRIPTION
These are required to set the submit button enablement properly according to dropdown changes.
![screenshot from 2017-11-29 13-41-17](https://user-images.githubusercontent.com/649130/33375683-013b307e-d50b-11e7-8c42-9357770120f3.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1517908