### PR TITLE
Don't return a duplicate object from MiqGroup#settings

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -45,7 +45,16 @@ class MiqGroup < ApplicationRecord
   end
 
   def settings
-    super && super.with_indifferent_access
+    current = super
+    return if current.nil?
+
+    self.settings = current.with_indifferent_access
+    super
+  end
+
+  def settings=(new_settings)
+    indifferent_settings = new_settings.try(:with_indifferent_access)
+    super(indifferent_settings)
   end
 
   def self.with_allowed_roles_for(user_or_group)

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -1,4 +1,19 @@
 describe MiqGroup do
+  describe "#settings" do
+    subject { FactoryGirl.create(:miq_group) }
+
+    it "returns a HashWithIndifferentAccess" do
+      subject.settings = {:a => 1}
+      expect(subject.settings["a"]).to eq(1)
+    end
+
+    it "returns the same object" do
+      subject.settings = {}
+      subject.settings[:a] = 1
+      expect(subject.settings[:a]).to eq(1)
+    end
+  end
+
   context "as a Super Administrator" do
     subject { FactoryGirl.create(:miq_group, :group_type => "system", :role => "super_administrator") }
 


### PR DESCRIPTION
Commit c0a662ba0b921e294de8671a8bdebb9bd527460d made the return value of `MiqGroup#settings` a `HashWithIndifferentAccess`. Unfortunately, `Hash#with_indifferent_access` returns a duplicate object.

This behavior breaks callers when they attempt to alter the settings hash in-place, for example:

https://github.com/ManageIQ/manageiq-ui-classic/blob/7d2ef009ac536770b1415ee59fa79c3a01e4d53e/app/controllers/report_controller/menus.rb#L230-L231

This PR changes the `#settings` method to also set the settings attribute so that it returns the same instance as is set for the group object. Additionally the `settings=` method had to be changed so that we are consistent with the new type in the column.

This has the same net effect as a data migration and a serialization type change to `ActiveSupport::HashWithIndifferentAccess`. I'm okay with either route.

/cc @yrudman @skateman 

https://bugzilla.redhat.com/show_bug.cgi?id=1516793