### PR TITLE
 Reverting changes from #16555 

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -16,10 +16,6 @@ class DialogFieldSerializer < Serializer
       "dialog_field_responders" => dialog_field.dialog_field_responders.map(&:name)
     }
 
-    if dialog_field.try(:force_multi_value) && dialog_field.default_value.present?
-      extra_attributes["default_value"] = dialog_field.default_value
-    end
-
     if dialog_field.dynamic?
       dynamic_values = dialog_field.trigger_automate_value_updates
       extra_attributes["values"] = dynamic_values

--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -17,7 +17,7 @@ class DialogFieldSerializer < Serializer
     }
 
     if dialog_field.try(:force_multi_value) && dialog_field.default_value.present?
-      extra_attributes["default_value"] = dialog_field.default_value.split(",")
+      extra_attributes["default_value"] = dialog_field.default_value
     end
 
     if dialog_field.dynamic?

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -139,7 +139,7 @@ describe DialogFieldSerializer do
       end
 
       it "serializes the category name, description and default value" do
-        default_values = "one,two"
+        default_values = "[\"one\", \"two\"]"
         dialog_field.update_attributes(:default_value => default_values)
 
         expect(dialog_field_serializer.serialize(dialog_field))
@@ -151,7 +151,7 @@ describe DialogFieldSerializer do
                      :category_name        => "best category ever",
                      :category_description => "best category ever"
                    },
-                   "default_value"           => %w(one two)
+                   "default_value"           => "[\"one\", \"two\"]"
           ))
       end
     end


### PR DESCRIPTION
~~After merging https://github.com/ManageIQ/manageiq-ui-classic/pull/3094, the type of values sent to the API is string.~~

~~Splitting it, leads to incorrect escaped values in DB, such as: `"[\"a\", \"b\"]"`.
Therefore removing the `split`.~~

Reverting changes done in PR #16555. The `default_value` is stored as it comes to the backend - escaped array (`"[\"a\", \"b\"]"`)



Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1516721
* https://github.com/ManageIQ/ui-components/pull/223
* https://github.com/ManageIQ/manageiq-ui-classic/pull/3094
* https://bugzilla.redhat.com/show_bug.cgi?id=1520001
  