### PR TITLE
Rename pretty model name for VmCloud from 'Instance to 'Cloud Instance'

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -925,7 +925,7 @@ en:
       User:                     EVM User
       VimPerformanceTrend:      Performance Trend
       Vm:                       VM and Instance
-      VmCloud:                  Instance
+      VmCloud:                  Cloud Instance
       VmdbIndex:                Index
       VmdbTable:                VMDB Table
       VmOrTemplate:             VM or Template


### PR DESCRIPTION
Rename pretty model name for `VmCloud` from `'Instance'` to `'Cloud Instance'`

In order to remove the duplication with -
`ManageIQ::Providers::CloudManager::Vm` which also calls it `'Instance'`

This change would fix the broken spec in ManageIQ/manageiq-ui-classic -- 
https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/313646359