### PR TITLE
ensure monitoring manager deletion and creation on endpoint update

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -13,12 +13,10 @@ class Endpoint < ApplicationRecord
   after_destroy :endpoint_destroyed
 
   def endpoint_created
-    # Make sure monitoring manager is created for the prometheus endpoint
     resource.endpoint_created(role) if resource.respond_to?(:endpoint_created)
   end
 
   def endpoint_destroyed
-    # Make sure monitoring manager is delete for the prometheus endpoint
     resource.endpoint_destroyed(role) if resource.respond_to?(:endpoint_destroyed)
   end
 

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -9,6 +9,19 @@ class Endpoint < ApplicationRecord
   validates :url, :uniqueness => true, :if => :url
   validate :validate_certificate_authority
 
+  after_create  :endpoint_created
+  after_destroy :endpoint_destroyed
+
+  def endpoint_created
+    # Make sure monitoring manager is created for the prometheus endpoint
+    resource.endpoint_created(role) if resource.respond_to?(:endpoint_created)
+  end
+
+  def endpoint_destroyed
+    # Make sure monitoring manager is delete for the prometheus endpoint
+    resource.endpoint_destroyed(role) if resource.respond_to?(:endpoint_destroyed)
+  end
+
   def verify_ssl=(val)
     val = resolve_verify_ssl_value(val)
     super

--- a/app/models/mixins/has_monitoring_manager_mixin.rb
+++ b/app/models/mixins/has_monitoring_manager_mixin.rb
@@ -1,18 +1,28 @@
 module HasMonitoringManagerMixin
   extend ActiveSupport::Concern
 
-  private
+  def ensure_monitoring_manager_with_params
+    if monitoring_manager.nil?
+      build_monitoring_manager(:parent_manager  => self,
+                               :name            => "#{name} Monitoring Manager",
+                               :zone_id         => zone_id,
+                               :provider_region => provider_region)
+    end
 
-  def ensure_monitoring_manager
-    # monitoring_manager should be defined by child classes.
-    if monitoring_manager_needed? && monitoring_manager.nil?
-      build_monitoring_manager(:parent_manager => self)
-      monitoring_manager.name = "#{name} Monitoring Manager"
-      monitoring_manager.zone_id = zone_id
-      monitoring_manager.provider_region = provider_region
-    elsif !monitoring_manager_needed? && monitoring_manager.present?
+    monitoring_manager
+  end
+
+  def endpoint_created(role)
+    if role == "prometheus_alerts" && monitoring_manager.nil?
+      monitoring_manager = ensure_monitoring_manager_with_params
+      monitoring_manager.save
+    end
+  end
+
+  def endpoint_destroyed(role)
+    if role == "prometheus_alerts" && monitoring_manager.present?
       # TODO: if someone deletes the alerts endpoint and then quickly readds it they can end up without a manager.
-      monitoring_manager.delete_queue
+      monitoring_manager.destroy_queue
     end
   end
 end

--- a/app/models/mixins/has_monitoring_manager_mixin.rb
+++ b/app/models/mixins/has_monitoring_manager_mixin.rb
@@ -1,20 +1,9 @@
 module HasMonitoringManagerMixin
   extend ActiveSupport::Concern
 
-  def ensure_monitoring_manager_with_params
-    if monitoring_manager.nil?
-      build_monitoring_manager(:parent_manager  => self,
-                               :name            => "#{name} Monitoring Manager",
-                               :zone_id         => zone_id,
-                               :provider_region => provider_region)
-    end
-
-    monitoring_manager
-  end
-
   def endpoint_created(role)
     if role == "prometheus_alerts" && monitoring_manager.nil?
-      monitoring_manager = ensure_monitoring_manager_with_params
+      monitoring_manager = ensure_monitoring_manager
       monitoring_manager.save
     end
   end
@@ -24,5 +13,18 @@ module HasMonitoringManagerMixin
       # TODO: if someone deletes the alerts endpoint and then quickly readds it they can end up without a manager.
       monitoring_manager.destroy_queue
     end
+  end
+
+  private
+
+  def ensure_monitoring_manager
+    if monitoring_manager.nil?
+      build_monitoring_manager(:parent_manager  => self,
+                               :name            => "#{name} Monitoring Manager",
+                               :zone_id         => zone_id,
+                               :provider_region => provider_region)
+    end
+
+    monitoring_manager
   end
 end

--- a/app/models/mixins/has_monitoring_manager_mixin.rb
+++ b/app/models/mixins/has_monitoring_manager_mixin.rb
@@ -5,17 +5,14 @@ module HasMonitoringManagerMixin
 
   def ensure_monitoring_manager
     # monitoring_manager should be defined by child classes.
-    if try(:monitoring_manager_needed?)
+    if monitoring_manager_needed? && monitoring_manager.nil?
       build_monitoring_manager(:parent_manager => self)
       monitoring_manager.name = "#{name} Monitoring Manager"
-    end
-    ensure_monitoring_manager_properties
-  end
-
-  def ensure_monitoring_manager_properties
-    if monitoring_manager
       monitoring_manager.zone_id = zone_id
       monitoring_manager.provider_region = provider_region
+    elsif !monitoring_manager_needed? && monitoring_manager.present?
+      # TODO: if someone deletes the alerts endpoint and then quickly readds it they can end up without a manager.
+      monitoring_manager.delete_queue
     end
   end
 end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1528955

Updating the monitoring endpoint on an existing provider did not create or delete the monitoring manager accordingly. 

Completed by https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/188

@moolitayer @cben @nimrodshn @yaacov  Please review

@miq-bot add_label providers/containers 