### PR TITLE
Consider cloud volumes as data storages in chargeback

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -28,6 +28,12 @@ class ChargebackRate < ApplicationRecord
   scope :with_rate_type, ->(rate_type) { where(:rate_type => rate_type) }
 
   VALID_CB_RATE_TYPES = ["Compute", "Storage"]
+  DATASTORE_MAPPING   = {'CloudVolume' => 'Storage'}.freeze
+
+  def self.tag_class(klass)
+    klass = ChargebackRate::DATASTORE_MAPPING[klass] || klass
+    super(klass)
+  end
 
   def rate_details_relevant_to(report_cols)
     # we can memoize, as we get the same report_cols thrrough the life of the object

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -32,10 +32,10 @@ module Metric::ChargebackHelper
   def resource_parents
     [parent_host || resource.try(:host),
      parent_ems_cluster || resource.try(:ems_cluster),
-     parent_storage || resource.try(:storage),
+     parent_storage || resource.try(:storage) || resource.try(:cloud_volumes),
      parent_ems || resource.try(:ext_management_system),
      resource.try(:tenant)
-    ].compact
+    ].flatten.compact
   end
 
   def parents_determining_rate

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -34,8 +34,7 @@ module Metric::ChargebackHelper
      parent_ems_cluster || resource.try(:ems_cluster),
      parent_storage || resource.try(:storage) || resource.try(:cloud_volumes),
      parent_ems || resource.try(:ext_management_system),
-     resource.try(:tenant)
-    ].flatten.compact
+     resource.try(:tenant)].flatten.compact
   end
 
   def parents_determining_rate

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -200,8 +200,7 @@ module AssignmentMixin
       tlist = Tagging.where("tags.name like '/managed/%'")
                      .where(:taggable => parents)
                      .references(:tag).includes(:tag).map do |t|
-        lower_klass = tag_class(t.taggable_type)
-        "#{lower_klass}/tag#{t.tag.name}"
+        "#{tag_class(t.taggable_type)}/tag#{t.tag.name}"
       end
       tagged_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
       (individually_assigned_resources + tagged_resources).uniq

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -173,6 +173,10 @@ module AssignmentMixin
         end
     end
 
+    def tag_class(klass)
+      klass == "VmOrTemplate" ? "vm" : klass.underscore
+    end
+
     # @param target
     # @option options :parents
     # @option options :tag_list
@@ -196,8 +200,7 @@ module AssignmentMixin
       tlist = Tagging.where("tags.name like '/managed/%'")
                      .where(:taggable => parents)
                      .references(:tag).includes(:tag).map do |t|
-        klass = t.taggable_type
-        lower_klass = klass == "VmOrTemplate" ? "vm" : klass.underscore
+        lower_klass = tag_class(t.taggable_type)
         "#{lower_klass}/tag#{t.tag.name}"
       end
       tagged_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq


### PR DESCRIPTION
We can assign rate according to the tag of data storages of Vm:
<img width="1429" alt="screen shot 2017-12-12 at 09 00 33" src="https://user-images.githubusercontent.com/14937244/33873436-3e60640a-df1b-11e7-9366-5550575e3b4c.png">

What is data storages ?
----------------------
for Infra: Vm#storage
for Cloud Vm#cloud_volumes

Variant 'for Cloud Vm#cloud_volumes' was missing and this PR is adding it.

Alternative
-----------
We can also add to the assignments option 'Tagged Cloud Volumes' but I think that this is beneficial, user can generate report for cloud and infra in one report. 

Next?
-----
Update in same way option   'Selected Datastores'  and here cloud volumes as well.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1510898


@miq-bot add_label gaprindashvili/yes, chargeback, bug

@miq-bot assign @gtanzillo 

