### PR TITLE
[FINE] Introduce $vcloud_log (backporting to fine branch)

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -18,6 +18,7 @@ GlobalVars:
   - $scvmm_log
   - $vim_log
   - $websocket_log
+  - $vcloud_log
   # In Automate methods
   - $evm
 #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1024,6 +1024,8 @@
   :level_vim_in_evm: error
   :level_websocket: info
   :level_websocket_in_evm: error
+  :level_vcloud: info
+  :level_vcloud_in_evm: error
 :management_system:
   :power_operation_expiration: 10.minutes
 :performance:

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -37,6 +37,7 @@ module Vmdb
       apply_config_value(config, $azure_log,         :level_azure,         :level_azure_in_evm)
       apply_config_value(config, $lenovo_log,        :level_lenovo,        :level_lenovo_in_evm)
       apply_config_value(config, $websocket_log,     :level_websocket,     :level_websocket_in_evm)
+      apply_config_value(config, $vcloud_log,        :level_vcloud,        :level_vcloud_in_evm)
     end
 
     private
@@ -69,6 +70,7 @@ module Vmdb
         $websocket_log     = MirroredLogger.new(path_dir.join("websocket.log"),     "<WEBSOCKET> ")
         $miq_ae_logger     = MirroredLogger.new(path_dir.join("automation.log"),    "<AutomationEngine> ")
         $miq_ae_logger.mirror_level = VMDBLogger::INFO
+        $vcloud_log        = MirroredLogger.new(path_dir.join("vcloud.log"),        "<VCLOUD> ")
       end
 
       configure_external_loggers


### PR DESCRIPTION
There is a [PR](https://github.com/ManageIQ/manageiq/pull/16641) already merged in master that introduces `$vcloud_log`, but since logging has changed in this [PR](https://github.com/ManageIQ/manageiq/pull/15397), there are merge conflicts for fine branch. Hence this commit.

@miq-bot assign @simaishi

/cc @gberginc