### PR TITLE
Reconfigure VM: Add / Remove Network Adapters

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -107,6 +107,7 @@ module SupportsFeatureMixin
     :reconfigure                         => 'Reconfiguration',
     :reconfigure_disks                   => 'Reconfigure Virtual Machines Disks',
     :reconfigure_disksize                => 'Reconfigure Virtual Machines Disk Size',
+    :reconfigure_network_adapters        => 'Reconfigure Network Adapters',
     :refresh_network_interfaces          => 'Refresh Network Interfaces for a Host',
     :refresh_new_target                  => 'Refresh non-existing record',
     :regions                             => 'Regions of a Provider',

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -24,17 +24,17 @@ class VmReconfigureTask < MiqRequestTask
     end
 
     new_settings = []
-    unless req_obj.options[:vm_memory].blank?
+    if req_obj.options[:vm_memory].present?
       new_settings << "Memory: #{req_obj.options[:vm_memory].to_i} MB"
     end
-    new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" unless req_obj.options[:number_of_sockets].blank?
-    new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" unless req_obj.options[:cores_per_socket].blank?
-    new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" unless req_obj.options[:number_of_cpus].blank?
-    new_settings << "Add Disks: #{req_obj.options[:disk_add].length}" unless req_obj.options[:disk_add].blank?
-    new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" unless req_obj.options[:disk_remove].blank?
-    new_settings << "Resize Disks: #{req_obj.options[:disk_resize].length}" unless req_obj.options[:disk_resize].blank?
-    new_settings << "Add Network Adapters: #{req_obj.options[:network_adapter_add].length}" unless req_obj.options[:network_adapter_add].blank?
-    new_settings << "Remove Network Adapters: #{req_obj.options[:network_adapter_remove].length}" unless req_obj.options[:network_adapter_remove].blank?
+    new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" if req_obj.options[:number_of_sockets].present?
+    new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" if req_obj.options[:cores_per_socket].present?
+    new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" if req_obj.options[:number_of_cpus].present?
+    new_settings << "Add Disks: #{req_obj.options[:disk_add].length}" if req_obj.options[:disk_add].present?
+    new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" if req_obj.options[:disk_remove].present?
+    new_settings << "Resize Disks: #{req_obj.options[:disk_resize].length}" if req_obj.options[:disk_resize].present?
+    new_settings << "Add Network Adapters: #{req_obj.options[:network_adapter_add].length}" if req_obj.options[:network_adapter_add].present?
+    new_settings << "Remove Network Adapters: #{req_obj.options[:network_adapter_remove].length}" if req_obj.options[:network_adapter_remove].present?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end
 

--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -33,6 +33,8 @@ class VmReconfigureTask < MiqRequestTask
     new_settings << "Add Disks: #{req_obj.options[:disk_add].length}" unless req_obj.options[:disk_add].blank?
     new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" unless req_obj.options[:disk_remove].blank?
     new_settings << "Resize Disks: #{req_obj.options[:disk_resize].length}" unless req_obj.options[:disk_resize].blank?
+    new_settings << "Add Network Adapters: #{req_obj.options[:network_adapter_add].length}" unless req_obj.options[:network_adapter_add].blank?
+    new_settings << "Remove Network Adapters: #{req_obj.options[:network_adapter_remove].length}" unless req_obj.options[:network_adapter_remove].blank?
     "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
   end
 


### PR DESCRIPTION
This PR adds the option to reconfigure network adapters at the Reconfigure VM webpage.

This PR is part of a set of PRs:
https://github.com/ManageIQ/vmware_web_service/pull/25 (merged by @agrare)
https://github.com/ManageIQ/manageiq-providers-vmware/pull/163
https://github.com/ManageIQ/manageiq/pull/16700
https://github.com/ManageIQ/manageiq-ui-classic/pull/3121

More info: https://github.com/ManageIQ/manageiq-ui-classic/issues/3119

