### PR TITLE
Disconnect inventory on targeted refresh

### DIFF
--- a/app/models/ems_refresh/save_inventory_helper.rb
+++ b/app/models/ems_refresh/save_inventory_helper.rb
@@ -187,7 +187,7 @@ module EmsRefresh::SaveInventoryHelper
   end
 
   def hashes_of_target_empty?(hashes, target)
-    hashes.blank? || (hashes[:storages].blank? &&
+    hashes.blank? ||
     case target
     when VmOrTemplate
       hashes[:vms].blank?
@@ -195,6 +195,6 @@ module EmsRefresh::SaveInventoryHelper
       hashes[:hosts].blank?
     when EmsFolder
       hashes[:folders].blank?
-    end)
+    end
   end
 end


### PR DESCRIPTION
When doing a targeted refresh the condition to disconnect the target
from the ems included a check to see if there are any "storages",
this causes problems in some targeted refresh scenarios.
Since it does not seem to make sense this check is being removed.

Spec: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/184