### PR TITLE
Add an ENV variable to override the PG version check in production

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -9,7 +9,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
     if postgresql_version >= 90600
       msg = "The version of PostgreSQL being connected to is incompatible with #{I18n.t("product.name")} (9.6+ is not supported yet)"
 
-      raise msg if Rails.env.production?
+      raise msg if Rails.env.production? && !ENV["UNSAFE_PG_VERSION"]
       $stderr.puts msg
     end
   end


### PR DESCRIPTION
This allows brave users to run the application in production mode even if their version of postgres is not tested.

Fixes #16486