### PR TITLE
Add rake script to export/import roles

### DIFF
--- a/lib/task_helpers/exports.rb
+++ b/lib/task_helpers/exports.rb
@@ -30,5 +30,9 @@ module TaskHelpers
 
       nil
     end
+
+    def self.exclude_attributes(attributes, excluded_attributes)
+      attributes.reject { |key, _| excluded_attributes.include?(key) }
+    end
   end
 end

--- a/lib/task_helpers/exports/roles.rb
+++ b/lib/task_helpers/exports/roles.rb
@@ -1,0 +1,26 @@
+module TaskHelpers
+  class Exports
+    class Roles
+      def export(options = {})
+        export_dir = options[:directory]
+
+        roles = if options[:all]
+                  MiqUserRole.order(:id).all
+                else
+                  MiqUserRole.order(:id).where(:read_only => [false, nil])
+                end
+
+        roles = roles.collect do |role|
+          Exports.exclude_attributes(role.attributes, %w[created_at updated_at id]).merge('feature_identifiers' => role.feature_identifiers.sort)
+        end
+
+        roles.compact
+
+        roles.each do |r|
+          fname = Exports.safe_filename(r['name'], options[:keep_spaces])
+          File.write("#{export_dir}/#{fname}.yaml", [r].to_yaml)
+        end
+      end
+    end
+  end
+end

--- a/lib/task_helpers/exports/roles.rb
+++ b/lib/task_helpers/exports/roles.rb
@@ -11,7 +11,7 @@ module TaskHelpers
                 end
 
         roles = roles.collect do |role|
-          Exports.exclude_attributes(role.attributes, %w[created_at updated_at id]).merge('feature_identifiers' => role.feature_identifiers.sort)
+          Exports.exclude_attributes(role.attributes, %w(created_at updated_at id)).merge('feature_identifiers' => role.feature_identifiers.sort)
         end
 
         roles.compact

--- a/lib/task_helpers/exports/roles.rb
+++ b/lib/task_helpers/exports/roles.rb
@@ -12,9 +12,7 @@ module TaskHelpers
 
         roles = roles.collect do |role|
           Exports.exclude_attributes(role.attributes, %w(created_at updated_at id)).merge('feature_identifiers' => role.feature_identifiers.sort)
-        end
-
-        roles.compact
+        end.compact
 
         roles.each do |r|
           fname = Exports.safe_filename(r['name'], options[:keep_spaces])

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -4,11 +4,13 @@ module TaskHelpers
       def import(options = {})
         return unless options[:source]
 
+        available_features = MiqProductFeature.all
+
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
         Dir.glob(glob) do |fname|
           begin
             roles = YAML.load_file(fname)
-            import_roles(roles)
+            import_roles(roles, available_features)
           rescue ActiveRecord::RecordInvalid => e
             warn("Error importing #{fname} : #{e.message}")
           end
@@ -17,9 +19,9 @@ module TaskHelpers
 
       private
 
-      def import_roles(roles)
+      def import_roles(roles, available_features)
         roles.each do |r|
-          r['miq_product_feature_ids'] = MiqProductFeature.all.collect do |f|
+          r['miq_product_feature_ids'] = available_features.collect do |f|
             f.id if r['feature_identifiers']&.include?(f.identifier)
           end.compact
           role = MiqUserRole.find_or_create_by(:name => r['name'])

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -4,13 +4,11 @@ module TaskHelpers
       def import(options = {})
         return unless options[:source]
 
-        available_features = MiqProductFeature.all
-
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
         Dir.glob(glob) do |fname|
           begin
             roles = YAML.load_file(fname)
-            import_roles(roles, available_features)
+            import_roles(roles)
           rescue ActiveRecord::RecordInvalid => e
             warn("Error importing #{fname} : #{e.message}")
           end
@@ -19,7 +17,9 @@ module TaskHelpers
 
       private
 
-      def import_roles(roles, available_features)
+      def import_roles(roles)
+        available_features = MiqProductFeature.all
+
         roles.each do |r|
           r['miq_product_feature_ids'] = available_features.collect do |f|
             f.id if r['feature_identifiers']&.include?(f.identifier)

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -1,0 +1,36 @@
+module TaskHelpers
+  class Imports
+    class Roles
+      class RoleImportYamlError < StandardError; end
+      def import(options = {})
+        return unless options[:source]
+
+        glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
+        Dir.glob(glob) do |fname|
+          begin
+            roles = YAML.load_file(fname)
+            import_roles(roles)
+          rescue => e
+            $stderr.puts "Error importing #{fname} : #{e.message}"
+          end
+        end
+      end
+
+      private
+
+      def import_roles(roles)
+        begin
+          roles.each do |r|
+            r['miq_product_feature_ids'] = MiqProductFeature.all.collect do |f|
+              f.id if r['feature_identifiers'] && r['feature_identifiers'].include?(f.identifier)
+            end.compact
+            role = MiqUserRole.find_or_create_by(name: r['name'])
+            role.update_attributes!(r.reject { |k| k == 'feature_identifiers' })
+          end
+        rescue => e
+          $stderr.puts "#{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -9,8 +9,8 @@ module TaskHelpers
           begin
             roles = YAML.load_file(fname)
             import_roles(roles)
-          rescue => e
-            $stderr.puts "Error importing #{fname} : #{e.message}"
+          rescue ActiveRecord::RecordInvalid => e
+            warn("Error importing #{fname} : #{e.message}")
           end
         end
       end
@@ -20,7 +20,7 @@ module TaskHelpers
       def import_roles(roles)
         roles.each do |r|
           r['miq_product_feature_ids'] = MiqProductFeature.all.collect do |f|
-            f.id if r['feature_identifiers'] && r['feature_identifiers'].include?(f.identifier)
+            f.id if r['feature_identifiers']&.include?(f.identifier)
           end.compact
           role = MiqUserRole.find_or_create_by(:name => r['name'])
           role.update_attributes!(r.reject { |k| k == 'feature_identifiers' })

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -1,7 +1,6 @@
 module TaskHelpers
   class Imports
     class Roles
-      class RoleImportYamlError < StandardError; end
       def import(options = {})
         return unless options[:source]
 
@@ -19,16 +18,12 @@ module TaskHelpers
       private
 
       def import_roles(roles)
-        begin
-          roles.each do |r|
-            r['miq_product_feature_ids'] = MiqProductFeature.all.collect do |f|
-              f.id if r['feature_identifiers'] && r['feature_identifiers'].include?(f.identifier)
-            end.compact
-            role = MiqUserRole.find_or_create_by(name: r['name'])
-            role.update_attributes!(r.reject { |k| k == 'feature_identifiers' })
-          end
-        rescue => e
-          $stderr.puts "#{e.message}"
+        roles.each do |r|
+          r['miq_product_feature_ids'] = MiqProductFeature.all.collect do |f|
+            f.id if r['feature_identifiers'] && r['feature_identifiers'].include?(f.identifier)
+          end.compact
+          role = MiqUserRole.find_or_create_by(:name => r['name'])
+          role.update_attributes!(r.reject { |k| k == 'feature_identifiers' })
         end
       end
     end

--- a/lib/tasks/evm_export_import.rake
+++ b/lib/tasks/evm_export_import.rake
@@ -83,5 +83,5 @@ namespace :evm do
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end
-   end
+  end
 end

--- a/lib/tasks/evm_export_import.rake
+++ b/lib/tasks/evm_export_import.rake
@@ -33,6 +33,14 @@ namespace :evm do
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end
+
+    desc 'Exports all roles to individual YAML files'
+    task :roles => :environment do
+      options = TaskHelpers::Exports.parse_options
+      TaskHelpers::Exports::Roles.new.export(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
   end
 
   namespace :import do
@@ -67,5 +75,13 @@ namespace :evm do
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end
-  end
+
+    desc 'Imports all roles from individual YAML files'
+    task :roles => :environment do
+      options = TaskHelpers::Imports.parse_options
+      TaskHelpers::Imports::Roles.new.import(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
+   end
 end

--- a/spec/lib/task_helpers/exports/roles_spec.rb
+++ b/spec/lib/task_helpers/exports/roles_spec.rb
@@ -1,0 +1,44 @@
+describe TaskHelpers::Exports::Roles do
+  let(:role_test_export) do
+    [{"name"                => "Test Role",
+      "read_only"           => false,
+      "settings"            => nil,
+      "feature_identifiers" => ["about"]}]
+  end
+
+  let(:role_super_export) do
+    [{"name"                => "EvmRole-super_administrator",
+      "read_only"           => true,
+      "settings"            => nil,
+      "feature_identifiers" => []}]
+  end
+
+  let(:export_dir) do
+    Dir.mktmpdir('miq_exp_dir')
+  end
+
+  before do
+    FactoryGirl.create(:miq_user_role, :name => "Test Role", :features => "about")
+    FactoryGirl.create(:miq_user_role, :role => "super_administrator")
+  end
+
+  after do
+    FileUtils.remove_entry export_dir
+  end
+
+  it 'exports user roles to a given directory' do
+    TaskHelpers::Exports::Roles.new.export(:directory => export_dir)
+    file_contents = File.read("#{export_dir}/Test_Role.yaml")
+    expect(YAML.load(file_contents)).to eq(role_test_export)
+    expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+  end
+
+  it 'exports all roles to a given directory' do
+    TaskHelpers::Exports::Roles.new.export(:directory => export_dir, :all => true)
+    file_contents = File.read("#{export_dir}/Test_Role.yaml")
+    file_contents2 = File.read("#{export_dir}/EvmRole-super_administrator.yaml")
+    expect(YAML.load(file_contents)).to eq(role_test_export)
+    expect(YAML.load(file_contents2)).to eq(role_super_export)
+    expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
+  end
+end

--- a/spec/lib/task_helpers/exports/roles_spec.rb
+++ b/spec/lib/task_helpers/exports/roles_spec.rb
@@ -23,13 +23,13 @@ describe TaskHelpers::Exports::Roles do
   end
 
   after do
-    FileUtils.remove_entry export_dir
+    # FileUtils.remove_entry export_dir
   end
 
   it 'exports user roles to a given directory' do
     TaskHelpers::Exports::Roles.new.export(:directory => export_dir)
     file_contents = File.read("#{export_dir}/Test_Role.yaml")
-    expect(YAML.load(file_contents)).to eq(role_test_export)
+    expect(YAML.safe_load(file_contents)).to eq(role_test_export)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
   end
 
@@ -37,8 +37,8 @@ describe TaskHelpers::Exports::Roles do
     TaskHelpers::Exports::Roles.new.export(:directory => export_dir, :all => true)
     file_contents = File.read("#{export_dir}/Test_Role.yaml")
     file_contents2 = File.read("#{export_dir}/EvmRole-super_administrator.yaml")
-    expect(YAML.load(file_contents)).to eq(role_test_export)
-    expect(YAML.load(file_contents2)).to eq(role_super_export)
+    expect(YAML.safe_load(file_contents)).to eq(role_test_export)
+    expect(YAML.safe_load(file_contents2)).to eq(role_super_export)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
   end
 end

--- a/spec/lib/task_helpers/exports/roles_spec.rb
+++ b/spec/lib/task_helpers/exports/roles_spec.rb
@@ -23,7 +23,7 @@ describe TaskHelpers::Exports::Roles do
   end
 
   after do
-    # FileUtils.remove_entry export_dir
+    FileUtils.remove_entry export_dir
   end
 
   it 'exports user roles to a given directory' do

--- a/spec/lib/task_helpers/exports_spec.rb
+++ b/spec/lib/task_helpers/exports_spec.rb
@@ -66,4 +66,20 @@ describe TaskHelpers::Exports do
       expect(TaskHelpers::Exports.validate_directory(@export_dir)).to eq('Destination directory must be writable')
     end
   end
+
+  describe '.exclude_attributes' do
+    let(:all_attributes) do
+      { "id"         => 1,
+        "name"       => "EvmRole-super_administrator",
+        "read_only"  => true,
+        "created_at" => Time.zone.now,
+        "updated_at" => Time.zone.now,
+        "settings"   => nil }
+    end
+
+    it 'removes selected attributes' do
+      filtered_attributes = TaskHelpers::Exports.exclude_attributes(all_attributes, %w[created_at updated_at id])
+      expect(filtered_attributes).to match("name" => "EvmRole-super_administrator", "read_only" => true, "settings" => nil)
+    end
+  end
 end

--- a/spec/lib/task_helpers/exports_spec.rb
+++ b/spec/lib/task_helpers/exports_spec.rb
@@ -78,7 +78,7 @@ describe TaskHelpers::Exports do
     end
 
     it 'removes selected attributes' do
-      filtered_attributes = TaskHelpers::Exports.exclude_attributes(all_attributes, %w[created_at updated_at id])
+      filtered_attributes = TaskHelpers::Exports.exclude_attributes(all_attributes, %w(created_at updated_at id))
       expect(filtered_attributes).to match("name" => "EvmRole-super_administrator", "read_only" => true, "settings" => nil)
     end
   end

--- a/spec/lib/task_helpers/imports/data/roles/Bad_Role_Import_Test.yml
+++ b/spec/lib/task_helpers/imports/data/roles/Bad_Role_Import_Test.yml
@@ -1,0 +1,6 @@
+---
+- name:
+  read_only: false
+  settings: 
+  feature_identifiers:
+  - about

--- a/spec/lib/task_helpers/imports/data/roles/Bad_Role_Import_Test.yml
+++ b/spec/lib/task_helpers/imports/data/roles/Bad_Role_Import_Test.yml
@@ -1,6 +1,6 @@
 ---
 - name:
   read_only: false
-  settings: 
+  settings:
   feature_identifiers:
   - about

--- a/spec/lib/task_helpers/imports/data/roles/Role_Import_Test.yaml
+++ b/spec/lib/task_helpers/imports/data/roles/Role_Import_Test.yaml
@@ -1,0 +1,8 @@
+---
+- name: Role Import Test
+  read_only: false
+  settings:
+    :restrictions:
+      :vms: :user_or_group
+  feature_identifiers:
+  - about

--- a/spec/lib/task_helpers/imports/data/roles/Role_Import_Test_2.yaml
+++ b/spec/lib/task_helpers/imports/data/roles/Role_Import_Test_2.yaml
@@ -1,0 +1,7 @@
+---
+- name: Role Import Test 2
+  read_only: false
+  settings: 
+  feature_identifiers:
+  - dashboard
+  - vm

--- a/spec/lib/task_helpers/imports/data/roles/Role_Import_Test_2.yaml
+++ b/spec/lib/task_helpers/imports/data/roles/Role_Import_Test_2.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Role Import Test 2
   read_only: false
-  settings: 
+  settings:
   feature_identifiers:
   - dashboard
   - vm

--- a/spec/lib/task_helpers/imports/roles_spec.rb
+++ b/spec/lib/task_helpers/imports/roles_spec.rb
@@ -2,21 +2,21 @@ describe TaskHelpers::Imports::Roles do
   let(:data_dir)        { File.join(File.expand_path(__dir__), 'data', 'roles') }
   let(:role_file)       { 'Role_Import_Test.yaml' }
   let(:bad_role_file)   { 'Bad_Role_Import_Test.yml' }
-  let(:role_one_name)   { 'Role Import Test'}
-  let(:role_two_name)   { 'Role Import Test 2'}
+  let(:role_one_name)   { 'Role Import Test' }
+  let(:role_two_name)   { 'Role Import Test 2' }
 
-  EvmSpecHelper.seed_specific_product_features(%w[
-        dashboard        
-        dashboard_add
-        dashboard_view
-        host_compare
-        host_edit
-        host_scan
-        host_show_list
-        policy
-        vm
-        about
-      ])
+  EvmSpecHelper.seed_specific_product_features(%w(
+                                                 dashboard
+                                                 dashboard_add
+                                                 dashboard_view
+                                                 host_compare
+                                                 host_edit
+                                                 host_scan
+                                                 host_show_list
+                                                 policy
+                                                 vm
+                                                 about
+                                               ))
 
   describe "#import" do
     let(:options) { {:source => source} }
@@ -62,14 +62,14 @@ describe TaskHelpers::Imports::Roles do
     expect(r.name).to eq(role_one_name)
     expect(r.read_only).to be false
     expect(r.feature_identifiers).to eq(["about"])
-    expect(r.settings).to eq({:restrictions=>{:vms=>:user_or_group}})
+    expect(r.settings).to eq(:restrictions=>{:vms=>:user_or_group})
   end
 
   def assert_test_role_two_present
     r = MiqUserRole.find_by(:name => role_two_name)
     expect(r.name).to eq(role_two_name)
     expect(r.read_only).to be false
-    expect(r.feature_identifiers).to eq(%w[dashboard vm])
+    expect(r.feature_identifiers).to eq(%w(dashboard vm))
     expect(r.settings).to be nil
   end
 end

--- a/spec/lib/task_helpers/imports/roles_spec.rb
+++ b/spec/lib/task_helpers/imports/roles_spec.rb
@@ -5,18 +5,20 @@ describe TaskHelpers::Imports::Roles do
   let(:role_one_name)   { 'Role Import Test' }
   let(:role_two_name)   { 'Role Import Test 2' }
 
-  EvmSpecHelper.seed_specific_product_features(%w(
-                                                 dashboard
-                                                 dashboard_add
-                                                 dashboard_view
-                                                 host_compare
-                                                 host_edit
-                                                 host_scan
-                                                 host_show_list
-                                                 policy
-                                                 vm
-                                                 about
-                                               ))
+  before do
+    EvmSpecHelper.seed_specific_product_features(%w(
+                                                   dashboard
+                                                   dashboard_add
+                                                   dashboard_view
+                                                   host_compare
+                                                   host_edit
+                                                   host_scan
+                                                   host_show_list
+                                                   policy
+                                                   vm
+                                                   about
+                                                 ))
+  end
 
   describe "#import" do
     let(:options) { {:source => source} }

--- a/spec/lib/task_helpers/imports/roles_spec.rb
+++ b/spec/lib/task_helpers/imports/roles_spec.rb
@@ -1,0 +1,75 @@
+describe TaskHelpers::Imports::Roles do
+  let(:data_dir)        { File.join(File.expand_path(__dir__), 'data', 'roles') }
+  let(:role_file)       { 'Role_Import_Test.yaml' }
+  let(:bad_role_file)   { 'Bad_Role_Import_Test.yml' }
+  let(:role_one_name)   { 'Role Import Test'}
+  let(:role_two_name)   { 'Role Import Test 2'}
+
+  EvmSpecHelper.seed_specific_product_features(%w[
+        dashboard        
+        dashboard_add
+        dashboard_view
+        host_compare
+        host_edit
+        host_scan
+        host_show_list
+        policy
+        vm
+        about
+      ])
+
+  describe "#import" do
+    let(:options) { {:source => source} }
+
+    describe "when the source is a directory" do
+      let(:source) { data_dir }
+
+      it 'imports all .yaml files in a specified directory' do
+        expect do
+          TaskHelpers::Imports::Roles.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_role_one_present
+        assert_test_role_two_present
+      end
+    end
+
+    describe "when the source is a valid role file" do
+      let(:source) { "#{data_dir}/#{role_file}" }
+
+      it 'imports a specified role export file' do
+        expect do
+          TaskHelpers::Imports::Roles.new.import(options)
+        end.to_not output.to_stderr
+
+        assert_test_role_one_present
+        expect(MiqUserRole.find_by(:name => role_two_name)).to be_nil
+      end
+    end
+
+    describe "when the source is an invalid role file" do
+      let(:source) { "#{data_dir}/#{bad_role_file}" }
+
+      it 'fails to import a specified role file' do
+        expect do
+          TaskHelpers::Imports::Roles.new.import(options)
+        end.to output.to_stderr
+      end
+    end
+  end
+
+  def assert_test_role_one_present
+    r = MiqUserRole.find_by(:name => role_one_name)
+    expect(r.name).to eq(role_one_name)
+    expect(r.read_only).to be false
+    expect(r.feature_identifiers).to eq(["about"])
+    expect(r.settings).to eq({:restrictions=>{:vms=>:user_or_group}})
+  end
+
+  def assert_test_role_two_present
+    r = MiqUserRole.find_by(:name => role_two_name)
+    expect(r.name).to eq(role_two_name)
+    expect(r.read_only).to be false
+    expect(r.feature_identifiers).to eq(%w[dashboard vm])
+    expect(r.settings).to be nil
+  end
+end


### PR DESCRIPTION
These rake scripts and classes provide functionality for exporting/importing of the following ManageIQ object types:

- roles (MiqUserRole)

This PR uses the framework that was implemented for PRs #14126 and #15256 to export/import other ManageIQ object types.

These scripts are based on the CFME RH Consulting Scripts and are used by Red Hat consultants to enable storing customizations in Git and maintaining customizations between environments (e.g. dev/qa/prod) for an SDLC lifecycle.