### PR TITLE
Remove unused shared examples for manageiq-ui-classic

### DIFF
--- a/spec/support/examples_group/shared_examples_for_application_helper.rb
+++ b/spec/support/examples_group/shared_examples_for_application_helper.rb
@@ -1,44 +1,3 @@
-shared_examples_for 'record without latest derived metrics' do |message|
-  it message.to_s do
-    allow(@record).to receive_messages(:latest_derived_metrics => false)
-    expect(subject).to eq(message)
-  end
-end
-
-shared_examples_for 'record without perf data' do |message|
-  it message.to_s do
-    allow(@record).to receive_messages(:has_perf_data? => false)
-    expect(subject).to eq(message)
-  end
-end
-
-shared_examples_for 'record without ems events and policy events' do |message|
-  it message.to_s do
-    allow(@record).to receive(:has_events?).and_return(false)
-    expect(subject).to eq(message)
-  end
-end
-
-shared_examples_for 'record with error message' do |name|
-  it "returns the #{name} error message" do
-    message = "xx #{name} message"
-    if @record.respond_to?("supports_#{name.to_sym}?")
-      allow(@record).to receive(:unsupported_reason).with(name.to_sym).and_return(message)
-    else
-      allow(@record).to receive(:is_available_now_error_message).with(name.to_sym).and_return(message)
-    end
-    expect(subject).to eq(message)
-  end
-end
-
-shared_examples_for 'default case' do
-  it { is_expected.to be_falsey }
-end
-
-shared_examples_for 'default true_case' do
-  it { is_expected.to be_truthy }
-end
-
 shared_examples_for 'will be skipped for this record' do |message|
   it message.to_s do
     view_context = setup_view_context_with_sandbox({})
@@ -52,32 +11,5 @@ shared_examples_for 'will not be skipped for this record' do |message|
     view_context = setup_view_context_with_sandbox({})
     button = described_class.new(view_context, {}, {'record' => @record}, {})
     expect(button.visible?).to be_truthy
-  end
-end
-
-shared_examples_for 'vm not powered on' do |message|
-  it message.to_s do
-    allow(@record).to receive_messages(:current_state => 'off')
-    expect(subject).to eq(message)
-  end
-end
-
-shared_examples_for 'when record is archived' do |message|
-  it "#{message} will be skipped" do
-    view_context = setup_view_context_with_sandbox({})
-    record = FactoryGirl.create(:vm_microsoft)
-    allow(record).to receive(:archived?).and_return(true)
-    button = described_class.new(view_context, {}, {'record' => record}, {})
-    expect(button.visible?).to be_falsey
-  end
-end
-
-shared_examples_for 'when record is orphaned' do |message|
-  it "#{message} will be skipped" do
-    view_context = setup_view_context_with_sandbox({})
-    record = FactoryGirl.create(:vm_microsoft)
-    allow(record).to receive(:orphaned?).and_return(true)
-    button = described_class.new(view_context, {}, {'record' => record}, {})
-    expect(button.visible?).to be_falsey
   end
 end


### PR DESCRIPTION
```bash
14:48:12 ~/projects/manageiq-ui-classic (master)$ git grep "record without latest derived metrics"
14:49:20 ~/projects/manageiq-ui-classic (master)$ git grep "record without perf data"
14:49:20 ~/projects/manageiq-ui-classic (master)$ git grep "record without ems events and policy events"
14:49:20 ~/projects/manageiq-ui-classic (master)$ git grep "record with error message"
14:49:20 ~/projects/manageiq-ui-classic (master)$ git grep "default case"
spec/helpers/quadicon_helper_spec.rb:449:    context "default case" do
14:49:20 ~/projects/manageiq-ui-classic (master)$ git grep "default true_case"
14:49:21 ~/projects/manageiq-ui-classic (master)$ git grep "will be skipped for this record"
spec/helpers/application_helper/buttons/instance_reset_spec.rb:18:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/server_demote_spec.rb:22:      it "will be skipped for this record" do
spec/helpers/application_helper/buttons/template_refresh_spec.rb:35:      it "will be skipped for this record" do
spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb:16:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/vm_refresh_spec.rb:20:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_now_spec.rb:18:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_spec.rb:18:      it_behaves_like "will be skipped for this record"
14:49:21 ~/projects/manageiq-ui-classic (master)$ git grep "will not be skipped for this record"
spec/helpers/application_helper/buttons/instance_reset_spec.rb:9:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/server_demote_spec.rb:8:      it "will not be skipped for this record" do
spec/helpers/application_helper/buttons/template_refresh_spec.rb:9:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/template_refresh_spec.rb:20:      it "will not be skipped for this record" do
spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb:8:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/vm_refresh_spec.rb:10:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_now_spec.rb:9:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_spec.rb:9:      it_behaves_like "will not be skipped for this record"
14:49:21 ~/projects/manageiq-ui-classic (master)$ git grep "vm not powered on"
14:49:21 ~/projects/manageiq-ui-classic (master)$ git grep "when record is archived"
14:49:21 ~/projects/manageiq-ui-classic (master)$ git grep "when record is orphaned"
14:49:21 ~/projects/manageiq-ui-classic (master)$ git checkout gaprindashvili
14:53:42 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "record without latest derived metrics"
14:55:35 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "record without perf data"
14:55:35 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "record without ems events and policy events"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "record with error message"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "default case"
spec/helpers/quadicon_helper_spec.rb:449:    context "default case" do
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "default true_case"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "will be skipped for this record"
spec/helpers/application_helper/buttons/instance_reset_spec.rb:18:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/server_demote_spec.rb:22:      it "will be skipped for this record" do
spec/helpers/application_helper/buttons/template_refresh_spec.rb:35:      it "will be skipped for this record" do
spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb:16:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/vm_refresh_spec.rb:20:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_now_spec.rb:18:      it_behaves_like "will be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_spec.rb:18:      it_behaves_like "will be skipped for this record"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "will not be skipped for this record"
spec/helpers/application_helper/buttons/instance_reset_spec.rb:9:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/server_demote_spec.rb:8:      it "will not be skipped for this record" do
spec/helpers/application_helper/buttons/template_refresh_spec.rb:9:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/template_refresh_spec.rb:20:      it "will not be skipped for this record" do
spec/helpers/application_helper/buttons/vm_reconfigure_spec.rb:8:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/vm_refresh_spec.rb:10:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_now_spec.rb:9:      it_behaves_like "will not be skipped for this record"
spec/helpers/application_helper/buttons/vm_retire_spec.rb:9:      it_behaves_like "will not be skipped for this record"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "vm not powered on"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "when record is archived"
14:55:36 ~/projects/manageiq-ui-classic (gaprindashvili)$ git grep "when record is orphaned"
```

cc @jrafanie for the ✂️ 🔥 