### PR TITLE
Introduce model changes for v2v

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -1,0 +1,9 @@
+class TransformationMapping < ApplicationRecord
+  has_many :transformation_mapping_items, :dependent => :destroy
+
+  validates :name, :presence => true, :uniqueness => true
+
+  def destination(source)
+    transformation_mapping_items.find_by(:source => source).try(:destination)
+  end
+end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -1,0 +1,7 @@
+class TransformationMappingItem < ApplicationRecord
+  belongs_to :transformation_mapping
+  belongs_to :source,      :polymorphic => true
+  belongs_to :destination, :polymorphic => true
+
+  validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
+end

--- a/spec/factories/transformation_mapping.rb
+++ b/spec/factories/transformation_mapping.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :transformation_mapping do
+    sequence(:name) { |n| "Transformation Mapping #{seq_padded_for_sorting(n)}" }
+  end
+end

--- a/spec/factories/transformation_mapping_item.rb
+++ b/spec/factories/transformation_mapping_item.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :transformation_mapping_item
+end

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,0 +1,21 @@
+describe TransformationMapping do
+  describe '#destination' do
+    let(:src) { FactoryGirl.create(:ems_cluster) }
+    let(:dst) { FactoryGirl.create(:ems_cluster) }
+
+    let(:mapping) do
+      FactoryGirl.create(
+        :transformation_mapping,
+        :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+      )
+    end
+
+    it "finds the destination" do
+      expect(mapping.destination(src)).to eq(dst)
+    end
+
+    it "returns nil for unmapped source" do
+      expect(mapping.destination(FactoryGirl.create(:ems_cluster))).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Initial work for modeling v2v tables introduced in https://github.com/ManageIQ/manageiq-schema/pull/149

Deletion of the mapping with items is automatically supported. Update with single request is to be done in a future PR.