### PR TITLE
[WIP] Deprecate dialog label

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -7,6 +7,7 @@ class Dialog < ApplicationRecord
   has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy
   validate :validate_children
 
+  include DeprecationMixin
   include DialogMixin
   has_many :resource_actions
   virtual_has_one :content, :class_name => "Hash"
@@ -14,7 +15,7 @@ class Dialog < ApplicationRecord
   before_destroy          :reject_if_has_resource_actions
   validates :label, :unique_within_region => true
 
-  alias_attribute  :name, :label
+  deprecate_attribute :label, :name
 
   attr_accessor :target_resource
 


### PR DESCRIPTION
We're using `label` to refer to the dialog name and we call it `name` in the UI (and prior to this PR we had an alias in the dialog model) so it kinda made sense to just name the thing `name`.

## Related to:
ManageIQ/manageiq#16507

## Depends on:
https://github.com/ManageIQ/manageiq-schema/pull/142