### PR TITLE
Remove ui lookup with static string argument

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -207,13 +207,8 @@ class ExtManagementSystem < ApplicationRecord
         :event        => "ems_created",
         :target_id    => ems.id,
         :target_class => "ExtManagementSystem",
-        :message      => "%{provider_type} %{provider_name} created" % {
-          :provider_type => Dictionary.gettext("ext_management_systems",
-                                               :type      => :table,
-                                               :notfound  => :titleize,
-                                               :plural    => false,
-                                               :translate => false),
-          :provider_name => ems.name})
+        :message      => "Provider %{provider_name} created" % {:provider_name => ems.name}
+      )
     end
   end
 

--- a/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/base_manager/inventory_collector_worker.rb
@@ -16,8 +16,7 @@ class ManageIQ::Providers::BaseManager::InventoryCollectorWorker < MiqWorker
       if ems.nil?
         queue_name.titleize
       else
-        _("Inventory Collector for %{table}: %{name}") % {:table => ui_lookup(:table => "ext_management_systems"),
-                                                          :name  => ems.name}
+        _("Inventory Collector for Provider: %{name}") % {:name => ems.name}
       end
     end
   end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -80,13 +80,13 @@ class PhysicalServer < ApplicationRecord
 
   def refresh_ems
     unless ext_management_system
-      raise _("No %{table} defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider defined")
     end
     unless ext_management_system.has_credentials?
-      raise _("No %{table} credentials defined") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("No Provider credentials defined")
     end
     unless ext_management_system.authentication_status_ok?
-      raise _("%{table} failed last authentication check") % {:table => ui_lookup(:table => "ext_management_systems")}
+      raise _("Provider failed last authentication check")
     end
     EmsRefresh.queue_refresh(self)
   end


### PR DESCRIPTION
This pull request removes few invocations of `ui_lookup()` and `Dictionary.gettext()` with static string argument: it's more desirable to use the resulting string right away, rather than constructing the strings with expansions / concatenations.

gaprindashvili/no