### PR TITLE
Parse models of > 3 namespaces

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -1,6 +1,6 @@
 class MiqExpression::Tag < MiqExpression::Target
   REGEX = /
-(?<model_name>([[:alnum:]]*(::)?){4})
+(?<model_name>(?:[[:upper:]][[:alnum:]]*(?:::[[:upper:]][[:alnum:]]*)*)?)
 \.?(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
 -(?<column>[a-z]+[_[:alnum:]]+)

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -36,21 +36,21 @@ RSpec.describe MiqExpression::Tag do
     end
 
     it "with model.associations.managed-in_tag" do
-      tag = "service.user.managed-service_level"
+      tag = "Service.user.managed-service_level"
       expect(described_class.parse(tag)).to have_attributes(:model        => Service,
                                                             :associations => ['user'],
                                                             :namespace    => "/managed/service_level")
     end
 
     it "with model.associations.user_tag-in_tag" do
-      tag = "service.user.user_tag-service_level"
+      tag = "Service.user.user_tag-service_level"
       expect(described_class.parse(tag)).to have_attributes(:model        => Service,
                                                             :associations => ['user'],
                                                             :namespace    => "/user/service_level")
     end
 
     it "with invalid case model.associations.managed-in_tag" do
-      tag = "service.user.mXaXnXaXged-service_level"
+      tag = "Service.user.mXaXnXaXged-service_level"
       expect(described_class.parse(tag)).to be_nil
     end
 
@@ -72,8 +72,17 @@ RSpec.describe MiqExpression::Tag do
     end
 
     it "returns nil with invalid case parent-model::model::somethingmanaged-se" do
-      tag = "ManageIQ::Providers::CloudManagermanaged-se'"
+      tag = "ManageIQ::Providers::CloudManagermanaged-se"
       expect(described_class.parse(tag)).to be_nil
+    end
+
+    it "can parse models in deeply nested namespaces" do
+      tag = "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem.managed-cc"
+
+      expected = {
+        :model => ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem
+      }
+      expect(described_class.parse(tag)).to have_attributes(expected)
     end
   end
 


### PR DESCRIPTION
It was found that the regex for parsing tags had edge cases that would
cause it to never finish evaluating. The solution to that at the time
was to limit models to an arbitrary number (3) of namespaces. The bug
below describes a tag that was created with a model more deeply nested
than that (which I have used as a test case). Since there is no number
that can be guaranteed to always work, we need a more sophisticated
regex that won't loop infinitely while also supporting arbitrarily
deep nesting.

I've attempted to do that here, while fixing some poorly formed tests
that failed to match the new pattern.

I will only add that this regex has probably reached the point where
it's a burden to maintain, and that we should look into reimplenting a
formal parser for fields/tags in the near future.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1524889

/cc @lgalis 