### PR TITLE
Handle autoload error not caught by safe_constantize

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -21,7 +21,12 @@ class MiqExpression::Field < MiqExpression::Target
     return false unless field.kind_of?(String)
     match = REGEX.match(field)
     return false unless match
-    model = match[:model_name].safe_constantize
+    model =
+      begin
+        match[:model_name].safe_constantize
+      rescue LoadError
+        nil
+      end
     return false unless model
     !!(model < ApplicationRecord)
   end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -190,6 +190,11 @@ describe MiqExpression do
       expect(sql).to eq("\"vms\".\"name\" = \"vms\".\"name\"")
     end
 
+    it "will handle values that look like they contain MiqExpression-encoded constants but cannot be loaded" do
+      sql, * = described_class.new("=" => {"field" => "Vm-name", "value" => "VM-name"}).to_sql
+      expect(sql).to eq(%q("vms"."name" = 'VM-name'))
+    end
+
     it "generates the SQL for a < expression" do
       sql, * = described_class.new("<" => {"field" => "Vm.hardware-cpu_sockets", "value" => "2"}).to_sql
       expect(sql).to eq("\"hardwares\".\"cpu_sockets\" < 2")


### PR DESCRIPTION
MiqExpression currently supports 'values' that are 'fields', i.e.:

```ruby
{"=" => {"field" => "Vm-name", "value" => "Vm-description"}}
```

It will however trip up on a value/field if it *looks* like it
contains a constant that can be autoloaded, but can't:

```ruby
{"=" => {"field" => "Vm-name", "value" => "VM-test"}}
```

...

```ruby
"VM".safe_constantize # => LoadError: Unable to autoload constant VM, expected /home/tim/src/manageiq/app/models/vm.rb to define it
```

We need to explicitly catch this `LoadError`, which does not inherit
from `StandardError`, returning `nil`, to prevent MiqExpression from
trying to interpret this as a "field value".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1521167

