### PR TITLE
[WIP] save_inventory_multi: actually cast to column type when matching to existing records

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -6,7 +6,7 @@ module EmsRefresh::SaveInventoryHelper
       # Save the columns associated with the find keys, so we can coerce the hash values during fetch
       if records.first
         model = records.first.class
-        @key_attribute_types = find_key.map { |k| model.type_for_attribute(k) }
+        @key_attribute_types = find_key.map { |k| model.type_for_attribute(k.to_s) }
       else
         @key_attribute_types = []
       end


### PR DESCRIPTION
The `find_key` passed usually consists of symbols like `[:foo, :bar]`.
Unfortunately, `type_for_attribute(:foo)` silently returns "identity type" objects whose `.cast()` does nothing.
Opened https://github.com/rails/rails/issues/31611, sent upstream PR https://github.com/rails/rails/pull/31615.
This PR is independent whether Rails will agree to accept symbols, `type_for_attribute("foo")` works and is currently documented API ("must be a string").

## Impact
This means no casting was happening, so if data from parser has different type from column (str vs int, float vs int etc.), records could be destroyed & recreated or archived & recreated unnecessarily :-(
~~I need this working for a new feature — #16722~~ — but I'm assuming this casting code exists for a reason, and something is broken in other places!  But don't know where.

~~I was particularly bitten by using a float column, turns out `4.0.hash != 4.hash` despite `4.0 == 4`.
It's likely nobody else used ints coerced to floats (or floats coerced to ints) in find_key before.~~
But I expect we do have ints coerced to string column or vice versa...

@agrare @Fryguy @Ladas   Can you help figuring out the impact?

- [ ] One idea I have is rig this code to explode when `type.cast(value).hash != value.hash`, and run tests of all providers?

This needs tests.  I don't see any unit tests for TypedIndex / save_inventory_with_findkey / save_inventory_multi ?!

- [ ] Is graph refresh affected by similar issue?  Didn't check yet, but I'll soon find out.

~~@miq-bot add-label bug, gaprindashvili/yes
for #16722 and https://bugzilla.redhat.com/show_bug.cgi?id=1504560~~
Found a way for that RFE to not depend on this fix.  We can decide whether to backport this based only on if it caused bugs.