### PR TITLE
Add Compute Infrastructure Hosts filter for ESX 6.5

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -257,6 +257,23 @@
     search_type: default
     db: Host
 - attributes:
+    name: default_Platform / ESX 6.5
+    description: Platform / ESX 6.5
+    filter: !ruby/object:MiqExpression
+      exp:
+        and:
+        - "=":
+            field: Host-vmm_vendor
+            value: vmware
+        - INCLUDES:
+            field: Host-vmm_product
+            value: ESX
+        - "=":
+            field: Host-vmm_version
+            value: 6.5.0
+    search_type: default
+    db: Host
+- attributes:
     name: default_Platform / HyperV
     description: Platform / HyperV
     filter: !ruby/object:MiqExpression


### PR DESCRIPTION
**NOTE**: Requires **MiqSearch.seed** in order to repopulate db table entries for proper UI display.
 
Fixes Hosts filter yaml file by adding a new definition filter of ESX 6.5

https://bugzilla.redhat.com/show_bug.cgi?id=1496582

Screen shot prior to code fix:
![compute infra hosts filters prior to code fix](https://user-images.githubusercontent.com/552686/34222227-b18163d0-e56f-11e7-8629-e42ee4e2ee06.png)


VMM Version 6.5.0 host created in db:
![compute infra hosts 6 5 0 vmm version](https://user-images.githubusercontent.com/552686/34273466-4776fe5c-e649-11e7-8595-41e8afe2144d.png)

VMM Version Host 6.5.0 selected via newly added filter:
![compute infra hosts 6 5 0 filter selection post fix](https://user-images.githubusercontent.com/552686/34273474-52d8f908-e649-11e7-9fc8-2c4caa839302.png)


