### PR TITLE
Add api_allowed_attributes to ExtManagementSystem and Provider

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -27,6 +27,10 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
+  def self.api_allowed_attributes
+    %w[]
+  end
+
   belongs_to :provider
   has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -34,6 +34,10 @@ class Provider < ApplicationRecord
     parent.name.demodulize
   end
 
+  def self.api_allowed_attributes
+    %w[]
+  end
+
   def image_name
     self.class.short_token.underscore
   end


### PR DESCRIPTION
Required for https://github.com/ManageIQ/manageiq-api/pull/279

This update will allow individual providers to have more control over the parameters that are allowed when creating a new manager. This will also be a good transition starting point to move a lot of the validation inside of the providers themselves, rather than having it all within the API controller.

As an example, the Azure provider would like users to provide azure_tenant_id, which is not possible under the current API validation. By updating API_ALLOWED_ATTRIBUTES on the Azure::CloudManager to return azure_tenant_id, users will be allowed to specify that attribute for Azure Cloud Managers.

cc: @bronaghs @juliancheal - let me know your thoughts on this approach

@miq-bot enhancement, providers