### PR TITLE
Expand scope of report definitions that visible to a user

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -59,7 +59,7 @@ class MiqReport < ApplicationRecord
       all
     else
       where(
-        arel_table[:rpt_type].eq('Custom').and(arel_table[:miq_group_id].eq(user.current_group_id))
+        arel_table[:rpt_type].eq('Custom').and(arel_table[:miq_group_id].in(user.current_tenant.miq_groups.pluck(:id)))
         .or(
           arel_table[:rpt_type].eq('Default')
         )

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -40,6 +40,24 @@ shared_examples "custom_report_with_custom_attributes" do |base_report, custom_a
 end
 
 describe MiqReport do
+  context ".for_user" do
+    let(:my_user) { FactoryGirl.create(:user_with_group) }
+    let(:group_in_my_tenant) { FactoryGirl.create(:miq_group, :tenant => my_user.current_tenant) }
+
+    let(:other_tenant) { FactoryGirl.create(:tenant) }
+    let(:group_in_other_tenant) { FactoryGirl.create(:miq_group, :tenant => other_tenant) }
+
+    let!(:my_report) { FactoryGirl.create(:miq_report, :miq_group => my_user.current_group, :rpt_type => "Custom") }
+    let!(:report_in_my_tenant) { FactoryGirl.create(:miq_report, :miq_group => group_in_my_tenant, :rpt_type => "Custom") }
+    let!(:report_in_another_tenant) { FactoryGirl.create(:miq_report, :miq_group => group_in_other_tenant, :rpt_type => "Custom") }
+
+    it "returns reports created by me or anyone in a group in my tenant" do
+      User.current_user = my_user
+
+      expect(described_class.for_user(my_user)).to match_array([my_report, report_in_my_tenant])
+    end
+  end
+
   context "report with filtering in Registry" do
     let(:options)  { {:targets_hash => true, :userid => "admin"} }
     let(:miq_task) { FactoryGirl.create(:miq_task) }


### PR DESCRIPTION
This change expands the existing scope of the current user's group to the current user's tenant
allowing visibility to all reports created by users within the tenant.

The scope was changed in https://github.com/ManageIQ/manageiq/pull/15472 but was too restrictive

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1526058