### PR TITLE
Skip nil objects in the ems_metadata_tree

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -957,6 +957,7 @@ class MiqRequestWorkflow
 
   def convert_to_xml(xml, result)
     result.each do |obj, children|
+      next if obj.nil?
       @ems_xml_nodes["#{obj.class.base_class}_#{obj.id}"] = node = xml.add_element(obj.class.base_class.name, :object => ci_to_hash_struct(obj))
       convert_to_xml(node, children)
     end


### PR DESCRIPTION
When building the ems_metadata_tree XML it is possible for a nil
relationship (i.e. a Relationship entry pointing to a resource which has
been deleted) to cause MiqRequestWorkflow#convert_to_xml to raise an
exception preventing the provision request from completing.

https://bugzilla.redhat.com/show_bug.cgi?id=1529307