### PR TITLE
define hand soap before rescuing

### DIFF
--- a/app/models/mixins/vim_connect_mixin.rb
+++ b/app/models/mixins/vim_connect_mixin.rb
@@ -42,6 +42,7 @@ module VimConnectMixin
     end
 
     def validate_connection
+      require 'handsoap'
       yield
     rescue SocketError, Errno::EHOSTUNREACH, Errno::ENETUNREACH
       _log.warn($!.inspect)


### PR DESCRIPTION
running into an error case that the `Handsoap::Fault` was not defined yet.

Not thrilled how much `Handsoap` has ingrained itself but... will be a good stopgap
Not totally sure why this is showing up now either

@miq-bot assign @agrare label bug