### PR TITLE
Lock rufus-scheduler to an official ManageIQ fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,7 +172,8 @@ group :rest_api, :manageiq_default do
 end
 
 group :scheduler, :manageiq_default do
-  gem "rufus-scheduler", :git => "https://github.com/chrisarcand/rufus-scheduler.git", :branch => "3-1-with-ruby-2-4-support", :require => false
+  # Modified gems (forked on Github)
+  gem "rufus-scheduler", "=3.1.10.2", :git => "https://github.com/ManageIQ/rufus-scheduler.git", :require => false, :tag => "v3.1.10-2"
 end
 
 group :seed, :manageiq_default do


### PR DESCRIPTION
@chrisarcand Please review.

Here is the official fork and branch: https://github.com/ManageIQ/rufus-scheduler/commits/rufus-scheduler_3_1_10  (tagged as `v3.1.10-1` as per the convention for the other forked repos)

@chrisarcand I left out the following commit from your fork: https://github.com/chrisarcand/rufus-scheduler/commit/fb7052f0810c24e8f208e2f2f3e7e52223a20e5d , because we don't do that in *any* of the other forked gems, so I don't know why it's needed.

cc @simaishi 