### PR TITLE
Add MiddlewareServer types to timeline event

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -143,10 +143,12 @@ class EmsEvent < EventStream
     end
   end
 
+  MIDDLEWARE_SERVERS_TYPES = %w[MiddlewareServerEap MiddlewareServerWildfly].freeze
+
   def self.process_middleware_entities_in_event!(event, _options = {})
     middleware_type = event[:middleware_type]
     if middleware_type
-      klass = middleware_type.safe_constantize
+      klass = MIDDLEWARE_SERVERS_TYPES.include?(middleware_type) ? MiddlewareServer : middleware_type.safe_constantize
       unless klass.nil?
         process_object_in_event!(klass, event, :ems_ref_key => :middleware_ref)
       end


### PR DESCRIPTION
Fix the link of MiddlewareServer in timeline events.

After add MiddlewareServerEap and MiddlewareServerWildfly the link is not in the timeline.

![middleware_link](https://user-images.githubusercontent.com/3019213/34100437-aef33442-e3e2-11e7-8762-36ee86bfe783.png)

cc @israel-hdez & @abonas 

Is there any reason to demodulize the type?
The other option is remove demodulize of all EmsEvent.add
```ruby
:middleware_type => mw_item.class.name.demodulize
```