### PR TITLE
remove satellite6 credential type from embedded ansible space

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -12,7 +12,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :OpenstackCredential
   require_nested :RackspaceCredential
   require_nested :ScmCredential
-  require_nested :Satellite6Credential
   require_nested :VmwareCredential
 
   require_nested :ConfigurationScript

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/satellite6_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/satellite6_credential.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Satellite6Credential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Satellite6Credential
-end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525172

Depends on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/46

After deploying both PR, I added an external Tower and refresh will still inventory the `Satellite6Credential` as follow db output,

```
vmdb_production=# select name, type, resource_type, resource_id from authentications where type like '%Satellite%';
      name      |                                    type                                    |    resource_type    | resource_id
----------------+----------------------------------------------------------------------------+---------------------+-------------
 hello_sat_cred | ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential | ExtManagementSystem |           5
 sat6_cred      | ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential | ExtManagementSystem |           5
(2 rows)
```

And at the same time, `Satellite6Credential` type is gone from embedded one as shown here
<img width="592" alt="screen shot 2017-12-13 at 6 06 35 pm" src="https://user-images.githubusercontent.com/2421248/33967372-3fef4478-e031-11e7-8503-679ea0f2fbf8.png">

