### PR TITLE
Scan Storage via EMS not Host

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -69,6 +69,8 @@ class Storage < ApplicationRecord
   supports :smartstate_analysis do
     if ext_management_systems.blank? || !ext_management_system.class.supports_smartstate_analysis?
       unsupported_reason_add(:smartstate_analysis, _("Smartstate Analysis cannot be performed on selected Datastore"))
+    elsif ext_management_systems_with_authentication_status_ok.blank?
+      unsupported_reason_add(:smartstate_analysis, _("There are no EMSs with valid credentials for this Datastore"))
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1036,7 +1036,7 @@
       - vmtx
       - vswp
       - "%redo%"
-  :max_parallel_scans_per_host: 1
+  :max_parallel_scans_per_ems: 5
   :max_qitems_per_scan_request: 0
   :watchdog_interval: 1.minute
 :task:

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -139,6 +139,13 @@ FactoryGirl.define do
     end
   end
 
+  factory :ems_vmware_with_valid_authentication,
+          :parent => :ems_vmware do
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication, :status => "Valid")
+    end
+  end
+
   factory :ems_microsoft,
           :aliases => ["manageiq/providers/microsoft/infra_manager"],
           :class   => "ManageIQ::Providers::Microsoft::InfraManager",


### PR DESCRIPTION
Storages are currently scanned via a host which the user has added
valid credentials for.  Storages are looked up by name which can be
different between the vCenter (where the refresh is done) and the ESXi
Host (where the scan is done).  If the name is different the scan will
fail with the following error:
`[MiqException::MiqVimResourceNotFound]: Could not find datastore: NFS-Datastore-1`

Since datastore files are scanned via the VIM SDK there is no
requirement on running the scan through the host.  We can scan the
datastore through the EMS and remove the restriction on needing to add
host credentials to be able to run storage smartstate.

Depends https://github.com/ManageIQ/manageiq-providers-vmware/pull/170
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1529725