### PR TITLE
Allow full error log

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -92,7 +92,7 @@ class Authentication < ApplicationRecord
   def validation_failed(status = :unreachable, message = nil)
     message ||= ERRORS[status]
     _log.warn("[#{resource_type}] [#{resource_id}], previously valid on: #{last_valid_on}, previous status: [#{self.status}]")
-    update_attributes(:status => status.to_s.capitalize, :status_details => message.to_s, :last_invalid_on => Time.now.utc)
+    update_attributes(:status => status.to_s.capitalize, :status_details => message.to_s.truncate(200), :last_invalid_on => Time.now.utc)
     raise_event(status, message)
   end
 

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -334,7 +334,7 @@ module AuthenticationMixin
       status == :valid ? auth.validation_successful : auth.validation_failed(status, details)
     end
 
-    return status == :valid, details
+    return status == :valid, details.truncate(20_000)
   end
 
   def default_authentication
@@ -360,9 +360,9 @@ module AuthenticationMixin
         end
       end
 
-    details &&= details.to_s.truncate(200)
+    details &&= details.to_s
 
-    _log.warn("#{header} Validation failed: #{status}, #{details}") unless status == :valid
+    _log.warn("#{header} Validation failed: #{status}, #{details.truncate(200)}") unless status == :valid
     return status, details
   end
 


### PR DESCRIPTION
Currently we truncate (after 200 characters) the log error / warning that was received when connecting to a provider - In this patch we discard this action in favor of dealing with the full log in the UI.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1506718

cc: @cben @serenamarie125  