### PR TITLE
Skip seeding of categories if their creation is invalid

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -262,7 +262,7 @@ class Classification < ApplicationRecord
     raise _("entries can only be added to classifications") unless category?
     # Inherit from parent classification
     options.merge!(:read_only => read_only, :syntax => syntax, :single_value => single_value, :ns => ns)
-    children.create(options)
+    children.create!(options)
   end
 
   def entries
@@ -446,11 +446,14 @@ class Classification < ApplicationRecord
 
   def self.seed
     YAML.load_file(FIXTURE_FILE).each do |c|
-      cat = find_by_name(c[:name], my_region_number, (c[:ns] || DEFAULT_NAMESPACE))
-      next if cat
+      category = find_by_name(c[:name], my_region_number, (c[:ns] || DEFAULT_NAMESPACE))
+      next if category
 
-      _log.info("Creating #{c[:name]}")
-      add_entries_from_hash(create(c.except(:entries)), c[:entries])
+      category = new(c.except(:entries))
+      next unless category.valid? # HACK: Skip seeding if categories aren't valid/unique
+      _log.info("Creating category #{c[:name]}")
+      category.save!
+      add_entries_from_hash(category, c[:entries])
     end
 
     # Fix categories that have a nill parent_id
@@ -466,7 +469,7 @@ class Classification < ApplicationRecord
   def self.add_entries_from_hash(cat, entries)
     entries.each do |entry|
       ent = cat.find_entry_by_name(entry[:name])
-      ent ? ent.update_attributes(entry) : cat.add_entry(entry)
+      ent ? ent.update_attributes!(entry) : cat.add_entry(entry)
     end
   end
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -440,6 +440,18 @@ describe Classification do
         Classification.seed
         expect(Classification.count).to eq(1)
       end
+
+      it "does not re-seed user-modified default categories" do
+        # If categories' names are edited they auto-save a different associated tag
+        # This tests that if seeding category and it's invalid (due to uniqueness constraints)
+        # then seeding still doesn't fail.
+        cat = Classification.find_by!(:description => "Cost Center", :parent_id => 0)
+        allow(YAML).to receive(:load_file).and_call_original
+        cat.update_attributes!(:name => "new_name")
+        expect {
+          2.times.each { Classification.seed }
+        }.to_not raise_error
+      end
     end
 
     it "does not re-seed existing categories" do


### PR DESCRIPTION
Warning: This is somewhat hacky and definitely an exception in what we've deemed 'standard practice' with our unusual seeding procedure.

This change skips seeding of categories in the event that creating them would be invalid - and they would be invalid because people would like to use their own categories with the same name. Because categories here in seeding are looked up via name (delegated to tag), a new category with the same name is attempted to be made, fails silently, and gives a weird error when entries are attempted to be added to an initialized but unpersisted category record.

https://bugzilla.redhat.com/show_bug.cgi?id=1507240

cc/ @jrafanie 