### PR TITLE
[WIP] Adds dialog field association circ ref checker to main validation for ui creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ manageiq_plugin "manageiq-providers-ansible_tower" # can't move this down yet, b
 manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
+gem "pry"
 gem "activerecord-id_regions",        "~>0.2.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -66,6 +66,13 @@ class Dialog < ApplicationRecord
       errors.add(:base, _("Dialog field name cannot be duplicated on a dialog: %{duplicates}") % {:duplicates => duplicate_field_names.join(', ')})
     end
 
+    associations = {}
+    dialog_fields.each { |df| associations.merge!(df[:name] => df[:dialog_field_responders]) unless df[:dialog_field_responders].nil? }
+    if associations.present?
+      circular_references = DialogFieldAssociationValidator.new.circular_references(associations)
+      errors.add(:base, _("Dialog field association circular reference error: %{circular_references}") % {:circular_references => circular_references.join(', ')})
+    end
+
     dialog_tabs.each do |dt|
       next if dt.valid?
       dt.errors.full_messages.each do |err_msg|


### PR DESCRIPTION
Dialog field associations are checked for circular references on dialog import but this check needs to also be included in the main dialog validation on save for association creation via the classic ui. 