### PR TITLE
Fix error in timeout checking for job without target

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -148,7 +148,7 @@ class Job < ApplicationRecord
   end
 
   def target_entity
-    target_class.constantize.find_by(:id => target_id)
+    target_class.constantize.find_by(:id => target_id) if target_class
   end
 
   def self.check_jobs_for_timeout

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -271,6 +271,11 @@ describe Job do
           expect(@job.timeout_adjustment).to eq(1)
           expect(@image_scan_job.timeout_adjustment).to eq(1)
         end
+
+        it "returns the correct adjusment 1 if target class was not defined" do
+          job_without_target = Job.create_job("VmScan", :target_class => nil)
+          expect(job_without_target.timeout_adjustment).to eq(1)
+        end
       end
     end
 


### PR DESCRIPTION
**Issue**:
Original design for `Job` model assumed that `target_class` attribute always initialized.

If job created without initialization of `target_class` (running Ansible Playbook methods, or creating some other job which does not require target) than this error thrown  when checking if job timed-out:
 `[----] E, [2017-12-07T10:42:36.205262 #36948:d39140] ERROR -- : MIQ(Job.check_jobs_for_timeout) undefined method `constantize' for nil:NilClass` 
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1523320

**Solution**:
create instance of target (to retrieve target specific timeout adjustment) only if `target_class` is not `nil`

@miq-bot add-label bug, core,  gaprindashvili/yes

\cc @mkanoor
