### PR TITLE
Remove empty Application event group

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -199,8 +199,6 @@
       - VmBeingCreatedEvent
       - VmBeingDeployedEvent
       :name: Creation/Addition
-    :application:
-      :name: Application
     :configuration:
       :critical:
       - ansible_tower_create

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -293,7 +293,6 @@ describe EmsEvent do
     it 'returns a list of expected groups' do
       event_group_names = [
         :addition,
-        :application,
         :configuration,
         :console,
         :deletion,


### PR DESCRIPTION
UI travis fails on this event group not having any `:detail` - removing the whole event group.

This is beacause it used to have some detail here, which was removed in https://github.com/ManageIQ/manageiq/pull/14883,
and also `:detail` came from manageiq-providers-hawkular, before it was removed in https://github.com/ManageIQ/manageiq-providers-hawkular/pull/125.

Cc @agrare 

Current UI failure: https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/324173970
Fails in https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/miq_policy_controller/alerts.rb#L460-L462 on `v[:detail]` being `nil`.