### PR TITLE
ActiveRecord extension for pluggable human model names

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -19,4 +19,8 @@ class ApplicationRecord < ActiveRecord::Base
     extend MiqDecorator::Klass
     include MiqDecorator::Instance
   end
+
+  def self.display_name(number = 1)
+    n_(model_name.singular.titleize, model_name.plural.titleize, number)
+  end
 end


### PR DESCRIPTION
Currently, we store human readable / understandable model names in `locale/en.yml` under `model:` subtree. On top of this, we have `Dictionary.gettext()` and `ui_lookup()` to return a nice looking model name for given model / class.

Problem with this implementation is:
* it's not standard gettext, so we have to extract the strings from yaml in a special way and construct string plurals during the extraction
* current implementation doesn't support multiple plural forms, it simply assumes one plural form only
* current implementation is not pluggable: all models (even the provider ones) have to maintain their pretty looking model names in the core repo.

What this PR proposes is an extension to `ActiveRecord`: class & instance method `human_model_name()`, which would, for given class or class instance, return human looking model name. The extension itself would obviously be just a fallback, every model would have to override this method on its own:

```
irb(main):001:0> MiqReport.human_model_name
=> "Miq Report"
irb(main):002:0> MiqReport.human_model_name 2
=> "Miq Reports"
irb(main):003:0> MiqReport.first.human_model_name 2
=> "Miq Reports"
``` 

and with the following change in `app/models/miq_report.rb`:
```patch
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
+  def self.human_model_name(number = 1)
+    n_('Report', 'Reports', number)
+  end
```
we'd see:
```
irb(main):001:0> MiqReport.human_model_name
=> "Report"
irb(main):002:0> MiqReport.human_model_name 2
=> "Reports"
```

PR migrating current content of `locale/en.yml` into models would come separately.