### PR TITLE
Rescue migration error and update status

### DIFF
--- a/app/models/vm_migrate_task.rb
+++ b/app/models/vm_migrate_task.rb
@@ -62,10 +62,16 @@ class VmMigrateTask < MiqRequestTask
                 end
 
     _log.warn("Calling VM #{vc_method} for #{vm.id}:#{vm.name}")
-    if vc_method == :migrate
-      vm.migrate(host, respool)
-    else
-      vm.relocate(host, respool, datastore, nil, disk_transform)
+
+    begin
+      if vc_method == :migrate
+        vm.migrate(host, respool)
+      else
+        vm.relocate(host, respool, datastore, nil, disk_transform)
+      end
+    rescue => err
+      update_and_notify_parent(:state => 'finished', :status => 'error', :message => "Failed. Reason[#{err.message}]")
+      return
     end
 
     if AUTOMATE_DRIVES

--- a/spec/models/vm_migrate_task_spec.rb
+++ b/spec/models/vm_migrate_task_spec.rb
@@ -1,0 +1,18 @@
+describe VmMigrateTask do
+  describe '.do_request' do
+    let(:vm) { Vm.new }
+    before { subject.vm = vm }
+
+    it 'migrates the vm and updates the status' do
+      expect(vm).to receive(:migrate)
+      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => 'migrated'))
+      subject.do_request
+    end
+
+    it 'catches migrate error and update the status' do
+      expect(vm).to receive(:migrate).and_raise("Bad things happened")
+      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => 'finished', :status => 'error', :message => 'Failed. Reason[Bad things happened]'))
+      subject.do_request
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1448023

vm_migrate_task needs to rescue migration error and finish with error.

VMWare migration already raises error when a problem is detected. We just need to rescue it in the task.
RHV migration needs to enhance to monitor the migration status and raise error accordingly. The enhancement will be done in manageiq-providers-ovirt.