### PR TITLE
adding missing factories for openscap_result

### DIFF
--- a/spec/factories/openscap_result.rb
+++ b/spec/factories/openscap_result.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :openscap_result_skip_callback, :class => OpenscapResult do
+    # This callback can be very annoying and handicaping in tests
+    after(:build) { |r| r.class.skip_callback(:save, :before, :create_rule_results, :raise => false) }
+  end
+
+  factory :openscap_result
+end

--- a/spec/factories/openscap_rule_result.rb
+++ b/spec/factories/openscap_rule_result.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :openscap_rule_result
+end


### PR DESCRIPTION
Adding missing factories needed for tests.

There are similar facories in [1][2] but they are needed in other repositories now (manageiq-api).

I disabled the `create_rule_results` before save callback because it is very limiting in tests: it requires the binary blob to be of a real Scap result file, and creates unwanted rule_results out of it. In most tests it would be much easier to create them manually instead.

This is coupled with https://github.com/ManageIQ/manageiq-providers-openshift/pull/82

[1] https://github.com/ManageIQ/manageiq-providers-openshift/blob/master/spec/factories/openscap_result.rb
[2] https://github.com/ManageIQ/manageiq-providers-openshift/blob/master/spec/factories/openscap_rule_result.rb