### PR TITLE
Adds unique within region check to pxe image type names

### DIFF
--- a/app/models/pxe_image_type.rb
+++ b/app/models/pxe_image_type.rb
@@ -4,7 +4,7 @@ class PxeImageType < ApplicationRecord
   has_many :windows_images
   has_many :iso_images
 
-  validates_uniqueness_of :name
+  validates :name, :unique_within_region => true
 
   def self.seed_file_name
     @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")


### PR DESCRIPTION
I'm pretty sure these template names should be unique _by region_.

https://github.com/ManageIQ/manageiq/issues/16739 led me to this issue. 