### PR TITLE
Additions for Amazon tag mapping in graph refresh

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -32,6 +32,9 @@ module ManageIQ::Providers
     has_many :security_groups,               :through     => :network_manager
     has_one  :source_tenant, :as => :source, :class_name  => 'Tenant'
     has_many :vm_and_template_labels,        :through     => :vms_and_templates, :source => :labels
+    # Only taggings mapped from labels, excluding user-assigned tags.
+    has_many :vm_and_template_taggings,      -> { joins(:tag).merge(Tag.controlled_by_mapping) },
+                                             :through     => :vms_and_templates, :source => :taggings
 
     validates_presence_of :zone
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -162,7 +162,7 @@ class Tag < ApplicationRecord
   # @return [ActiveRecord::Relation] Scope for tags controlled by ContainerLabelTagMapping.
   def self.controlled_by_mapping
     queries = ContainerLabelTagMapping::TAG_PREFIXES.collect do |prefix|
-      where("name LIKE ?", "#{sanitize_sql_like(prefix)}%")
+      where(arel_table[:name].matches("#{sanitize_sql_like(prefix)}%", nil, true)) # case sensitive LIKE
     end
     queries.inject(:or).read_only.is_entry
   end


### PR DESCRIPTION
For https://github.com/ManageIQ/manageiq-providers-amazon/pull/382
cc @juliancheal @Ladas

https://bugzilla.redhat.com/show_bug.cgi?id=1506404

`ems.vm_and_template_taggings` resulting query:
```
SELECT "taggings".* FROM "taggings" 
INNER JOIN "tags" ON "tags"."id" = "taggings"."tag_id" 
LEFT OUTER JOIN "classifications" ON "classifications"."tag_id" = "tags"."id" 
INNER JOIN "vms" ON "taggings"."taggable_id" = "vms"."id" 
WHERE "vms"."ems_id" = 7 
  AND "taggings"."taggable_type" = 'VmOrTemplate' 
  AND (("tags"."name" LIKE '/managed/amazon:%') OR ("tags"."name" LIKE '/managed/kubernetes:%'))
  AND "classifications"."read_only" = 't' 
  AND ("classifications"."parent_id" != 0)
```

- [x] Tested manageiq-providers-kubernetes specs still pass, including tag mapping 
- [x] Tested manageiq-providers-openshift specs still pass, including tag mapping 