### PR TITLE
Add product/compare/*.yaml to string extraction

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -78,6 +78,7 @@ namespace :locale do
       Rails.root.join("db/fixtures/notification_types.*")          => %w(message),
       Rails.root.join("product/charts/layouts/*.yaml")             => %w(title),
       Rails.root.join("product/charts/layouts/*/*.yaml")           => %w(title),
+      Rails.root.join("product/compare/*.yaml")                    => %w(headers group menu_name title),
       Rails.root.join("product/reports/*/*.*")                     => %w(headers menu_name title),
       Rails.root.join("product/timelines/miq_reports/*.*")         => %w(title name headers),
       ManageIQ::UI::Classic::Engine.root.join('product/views/*.*') => %w(title name headers)


### PR DESCRIPTION
This change is to make sure strings from `product/compare/*.yaml` files will be extracted and translated.

`gaprindashvili/yes`

https://bugzilla.redhat.com/show_bug.cgi?id=1495849