### PR TITLE
Removed deprecation warnings

### DIFF
--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -170,7 +170,7 @@ describe MiqAction do
 
         expect(VmOrTemplate).to receive(:retire) do |vms, options|
           expect(vms).to eq([@vm])
-          expect(options[:date]).to be_same_time_as date
+          expect(options[:date]).to be_within(0.1).of(date)
         end
         @action.action_vm_retire(@action, @vm, input)
       end

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -24,7 +24,7 @@ describe MiqUserRole do
 
       expect(MiqUserRole.count).to eq(@expected_user_role_count + 1)
       expect(changed.reload.read_only).to    be_truthy
-      expect(unchanged.reload.updated_at).to be_same_time_as unchanged_orig_updated_at
+      expect(unchanged.reload.updated_at).to be_within(0.1).of(unchanged_orig_updated_at)
     end
 
     it "fills up EvmRole-consumption_administrator role with 3 product features" do


### PR DESCRIPTION
```
WARNING: The `be_same_time_as` matcher is deprecated
and will be removed shortly. Use the `be_within` matcher instead:
`be_same_time_as(expected_time).precision(1) == be_within(0.1).of(expected_time)`
```

@chrisarcand Did I put in the right precision for these?