### PR TITLE
Fix max method on empty array in chargeback storage report

### DIFF
--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -37,7 +37,8 @@ class Chargeback
     end
 
     def max(metric, sub_metric = nil)
-      values(metric, sub_metric).max
+      values = values(metric, sub_metric)
+      values.present? ? values.max : 0
     end
 
     def avg(metric, sub_metric = nil)

--- a/spec/models/chargeback/consumption_with_rollups_spec.rb
+++ b/spec/models/chargeback/consumption_with_rollups_spec.rb
@@ -10,7 +10,7 @@ describe Chargeback::ConsumptionWithRollups do
     let!(:metric_rollup) { FactoryGirl.create(:metric_rollup_vm_hr, :timestamp => starting_date + 1.hour, :resource => vm) }
 
     before do
-      Timecop.travel(starting_date)
+      Timecop.travel(starting_date + 10.hours)
     end
 
     it "doesn't fail when there are no state data about disks" do

--- a/spec/models/chargeback/consumption_with_rollups_spec.rb
+++ b/spec/models/chargeback/consumption_with_rollups_spec.rb
@@ -31,6 +31,18 @@ describe Chargeback::ConsumptionWithRollups do
       end
     end
 
+    context "vim performance state records don't exist" do
+      before do
+        VimPerformanceState.destroy_all
+      end
+
+      it 'all chargeback calculations return 0' do
+        expect(consumption.send(:max, 'derived_vm_allocated_disk_storage', sub_metric)).to be_zero
+        expect(consumption.send(:avg, 'derived_vm_allocated_disk_storage', sub_metric)).to be_zero
+        expect(consumption.send(:sum, 'derived_vm_allocated_disk_storage', sub_metric)).to be_zero
+      end
+    end
+
     after do
       Timecop.return
     end


### PR DESCRIPTION
Issue is that when we have result as empty array(It is because we don't have any VimPerformance yet) of method [VimPerformanceStates#sub_metric_rollups](https://github.com/manageiq/manageiq/blob/6757fe61ef58b7b8bd7f52b32ecc003a071c082d/app/models/chargeback/consumption_with_rollups.rb#L73) then on this empty array can be called [method max](https://github.com/manageiq/manageiq/blob/master/app/models/chargeback/consumption_with_rollups.rb#L39) and then we have nil in value:
```
[].max => nil
```

Note: for sum it is ok:
```
[].sum => 0
```
Error message
-------------
```
➜  manageiq git:(master) ✗ ./tools/generate_report.rb 'storage-volume'
** override_gem: manageiq-ui-classic, [{:path=>"/Users/liborpichler/manageiq/manageiq-ui-classic"}], caller: /Users/liborpichler/manageiq/manageiq/bundler.d/Gemfile.dev.rb
** Using session_store: ActionDispatch::Session::MemCacheStore
Generating report... storage-volume
/Users/liborpichler/manageiq/manageiq/app/models/chargeback_rate_detail.rb:104:in `block in find_rate': undefined method `*' for nil:NilClass (NoMethodError)
	from /Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:38:in `each'
	from /Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:38:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_rate_detail.rb:104:in `detect'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_rate_detail.rb:104:in `find_rate'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_rate_detail.rb:123:in `hourly_cost'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_rate_detail.rb:228:in `metric_and_cost_by'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_rate_detail.rb:90:in `charge'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:137:in `block (2 levels) in calculate_costs'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:136:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:136:in `block in calculate_costs'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:135:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:135:in `calculate_costs'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:33:in `block in build_results_for_report_chargeback'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:27:in `block (2 levels) in for_report'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:25:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:25:in `block in for_report'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:9:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:9:in `each_cons'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:9:in `for_report'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:20:in `build_results_for_report_chargeback'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_vm.rb:62:in `build_results_for_report_ChargebackVm'
	from /Users/liborpichler/manageiq/manageiq/app/models/miq_report/generator.rb:199:in `_generate_table'
	from /Users/liborpichler/manageiq/manageiq/app/models/miq_report/generator.rb:173:in `block in generate_table'
	from /Users/liborpichler/manageiq/manageiq/app/models/user.rb:246:in `with_user'
```
Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1517956


@miq-bot assign @gtanzillo 

@miq-bot add_label bug, chargeback, blocker

