### PR TITLE
Use UUID to ensure the uniqueness of job template name

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -15,15 +15,17 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook <
   # return provider raw object
   def raw_create_job_template(options)
     job_template_klass = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript
-    job_template_klass.raw_create_in_provider(manager, build_parameter_list(options))
+    jt_options = build_parameter_list(options)
+    _log.info("Creating job template with options (#{jt_options})")
+    job_template_klass.raw_create_in_provider(manager, jt_options)
   end
 
   private
 
   def build_parameter_list(options)
     params = {
-      :name                     => options[:template_name] || "#{name}_#{Time.zone.now.to_i}",
-      :description              => options[:description] || '',
+      :name                     => options[:template_name] || "#{name}_#{SecureRandom.uuid}",
+      :description              => options[:description] || "Created on #{Time.zone.now}",
       :project                  => configuration_script_source.manager_ref,
       :playbook                 => name,
       :become_enabled           => options[:become_enabled].present?,

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -40,6 +40,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
       it 'creates an inventory and moves on to create_job_template' do
         # Also test signal with queue
         subject.send(:minimize_indirect=, false)
+        expect(SecureRandom).to receive(:uuid).and_return('random-uuid')
         expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Inventory).to receive(:raw_create_inventory).and_return(double(:id => 'inv1'))
         expect(subject).to receive(:queue_signal).with(:create_job_template, :deliver_on => nil)
         subject.create_inventory

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -22,6 +22,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
       )
 
       allow(subject).to receive(:configuration_script_source).and_return(double(:manager_ref => 'mref'))
+      expect(SecureRandom).to receive(:uuid).and_return('random-uuid')
       expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
         .to receive(:raw_create_in_provider).with(instance_of(manager.class), option_matcher)
       subject.raw_create_job_template(options)


### PR DESCRIPTION
When we create job template (and inventory) to run a playbook, a timestamp was appended to the name to ensure the name uniqueness at the tower side. For the setup reported in the BZ after multiple VM provisioning completed they all tried to run the same playbook at the same second, causing a naming collision.

The solution is to replace the timestamp with a UUID.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525683