### PR TITLE
Update translation to resolve ambiguous Provider:Type field

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -238,7 +238,7 @@ en:
       effective_cpu: CPU - Effective
       effective_memory: Memory - Effective
       ems_cluster_name: Cluster
-      emstype_description: Type
+      emstype_description: Type Description
       enabled: Active
       end_trend_value: End
       evaluation_description: What is evaluated


### PR DESCRIPTION
There are 2 attributes `ExtManagementSystem#type` and `ExtManagementSystem#emstype_description`which translated to the same name `Provider:Type` in expression builder.

This PR updates translation to resolve ambiguous `Provider:Type` field in expression builder

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514503

**Before:**
![before](https://user-images.githubusercontent.com/6556758/34059087-765d4962-e1ab-11e7-94c6-753c99c1b395.png)

**After:**
<img width="621" alt="after" src="https://user-images.githubusercontent.com/6556758/34059088-79d9effa-e1ab-11e7-9585-d2daff4a97a2.png">

@miq-bot add-label bug, reporting, gaprindashvili/yes, fine/yes
