### PR TITLE
[WIP] Alert sync refresher

### DIFF
--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -3,6 +3,8 @@ class MiqAlertSet < ApplicationRecord
 
   before_validation :default_name_to_guid, :on => :create
 
+  scope :on_mode, ->(mode) { where(:mode => mode) }
+
   include AssignmentMixin
 
   def self.assigned_to_target(target, options = {})

--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -25,6 +25,24 @@ class MiqAlertSet < ApplicationRecord
     !members.all? { |p| !p.active }
   end
 
+  def assigned_resources
+    assigned_resources_tags.map do |assignment_tag|
+      match_data = assignment_tag.name.match(/^.+\/assigned_to\/(.+)\/id\/(\d+)$/)
+      resource_type, resource_id = match_data[1, 2]
+      next if resource_type.nil? || resource_id.nil?
+
+      resource_type.camelcase.constantize.find(resource_id)
+    end
+  end
+
+  def assigned_resources_tags
+    tags.select { |tag| tag.name.match(/.+\/assigned_to\/.+/) }
+  end
+
+  def assigned_resources?
+    assigned_resources_tags.any?
+  end
+
   def export_to_array
     [self.class.to_s => ContentExporter.export_to_hash(attributes, "MiqAlert", members)]
   end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -28,6 +28,12 @@ FactoryGirl.define do
         create_list :storage, evaluator.storage_count, :ext_management_system => ems
       end
     end
+
+    trait :with_region do
+      after :create do |ems|
+        create :miq_region, :region => ems.region_number
+      end
+    end
   end
 
   # Intermediate classes


### PR DESCRIPTION
[WIP] Description
Added a PostRefresh hook in charge of sync'ing alerts and alert profiles for a ems with hawkular backend.

This PR fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1510421
https://bugzilla.redhat.com/show_bug.cgi?id=1515396

Depending on:
ManageIQ/manageiq-providers-hawkular#121

@miq-bot add_label alerts, wip, gaprindashvili/no, providers/middleware