### PR TITLE
Adding hostname format validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "manageiq-messaging",                              :require => false, :git =
 gem "manageiq-network_discovery",     "~>0.1.2",       :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>2.6.1",       :path => File.expand_path("mime-types-redirector", __dir__)
-gem "more_core_extensions",           "~>3.3"
+gem "more_core_extensions",           "~>3.5"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.14.0",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -76,7 +76,7 @@ class ExtManagementSystem < ApplicationRecord
 
   validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
   validates :hostname, :presence => true, :if => :hostname_required?
-  validate :hostname_uniqueness_valid?, :if => :hostname_required?
+  validate :hostname_uniqueness_valid?, :hostname_format_valid?, :if => :hostname_required?
 
   scope :with_eligible_manager_types, ->(eligible_types) { where(:type => eligible_types) }
 
@@ -90,6 +90,11 @@ class ExtManagementSystem < ApplicationRecord
     existing_hostnames = (self.class.all - [self]).map(&:hostname).compact.map(&:downcase)
 
     errors.add(:hostname, N_("has to be unique per provider type")) if existing_hostnames.include?(hostname.downcase)
+  end
+
+  def hostname_format_valid?
+    return if hostname.ipaddress? || hostname.hostname?
+    errors.add(:hostname, _("format is invalid."))
   end
 
   include NewWithTypeStiMixin


### PR DESCRIPTION
This PR is based on this discussion:
https://github.com/ManageIQ/manageiq-ui-classic/pull/2455

This PR depends on:
https://github.com/ManageIQ/more_core_extensions/pull/58

This PR extends the UI validation to the backend model.

This PR is able to:

- validate hostname format in backend;
- avoid hostname have protocol;
- avoid hostname have path;
- avoid hostname have port.