### PR TITLE
Allowing OperatingSystem for CloudManager graph refresh

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -42,6 +42,7 @@ class ExtManagementSystem < ApplicationRecord
            :class_name => "VmOrTemplate", :inverse_of => :ext_management_system
   has_many :miq_templates,     :foreign_key => :ems_id, :inverse_of => :ext_management_system
   has_many :vms,               :foreign_key => :ems_id, :inverse_of => :ext_management_system
+  has_many :operating_systems, :through => :vms_and_templates
   has_many :hardwares,         :through => :vms_and_templates
   has_many :networks,          :through => :hardwares
   has_many :disks,             :through => :hardwares

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -13,7 +13,6 @@ module ManageIQ::Providers
     has_many :host_switches,              :through => :hosts
     has_many :host_networks,              :through => :hosts, :source => :networks
     has_many :snapshots,                  :through => :vms_and_templates
-    has_many :operating_systems,          :through => :vms_and_templates
     has_many :switches, -> { distinct },  :through => :hosts
     has_many :lans, -> { distinct },      :through => :hosts
     has_many :subnets, -> { distinct },   :through => :lans

--- a/app/models/manager_refresh/inventory_collection_default.rb
+++ b/app/models/manager_refresh/inventory_collection_default.rb
@@ -72,6 +72,24 @@ class ManagerRefresh::InventoryCollectionDefault
       attributes.merge!(extra_attributes)
     end
 
+    def operating_systems(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::OperatingSystem,
+        :manager_ref                  => [:vm_or_template],
+        :association                  => :operating_systems,
+        :parent_inventory_collections => [:vms, :miq_templates],
+      }
+
+      attributes[:targeted_arel] = lambda do |inventory_collection|
+        manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
+        inventory_collection.parent.operating_systems.joins(:vm_or_template).where(
+          'vms' => {:ems_ref => manager_uuids}
+        )
+      end
+
+      attributes.merge!(extra_attributes)
+    end
+
     def disks(extra_attributes = {})
       attributes = {
         :model_class                  => ::Disk,


### PR DESCRIPTION
Allowing OperatingSystem for CloudManager graph refresh

Partially fixes BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1521018