### PR TITLE
Changing the key of network device to be both ipv4 + ipv6

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -291,7 +291,7 @@ module EmsRefresh::SaveInventory
       saved_hashes, new_hashes = hashes.partition { |h| h[:id] }
       saved_hashes.each { |h| deletes.delete_if { |d| d.id == h[:id] } } unless deletes.empty? || saved_hashes.empty?
 
-      save_inventory_multi(hardware.networks, new_hashes, deletes, [:ipaddress], nil, :guest_device)
+      save_inventory_multi(hardware.networks, new_hashes, deletes, [:ipaddress, :ipv6address], nil, :guest_device)
     when :scan
       save_inventory_multi(hardware.networks, hashes, :use_association, [:description, :guid])
     end

--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -3,7 +3,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
     def networks(extra_attributes = {})
       attributes = {
           :model_class => ::Network,
-          :manager_ref => [:hardware, :ipaddress],
+          :manager_ref => [:hardware, :ipaddress, :ipv6address],
           :association => :networks,
       }
 


### PR DESCRIPTION
A network device may not have ipv4 addresses at all, using ipv4 as the sole
key is not enough.