### PR TITLE
Add method for Vm to get 'My Company'  tags

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -35,6 +35,8 @@ class Classification < ApplicationRecord
   scope :is_category, -> { where(:parent_id => 0) }
   scope :is_entry,    -> { where.not(:parent_id => 0) }
 
+  scope :with_writable_parents, -> { includes(:parent).where(:parents_classifications => { :read_only => false}) }
+
   DEFAULT_NAMESPACE = "/managed"
 
   default_value_for :read_only,    false

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -25,6 +25,10 @@ module ActsAsTaggable
     end.map(&:strip).uniq
   end
 
+  def writable_classification_tags
+    tags.merge(Classification.with_writable_parents)
+  end
+
   module ClassMethods
     # @option options :cat [String|nil] optional category for the tags
     # @option options :ns  [String|nil] optional namespace for the tags

--- a/spec/lib/extensions/ar_taggable_spec.rb
+++ b/spec/lib/extensions/ar_taggable_spec.rb
@@ -16,6 +16,25 @@ describe ActsAsTaggable do
     @vm4.tag_add("bos phi blt")
   end
 
+  describe '#writable_classification_tags' do
+    let(:parent_classification) { FactoryGirl.create(:classification, :description => "Environment", :name => "environment", :read_only => false) }
+    let(:classification)        { FactoryGirl.create(:classification, :name => "prod", :description => "Production", :parent => parent_classification, :read_only => true) }
+
+    before do
+      classification.assign_entry_to(@vm1)
+    end
+
+    it "returns only tags as they would be entered in UI by user(edit tags screen)" do
+      expect(@vm1.tags.count).to eq(4)
+      expect(@vm1.writable_classification_tags.count).to eq(1)
+      expect(@vm1.writable_classification_tags.first.name).to eq('/managed/environment/prod')
+      expect(@vm1.writable_classification_tags.first).to be_kind_of(Tag)
+
+      expect(@vm3.writable_classification_tags.count).to eq(0)
+      expect(@vm3.tags.count).to eq(3)
+    end
+  end
+
   context ".find_tagged_with" do
     it ":any" do
       found = Host.find_tagged_with(:any => "red black", :ns => "/test/tags")


### PR DESCRIPTION
'My Company' tags  - there is used name `writable_classification_tags` for this method - it is inherited from names of used relations and scopes but maybe there is better name

 **in UI:**
(for example)
<img width="796" alt="screen shot 2017-12-12 at 11 05 45" src="https://user-images.githubusercontent.com/14937244/33878736-89f6f09e-df2c-11e7-95f5-efa727f4dd2e.png">
<img width="1345" alt="screen shot 2017-12-12 at 11 06 26" src="https://user-images.githubusercontent.com/14937244/33878735-890a5e96-df2c-11e7-8aa4-85b94b70cc90.png">

### How it looks in DB ?

Vm (for example) -> Taggings -> Tags -> Classification -> parent of Classification is read_only 

it was derived from [code in UI screen ](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/application_controller/tags.rb#L238)

### Usage:
```
irb(main):001:0> Vm.find(10000000000151).writable_classification_tags
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 50, connections: 1, in use: 1, waiting_in_queue: 0
  Vm Load (1.5ms)  SELECT  "vms".* FROM "vms" WHERE "vms"."type" IN ('Vm', 'VmServer', 'ManageIQ::Providers::InfraManager::Vm', 'ManageIQ::Providers::CloudManager::Vm', 'VmXen', 'ManageIQ::Providers::Redhat::InfraManager::Vm', 'ManageIQ::Providers::Microsoft::InfraManager::Vm', 'ManageIQ::Providers::Vmware::InfraManager::Vm', 'ManageIQ::Providers::Amazon::CloudManager::Vm', 'ManageIQ::Providers::Azure::CloudManager::Vm', 'ManageIQ::Providers::Google::CloudManager::Vm', 'ManageIQ::Providers::Openstack::CloudManager::Vm', 'ManageIQ::Providers::Vmware::CloudManager::Vm') AND "vms"."template" = $1 AND "vms"."id" = $2 LIMIT $3  [["template", "f"], ["id", 10000000000151], ["LIMIT", 1]]
  Vm Inst Including Associations (709.8ms - 1rows)
   (1.5ms)  SELECT DISTINCT COUNT(DISTINCT "tags"."id") FROM "tags" LEFT OUTER JOIN "classifications" ON "classifications"."tag_id" = "tags"."id" LEFT OUTER JOIN "classifications" "parents_classifications" ON "parents_classifications"."id" = "classifications"."parent_id" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2 AND "parents_classifications"."read_only" = $3  [["taggable_id", 10000000000151], ["taggable_type", "VmOrTemplate"], ["read_only", "f"]]
  Query Trace > lib/extensions/ar_virtual.rb:741:in `calculate'
     from lib/extensions/ar_virtual.rb:741:in `calculate'
  SQL (1.1ms)  SELECT "tags"."id" AS t0_r0, "tags"."name" AS t0_r1, "classifications"."id" AS t1_r0, "classifications"."description" AS t1_r1, "classifications"."icon" AS t1_r2, "classifications"."read_only" AS t1_r3, "classifications"."syntax" AS t1_r4, "classifications"."single_value" AS t1_r5, "classifications"."example_text" AS t1_r6, "classifications"."tag_id" AS t1_r7, "classifications"."parent_id" AS t1_r8, "classifications"."show" AS t1_r9, "classifications"."default" AS t1_r10, "classifications"."perf_by_tag" AS t1_r11, "parents_classifications"."id" AS t2_r0, "parents_classifications"."description" AS t2_r1, "parents_classifications"."icon" AS t2_r2, "parents_classifications"."read_only" AS t2_r3, "parents_classifications"."syntax" AS t2_r4, "parents_classifications"."single_value" AS t2_r5, "parents_classifications"."example_text" AS t2_r6, "parents_classifications"."tag_id" AS t2_r7, "parents_classifications"."parent_id" AS t2_r8, "parents_classifications"."show" AS t2_r9, "parents_classifications"."default" AS t2_r10, "parents_classifications"."perf_by_tag" AS t2_r11 FROM "tags" LEFT OUTER JOIN "classifications" ON "classifications"."tag_id" = "tags"."id" LEFT OUTER JOIN "classifications" "parents_classifications" ON "parents_classifications"."id" = "classifications"."parent_id" INNER JOIN "taggings" ON "tags"."id" = "taggings"."tag_id" WHERE "taggings"."taggable_id" = $1 AND "taggings"."taggable_type" = $2 AND "parents_classifications"."read_only" = $3  [["taggable_id", 10000000000151], ["taggable_type", "VmOrTemplate"], ["read_only", "f"]]
  Query Trace > lib/extensions/ar_virtual.rb:704:in `find_with_associations'
  Tag Inst Including Associations (22.1ms - 1rows)
[
    [0] #<Tag:0x00007f9152d767f8> {
          :id => 10000000000167,
        :name => "/managed/turbonomic/candidate"
    }
```

🎁 for  @skateman 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1519457
https://bugzilla.redhat.com/show_bug.cgi?id=1467805
