### PR TITLE
Fixed expression evaluation for custom button in CustomActionMixin

### DIFF
--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -8,19 +8,19 @@ module CustomActionsMixin
     virtual_has_one :custom_action_buttons, :class_name => "Array"
   end
 
-  def custom_actions
+  def custom_actions(applies_to = self)
     {
-      :buttons       => filter_by_visibility(custom_buttons).collect(&method(:serialize_button)),
+      :buttons       => serialize_buttons_if_visible(custom_buttons, applies_to),
       :button_groups => custom_button_sets_with_generics.collect do |button_set|
         button_set.serializable_hash.merge(
-          :buttons => filter_by_visibility(button_set.children).collect(&method(:serialize_button))
+          :buttons => serialize_buttons_if_visible(button_set.children, applies_to)
         )
       end
     }
   end
 
-  def custom_action_buttons
-    filter_by_visibility(custom_buttons + custom_button_sets_with_generics.collect(&:children).flatten)
+  def custom_action_buttons(applies_to = self)
+    filter_by_visibility(custom_buttons + custom_button_sets_with_generics.collect(&:children).flatten, applies_to)
   end
 
   def generic_button_group
@@ -39,15 +39,26 @@ module CustomActionsMixin
     CustomButton.buttons_for(self).select { |b| b.parent.nil? }
   end
 
-  def filter_by_visibility(buttons)
-    buttons.select { |b| b.evaluate_visibility_expression_for(self) }
+  def filter_by_visibility(buttons, applies_to = self)
+    buttons.select { |b| b.evaluate_visibility_expression_for(target_for_expression(b, applies_to)) }
   end
 
-  def serialize_button(button)
-    button.expanded_serializable_hash.merge("enabled" => button.evaluate_enablement_expression_for(self))
+  def serialize_button(button, applies_to = self)
+    obj = target_for_expression(button, applies_to)
+    button.expanded_serializable_hash.merge("enabled" => button.evaluate_enablement_expression_for(obj))
   end
 
   def generic_custom_buttons
     CustomButton.buttons_for(self.class.base_model.name)
+  end
+
+  private
+
+  def serialize_buttons_if_visible(buttons, applies_to)
+    filter_by_visibility(buttons, applies_to).collect { |button| serialize_button(button, applies_to) }
+  end
+
+  def target_for_expression(button, applies_to)
+    button.applies_to_class == applies_to.class.base_model.name ? applies_to : self
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -54,7 +54,6 @@ class Service < ApplicationRecord
   before_validation :set_tenant_from_group
   before_create     :apply_dialog_settings
 
-  delegate :custom_actions, :custom_action_buttons, :to => :service_template, :allow_nil => true
   delegate :provision_dialog, :to => :miq_request, :allow_nil => true
   delegate :user, :to => :miq_request, :allow_nil => true
 
@@ -97,6 +96,14 @@ class Service < ApplicationRecord
 
   def power_states
     vms.map(&:power_state)
+  end
+
+  def custom_actions
+    service_template&.custom_actions(self)
+  end
+
+  def custom_action_buttons
+    service_template&.custom_action_buttons(self)
   end
 
   def power_state

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -808,4 +808,23 @@ describe Service do
     @service_c121 = FactoryGirl.create(:service, :service => @service_c12)
     @service_c2   = FactoryGirl.create(:service, :service => @service)
   end
+
+  context "custom actions" do
+    let(:service_template) { FactoryGirl.create(:service_template) }
+    let(:service) { FactoryGirl.create(:service, :service_template => service_template) }
+
+    describe "#custom_actions" do
+      it "get list of custom actions from linked service template" do
+        expect(service_template).to receive(:custom_actions)
+        service.custom_actions
+      end
+    end
+
+    describe "#custom_action_buttons" do
+      it "get list of custom action buttons from linked service template" do
+        expect(service_template).to receive(:custom_action_buttons)
+        service.custom_action_buttons
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1505988

`MiqExpressions` for Custom Action defined on `Service` class are built based on `Service` model. `MiqExpressions` for Custom Action  defined on `ServiceTemplate` are built based on `ServiceTemplate` model.
**Before:** 
`CustomActionMixin` did not have ability to evaluate actions defined on template or class differently. Expression were evaluated in the same way using instance of `ServcieTemplate`, regardless where button come from -  `ServcieTemplate`or `Service` class. 
As a result, evaluating expression for custom action defined on `Service` class was throwing error: `NoMethodError: undefined method `vms' for #<ServiceTemplate:0x007fd4b6f74490>`
![before](https://user-images.githubusercontent.com/6556758/34776178-e83b8d68-f5e3-11e7-9a30-ef2e90855402.gif)


**After**:
Use different object for expression evaluation: instance of `Service` for actions defined on `Service` and instance of `ServiceTemplate for action defined on `ServicesTemplate`
![after](https://user-images.githubusercontent.com/6556758/34776181-ede8b358-f5e3-11e7-9569-3c71928863eb.gif)


@miq-bit add-label bug, core

\cc @lpichler @gtanzillo
