### PR TITLE
Log Decorator is required by VMDB::Loggers, but not in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "kubeclient",                     "~>2.4.0",       :require => false # For scaling pods at runtime
 gem "linux_admin",                    "~>1.2.0",       :require => false
+gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
 gem "manageiq-network_discovery",     "~>0.1.2",       :require => false


### PR DESCRIPTION
It seems to only be required in Amazon SSA Support gem.
Meaning if that gem isn't included ManageIQ doesn't run.