### PR TITLE
Disconnect inventory on targeted refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -185,4 +185,16 @@ module EmsRefresh::SaveInventoryHelper
       []
     end
   end
+
+  def hashes_of_target_empty?(hashes, target)
+    hashes.blank? || (hashes[:storages].blank? &&
+    case target
+    when VmOrTemplate
+      hashes[:vms].blank?
+    when Host
+      hashes[:hosts].blank?
+    when EmsFolder
+      hashes[:folders].blank?
+    end)
+  end
 end

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -39,7 +39,7 @@ module EmsRefresh::SaveInventoryInfra
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
 
     # Check if the data coming in reflects a complete removal from the ems
-    if hashes.blank? || (hashes[:hosts].blank? && hashes[:vms].blank? && hashes[:storages].blank? && hashes[:folders].blank?)
+    if hashes_of_target_empty?(hashes, target)
       target.disconnect_inv if disconnect
       return
     end


### PR DESCRIPTION
When doing a targeted refresh the condition to disconnect the target
from the ems was not granular enough.
For example in some cases when refreshing a template the 'folder' hashes
were not not empty while the 'template' hashes were, still the template
was not disconnected from the ems in that case.
The new condition is more accurate and should mitigate this kind of
scenarios.

The specs for this PR are here: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/184