### PR TITLE
Verify that the metric is unique within the region

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -16,7 +16,7 @@ class ChargeableField < ApplicationRecord
 
   belongs_to :detail_measure, :class_name => 'ChargebackRateDetailMeasure', :foreign_key => :chargeback_rate_detail_measure_id
 
-  validates :metric, :uniqueness => true, :presence => true
+  validates :metric, :presence => true, :unique_within_region => true
   validates :group, :source, :presence => true
 
   def showback_measure


### PR DESCRIPTION
On an appliance with replication enabled, the error would be:
```
[root@localhost vmdb]# rake db:seed
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Metric has already been taken
/var/www/miq/vmdb/app/models/chargeable_field.rb:107:in `block in seed'
/var/www/miq/vmdb/app/models/chargeable_field.rb:97:in `each'
/var/www/miq/vmdb/app/models/chargeable_field.rb:97:in `seed'
/var/www/miq/vmdb/lib/evm_database.rb:80:in `block (2 levels) in seed'
/var/www/miq/vmdb/lib/evm_database.rb:69:in `each'
/var/www/miq/vmdb/lib/evm_database.rb:69:in `block in seed'
/var/www/miq/vmdb/lib/extensions/ar_table_lock.rb:21:in `block (2 levels) in with_lock'
/var/www/miq/vmdb/lib/extensions/ar_table_lock.rb:21:in `block in with_lock'
/var/www/miq/vmdb/lib/extensions/ar_table_lock.rb:15:in `with_lock'
/var/www/miq/vmdb/lib/evm_database.rb:68:in `seed'
/var/www/miq/vmdb/db/seeds.rb:8:in `<top (required)>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```