### PR TITLE
[WIP] virtual_attributes: throw errors for bad includes

### DIFF
--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -30,9 +30,12 @@ class Chargeback
     end
 
     def self.base_rollup_scope
+      # Container and ContainerProject does not have hardware (do we want?)
+      # Vm does not have a container_image
+      # Container does not have custom_attributes
       base_rollup = MetricRollup.includes(
-        :resource           => [:hardware, :tenant, :tags, :vim_performance_states, :custom_attributes,
-                                {:container_image => :custom_attributes}],
+        :resource           => [:tags, :vim_performance_states,
+                                ],
         :parent_host        => :tags,
         :parent_ems_cluster => :tags,
         :parent_storage     => :tags,

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -145,6 +145,7 @@ module EmsRefresh
                ids.map { |x| ManagerRefresh::Target.load(x) }
              else
                active_record_recs = target_class.where(:id => ids)
+               # ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource no ems
                active_record_recs = active_record_recs.includes(:ext_management_system) unless target_class <= ExtManagementSystem
                active_record_recs
              end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -154,7 +154,7 @@ class Service < ApplicationRecord
   end
 
   def all_vms
-    MiqPreloader.preload_and_map(subtree, :direct_vms)
+    direct_vms
   end
 
   def vms

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -942,7 +942,9 @@ describe VirtualFields do
       end
 
       it "as Hash" do
+        # virtual => actual
         expect { Vm.includes(:lans => :switch).load }.not_to raise_error
+        # actual => actual
         expect { Vm.includes(:lans => :switch, :host => :hardware).load }.not_to raise_error
       end
     end


### PR DESCRIPTION
The following works but was expected to throw an error:

```ruby
Container.includes(:asdf).all.each { |x| puts x }
# => []
```
It now throws an error when the `.includes()` is not valid.

The old code filtered out all associations that did not exist (assuming it was specifying a virtual attribute). The new code filters out only associations, and then fails if it doesn't point to a real association.

fixes #15111

See also:
- issue this fixes #15111
- example of problem https://github.com/ManageIQ/manageiq/pull/15069#discussion_r116131836
- similar issue in rails rails/rails#8005