### PR TITLE
Introduce virtualization manager

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers
 
     include AvailabilityMixin
     include HasMonitoringManagerMixin
+    include HasInfraManagerMixin
     include SupportsFeatureMixin
 
     has_many :container_nodes, -> { active }, :foreign_key => :ems_id
@@ -46,6 +47,11 @@ module ManageIQ::Providers
     has_many :all_container_images, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerImage"
     has_many :all_container_nodes, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerNode"
 
+    has_one :infra_manager,
+            :foreign_key => :parent_ems_id,
+            :class_name  => "ManageIQ::Providers::Kubevirt::InfraManager",
+            :autosave    => true,
+            :dependent   => :destroy
 
     virtual_column :port_show, :type => :string
 
@@ -91,6 +97,16 @@ module ManageIQ::Providers
 
     def port_show
       port.to_s
+    end
+
+    def endpoint_created(role)
+      monitoring_endpoint_created(role) if respond_to?(:monitoring_endpoint_created)
+      virtualization_endpoint_created(role) if respond_to?(:virtualization_endpoint_created)
+    end
+
+    def endpoint_destroyed(role)
+      monitoring_endpoint_destroyed(role) if respond_to?(:monitoring_endpoint_destroyed)
+      virtualization_endpoint_destroyed(role) if respond_to?(:virtualization_endpoint_destroyed)
     end
   end
 end

--- a/app/models/mixins/has_infra_manager_mixin.rb
+++ b/app/models/mixins/has_infra_manager_mixin.rb
@@ -1,0 +1,29 @@
+module HasInfraManagerMixin
+  extend ActiveSupport::Concern
+
+  def virtualization_endpoint_created(role)
+    if role == "kubevirt" && infra_manager.nil?
+      infra_manager = ensure_infra_manager
+      infra_manager.save
+    end
+  end
+
+  def virtualization_endpoint_destroyed(role)
+    if role == "kubevirt" && infra_manager.present?
+      infra_manager.destroy_queue
+    end
+  end
+
+  private
+
+  def ensure_infra_manager
+    if infra_manager.nil?
+      build_infra_manager(:parent_manager  => self,
+                          :name            => "#{name} Virtualization Manager",
+                          :zone_id         => zone_id,
+                          :provider_region => provider_region)
+    end
+
+    infra_manager
+  end
+end

--- a/app/models/mixins/has_monitoring_manager_mixin.rb
+++ b/app/models/mixins/has_monitoring_manager_mixin.rb
@@ -1,14 +1,14 @@
 module HasMonitoringManagerMixin
   extend ActiveSupport::Concern
 
-  def endpoint_created(role)
+  def monitoring_endpoint_created(role)
     if role == "prometheus_alerts" && monitoring_manager.nil?
       monitoring_manager = ensure_monitoring_manager
       monitoring_manager.save
     end
   end
 
-  def endpoint_destroyed(role)
+  def monitoring_endpoint_destroyed(role)
     if role == "prometheus_alerts" && monitoring_manager.present?
       # TODO: if someone deletes the alerts endpoint and then quickly readds it they can end up without a manager.
       monitoring_manager.destroy_queue


### PR DESCRIPTION
In order to support kubevirt as a secondary manager of the
openshift/kubevirt provider, a new virtualization manager mixin is added to introduce it.

The corresponding PR of the container providers is https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/197