### PR TITLE
Use LinuxAdmin::SubscriptionManager directly.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "hamlit",                         "~>2.7.0"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "kubeclient",                     "~>2.4.0",       :require => false # For scaling pods at runtime
+gem "linux_admin",                    "~>1.2.0",       :require => false
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
 gem "manageiq-network_discovery",     "~>0.1.2",       :require => false

--- a/app/models/miq_server/update_management.rb
+++ b/app/models/miq_server/update_management.rb
@@ -73,13 +73,11 @@ module MiqServer::UpdateManagement
       _log.info("Registering appliance...")
       registration_type = MiqDatabase.first.registration_type
 
-      registration_class = LinuxAdmin::SubscriptionManager
-
       # TODO: Prompt user for environment in UI for Satellite 6 registration, use default environment for now.
       registration_options = assemble_registration_options
       registration_options[:environment] = "Library" if registration_type == "rhn_satellite6"
 
-      registration_class.register(registration_options)
+      LinuxAdmin::SubscriptionManager.register(registration_options)
 
       # Reload the registration_type
       LinuxAdmin::SubscriptionManager.registration_type(true)

--- a/app/models/registration_system.rb
+++ b/app/models/registration_system.rb
@@ -73,7 +73,7 @@ module RegistrationSystem
   end
 
   def self.verify_credentials(options = {})
-    LinuxAdmin::RegistrationSystem.validate_credentials(assemble_options(options))
+    LinuxAdmin::SubscriptionManager.validate_credentials(assemble_options(options))
   rescue NotImplementedError, LinuxAdmin::CredentialError
     false
   end


### PR DESCRIPTION
~~Depends on https://github.com/ManageIQ/linux_admin/pull/197 and a new release of linux_admin v1.2.0~~

LinuxAdmin::RegistrationSystem can't auto-detect the type when using SubscriptionManager with a proxy due to its need to use the proxy info to validate that it is registered.

Since RHN is no longer supported, we can use the SubscriptionManager class directly.

Also, pass the registration options (proxy info) to the registered? method since it is required when using a proxy.

Add linux_admin to the Gemfile since we use it directly.

https://bugzilla.redhat.com/show_bug.cgi?id=1518695