### PR TITLE
Calculate Metering Used Hours only from used metrics in metering reports

### DIFF
--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -63,6 +63,10 @@ class Chargeback
       @chargeback_fields_present ||= @rollups.count(&:chargeback_fields_present?)
     end
 
+    def metering_used_fields_present
+      @metering_used_fields_present ||= @rollups.count(&:metering_used_fields_present?)
+    end
+
     private
 
     def born_at

--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -41,6 +41,10 @@ class Chargeback
       1 # Yes, charge this interval as fixed_compute_*_*
     end
 
+    def metering_used_fields_present
+      0 # we don't count used hours in metering report
+    end
+
     def current_value(metric, _sub_metric = nil)
       # Return the last seen allocation for charging purposes.
       @value ||= {}

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -1,7 +1,7 @@
 module Metering
   def calculate_costs(consumption, _)
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
-    self.metering_used_metric = fixed_compute_metric
+    self.metering_used_metric = consumption.metering_used_fields_present if consumption.metering_used_fields_present
     self.existence_hours_metric = consumption.consumed_hours_in_interval
 
     relevant_fields.each do |field|

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -8,6 +8,8 @@ class MetricRollup < ApplicationRecord
                                 net_usage_rate_average derived_vm_used_disk_storage
                                 derived_vm_allocated_disk_storage).freeze
 
+  METERING_USED_METRIC_FIELDS = %w(cpu_usagemhz_rate_average derived_memory_used net_usage_rate_average).freeze
+
   CAPTURE_INTERVAL_NAMES = %w(hourly daily).freeze
 
   #
@@ -69,5 +71,9 @@ class MetricRollup < ApplicationRecord
     return @chargeback_fields_present if defined?(@chargeback_fields_present)
 
     @chargeback_fields_present = CHARGEBACK_METRIC_FIELDS.any? { |field| send(field).present? && send(field).nonzero? }
+  end
+
+  def metering_used_fields_present?
+    @metering_used_fields_present ||= METERING_USED_METRIC_FIELDS.any? { |field| send(field).present? && send(field).nonzero? }
   end
 end


### PR DESCRIPTION
**Metric Fixed Compute** - is count of metric rollups (=hours) which have at least one non-zeros of chargeable metrics

### Metric Used Hours
**before** 
same as **Metric Fixed Compute**

**after**
is count of metric rollups (=hours) which have at least one non-zeros of **used chargeable metrics**
in discussion with  @Loicavenel **used chargeable metrics** are these:
[Memory Used, CPU Used and Network I/O Used ](https://github.com/ManageIQ/manageiq/pull/16677/commits/4b3f51e10c161ae2674312533d2b97c6971eda72#diff-04eefa3a83083e8cfed3f286f63f31ddR11)

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign  @gtanzillo 

# Reproducer

1. Manage Provider with metric and enable C&U
2. Create Metering Vm report and add here **used chargeable metrics** mentioned above at least and metering used hours, fixed metric compute
3. PUT zeros to metric in MetricRollups record for   **used chargeable metrics** metrics
in rails console e.g.: 
```ruby
# for Oct's rollups
 MetricRollup.where('extract(month from timestamp) = ?', 11).update_all({"cpu_usagemhz_rate_average"=>0, "derived_memory_used"=>0, "net_usage_rate_average"=>0})
```
4. If all  **used chargeable metrics** are zeroed then `Metric Used Hours` is zero


cc @nachandr

