### PR TITLE
Don't expect nil values in the container logger output

### DIFF
--- a/spec/lib/vmdb/loggers/container_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/container_logger_spec.rb
@@ -2,7 +2,7 @@ describe Vmdb::Loggers::ContainerLogger::Formatter do
   it "stuff" do
     time = Time.now
     result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")
-    expect(JSON.parse(result)).to eq(
+    expected = {
       "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N "),
       "hostname"   => ENV["HOSTNAME"],
       "level"      => "info",
@@ -10,6 +10,7 @@ describe Vmdb::Loggers::ContainerLogger::Formatter do
       "pid"        => $PROCESS_ID,
       "service"    => "some_program",
       "tid"        => Thread.current.object_id.to_s(16),
-    )
+    }.delete_nils
+    expect(JSON.parse(result)).to eq(expected)
   end
 end


### PR DESCRIPTION
Previously this spec would fail if `ENV["HOSTNAME"]` was not set
  