### PR TITLE
Fix test for MW datasource - missing parent

### DIFF
--- a/spec/factories/middleware_datasource.rb
+++ b/spec/factories/middleware_datasource.rb
@@ -12,5 +12,6 @@ FactoryGirl.define do
           :parent => :hawkular_middleware_datasource do
     name 'ExampleDS'
     nativeid 'Local~/subsystem=datasources/data-source=ExampleDS'
+    middleware_server { FactoryGirl.create(:middleware_server) }
   end
 end


### PR DESCRIPTION
Fix broken UI classic Travis where test for MW Datasource controller was failing due to missing parent MW server.

Found thanks to: https://github.com/ManageIQ/manageiq/pull/16611
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/2972, https://github.com/ManageIQ/manageiq-ui-classic/pull/3040, https://github.com/ManageIQ/manageiq-ui-classic/pull/3044

@himdel, please review