### PR TITLE
Replace deprecated be_same_time_as matcher

### DIFF
--- a/spec/support/custom_matchers/have_attributes.rb
+++ b/spec/support/custom_matchers/have_attributes.rb
@@ -19,7 +19,7 @@ RSpec::Matchers.define :have_attributes do |attrs|
           end
 
         matcher = if actual.respond_to?(:acts_like_time?) && expected.respond_to?(:acts_like_time?)
-                    be_same_time_as(expected)
+                    be_within(0.1).of(expected)
                   elsif expected.kind_of?(RSpec::Matchers::BuiltIn::Match)
                     match(expected.expected)
                   else


### PR DESCRIPTION
When test suite is run, a few warnings about deprecated `be_same_time_as` matcher pop up.

Since deprecation warning clearly stated what should be used to replace the phased-out matcher, we went ahead and replaced the last remaining occurrence from the repository.

Related issue: [Rspec deprecation warnings](#16326)

/cc @gberginc