### PR TITLE
Dialog validations

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -4,8 +4,8 @@ class Dialog < ApplicationRecord
   # The following gets around a glob symbolic link issue
   YAML_FILES_PATTERN = "{,*/**/}*.{yaml,yml}".freeze
 
-  has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy
   validate :validate_children
+  has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy, :autosave => true
 
   include DialogMixin
   has_many :resource_actions

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -13,6 +13,7 @@ class Dialog < ApplicationRecord
 
   before_destroy :reject_if_has_resource_actions
   validates      :name, :unique_within_region => true
+  validates      :dialog_tabs, :presence => {:message => ->(object, _) { "missing for Dialog #{object.name}" }}
 
   alias_attribute  :name, :label
 
@@ -55,12 +56,6 @@ class Dialog < ApplicationRecord
   end
 
   def validate_children
-    # To remove the meaningless error message like "Dialog tabs is invalid" when child's validation fails
-    errors[:dialog_tabs].delete("is invalid")
-    if dialog_tabs.blank?
-      errors.add(:base, _("Dialog %{dialog_label} must have at least one Tab") % {:dialog_label => label})
-    end
-
     duplicate_field_names = dialog_fields.collect(&:name).duplicates
     if duplicate_field_names.present?
       errors.add(:base, _("Dialog field name cannot be duplicated on a dialog: %{duplicates}") % {:duplicates => duplicate_field_names.join(', ')})

--- a/app/models/dialog/ansible_playbook_service_dialog.rb
+++ b/app/models/dialog/ansible_playbook_service_dialog.rb
@@ -8,7 +8,7 @@ class Dialog
     # The job_template contains the playbook
     def create_dialog(label, extra_vars, hosts = 'localhost')
       Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
-        tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
+        tab = dialog.dialog_tabs.build(:dialog => dialog, :display => "edit", :label => "Basic Information", :position => 0)
         add_options_group(tab, 0, hosts)
         unless extra_vars.blank?
           add_variables_group(tab, 1, extra_vars)

--- a/app/models/dialog/container_template_service_dialog.rb
+++ b/app/models/dialog/container_template_service_dialog.rb
@@ -7,7 +7,7 @@ class Dialog
     # This dialog is to be used by a container template service
     def create_dialog(name, parameters)
       Dialog.new(:name => name, :buttons => "submit,cancel").tap do |dialog|
-        tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
+        tab = dialog.dialog_tabs.build(:dialog => dialog, :display => "edit", :label => "Basic Information", :position => 0)
         add_options_group(tab, 0)
         add_parameters_group(tab, 1, parameters)
         dialog.save!

--- a/app/models/dialog/orchestration_template_service_dialog.rb
+++ b/app/models/dialog/orchestration_template_service_dialog.rb
@@ -6,7 +6,7 @@ class Dialog
 
     def create_dialog(name, template)
       Dialog.new(:name => name, :buttons => "submit,cancel").tap do |dialog|
-        tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
+        tab = dialog.dialog_tabs.build(:dialog => dialog, :display => "edit", :label => "Basic Information", :position => 0)
         add_stack_group(template.deployment_options, tab, 0)
 
         template.parameter_groups.each_with_index do |parameter_group, index|

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -3,6 +3,7 @@ class DialogTab < ApplicationRecord
   has_many   :dialog_groups, -> { order(:position) }, :dependent => :destroy
   belongs_to :dialog
   validate :validate_children
+  validates :dialog, :presence => true
 
   alias_attribute :order, :position
 

--- a/spec/factories/dialog.rb
+++ b/spec/factories/dialog.rb
@@ -14,10 +14,4 @@ FactoryGirl.define do
       instance.save!
     end
   end
-
-  factory :dialog_with_tab_and_group_and_field, :parent => :dialog do
-    after(:create) do |dialog|
-      create(:dialog_tab_with_group_and_field, :dialog => dialog)
-    end
-  end
 end

--- a/spec/factories/dialog_group.rb
+++ b/spec/factories/dialog_group.rb
@@ -14,10 +14,4 @@ FactoryGirl.define do
       instance.save!
     end
   end
-
-  factory :dialog_group_with_field, :parent => :dialog_group do
-    after(:create) do |dialog_group|
-      create(:dialog_field_text_box, :dialog_group => dialog_group)
-    end
-  end
 end

--- a/spec/factories/dialog_tab.rb
+++ b/spec/factories/dialog_tab.rb
@@ -14,10 +14,4 @@ FactoryGirl.define do
       instance.save!
     end
   end
-
-  factory :dialog_tab_with_group_and_field, :parent => :dialog_tab do
-    after(:create) do |dialog_tab|
-      create(:dialog_group_with_field, :dialog_tab => dialog_tab)
-    end
-  end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -34,7 +34,7 @@ describe Dialog do
 
   describe "#content" do
     it "returns the serialized content" do
-      dialog = FactoryGirl.create(:dialog, :description => "foo", :label => "bar")
+      dialog = FactoryGirl.build(:dialog, :description => "foo", :label => "bar")
       expect(dialog.content).to match([hash_including("description" => "foo", "label" => "bar")])
     end
   end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -1,4 +1,14 @@
 describe Dialog do
+  def build_basic_dialog_with_components
+    Dialog.new(:label => "dialog").tap do |dialog|
+      dialog.dialog_tabs.build(:label => "tab").tap do |tab|
+        tab.dialog_groups.build(:label => "group").tap do |group|
+          group.dialog_fields.build(:name => "field")
+        end
+      end
+    end
+  end
+
   describe ".seed" do
     let(:dialog_import_service) { double("DialogImportService") }
     let(:test_file_path) { "spec/fixtures/files/dialogs" }

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -72,20 +72,16 @@ describe Dialog do
   end
 
   context "#destroy" do
-    before(:each) do
-      @dialog = FactoryGirl.create(:dialog, :label => 'dialog')
-    end
-
     it "destroy without resource_action association" do
-      expect(@dialog.destroy).to be_truthy
+      dialog = build_basic_dialog_with_components.tap(&:save!)
+      expect(dialog.destroy).to be_truthy
       expect(Dialog.count).to eq(0)
     end
 
     it "destroy with resource_action association" do
-      FactoryGirl.create(:resource_action, :action => "Provision", :dialog => @dialog)
-      @dialog.reload
-      expect { @dialog.destroy }
-        .to raise_error(RuntimeError, /Dialog cannot be deleted.*connected to other components/)
+      dialog = build_basic_dialog_with_components.tap(&:save!)
+      FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog)
+      expect { dialog.destroy }.to raise_error(RuntimeError, /Dialog cannot be deleted.*connected to other components/)
       expect(Dialog.count).to eq(1)
     end
   end
@@ -143,32 +139,25 @@ describe Dialog do
   end
 
   context "#remove_all_resources" do
-    before(:each) do
-      @dialog       = FactoryGirl.create(:dialog, :label => 'dialog')
-      @dialog_tab   = FactoryGirl.create(:dialog_tab, :label => 'tab')
-      @dialog_group = FactoryGirl.create(:dialog_group, :label => 'group')
-      @dialog_field = FactoryGirl.create(:dialog_field, :label => 'field 1', :name => "field_1")
-    end
-
     it "dialogs contain tabs" do
-      @dialog.dialog_tabs << @dialog_tab
-      expect(@dialog.dialog_resources.size).to eq(1)
-      @dialog.remove_all_resources
-      expect(@dialog.dialog_resources.size).to eq(0)
+      dialog = build_basic_dialog_with_components.tap(&:save!)
+      expect(dialog.dialog_resources.size).to eq(1)
+      dialog.remove_all_resources
+      expect(dialog.dialog_resources.size).to eq(0)
     end
 
     it "tabs contain groups" do
-      @dialog_tab.dialog_groups << @dialog_group
-      expect(@dialog_tab.dialog_resources.size).to eq(1)
-      @dialog_tab.remove_all_resources
-      expect(@dialog_tab.dialog_resources.size).to eq(0)
+      dialog_tab = build_basic_dialog_with_components.tap(&:save!).dialog_tabs.first
+      expect(dialog_tab.dialog_resources.size).to eq(1)
+      dialog_tab.remove_all_resources
+      expect(dialog_tab.dialog_resources.size).to eq(0)
     end
 
     it "groups contain fields" do
-      @dialog_group.dialog_fields << @dialog_field
-      expect(@dialog_group.dialog_resources.size).to eq(1)
-      @dialog_group.remove_all_resources
-      expect(@dialog_group.dialog_resources.size).to eq(0)
+      dialog_group = build_basic_dialog_with_components.tap(&:save!).dialog_tabs.first.dialog_groups.first
+      expect(dialog_group.dialog_resources.size).to eq(1)
+      dialog_group.remove_all_resources
+      expect(dialog_group.dialog_resources.size).to eq(0)
     end
   end
 
@@ -296,35 +285,16 @@ describe Dialog do
   end
 
   context "#dialog_fields" do
-    before(:each) do
-      @dialog        = FactoryGirl.create(:dialog, :label => 'dialog')
-      @dialog_tab    = FactoryGirl.create(:dialog_tab, :label => 'tab')
-      @dialog_group  = FactoryGirl.create(:dialog_group, :label => 'group')
-      @dialog_field  = FactoryGirl.create(:dialog_field, :label => 'field 1', :name => "field_1")
-      @dialog_field2 = FactoryGirl.create(:dialog_field, :label => 'field 2', :name => "field_2")
-
-      @dialog.dialog_tabs << @dialog_tab
-      @dialog.dialog_tabs << FactoryGirl.create(:dialog_tab, :label => 'tab2')
-      @dialog_tab.dialog_groups << @dialog_group
-      @dialog_tab.dialog_groups << FactoryGirl.create(:dialog_group, :label => 'group2')
-      @dialog_group.dialog_fields << @dialog_field
-      @dialog_group.dialog_fields << @dialog_field2
-
-      @dialog_group.save
-      @dialog_tab.save
-      @dialog.save
-    end
-
     it "dialog_group" do
-      expect(@dialog_group.dialog_fields.count).to eq(2)
+      expect(build_basic_dialog_with_components.tap(&:save!).dialog_tabs.first.dialog_groups.first.dialog_fields.count).to eq(1)
     end
 
     it "dialog_tab" do
-      expect(@dialog_tab.dialog_fields.count).to eq(2)
+      expect(build_basic_dialog_with_components.tap(&:save!).dialog_tabs.first.dialog_fields.count).to eq(1)
     end
 
     it "dialog" do
-      expect(@dialog.dialog_fields.count).to eq(2)
+      expect(build_basic_dialog_with_components.tap(&:save!).dialog_fields.count).to eq(1)
     end
   end
 

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -161,43 +161,6 @@ describe Dialog do
     end
   end
 
-  context "#each_field" do
-    before(:each) do
-      @dialog        = FactoryGirl.create(:dialog, :label => 'dialog')
-      @dialog_tab    = FactoryGirl.create(:dialog_tab, :label => 'tab')
-      @dialog_group  = FactoryGirl.create(:dialog_group, :label => 'group')
-      @dialog_field  = FactoryGirl.create(:dialog_field, :label => 'field 1', :name => "field_1")
-      @dialog_field2 = FactoryGirl.create(:dialog_field, :label => 'field 2', :name => "field_2")
-
-      @dialog.dialog_tabs << @dialog_tab
-      @dialog_tab.dialog_groups << @dialog_group
-      @dialog_group.dialog_fields << @dialog_field
-      @dialog_group.dialog_fields << @dialog_field2
-
-      @dialog_group.save
-      @dialog_tab.save
-      @dialog.save
-    end
-
-    it "dialog_group" do
-      count = 0
-      @dialog_group.each_dialog_field { |_df| count += 1 }
-      expect(count).to eq(2)
-    end
-
-    it "dialog_tab" do
-      count = 0
-      @dialog_tab.each_dialog_field { |_df| count += 1 }
-      expect(count).to eq(2)
-    end
-
-    it "dialog" do
-      count = 0
-      @dialog.each_dialog_field { |_df| count += 1 }
-      expect(count).to eq(2)
-    end
-  end
-
   describe '#update_tabs' do
     let(:dialog_field) { FactoryGirl.create_list(:dialog_field, 1, :label => 'field') }
     let(:dialog_group) { FactoryGirl.create_list(:dialog_group, 1, :label => 'group', :dialog_fields => dialog_field) }

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -162,51 +162,6 @@ describe Dialog do
     end
   end
 
-  context "remove resources" do
-    before(:each) do
-      @dialog             = FactoryGirl.create(:dialog,       :label => 'dialog')
-      @dialog_tab         = FactoryGirl.create(:dialog_tab,   :label => 'tab')
-      @dialog_group       = FactoryGirl.create(:dialog_group, :label => 'group')
-      @dialog_group_field = FactoryGirl.create(:dialog_field, :label => 'group field', :name => "group field")
-
-      @dialog.dialog_tabs << @dialog_tab
-      @dialog_tab.dialog_groups << @dialog_group
-      @dialog_group.dialog_fields << @dialog_group_field
-
-      @dialog.save
-      @dialog_tab.save
-      @dialog_group.save
-    end
-
-    it "dialog" do
-      @dialog.destroy
-      expect(Dialog.count).to eq(0)
-      expect(DialogTab.count).to eq(0)
-      expect(DialogGroup.count).to eq(0)
-      expect(DialogField.count).to eq(0)
-    end
-
-    it "dialog_tab" do
-      @dialog_tab.destroy
-      expect(Dialog.count).to eq(1)
-      expect(DialogTab.count).to eq(0)
-      expect(DialogGroup.count).to eq(0)
-      expect(DialogField.count).to eq(0)
-    end
-
-    it "dialog_group" do
-      @dialog_group.destroy
-      expect(Dialog.count).to eq(1)
-      expect(DialogTab.count).to eq(1)
-      expect(DialogGroup.count).to eq(0)
-      expect(DialogField.count).to eq(0)
-
-      @dialog_tab.destroy
-      expect(Dialog.count).to eq(1)
-      expect(DialogTab.count).to eq(0)
-    end
-  end
-
   context "#each_field" do
     before(:each) do
       @dialog        = FactoryGirl.create(:dialog, :label => 'dialog')

--- a/spec/models/dialog_tab_spec.rb
+++ b/spec/models/dialog_tab_spec.rb
@@ -1,9 +1,10 @@
 describe DialogTab do
-  let(:dialog_tab) { FactoryGirl.build(:dialog_tab, :label => 'tab') }
+  let(:dialog)     { FactoryGirl.build(:dialog) }
+  let(:dialog_tab) { FactoryGirl.build(:dialog_tab, :dialog => dialog) }
+
   context "#validate_children" do
     it "fails without box" do
-      expect { dialog_tab.save! }
-        .to raise_error(ActiveRecord::RecordInvalid, /tab must have at least one Box/)
+      expect { dialog_tab.save! }.to raise_error(ActiveRecord::RecordInvalid, /#{dialog_tab.label} must have at least one Box/)
     end
 
     it "validates with box" do
@@ -29,7 +30,7 @@ describe DialogTab do
   describe '#update_dialog_groups' do
     let(:dialog_fields) { FactoryGirl.create_list(:dialog_field, 2) }
     let(:dialog_groups) { FactoryGirl.create_list(:dialog_group, 2) }
-    let(:dialog_tab) { FactoryGirl.create(:dialog_tab, :dialog_groups => dialog_groups) }
+    let(:dialog_tab) { FactoryGirl.create(:dialog_tab, :dialog => dialog, :dialog_groups => dialog_groups) }
 
     before do
       dialog_groups.each_with_index { |group, index| group.dialog_fields << dialog_fields[index] }
@@ -57,8 +58,8 @@ describe DialogTab do
         dialog_tab.update_dialog_groups(updated_groups)
 
         dialog_tab.reload
-        expect(dialog_tab.dialog_groups.collect(&:label))
-          .to match_array(['updated_label', 'updated_label', 'a new label'])
+
+        expect(dialog_tab.dialog_groups.collect(&:label)).to match_array(['updated_label', 'updated_label', 'a new label'])
       end
 
       it 'creates a new dialog group from the dialog group without an id' do


### PR DESCRIPTION
- Use a regular validation for Dialog -> DialogTabs presence
- Ensure that Dialog.save also saves DialogTabs (since they're required)
- Add a validation that DialogTab is connected to a Dialog so that there aren't any disconnected DialogTabs
- Fix tests