### PR TITLE
[WIP] Tests unique_within_region with class that uses STI 

### DIFF
--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -5,7 +5,7 @@ class CustomizationTemplate < ApplicationRecord
   has_many   :pxe_images, :through => :pxe_image_type
 
   validates :pxe_image_type, :presence => true, :unless => :system?
-  validates :name,           :uniqueness => { :scope => :pxe_image_type }, :unique_within_region => true
+  validates :name,           :unique_within_region => true
 
   scope :with_pxe_image_type_id, ->(pxe_image_type_id) { where(:pxe_image_type_id => pxe_image_type_id) }
   scope :with_system,            ->(bool = true)       { where(:system => bool) }

--- a/spec/factories/customization_template.rb
+++ b/spec/factories/customization_template.rb
@@ -22,7 +22,7 @@ FactoryGirl.define do
   end
 
   factory :customization_template_sysprep do
-    sequence(:name)        { |n| "customization_template_syspre_#{seq_padded_for_sorting(n)}" }
+    sequence(:name)        { |n| "customization_template_sysprep_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "Customization Template Sysprep #{seq_padded_for_sorting(n)}" }
     after(:build) do |x|
       x.pxe_image_type ||= FactoryGirl.create(:pxe_image_type)

--- a/spec/factories/pxe_image_type.rb
+++ b/spec/factories/pxe_image_type.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :pxe_image_type do
+    sequence(:name) { |n| "pxe_image_type_#{seq_padded_for_sorting(n)}" }
   end
 end


### PR DESCRIPTION
This addresses a concern that the CustomizationTemplate class uses STI and thus the unique_within_region validation (that currently uses record.class) being applied to it may not properly scope across leaf classes. The suggestion was to use record.class.base_class instead.


## Depends on 
https://github.com/ManageIQ/manageiq/pull/16775/
  
  
  