### PR TITLE
Environment variable allowing http cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -10,7 +10,7 @@ else
 
   session_options = {}
   if MiqEnvironment::Command.is_appliance?
-    session_options[:secure]   = true unless MiqEnvironment::Command.is_container?
+    session_options[:secure]   = true unless MiqEnvironment::Command.is_container? || ENV['MIQ_ALLOW_HTTP_COOKIES'] == "true"
     session_options[:httponly] = true
   end
 


### PR DESCRIPTION
Debugging ManageIQ in RubyMine is only possible when secure cookies are disabled. 
This patch introduces usage of the environment variable MIQ_ALLOW_HTTP_COOKIES. When set to "true" ManageIQ secure cookies are disabled which makes it possible to connect using http.