### PR TITLE
Fix chargeback report when VM is destroyed

### DIFF
--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -127,7 +127,7 @@ class ChargebackVm < Chargeback
 
   def self.vm_owner(consumption)
     @vm_owners ||= vms.each_with_object({}) { |vm, res| res[vm.id] = vm.evm_owner_name }
-    @vm_owners[consumption.resource_id] ||= consumption.resource.evm_owner_name
+    @vm_owners[consumption.resource_id] ||= consumption.resource.try(:evm_owner_name)
   end
 
   def self.vms
@@ -172,7 +172,7 @@ class ChargebackVm < Chargeback
   def init_extra_fields(consumption)
     self.vm_id         = consumption.resource_id
     self.vm_name       = consumption.resource_name
-    self.vm_uid        = consumption.resource.ems_ref
+    self.vm_uid        = consumption.resource.try(:ems_ref)
     self.vm_guid       = consumption.resource.try(:guid)
     self.owner_name    = self.class.vm_owner(consumption)
     self.provider_name = consumption.parent_ems.try(:name)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -190,6 +190,22 @@ describe ChargebackVm do
 
         subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
 
+        context 'when the Vm resource of a consumption is destroyed' do
+          let(:hours_in_day) { (finish_time.end_of_day - start_time) / 1.hour }
+
+          before do
+            @vm1.destroy
+          end
+
+          it "calculates allocated cpu cost and metric values" do
+            skip('this case needs to be fixed in new chargeback') if Settings.new_chargeback
+
+            expect(subject.cpu_allocated_metric).to eq(cpu_count)
+            expect(subject.cpu_allocated_cost).to eq(cpu_count * count_hourly_rate * hours_in_day)
+            expect(subject.cpu_cost).to eq(subject.cpu_allocated_cost + subject.cpu_used_cost)
+          end
+        end
+
         context 'when first metric rollup has tag_names=nil' do
           before do
             options[:tag] = nil


### PR DESCRIPTION
Fix some cases when Vm is destroyed => then relation Vm -  MetricRollup(thru MetricRollup#resource) is destroyed but chargeback report was counting with some attributes of the VM - which doesn't exist so I am adding here `try`s.

Error message
-------------
```
➜  manageiq git:(master) ✗ ./tools/generate_report.rb 'CHEM_chargeback'
** override_gem: manageiq-ui-classic, [{:path=>"/Users/liborpichler/manageiq/manageiq-ui-classic"}], caller: /Users/liborpichler/manageiq/manageiq/bundler.d/Gemfile.dev.rb
** Using session_store: ActionDispatch::Session::MemCacheStore
Generating report... CHEM_chargeback
/Users/liborpichler/manageiq/manageiq/app/models/chargeback_vm.rb:175:in `init_extra_fields': undefined method `ems_ref' for nil:NilClass (NoMethodError)
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:72:in `initialize'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:24:in `new'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:24:in `block in build_results_for_report_chargeback'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:27:in `block (2 levels) in for_report'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:25:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:25:in `block in for_report'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:9:in `each'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:9:in `each_cons'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_history.rb:9:in `for_report'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback.rb:20:in `build_results_for_report_chargeback'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback_vm.rb:62:in `build_results_for_report_ChargebackVm'
	from /Users/liborpichler/manageiq/manageiq/app/models/miq_report/generator.rb:199:in `_generate_table'
	from /Users/liborpichler/manageiq/manageiq/app/models/miq_report/generator.rb:173:in `block in generate_table'
	from /Users/liborpichler/manageiq/manageiq/app/models/user.rb:246:in `with_user'
	from /Users/liborpichler/manageiq/manageiq/app/models/miq_report/generator.rb:173:in `generate_table'
	from /Users/liborpichler/manageiq/manageiq/app/models/miq_report/generator/async.rb:94:in `_async_generate_table'
	from ./tools/generate_report.rb:29:in `<main>'
```


cc @gtanzillo 
@miq-bot assign @jrafanie 
@miq-bot add_label bug, chargeback, gaprindashvili/yes