### PR TITLE
Introduce $vcloud_log that logs into log/vcloud.log

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -20,6 +20,7 @@ GlobalVars:
   - $scvmm_log
   - $vim_log
   - $websocket_log
+  - $vcloud_log
   # In Automate methods
   - $evm
 #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -882,6 +882,7 @@
   :level_scvmm: info
   :level_vim: warn
   :level_websocket: info
+  :level_vcloud: info
 :ntp:
   :server:
   - 0.pool.ntp.org

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -33,6 +33,7 @@ module Vmdb
       apply_config_value(config, $azure_log,         :level_azure)
       apply_config_value(config, $lenovo_log,        :level_lenovo)
       apply_config_value(config, $websocket_log,     :level_websocket)
+      apply_config_value(config, $vcloud_log,        :level_vcloud)
     end
 
     def self.create_loggers
@@ -57,6 +58,7 @@ module Vmdb
       $api_log           = create_multicast_logger(path_dir.join("api.log"))
       $websocket_log     = create_multicast_logger(path_dir.join("websocket.log"))
       $miq_ae_logger     = create_multicast_logger(path_dir.join("automation.log"))
+      $vcloud_log        = create_multicast_logger(path_dir.join("vcloud.log"))
 
       configure_external_loggers
     end


### PR DESCRIPTION
With this commit we introduce yet another global logger that is to be used by VMware provider. We're having quite some logs there and it's better to log them into its own file.

@miq-bot add_label enhancement
@miq-bot assign @Fryguy 

Related issue: https://github.com/ManageIQ/manageiq/issues/16642
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1525201

/cc @blomquisg @gberginc