### PR TITLE
GenericObjectDefinition: add pretty & translatable type names

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -8,6 +8,15 @@ class GenericObjectDefinition < ApplicationRecord
     :time     => ActiveModel::Type::Time.new
   }.freeze
 
+  TYPE_NAMES = {
+    :boolean  => N_('Boolean'),
+    :datetime => N_('Date/Time'),
+    :float    => N_('Float'),
+    :integer  => N_('Integer'),
+    :string   => N_('String'),
+    :time     => N_('Time')
+  }.freeze
+
   FEATURES = %w(attribute association method).freeze
   REG_ATTRIBUTE_NAME = /\A[a-z][a-zA-Z_0-9]*\z/
   REG_METHOD_NAME    = /\A[a-z][a-zA-Z_0-9]*[!?]?\z/


### PR DESCRIPTION
This change is to have pretty (human readable & translatable) type names directly in the `GenericObjectDefinition` model.

With this change in place, we can then get rid of the `data_type` subtree in `locale/en.yml` (this willl be done after this PR is merged, as other stuff in API repo depends on it).