### PR TITLE
Stop generating `vim_performance_tag_values` rows

### DIFF
--- a/app/models/metric/ci_mixin/rollup.rb
+++ b/app/models/metric/ci_mixin/rollup.rb
@@ -97,7 +97,6 @@ module Metric::CiMixin::Rollup
       end
 
       Benchmark.realtime_block(:db_update_perf) { perf.update_attributes(new_perf) }
-      Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
 
       case interval_name
       when "hourly"

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -812,8 +812,6 @@ class Storage < ApplicationRecord
         perf.update_attributes(attrs)
       end
 
-      Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
-
       update_attribute(:last_perf_capture_on, hour)
 
       # We don't rollup realtime to Storage, so we need to manually create bottlenecks

--- a/lib/active_metrics/connection_adapters/miq_postgres_adapter.rb
+++ b/lib/active_metrics/connection_adapters/miq_postgres_adapter.rb
@@ -53,10 +53,6 @@ module ActiveMetrics
 
         if interval_name == 'hourly'
           # TODO(lsmola) pff, it needs AR objects, quite ineffective to batch here
-          samples_arel.find_each do |perf|
-            Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
-          end
-
           _log.info("#{log_header} Adding missing timestamp intervals...")
           resources.each do |resource|
             Benchmark.realtime_block(:add_missing_intervals) { Metric::Processing.add_missing_intervals(resource, "hourly", start_time, end_time) }

--- a/lib/active_metrics/connection_adapters/miq_postgres_legacy_adapter.rb
+++ b/lib/active_metrics/connection_adapters/miq_postgres_legacy_adapter.rb
@@ -68,10 +68,6 @@ module ActiveMetrics
 
           # TODO: Should we change this into a single metrics.push like we do in ems_refresh?
           Benchmark.realtime_block(:process_perfs_db) { perf.update_attributes(v) }
-
-          if interval_name == 'hourly'
-            Benchmark.realtime_block(:process_perfs_tag) { VimPerformanceTagValue.build_from_performance_record(perf) }
-          end
         end
 
         if interval_name == 'hourly'

--- a/spec/models/vim_performance_tag_spec.rb
+++ b/spec/models/vim_performance_tag_spec.rb
@@ -105,7 +105,6 @@ describe VimPerformanceTag do
                                        )
             end
             vm.metric_rollups << perf
-            VimPerformanceTagValue.build_from_performance_record(perf)
           end
           vm.save!
         end
@@ -116,7 +115,6 @@ describe VimPerformanceTag do
                                     :cpu_usagemhz_rate_average => value
                                    )
           @host.metric_rollups << perf
-          VimPerformanceTagValue.build_from_performance_record(perf)
         end
         @host.save!
       end

--- a/tools/metrics_populate_retro_tags.rb
+++ b/tools/metrics_populate_retro_tags.rb
@@ -33,16 +33,3 @@ vm_perf_recs.group_by(&:resource_id).sort.each do |resource_id, perfs|
     :id        => perfs.collect(&:id)
   )
 end
-
-host_ids = vm_perf_recs.collect(&:parent_host_id).compact.uniq
-Host.where(:id => host_ids).order(:id).each do |host|
-  puts "Updating performance breakdown by tags for VMs under Host: ID: #{host.id} => #{host.name}"
-
-  host.preload_vim_performance_state_for_ts(time_cond)
-  perf_recs = host.metric_rollups.where(time_cond).where(:capture_interval_name => 'hourly')
-  VimPerformanceTagValue.where(:metric_type => "Host", :metric_id => perf_recs.collect(&:id)).delete_all
-  perf_recs.each do |perf|
-    perf.resource.target = host
-    VimPerformanceTagValue.build_from_performance_record(perf)
-  end
-end


### PR DESCRIPTION
This is a followup to #16582 where `vim_performance_tags` are generated on the fly instead of read from the table. Once that PR is merged, there will be no need to continue to generate and persist this tag values during performance processing. 

This will eliminate huge database sizes that persisting this data causes. Once this is merged we should be able to removed the table altogether. That can be done in a different PR.

/cc @carbonin @Fryguy

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1510484
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514505
