### PR TITLE
dialog field associations should always be passed to validator as array

### DIFF
--- a/app/models/dialog_field_association_validator.rb
+++ b/app/models/dialog_field_association_validator.rb
@@ -14,7 +14,7 @@ class DialogFieldAssociationValidator
   private
 
   def initial_paths(associations)
-    associations.flat_map { |key, values| values.map { |value| [key, value] } }
+    associations.flat_map { |key, values| values.collect { |value| [key, value] } }
   end
 
   def walk_value_path(fieldname_being_triggered, associations, path)

--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -57,8 +57,8 @@ class DialogImportValidator
 
   def check_dialog_associations_for_validity(dialog_fields)
     associations = {}
-    dialog_fields.each { |df| associations.merge!(df["name"] => df["dialog_field_responders"]) unless df["dialog_field_responders"].nil? }
-    unless associations.blank?
+    dialog_fields.each { |df| associations.merge!(df["name"] => [df["dialog_field_responders"]]) unless df["dialog_field_responders"].nil? }
+    if associations.present?
       circular_references = @dialog_field_association_validator.circular_references(associations)
       raise DialogFieldAssociationCircularReferenceError, circular_references if circular_references
     end

--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -131,7 +131,7 @@ class DialogImportService
       fields = new_or_existing_dialog.dialog_fields
       (associations_to_be_created + build_old_association_list(fields).flatten).reject(&:blank?).each do |association|
         association.values.each do |values|
-          values.each do |responder|
+          values.split(' ').flatten.each do |responder|
             next if fields.select { |field| field.name == responder }.empty?
             DialogFieldAssociation.create(:trigger_id => fields.find { |field| field.name.include?(association.keys.first) }.id,
                                           :respond_id => fields.find { |field| field.name == responder }.id)


### PR DESCRIPTION
The dialog field association validator first creates the paths to walk for circular references and so this fix makes sure that they're being passed as arrays rather than strings in the case of the single associations so that the validation will not barf.