### PR TITLE
Catalog Item type list is dependent on installed providers

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -16,6 +16,10 @@ module ManageIQ::Providers
       self
     end
 
+    def supported_catalog_types
+      []
+    end
+
     def refresher
       self.class::Refresher
     end

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -5,4 +5,8 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
   require_nested :ConfigurationScriptSource
   require_nested :ConfiguredSystem
   require_nested :OrchestrationStack
+
+  def supported_catalog_types
+    %w(generic_ansible_playbook)
+  end
 end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -70,9 +70,9 @@ class ServiceTemplate < ApplicationRecord
   scope :displayed,                                 ->         { where(:display => true) }
 
   def self.catalog_item_types
-    ci_types = Rbac.filtered(ExtManagementSystem.all).flat_map(&:supported_catalog_types).uniq
-    ci_types << 'generic_orchestration' if Rbac.filtered(OrchestrationTemplate).exists?
-    ci_types << 'generic'
+    ci_types = Set.new(Rbac.filtered(ExtManagementSystem.all).flat_map(&:supported_catalog_types))
+    ci_types.add('generic_orchestration') if Rbac.filtered(OrchestrationTemplate).exists?
+    ci_types.add('generic')
     CATALOG_ITEM_TYPES.each.with_object({}) do |(key, description), hash|
       hash[key] = { :description => description, :display => ci_types.include?(key) }
     end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -69,6 +69,15 @@ class ServiceTemplate < ApplicationRecord
   scope :with_existent_service_template_catalog_id, ->         { where.not(:service_template_catalog_id => nil) }
   scope :displayed,                                 ->         { where(:display => true) }
 
+  def self.catalog_item_types
+    ci_types = Rbac.filtered(ExtManagementSystem.all).flat_map(&:supported_catalog_types).uniq
+    ci_types << 'generic_orchestration' if Rbac.filtered(OrchestrationTemplate).exists?
+    ci_types << 'generic'
+    CATALOG_ITEM_TYPES.each.with_object({}) do |(key, description), hash|
+      hash[key] = { :description => description, :display => ci_types.include?(key) }
+    end
+  end
+
   def self.create_catalog_item(options, auth_user)
     transaction do
       create_from_options(options).tap do |service_template|

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
@@ -1,3 +1,11 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
   it_behaves_like 'ansible automation_manager'
+
+  context 'catalog types' do
+    let(:ems) { FactoryGirl.create(:embedded_automation_manager) }
+
+    it "#supported_catalog_types" do
+      expect(ems.supported_catalog_types).to eq(%w(generic_ansible_playbook))
+    end
+  end
 end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -776,6 +776,27 @@ describe ServiceTemplate do
       expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
     end
   end
+
+  context "catalog_item_types" do
+    it "only returns generic with no providers" do
+      expect(ServiceTemplate.catalog_item_types).to match(
+        hash_including('amazon'  => {:description => 'Amazon',  :display => false},
+                       'generic' => {:description => 'Generic', :display => true })
+      )
+    end
+
+    it "returns orchestration template and generic" do
+      FactoryGirl.create(:orchestration_template)
+      expect(ServiceTemplate.catalog_item_types).to match(
+        hash_including('amazon'                => { :description => 'Amazon',
+                                                    :display     => false },
+                       'generic'               => { :description => 'Generic',
+                                                    :display     => true },
+                       'generic_orchestration' => { :description => 'Orchestration',
+                                                    :display     => true})
+      )
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1515371

Currently we display all catalog item types irrespective of what
providers are installed in the appliance. This PR links the catalog
items to different providers and sets the display attribute based
on the presence of specific provider(s). This would be used by the
UI to list the valid catalog item types


Amazon Provider Changes are in PR
https://github.com/ManageIQ/manageiq-providers-amazon/pull/377

VMware Provider changes in PR
https://github.com/ManageIQ/manageiq-providers-vmware/pull/151

Openshift Provider changes in 
https://github.com/ManageIQ/manageiq-providers-openshift/pull/74

SCVMM Provider changes in PR
https://github.com/ManageIQ/manageiq-providers-scvmm/pull/54

Openstack Provider PR
https://github.com/ManageIQ/manageiq-providers-openstack/pull/177

Azure Provider PR
https://github.com/ManageIQ/manageiq-providers-azure/pull/185

External Ansible Tower PR
https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/42

Redhat Provider PR
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/174

Google Provider PR
https://github.com/ManageIQ/manageiq-providers-google/pull/35