### PR TITLE
Enable OpenID-Connect in the appliance console.

### DIFF
--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -2,6 +2,7 @@ module EvmSettings
   ALLOWED_KEYS = [
     "/authentication/sso_enabled",
     "/authentication/saml_enabled",
+    "/authentication/oidc_enabled",
     "/authentication/local_login_disabled"
   ].freeze
 

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -3,6 +3,7 @@ module EvmSettings
     "/authentication/sso_enabled",
     "/authentication/saml_enabled",
     "/authentication/oidc_enabled",
+    "/authentication/provider_type",
     "/authentication/local_login_disabled"
   ].freeze
 
@@ -81,8 +82,8 @@ module EvmSettings
   private_class_method :str_to_value
 
   def self.value_to_str(value)
-    return "true"  if value  || value =~ /true/i
-    return "false" if !value || value =~ /false/i
+    return "true"  if value == true || value =~ /true/i
+    return "false" if value == false || value =~ /false/i
     value
   end
   private_class_method :value_to_str

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -1,5 +1,5 @@
 module EvmSettings
-  ALLOWED_KEYS = [
+  ALLOWED_KEYS ||= [
     "/authentication/sso_enabled",
     "/authentication/saml_enabled",
     "/authentication/oidc_enabled",
@@ -7,10 +7,12 @@ module EvmSettings
     "/authentication/local_login_disabled"
   ].freeze
 
-  INFO, WARN, ERROR = %w(info warn error)
+  INFO  ||= "info".freeze
+  WARN  ||= "warn".freeze
+  ERROR ||= "error".freeze
 
   def self.get_keys(keylist = nil)
-    keylist = ALLOWED_KEYS unless keylist.present?
+    keylist = ALLOWED_KEYS if keylist.blank?
     settings_hash = Settings.to_hash
     keylist.each do |key|
       validate_key(key)

--- a/spec/lib/tasks/evm_settings_spec.rb
+++ b/spec/lib/tasks/evm_settings_spec.rb
@@ -1,0 +1,70 @@
+require "rake"
+
+describe "EvmSettings", :type => :rake_task do
+  let(:task_path) { "lib/tasks/evm_settings" }
+  let(:keys) { ["/authentication/sso_enabled", "/authentication/saml_enabled", "/authentication/oidc_enabled", "/authentication/local_login_disabled"] }
+
+  describe ".get_keys" do
+    context "gets the current keys" do
+      it "when provider_type is none" do
+        @settings_hash =
+          {:authentication => {:user_type            => "userprincipalname",
+                               :amazon_key           => nil,
+                               :oidc_enabled         => false,
+                               :saml_enabled         => false,
+                               :local_login_disabled => false,
+                               :provider_type        => "none",
+                               :sso_enabled          => false},
+           :binary_blob    => {:purge_window_size    => 100}}
+
+        allow(Settings).to receive(:to_hash).and_return(@settings_hash)
+        expect(STDOUT).to receive(:puts).with("/authentication/sso_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/saml_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/provider_type=none")
+        expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
+        EvmSettings.get_keys
+      end
+
+      it "when provider_type is oidc" do
+        @settings_hash =
+          {:authentication => {:user_type            => "userprincipalname",
+                               :amazon_key           => nil,
+                               :oidc_enabled         => true,
+                               :saml_enabled         => false,
+                               :local_login_disabled => false,
+                               :provider_type        => "oidc",
+                               :sso_enabled          => false},
+           :binary_blob    => {:purge_window_size    => 100}}
+
+        allow(Settings).to receive(:to_hash).and_return(@settings_hash)
+        expect(STDOUT).to receive(:puts).with("/authentication/sso_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/saml_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=true")
+        expect(STDOUT).to receive(:puts).with("/authentication/provider_type=oidc")
+        expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
+        EvmSettings.get_keys
+      end
+
+      it "when provider_type is saml" do
+        @settings_hash =
+          {:authentication => {:user_type            => "userprincipalname",
+                               :amazon_key           => nil,
+                               :oidc_enabled         => false,
+                               :saml_enabled         => true,
+                               :local_login_disabled => false,
+                               :provider_type        => "saml",
+                               :sso_enabled          => false},
+           :binary_blob    => {:purge_window_size    => 100}}
+
+        allow(Settings).to receive(:to_hash).and_return(@settings_hash)
+        expect(STDOUT).to receive(:puts).with("/authentication/sso_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/saml_enabled=true")
+        expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
+        expect(STDOUT).to receive(:puts).with("/authentication/provider_type=saml")
+        expect(STDOUT).to receive(:puts).with("/authentication/local_login_disabled=false")
+        EvmSettings.get_keys
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/121849185

The change introduced by this PR will prepare the appliance console for handling the upcoming support of the OpenID Connect protocol.

The change introduced by this PR is reliant on the following work for full OpenID Connect support:

- https://github.com/ManageIQ/manageiq/pull/16495
- https://github.com/ManageIQ/manageiq-ui-classic/pull/2855

