### PR TITLE
Removes test that is no longer necessary since label is now name

### DIFF
--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -22,11 +22,6 @@ describe Dialog do
     end
   end
 
-  it "#name" do
-    dialog = FactoryGirl.create(:dialog, :label => 'dialog')
-    expect(dialog.label).to eq(dialog.name)
-  end
-
   describe "#content" do
     it "returns the serialized content" do
       dialog = FactoryGirl.create(:dialog, :description => "foo", :label => "bar")


### PR DESCRIPTION
Label is now a goner, so we shouldn't need test that says that label should be equivalent to name. 


