### PR TITLE
Remove data_type subtree from locale/en.yml

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1090,14 +1090,6 @@ en:
       zone:                        Zone
       zones:                       Zones
 
-    data_type:
-      boolean:             Boolean
-      datetime:            Date/Time
-      float:               Float
-      integer:             Integer
-      string:              String
-      time:                Time
-
     ui_title:
       foreman:             Foreman
       ansible_tower:       Ansible Tower


### PR DESCRIPTION
With https://github.com/ManageIQ/manageiq/pull/16563 and https://github.com/ManageIQ/manageiq-api/pull/232 merged, this subtree is no longer needed.