### PR TITLE
Shift qpid_proton version to 0.19.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ group :nuage, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.18.1",      :require => false
+  gem "qpid_proton",                    "~>0.19.0",      :require => false
 end
 
 group :openshift, :manageiq_default do


### PR DESCRIPTION
There is a huge performance issue with version 0.18.1 which is resolved in 0.19.0.

Related PR on Nuage (both should be merged together): https://github.com/ManageIQ/manageiq-providers-nuage/pull/58

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1534440

@miq-bot add_label dependencies
@miq-bot assign @juliancheal 

/cc @gberginc @gasper-vrhovsek 