### PR TITLE
Add vm_destroy event to MiqEventDefinition.

### DIFF
--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -120,6 +120,7 @@ request_vm_destroy,VM Delete (from Disk) Request,Default,vm_configurational
 #
 # VM lifecycle
 #
+vm_destroy,VM Delete (from Disk),Default,vm_process
 vm_retired,VM Retired,Default,vm_process
 request_vm_retire,VM Retire Request,Default,vm_process
 vm_retire_warn,VM Retirement Warning,Default,vm_process


### PR DESCRIPTION
Add missing vm_destroy event.

For clarity, vm_delete is the policy event when a VM is removed from inventory from MIQ UI.
vm_destroy is the policy event raised when a VM is deleted from disk from VMware side.
vm_unregister is the policy event raised when a VM is removed from inventory from VMware side.

Includes https://github.com/ManageIQ/manageiq-content/pull/223.
https://bugzilla.redhat.com/show_bug.cgi?id=1506520

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, fine/yes, gaprindashvili/yes