### PR TITLE
Fix missing operations for MW datasource.

### DIFF
--- a/app/models/middleware_datasource.rb
+++ b/app/models/middleware_datasource.rb
@@ -7,6 +7,8 @@ class MiddlewareDatasource < ApplicationRecord
   acts_as_miq_taggable
   serialize :properties
 
+  delegate :mutable?, :in_domain?, :to => :middleware_server
+
   def metrics_capture
     @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
   end


### PR DESCRIPTION
Add a delegation for `MiddewareDatasource` mutability to the `MiddewareServer` similarly as it is for `MiddlewareDeployment`. This allows to calculate visibility in [`MiddlewareStandaloneServerAction`](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/button/middleware_standalone_server_action.rb) helper  properly and show Operation buttons on MW datasource page.

Fixes: [BUG 1460296](https://bugzilla.redhat.com/show_bug.cgi?id=1460296)
Test coverage in related: https://github.com/ManageIQ/manageiq-ui-classic/pull/2972

Before:
![image](https://user-images.githubusercontent.com/7453394/33687732-524b03bc-dad9-11e7-83bb-c2578be00dcf.png)

After:
![image](https://user-images.githubusercontent.com/7453394/33687658-15d95a78-dad9-11e7-83fb-d5966aec9150.png)