### PR TITLE
move embedded manager factory object out of shared_example

### DIFF
--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -1,3 +1,10 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource do
+  let(:manager) do
+    FactoryGirl.create(:provider_embedded_ansible, :with_authentication, :default_organization => 1).managers.first
+  end
+  before do
+    EvmSpecHelper.assign_embedded_ansible_role
+  end
+
   it_behaves_like 'ansible configuration_script_source'
 end


### PR DESCRIPTION
This depends on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/43 and is needed to fix the build failure.