### PR TITLE
Changes cloud network list to follow availability zone rules

### DIFF
--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -124,6 +124,18 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
                                               :ext_management_system => ems.network_manager)
     end
 
+    context "#allowed_cloud_networks" do
+      it "without a zone", :skip_before do
+        expect(workflow.allowed_cloud_networks.length).to be_zero
+      end
+
+      it "with a zone" do
+        workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
+        expect(workflow.allowed_cloud_networks.length).to eq(1)
+        expect(workflow.allowed_cloud_networks).to eq(@cn1.id => @cn1.name)
+      end
+    end
+
     context "#allowed_cloud_subnets" do
       it "without a cloud_network", :skip_before do
         expect(workflow.allowed_cloud_subnets.length).to be_zero


### PR DESCRIPTION
Previously, cloud network list was only updated after selection of security group, or change of tab, or a select set of other actions that completely voided the list of parameters passed to the filtering method. This adds a change so that availability zone updates the selection of cloud network, preventing incorrect cloud networks from showing up in the after the zone dropdown changes. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518847
