### PR TITLE
Set CloudVolume name to ID if empty

### DIFF
--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser.rb
@@ -111,7 +111,7 @@ module ManageIQ::Providers
         # TODO: has its own CloudVolume?
         # TODO: These classes should not be OpenStack specific, but rather Cinder-specific.
         :type          => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume",
-        :name          => volume_name(volume),
+        :name          => volume_name(volume).blank? ? volume.id : volume_name(volume),
         :status        => volume.status,
         :bootable      => volume.attributes['bootable'],
         :creation_time => volume.created_at,


### PR DESCRIPTION
Volume can have empty name. This PR set name to its id when name was empty
in order to allow user identify volumes with empty names.

Links
----------------

* Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518637
* Provisioning from Volumes part https://github.com/ManageIQ/manageiq-providers-openstack/pull/169

Steps for Testing/QA
-------------------------------
Create volume with empty name in OSP and you should be able see volume UUID instead of empty string in name in MIQ Storage Volumes.