### PR TITLE
disconnect flag not respected in link_ems_inventory

### DIFF
--- a/app/models/ems_refresh/link_inventory.rb
+++ b/app/models/ems_refresh/link_inventory.rb
@@ -15,9 +15,9 @@ module EmsRefresh::LinkInventory
     _log.info("#{log_header} Updating EMS root folder relationship.")
     root_id = new_relats[:ext_management_systems_to_folders][ems.id][0]
     if root_id.nil?
-      ems.remove_all_children
+      ems.remove_all_children if disconnect
     else
-      ems.replace_children(instance_with_id(EmsFolder, root_id))
+      ems.replace_children(instance_with_id(EmsFolder, root_id)) if disconnect
     end
 
     # Do the Folders to *, and Clusters to * relationships


### PR DESCRIPTION
When new vm is created we use `save_ems_inventory_no_disconnect` where
we set disconnect flag to `false`. It was not respected for all
operations.

Bug-Url:
https://bugzilla.redhat.com/1518739