### PR TITLE
Use USS (unique set size) instead of PSS for all the things

### DIFF
--- a/app/models/miq_server/status_management.rb
+++ b/app/models/miq_server/status_management.rb
@@ -41,7 +41,7 @@ module MiqServer::StatusManagement
     def log_status
       log_system_status
       svr = my_server(true)
-      _log.info("[#{svr.friendly_name}] Process info: Memory Usage [#{svr.memory_usage}], Memory Size [#{svr.memory_size}], Proportional Set Size: [#{svr.proportional_set_size}], Memory % [#{svr.percent_memory}], CPU Time [#{svr.cpu_time}], CPU % [#{svr.percent_cpu}], Priority [#{svr.os_priority}]") unless svr.nil?
+      _log.info("[#{svr.friendly_name}] Process info: Memory Usage [#{svr.memory_usage}], Memory Size [#{svr.memory_size}], Proportional Set Size: [#{svr.proportional_set_size}], Unique Set Size: [#{svr.unique_set_size}], Memory % [#{svr.percent_memory}], CPU Time [#{svr.cpu_time}], CPU % [#{svr.percent_cpu}], Priority [#{svr.os_priority}]") unless svr.nil?
     end
 
     def log_system_status

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -20,8 +20,8 @@ module MiqServer::WorkerManagement::Monitor::Validation
 
     return true unless worker_get_monitor_status(w.pid).nil?
 
-    # Proportional set size is only implemented on linux
-    usage = w.proportional_set_size || w.memory_usage
+    # Unique set size is only implemented on linux
+    usage = w.unique_set_size || w.memory_usage
     if MiqWorker::STATUSES_CURRENT.include?(w.status) && usage_exceeds_threshold?(usage, memory_threshold)
       msg = "#{w.format_full_log_msg} process memory usage [#{usage}] exceeded limit [#{memory_threshold}], requesting worker to exit"
       _log.warn(msg)

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -496,7 +496,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def log_status(level = :info)
-    _log.send(level, "[#{friendly_name}] Worker ID [#{id}], PID [#{pid}], GUID [#{guid}], Last Heartbeat [#{last_heartbeat}], Process Info: Memory Usage [#{memory_usage}], Memory Size [#{memory_size}], Proportional Set Size: [#{proportional_set_size}], Memory % [#{percent_memory}], CPU Time [#{cpu_time}], CPU % [#{percent_cpu}], Priority [#{os_priority}]")
+    _log.send(level, "[#{friendly_name}] Worker ID [#{id}], PID [#{pid}], GUID [#{guid}], Last Heartbeat [#{last_heartbeat}], Process Info: Memory Usage [#{memory_usage}], Memory Size [#{memory_size}], Proportional Set Size: [#{proportional_set_size}], Unique Set Size: [#{unique_set_size}], Memory % [#{percent_memory}], CPU Time [#{cpu_time}], CPU % [#{percent_cpu}], Priority [#{os_priority}]")
   end
 
   def current_timeout

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -81,7 +81,7 @@ class EvmApplication
        s.drb_uri,
        s.started_on && s.started_on.iso8601,
        s.last_heartbeat && s.last_heartbeat.iso8601,
-       (mem = (s.proportional_set_size || s.memory_usage)).nil? ? "" : mem / 1.megabyte,
+       (mem = (s.unique_set_size || s.memory_usage)).nil? ? "" : mem / 1.megabyte,
        s.is_master,
        s.active_role_names.join(':'),
       ]
@@ -104,7 +104,7 @@ class EvmApplication
            w.queue_name || w.uri,
            w.started_on && w.started_on.iso8601,
            w.last_heartbeat && w.last_heartbeat.iso8601,
-           (mem = (w.proportional_set_size || w.memory_usage)).nil? ? "" : mem / 1.megabyte]
+           (mem = (w.unique_set_size || w.memory_usage)).nil? ? "" : mem / 1.megabyte]
       end
     end
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1479356

Builds on top of https://github.com/ManageIQ/manageiq/pull/16569 [MERGED]

* Change worker validation to check USS not PSS 
* Show USS instead of PSS in rake evm:status
* Also log the server/worker unique set size (USS)

The first bullet point should alleviate the false positives where a large server process was causing new forked workers to exceed PSS memory thresholds very quickly.  If the server process grows over time, that's a separate problem.  We shouldn't flag and kill workers that inherited a large shared memory, only ones that grow beyond the thresholds on their own.

For prior versions such as [euwe](https://github.com/ManageIQ/manageiq/pull/16480) and [fine](https://github.com/ManageIQ/manageiq-gems-pending/pull/313), we can accomplish a similar result by storing the USS in the existing PSS column:
