### PR TITLE
Fix allowed_vlans to call preload correctly.

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -230,7 +230,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     unless @vlan_options[:vlans] == false
       rails_logger('allowed_vlans', 0)
       # TODO: Use Active Record to preload this data?
-      MiqPreloader.preload(hosts, :switches => :lans)
+      MiqPreloader.preload(hosts, :lans => :switches)
       load_allowed_vlans(hosts, vlans)
       rails_logger('allowed_vlans', 1)
     end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -97,6 +97,12 @@ describe MiqProvisionVirtWorkflow do
         expect(vlans.keys).to match_array(lan_keys)
         expect(vlans.values).to match_array(lan_keys)
       end
+
+      it '#load_hosts_vlans' do
+        hosts = [@host1]
+        MiqPreloader.preload(hosts, :lans => :switches)
+        expect { workflow.load_hosts_vlans(hosts, {}) }.not_to exceed_query_limit(0)
+      end
     end
   end
 


### PR DESCRIPTION
The existing preload association option is not specified correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1510069

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, provisioning, fine/yes, gaprindashvili/yes
cc @agrare 

To verify the N+1 queries in Rails console.
**With existing preload association option.**
```
[1] pry(main)> hosts = [Host.first, Host.last]
[2] pry(main)> vlans = {}
[3] pry(main)> MiqPreloader.preload(hosts, :switches => :lans)
  HostSwitch Load (0.3ms)  SELECT "host_switches".* FROM "host_switches" WHERE "host_switches"."host_id" IN (1, 23)
  HostSwitch Inst Including Associations (30.1ms - 5rows)
  Switch Load (0.5ms)  SELECT "switches".* FROM "switches" WHERE "switches"."id" IN (1, 2, 47, 43, 44)
  Switch Inst Including Associations (8.5ms - 5rows)
  Lan Load (0.4ms)  SELECT "lans".* FROM "lans" WHERE "lans"."switch_id" IN (2, 1, 43, 44, 47)
  Lan Inst Including Associations (10.0ms - 10rows)
=> [#<ActiveRecord::Associations::Preloader::HasManyThrough:0x00007fa4a70cd9d0
  @klass=
......
[4] pry(main)> hosts.each do |h|
[4] pry(main)*   h.lans.each { |l| vlans[l.name] = l.name unless l.switch.shared? }
[4] pry(main)* end
  Lan Load (0.4ms)  SELECT "lans".* FROM "lans" INNER JOIN "switches" ON "lans"."switch_id" = "switches"."id" INNER JOIN "host_switches" ON "switches"."id" = "host_switches"."switch_id" WHERE "host_switches"."host_id" = $1  [["host_id", 1]]
  Lan Inst Including Associations (0.1ms - 4rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  Switch Inst Including Associations (0.1ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Switch Inst Including Associations (0.1ms - 1rows)
  Lan Load (0.4ms)  SELECT "lans".* FROM "lans" INNER JOIN "switches" ON "lans"."switch_id" = "switches"."id" INNER JOIN "host_switches" ON "switches"."id" = "host_switches"."switch_id" WHERE "host_switches"."host_id" = $1  [["host_id", 23]]
  Lan Inst Including Associations (0.1ms - 6rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 43], ["LIMIT", 1]]
  Switch Inst Including Associations (0.1ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 43], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
  Switch Load (0.1ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 44], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 44], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 44], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
  Switch Load (0.2ms)  SELECT  "switches".* FROM "switches" WHERE "switches"."id" = $1 LIMIT $2  [["id", 47], ["LIMIT", 1]]
  Switch Inst Including Associations (0.0ms - 1rows)
=> [#<ManageIQ::Providers::Vmware::InfraManager::HostEsx:0x00007fa4a77e0bf0
  id: 1,
......
```

**With modified preload association.**
```
[1] pry(main)> hosts = [Host.first, Host.last]
[2] pry(main)> vlans = {}
[3] pry(main)> MiqPreloader.preload(hosts, :lans => :switches)
  HostSwitch Load (0.5ms)  SELECT "host_switches".* FROM "host_switches" WHERE "host_switches"."host_id" IN (1, 23)
  HostSwitch Inst Including Associations (4.8ms - 5rows)
  Switch Load (1.2ms)  SELECT "switches".* FROM "switches" WHERE "switches"."id" IN (1, 2, 47, 43, 44)
  Switch Inst Including Associations (7.5ms - 5rows)
  Lan Load (0.7ms)  SELECT "lans".* FROM "lans" WHERE "lans"."switch_id" IN (1, 2, 47, 43, 44)
  Lan Inst Including Associations (11.1ms - 10rows)
=> [#<ActiveRecord::Associations::Preloader::HasManyThrough:0x00007fb8d5456678
  @klass=
......
[4] pry(main)>
[5] pry(main)> hosts.each do |h|
[5] pry(main)*   h.lans.each { |l| vlans[l.name] = l.name unless l.switch.shared? }
[5] pry(main)* end
=> [#<ManageIQ::Providers::Vmware::InfraManager::HostEsx:0x00007fb8b66e7eb0
  id: 1,
........
```