### PR TITLE
Configurable yaml string extraction

### DIFF
--- a/config/locale_task_config.yaml
+++ b/config/locale_task_config.yaml
@@ -1,0 +1,26 @@
+---
+yaml_strings_to_extract:
+  db/fixtures/miq_product_features.*:
+  - name
+  - description
+  db/fixtures/miq_report_formats.*:
+  - description
+  db/fixtures/notification_types.*:
+  - message
+  product/charts/layouts/*.yaml:
+  - title
+  product/charts/layouts/*/*.yaml:
+  - title
+  product/compare/*.yaml:
+  - headers
+  - group
+  - menu_name
+  - title
+  product/reports/*/*.*:
+  - headers
+  - menu_name
+  - title
+  product/timelines/miq_reports/*.*:
+  - title
+  - name
+  - headers


### PR DESCRIPTION
This pull request is to  make yaml string extraction configurable: a new file `config/locale_task_config.yaml` contains paths to yaml files from which to extract strings. This change means that:
* the task can be shared across plugins (every plugin would just pass its root to the task)
* strings from UI (`product/views`) will not live in core repo anymore
* no more `ManageIQ::UI::Classic::Engine` in the core repo

gaprindashvili/no