### PR TITLE
[WIP] Deletion not allowed for a group if the group is the login group for any user

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -273,9 +273,14 @@ class MiqGroup < ApplicationRecord
     id == current_user_group.try(:id)
   end
 
+  def current_group_for_any_user?
+    users.where(:current_group_id => id).count != 0
+  end
+
   def ensure_can_be_destroyed
     raise _("The login group cannot be deleted") if current_user_group?
     raise _("The group has users assigned that do not belong to any other group") if single_group_users?
+    raise _("The group is the login group for at least one user in the group") if current_group_for_any_users?
     raise _("A tenant default group can not be deleted") if tenant_group? && referenced_by_tenant?
     raise _("A read only group cannot be deleted.") if system_group?
   end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -280,7 +280,7 @@ class MiqGroup < ApplicationRecord
   def ensure_can_be_destroyed
     raise _("The login group cannot be deleted") if current_user_group?
     raise _("The group has users assigned that do not belong to any other group") if single_group_users?
-    raise _("The group is the login group for at least one user in the group") if current_group_for_any_users?
+    raise _("The group is the login group for at least one user in the group") if current_group_for_any_user?
     raise _("A tenant default group can not be deleted") if tenant_group? && referenced_by_tenant?
     raise _("A read only group cannot be deleted.") if system_group?
   end


### PR DESCRIPTION
Deletion not allowed for a group if the group is the login group for any user

Links 
---------
https://bugzilla.redhat.com/show_bug.cgi?id=1264967

Steps for Testing/QA 
-------------------------------
