### PR TITLE
Move inventory_object_attrs to default collections

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default.rb
+++ b/app/models/manager_refresh/inventory_collection_default.rb
@@ -2,15 +2,43 @@ class ManagerRefresh::InventoryCollectionDefault
   class << self
     def vms(extra_attributes = {})
       attributes = {
-        :model_class            => ::Vm,
-        :association            => :vms,
-        :delete_method          => :disconnect_inv,
-        :attributes_blacklist   => [:genealogy_parent],
-        :use_ar_object          => true, # Because of raw_power_state setter and hooks are needed for settings user
+        :model_class                 => ::Vm,
+        :association                 => :vms,
+        :delete_method               => :disconnect_inv,
+        :attributes_blacklist        => [:genealogy_parent],
+        :use_ar_object               => true, # Because of raw_power_state setter and hooks are needed for settings user
         # TODO(lsmola) can't do batch strategy for vms because of key_pairs relation
-        :saver_strategy         => :default,
-        :batch_extra_attributes => [:power_state, :state_changed_on, :previous_state],
-        :builder_params         => {
+        :saver_strategy              => :default,
+        :batch_extra_attributes      => [:power_state, :state_changed_on, :previous_state],
+        :inventory_object_attributes => [
+          :type,
+          :cpu_limit,
+          :cpu_reserve,
+          :cpu_reserve_expand,
+          :cpu_shares,
+          :cpu_shares_level,
+          :ems_ref,
+          :ems_ref_obj,
+          :uid_ems,
+          :connection_state,
+          :vendor,
+          :name,
+          :location,
+          :template,
+          :memory_limit,
+          :memory_reserve,
+          :memory_reserve_expand,
+          :memory_shares,
+          :memory_shares_level,
+          :raw_power_state,
+          :boot_time,
+          :host,
+          :ems_cluster,
+          :storages,
+          :storage,
+          :snapshots
+        ],
+        :builder_params              => {
           :ems_id   => ->(persister) { persister.manager.id },
           :name     => "unknown",
           :location => "unknown",
@@ -22,14 +50,34 @@ class ManagerRefresh::InventoryCollectionDefault
 
     def miq_templates(extra_attributes = {})
       attributes = {
-        :model_class            => ::MiqTemplate,
-        :association            => :miq_templates,
-        :delete_method          => :disconnect_inv,
-        :attributes_blacklist   => [:genealogy_parent],
-        :use_ar_object          => true, # Because of raw_power_state setter
-        :saver_strategy         => :default, # Hooks are needed for setting user
-        :batch_extra_attributes => [:power_state, :state_changed_on, :previous_state],
-        :builder_params         => {
+        :model_class                 => ::MiqTemplate,
+        :association                 => :miq_templates,
+        :delete_method               => :disconnect_inv,
+        :attributes_blacklist        => [:genealogy_parent],
+        :use_ar_object               => true, # Because of raw_power_state setter
+        :saver_strategy              => :default, # Hooks are needed for setting user
+        :batch_extra_attributes      => [:power_state, :state_changed_on, :previous_state],
+        :inventory_object_attributes => [
+          :type,
+          :ems_ref,
+          :ems_ref_obj,
+          :uid_ems,
+          :connection_state,
+          :vendor,
+          :name,
+          :location,
+          :template,
+          :memory_limit,
+          :memory_reserve,
+          :raw_power_state,
+          :boot_time,
+          :host,
+          :ems_cluster,
+          :storages,
+          :storage,
+          :snapshots
+        ],
+        :builder_params              => {
           :ems_id   => ->(persister) { persister.manager.id },
           :name     => "unknown",
           :location => "unknown",
@@ -46,6 +94,22 @@ class ManagerRefresh::InventoryCollectionDefault
         :manager_ref                  => [:vm_or_template],
         :association                  => :hardwares,
         :parent_inventory_collections => [:vms, :miq_templates],
+        :inventory_object_attributes  => [
+          :annotation,
+          :cpu_cores_per_socket,
+          :cpu_sockets,
+          :cpu_speed,
+          :cpu_total_cores,
+          :cpu_type,
+          :guest_os,
+          :manufacturer,
+          :memory_mb,
+          :model,
+          :networks,
+          :number_of_nics,
+          :serial_number,
+          :virtual_hw_version
+        ],
         # TODO(lsmola) just because of default value on cpu_sockets, this can be fixed by separating instances_hardwares and images_hardwares
         :use_ar_object                => true,
       }
@@ -78,6 +142,13 @@ class ManagerRefresh::InventoryCollectionDefault
         :manager_ref                  => [:vm_or_template],
         :association                  => :operating_systems,
         :parent_inventory_collections => [:vms, :miq_templates],
+        :inventory_object_attributes  => [
+          :name,
+          :product_name,
+          :product_type,
+          :system_type,
+          :version
+        ],
       }
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
@@ -96,6 +167,20 @@ class ManagerRefresh::InventoryCollectionDefault
         :manager_ref                  => [:hardware, :device_name],
         :association                  => :disks,
         :parent_inventory_collections => [:vms],
+        :inventory_object_attributes  => [
+          :device_name,
+          :device_type,
+          :controller_type,
+          :present,
+          :filename,
+          :location,
+          :size,
+          :size_on_disk,
+          :disk_type,
+          :mode,
+          :bootable,
+          :storage
+        ],
       }
 
       if extra_attributes[:strategy] == :local_db_cache_all

--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -2,9 +2,16 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
   class << self
     def networks(extra_attributes = {})
       attributes = {
-          :model_class => ::Network,
-          :manager_ref => [:hardware, :ipaddress, :ipv6address],
-          :association => :networks,
+        :model_class                 => ::Network,
+        :manager_ref                 => [:hardware, :ipaddress, :ipv6address],
+        :association                 => :networks,
+        :inventory_object_attributes => [
+          :description,
+          :hostname,
+          :ipaddress,
+          :subnet_mask,
+          :ipv6address,
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -12,9 +19,15 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def host_networks(extra_attributes = {})
       attributes = {
-          :model_class => ::Network,
-          :manager_ref => [:hardware, :ipaddress],
-          :association => :host_networks,
+        :model_class                 => ::Network,
+        :manager_ref                 => [:hardware, :ipaddress],
+        :association                 => :host_networks,
+        :inventory_object_attributes => [
+          :description,
+          :hostname,
+          :ipaddress,
+          :subnet_mask
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -22,9 +35,21 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def guest_devices(extra_attributes = {})
       attributes = {
-        :model_class => ::GuestDevice,
-        :manager_ref => [:hardware, :uid_ems],
-        :association => :guest_devices,
+        :model_class                 => ::GuestDevice,
+        :manager_ref                 => [:hardware, :uid_ems],
+        :association                 => :guest_devices,
+        :inventory_object_attributes => [
+          :address,
+          :controller_type,
+          :device_name,
+          :device_type,
+          :lan,
+          :location,
+          :network,
+          :present,
+          :switch,
+          :uid_ems
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -35,6 +60,21 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class => ::Hardware,
         :manager_ref => [:host],
         :association => :host_hardwares,
+        :inventory_object_attributes => [
+          :annotation,
+          :cpu_cores_per_socket,
+          :cpu_sockets,
+          :cpu_speed,
+          :cpu_total_cores,
+          :cpu_type,
+          :guest_os,
+          :manufacturer,
+          :memory_mb,
+          :model,
+          :networks,
+          :number_of_nics,
+          :serial_number
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -42,9 +82,19 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def snapshots(extra_attributes = {})
       attributes = {
-        :model_class => ::Snapshot,
-        :manager_ref => [:uid],
-        :association => :snapshots,
+        :model_class                 => ::Snapshot,
+        :manager_ref                 => [:uid],
+        :association                 => :snapshots,
+        :inventory_object_attributes => [
+          :uid_ems,
+          :uid,
+          :parent_uid,
+          :name,
+          :description,
+          :create_time,
+          :current,
+          :vm_or_template
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -52,9 +102,16 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def operating_systems(extra_attributes = {})
       attributes = {
-        :model_class => ::OperatingSystem,
-        :manager_ref => [:vm_or_template],
-        :association => :operating_systems,
+        :model_class                 => ::OperatingSystem,
+        :manager_ref                 => [:vm_or_template],
+        :association                 => :operating_systems,
+        :inventory_object_attributes => [
+          :name,
+          :product_name,
+          :product_type,
+          :system_type,
+          :version
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -62,9 +119,16 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def host_operating_systems(extra_attributes = {})
       attributes = {
-        :model_class => ::OperatingSystem,
-        :manager_ref => [:host],
-        :association => :host_operating_systems,
+        :model_class                 => ::OperatingSystem,
+        :manager_ref                 => [:host],
+        :association                 => :host_operating_systems,
+        :inventory_object_attributes => [
+          :name,
+          :product_name,
+          :product_type,
+          :system_type,
+          :version
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -72,9 +136,15 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def custom_attributes(extra_attributes = {})
       attributes = {
-        :model_class => ::CustomAttribute,
-        :manager_ref => [:name],
-        :association => :custom_attributes,
+        :model_class                 => ::CustomAttribute,
+        :manager_ref                 => [:name],
+        :association                 => :custom_attributes,
+        :inventory_object_attributes => [
+          :section,
+          :name,
+          :value,
+          :source,
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -82,11 +152,38 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def ems_folders(extra_attributes = {})
       attributes = {
-        :model_class          => ::EmsFolder,
-        :association          => :ems_folders,
-        :manager_ref          => [:uid_ems],
-        :attributes_blacklist => [:ems_children],
-        :builder_params => {
+        :model_class                 => ::EmsFolder,
+        :association                 => :ems_folders,
+        :manager_ref                 => [:uid_ems],
+        :attributes_blacklist        => [:ems_children],
+        :inventory_object_attributes => [
+          :ems_ref,
+          :name,
+          :type,
+          :uid_ems,
+          :hidden
+        ],
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.id },
+        },
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def datacenters(extra_attributes = {})
+      attributes = {
+        :model_class                 => ::Datacenter,
+        :association                 => :datacenters,
+        :inventory_object_attributes => [
+          :name,
+          :type,
+          :uid_ems,
+          :ems_ref,
+          :ems_ref_obj,
+          :hidden
+        ],
+        :builder_params              => {
           :ems_id => ->(persister) { persister.manager.id },
         },
       }
@@ -96,11 +193,17 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def resource_pools(extra_attributes = {})
       attributes = {
-        :model_class          => ::ResourcePool,
-        :association          => :resource_pools,
-        :manager_ref          => [:uid_ems],
-        :attributes_blacklist => [:ems_children],
-        :builder_params       => {
+        :model_class                 => ::ResourcePool,
+        :association                 => :resource_pools,
+        :manager_ref                 => [:uid_ems],
+        :attributes_blacklist        => [:ems_children],
+        :inventory_object_attributes => [
+          :ems_ref,
+          :name,
+          :uid_ems,
+          :is_default,
+        ],
+        :builder_params              => {
           :ems_id => ->(persister) { persister.manager.id },
         },
       }
@@ -110,10 +213,17 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def ems_clusters(extra_attributes = {})
       attributes = {
-        :model_class          => ::EmsCluster,
-        :association          => :ems_clusters,
-        :attributes_blacklist => [:ems_children, :datacenter_id],
-        :builder_params       => {
+        :model_class                 => ::EmsCluster,
+        :association                 => :ems_clusters,
+        :attributes_blacklist        => [:ems_children, :datacenter_id],
+        :inventory_object_attributes => [
+          :ems_ref,
+          :ems_ref_obj,
+          :uid_ems,
+          :name,
+          :datacenter_id,
+        ],
+        :builder_params              => {
           :ems_id => ->(persister) { persister.manager.id },
         },
       }
@@ -123,11 +233,24 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def storages(extra_attributes = {})
       attributes = {
-        :model_class => ::Storage,
-        :manager_ref => [:location],
-        :association => :storages,
-        :complete    => false,
-        :arel        => Storage
+        :model_class                 => ::Storage,
+        :manager_ref                 => [:location],
+        :association                 => :storages,
+        :complete                    => false,
+        :arel                        => Storage,
+        :inventory_object_attributes => [
+          :ems_ref,
+          :ems_ref_obj,
+          :name,
+          :store_type,
+          :storage_domain_type,
+          :total_space,
+          :free_space,
+          :uncommitted,
+          :multiplehostaccess,
+          :location,
+          :master
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -135,9 +258,27 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def hosts(extra_attributes = {})
       attributes = {
-        :model_class    => ::Host,
-        :association    => :hosts,
-        :builder_params => {
+        :model_class                 => ::Host,
+        :association                 => :hosts,
+        :inventory_object_attributes => [
+          :type,
+          :ems_ref,
+          :ems_ref_obj,
+          :name,
+          :hostname,
+          :ipaddress,
+          :uid_ems,
+          :vmm_vendor,
+          :vmm_product,
+          :vmm_version,
+          :vmm_buildnumber,
+          :connection_state,
+          :power_state,
+          :ems_cluster,
+          :ipmi_address,
+          :maintenance
+        ],
+        :builder_params              => {
           :ems_id => ->(persister) { persister.manager.id },
         },
       }
@@ -147,9 +288,15 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def host_storages(extra_attributes = {})
       attributes = {
-        :model_class => ::HostStorage,
-        :manager_ref => [:host, :storage],
-        :association => :host_storages,
+        :model_class                 => ::HostStorage,
+        :manager_ref                 => [:host, :storage],
+        :association                 => :host_storages,
+        :inventory_object_attributes => [
+          :ems_ref,
+          :read_only,
+          :host,
+          :storage,
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -157,9 +304,13 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def host_switches(extra_attributes = {})
       attributes = {
-        :model_class => ::HostSwitch,
-        :manager_ref => [:host, :switch],
-        :association => :host_switches
+        :model_class                 => ::HostSwitch,
+        :manager_ref                 => [:host, :switch],
+        :association                 => :host_switches,
+        :inventory_object_attributes => [
+          :host,
+          :switch,
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -167,9 +318,14 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def switches(extra_attributes = {})
       attributes = {
-        :model_class => ::Switch,
-        :manager_ref => [:uid_ems],
-        :association => :switches,
+        :model_class                 => ::Switch,
+        :manager_ref                 => [:uid_ems],
+        :association                 => :switches,
+        :inventory_object_attributes => [
+          :uid_ems,
+          :name,
+          :lans
+        ],
       }
 
       attributes.merge!(extra_attributes)
@@ -177,9 +333,14 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
 
     def lans(extra_attributes = {})
       attributes = {
-        :model_class => ::Lan,
-        :manager_ref => [:uid_ems],
-        :association => :lans,
+        :model_class                 => ::Lan,
+        :manager_ref                 => [:uid_ems],
+        :association                 => :lans,
+        :inventory_object_attributes => [
+          :name,
+          :uid_ems,
+          :tag
+        ],
       }
 
       attributes.merge!(extra_attributes)


### PR DESCRIPTION
In order to use find_or_build().assign_attributes the attributes must be
defined on the inventory_collection.  These are defined in ovirt but are
common for all InfraManagers.  These should be moved up to the default
inventory_collections.

Related: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/172