### PR TITLE
Add condition to fix deletion of Default Container Image Rate

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -150,7 +150,7 @@ class ChargebackRate < ApplicationRecord
   end
 
   def ensure_nondefault
-    if default?
+    if default? || description == 'Default Container Image Rate'
       errors.add(:rate, "default rate cannot be deleted")
       throw :abort
     end

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -56,6 +56,14 @@ describe ChargebackRate do
       expect(cbr.errors.first).to include("default rate cannot be deleted")
     end
 
+    it "when non-default with default description" do
+      cbr = FactoryGirl.create(:chargeback_rate, :description => "Default Container Image Rate", :default => false)
+      cbr.destroy
+      expect(cbr).to_not be_destroyed
+      expect(cbr.errors.count).to be(1)
+      expect(cbr.errors.first).to include("default rate cannot be deleted")
+    end
+
     it "when non-default" do
       cbr = FactoryGirl.create(:chargeback_rate, :description => "Non-default", :default => false)
       cbr.destroy


### PR DESCRIPTION
**Fixing** https://bugzilla.redhat.com/show_bug.cgi?id=1486658
**This PR has to be merged with** https://github.com/ManageIQ/manageiq-ui-classic/pull/3215
to completely fix the bug.

---
**Summary:**
Add condition to `ensure_nondefault` method in chargeback rate model to fix deletion of _Default Container Image Rate_ in _Cloud Intel -> Chargeback -> Rates_ so that the Rate can't be deleted and error message is properly displayed.

**Explanation:**
Originally, checking if the selected rate is default (before its deletion), did not work well only if deleting rate(s) from a list of the rates. This was because of missing part of the condition for checking default rates here:
https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback_rate.rb#L153
Checking if the rate is default, worked only from rate details page. This was because of
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/button/chargeback_rate_remove.rb#L12
So I added the missing part of the condition here (this PR): https://github.com/ManageIQ/manageiq/compare/master...hstastna:Default_Container_Image_Rate_delete_description?expand=1#diff-7c998acd3d11c70ed830e216754f4b6bR153
I also edited `cb_rates_delete` method in chargeback controller to be able to properly delete nondefault rates and also to show error messages about deleting default rates and list of the remaining rates - in a one step (more about this here https://github.com/ManageIQ/manageiq-ui-classic/pull/3215)

The bug is related to _Compute_ Chargeback rates.