### PR TITLE
Save unique_set_size when saving process info

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -32,7 +32,7 @@ class MiqWorker < ApplicationRecord
   STATUSES_STOPPED  = [STATUS_STOPPED, STATUS_KILLED, STATUS_ABORTED]
   STATUSES_CURRENT_OR_STARTING = STATUSES_CURRENT + STATUSES_STARTING
   STATUSES_ALIVE    = STATUSES_CURRENT_OR_STARTING + [STATUS_STOPPING]
-  PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time proportional_set_size)
+  PROCESS_INFO_FIELDS = %i(priority memory_usage percent_memory percent_cpu memory_size cpu_time proportional_set_size unique_set_size)
 
   PROCESS_TITLE_PREFIX = "MIQ:".freeze
 

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -454,7 +454,8 @@ describe MiqWorker do
           :cpu_time              => 660,
           :priority              => "31",
           :name                  => "ruby",
-          :proportional_set_size => 198_721_987
+          :proportional_set_size => 198_721_987,
+          :unique_set_size       => 172_122_122
         }
 
         fields = described_class::PROCESS_INFO_FIELDS.dup
@@ -475,6 +476,7 @@ describe MiqWorker do
           expect(@worker.public_send(field)).to be_present
         end
         expect(@worker.proportional_set_size).to eq 198_721_987
+        expect(@worker.unique_set_size).to       eq 172_122_122
       end
     end
   end


### PR DESCRIPTION
Why?  USS is a more reliable mechanism for tracking workers with runaway
memory growth.  PSS is great, until the server process that forks new
processes grows large. As each new worker is forked, it inherits a share
of the large amount of the parent process' memory and therefore starts
with a large PSS, possibly exceeding our limits before doing any work.
USS only measures a process' private memory and is a better indicator
when a process is responsible for allocating too much memory without
freeing it.

Depends on: 

- [x] https://github.com/ManageIQ/manageiq-schema/pull/139
- [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/317