### PR TITLE
[FINE] - Fixed product feature id for "Containers"

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5063,7 +5063,7 @@
 - :name: Containers Explorer
   :description: Everything under Containers
   :feature_type: node
-  :identifier: containers
+  :identifier: container
   :children:
   - :name: Relationships
     :description: Everything under All Containers Accordion

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -237,7 +237,7 @@
 - :name: containers
   :description: Compute / Containers / Containers
   :url: /container/show_list
-  :rbac_feature_name: containers
+  :rbac_feature_name: container
   :startup: true
 - :name: container_nodes
   :description: Compute / Containers / Container Nodes

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -46,7 +46,7 @@
   - container_service
   - container_replicator
   - container_group
-  - containers
+  - container
   - container_node
   - persistent_volume
   - container_build
@@ -1182,7 +1182,7 @@
   - container_service
   - container_route
   - container_project
-  - containers
+  - container
   - container_topology
   - container_dashboard
   - ems_infra_dashboard


### PR DESCRIPTION
This was causing Containers Explorer to be available when user's role had any of the other features access under Containers main tab. Due to the same "Containers Explorer" node was missing from User Role edit/details screen.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1510142

@dclarizio please review, this issue was fixed on master by https://github.com/ManageIQ/manageiq/pull/15935

before:
![before](https://user-images.githubusercontent.com/3450808/33945357-cabf6096-dfec-11e7-8be8-cc975c605d5d.png)

after:
![after](https://user-images.githubusercontent.com/3450808/33945366-ce907b9c-dfec-11e7-9f2d-408ac74ca5b5.png)
