### PR TITLE
:storage_redhat trait with storage_domain_type

### DIFF
--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -74,6 +74,22 @@ FactoryGirl.define do
   end
 
   trait :storage do
-    after(:create) { |h| h.storages << FactoryGirl.create(:storage) }
+    transient do
+      storage_count 1
+    end
+
+    after :create do |h, evaluator|
+      h.storages = create_list :storage, evaluator.storage_count
+    end
+  end
+
+  trait :storage_redhat do
+    transient do
+      storage_count 1
+    end
+
+    after :create do |h, evaluator|
+      h.storages = create_list :storage_redhat, evaluator.storage_count
+    end
   end
 end

--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
 
   factory :storage_redhat, :parent => :storage_nfs do
     sequence(:ems_ref_obj) { |n| "/api/storagedomains/#{n}" }
+    sequence(:storage_domain_type) { |n| n == 2 ? "iso" : "data" }
   end
 
   factory :storage_block, :parent => :storage do


### PR DESCRIPTION
Added `storage_domain_type` property to `:storage_redhat` factory. The
second `:storage_redhat` created will be of `"iso"` type, others will be of
`"data"` type.

Added `:storage_redhat` trait to `:host` factory that will add
`:storage_redhat` instances to the host instead of `:storage`.

Making number of storages in the list tunable (1 by default).