### PR TITLE
Rename "Cloud Instance" back to "Instance"

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -68,7 +68,6 @@
 - User
 - VimPerformanceTrend
 - Vm
-- VmCloud
 - ManageIQ::Providers::CloudManager::Vm
 - ManageIQ::Providers::InfraManager::Vm
 - VmPerformance

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -926,7 +926,7 @@ en:
       User:                     EVM User
       VimPerformanceTrend:      Performance Trend
       Vm:                       VM and Instance
-      VmCloud:                  Cloud Instance
+      VmCloud:                  Instance
       VmdbIndex:                Index
       VmdbTable:                VMDB Table
       VmOrTemplate:             VM or Template

--- a/product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
+++ b/product/reports/180_Configuration Management - Instances/010 Amazon - Active VMs.yaml
@@ -3,7 +3,7 @@ title: Amazon - Active VMs
 rpt_group: Custom
 rpt_type: Custom
 priority: 20
-db: VmCloud
+db: ManageIQ::Providers::CloudManager::Vm
 cols:
 - name
 - power_state

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -204,8 +204,8 @@ describe GenericObjectDefinition do
     end
 
     it 'updates the association with different class' do
-      definition.add_property_association(:vms, 'vm_cloud')
-      expect(definition.properties[:associations]).to include('vms' => 'VmCloud')
+      definition.add_property_association(:vms, 'zone')
+      expect(definition.properties[:associations]).to include('vms' => 'Zone')
     end
 
     it 'accepts GenericObject as the association' do


### PR DESCRIPTION
Human readable model name for `VmCloud` was renamed from `Instance` to `Cloud Instance` in https://github.com/ManageIQ/manageiq/pull/16629 Reason for this change was a failing spec in ui-classic.

The spec in ui-classic would be failing because of changes in https://github.com/ManageIQ/manageiq/pull/15445 -- since `VmCloud` was added into `config/miq_expression.yml` under `base_tables` tree.

I'm reverting `Cloud Instance` back to `Instance`, because:
1. `VmCloud` is just an alias for `ManageIQ::Providers::CloudManager::Vm`. `ManageIQ::Providers::CloudManager::Vm` is already called `Instance` so we don't want to introduce inconsitencies.
2. Regardless of the above, we don't have any Instances that are not cloud instances, do we? There's no need to introduce this confusion into our project / product.
3. The problem with failing spec in ui-classic can be addressed by removing `VmCloud` from `miq_expression.yml`: we don't need it there, since `ManageIQ::Providers::CloudManager::Vm` is already there. Also, reports using `VmCloud` can safely use `ManageIQ::Providers::CloudManager::Vm` (`VmCloud` is just an alias, right?)

@Fryguy @dclarizio 