### PR TITLE
Change aliases for container entities

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -700,23 +700,23 @@ en:
       Compliance:               Compliance History
       Compliances:              Compliance History
       Condition:                Condition
-      ContainerBuild:           Build
+      ContainerBuild:           Container Build
       ContainerQuota:           Container Quota
       CustomButton:             Button
       CustomButtonSet:          Button Group
       ConfigurationScriptSource: Repository
       Container:                Container
       ContainerPerformance:     Performance - Container
-      ContainerGroup:           Pod
+      ContainerGroup:           Container Pod
       ContainerGroupPerformance: Performance - Pod
-      ContainerImageRegistry:   Image Registry
+      ContainerImageRegistry:   Container Image Registry
       ContainerImage:           Container Image
-      ContainerNode:            Node
+      ContainerNode:            Container Node
       ContainerNodePerformance: Performance - Container Node
-      ContainerProject:         Project
-      ContainerProjectPerformance: Performance - ContainerProject
-      ContainerRoute:           Route
-      ContainerReplicator:      Replicator
+      ContainerProject:         Container Project
+      ContainerProjectPerformance: Performance - Container Project
+      ContainerRoute:           Container Route
+      ContainerReplicator:      Container Replicator
       ContainerService:         Container Service
       ContainerTemplate:        Container Template
       EmsCluster:               Cluster / Deployment Role


### PR DESCRIPTION
Currently there are a number of Container related entities who's aliases create confusion. (See `Node` vs `Host / Node` in screenshot).

This PR fixes this issue.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1513420
cc: @himdel @Loicavenel 

Screenshot:
![host-node-issue](https://user-images.githubusercontent.com/8366181/34673654-a769c966-f48b-11e7-8976-eb61319e5eb7.png)


  