### PR TITLE
Remove missing factory spec and all blank factories

### DIFF
--- a/spec/factories/advanced_setting.rb
+++ b/spec/factories/advanced_setting.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :advanced_setting
-end

--- a/spec/factories/application_record.rb
+++ b/spec/factories/application_record.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :application_record
-end

--- a/spec/factories/asset_details.rb
+++ b/spec/factories/asset_details.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :asset_detail
-end

--- a/spec/factories/asset_tag_import.rb
+++ b/spec/factories/asset_tag_import.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :asset_tag_import
-end

--- a/spec/factories/audit_event.rb
+++ b/spec/factories/audit_event.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :audit_event
-end

--- a/spec/factories/auth_private_key.rb
+++ b/spec/factories/auth_private_key.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :auth_private_key
-end

--- a/spec/factories/auth_token.rb
+++ b/spec/factories/auth_token.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :auth_token
-end

--- a/spec/factories/auth_userid_password.rb
+++ b/spec/factories/auth_userid_password.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :auth_userid_password
-end

--- a/spec/factories/authentication_configuration_script_base.rb
+++ b/spec/factories/authentication_configuration_script_base.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :authentication_configuration_script_base
-end

--- a/spec/factories/authentication_orchestration_stack.rb
+++ b/spec/factories/authentication_orchestration_stack.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :authentication_orchestration_stack
-end

--- a/spec/factories/authentication_rhsm.rb
+++ b/spec/factories/authentication_rhsm.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :authentication_rhsm
-end

--- a/spec/factories/authenticator.rb
+++ b/spec/factories/authenticator.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :authenticator
-end

--- a/spec/factories/binary_blob.rb
+++ b/spec/factories/binary_blob.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :binary_blob do
-  end
-end

--- a/spec/factories/binary_blob_part.rb
+++ b/spec/factories/binary_blob_part.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :binary_blob_part do
-  end
-end

--- a/spec/factories/bottleneck_event.rb
+++ b/spec/factories/bottleneck_event.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :bottleneck_event, :class => "BottleneckEvent" do
-  end
-end

--- a/spec/factories/chargeback.rb
+++ b/spec/factories/chargeback.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :chargeback
-end

--- a/spec/factories/chargeback_container_image.rb
+++ b/spec/factories/chargeback_container_image.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :chargeback_container_image
-end

--- a/spec/factories/chargeback_container_project.rb
+++ b/spec/factories/chargeback_container_project.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :chargeback_container_project
-end

--- a/spec/factories/chargeback_vm.rb
+++ b/spec/factories/chargeback_vm.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :chargeback_vm
-end

--- a/spec/factories/classification_import.rb
+++ b/spec/factories/classification_import.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :classification_import
-end

--- a/spec/factories/cloud_database.rb
+++ b/spec/factories/cloud_database.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :cloud_database
-end

--- a/spec/factories/cloud_database_flavor.rb
+++ b/spec/factories/cloud_database_flavor.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :cloud_database_flavor
-end

--- a/spec/factories/cloud_object.rb
+++ b/spec/factories/cloud_object.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :cloud_object_store_container, :class => "CloudObjectStoreContainer"
-
-  factory :cloud_object_store_object, :class => "CloudObjectStoreObject"
-end

--- a/spec/factories/cloud_resource_quota.rb
+++ b/spec/factories/cloud_resource_quota.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :cloud_resource_quota
-end

--- a/spec/factories/cloud_subnet_network_port.rb
+++ b/spec/factories/cloud_subnet_network_port.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :cloud_subnet_network_port
-end

--- a/spec/factories/cloud_tenant_flavor.rb
+++ b/spec/factories/cloud_tenant_flavor.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :cloud_tenant_flavor do
-    # mapping of cloud_tenant to flavor
-  end
-end

--- a/spec/factories/compute_node.rb
+++ b/spec/factories/compute_node.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :compute_node
-end

--- a/spec/factories/computer_system.rb
+++ b/spec/factories/computer_system.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :computer_system do
-  end
-end

--- a/spec/factories/condition_set.rb
+++ b/spec/factories/condition_set.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :condition_set
-end

--- a/spec/factories/configuration_architecture.rb
+++ b/spec/factories/configuration_architecture.rb
@@ -1,1 +1,0 @@
-FactoryGirl.define { factory :configuration_architecture }

--- a/spec/factories/configuration_compute_profile.rb
+++ b/spec/factories/configuration_compute_profile.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :configuration_compute_profile
-end

--- a/spec/factories/configuration_domain.rb
+++ b/spec/factories/configuration_domain.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :configuration_domain
-end

--- a/spec/factories/configuration_environment.rb
+++ b/spec/factories/configuration_environment.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :configuration_environment
-end

--- a/spec/factories/configuration_realm.rb
+++ b/spec/factories/configuration_realm.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :configuration_realm
-end

--- a/spec/factories/configuration_tag.rb
+++ b/spec/factories/configuration_tag.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :configuration_tag
-end

--- a/spec/factories/container_build.rb
+++ b/spec/factories/container_build.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_build
-end

--- a/spec/factories/container_build_pod.rb
+++ b/spec/factories/container_build_pod.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_build_pod
-end

--- a/spec/factories/container_condition.rb
+++ b/spec/factories/container_condition.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_condition
-end

--- a/spec/factories/container_deployment.rb
+++ b/spec/factories/container_deployment.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :container_deployment, :class => "ContainerDeployment" do
-  end
-end

--- a/spec/factories/container_deployment_node.rb
+++ b/spec/factories/container_deployment_node.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :container_deployment_node, :class => "ContainerDeploymentNode" do
-  end
-end

--- a/spec/factories/container_env_var.rb
+++ b/spec/factories/container_env_var.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_env_var
-end

--- a/spec/factories/container_group_performance.rb
+++ b/spec/factories/container_group_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_group_performance
-end

--- a/spec/factories/container_groups_container_services.rb
+++ b/spec/factories/container_groups_container_services.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_groups_container_services
-end

--- a/spec/factories/container_limit.rb
+++ b/spec/factories/container_limit.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_limit
-end

--- a/spec/factories/container_limit_item.rb
+++ b/spec/factories/container_limit_item.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_limit_item
-end

--- a/spec/factories/container_node_performance.rb
+++ b/spec/factories/container_node_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_node_performance
-end

--- a/spec/factories/container_performance.rb
+++ b/spec/factories/container_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_performance
-end

--- a/spec/factories/container_port_config.rb
+++ b/spec/factories/container_port_config.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_port_config
-end

--- a/spec/factories/container_project_performance.rb
+++ b/spec/factories/container_project_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_project_performance
-end

--- a/spec/factories/container_quota.rb
+++ b/spec/factories/container_quota.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_quota
-end

--- a/spec/factories/container_quota_item.rb
+++ b/spec/factories/container_quota_item.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_quota_item
-end

--- a/spec/factories/container_service_port_config.rb
+++ b/spec/factories/container_service_port_config.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_service_port_config
-end

--- a/spec/factories/container_template.rb
+++ b/spec/factories/container_template.rb
@@ -1,4 +1,1 @@
-FactoryGirl.define do
-  factory :container_template do
-  end
-end
+FactoryGirl.define { factory(:container_template) }

--- a/spec/factories/container_template_parameter.rb
+++ b/spec/factories/container_template_parameter.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :container_template_parameter do
-  end
-end

--- a/spec/factories/container_volume_kubernetes.rb
+++ b/spec/factories/container_volume_kubernetes.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :container_volume_kubernetes
-end

--- a/spec/factories/custom_event.rb
+++ b/spec/factories/custom_event.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :custom_event
-end

--- a/spec/factories/customization_script.rb
+++ b/spec/factories/customization_script.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :customization_script do
-  end
-end

--- a/spec/factories/customization_script_medium.rb
+++ b/spec/factories/customization_script_medium.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :customization_script_medium
-end

--- a/spec/factories/customization_script_ptable.rb
+++ b/spec/factories/customization_script_ptable.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :customization_script_ptable
-end

--- a/spec/factories/dialog_field_association.rb
+++ b/spec/factories/dialog_field_association.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_association
-end

--- a/spec/factories/dialog_field_association_validator.rb
+++ b/spec/factories/dialog_field_association_validator.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_association_validator
-end

--- a/spec/factories/dialog_field_check_box.rb
+++ b/spec/factories/dialog_field_check_box.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_check_box
-end

--- a/spec/factories/dialog_field_date_control.rb
+++ b/spec/factories/dialog_field_date_control.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_date_control
-end

--- a/spec/factories/dialog_field_date_time_control.rb
+++ b/spec/factories/dialog_field_date_time_control.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_date_time_control
-end

--- a/spec/factories/dialog_field_importer.rb
+++ b/spec/factories/dialog_field_importer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_importer
-end

--- a/spec/factories/dialog_field_radio_button.rb
+++ b/spec/factories/dialog_field_radio_button.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_radio_button
-end

--- a/spec/factories/dialog_field_serializer.rb
+++ b/spec/factories/dialog_field_serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_serializer
-end

--- a/spec/factories/dialog_field_text_area_box.rb
+++ b/spec/factories/dialog_field_text_area_box.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_field_text_area_box
-end

--- a/spec/factories/dialog_group_serializer.rb
+++ b/spec/factories/dialog_group_serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_group_serializer
-end

--- a/spec/factories/dialog_import_validator.rb
+++ b/spec/factories/dialog_import_validator.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_import_validator
-end

--- a/spec/factories/dialog_serializer.rb
+++ b/spec/factories/dialog_serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_serializer
-end

--- a/spec/factories/dialog_tab_serializer.rb
+++ b/spec/factories/dialog_tab_serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_tab_serializer
-end

--- a/spec/factories/dialog_yaml_serializer.rb
+++ b/spec/factories/dialog_yaml_serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dialog_yaml_serializer
-end

--- a/spec/factories/dictionary.rb
+++ b/spec/factories/dictionary.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dictionary
-end

--- a/spec/factories/disk.rb
+++ b/spec/factories/disk.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :disk do
-  end
-end

--- a/spec/factories/drift_state.rb
+++ b/spec/factories/drift_state.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :drift_state do
-  end
-end

--- a/spec/factories/dynamic_dialog_field_value_processor.rb
+++ b/spec/factories/dynamic_dialog_field_value_processor.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :dynamic_dialog_field_value_processor
-end

--- a/spec/factories/ems_cluster_performance.rb
+++ b/spec/factories/ems_cluster_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :ems_cluster_performance
-end

--- a/spec/factories/ems_event.rb
+++ b/spec/factories/ems_event.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :ems_event, :class => "EmsEvent" do
-  end
-end

--- a/spec/factories/ems_refresh.rb
+++ b/spec/factories/ems_refresh.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :ems_refresh
-end

--- a/spec/factories/event_log.rb
+++ b/spec/factories/event_log.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :event_log
-end

--- a/spec/factories/event_stream.rb
+++ b/spec/factories/event_stream.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :event_stream
-end

--- a/spec/factories/ext_management_system_performance.rb
+++ b/spec/factories/ext_management_system_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :ext_management_system_performance
-end

--- a/spec/factories/file_depot_ftp_anonymous.rb
+++ b/spec/factories/file_depot_ftp_anonymous.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :file_depot_ftp_anonymous
-end

--- a/spec/factories/file_depot_nfs.rb
+++ b/spec/factories/file_depot_nfs.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :file_depot_nfs
-end

--- a/spec/factories/file_depot_smb.rb
+++ b/spec/factories/file_depot_smb.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :file_depot_smb
-end

--- a/spec/factories/firewall_rule.rb
+++ b/spec/factories/firewall_rule.rb
@@ -1,4 +1,3 @@
 FactoryGirl.define do
-  factory :firewall_rule do
-  end
+  factory :firewall_rule
 end

--- a/spec/factories/firmware.rb
+++ b/spec/factories/firmware.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :firmware do
-  end
-end

--- a/spec/factories/guest_application.rb
+++ b/spec/factories/guest_application.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :guest_application do
-  end
-end

--- a/spec/factories/host_aggregate_host.rb
+++ b/spec/factories/host_aggregate_host.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :host_aggregate_host
-end

--- a/spec/factories/host_metric.rb
+++ b/spec/factories/host_metric.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :host_metric
-end

--- a/spec/factories/host_performance.rb
+++ b/spec/factories/host_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :host_performance
-end

--- a/spec/factories/host_storage.rb
+++ b/spec/factories/host_storage.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :host_storage
-end

--- a/spec/factories/host_switch.rb
+++ b/spec/factories/host_switch.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :host_switch
-end

--- a/spec/factories/import_file_upload.rb
+++ b/spec/factories/import_file_upload.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :import_file_upload do
-  end
-end

--- a/spec/factories/iso_datastore.rb
+++ b/spec/factories/iso_datastore.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :iso_datastore do
-  end
-end

--- a/spec/factories/iso_image.rb
+++ b/spec/factories/iso_image.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :iso_image do
-  end
-end

--- a/spec/factories/job.rb
+++ b/spec/factories/job.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :job
-end

--- a/spec/factories/job_proxy_dispatcher.rb
+++ b/spec/factories/job_proxy_dispatcher.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :job_proxy_dispatcher
-end

--- a/spec/factories/ldap_domain.rb
+++ b/spec/factories/ldap_domain.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :ldap_domain do
-  end
-end

--- a/spec/factories/ldap_group.rb
+++ b/spec/factories/ldap_group.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :ldap_group do
-  end
-end

--- a/spec/factories/ldap_management.rb
+++ b/spec/factories/ldap_management.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :ldap_management
-end

--- a/spec/factories/ldap_server.rb
+++ b/spec/factories/ldap_server.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :ldap_server do
-  end
-end

--- a/spec/factories/ldap_user.rb
+++ b/spec/factories/ldap_user.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :ldap_user do
-  end
-end

--- a/spec/factories/lifecycle_event.rb
+++ b/spec/factories/lifecycle_event.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :lifecycle_event
-end

--- a/spec/factories/live_metric.rb
+++ b/spec/factories/live_metric.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :live_metric
-end

--- a/spec/factories/load_balancer_health_check_member.rb
+++ b/spec/factories/load_balancer_health_check_member.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :load_balancer_health_check_member do
-  end
-end

--- a/spec/factories/load_balancer_listener_pool.rb
+++ b/spec/factories/load_balancer_listener_pool.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :load_balancer_listener_pool do
-  end
-end

--- a/spec/factories/load_balancer_pool_member_pool.rb
+++ b/spec/factories/load_balancer_pool_member_pool.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :load_balancer_pool_member_pool do
-  end
-end

--- a/spec/factories/metering.rb
+++ b/spec/factories/metering.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :metering
-end

--- a/spec/factories/metering_container_image.rb
+++ b/spec/factories/metering_container_image.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :metering_container_image
-end

--- a/spec/factories/metering_container_project.rb
+++ b/spec/factories/metering_container_project.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :metering_container_project
-end

--- a/spec/factories/metering_vm.rb
+++ b/spec/factories/metering_vm.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :metering_vm
-end

--- a/spec/factories/middleware_datasource_performance.rb
+++ b/spec/factories/middleware_datasource_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :middleware_datasource_performance
-end

--- a/spec/factories/middleware_diagnostic_report.rb
+++ b/spec/factories/middleware_diagnostic_report.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :middleware_diagnostic_report
-end

--- a/spec/factories/middleware_performance.rb
+++ b/spec/factories/middleware_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :middleware_performance
-end

--- a/spec/factories/middleware_server_performance.rb
+++ b/spec/factories/middleware_server_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :middleware_server_performance
-end

--- a/spec/factories/miq_action_set.rb
+++ b/spec/factories/miq_action_set.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_action_set
-end

--- a/spec/factories/miq_ae_field.rb
+++ b/spec/factories/miq_ae_field.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_ae_field do
-  end
-end

--- a/spec/factories/miq_ae_value.rb
+++ b/spec/factories/miq_ae_value.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_ae_value do
-  end
-end

--- a/spec/factories/miq_ae_workspace.rb
+++ b/spec/factories/miq_ae_workspace.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_ae_workspace
-end

--- a/spec/factories/miq_alert_status.rb
+++ b/spec/factories/miq_alert_status.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_alert_status do
-  end
-end

--- a/spec/factories/miq_approval.rb
+++ b/spec/factories/miq_approval.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_approval do
-  end
-end

--- a/spec/factories/miq_automate.rb
+++ b/spec/factories/miq_automate.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_automate
-end

--- a/spec/factories/miq_bulk_import.rb
+++ b/spec/factories/miq_bulk_import.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_bulk_import
-end

--- a/spec/factories/miq_cockpit_ws_worker.rb
+++ b/spec/factories/miq_cockpit_ws_worker.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_cockpit_ws_worker
-end

--- a/spec/factories/miq_event.rb
+++ b/spec/factories/miq_event.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_event, :class => "MiqEvent" do
-  end
-end

--- a/spec/factories/miq_event_definition_set.rb
+++ b/spec/factories/miq_event_definition_set.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_event_definition_set
-end

--- a/spec/factories/miq_event_handler.rb
+++ b/spec/factories/miq_event_handler.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_event_handler
-end

--- a/spec/factories/miq_filter.rb
+++ b/spec/factories/miq_filter.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_filter
-end

--- a/spec/factories/miq_host_provision_workflow.rb
+++ b/spec/factories/miq_host_provision_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_host_provision_workflow
-end

--- a/spec/factories/miq_policy_content.rb
+++ b/spec/factories/miq_policy_content.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_policy_content do
-  end
-end

--- a/spec/factories/miq_priority_worker.rb
+++ b/spec/factories/miq_priority_worker.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_priority_worker
-end

--- a/spec/factories/miq_product_features_share.rb
+++ b/spec/factories/miq_product_features_share.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_product_features_share
-end

--- a/spec/factories/miq_provision_configured_system_request.rb
+++ b/spec/factories/miq_provision_configured_system_request.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_provision_configured_system_request
-end

--- a/spec/factories/miq_provision_configured_system_workflow.rb
+++ b/spec/factories/miq_provision_configured_system_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_provision_configured_system_workflow
-end

--- a/spec/factories/miq_provision_request_template.rb
+++ b/spec/factories/miq_provision_request_template.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_provision_request_template do
-  end
-end

--- a/spec/factories/miq_queue_worker_base.rb
+++ b/spec/factories/miq_queue_worker_base.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_queue_worker_base
-end

--- a/spec/factories/miq_region_remote.rb
+++ b/spec/factories/miq_region_remote.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_region_remote
-end

--- a/spec/factories/miq_report_result_detail.rb
+++ b/spec/factories/miq_report_result_detail.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_report_result_detail
-end

--- a/spec/factories/miq_reportable.rb
+++ b/spec/factories/miq_reportable.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_reportable
-end

--- a/spec/factories/miq_reporting_worker.rb
+++ b/spec/factories/miq_reporting_worker.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_reporting_worker
-end

--- a/spec/factories/miq_shortcut.rb
+++ b/spec/factories/miq_shortcut.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_shortcut
-end

--- a/spec/factories/miq_smart_proxy_worker.rb
+++ b/spec/factories/miq_smart_proxy_worker.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_smart_proxy_worker
-end

--- a/spec/factories/miq_snmp.rb
+++ b/spec/factories/miq_snmp.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_snmp
-end

--- a/spec/factories/miq_user_scope.rb
+++ b/spec/factories/miq_user_scope.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_user_scope
-end

--- a/spec/factories/miq_vim_broker_worker.rb
+++ b/spec/factories/miq_vim_broker_worker.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_vim_broker_worker do
-  end
-end

--- a/spec/factories/miq_web_service_worker.rb
+++ b/spec/factories/miq_web_service_worker.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_web_service_worker
-end

--- a/spec/factories/miq_widget_content.rb
+++ b/spec/factories/miq_widget_content.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :miq_widget_content do
-  end
-end

--- a/spec/factories/miq_widget_shortcut.rb
+++ b/spec/factories/miq_widget_shortcut.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :miq_widget_shortcut
-end

--- a/spec/factories/network_group.rb
+++ b/spec/factories/network_group.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :network_group
-end

--- a/spec/factories/network_port_security_group.rb
+++ b/spec/factories/network_port_security_group.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :network_port_security_group
-end

--- a/spec/factories/notification_recipient.rb
+++ b/spec/factories/notification_recipient.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :notification_recipient
-end

--- a/spec/factories/operating_system.rb
+++ b/spec/factories/operating_system.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :operating_system do
-  end
-end

--- a/spec/factories/operating_system_flavor.rb
+++ b/spec/factories/operating_system_flavor.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :operating_system_flavor do
-  end
-end

--- a/spec/factories/orchestration_stack_parameter.rb
+++ b/spec/factories/orchestration_stack_parameter.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :orchestration_stack_parameter
-end

--- a/spec/factories/os_process.rb
+++ b/spec/factories/os_process.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :os_process
-end

--- a/spec/factories/partition.rb
+++ b/spec/factories/partition.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :partition do
-  end
-end

--- a/spec/factories/patch.rb
+++ b/spec/factories/patch.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :patch
-end

--- a/spec/factories/pglogical_subscription.rb
+++ b/spec/factories/pglogical_subscription.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :pglogical_subscription
-end

--- a/spec/factories/physical_server_provision_request.rb
+++ b/spec/factories/physical_server_provision_request.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :physical_server_provision_request
-end

--- a/spec/factories/physical_server_provision_workflow.rb
+++ b/spec/factories/physical_server_provision_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :physical_server_provision_workflow
-end

--- a/spec/factories/policy_event.rb
+++ b/spec/factories/policy_event.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :policy_event do
-  end
-end

--- a/spec/factories/policy_event_content.rb
+++ b/spec/factories/policy_event_content.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :policy_event_content
-end

--- a/spec/factories/pxe_menu.rb
+++ b/spec/factories/pxe_menu.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :pxe_menu do
-  end
-end

--- a/spec/factories/pxe_menu_ipxe.rb
+++ b/spec/factories/pxe_menu_ipxe.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :pxe_menu_ipxe do
-  end
-end

--- a/spec/factories/pxe_menu_pxelinux.rb
+++ b/spec/factories/pxe_menu_pxelinux.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :pxe_menu_pxelinux do
-  end
-end

--- a/spec/factories/registration_system.rb
+++ b/spec/factories/registration_system.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :registration_system
-end

--- a/spec/factories/registry_item.rb
+++ b/spec/factories/registry_item.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :registry_item do
-  end
-end

--- a/spec/factories/request_event.rb
+++ b/spec/factories/request_event.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :request_event
-end

--- a/spec/factories/resource_action_serializer.rb
+++ b/spec/factories/resource_action_serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :resource_action_serializer
-end

--- a/spec/factories/resource_action_workflow.rb
+++ b/spec/factories/resource_action_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :resource_action_workflow
-end

--- a/spec/factories/retirement_manager.rb
+++ b/spec/factories/retirement_manager.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :retirement_manager
-end

--- a/spec/factories/scan_history.rb
+++ b/spec/factories/scan_history.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :scan_history
-end

--- a/spec/factories/scan_result.rb
+++ b/spec/factories/scan_result.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :scan_result
-end

--- a/spec/factories/scanning_operations.rb
+++ b/spec/factories/scanning_operations.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :scanning_operations
-end

--- a/spec/factories/schema_migration.rb
+++ b/spec/factories/schema_migration.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :schema_migration
-end

--- a/spec/factories/security_context.rb
+++ b/spec/factories/security_context.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :security_context
-end

--- a/spec/factories/serializer.rb
+++ b/spec/factories/serializer.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :serializer
-end

--- a/spec/factories/service_generic.rb
+++ b/spec/factories/service_generic.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :service_generic
-end

--- a/spec/factories/service_resource.rb
+++ b/spec/factories/service_resource.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :service_resource do
-  end
-end

--- a/spec/factories/service_template_ansible_tower.rb
+++ b/spec/factories/service_template_ansible_tower.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :service_template_ansible_tower
-end

--- a/spec/factories/service_template_generic.rb
+++ b/spec/factories/service_template_generic.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :service_template_generic
-end

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :session
-end

--- a/spec/factories/settings_change.rb
+++ b/spec/factories/settings_change.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :settings_change do
-  end
-end

--- a/spec/factories/share.rb
+++ b/spec/factories/share.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :share
-end

--- a/spec/factories/storage_performance.rb
+++ b/spec/factories/storage_performance.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :storage_performance
-end

--- a/spec/factories/storage_profile.rb
+++ b/spec/factories/storage_profile.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :storage_profile do
-  end
-end

--- a/spec/factories/storage_profile_storage.rb
+++ b/spec/factories/storage_profile_storage.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :storage_profile_storage
-end

--- a/spec/factories/subnet.rb
+++ b/spec/factories/subnet.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :subnet
-end

--- a/spec/factories/switch.rb
+++ b/spec/factories/switch.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :switch do
-  end
-end

--- a/spec/factories/sysprep_file.rb
+++ b/spec/factories/sysprep_file.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :sysprep_file
-end

--- a/spec/factories/tagging.rb
+++ b/spec/factories/tagging.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :tagging
-end

--- a/spec/factories/vim_performance_analysis.rb
+++ b/spec/factories/vim_performance_analysis.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_analysis
-end

--- a/spec/factories/vim_performance_daily.rb
+++ b/spec/factories/vim_performance_daily.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_daily
-end

--- a/spec/factories/vim_performance_operating_range.rb
+++ b/spec/factories/vim_performance_operating_range.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_operating_range
-end

--- a/spec/factories/vim_performance_planning.rb
+++ b/spec/factories/vim_performance_planning.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_planning
-end

--- a/spec/factories/vim_performance_tag.rb
+++ b/spec/factories/vim_performance_tag.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_tag
-end

--- a/spec/factories/vim_performance_tag_daily.rb
+++ b/spec/factories/vim_performance_tag_daily.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_tag_daily
-end

--- a/spec/factories/vim_performance_tag_value.rb
+++ b/spec/factories/vim_performance_tag_value.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_tag_value
-end

--- a/spec/factories/vim_performance_trend.rb
+++ b/spec/factories/vim_performance_trend.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vim_performance_trend
-end

--- a/spec/factories/vm_cloud_reconfigure_request.rb
+++ b/spec/factories/vm_cloud_reconfigure_request.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vm_cloud_reconfigure_request
-end

--- a/spec/factories/vm_cloud_reconfigure_task.rb
+++ b/spec/factories/vm_cloud_reconfigure_task.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vm_cloud_reconfigure_task
-end

--- a/spec/factories/vm_metric.rb
+++ b/spec/factories/vm_metric.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vm_metric
-end

--- a/spec/factories/vm_migrate_workflow.rb
+++ b/spec/factories/vm_migrate_workflow.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vm_migrate_workflow
-end

--- a/spec/factories/vm_reconfigure_task.rb
+++ b/spec/factories/vm_reconfigure_task.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vm_reconfigure_task
-end

--- a/spec/factories/vm_scan.rb
+++ b/spec/factories/vm_scan.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vm_scan
-end

--- a/spec/factories/vmdb_database.rb
+++ b/spec/factories/vmdb_database.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :vmdb_database do
-  end
-end

--- a/spec/factories/vmdb_database_connection.rb
+++ b/spec/factories/vmdb_database_connection.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vmdb_database_connection
-end

--- a/spec/factories/vmdb_database_lock.rb
+++ b/spec/factories/vmdb_database_lock.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vmdb_database_lock
-end

--- a/spec/factories/vmdb_database_metric.rb
+++ b/spec/factories/vmdb_database_metric.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :vmdb_database_metric do
-  end
-end

--- a/spec/factories/vmdb_database_setting.rb
+++ b/spec/factories/vmdb_database_setting.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :vmdb_database_setting
-end

--- a/spec/factories/vmdb_index.rb
+++ b/spec/factories/vmdb_index.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :vmdb_index do
-  end
-end

--- a/spec/factories/volume.rb
+++ b/spec/factories/volume.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :volume
-end

--- a/spec/factories/widget_import_validator.rb
+++ b/spec/factories/widget_import_validator.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :widget_import_validator
-end

--- a/spec/models/factory_girl_spec.rb
+++ b/spec/models/factory_girl_spec.rb
@@ -1,7 +1,0 @@
-describe 'FactoryGirl' do
-  let(:local_models) { Dir.glob('app/models/*.rb').map { |file| File.basename(file, '.rb').to_sym } }
-
-  it 'All models have a factory defined' do
-    expect(FactoryGirl.factories.map { |x| x.name.to_sym } & local_models).to match_array(local_models)
-  end
-end

--- a/spec/support/missing_factory_helper.rb
+++ b/spec/support/missing_factory_helper.rb
@@ -1,0 +1,29 @@
+# HACK: Allow calling FactoryGirl.create or FactoryGirl.build on anything.
+module Spec
+  module Support
+    module MissingFactoryHelper
+      def build(factory, *args, &block)
+        registered_factory_symbols.include?(factory) ? super : class_from_symbol(factory).new(*args)
+      end
+
+      def create(factory, *args, &block)
+        registered_factory_symbols.include?(factory) ? super : class_from_symbol(factory).create!(*args)
+      end
+
+      private
+
+      def class_from_symbol(symbol)
+        symbol.to_s.classify.constantize
+      end
+
+      def registered_factory_symbols
+        @registered_factory_symbols ||= begin
+          require 'set'
+          FactoryGirl.factories.collect { |i| i.name.to_sym }.to_set
+        end
+      end
+    end
+  end
+end
+
+FactoryGirl.singleton_class.prepend(Spec::Support::MissingFactoryHelper)


### PR DESCRIPTION
Enhance FactoryGirl.create and FactoryGirl.build to super if the factory exists, otherwise call create or new directly.

- No longer need to create an empty factory every time a new class is created
- No longer need factories for things that shouldn't be factories (SchemaMigrations and join tables)
- Many of the factories were incorrect to begin with (not inheriting from the base factory)

cc @jrafanie for the ✂️ 🔥 🎁 