### PR TITLE
Graph refresh enhance local db finders

### DIFF
--- a/app/models/manager_refresh/inventory_collection/index/type/base.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/base.rb
@@ -11,6 +11,8 @@ module ManagerRefresh
             @inventory_collection = inventory_collection
             @index_name           = index_name
             @attribute_names      = attribute_names
+
+            assert_attribute_names!
           end
 
           delegate :keys, :to => :index
@@ -41,7 +43,21 @@ module ManagerRefresh
 
           attr_writer :index
 
-          delegate :build_stringified_reference, :data, :to => :inventory_collection
+          delegate :build_stringified_reference, :data, :model_class, :to => :inventory_collection
+
+          def assert_attribute_names!
+            # Skip for manually defined nodes
+            return if model_class.nil?
+
+            # We cannot simply do model_class.method_defined?(attribute_name.to_sym), because e.g. db attributes seems
+            # to be create lazily
+            test_model_object = model_class.new
+            attribute_names.each do |attribute_name|
+              unless test_model_object.respond_to?(attribute_name.to_sym)
+                raise "Invalid definition of index :#{index_name}, there is no attribute :#{attribute_name} on model #{model_class}"
+              end
+            end
+          end
         end
       end
     end

--- a/app/models/manager_refresh/inventory_collection/index/type/base.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/base.rb
@@ -43,11 +43,13 @@ module ManagerRefresh
 
           attr_writer :index
 
-          delegate :build_stringified_reference, :data, :model_class, :to => :inventory_collection
+          delegate :build_stringified_reference, :data, :model_class, :custom_save_block, :to => :inventory_collection
 
           def assert_attribute_names!
             # Skip for manually defined nodes
             return if model_class.nil?
+            # When we do custom saving, we allow any indexes to be passed, to no limit the user
+            return unless custom_save_block.nil?
 
             # We cannot simply do model_class.method_defined?(attribute_name.to_sym), because e.g. db attributes seems
             # to be create lazily

--- a/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
@@ -93,7 +93,7 @@ module ManagerRefresh
             all_values = []
             full_references.each do |ref|
               value = []
-              schema.each do |schema_item_path, _column_name|
+              schema.each_key do |schema_item_path|
                 value << fetch_hash_path(schema_item_path, ref)
               end
               all_values << value

--- a/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
@@ -6,9 +6,9 @@ module ManagerRefresh
           def initialize(inventory_collection, index_name, attribute_names, data_index)
             super
 
-            @index             = nil
-            @loaded_references = Set.new
-            @data_index        = data_index
+            @index                 = nil
+            @loaded_references     = Set.new
+            @data_index            = data_index
             @all_references_loaded = false
           end
 
@@ -39,7 +39,7 @@ module ManagerRefresh
 
           private
 
-          attr_accessor :all_references_loaded
+          attr_accessor :all_references_loaded, :schema
           attr_reader :data_index, :loaded_references
           attr_writer :index
 
@@ -50,18 +50,19 @@ module ManagerRefresh
                    :association_to_foreign_key_mapping,
                    :association_to_foreign_type_mapping,
                    :attribute_references,
-                   :build_multi_selection_condition,
-                   :build_stringified_reference_for_record,
                    :custom_manager_uuid,
                    :custom_db_finder,
                    :data_collection_finalized?,
                    :db_relation,
+                   :inventory_object?,
+                   :inventory_object_lazy?,
                    :model_class,
                    :new_inventory_object,
                    :parent,
                    :references,
                    :strategy,
                    :stringify_joiner,
+                   :table_name,
                    :to => :inventory_collection
 
           alias all_references_loaded? all_references_loaded
@@ -84,71 +85,164 @@ module ManagerRefresh
             # selected << :type if model_class.new.respond_to? :type
             # load_from_db.select(selected).find_each do |record|
 
+            full_references = references[index_name].select { |key, _value| new_references.include?(key) } # O(1) include on Set
+            full_references = full_references.values.map(&:full_reference)
+
+            schema                         = get_schema(full_references)
+            paths                          = schema.keys
+            rails_friendly_includes_schema = get_rails_friendly_includes_schema(paths)
+
+            all_values = []
+            full_references.each do |ref|
+              value = []
+              schema.each do |schema_item_path, _column_name|
+                value << fetch_hash_path(schema_item_path, ref)
+              end
+              all_values << value
+            end
+
             # Return the the correct relation based on strategy and selection&projection
-            selection  = extract_references(new_references) unless strategy == :local_db_cache_all
             projection = nil
 
-            db_relation(selection, projection).find_each do |record|
-              process_db_record!(record)
+            db_relation(rails_friendly_includes_schema, schema.values, all_values, projection).find_each do |record|
+              process_db_record!(record, paths)
             end
+          end
+
+          # Builds a multiselection conditions like (table1.a, table2.b) IN ((a1, b1), (a2, b2))
+          # @param column_names [Array] Array of column names in format "<table_name>.<column_name>"
+          # @param all_values [Array<Array>] nested array of values in format [[a1, b1], [a2, b2]] the nested array
+          #        values must have the order of column_names
+          # @return [String] A condition e.g. (table1.a, table2.b) IN ((a1, b1), (a2, b2)), usable in .where of an
+          #         ActiveRecord relation
+          def build_multi_selection_condition(column_names, all_values)
+            cond_data    = all_values.map do |values|
+              "(#{values.map { |x| ActiveRecord::Base.connection.quote(x) }.join(",")})"
+            end.join(",")
+            column_names = column_names.join(",")
+
+            "(#{column_names}) IN (#{cond_data})"
+          end
+
+          # Traverses the schema_item_path e.g. [:hardware, :vm_or_template, :ems_ref] and gets the value on the path
+          # in hash.
+          # @param path [Array] path for traversing hash e.g. [:hardware, :vm_or_template, :ems_ref]
+          # @param hash [Hash] nested hash with data e.g. {:hardware => {:vm_or_template => {:ems_ref => "value"}}}
+          # @return [Object] value in the Hash on the path, in the example that would be "value"
+          def fetch_hash_path(path, hash)
+            path.inject(hash) { |x, r| x.try(:[], r) }
+          end
+
+          # Traverses the schema_item_path e.g. [:hardware, :vm_or_template, :ems_ref] and gets the value on the path
+          # in object.
+          # @param path [Array] path for traversing hash e.g. [:hardware, :vm_or_template, :ems_ref]
+          # @param object [ApplicationRecord] an ApplicationRecord fetched from the DB
+          # @return [Object] value in the Hash on the path, in the example that would be "value"
+          def fetch_object_path(path, object)
+            path.inject(object) { |x, r| x.public_send(r) }
+          end
+
+          def get_schema(full_references)
+            @schema ||= get_schema_recursive(attribute_names, table_name, full_references.first, {}, [], 0)
+          end
+
+          # Converts an array of paths to attributes in different DB tables into rails friendly format, that can be used
+          # for correct DB JOIN of those tables (references&includes methods)
+          # @param [Array[Array]] Nested array with paths e.g. [[:hardware, :vm_or_template, :ems_ref], [:description]
+          # @return [Array] A rails friendly format for ActiveRecord relation .includes and .references
+          def get_rails_friendly_includes_schema(paths)
+            return @rails_friendly_includes_schema if @rails_friendly_includes_schema
+
+            nested_hashes_schema = {}
+            # Ignore last value in path and build nested hash from paths, e.g. paths
+            # [[:hardware, :vm_or_template, :ems_ref], [:description] will be transformed to
+            # [[:hardware, :vm_or_template]], so only relations we need for DB join and then to nested hash
+            # {:hardware => {:vm_or_template => {}}}
+            paths.map { |x| x[0..-2] }.select { |x| x.present? }.each { |x| nested_hashes_schema.store_path(x, {}) }
+            # Convert nested Hash to Rails friendly format, e.g. {:hardware => {:vm_or_template => {}}} will be
+            # transformed to [:hardware => :vm_or_template]
+            @rails_friendly_includes_schema = transform_hash_to_rails_friendly_array_recursive(nested_hashes_schema, [])
+          end
+
+          def transform_hash_to_rails_friendly_array_recursive(hash, current_layer)
+            array_attributes, hash_attributes = hash.partition { |_key, value| value.blank? }
+
+            array_attributes = array_attributes.map(&:first)
+            current_layer.concat(array_attributes)
+            # current_array.concat(array_attributes)
+            if hash_attributes.present?
+              last_hash_attr = hash_attributes.each_with_object({}) do |(key, value), obj|
+                obj[key] = transform_hash_to_rails_friendly_array_recursive(value, [])
+              end
+              current_layer << last_hash_attr
+            end
+
+            current_layer
+          end
+
+          def get_schema_recursive(attribute_names, table_name, data, schema, path, total_level)
+            raise "Nested too deep" if total_level > 100
+
+            attribute_names.each do |key|
+              new_path = path + [key]
+
+              value = data[key]
+
+              if inventory_object?(value)
+                get_schema_recursive(value.inventory_collection.manager_ref,
+                                     value.inventory_collection.table_name,
+                                     value,
+                                     schema,
+                                     new_path,
+                                     total_level + 1)
+              elsif inventory_object_lazy?(value)
+                get_schema_recursive(value.inventory_collection.index_proxy.named_ref(value.ref),
+                                     value.inventory_collection.table_name,
+                                     value.reference.full_reference,
+                                     schema,
+                                     new_path,
+                                     total_level + 1)
+              else
+                schema[new_path] = "#{table_name}.#{ActiveRecord::Base.connection.quote_column_name(key)}"
+              end
+            end
+
+            schema
           end
 
           def index_references
             Set.new(references[index_name].try(:keys) || [])
           end
 
-          # Return a Rails relation or array that will be used to obtain the records we need to load from the DB
+          # Return a Rails relation that will be used to obtain the records we need to load from the DB
           #
-          # @param selection [Hash] A selection hash resulting in Select operation (in Relation algebra terms)
+          # @param rails_friendly_includes_schema [Array] Schema usable in .includes and .references methods of
+          #        ActiveRecord relation object
+          # @param column_names [Array] Array of column names in format "<table_name>.<column_name>"
+          # @param all_values [Array<Array>] nested array of values in format [[a1, b1], [a2, b2]] the nested array
+          #        values must have the order of column_names
           # @param projection [Array] A projection array resulting in Project operation (in Relation algebra terms)
-          def db_relation(selection = nil, projection = nil)
-            relation = if !custom_db_finder.blank?
-                         custom_db_finder.call(self, selection, projection)
-                       else
-                         rel = if !parent.nil? && !association.nil?
-                                 parent.send(association)
-                               elsif !arel.nil?
-                                 arel
-                               end
-                         rel = rel.where(build_multi_selection_condition(selection)) if rel && selection
-                         rel = rel.select(projection) if rel && projection
-                         rel
+          # @return [ActiveRecord::AssociationRelation] relation object having filtered data
+          def db_relation(rails_friendly_includes_schema, column_names, all_values = nil, projection = nil)
+            relation = if !parent.nil? && !association.nil?
+                         parent.send(association)
+                       elsif !arel.nil?
+                         arel
                        end
-
+            relation = relation.where(build_multi_selection_condition(column_names, all_values)) if relation && all_values
+            relation = relation.select(projection) if relation && projection
+            relation = relation.includes(rails_friendly_includes_schema).references(rails_friendly_includes_schema) if rails_friendly_includes_schema.present?
             relation || model_class.none
-          end
-
-          # Extracting references to a relation friendly format, or a format processable by a custom_db_finder
-          #
-          # @param new_references [Array] array of index_values of the InventoryObjects
-          def extract_references(new_references = [])
-            hash_uuids_by_ref = []
-
-            new_references.each do |index_value|
-              next if index_value.nil?
-              # TODO(lsmola) no need when hashes are the original hashes
-              uuids = index_value.split("__")
-
-              reference = {}
-              attribute_names.each_with_index do |ref, uuid_value|
-                reference[ref] = uuids[uuid_value]
-              end
-              hash_uuids_by_ref << reference
-            end
-            hash_uuids_by_ref
           end
 
           # Takes ApplicationRecord record, converts it to the InventoryObject and places it to index
           #
           # @param record [ApplicationRecord] ApplicationRecord record we want to place to the index
-          def process_db_record!(record)
-            # TODO(lsmola) rethink this. If references will be the full Hash references, we can construct this automatically
-            index_value = if custom_manager_uuid.nil?
-                            build_stringified_reference_for_record(record, attribute_names)
-                          else
-                            # TODO(lsmola) hm this will not really work for the secondary indexes anyway
-                            custom_manager_uuid.call(record).join("__")
-                          end
+          def process_db_record!(record, paths)
+            # Important fact is that the path was added as .includes in the query, so this doesn't generate n+1 queries
+            index_value = ManagerRefresh::InventoryCollection::Reference.stringify_reference(
+              paths.map { |path| fetch_object_path(path, record) }
+            )
 
             attributes = record.attributes.symbolize_keys
             attribute_references.each do |ref|

--- a/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
@@ -114,7 +114,7 @@ module ManagerRefresh
           # @return [String] A condition e.g. (table1.a, table2.b) IN ((a1, b1), (a2, b2)), usable in .where of an
           #         ActiveRecord relation
           def build_multi_selection_condition(column_names, all_values)
-            cond_data    = all_values.map do |values|
+            cond_data = all_values.map do |values|
               "(#{values.map { |x| ActiveRecord::Base.connection.quote(x) }.join(",")})"
             end.join(",")
             column_names = column_names.join(",")
@@ -156,7 +156,7 @@ module ManagerRefresh
             # [[:hardware, :vm_or_template, :ems_ref], [:description] will be transformed to
             # [[:hardware, :vm_or_template]], so only relations we need for DB join and then to nested hash
             # {:hardware => {:vm_or_template => {}}}
-            paths.map { |x| x[0..-2] }.select { |x| x.present? }.each { |x| nested_hashes_schema.store_path(x, {}) }
+            paths.map { |x| x[0..-2] }.select(&:present?).each { |x| nested_hashes_schema.store_path(x, {}) }
             # Convert nested Hash to Rails friendly format, e.g. {:hardware => {:vm_or_template => {}}} will be
             # transformed to [:hardware => :vm_or_template]
             @rails_friendly_includes_schema = transform_hash_to_rails_friendly_array_recursive(nested_hashes_schema, [])

--- a/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/local_db.rb
@@ -50,8 +50,6 @@ module ManagerRefresh
                    :association_to_foreign_key_mapping,
                    :association_to_foreign_type_mapping,
                    :attribute_references,
-                   :custom_manager_uuid,
-                   :custom_db_finder,
                    :data_collection_finalized?,
                    :db_relation,
                    :inventory_object?,

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -5,6 +5,8 @@ module ManagerRefresh
 
       attr_reader :full_reference, :ref, :stringified_reference
 
+      delegate :[], :to => :full_reference
+
       def initialize(data, ref, keys)
         @full_reference = build_full_reference(data, keys)
         @ref            = ref
@@ -29,6 +31,10 @@ module ManagerRefresh
           object_index_with_keys(keys, record)
         end
 
+        def stringify_reference(reference)
+          reference.join(stringify_joiner)
+        end
+
         private
 
         def hash_index_with_keys(keys, hash)
@@ -41,10 +47,6 @@ module ManagerRefresh
 
         def stringify_joiner
           "__"
-        end
-
-        def stringify_reference(reference)
-          reference.join(stringify_joiner)
         end
       end
 

--- a/app/models/manager_refresh/inventory_collection_default.rb
+++ b/app/models/manager_refresh/inventory_collection_default.rb
@@ -114,18 +114,6 @@ class ManagerRefresh::InventoryCollectionDefault
         :use_ar_object                => true,
       }
 
-      attributes[:custom_manager_uuid] = lambda do |hardware|
-        [hardware.vm_or_template.ems_ref]
-      end
-
-      attributes[:custom_db_finder] = lambda do |inventory_collection, selection, _projection|
-        relation = inventory_collection.parent.send(inventory_collection.association)
-                                       .includes(:vm_or_template)
-                                       .references(:vm_or_template)
-        relation = relation.where(:vms => {:ems_ref => selection.map { |x| x[:vm_or_template] }}) unless selection.blank?
-        relation
-      end
-
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.hardwares.joins(:vm_or_template).where(
@@ -182,12 +170,6 @@ class ManagerRefresh::InventoryCollectionDefault
           :storage
         ],
       }
-
-      if extra_attributes[:strategy] == :local_db_cache_all
-        attributes[:custom_manager_uuid] = lambda do |disk|
-          [disk.hardware.vm_or_template.ems_ref, disk.device_name]
-        end
-      end
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }

--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -72,25 +72,6 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
         :parent_inventory_collections => [:vms],
       }
 
-      attributes[:custom_manager_uuid] = lambda do |network|
-        [network.hardware.vm_or_template.ems_ref, network.description]
-      end
-
-      attributes[:custom_db_finder] = lambda do |inventory_collection, selection, _projection|
-        relation = inventory_collection.parent.send(inventory_collection.association)
-                                       .joins(:hardware => :vm_or_template)
-                                       .references(:hardware => :vm_or_template)
-
-        unless selection.blank?
-          vms_ems_refs = selection.map { |x| x[:hardware] }.uniq
-          descriptions = selection.map { |x| x[:description] }.uniq
-
-          relation = relation.where(:hardware => {'vms' => {:ems_ref => vms_ems_refs}})
-          relation = relation.where(:description => descriptions)
-        end
-        relation
-      end
-
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.networks.joins(:hardware => :vm_or_template).where(

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -4,7 +4,7 @@ module ManagerRefresh
 
     attr_reader :reference, :inventory_collection, :key, :default
 
-    delegate :stringified_reference, :ref, :to => :reference
+    delegate :stringified_reference, :ref, :[], :to => :reference
 
     def initialize(inventory_collection, index_data, ref: :manager_ref, key: nil, default: nil)
       @inventory_collection = inventory_collection

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -12,6 +12,7 @@ module ManagerRefresh::SaveCollection
 
         # Private attrs
         @model_class            = inventory_collection.model_class
+        @table_name             = @model_class.table_name
         @primary_key            = @model_class.primary_key
         @arel_primary_key       = @model_class.arel_attribute(@primary_key)
         @unique_index_keys      = inventory_collection.manager_ref_to_cols.map(&:to_sym)
@@ -75,7 +76,7 @@ module ManagerRefresh::SaveCollection
 
       attr_reader :unique_index_keys, :unique_index_keys_to_s, :select_keys, :unique_db_primary_keys, :unique_db_indexes,
                   :primary_key, :arel_primary_key, :record_key_method, :pure_sql_records_fetching, :select_keys_indexes,
-                  :batch_size, :batch_size_for_persisting, :model_class, :serializable_keys, :pg_types
+                  :batch_size, :batch_size_for_persisting, :model_class, :serializable_keys, :pg_types, :table_name
 
       def save!(association)
         attributes_index        = {}

--- a/app/models/manager_refresh/save_collection/saver/sql_helper.rb
+++ b/app/models/manager_refresh/save_collection/saver/sql_helper.rb
@@ -17,7 +17,6 @@ module ManagerRefresh::SaveCollection
 
         # Make sure we don't send a primary_key for INSERT in any form, it could break PG sequencer
         all_attribute_keys_array = all_attribute_keys.to_a - [primary_key.to_s, primary_key.to_sym]
-        table_name               = inventory_collection.model_class.table_name
         values                   = hashes.map do |hash|
           "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x) }.join(",")})"
         end.join(",")
@@ -78,7 +77,6 @@ module ManagerRefresh::SaveCollection
         # We want to ignore type and create timestamps when updating
         all_attribute_keys_array = all_attribute_keys.to_a.delete_if { |x| %i(type created_at created_on).include?(x) }
         all_attribute_keys_array << :id
-        table_name               = inventory_collection.model_class.table_name
 
         values = hashes.map! do |hash|
           "(#{all_attribute_keys_array.map { |x| quote(connection, hash[x], x, true) }.join(",")})"

--- a/spec/models/manager_refresh/helpers/spec_mocked_data.rb
+++ b/spec/models/manager_refresh/helpers/spec_mocked_data.rb
@@ -173,5 +173,54 @@ module SpecMockedData
         :device => @vm4
       )
     )
+
+    @orchestration_stack_0_1 = FactoryGirl.create(
+      :orchestration_stack,
+      orchestration_stack_data("0_1").merge(
+        :parent => nil
+      )
+    )
+
+    @orchestration_stack_1_11 = FactoryGirl.create(
+      :orchestration_stack,
+      orchestration_stack_data("1_11").merge(
+        :parent => @orchestration_stack_0_1
+      )
+    )
+
+    @orchestration_stack_1_12 = FactoryGirl.create(
+      :orchestration_stack,
+      orchestration_stack_data("1_12").merge(
+        :parent => @orchestration_stack_0_1
+      )
+    )
+
+    @orchestration_stack_resource_1_11_1 = FactoryGirl.create(
+      :orchestration_stack_resource,
+      orchestration_stack_resource_data("1_11_1").merge(
+        :stack => @orchestration_stack_1_11
+      )
+    )
+
+    @orchestration_stack_resource_1_11_2 = FactoryGirl.create(
+      :orchestration_stack_resource,
+      orchestration_stack_resource_data("1_11_2").merge(
+        :stack => @orchestration_stack_1_11
+      )
+    )
+
+    @orchestration_stack_resource_1_12_1 = FactoryGirl.create(
+      :orchestration_stack_resource,
+      orchestration_stack_resource_data("1_12_1").merge(
+        :stack => @orchestration_stack_1_12
+      )
+    )
+
+    @orchestration_stack_resource_1_12_2 = FactoryGirl.create(
+      :orchestration_stack_resource,
+      orchestration_stack_resource_data("1_12_2").merge(
+        :stack => @orchestration_stack_1_12
+      )
+    )
   end
 end

--- a/spec/models/manager_refresh/helpers/spec_mocked_data.rb
+++ b/spec/models/manager_refresh/helpers/spec_mocked_data.rb
@@ -35,7 +35,7 @@ module SpecMockedData
     @key_pair2  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(2).merge(:resource => @ems))
     @key_pair3  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(3).merge(:resource => @ems))
 
-    @vm1  = FactoryGirl.create(
+    @vm1 = FactoryGirl.create(
       :vm_cloud,
       vm_data(1).merge(
         :flavor                => @flavor_1,
@@ -55,7 +55,7 @@ module SpecMockedData
         :ext_management_system => @ems,
       )
     )
-    @vm2  = FactoryGirl.create(
+    @vm2 = FactoryGirl.create(
       :vm_cloud,
       vm_data(2).merge(
         :flavor                => @flavor2,
@@ -65,7 +65,7 @@ module SpecMockedData
         :ext_management_system => @ems,
       )
     )
-    @vm4  = FactoryGirl.create(
+    @vm4 = FactoryGirl.create(
       :vm_cloud,
       vm_data(4).merge(
         :location              => 'default_value_unknown',
@@ -73,7 +73,7 @@ module SpecMockedData
       )
     )
 
-    @hardware1  = FactoryGirl.create(
+    @hardware1 = FactoryGirl.create(
       :hardware,
       hardware_data(1).merge(
         :guest_os       => @image1.hardware.guest_os,
@@ -87,7 +87,7 @@ module SpecMockedData
         :vm_or_template => @vm12
       )
     )
-    @hardware2  = FactoryGirl.create(
+    @hardware2 = FactoryGirl.create(
       :hardware,
       hardware_data(2).merge(
         :guest_os       => @image2.hardware.guest_os,
@@ -95,7 +95,7 @@ module SpecMockedData
       )
     )
 
-    @disk1  = FactoryGirl.create(
+    @disk1 = FactoryGirl.create(
       :disk,
       disk_data(1).merge(
         :hardware => @hardware1,
@@ -113,14 +113,14 @@ module SpecMockedData
         :hardware => @hardware12,
       )
     )
-    @disk2  = FactoryGirl.create(
+    @disk2 = FactoryGirl.create(
       :disk,
       disk_data(2).merge(
         :hardware => @hardware2,
       )
     )
 
-    @public_network1  = FactoryGirl.create(
+    @public_network1 = FactoryGirl.create(
       :network,
       public_network_data(1).merge(
         :hardware => @hardware1,
@@ -139,7 +139,7 @@ module SpecMockedData
         :description => "public_2"
       )
     )
-    @public_network2  = FactoryGirl.create(
+    @public_network2 = FactoryGirl.create(
       :network,
       public_network_data(2).merge(
         :hardware => @hardware2,

--- a/spec/models/manager_refresh/helpers/spec_mocked_data.rb
+++ b/spec/models/manager_refresh/helpers/spec_mocked_data.rb
@@ -1,0 +1,177 @@
+module SpecMockedData
+  def initialize_mocked_records
+    @flavor1 = FactoryGirl.create(:flavor, flavor_data(1).merge(:ext_management_system => @ems))
+    @flavor2 = FactoryGirl.create(:flavor, flavor_data(2).merge(:ext_management_system => @ems))
+    @flavor3 = FactoryGirl.create(:flavor, flavor_data(3).merge(:ext_management_system => @ems))
+
+    @image1 = FactoryGirl.create(:miq_template, image_data(1).merge(:ext_management_system => @ems))
+    @image2 = FactoryGirl.create(:miq_template, image_data(2).merge(:ext_management_system => @ems))
+    @image3 = FactoryGirl.create(:miq_template, image_data(3).merge(:ext_management_system => @ems))
+
+    @image_hardware1 = FactoryGirl.create(
+      :hardware,
+      image_hardware_data(1).merge(
+        :guest_os       => "linux_generic_1",
+        :vm_or_template => @image1
+      )
+    )
+    @image_hardware2 = FactoryGirl.create(
+      :hardware,
+      image_hardware_data(2).merge(
+        :guest_os       => "linux_generic_2",
+        :vm_or_template => @image2
+      )
+    )
+    @image_hardware3 = FactoryGirl.create(
+      :hardware,
+      image_hardware_data(3).merge(
+        :guest_os       => "linux_generic_3",
+        :vm_or_template => @image3
+      )
+    )
+
+    @key_pair1  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(1).merge(:resource => @ems))
+    @key_pair12 = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(12).merge(:resource => @ems))
+    @key_pair2  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(2).merge(:resource => @ems))
+    @key_pair3  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(3).merge(:resource => @ems))
+
+    @vm1  = FactoryGirl.create(
+      :vm_cloud,
+      vm_data(1).merge(
+        :flavor                => @flavor_1,
+        :genealogy_parent      => @image1,
+        :key_pairs             => [@key_pair1],
+        :location              => 'host_10_10_10_1.com',
+        :ext_management_system => @ems,
+      )
+    )
+    @vm12 = FactoryGirl.create(
+      :vm_cloud,
+      vm_data(12).merge(
+        :flavor                => @flavor1,
+        :genealogy_parent      => @image1,
+        :key_pairs             => [@key_pair1, @key_pair12],
+        :location              => 'host_10_10_10_1.com',
+        :ext_management_system => @ems,
+      )
+    )
+    @vm2  = FactoryGirl.create(
+      :vm_cloud,
+      vm_data(2).merge(
+        :flavor                => @flavor2,
+        :genealogy_parent      => @image2,
+        :key_pairs             => [@key_pair2],
+        :location              => 'host_10_10_10_2.com',
+        :ext_management_system => @ems,
+      )
+    )
+    @vm4  = FactoryGirl.create(
+      :vm_cloud,
+      vm_data(4).merge(
+        :location              => 'default_value_unknown',
+        :ext_management_system => @ems
+      )
+    )
+
+    @hardware1  = FactoryGirl.create(
+      :hardware,
+      hardware_data(1).merge(
+        :guest_os       => @image1.hardware.guest_os,
+        :vm_or_template => @vm1
+      )
+    )
+    @hardware12 = FactoryGirl.create(
+      :hardware,
+      hardware_data(12).merge(
+        :guest_os       => @image1.hardware.guest_os,
+        :vm_or_template => @vm12
+      )
+    )
+    @hardware2  = FactoryGirl.create(
+      :hardware,
+      hardware_data(2).merge(
+        :guest_os       => @image2.hardware.guest_os,
+        :vm_or_template => @vm2
+      )
+    )
+
+    @disk1  = FactoryGirl.create(
+      :disk,
+      disk_data(1).merge(
+        :hardware => @hardware1,
+      )
+    )
+    @disk12 = FactoryGirl.create(
+      :disk,
+      disk_data(12).merge(
+        :hardware => @hardware12,
+      )
+    )
+    @disk13 = FactoryGirl.create(
+      :disk,
+      disk_data(13).merge(
+        :hardware => @hardware12,
+      )
+    )
+    @disk2  = FactoryGirl.create(
+      :disk,
+      disk_data(2).merge(
+        :hardware => @hardware2,
+      )
+    )
+
+    @public_network1  = FactoryGirl.create(
+      :network,
+      public_network_data(1).merge(
+        :hardware => @hardware1,
+      )
+    )
+    @public_network12 = FactoryGirl.create(
+      :network,
+      public_network_data(12).merge(
+        :hardware => @hardware12,
+      )
+    )
+    @public_network13 = FactoryGirl.create(
+      :network,
+      public_network_data(13).merge(
+        :hardware    => @hardware12,
+        :description => "public_2"
+      )
+    )
+    @public_network2  = FactoryGirl.create(
+      :network,
+      public_network_data(2).merge(
+        :hardware => @hardware2,
+      )
+    )
+
+    @network_port1 = FactoryGirl.create(
+      :network_port,
+      network_port_data(1).merge(
+        :device => @vm1
+      )
+    )
+
+    @network_port12 = FactoryGirl.create(
+      :network_port,
+      network_port_data(12).merge(
+        :device => @vm1
+      )
+    )
+
+    @network_port2 = FactoryGirl.create(
+      :network_port,
+      network_port_data(2).merge(
+        :device => @vm2
+      )
+    )
+
+    @network_port4 = FactoryGirl.create(
+      :network_port,
+      network_port_data(4).merge(
+        :device => @vm4
+      )
+    )
+  end
+end

--- a/spec/models/manager_refresh/helpers/spec_parsed_data.rb
+++ b/spec/models/manager_refresh/helpers/spec_parsed_data.rb
@@ -73,6 +73,7 @@ module SpecParsedData
   def orchestration_stack_data(i, data = {})
     {
       :ems_ref               => "stack_ems_ref_#{i}",
+      :type                  => "ManageIQ::Providers::CloudManager::OrchestrationStack",
       :ext_management_system => @ems,
       :name                  => "stack_name_#{i}",
       :description           => "stack_description_#{i}",

--- a/spec/models/manager_refresh/persister/finders_spec.rb
+++ b/spec/models/manager_refresh/persister/finders_spec.rb
@@ -64,6 +64,22 @@ describe ManagerRefresh::Inventory::Persister do
     end.to(raise_error(expected_error))
   end
 
+  it "checks that we recognize first argument vs passed kwargs" do
+    # This passes nicely
+    lazy_vm = persister.vms.lazy_find({:name => "name"}, :ref => :by_name)
+    expect(lazy_vm.reference.full_reference).to eq(:name => "name")
+
+    # TODO(lsmola) But this fails, since it takes the whole hash as 1st arg, it should correctly raise invalid format
+    expected_error = "Finder has missing keys for index :manager_ref, missing indexes are: [:ems_ref]"
+    expect do
+      persister.vms.lazy_find(:name => "name", :ref => :by_name)
+    end.to(raise_error(expected_error))
+
+    # TODO(lsmola) And this doesn't fail, but the :key is silently ignored, it should also raise invalid format
+    lazy_vm = persister.vms.lazy_find(:ems_ref => "ems_ref_1", :key => :name)
+    expect(lazy_vm.reference.full_reference).to eq(:ems_ref => "ems_ref_1", :key => :name)
+  end
+
   it "checks passing more keys to index passes just fine" do
     # There is not need to force exact match as long as all keys of the index are passed
     vm_lazy_1 = persister.vms.lazy_find({:name => "name", :uid_ems => "uid_ems", :ems_ref => "ems_ref"}, {:ref => :by_uid_ems_and_name})

--- a/spec/models/manager_refresh/persister/local_db_finders_spec.rb
+++ b/spec/models/manager_refresh/persister/local_db_finders_spec.rb
@@ -144,7 +144,53 @@ describe ManagerRefresh::Inventory::Persister do
   end
 
   context "check secondary indexes on Vms" do
+    it "finds Vm by name" do
+      vm1 = persister.vms.lazy_find({:name => vm_data(1)[:name]}, :ref => :by_name).load
+      expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
 
+      expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_name].send(:index).keys).to(
+        match_array(
+          [
+            "vm_name_1",
+          ]
+        )
+      )
+
+      vm1 = persister.vms.find({:name => vm_data(1)[:name]}, :ref => :by_name)
+      expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
+
+      expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_name].send(:index).keys).to(
+        match_array(
+          [
+            "vm_name_1",
+          ]
+        )
+      )
+    end
+
+    it "finds Vm by uid_ems and name" do
+      vm1 = persister.vms.lazy_find({:name => vm_data(1)[:name], :uid_ems => vm_data(1)[:uid_ems]}, :ref => :by_uid_ems_and_name).load
+      expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
+
+      expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_uid_ems_and_name].send(:index).keys).to(
+        match_array(
+          [
+            "vm_uid_ems_1__vm_name_1",
+          ]
+        )
+      )
+
+      vm1 = persister.vms.find({:uid_ems => vm_data(1)[:uid_ems], :name => vm_data(1)[:name]}, :ref => :by_uid_ems_and_name)
+      expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
+
+      expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_uid_ems_and_name].send(:index).keys).to(
+        match_array(
+          [
+            "vm_uid_ems_1__vm_name_1",
+          ]
+        )
+      )
+    end
   end
 
   context "check secondary index with polymorphic relation inside" do

--- a/spec/models/manager_refresh/persister/local_db_finders_spec.rb
+++ b/spec/models/manager_refresh/persister/local_db_finders_spec.rb
@@ -249,5 +249,16 @@ describe ManagerRefresh::Inventory::Persister do
         )
       end.to raise_error("Invalid definition of index :by_availability_zone_and_name, there is no attribute :availability_zone on model Vm")
     end
+
+    it "checks we allow any index attributes when we use custom_saving block" do
+      persister.send(:add_inventory_collection,
+                     :model_class       => ::Vm,
+                     :association       => :vms,
+                     :custom_save_block => ->(ems, _ic) { ems },
+                     :manager_ref       => [:a, :b, :c]
+      )
+
+      expect(persister.vms.index_proxy.send(:data_indexes).keys).to match_array([:manager_ref])
+    end
   end
 end

--- a/spec/models/manager_refresh/persister/local_db_finders_spec.rb
+++ b/spec/models/manager_refresh/persister/local_db_finders_spec.rb
@@ -1,0 +1,165 @@
+require_relative '../helpers/spec_mocked_data'
+require_relative '../helpers/spec_parsed_data'
+require_relative 'test_persister'
+require_relative 'targeted_refresh_spec_helper'
+
+describe ManagerRefresh::Inventory::Persister do
+  include SpecMockedData
+  include SpecParsedData
+  include TargetedRefreshSpecHelper
+
+  ######################################################################################################################
+  # Spec scenarios for making sure the local db index is able to build complex queries using references
+  ######################################################################################################################
+  #
+  before :each do
+    @zone = FactoryGirl.create(:zone)
+    @ems  = FactoryGirl.create(:ems_cloud,
+                               :zone            => @zone,
+                               :network_manager => FactoryGirl.create(:ems_network, :zone => @zone))
+
+    allow(@ems.class).to receive(:ems_type).and_return(:mock)
+    allow(Settings.ems_refresh).to receive(:mock).and_return({})
+  end
+
+  before :each do
+    initialize_mocked_records
+  end
+
+  let(:persister) { create_persister }
+
+  context "check we can load network records from the DB" do
+    it "finds in one batch after the scanning" do
+      lazy_find_vm1        = persister.vms.lazy_find(:ems_ref => vm_data(1)[:ems_ref])
+      lazy_find_vm2        = persister.vms.lazy_find(:ems_ref => vm_data(2)[:ems_ref])
+      lazy_find_vm60       = persister.vms.lazy_find(:ems_ref => vm_data(60)[:ems_ref])
+      lazy_find_hardware1  = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm1)
+      lazy_find_hardware2  = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm2)
+      lazy_find_hardware60 = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm60)
+
+      lazy_find_network1  = persister.networks.lazy_find(
+        {:hardware => lazy_find_hardware1, :description => "public"},
+        :key     => :hostname,
+        :default => 'default_value_unknown')
+      lazy_find_network2  = persister.networks.lazy_find(
+        {:hardware => lazy_find_hardware2, :description => "public"},
+        :key     => :hostname,
+        :default => 'default_value_unknown')
+      lazy_find_network60 = persister.networks.lazy_find(
+        {:hardware => lazy_find_hardware60, :description => "public"},
+        :key     => :hostname,
+        :default => 'default_value_unknown')
+
+      @vm_data101 = vm_data(101).merge(
+        :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
+        :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
+        :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+        :location         => lazy_find_network1,
+      )
+
+      @vm_data102 = vm_data(102).merge(
+        :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
+        :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
+        :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+        :location         => lazy_find_network2,
+      )
+
+      @vm_data160 = vm_data(160).merge(
+        :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
+        :genealogy_parent => persister.miq_templates.lazy_find(:ems_ref => image_data(1)[:ems_ref]),
+        :key_pairs        => [persister.key_pairs.lazy_find(:name => key_pair_data(1)[:name])],
+        :location         => lazy_find_network60,
+      )
+
+      persister.vms.build(@vm_data101)
+      persister.vms.build(@vm_data102)
+      persister.vms.build(@vm_data160)
+
+      ManagerRefresh::InventoryCollection::Scanner.scan!(persister.inventory_collections)
+
+      # Assert the local db index is empty if we do not load the reference
+      expect(persister.networks.index_proxy.send(:local_db_indexes)[:manager_ref].send(:index)).to be_nil
+
+      lazy_find_network1.load
+
+      # Assert all references are loaded at once
+      expect(persister.networks.index_proxy.send(:local_db_indexes)[:manager_ref].send(:index).keys).to(
+        match_array(
+          [
+            "vm_ems_ref_1__public",
+            "vm_ems_ref_2__public"
+          ]
+        )
+      )
+
+      expect(lazy_find_network1.load).to eq ("host_10_10_10_1.com")
+      expect(lazy_find_network2.load).to eq ("host_10_10_10_2.com")
+      expect(lazy_find_network60.load).to eq ("default_value_unknown")
+    end
+
+    it "finds one by one before we scan" do
+      lazy_find_vm1        = persister.vms.lazy_find(:ems_ref => vm_data(1)[:ems_ref])
+      lazy_find_vm2        = persister.vms.lazy_find(:ems_ref => vm_data(2)[:ems_ref])
+      lazy_find_vm60       = persister.vms.lazy_find(:ems_ref => vm_data(60)[:ems_ref])
+      lazy_find_hardware1  = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm1)
+      lazy_find_hardware2  = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm2)
+      lazy_find_hardware60 = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm60)
+      # Assert the local db index is empty if we do not load the reference
+      expect(persister.networks.index_proxy.send(:local_db_indexes)[:manager_ref].send(:index)).to be_nil
+
+      network1 = persister.networks.lazy_find(:hardware => lazy_find_hardware1, :description => "public").load
+      # Assert all references are one by one
+      expect(persister.networks.index_proxy.send(:local_db_indexes)[:manager_ref].send(:index).keys).to(
+        match_array(
+          [
+            "vm_ems_ref_1__public",
+          ]
+        )
+      )
+      network2 = persister.networks.find(:hardware => lazy_find_hardware2, :description => "public")
+      expect(persister.networks.index_proxy.send(:local_db_indexes)[:manager_ref].send(:index).keys).to(
+        match_array(
+          [
+            "vm_ems_ref_1__public",
+            "vm_ems_ref_2__public"
+          ]
+        )
+      )
+      network60 = persister.networks.find(:hardware => lazy_find_hardware60, :description => "public")
+      expect(persister.networks.index_proxy.send(:local_db_indexes)[:manager_ref].send(:index).keys).to(
+        match_array(
+          [
+            "vm_ems_ref_1__public",
+            "vm_ems_ref_2__public"
+          ]
+        )
+      )
+
+      # TODO(lsmola) known weakens, manager_uuid is wrong, but index is correct. So this doesn't affect a functionality
+      # now, but it can be confusing
+      expect(network1.manager_uuid).to eq "__public"
+      expect(network2.manager_uuid).to eq "__public"
+      expect(network60).to be_nil
+    end
+  end
+
+  context "check secondary indexes on Vms" do
+
+  end
+
+  context "check secondary index with polymorphic relation inside" do
+    it "will fail trying to build query using polymorphic column as index" do
+      lazy_find_vm1 = persister.vms.lazy_find(:ems_ref => vm_data(1)[:ems_ref])
+
+      # TODO(lsmola) Will we need to search by polymorphic columns? We do not do that now in any refresh. By design,
+      # polymoprhic columns can't do join (they can, only for 1 table). Maybe union of 1 table joins using polymorphic
+      # relations?
+      # TODO(lsmola) We should probably assert this sooner? Now we are getting a failure trying to add :device in
+      # .includes
+      expect { persister.network_ports.lazy_find({:device => lazy_find_vm1}, :ref => :by_device).load }.to(
+        raise_error(ActiveRecord::EagerLoadPolymorphicError,
+                    "Cannot eagerly load the polymorphic association :device")
+      )
+    end
+  end
+end

--- a/spec/models/manager_refresh/persister/local_db_finders_spec.rb
+++ b/spec/models/manager_refresh/persister/local_db_finders_spec.rb
@@ -37,18 +37,21 @@ describe ManagerRefresh::Inventory::Persister do
       lazy_find_hardware2  = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm2)
       lazy_find_hardware60 = persister.hardwares.lazy_find(:vm_or_template => lazy_find_vm60)
 
-      lazy_find_network1  = persister.networks.lazy_find(
+      lazy_find_network1 = persister.networks.lazy_find(
         {:hardware => lazy_find_hardware1, :description => "public"},
-        :key     => :hostname,
-        :default => 'default_value_unknown')
-      lazy_find_network2  = persister.networks.lazy_find(
+        {:key     => :hostname,
+         :default => 'default_value_unknown'}
+      )
+      lazy_find_network2 = persister.networks.lazy_find(
         {:hardware => lazy_find_hardware2, :description => "public"},
-        :key     => :hostname,
-        :default => 'default_value_unknown')
+        {:key     => :hostname,
+         :default => 'default_value_unknown'}
+      )
       lazy_find_network60 = persister.networks.lazy_find(
         {:hardware => lazy_find_hardware60, :description => "public"},
-        :key     => :hostname,
-        :default => 'default_value_unknown')
+        {:key     => :hostname,
+         :default => 'default_value_unknown'}
+      )
 
       @vm_data101 = vm_data(101).merge(
         :flavor           => persister.flavors.lazy_find(:ems_ref => flavor_data(1)[:name]),
@@ -92,9 +95,9 @@ describe ManagerRefresh::Inventory::Persister do
         )
       )
 
-      expect(lazy_find_network1.load).to eq ("host_10_10_10_1.com")
-      expect(lazy_find_network2.load).to eq ("host_10_10_10_2.com")
-      expect(lazy_find_network60.load).to eq ("default_value_unknown")
+      expect(lazy_find_network1.load).to eq "host_10_10_10_1.com"
+      expect(lazy_find_network2.load).to eq "host_10_10_10_2.com"
+      expect(lazy_find_network60.load).to eq "default_value_unknown"
     end
 
     it "finds one by one before we scan" do
@@ -145,7 +148,7 @@ describe ManagerRefresh::Inventory::Persister do
 
   context "check secondary indexes on Vms" do
     it "finds Vm by name" do
-      vm1 = persister.vms.lazy_find({:name => vm_data(1)[:name]}, :ref => :by_name).load
+      vm1 = persister.vms.lazy_find({:name => vm_data(1)[:name]}, {:ref => :by_name}).load
       expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
 
       expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_name].send(:index).keys).to(
@@ -156,7 +159,7 @@ describe ManagerRefresh::Inventory::Persister do
         )
       )
 
-      vm1 = persister.vms.find({:name => vm_data(1)[:name]}, :ref => :by_name)
+      vm1 = persister.vms.find({:name => vm_data(1)[:name]}, {:ref => :by_name})
       expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
 
       expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_name].send(:index).keys).to(
@@ -169,7 +172,7 @@ describe ManagerRefresh::Inventory::Persister do
     end
 
     it "finds Vm by uid_ems and name" do
-      vm1 = persister.vms.lazy_find({:name => vm_data(1)[:name], :uid_ems => vm_data(1)[:uid_ems]}, :ref => :by_uid_ems_and_name).load
+      vm1 = persister.vms.lazy_find({:name => vm_data(1)[:name], :uid_ems => vm_data(1)[:uid_ems]}, {:ref => :by_uid_ems_and_name}).load
       expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
 
       expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_uid_ems_and_name].send(:index).keys).to(
@@ -180,7 +183,7 @@ describe ManagerRefresh::Inventory::Persister do
         )
       )
 
-      vm1 = persister.vms.find({:uid_ems => vm_data(1)[:uid_ems], :name => vm_data(1)[:name]}, :ref => :by_uid_ems_and_name)
+      vm1 = persister.vms.find({:uid_ems => vm_data(1)[:uid_ems], :name => vm_data(1)[:name]}, {:ref => :by_uid_ems_and_name})
       expect(vm1[:ems_ref]).to eq "vm_ems_ref_1"
 
       expect(persister.vms.index_proxy.send(:local_db_indexes)[:by_uid_ems_and_name].send(:index).keys).to(
@@ -202,7 +205,7 @@ describe ManagerRefresh::Inventory::Persister do
       # relations?
       # TODO(lsmola) We should probably assert this sooner? Now we are getting a failure trying to add :device in
       # .includes
-      expect { persister.network_ports.lazy_find({:device => lazy_find_vm1}, :ref => :by_device).load }.to(
+      expect { persister.network_ports.lazy_find({:device => lazy_find_vm1}, {:ref => :by_device}).load }.to(
         raise_error(ActiveRecord::EagerLoadPolymorphicError,
                     "Cannot eagerly load the polymorphic association :device")
       )
@@ -215,8 +218,7 @@ describe ManagerRefresh::Inventory::Persister do
         persister.send(:add_inventory_collection,
                        :model_class => ::Vm,
                        :association => :vms,
-                       :manager_ref => [:ems_ref, :ems_gref]
-        )
+                       :manager_ref => %i(ems_ref ems_gref))
       end.to raise_error("Invalid definition of index :manager_ref, there is no attribute :ems_gref on model Vm")
     end
 
@@ -225,8 +227,7 @@ describe ManagerRefresh::Inventory::Persister do
         persister.send(:add_inventory_collection,
                        :model_class    => ::Vm,
                        :association    => :vms,
-                       :secondary_refs => {:by_uid_ems_and_name => %i(uid_emsa name)}
-        )
+                       :secondary_refs => {:by_uid_ems_and_name => %i(uid_emsa name)})
       end.to raise_error("Invalid definition of index :by_uid_ems_and_name, there is no attribute :uid_emsa on model Vm")
     end
 
@@ -234,10 +235,9 @@ describe ManagerRefresh::Inventory::Persister do
       persister.send(:add_inventory_collection,
                      :model_class    => ::ManageIQ::Providers::CloudManager::Vm,
                      :association    => :vms,
-                     :secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)}
-      )
+                     :secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)})
 
-      expect(persister.vms.index_proxy.send(:data_indexes).keys).to match_array([:manager_ref, :by_availability_zone_and_name])
+      expect(persister.vms.index_proxy.send(:data_indexes).keys).to match_array(%i(manager_ref by_availability_zone_and_name))
     end
 
     it "checks relation is on model class" do
@@ -245,8 +245,7 @@ describe ManagerRefresh::Inventory::Persister do
         persister.send(:add_inventory_collection,
                        :model_class    => ::Vm,
                        :association    => :vms,
-                       :secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)}
-        )
+                       :secondary_refs => {:by_availability_zone_and_name => %i(availability_zone name)})
       end.to raise_error("Invalid definition of index :by_availability_zone_and_name, there is no attribute :availability_zone on model Vm")
     end
 
@@ -255,8 +254,7 @@ describe ManagerRefresh::Inventory::Persister do
                      :model_class       => ::Vm,
                      :association       => :vms,
                      :custom_save_block => ->(ems, _ic) { ems },
-                     :manager_ref       => [:a, :b, :c]
-      )
+                     :manager_ref       => %i(a b c))
 
       expect(persister.vms.index_proxy.send(:data_indexes).keys).to match_array([:manager_ref])
     end

--- a/spec/models/manager_refresh/persister/test_persister.rb
+++ b/spec/models/manager_refresh/persister/test_persister.rb
@@ -104,10 +104,6 @@ class TestPersister < ManagerRefresh::Inventory::Persister
   end
 
   def add_inventory_collection(options)
-    # For tests we want to make sure the db based params are not filled
-    options[:custom_manager_uuid] = nil
-    options[:custom_db_finder]    = nil
-
     super(options)
   end
 

--- a/spec/models/manager_refresh/persister/test_persister.rb
+++ b/spec/models/manager_refresh/persister/test_persister.rb
@@ -39,7 +39,8 @@ class TestPersister < ManagerRefresh::Inventory::Persister
       network,
       :network_ports,
       references(:vms) + references(:network_ports) + references(:load_balancers),
-      :parent => manager.network_manager
+      :parent         => manager.network_manager,
+      :secondary_refs => {:by_device => [:device], :by_device_and_name => [:device, :name]}
     )
 
     add_inventory_collection_with_references(
@@ -105,7 +106,7 @@ class TestPersister < ManagerRefresh::Inventory::Persister
   def add_inventory_collection(options)
     # For tests we want to make sure the db based params are not filled
     options[:custom_manager_uuid] = nil
-    options[:custom_db_finder] = nil
+    options[:custom_db_finder]    = nil
 
     super(options)
   end
@@ -116,6 +117,13 @@ class TestPersister < ManagerRefresh::Inventory::Persister
 
   def strategy
     :local_db_find_missing_references
+  end
+
+  def shared_options
+    {
+      :strategy => strategy,
+      :targeted => targeted,
+    }
   end
 
   def references(collection)

--- a/spec/models/manager_refresh/persister/test_persister.rb
+++ b/spec/models/manager_refresh/persister/test_persister.rb
@@ -21,7 +21,13 @@ class TestPersister < ManagerRefresh::Inventory::Persister
     # Child models with references in the Parent InventoryCollections for Cloud
     add_inventory_collections(
       cloud,
-      %i(hardwares networks disks vm_and_template_labels orchestration_stacks_resources orchestration_stacks_outputs
+      %i(orchestration_stacks_resources),
+      :secondary_refs => {:by_stack_and_ems_ref => %i(stack ems_ref)}
+    )
+
+    add_inventory_collections(
+      cloud,
+      %i(hardwares networks disks vm_and_template_labels orchestration_stacks_outputs
          orchestration_stacks_parameters)
     )
 
@@ -40,7 +46,7 @@ class TestPersister < ManagerRefresh::Inventory::Persister
       :network_ports,
       references(:vms) + references(:network_ports) + references(:load_balancers),
       :parent         => manager.network_manager,
-      :secondary_refs => {:by_device => [:device], :by_device_and_name => [:device, :name]}
+      :secondary_refs => {:by_device => [:device], :by_device_and_name => %i(device name)}
     )
 
     add_inventory_collection_with_references(

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -1,9 +1,11 @@
 require_relative 'spec_helper'
 require_relative '../helpers/spec_parsed_data'
+require_relative '../helpers/spec_mocked_data'
 
 describe ManagerRefresh::SaveInventory do
   include SpecHelper
   include SpecParsedData
+  include SpecMockedData
 
   ######################################################################################################################
   #
@@ -903,154 +905,6 @@ describe ManagerRefresh::SaveInventory do
 
     @public_network_data_2 = public_network_data(2).merge(
       :hardware => @data[:hardwares].lazy_find(@data[:vms].lazy_find(vm_data(2)[:ems_ref])),
-    )
-  end
-
-  def initialize_mocked_records
-    @flavor1 = FactoryGirl.create(:flavor, flavor_data(1).merge(:ext_management_system => @ems))
-    @flavor2 = FactoryGirl.create(:flavor, flavor_data(2).merge(:ext_management_system => @ems))
-    @flavor3 = FactoryGirl.create(:flavor, flavor_data(3).merge(:ext_management_system => @ems))
-
-    @image1 = FactoryGirl.create(:miq_template, image_data(1).merge(:ext_management_system => @ems))
-    @image2 = FactoryGirl.create(:miq_template, image_data(2).merge(:ext_management_system => @ems))
-    @image3 = FactoryGirl.create(:miq_template, image_data(3).merge(:ext_management_system => @ems))
-
-    @image_hardware1 = FactoryGirl.create(
-      :hardware,
-      image_hardware_data(1).merge(
-        :guest_os       => "linux_generic_1",
-        :vm_or_template => @image1
-      )
-    )
-    @image_hardware2 = FactoryGirl.create(
-      :hardware,
-      image_hardware_data(2).merge(
-        :guest_os       => "linux_generic_2",
-        :vm_or_template => @image2
-      )
-    )
-    @image_hardware3 = FactoryGirl.create(
-      :hardware,
-      image_hardware_data(3).merge(
-        :guest_os       => "linux_generic_3",
-        :vm_or_template => @image3
-      )
-    )
-
-    @key_pair1  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(1).merge(:resource => @ems))
-    @key_pair12 = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(12).merge(:resource => @ems))
-    @key_pair2  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(2).merge(:resource => @ems))
-    @key_pair3  = FactoryGirl.create(:auth_key_pair_cloud, key_pair_data(3).merge(:resource => @ems))
-
-    @vm1 = FactoryGirl.create(
-      :vm_cloud,
-      vm_data(1).merge(
-        :flavor                => @flavor_1,
-        :genealogy_parent      => @image1,
-        :key_pairs             => [@key_pair1],
-        :location              => 'host_10_10_10_1.com',
-        :ext_management_system => @ems,
-      )
-    )
-    @vm12 = FactoryGirl.create(
-      :vm_cloud,
-      vm_data(12).merge(
-        :flavor                => @flavor1,
-        :genealogy_parent      => @image1,
-        :key_pairs             => [@key_pair1, @key_pair12],
-        :location              => 'host_10_10_10_1.com',
-        :ext_management_system => @ems,
-      )
-    )
-    @vm2 = FactoryGirl.create(
-      :vm_cloud,
-      vm_data(2).merge(
-        :flavor                => @flavor2,
-        :genealogy_parent      => @image2,
-        :key_pairs             => [@key_pair2],
-        :location              => 'host_10_10_10_2.com',
-        :ext_management_system => @ems,
-      )
-    )
-    @vm4 = FactoryGirl.create(
-      :vm_cloud,
-      vm_data(4).merge(
-        :location              => 'default_value_unknown',
-        :ext_management_system => @ems
-      )
-    )
-
-    @hardware1 = FactoryGirl.create(
-      :hardware,
-      hardware_data(1).merge(
-        :guest_os       => @image1.hardware.guest_os,
-        :vm_or_template => @vm1
-      )
-    )
-    @hardware12 = FactoryGirl.create(
-      :hardware,
-      hardware_data(12).merge(
-        :guest_os       => @image1.hardware.guest_os,
-        :vm_or_template => @vm12
-      )
-    )
-    @hardware2 = FactoryGirl.create(
-      :hardware,
-      hardware_data(2).merge(
-        :guest_os       => @image2.hardware.guest_os,
-        :vm_or_template => @vm2
-      )
-    )
-
-    @disk1 = FactoryGirl.create(
-      :disk,
-      disk_data(1).merge(
-        :hardware => @hardware1,
-      )
-    )
-    @disk12 = FactoryGirl.create(
-      :disk,
-      disk_data(12).merge(
-        :hardware => @hardware12,
-      )
-    )
-    @disk13 = FactoryGirl.create(
-      :disk,
-      disk_data(13).merge(
-        :hardware => @hardware12,
-      )
-    )
-    @disk2 = FactoryGirl.create(
-      :disk,
-      disk_data(2).merge(
-        :hardware => @hardware2,
-      )
-    )
-
-    @public_network1 = FactoryGirl.create(
-      :network,
-      public_network_data(1).merge(
-        :hardware => @hardware1,
-      )
-    )
-    @public_network12 = FactoryGirl.create(
-      :network,
-      public_network_data(12).merge(
-        :hardware => @hardware12,
-      )
-    )
-    @public_network13 = FactoryGirl.create(
-      :network,
-      public_network_data(13).merge(
-        :hardware    => @hardware12,
-        :description => "public_2"
-      )
-    )
-    @public_network2 = FactoryGirl.create(
-      :network,
-      public_network_data(2).merge(
-        :hardware => @hardware2,
-      )
     )
   end
 end

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -425,7 +425,6 @@ describe ManagerRefresh::SaveInventory do
           :arel                => @ems.hardwares,
           :manager_ref         => [:vm_or_template],
           :strategy            => :local_db_cache_all,
-          :custom_manager_uuid => ->(hardware) { [hardware.vm_or_template.try(:ems_ref)] },
           :name                => :image_hardwares,
         )
 


### PR DESCRIPTION
Depends on:

- [x] https://github.com/ManageIQ/manageiq/pull/16659

By enhancing local db find index, we can get rid of options ```:custom_manager_uuid``` and ```custom_db_finder``` since we can infer these automatically now. Doing this we also bring support of local db indexes for secondary indexes.