### PR TITLE
BZ1518673 add middleware server to available fields in advanced search

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -121,6 +121,7 @@
 - lans
 - last_compliances
 - linux_initprocesses
+- middleware_servers
 - miq_actions
 - miq_approval_stamps
 - miq_custom_attributes


### PR DESCRIPTION
RFE BZ#1518673
Adding the ability to filter in advanced filter by Middleware server for deployments, datasources and messaging.

![adv_search_server](https://user-images.githubusercontent.com/6277245/33431180-fd8f163a-d5db-11e7-99ea-7820379caa5e.png)


@miq-bot add_label providers/middleware, enhancement
@miq-bot add_label gaprindashvili/no