### PR TITLE
[FINE] Enable Web Console on RHOS provider

### DIFF
--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -18,11 +18,12 @@ module Vm::Operations
   end
 
   def ipv4_address
-    %w(amazon google).include?(vendor) ? public_address : ipaddresses.find { |ip| (IPAddr.new ip).ipv4? }
+    return public_address unless public_address.nil?
+    ipaddresses.find { |ip| IPAddr.new(ip).ipv4? && !ip.starts_with?('192') }
   end
 
   def public_address
-    ipaddresses.find { |ip| !Addrinfo.tcp(ip, 80).ipv4_private? }
+    ipaddresses.find { |ip| !Addrinfo.tcp(ip, 80).ipv4_private? && IPAddr.new(ip).ipv4? }
   end
 
   def validate_collect_running_processes

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -14,7 +14,7 @@ describe 'VM::Operations' do
   context '#cockpit_url' do
     it '#returns a valid Cockpit url' do
       url = @vm.send(:cockpit_url)
-      expect(url).to eq('http://127.0.0.1:9090')
+      expect(url).to eq(URI::HTTP.build(:host => "127.0.0.1", :port => 9090).to_s)
     end
   end
 


### PR DESCRIPTION
This PR needs to be merged before #2039 can be backported to FINE.

Cherry-picked refactorings from the upstream PR #15901 to enable the Web Console on RHOS.

@miq-bot add_labels bug, core, ui

https://bugzilla.redhat.com/show_bug.cgi?id=1496903