### PR TITLE
Fixes Custom Button Group model lookup in yaml

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2452,7 +2452,7 @@
           :hidden: true
           :identifier: ab_group_delete
         - :name: Reorder
-          :description: Buttons Groups
+          :description: Reorder Button Groups
           :feature_type: admin
           :hidden: true
           :identifier: ab_group_reorder

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -701,7 +701,7 @@ en:
       ContainerBuild:           Build
       ContainerQuota:           Container Quota
       CustomButton:             Button
-      CustomButtonSet:          Buttons Group
+      CustomButtonSet:          Button Group
       ConfigurationScriptSource: Repository
       Container:                Container
       ContainerPerformance:     Performance - Container
@@ -982,7 +982,7 @@ en:
       container_template:          Template
       container_templates:         Templates
       custom_button:               Button
-      custom_button_set:           Buttons Group
+      custom_button_set:           Button Group
       ems_block_storage:           Block Storage Manager
       ems_block_storages:          Block Storage Managers
       ems_cloud:                   Cloud Provider


### PR DESCRIPTION
FIx yaml translation layer for model name lookup in UI. Translations fixed to say "Button Group" instead of "Buttons Group", to be consistent with other translation definitions. All user actions now are synchronized, please see screen images. 

https://bugzilla.redhat.com/show_bug.cgi?id=1516836

Required for https://github.com/ManageIQ/manageiq-ui-classic/pull/3072


Screen shots post code fix:
=======================
<img width="1666" alt="custom button group adding post code fix" src="https://user-images.githubusercontent.com/552686/33973749-5bf9db4e-e039-11e7-8b2a-aac45035f480.png">

<img width="1673" alt="custom button group added post code fix" src="https://user-images.githubusercontent.com/552686/33973754-6585a71a-e039-11e7-999d-cf06eabdf606.png">

<img width="1667" alt="custom button group edit post code fix" src="https://user-images.githubusercontent.com/552686/33973755-6f96132a-e039-11e7-96c7-09c2082735cf.png">





