### PR TITLE
Fixed control explorer feature id

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -102,7 +102,7 @@
   - chargeback_reports
   - customization_template_view
   - iso_datastore_view
-  - control_explorer_view
+  - control_explorer
   - dashboard
   - ems_cluster_show
   - ems_cluster_show_list
@@ -195,7 +195,7 @@
   - chargeback_reports
   - customization_template_view
   - iso_datastore_view
-  - control_explorer_view
+  - control_explorer
   - dashboard
   - ems_cluster_show
   - ems_cluster_show_list
@@ -477,7 +477,7 @@
   - compute
   - chargeback
   - chargeback_reports
-  - control_explorer_view
+  - control_explorer
   - dashboard
   - datastore
   - ems_cluster_show
@@ -562,7 +562,7 @@
   - compute
   - chargeback
   - chargeback_reports
-  - control_explorer_view
+  - control_explorer
   - dashboard
   - datastore
   - ems_cluster_show


### PR DESCRIPTION
Fixed control explorer feature id for EvmRole-security, EvmRole-support,EvmRole-auditor, EvmRole-approver roles. This was causing confusion by not showing them as selected in the Product features tree whereas these roles did have an access to Control explorer in UI.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525598

before:
![before](https://user-images.githubusercontent.com/3450808/34733773-945cb020-f537-11e7-9c15-47a8fce0ba27.png)

after:
![after](https://user-images.githubusercontent.com/3450808/34733781-9b4a3b14-f537-11e7-89f1-70556d33f756.png)
