### PR TITLE
Bump config to ~>1.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "ancestry",                       "~>2.2.1",       :require => false
 gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"
-gem "config",                         "~>1.3.0",       :require => false
+gem "config",                         "~>1.6.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false


### PR DESCRIPTION
This pulls in https://github.com/railsconfig/config/pull/167 which allows us to reference keys called "count" properly