### PR TITLE
Don't connect to a host when detecting the type

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -168,7 +168,6 @@ class Host < ApplicationRecord
   include AuthenticationMixin
   include AsyncDeleteMixin
   include ComplianceMixin
-  include VimConnectMixin
   include AvailabilityMixin
 
   before_create :make_smart
@@ -899,20 +898,7 @@ class Host < ApplicationRecord
       self.ipaddress   = ipaddr
       self.vmm_vendor  = "vmware"
       self.vmm_product = "Esx"
-      if has_credentials?(:ws)
-        begin
-          with_provider_connection(:ip => ipaddr) do |vim|
-            _log.info("VIM Information for ESX Host with IP Address: [#{ipaddr}], Information: #{vim.about.inspect}")
-            self.vmm_product     = vim.about['name'].dup.split(' ').last
-            self.vmm_version     = vim.about['version']
-            self.vmm_buildnumber = vim.about['build']
-            self.name            = "#{vim.about['name']} (#{ipaddr})"
-          end
-        rescue => err
-          _log.warn("Cannot connect to ESX Host with IP Address: [#{ipaddr}], Username: [#{authentication_userid(:ws)}] because #{err.message}")
-        end
-      end
-      self.type = %w(esx esxi).include?(vmm_product.to_s.downcase) ? "ManageIQ::Providers::Vmware::InfraManager::HostEsx" : "ManageIQ::Providers::Vmware::InfraManager::Host"
+      self.type        = "ManageIQ::Providers::Vmware::InfraManager::HostEsx"
     elsif ost.hypervisor.include?(:ipmi)
       find_method       = :find_by_ipmi_address
       self.name         = "IPMI (#{ipaddr})"


### PR DESCRIPTION
Instead of connecting to the host to determine if the type is Host or
HostESX, just assume it is ESX.

@Fryguy what is the purpose of the `ManageIQ::Providers::Vmware::InfraManager::Host` instead of the `ManageIQ::Providers::Vmware::InfraManager::HostEsx` type?  Is this supposed to be `GSX` or workstation?  Can we just assume all hosts connected to vSphere are ESX/ESXi?

Also this is the last place `VimConnectMixin` is included in the main repo so we can move it to `-providers-vmware` after this.

cc @kbrock 