### PR TITLE
Keep container quota history by archiving

### DIFF
--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -14,7 +14,8 @@ class ContainerProject < ApplicationRecord
   has_many :containers, :through => :container_groups
   has_many :container_images, -> { distinct }, :through => :container_groups
   has_many :container_nodes, -> { distinct }, :through => :container_groups
-  has_many :container_quotas
+  has_many :container_quotas, -> { active }
+  has_many :container_quota_scopes, :through => :container_quotas
   has_many :container_quota_items, :through => :container_quotas
   has_many :container_limits
   has_many :container_limit_items, :through => :container_limits

--- a/app/models/container_quota.rb
+++ b/app/models/container_quota.rb
@@ -1,7 +1,30 @@
 class ContainerQuota < ApplicationRecord
+  # For this model and children, we want to record full changes history.
+  #
+  # - The ContainerQuota itself doesn't have anything that changes
+  #   (except resource_version whose history is not interesting).
+  #   So we do standard archiving on deletion here.
+  #
+  # - Scopes are immutable once ContainerQuota is created, so don't need archiving.
+  #
+  # - ContainerQuotaItems can be added/deleted/changed, and we use archiving to
+  #   record changes too!
+  include ArchivedMixin
+
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project
 
   has_many :container_quota_scopes, :dependent => :destroy
-  has_many :container_quota_items, :dependent => :destroy
+  has_many :container_quota_items, -> { active }
+  has_many :all_container_quota_items, :class_name => "ContainerQuotaItem", :dependent => :destroy
+
+  def disconnect_inv
+    return if archived?
+    _log.info("Archiving Container Quota [#{name}] id [#{id}]")
+    # This allows looking only at ContainerQuotaItem created_at..deleted_on
+    # without also checking parent ContaineQuota is active.
+    container_quota_items.each(&:disconnect_inv)
+    self.deleted_on = Time.now.utc
+    save
+  end
 end

--- a/app/models/container_quota_item.rb
+++ b/app/models/container_quota_item.rb
@@ -1,9 +1,23 @@
 class ContainerQuotaItem < ApplicationRecord
+  # This model is unusual in using archiving not only to record deletions but also changes in quota_desired, quota_enforced, quota_observed.
+  # Instead of updating in-place, we archive the old record and create a new one.
+  include ArchivedMixin
+
   belongs_to :container_quota
+  has_many :container_quota_scopes, :through => :container_quota
 
   virtual_column :quota_desired_display,  :type => :string
   virtual_column :quota_enforced_display, :type => :string
   virtual_column :quota_observed_display, :type => :string
+
+  def disconnect_inv
+    return if archived?
+    _log.info("Archiving Container Quota id [#{container_quota_id}] Item [#{resource}]")
+    # This allows looking only at ContainerQuotaItem created_at..deleted_on
+    # without also checking parent ContaineQuota is active.
+    self.deleted_on = Time.now.utc
+    save
+  end
 
   def quota_desired_display
     quota_display(quota_desired)

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -62,7 +62,8 @@ module EmsRefresh::SaveInventoryContainer
     end
 
     save_inventory_multi(ems.container_quotas, hashes, :use_association,
-                         [:ems_ref], [:container_quota_items, :container_quota_scopes], :project)
+                         [:ems_ref], [:container_quota_items, :container_quota_scopes], :project,
+                         true)
     store_ids_for_new_records(ems.container_quotas, hashes, :ems_ref)
   end
 
@@ -78,7 +79,10 @@ module EmsRefresh::SaveInventoryContainer
     return if hashes.nil?
     container_quota.container_quota_items.reset
 
-    save_inventory_multi(container_quota.container_quota_items, hashes, :use_association, [:resource])
+    # Archive and create new on changes, not only on deletion - by including the data in find_key.
+    save_inventory_multi(container_quota.container_quota_items, hashes, :use_association,
+                         [:resource, :quota_desired, :quota_enforced, :quota_observed], [], [],
+                         true)
     store_ids_for_new_records(container_quota.container_quota_items, hashes, :resource)
   end
 

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers
     has_many :container_replicators, :foreign_key => :ems_id, :dependent => :destroy
     has_many :containers, -> { active }, :foreign_key => :ems_id
     has_many :container_projects, -> { active }, :foreign_key => :ems_id
-    has_many :container_quotas, :foreign_key => :ems_id, :dependent => :destroy
+    has_many :container_quotas, -> { active }, :foreign_key => :ems_id
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_images, -> { active }, :foreign_key => :ems_id
@@ -46,6 +46,7 @@ module ManageIQ::Providers
     has_many :all_container_projects, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerProject"
     has_many :all_container_images, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerImage"
     has_many :all_container_nodes, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerNode"
+    has_many :all_container_quotas, :foreign_key => :ems_id, :dependent => :destroy, :class_name => "ContainerQuota"
 
     has_one :infra_manager,
             :foreign_key => :parent_ems_id,


### PR DESCRIPTION
Container projects have quotas (optionally scoped), and quota items for specific resources.  Some users desire "chargeback by allocation" where the quota is what tenants pay for (whether they used it or not).
We're already collecting quotas, but we need to also retain full quota history — this PR implements this by (mis)using archiving.

See comments in models for design assumptions/choices.

- [x] depends on https://github.com/ManageIQ/manageiq/pull/17020 — merged
- [ ] simultaneous with https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/198

https://bugzilla.redhat.com/show_bug.cgi?id=1504560
@miq-bot add-label enhancement, gaprindashvili/yes

Docs on quotas: https://kubernetes.io/docs/concepts/policy/resource-quotas/, https://docs.openshift.com/container-platform/3.9/admin_guide/quota.html