### PR TITLE
Add raw_connect? method to ExtManagementSystem

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -217,6 +217,10 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
+  def self.raw_connect?(*params)
+    !!raw_connect(*params)
+  end
+
   def self.model_name_from_emstype(emstype)
     model_from_emstype(emstype).try(:name)
   end

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -22,7 +22,7 @@ module AuthenticationMixin
       queue_opts = {
         :args        => [*args],
         :class_name  => self,
-        :method_name => "raw_connect",
+        :method_name => "raw_connect?",
         :queue_name  => "generic",
         :role        => "ems_operations",
         :zone        => zone

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -434,4 +434,13 @@ describe ExtManagementSystem do
       expect(ems.supports_cloud_object_store_container_create).to eq(true)
     end
   end
+
+  describe ".raw_connect?" do
+    it "returns true if validation was successful" do
+      connection = double
+      allow(ManageIQ::Providers::Amazon::CloudManager).to receive(:raw_connect).and_return(connection)
+
+      expect(ManageIQ::Providers::Amazon::CloudManager.raw_connect?).to eq(true)
+    end
+  end
 end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -264,7 +264,7 @@ describe AuthenticationMixin do
         {
           :args        => [*args],
           :class_name  => ExtManagementSystem,
-          :method_name => "raw_connect",
+          :method_name => "raw_connect?",
           :queue_name  => "generic",
           :role        => "ems_operations",
           :zone        => 'zone'


### PR DESCRIPTION
When validating credentials on the queue, existing raw_connect methods return the actual connection, which is then being placed into the logs on callback. It should not be present in the logs. The credential validation only cares about a success or failure, not the connection, so this raw_connect? wrapper method will return a true value on successful validation, rather than the connection itself.

Log Before where you will see `#<Aws::EC2::Resource>` in the result:
```
[----] I, [2017-12-11T10:46:29.647721 #56400:3ff011c666f0]  INFO -- : MIQ(MiqTask.generic_action_with_callback) Task: [10000000125494] Queued the action: [Validate EMS Provider Credentials] being run for user: [admin]
[----] I, [2017-12-11T10:46:29.681968 #56450:3fcc1203f9d0]  INFO -- : MIQ(MiqQueue#deliver) Message id: [10000066183441], Delivering...
[----] I, [2017-12-11T10:46:31.450052 #56450:3fcc1203f9d0]  INFO -- : MIQ(MiqQueue#delivered) Message id: [10000066183441], State: [ok], Delivered in [1.768087] seconds
[----] I, [2017-12-11T10:46:31.453199 #56450:3fcc1203f9d0]  INFO -- : MIQ(MiqQueue#m_callback) Message id: [10000066183441], Invoking Callback with args: ["Finished", "ok", "Message delivered successfully", "#<Aws::EC2::Resource>"]
[----] I, [2017-12-11T10:46:32.972244 #56450:3fcc1203f9d0]  INFO -- : MIQ(MiqTask#update_status) Task: [10000000125494] [Finished] [Ok] [Task completed successfully]
```

Log after where you will only see true:
```
[----] I, [2017-12-11T12:09:19.744378 #61224:3fce65664554]  INFO -- : MIQ(MiqTask.generic_action_with_callback) Task: [10000000125503] Queued the action: [Validate EMS Provider Credentials] being run for user: [admin]
[----] I, [2017-12-11T12:09:23.710034 #61242:3ff0c203f9d8]  INFO -- : MIQ(MiqQueue#deliver) Message id: [10000066183450], Delivering...
[----] I, [2017-12-11T12:09:26.380073 #61242:3ff0c203f9d8]  INFO -- : MIQ(MiqQueue#delivered) Message id: [10000066183450], State: [ok], Delivered in [2.670068] seconds
[----] I, [2017-12-11T12:09:26.407804 #61242:3ff0c203f9d8]  INFO -- : MIQ(MiqQueue#m_callback) Message id: [10000066183450], Invoking Callback with args: ["Finished", "ok", "Message delivered successfully", "true"]
[----] I, [2017-12-11T12:09:26.478115 #61242:3ff0c203f9d8]  INFO -- : MIQ(MiqTask#update_status) Task: [10000000125503] [Finished] [Ok] [Task completed successfully]
```

Resolves https://github.com/ManageIQ/manageiq-providers-openstack/issues/174 

@miq-bot add_label gaprindashvili/yes, bug 
@miq-bot assign @Fryguy 
cc: @aufi @Ladas @dikonoor

