### PR TITLE
Handle deprecated classes in arel

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -31,7 +31,7 @@ module VirtualArel
   module ClassMethods
     def arel_attribute(column_name, arel_table = self.arel_table)
       load_schema
-      if virtual_attribute?(column_name)
+      if virtual_attribute?(column_name) && !attribute_alias?(column_name)
         col = _virtual_arel[column_name.to_s]
         col.call(arel_table) if col
       else

--- a/spec/models/mixins/deprecation_mixin_spec.rb
+++ b/spec/models/mixins/deprecation_mixin_spec.rb
@@ -1,0 +1,10 @@
+describe DeprecationMixin do
+  # Host.deprecate_attribute :address, :hostname
+  context ".arel_attribute" do
+    it "works for deprecate_attribute columns" do
+      expect(Host.attribute_supported_by_sql?(:address)).to eq(true)
+      expect(Host.arel_attribute(:address)).to_not be_nil
+      expect(Host.arel_attribute(:address).name).to eq("hostname") # typically this is a symbol. not perfect but it works
+    end
+  end
+end


### PR DESCRIPTION
Attribute deprecation is based upon aliases and virtual attributes.
Ensure both concepts are working correctly together.

Bug: The virtual attribute was generating bogus arel, when it should
have been deferring to the attribute_alias mechanism built into rails

So the new code prioritizes attribute_alias over virtual_attribute

https://bugzilla.redhat.com/show_bug.cgi?id=1507047

This is an alternative to #16489

/cc @gtanzillo @imtayadeway