### PR TITLE
Bumping the ovirt_metrics gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ end
 
 group :ovirt, :manageiq_default do
   manageiq_plugin "manageiq-providers-ovirt"
-  gem "ovirt_metrics",                  "~>1.4.1",       :require => false
+  gem "ovirt_metrics",                  "~>2.0.0",       :require => false
 end
 
 group :scvmm, :manageiq_default do


### PR DESCRIPTION
Several bug fixes are included in the new release, including:
https://bugzilla.redhat.com/show_bug.cgi?id=1495133
https://bugzilla.redhat.com/show_bug.cgi?id=1487735