### PR TITLE
Safely get @target.id if @target is nil

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -59,7 +59,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
 
   def create_values
     create_values_hash.tap do |value|
-      value[:src_id] = @target.id
+      value[:src_id] = @target.try(:id)
       value[:request_options] = request_options unless request_options.blank?
     end
   end


### PR DESCRIPTION
Fixes exception raised when submitting VM Transform dialog in the case of mass transformation. See https://bugzilla.redhat.com/show_bug.cgi?id=1514939