### PR TITLE
Simplify MIQ::WM::Monitor#do_system_limit_exceeded

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -114,7 +114,7 @@ module MiqServer::WorkerManagement::Monitor
       workers = class_name.constantize.find_current.to_a
       next if workers.empty?
 
-      w = workers.sort_by { |w| [w.memory_usage || -1, w.id] }.last
+      w = workers.max_by { |w| [w.memory_usage || -1, w.id] }
 
       msg = "#{w.format_full_log_msg} is being stopped because system resources exceeded threshold, it will be restarted once memory has freed up"
       _log.warn(msg)


### PR DESCRIPTION
Not only the new version is a little bit readable, but it also uses less memory and generally more performant.

Unscientific benchmarks:

```
 a = (1..1000).to_a.shuffle; Benchmark.ips { |x| x.report('sort_by') { a.sort_by(&:itself).last }; x.report('max_by') { a.max_by(&:itself) }; x.compare! }
Warming up --------------------------------------
             sort_by   196.000  i/100ms
              max_by     1.025k i/100ms
Calculating -------------------------------------
             sort_by      1.935k (± 7.1%) i/s -      9.800k in   5.092358s
              max_by     10.168k (± 6.4%) i/s -     51.250k in   5.065552s

Comparison:
              max_by:    10167.7 i/s
             sort_by:     1934.9 i/s - 5.25x  slower
```

```
a = [1]; Benchmark.ips { |x| x.report('sort_by') { a.sort_by(&:itself).last }; x.report('max_by') { a.max_by(&:itself) }; x.compare! }
Warming up --------------------------------------
             sort_by    96.193k i/100ms
              max_by   162.485k i/100ms
Calculating -------------------------------------
             sort_by      1.377M (± 7.2%) i/s -      6.926M in   5.056906s
              max_by      2.952M (± 6.8%) i/s -     14.786M in   5.031407s

Comparison:
              max_by:  2952215.6 i/s
             sort_by:  1376623.6 i/s - 2.14x  slower
```
