### PR TITLE
remove available check

### DIFF
--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -6,11 +6,6 @@ module VimConnectMixin
     raise _("no credentials defined") if missing_credentials?(options[:auth_type])
 
     options[:use_broker] = (self.class.respond_to?(:use_vim_broker?) ? self.class.use_vim_broker? : ManageIQ::Providers::Vmware::InfraManager.use_vim_broker?) unless options.key?(:use_broker)
-    if options[:use_broker] && !MiqVimBrokerWorker.available?
-      msg = "Broker Worker is not available"
-      _log.error(msg)
-      raise MiqException::MiqVimBrokerUnavailable, _("Broker Worker is not available")
-    end
     options[:vim_broker_drb_port] ||= MiqVimBrokerWorker.method(:drb_port) if options[:use_broker]
 
     # The following require pulls in both MiqFaultTolerantVim and MiqVim


### PR DESCRIPTION
Slowly chipping away at `VmWare` `connect`:
This check is already performed in the actual `connect` operation.
So it is just hitting the worker tables unnecessarily.

The same exception is thrown (just from a different point)

extracted from #16505

removes 1 query for every `connect` which happens 1-7 times per `vm.perf_collect`:

|     ms |query | qry ms |     rows |`comments`
|    ---:|  ---:|   ---:|      ---:| ---
|    0.8 |    1 |   0.6 |        1 |`.SELECT  "miq_workers".*  -- [239]` second commit

now raises the following exception when a broker is not available. Same exception, different location

```
MiqException::MiqVimBrokerUnavailable: Broker is not available (connection error).
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:192:in `rescue in _connect_with_broker'
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:187:in `_connect_with_broker'
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:174:in `block in _connect'
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:86:in `_execute_with_broker'
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:75:in `_execute'
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:172:in `_connect'
  from vmware_web_service-0.2.3/lib/VMwareWebService/miq_fault_tolerant_vim.rb:29:in `initialize'
  from app/models/mixins/vim_connect_mixin.rb:15:in `new'
  from app/models/mixins/vim_connect_mixin.rb:15:in `connect'
```
