### PR TITLE
[FINE] Fix Containers-Containers URL in Start At pages

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -236,7 +236,7 @@
   :startup: true
 - :name: containers
   :description: Compute / Containers / Containers
-  :url: /container/explorer
+  :url: /container/show_list
   :rbac_feature_name: containers
   :startup: true
 - :name: container_nodes


### PR DESCRIPTION
NOTE: Requires **MiqShortcut.seed** to enable changes.

https://bugzilla.redhat.com/show_bug.cgi?id=1523788

Previously reported in: https://bugzilla.redhat.com/show_bug.cgi?id=1466350
