### PR TITLE
Set limits for VM and Template names and descriptions

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_template.yaml
@@ -187,7 +187,7 @@
           :display: :edit
           :data_type: :string
           :min_length:
-          :max_length: 100
+          :max_length: 255
         :vm_prefix:
           :description: VM Name Prefix/Suffix
           :required_method: :validate_vm_name
@@ -241,7 +241,7 @@
           :data_type: :string
           :notes_display: :show
           :min_length:
-          :max_length:
+          :max_length: 255
         :pxe_image_id:
           :values_from:
             :method: :allowed_images

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -272,7 +272,7 @@
           :display: :edit
           :data_type: :string
           :min_length:
-          :max_length: 100
+          :max_length: 255
         :vm_prefix:
           :description: VM Name Prefix/Suffix
           :required_method: :validate_vm_name
@@ -317,7 +317,7 @@
           :data_type: :string
           :notes_display: :show
           :min_length:
-          :max_length:
+          :max_length: 255
         :pxe_image_id:
           :values_from:
             :method: :allowed_images

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -293,7 +293,7 @@
           :display: :edit
           :data_type: :string
           :min_length:
-          :max_length: 100
+          :max_length: 255
         :vm_prefix:
           :description: VM Name Prefix/Suffix
           :required_method: :validate_vm_name
@@ -338,7 +338,7 @@
           :data_type: :string
           :notes_display: :show
           :min_length:
-          :max_length:
+          :max_length: 255
         :pxe_image_id:
           :values_from:
             :method: :allowed_images


### PR DESCRIPTION
RHV enforce the following limits:
* VM name to 255 characters
* VM description to 255 characters
* Template name to 40 characters (it will be extended to 255 in ovirt-engine-4.2)
* Template description to 255 characters

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1529052

The UI enforces the limits on insertion for the name and description fields:
![provision_vm_name_limit](https://user-images.githubusercontent.com/316242/34525673-74ad8e90-f0a8-11e7-80db-f423c7af9fa3.png)

![publish_vm_template_name_limit](https://user-images.githubusercontent.com/316242/34525679-7bed0596-f0a8-11e7-872a-841a3ed220e2.png)

