### PR TITLE
Procfile.example - add workers needed for embedded ansible

### DIFF
--- a/Procfile.example
+++ b/Procfile.example
@@ -49,6 +49,12 @@
 # vmware_event_<id>:        ruby lib/workers/bin/run_single_worker.rb --ems-id <id> ManageIQ::Providers::Vmware::InfraManager::EventCatcher
 # vmware_refresh_core_<id>: ruby lib/workers/bin/run_single_worker.rb --ems-id <id> MiqEmsRefreshCoreWorker
 
+# Embedded Ansible workers
+
+# ansible: ruby lib/workers/bin/run_single_worker.rb EmbeddedAnsibleWorker
+# embedded_ansible_refresh: ruby lib/workers/bin/run_single_worker.rb --ems-id <id> ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RefreshWorker
+# embedded_ansible_event:   ruby lib/workers/bin/run_single_worker.rb --ems-id <id> ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventCatcher
+
 # Logs
 #
 # If you also want to see the log output in the same terminal session that you see the foreman output, uncomment these lines


### PR DESCRIPTION
(created because https://github.com/ManageIQ/guides/pull/276/files#r156100289)

This adds the 3 workers needed to get Embedded Ansible working.

For details, please check https://github.com/ManageIQ/guides/pull/276.

Cc @bdunne 