### PR TITLE
Destroy ems alert statuses when ems is destroyed

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -54,7 +54,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :policy_events,  -> { order("timestamp") }, :class_name => "PolicyEvent", :foreign_key => "ems_id"
 
   has_many :blacklisted_events, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
-  has_many :miq_alert_statuses, :foreign_key => "ems_id"
+  has_many :miq_alert_statuses, :foreign_key => "ems_id", :dependent => :destroy
   has_many :ems_folders,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :ems_clusters,   :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :resource_pools, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1514928

@moolitayer @zgalor @cben Please review

@miq-bot add_label providers/containers