### PR TITLE
Add ruby_parser gem as devel dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -214,6 +214,8 @@ unless ENV["APPLIANCE"]
     gem "foreman"
     gem "haml_lint",        "~>0.20.0", :require => false
     gem "rubocop",          "~>0.49.0", :require => false
+    # ruby_parser is required for i18n string extraction
+    gem "ruby_parser",                  :require => false
     gem "scss_lint",        "~>0.48.0", :require => false
     gem "yard"
   end


### PR DESCRIPTION
The gem is required for gettext string extraction.

Without the gem:
```
$ be rake locale:plugin:find[ManageIQ::UI::Classic]
** override_gem: manageiq-ui-classic, [{:path=>"/home/milan/src/manage-iq/manageiq-ui-classic"}], caller: /home/milan/src/manage-iq/manageiq/bundler.d/pry.rb
** Using session_store: ActionDispatch::Session::MemCacheStore
rake aborted!
Gem::LoadError: ruby_parser is not part of the bundle. Add it to your Gemfile.
/home/milan/src/manage-iq/manageiq/lib/tasks/locale.rake:184:in `block (2 levels) in <top (required)>'
/home/milan/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/home/milan/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => gettext:po:update => gettext:po:ja:update => /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.po => /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.edit.po => /home/milan/src/manage-iq/manageiq-ui-classic/locale/ManageIQ_UI_Classic.pot
(See full trace by running task with --trace)
```

With the gem:
```
$ be rake locale:plugin:find[ManageIQ::UI::Classic]
** override_gem: manageiq-ui-classic, [{:path=>"/home/milan/src/manage-iq/manageiq-ui-classic"}], caller: /home/milan/src/manage-iq/manageiq/bundler.d/pry.rb
** Using session_store: ActionDispatch::Session::MemCacheStore
rm -f /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.edit.po
cp /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.po /home/milan/src/manage-iq/manageiq-ui-classic/locale/ja/ManageIQ_UI_Classic.edit.po
Warning: fuzzy message was used.
...
```

gaprindashvili/yes