### PR TITLE
Fix email issue in miq_provision_quota_mixin active_provision by_owner method.

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -252,12 +252,11 @@ module MiqProvisionQuotaMixin
   end
 
   def quota_find_active_prov_request_by_owner(options)
-    email = get_option(:owner_email).to_s.strip
-    quota_find_active_prov_request(options).select { |p| email.casecmp(p.request_owner_email(p)).zero? }
+    quota_find_active_prov_request(options).select { |p| request_owner_email(self).casecmp(p.request_owner_email(p)).zero? }
   end
 
   def request_owner_email(request)
-    service_request?(request) ? request.requester.email : request.get_option(:owner_email).to_s.strip
+    service_request?(request) ? request.requester.email : request.get_option(:owner_email)
   end
 
   def service_request?(request)

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -266,6 +266,12 @@ describe MiqProvisionRequest do
                 {:count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 2.gigabytes}
               end
               it_behaves_like "check_quota"
+
+              it "fails without owner_email option" do
+                load_queue
+                request.options = {}
+                expect { request.check_quota(quota_method) }.to raise_error(NoMethodError)
+              end
             end
           end
 

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -117,6 +117,12 @@ describe ServiceTemplateProvisionRequest do
             {:count => 3, :memory => 3.gigabytes, :cpu => 8, :storage => 1_610_612_736}
           end
           it_behaves_like "check_quota"
+
+          it "fails without requester.email" do
+            load_queue
+            @vmware_user1.update_attributes(:email => nil)
+            expect { request.check_quota(quota_method) }.to raise_error(NoMethodError)
+          end
         end
       end
 


### PR DESCRIPTION
The active_provisions_by_owner method was getting  a "no implicit conversion of nil into String" error for service provisioning.  The error occurs when the Service request.requester.email is nil. 

Content PR protects against calling the active_provisions_by_owner method without the requester email.
https://github.com/ManageIQ/manageiq-content/pull/230   

Changed miq_provision_quota_mixin to call the request_owner_email method to handle getting email for Services and VM provisions. Removed to_s from get_option(:owner_email) to cause an error if email is nil.

https://bugzilla.redhat.com/show_bug.cgi?id=1509977

