### PR TITLE
EmsRefresh task name to use demodularize classname

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -204,6 +204,7 @@ module EmsRefresh
   end
 
   def self.create_refresh_task(ems, targets)
+    targets = targets.collect { |target_class, target_id| [target_class.demodulize, target_id] }
     task_options = {
       :action => "EmsRefresh(#{ems.name}) [#{targets}]".truncate(255),
       :userid => "system"

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -90,10 +90,21 @@ describe EmsRefresh do
       end
     end
 
+    context "task name" do
+      let(:vm1) { FactoryGirl.create(:vm_vmware, :ext_management_system => @ems) }
+      let(:vm2) { FactoryGirl.create(:vm_vmware, :ext_management_system => @ems) }
+      it "uses targets' short classnames to compose task name" do
+        task_ids = described_class.queue_refresh_task([vm1, vm2])
+        task_name = MiqTask.find(task_ids.first).name
+        expect(task_name).to include([vm1.class.name.demodulize, vm1.id].to_s)
+        expect(task_name).to include([vm2.class.name.demodulize, vm1.id].to_s)
+      end
+    end
+
     describe ".create_refresh_task" do
       it "create refresh task and trancates task name to 255 symbols" do
         vm = FactoryGirl.create(:vm_vmware, :name => "vm_vmware1", :ext_management_system => @ems)
-        targets = Array.new(500) { vm }
+        targets = Array.new(500) { [vm.class.name, vm.id] }
         task_name = described_class.send(:create_refresh_task, @ems, targets).name
         expect(task_name.include?(@ems.name)).to eq true
         expect(task_name.length).to eq 255


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1503660

It used to be like
`EmsRefresh(ems_0000000000001) [[["ManageIQ::Providers::Vmware::InfraManager::Vm", 30], ["ManageIQ::Providers::Vmware::InfraManager::Vm", 31]]]`
and now it will be
`EmsRefresh(ems_0000000000001) [[["Vm", 30], ["Vm", 31]]]`