### PR TITLE
Use the server IP for the AWX database host when the rails config is no good

### DIFF
--- a/lib/embedded_ansible/docker_embedded_ansible.rb
+++ b/lib/embedded_ansible/docker_embedded_ansible.rb
@@ -162,16 +162,13 @@ class DockerEmbeddedAnsible < EmbeddedAnsible
     database_auth = find_or_create_database_authentication
     rabbitmq_auth = find_or_create_rabbitmq_authentication
 
-    db_host = database_configuration["host"] || docker_bridge_gateway
-    db_host = docker_bridge_gateway if db_host == "localhost"
-
     [
       "SECRET_KEY=#{find_or_create_secret_key}",
       "DATABASE_NAME=awx",
       "DATABASE_USER=#{database_auth.userid}",
       "DATABASE_PASSWORD=#{database_auth.password}",
       "DATABASE_PORT=#{database_configuration["port"] || 5432}",
-      "DATABASE_HOST=#{db_host}",
+      "DATABASE_HOST=#{database_host}",
       "RABBITMQ_USER=#{rabbitmq_auth.userid}",
       "RABBITMQ_PASSWORD=#{rabbitmq_auth.password}",
       "RABBITMQ_HOST=#{rabbitmq_container_name}",
@@ -182,6 +179,13 @@ class DockerEmbeddedAnsible < EmbeddedAnsible
       "AWX_ADMIN_USER=#{admin_auth.userid}",
       "AWX_ADMIN_PASSWORD=#{admin_auth.password}"
     ]
+  end
+
+  def database_host
+    db_host = database_configuration["host"]
+    return db_host if db_host.presence && db_host != "localhost"
+
+    MiqServer.my_server.ipaddress || docker_bridge_gateway
   end
 
   def docker_bridge_gateway


### PR DESCRIPTION
Previously we would check the database configuration (database.yml)
then if that host wasn't set or was localhost we would try to use the
docker host gateway.

But we have a better option. We can use the server's ip instead.
This leaves the docker gateway as the last option as that will probably
still be needed for development environments.

Before this change AWX was failing on appliances if the appliance was running the database locally.