### PR TITLE
Looks like self is needed on PRODUCT_NAME and VERSION calls

### DIFF
--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -21,11 +21,11 @@ module Vmdb
     end
 
     def self.PRODUCT_NAME
-      I18n.t("product.name")
+      I18n.t("product.name").freeze
     end
 
     def self.USER_AGENT
-      "#{PRODUCT_NAME}/#{VERSION}".freeze
+      "#{self.PRODUCT_NAME}/#{self.VERSION}".freeze
     end
 
     def self.log_config(*args)


### PR DESCRIPTION
Also making sure `PRODUCT_NAME` is also frozen.

In trying to get this Lenovo PR green https://github.com/ManageIQ/manageiq-providers-lenovo/pull/96 we realised we should have kept the `self.` prefix to `PRODUCT_NAME` and `VERSION` in https://github.com/ManageIQ/manageiq/pull/16410

Otherwise you get
```
Vmdb::Appliance.USER_AGENT NameError: uninitialised constant Vmdb::Appliance::PRODUCT_NAME
```
/cc @Fryguy 