### PR TITLE
Build VimPerformanceTagValues for utilization charts by tags on the fly

### DIFF
--- a/app/models/vim_performance_tag.rb
+++ b/app/models/vim_performance_tag.rb
@@ -19,7 +19,7 @@ class VimPerformanceTag < MetricRollup
     tp = options.fetch_path(:ext_options, :time_profile)
     results = recs.inject(:res => [], :tags => [], :tcols => []) do |h, rec|
       if rec.class.name == "VimPerformanceTag"
-        tvrecs = rec.vim_performance_tag_values.build_for_association(rec,
+        tvrecs = VimPerformanceTagValue.build_for_association(rec,
                                                                       options[:cat_model].pluralize.underscore,
                                                                       :save     => false,
                                                                       :category => options[:category])

--- a/app/models/vim_performance_tag.rb
+++ b/app/models/vim_performance_tag.rb
@@ -18,26 +18,11 @@ class VimPerformanceTag < MetricRollup
     cat_assoc = Object.const_get(options[:cat_model].to_s).table_name.to_sym
     tp = options.fetch_path(:ext_options, :time_profile)
     results = recs.inject(:res => [], :tags => [], :tcols => []) do |h, rec|
+      tvrecs = build_tag_value_recs(rec, options)
       if rec.class.name == "VimPerformanceTag"
-        tvrecs = VimPerformanceTagValue.build_for_association(rec,
-                                                                      options[:cat_model].pluralize.underscore,
-                                                                      :save     => false,
-                                                                      :category => options[:category])
-        tvrecs = tvrecs.select { |r| r.category == options[:category] }
         rec.inside_time_profile = tp ? tp.ts_in_profile?(rec.timestamp) : true
       else
-        # TODO: - Should use table name instead of options[:cat_model].pluralize.underscore
-        tvrecs = VimPerformanceTagValue.build_for_association(rec, options[:cat_model].pluralize.underscore, :save => false, :category => options[:category])
-        tvrecs = tvrecs.find_all { |r| r.category == options[:category] }
         rec.inside_time_profile = tp ? tp.ts_day_in_profile?(rec.timestamp) : true
-      end
-      if tvrecs.empty?
-        tvrecs = VimPerformanceTagValue.tag_cols(rec.resource_type).inject([]) do |arr, c|
-          trec = VimPerformanceTagValue.new(:column_name => c, :tag_name => "_none_")
-          c == "assoc_ids" ? trec.assoc_ids = rec.send(c) : trec.value = rec.send(c)
-          arr.push(trec)
-          arr
-        end
       end
 
       tvrecs.each do |tv|
@@ -67,6 +52,24 @@ class VimPerformanceTag < MetricRollup
     end
 
     return results[:res], results[:tcols].sort, results[:tags].sort
+  end
+
+  def self.build_tag_value_recs(rec, options)
+    tvrecs = VimPerformanceTagValue.build_for_association(rec,
+                                                          options[:cat_model].pluralize.underscore,
+                                                          :save     => false,
+                                                          :category => options[:category])
+    tvrecs = tvrecs.select { |r| r.category == options[:category] }
+
+    if tvrecs.empty?
+      tvrecs = VimPerformanceTagValue.tag_cols(rec.resource_type).inject([]) do |arr, c|
+        trec = VimPerformanceTagValue.new(:column_name => c, :tag_name => "_none_")
+        c == "assoc_ids" ? trec.assoc_ids = rec.send(c) : trec.value = rec.send(c)
+        arr << trec
+      end
+    end
+
+    tvrecs
   end
 
   def self.fill_assoc_ids(_ts, result, assoc, tags)

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -103,11 +103,6 @@ class VimPerformanceTagValue < ApplicationRecord
       end
     end
 
-    parent_perf_tag_value_recs = parent_perf.vim_performance_tag_values.inject({}) do |h, tv|
-      h.store_path(tv.association_type, tv.category, tv.tag_name, tv.column_name, tv)
-      h
-    end
-
     result.keys.inject([]) do |a, key|
       col, tag = key.to_s.split(TAG_SEP)
       category = tag.split("/").first
@@ -122,6 +117,11 @@ class VimPerformanceTagValue < ApplicationRecord
       attr = col == 'assoc_ids' ? :assoc_ids : :value
       new_rec[attr] = result[key]
       if options[:save]
+        parent_perf_tag_value_recs = parent_perf.vim_performance_tag_values.inject({}) do |h, tv|
+          h.store_path(tv.association_type, tv.category, tv.tag_name, tv.column_name, tv)
+          h
+        end
+
         tag_value_rec   = parent_perf_tag_value_recs.fetch_path(association_type, category, tag_name, col)
         tag_value_rec ||= parent_perf_tag_value_recs.store_path(association_type, category, tag_name, col, parent_perf.vim_performance_tag_values.build)
         tag_value_rec.update_attributes(new_rec)


### PR DESCRIPTION
This PR is the first step towards getting rid of the `vim_performance_tag_values` table.  The table allows for grouping metrics by assigned tags at the timestamp of each metric. This table can get huge with only a few tag categories enabled for rollup. See referenced BZs below.

After digging through the code that uses that table Nick and I discovered that it's not actually used. The table is queried but the contents are not used in the resulting chart. Instead, instances of `VimPerformanceTagValue` are generate on the fly.

The first commit eliminates queries to the table for report generation. It will still read and write to the table during metrics processing. Will want to remove that too.

The second commit cleans up some of the code to hopefully make it easier to follow.

/cc @carbonin @Fryguy @blomquisg 

https://bugzilla.redhat.com/show_bug.cgi?id=1510484
https://bugzilla.redhat.com/show_bug.cgi?id=1514505