### PR TITLE
Apply logger level

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -85,9 +85,9 @@ module Vmdb
       old_level      = logger.level
       new_level_name = (config[key] || "INFO").to_s.upcase
       new_level      = VMDBLogger.const_get(new_level_name)
+      logger.level   = new_level
       if old_level != new_level
         $log.info("MIQ(#{name}.apply_config) Log level for #{File.basename(logger.filename)} has been changed to [#{new_level_name}]")
-        logger.level = new_level
       end
     end
     private_class_method :apply_config_value


### PR DESCRIPTION
With this commit we fix a bug that custom logger levels were always set to INFO no matter what was there in settings.yaml. Specifically, I've been trying to set DEBUG level for $vcloud_log logger but even if server confirmed following settings when started:

```
...
:log:
  :level_aws: info
  :level_azure: warn
  :level_datawarehouse: info
  :level_kube: info
  :level_rhevm: info
  :level_vcloud: debug  <----------------------- OK
...
```
the logger wasn't printing DEBUG messages, only INFO. Not sure why this happens, but in apply_config_value() the "old_level" was reported to be 0 (debug) already when it was actually 1 (info). Quick fix is simple: always set log level no matter what logger reports as current value.

Am I perhaps missing something?

@miq-bot assign @agrare 
@miq-bot add_label bug
/cc @gberginc 
