### PR TITLE
Fix cached query for total unregistered vms

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -433,7 +433,7 @@ class Storage < ApplicationRecord
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.where(:host => nil).group(:storage_id).count
+    Vm.where(:host => nil).where.not(:storage => nil).group(:storage_id).count
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -433,8 +433,7 @@ class Storage < ApplicationRecord
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.where(:host => nil)
-      .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
+    Vm.where(:host => nil).group("storage_id").count
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -433,7 +433,7 @@ class Storage < ApplicationRecord
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.where("((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true)
+    Vm.where.not("((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true)
       .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -433,7 +433,7 @@ class Storage < ApplicationRecord
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.where.not("(vms.host_id IS NOT NULL)")
+    Vm.where(:host => nil)
       .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -433,7 +433,7 @@ class Storage < ApplicationRecord
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.where.not("((vms.template = ? AND vms.ems_id IS NULL) OR vms.host_id IS NOT NULL)", true)
+    Vm.where.not("(vms.host_id IS NOT NULL)")
       .group("storage_id").pluck("storage_id, COUNT(*) AS vm_count")
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -433,7 +433,7 @@ class Storage < ApplicationRecord
   end
 
   cache_with_timeout(:unregistered_vm_counts_by_storage_id, 15.seconds) do
-    Vm.where(:host => nil).group("storage_id").count
+    Vm.where(:host => nil).group(:storage_id).count
       .each_with_object(Hash.new(0)) { |(storage_id, count), h| h[storage_id] = count.to_i }
   end
 

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -1,4 +1,18 @@
 describe Storage do
+  describe "#total_unregistered_vms" do
+    let(:ext_management_system)  { FactoryGirl.create(:ext_management_system) }
+    let(:host)                   { FactoryGirl.create(:host) }
+    let(:storage)                { FactoryGirl.create(:storage) }
+    let!(:vm_registered_1) { FactoryGirl.create(:vm, :storage => storage, :ext_management_system => ext_management_system, :host => host) }
+    let!(:vm_registered_2) { FactoryGirl.create(:vm, :storage => storage, :host => host) }
+    let!(:vm_unregistered) { FactoryGirl.create(:vm, :storage => storage, :ext_management_system => ext_management_system) }
+
+    it 'returns only unregistred vms' do
+      expect(storage.total_unregistered_vms).to eq(1)
+      expect(storage.total_unregistered_vms).to eq(storage.unregistered_vms.size)
+    end
+  end
+
   it "#scan_watchdog_interval" do
     stub_settings(:storage => {'watchdog_interval' => '5.minutes'})
     expect(Storage.scan_watchdog_interval).to eq(5.minutes)


### PR DESCRIPTION
`Storage#total_unregistered_vms` and `Storage#unregistered_vms` are using different queries.

Query [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/storage.rb#L435) is not same as it is [here](https://github.com/ManageIQ/manageiq/blob/master/app/models/vm_or_template.rb#L302) (method registered? on VM: [Vm#registered?](https://github.com/ManageIQ/manageiq/blob/master/app/models/storage.rb#L417
) )

@kbrock can you please review? (you touched this code last time )

🎁 @ZitaNemeckova 

@miq-bot add_label bug, core

@miq-bot assign @gtanzillo 