### PR TITLE
Change the type name for the catalog Item from 'Container Template' to 'Openshift Template'

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -17,7 +17,7 @@ class ServiceTemplate < ApplicationRecord
     "generic_orchestration"      => _("Orchestration"),
     "generic_ansible_playbook"   => _("Ansible Playbook"),
     "generic_ansible_tower"      => _("AnsibleTower"),
-    "generic_container_template" => _("Container Template"),
+    "generic_container_template" => _("OpenShift Template"),
     "google"                     => _("Google"),
     "microsoft"                  => _("SCVMM"),
     "openstack"                  => _("OpenStack"),


### PR DESCRIPTION
Change the type name for the catalog Item from 'Container Template' to 'Openshift Template'

Links 
--------
https://bugzilla.redhat.com/show_bug.cgi?id=1518987


![screenshot from 2017-12-11 15-28-17](https://user-images.githubusercontent.com/12769982/33852293-f23353fa-de87-11e7-939f-3e965921c999.png)

