### PR TITLE
[WIP] Vm inheritance change for type column

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1793,4 +1793,8 @@ class VmOrTemplate < ApplicationRecord
   def self.arel_coalesce(values)
     Arel::Nodes::NamedFunction.new('COALESCE', values)
   end
+
+  def self.type_condition(table = arel_table)
+    super unless (self == Vm || self == MiqTemplate || self == VmOrTemplate)
+  end
 end

--- a/spec/models/miq_template_spec.rb
+++ b/spec/models/miq_template_spec.rb
@@ -11,6 +11,12 @@ describe MiqTemplate do
     expect(ManageIQ::Providers::Redhat::InfraManager::Template.corresponding_vm_model).to eq(ManageIQ::Providers::Redhat::InfraManager::Vm)
   end
 
+  context "#template" do
+    it "defaults to true" do
+      expect(described_class.new.template).to eq(true)
+    end
+  end
+
   context "#template=" do
     before(:each) { @template = FactoryGirl.create(:template_vmware) }
 

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -13,6 +13,12 @@ describe Vm do
     expect(ManageIQ::Providers::Redhat::InfraManager::Vm.corresponding_template_model).to eq(ManageIQ::Providers::Redhat::InfraManager::Template)
   end
 
+  context "#template" do
+    it "defaults to true" do
+      expect(described_class.new.template).to eq(false)
+    end
+  end
+
   context "#template=" do
     before(:each) { @vm = FactoryGirl.create(:vm_vmware) }
 


### PR DESCRIPTION
Our `Vm` (and `MiqTemplate`) queries are quite large.
Curiously, we should only need to look at the `template` value rather than building the long `type IN()` queries.

The numbers for the `Vm` queries are the most important since most of our access is through `VmOrTemplate` and `Vm`.

### Before

All `Vm`, `MiqTemplate`, and subclasses build `"type" IN ()` queries that are often 500-800 characters long. The range prevents us from using indexes (`IN` clauses prevent us from using indexes except in rare cases)

### After

This change turns off the typical STI `"type" IN ()` query only for `Vm` and `MiqTemplate`.

The queries are shorter, use fewer fields, and use less memory to construct.

# Shorter

Number of characters to bring back all objects: (e.g.: `VmOrTemplate.all.to_sql.size`)

|object|before|after|change|explain|
|   ---|  ---:| ---:|---:|---|
|`VmOrTemplate`   |  25  |  25 |0|No change|
|**`Vm`**    | **581**  |  76 |87%|No longer have `"type" IN ()`
|`MiqTemplate`     | 838  |  76 |91%|No longer have `"type" IN ()`
|`Vmware::Vm`  | 124  |  124 |0|No change

### before

```sql
SELECT "vms".*
FROM "vms"
WHERE "vms"."type" IN ('Vm', 'ManageIQ::Providers::InfraManager::Vm', 'ManageIQ::Providers::CloudManager::Vm',
                       'VmServer', 'ManageIQ::Providers::Vmware::InfraManager::Vm',
                       'ManageIQ::Providers::Redhat::InfraManager::Vm',
                       'ManageIQ::Providers::Microsoft::InfraManager::Vm', 'VmXen',
                       'ManageIQ::Providers::Amazon::CloudManager::Vm', 'ManageIQ::Providers::Azure::CloudManager::Vm',
                       'ManageIQ::Providers::Google::CloudManager::Vm',
                       'ManageIQ::Providers::Openstack::CloudManager::Vm', 'ManageIQ::Providers::Vmware::CloudManager::Vm')
  AND "vms"."template" = 'f'"
```

### after

```sql
SELECT "vms".*
FROM "vms"
WHERE "vms"."template" = 'f'"
```

# Fewer Fields

Using fewer fields mean better index use. Especially when an `"type" IN ()` is replaced by `template = true`.

|    object     |before|after|
|            ---|  ---:| ---:|
|`VmOrTemplate` | neither | neither |
|`Vm`           | `type`, `template` | `template` |
|`MiqTemplate`  | `type`, `template` | `template` |
|`Vmware::Vm`   | `type`, `template` | `type`,`template` |

# Less Memory

The number of objects required to build the SQL reveals the difference in complexity.
Our base case for looking up meta-data is `VmOrTemplate`. The significant place is `Vm`

### Vm

Timings for `Vm.all.to_s`:

|object|ms|bytes|obj|comment
|--- | --- | --- | --- |---
|Vm-2| 45.3 | 25,712 | 346|before
|Vm-2| 37.3 | 6,857 | 106|after
|Vm-2|17.7% | 73%|69%|change

### various objects

|object   |ms|bytes|obj|ms'|bytes'|obj'
| ---     |    ---:|        ---:|     ---:|    ---:|        ---:|     ---:
| VmOrTemplate-0   |   40.6 |      6,673 |      85 |   37.3 |      6,673 |      85 
| VmOrTemplate-1   |   44.4 |      3,913 |      51 |   35.6 |      3,913 |      51 
| VmOrTemplate-2   |   38.8 |      3,913 |      51 |   35.9 |      3,913 |      51 
|  Vm-0   |  658.1 | 44,567,755*| 516,847 |  170.8 | 14,770,451*| 160,730 
|  **Vm-1**   |   **41.9** |     **25,712** |     **346** |   **39.0** |      **6,857** |     **106** 
|  **Vm-2**   |   **45.3** |     **25,712** |     **346** |   **37.3** |      **6,857** |     **106** 
|   MiqTemplate-0   |  555.6 | 44,735,062*| 518,469 |  163.8 | 14,759,203*| 160,729 
|   MiqTemplate-1   |   47.6 |     27,099 |     358 |   37.3 |      6,857 |     106 
|   MiqTemplate-2   |   49.5 |     27,099 |     358 |   36.6 |      6,857 |     106 
|Vmware::Vm-0   |  170.0 | 14,834,436*| 160,990 |  166.3 | 14,820,758*| 160,825 
|Vmware::Vm-1   |   48.3 |     20,380 |     276 |   37.7 |      7,484 |     120 
|Vmware::Vm-2   |   45.8 |     20,380 |     276 |   37.7 |      7,484 |     120 

\* Memory usage does not reflect 2,581 freed objects. (before)
\* Memory usage does not reflect 2,585 freed objects. (before)
\* Memory usage does not reflect 273 freed objects. (after)

- We are already connected to the database by pre-loading a `Host` record.
- The `VMWare::Vm` values should be very similar before and after since only the default query (i.e.: `template = 'false'`) is removed.
