### PR TITLE
Reconnect host on provider add

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -281,9 +281,45 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :builder_params              => {
           :ems_id => ->(persister) { persister.manager.id },
         },
+        :custom_reconnect_block      => reconnect_block
       }
 
       attributes.merge!(extra_attributes)
+    end
+
+    def vms(extra_attributes = {})
+      attributes = {
+        :custom_reconnect_block => reconnect_block
+      }
+
+      super(attributes.merge!(extra_attributes))
+    end
+
+    def reconnect_block
+      lambda do |inventory_collection, inventory_objects_index, attributes_index|
+        relation = inventory_collection.model_class.where(:ems_id => nil)
+
+        return if relation.count <= 0
+
+        inventory_objects_index.each_slice(100) do |batch|
+          relation.where(inventory_collection.manager_ref.first => batch.map(&:first)).each do |record|
+            index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
+
+            # We need to delete the record from the inventory_objects_index and attributes_index, otherwise it
+            # would be sent for create.
+            inventory_object = inventory_objects_index.delete(index)
+            hash             = attributes_index.delete(index)
+
+            record.assign_attributes(hash.except(:id, :type))
+            if !inventory_collection.check_changed? || record.changed?
+              record.save!
+              inventory_collection.store_updated_records(record)
+            end
+
+            inventory_object.id = record.id
+          end
+        end
+      end
     end
 
     def host_storages(extra_attributes = {})


### PR DESCRIPTION
We need to make sure that when we remove a provider and add it again we
will keep using the same host entities. Without this change add and remove
provider cause to duplicate hosts.

Fixes https://bugzilla.redhat.com/1528859