### PR TITLE
[wip] dialog field associations should be passed to validator as array

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -66,6 +66,13 @@ class Dialog < ApplicationRecord
       errors.add(:base, _("Dialog field name cannot be duplicated on a dialog: %{duplicates}") % {:duplicates => duplicate_field_names.join(', ')})
     end
 
+    associations = {}
+    dialog_fields.each { |df| associations.merge!(df[:name] => df[:dialog_field_responders]) unless df[:dialog_field_responders].nil? }
+    if associations.present?
+      circular_references = DialogFieldAssociationValidator.new.circular_references(associations)
+      errors.add(:base, _("Dialog field association circular reference error: %{circular_references}") % {:circular_references => circular_references.join(', ')})
+    end
+
     dialog_tabs.each do |dt|
       next if dt.valid?
       dt.errors.full_messages.each do |err_msg|

--- a/app/models/dialog_field_association_validator.rb
+++ b/app/models/dialog_field_association_validator.rb
@@ -14,7 +14,7 @@ class DialogFieldAssociationValidator
   private
 
   def initial_paths(associations)
-    associations.flat_map { |key, values| values.map { |value| [key, value] } }
+    associations.collect { |key, values| values.collect { |value| [key, value] } }
   end
 
   def walk_value_path(fieldname_being_triggered, associations, path)

--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -57,8 +57,8 @@ class DialogImportValidator
 
   def check_dialog_associations_for_validity(dialog_fields)
     associations = {}
-    dialog_fields.each { |df| associations.merge!(df["name"] => df["dialog_field_responders"]) unless df["dialog_field_responders"].nil? }
-    unless associations.blank?
+    dialog_fields.each { |df| associations.merge!(df["name"] => [df["dialog_field_responders"]]) unless df["dialog_field_responders"].nil? }
+    if associations.present?
       circular_references = @dialog_field_association_validator.circular_references(associations)
       raise DialogFieldAssociationCircularReferenceError, circular_references if circular_references
     end


### PR DESCRIPTION
The validator first creates the paths to walk for circular references and so this fix makes sure that they're being passed as arrays rather than strings in the case of the single associations.