### PR TITLE
Ensure that the zone name is unique only within the current region

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,6 +1,6 @@
 class Zone < ApplicationRecord
   validates_presence_of   :name, :description
-  validates_uniqueness_of :name
+  validates :name, :unique_within_region => true
 
   serialize :settings, Hash
 


### PR DESCRIPTION
This allows for properties of a zone in the global region to be
changed even if there is a zone with the same name in a remote region

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1467348