### PR TITLE
Add MiqWdigetSet to Dashboard dictionary translation

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -892,6 +892,7 @@ en:
       MiqTemplate:              VM Template and Image
       MiqUserRole:              Role
       MiqWidget:                Widget
+      MiqWidgetSet:             Dashboard
       MiqWorker:                EVM Worker
       NetworkPort:              Network Port
       NetworkRouter:            Network Router


### PR DESCRIPTION
Fixes and adds missing dictionary definition for Dashboard (MiqWidgetSet) for Delete action in UI. 

This PR is for Delete Dashboard action code fix, please see related PR for Add/Edit actions here: https://github.com/ManageIQ/manageiq-ui-classic/pull/2688

https://bugzilla.redhat.com/show_bug.cgi?id=1513603

Screen shot prior to code fix:
![dashboard dictrionary entry missing display](https://user-images.githubusercontent.com/552686/34745424-5618d326-f545-11e7-85e0-d66cac4b9c7c.png)


Screen shot post code fix:
![dashboard dictionary entry display post code fix](https://user-images.githubusercontent.com/552686/34745435-5ef20c38-f545-11e7-886a-bcb07a846ffa.png)


  