### PR TITLE
Give option to opt out of verbose connection info

### DIFF
--- a/lib/extensions/ar_adapter/ar_checkin_checkout_callbacks.rb
+++ b/lib/extensions/ar_adapter/ar_checkin_checkout_callbacks.rb
@@ -1,6 +1,8 @@
 ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-  set_callback(:checkout, :after, :log_after_checkout)
-  set_callback(:checkin,  :after, :log_after_checkin)
+  unless ENV["VERBOSE_CONNECTIONS"] == "false"
+    set_callback(:checkout, :after, :log_after_checkout)
+    set_callback(:checkin,  :after, :log_after_checkin)
+  end
 
   def connection_info_for_logging
     pool             = ActiveRecord::Base.connection_pool


### PR DESCRIPTION
The connection pool displays lines every time a connection is established to the database.
This can be quite verbose. Especially when saving script output to files.

This defaults to printing this information but gives the developer the option of hiding it.

Alternative:
We could take a lot of these values and emit an `ActiveSupport::Notification`. This would allow developers to 

Alternative 2:
This could just be a local monkey patch for those developers who want this.

@jrafanie Do we still need this?