### PR TITLE
Hide by default the Middleware tab in UI

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -11,7 +11,6 @@
 - :conf
 - :help
 - :inf
-- :mdl
 - :monitor
 - :monitor_alerts
 - :dwh


### PR DESCRIPTION
per [BZ 1526791](https://bugzilla.redhat.com/show_bug.cgi?id=1526791), there is a need to hide the Middleware UI from miq
(this is a first PR in a series of PRs that handles this for misc screens)
before:
![withmw](https://user-images.githubusercontent.com/6277245/34201533-7158a27e-e57d-11e7-82b7-6f4d62e4caa5.png)

after
![nomw](https://user-images.githubusercontent.com/6277245/34201535-74618ddc-e57d-11e7-946c-1fdfd698c2fe.png)


can be tested with `mv permissions.tmpl.yml permissions.yml` (and restarting miq)