### PR TITLE
Fix test failure where tempfile goes out of scope

### DIFF
--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -1,8 +1,10 @@
 describe ContainerOrchestrator do
   let(:connection)      { subject.send(:connection) }
   let(:kube_connection) { subject.send(:kube_connection) }
-  let(:cert_path)       { Tempfile.new("cert").path }
-  let(:token_path)      { Tempfile.new("servicetoken").path }
+  let(:cert)            { Tempfile.new("cert") }
+  let(:token)           { Tempfile.new("token") }
+  let(:cert_path)       { cert.path }
+  let(:token_path)      { token.path }
   let(:kube_host)       { "kube.example.com" }
   let(:kube_port)       { "8443" }
   let(:namespace)       { "manageiq" }


### PR DESCRIPTION
The tempfile object backing the cert and token paths was going out of
scope while the test was running which caused the check for .available?
to incorrectly return false.  This explicitly gets the Tempfile objects
seperately from the path to ensure the object stays in scope and the
tempfile isn't unlinked.

https://travis-ci.org/ManageIQ/manageiq/jobs/315573148#L1012-L1019