### PR TITLE
Fix check_quota(:active_provisions) for Service MiqRequest invalid service_template.

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -319,6 +319,7 @@ module MiqProvisionQuotaMixin
   end
 
   def service_quota_values(request, result)
+    return unless request.service_template
     request.service_template.service_resources.each do |sr|
       if request.service_template.service_type == 'composite'
         bundle_quota_values(sr, result)

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -104,6 +104,12 @@ describe ServiceTemplateProvisionRequest do
         context "active_provisions_by_tenant," do
           let(:quota_method) { :active_provisions_by_tenant }
           it_behaves_like "check_quota"
+
+          it "invalid service_template does not raise error" do
+            requests = load_queue
+            requests.first.update_attributes(:service_template => nil)
+            expect { request.check_quota(quota_method) }.not_to raise_error
+          end
         end
 
         context "active_provisions_by_group," do


### PR DESCRIPTION
Prevent error in check_quota(:active_provisions) for Service MiqRequests with invalid service_templates.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1531914

We recently changed the active_provision code to calculate quota values for Service requests by looking at the request service_template.service_resource information.  
The customer supplied data showed Service requests miq_tasks queued to a zone but never dispatched, it appears the Zone or automate role for the zone was disabled. This made the Service requests look like they were active, but were not being processed. Then the service_template for which the Service request was created was deleted causing the Service request to have an invalid service_template relationship.

Although the issue impacts any calls to the check_quota(:active_provisions) method,  the customer encountered it in the request.check_quota(:active_provisions) call here:
RedHat Automate domain method: 
/Infrastructure/VM/Provisioning/Placement/vmware_best_fit_with_scope
Since the vmware_best_fit_with_scope method is used during VM Provisioning, all provisions would fail if the active_quota calculations encountered a single Service MiqRequest with an invalid service_template, even if Quota is not being used. 
 