### PR TITLE
Add ContainerQuotaScope model, save them in save_inventory

### DIFF
--- a/app/models/container_quota.rb
+++ b/app/models/container_quota.rb
@@ -2,5 +2,6 @@ class ContainerQuota < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
 
+  has_many :container_quota_scopes, :dependent => :destroy
   has_many :container_quota_items, :dependent => :destroy
 end

--- a/app/models/container_quota_scope.rb
+++ b/app/models/container_quota_scope.rb
@@ -1,0 +1,3 @@
+class ContainerQuotaScope < ApplicationRecord
+  belongs_to :container_quota
+end

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -61,8 +61,17 @@ module EmsRefresh::SaveInventoryContainer
       h[:container_project_id] = h.fetch_path(:project, :id)
     end
 
-    save_inventory_multi(ems.container_quotas, hashes, :use_association, [:ems_ref], :container_quota_items, :project)
+    save_inventory_multi(ems.container_quotas, hashes, :use_association,
+                         [:ems_ref], [:container_quota_items, :container_quota_scopes], :project)
     store_ids_for_new_records(ems.container_quotas, hashes, :ems_ref)
+  end
+
+  def save_container_quota_scopes_inventory(container_quota, hashes)
+    return if hashes.nil?
+    container_quota.container_quota_scopes.reset
+
+    save_inventory_multi(container_quota.container_quota_scopes, hashes, :use_association, [:scope])
+    store_ids_for_new_records(container_quota.container_quota_scopes, hashes, :scope)
   end
 
   def save_container_quota_items_inventory(container_quota, hashes)

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -34,6 +34,7 @@ module ManageIQ::Providers
     has_many :security_contexts, :through => :containers
     has_many :container_service_port_configs, :through => :container_services
     has_many :container_routes, :through => :container_services
+    has_many :container_quota_scopes, :through => :container_quotas
     has_many :container_quota_items, :through => :container_quotas
     has_many :container_limit_items, :through => :container_limits
     has_many :container_template_parameters, :through => :container_templates

--- a/spec/factories/container_quota_scope.rb
+++ b/spec/factories/container_quota_scope.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :container_quota_scope do
+    scope "NotTerminating"
+  end
+end


### PR DESCRIPTION
Kubernetes namespaces (aka openshift projects) may have quotas.
Each quota may have one or more *scopes*, which we didn't store before but should:
https://kubernetes.io/docs/concepts/policy/resource-quotas/#quota-scopes
https://docs.openshift.com/container-platform/3.7/admin_guide/quota.html#quota-scopes
Schema was added in https://github.com/ManageIQ/manageiq-schema/pull/111

Core side, followed by https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/190.
I think this PR is safe to merge first.

https://bugzilla.redhat.com/show_bug.cgi?id=1504560
