### PR TITLE
[WIP] Adds field associations circular reference check to backend validations

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -161,9 +161,9 @@ class Dialog < ApplicationRecord
   private
 
   def create_association_list(associations_on_dialog_fields, dialog_field_list)
-    associations = {}
-    associations_on_dialog_fields.each { |a| associations.merge!(dialog_field_list.find { |df| df.id == a.trigger_id }.name => dialog_field_list.select { |df| df.id == a.respond_id }.pluck(:name)) }
-    associations
+    associations_on_dialog_fields.each_with_object({}) do |a, associations|
+      associations[dialog_field_list.find { |df| df.id == a.trigger_id }.name] = dialog_field_list.select { |df| df.id == a.respond_id }.pluck(:name)
+    end
   end
 
   def dialog_field_hash

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -386,6 +386,36 @@ describe Dialog do
       end
     end
 
+    context "non-circular field associations" do
+      let(:dialog_tab) { FactoryGirl.create(:dialog_tab, :dialog => dialog) }
+      let(:dialog_group) { FactoryGirl.create(:dialog_group, :dialog_tab => dialog_tab) }
+      let(:dialog_field1) { FactoryGirl.build(:dialog_field, :dialog_group => dialog_group, :label => 'field 1', :name => 'field1') }
+      let(:dialog_field2) { FactoryGirl.build(:dialog_field, :dialog_group => dialog_group, :label => 'field 2', :name => 'field2') }
+      let(:dialog_field3) { FactoryGirl.build(:dialog_field, :dialog_group => dialog_group, :label => 'field 3', :name => 'field3') }
+
+      before do
+        FactoryGirl.create(:dialog_field_association, :trigger => dialog_field1, :respond => dialog_field2)
+        dialog.dialog_tabs << dialog_tab
+      end
+
+      it "adds error on simple circular reference" do
+        FactoryGirl.create(:dialog_field_association, :trigger => dialog_field2, :respond => dialog_field1)
+
+        expect { dialog.save! }.to raise_error(ActiveRecord::RecordInvalid, /Dialog field associations cannot be circular/)
+      end
+
+      it "adds error on complex circular reference" do
+        FactoryGirl.create(:dialog_field_association, :trigger => dialog_field2, :respond => dialog_field3)
+        FactoryGirl.create(:dialog_field_association, :trigger => dialog_field3, :respond => dialog_field1)
+
+        expect { dialog.save! }.to raise_error(ActiveRecord::RecordInvalid, /Dialog field associations cannot be circular/)
+      end
+
+      it "validates with non-circular reference" do
+        expect { dialog.save! }.not_to raise_error
+      end
+    end
+
     it "validates with tab" do
       dialog.dialog_tabs << FactoryGirl.create(:dialog_tab, :label => 'tab')
       expect_any_instance_of(DialogTab).to receive(:valid?)


### PR DESCRIPTION
Dialog field associations are checked for circular references on dialog import but this check needs to also be included in the main dialog validation on save for association creation via the classic ui.