### PR TITLE
[FINE] Drop the test for missing factories as it has been backported

### DIFF
--- a/spec/models/factory_girl_spec.rb
+++ b/spec/models/factory_girl_spec.rb
@@ -1,7 +1,0 @@
-describe 'FactoryGirl' do
-  let(:local_models) { Dir.glob('app/models/*.rb').map { |file| File.basename(file, '.rb').to_sym } }
-
-  it 'All models have a factory defined' do
-    expect(FactoryGirl.factories.map { |x| x.name.to_sym } & local_models).to match_array(local_models)
-  end
-end


### PR DESCRIPTION
We backported a spec for [testing missing factories](https://github.com/ManageIQ/manageiq/pull/16404#issuecomment-350344057), however, we have a lot of missing factories in fine. Instead of creating the factories we don't use, I'm rather taking a shortcut and dropping the related spec.

@miq-bot assign @simaishi 