### PR TITLE
[WIP] Fix Provisioning of disconnected VolumeTemplate

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision/cloning.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/cloning.rb
@@ -1,6 +1,10 @@
 module ManageIQ::Providers::CloudManager::Provision::Cloning
   def find_destination_in_vmdb(ems_ref)
     vm_model_class.find_by(:ems_id => source.ext_management_system.id, :ems_ref => ems_ref)
+  rescue NoMethodError => ex
+    _log.debug("Unable to find Provison Source ExtmanagementSystem: #{ex.to_s}")
+    _log.debug("Trying use attribute src_ems_id=#{options[:src_ems_id].try(:first)} instead.")
+    vm_model_class.find_by(:ems_id => options[:src_ems_id].try(:first), :ems_ref => ems_ref)
   end
 
   def vm_model_class


### PR DESCRIPTION
Since provisioning from OpenStack Volumes was enabled, situation when original
Volume template can be disconnected from EMS by refresher can happen and it
doesn't look to be possible fix it on OpenStack side.

This PR allows EMS lookup fallback to options[:src_ems_id] when getting EMS
from source object fails.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518381

Links
----------------

* BZ https://bugzilla.redhat.com/show_bug.cgi?id=1518381
* PRs adding provision from OpenStack Volumes for better understanding https://github.com/ManageIQ/manageiq/pull/16066 and  https://github.com/ManageIQ/manageiq-providers-openstack/pull/104

Steps for Testing/QA
-------------------------------
Vm provision process from OpenStack Volume should pass even refresh of given provider runs faster than provisioning process.