### PR TITLE
Removed redundant "Monitor" main tab node.

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6509,28 +6509,23 @@
     :identifier: physical_infra_topology_view
 
 # Monitor
-- :name: Monitor
-  :description: Everything under Monitor
+- :name: Alerts
+  :description: Alerts
   :feature_type: node
-  :identifier: monitor
+  :identifier: monitor_alerts
   :children:
-  - :name: Alerts
-    :description: Alerts
-    :feature_type: node
-    :identifier: monitor_alerts
-    :children:
-    - :name: Overview
-      :description: Alerts Overview
-      :feature_type: view
-      :identifier: monitor_alerts_overview
-    - :name: All Alerts
-      :description: Show Alerts List
-      :feature_type: view
-      :identifier: monitor_alerts_list
-    - :name: Most Recent Alerts
-      :description: Show Most Recent Alerts
-      :feature_type: view
-      :identifier: monitor_alerts_most_recent
+  - :name: Overview
+    :description: Alerts Overview
+    :feature_type: view
+    :identifier: monitor_alerts_overview
+  - :name: All Alerts
+    :description: Show Alerts List
+    :feature_type: view
+    :identifier: monitor_alerts_list
+  - :name: Most Recent Alerts
+    :description: Show Most Recent Alerts
+    :feature_type: view
+    :identifier: monitor_alerts_most_recent
 
 # API
 - :name: API


### PR DESCRIPTION
Removed an extra node that was causing confusion on role edit/summary screen while showing the node and it's children as selected even tho it was selected and user had an access to Monitor main tab in UI.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514279

@dclarizio @martinpovolny please review.

before fix, when i unselected "Control" after saving role, role summary and role edit screens showed "Monitor" as unselected as well, even tho when logging in with the new role, i could see/access Monitor menu.

![role_summary_before](https://user-images.githubusercontent.com/3450808/33903292-f04fcff0-df45-11e7-959f-74684d19c00f.png)


after, display correct selections:
![user_role_summary_after](https://user-images.githubusercontent.com/3450808/33903300-f76908ec-df45-11e7-9f82-63cf6f42ff01.png)
