### PR TITLE
[FINE] Limit number of '::' when parsing model

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,6 +1,6 @@
 class MiqExpression::Tag < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:alnum:]]*(::)?)+)
+(?<model_name>([[:alnum:]]*(::)?){4})
 \.(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)


### PR DESCRIPTION
Note, this bug doesn't exist on master or gaprindashvili, but does on both the fine and euwe branches.  This PR is for fine and can be cleanly cherry-picked to euwe.

https://bugzilla.redhat.com/show_bug.cgi?id=1519809

This will prevent an infinite loop inside regex when parsing strings
like "ManageIQ::Providers::CloudManager::Vm.miq_custom_attributes-name"

This is a manual partial backport of
b19567af31ebb90cd0745de438354db987c17e98 which was in PR:
https://github.com/ManageIQ/manageiq/pull/16211

Before this change, this will spin at 100% cpu in rails console:
`MiqExpression::Tag.parse("ManageIQ::Providers::CloudManager::Vm.miq_custom_attributes-name")`

After this change, it returns nil nearly immediately.