### PR TITLE
Missing required fields should result in 400 Bad Request

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -760,7 +760,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     if p.validate(values) == false
       errors = []
       p.fields { |_fn, f, _dn, _d| errors << f[:error] unless f[:error].nil? }
-      raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
+      raise Api::BadRequestError, _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
     end
 
     p.make_request(nil, values, nil, auto_approve)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1449,7 +1449,7 @@ class MiqRequestWorkflow
     fields { |_fn, f, _dn, _d| errors << f[:error] unless f[:error].nil? }
     err_text = "Provision failed for the following reasons:\n#{errors.join("\n")}"
     _log.error("<#{err_text}>")
-    raise _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
+    raise Api::BadRequestError, _("Provision failed for the following reasons:\n%{errors}") % {:errors => errors.join("\n")}
   end
 
   private


### PR DESCRIPTION
When a provisioning API request fails due to a field validation error the result code is currently 500 Internal Server Error. According to RFC 2616 a client error should result in 400 Bad Request. 

This patch returns result status 400 Bad Request when a field validation error occurs during provisioning. 