### PR TITLE
Purge miq alert statuses

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -1,4 +1,6 @@
 class MiqAlertStatus < ApplicationRecord
+  include_concern 'Purging'
+
   SEVERITY_LEVELS = %w(error warning info).freeze
 
   belongs_to :miq_alert

--- a/app/models/miq_alert_status/purging.rb
+++ b/app/models/miq_alert_status/purging.rb
@@ -1,0 +1,21 @@
+class MiqAlertStatus < ApplicationRecord
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.miq_alert_status.history.keep_miq_alert_statuses.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.miq_alert_status.history.purge_window_size
+      end
+
+      def purge_scope(older_than)
+        where(:ems_id => nil)
+        where(arel_table[:timestamp].lt(older_than))
+      end
+    end
+  end
+end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -99,6 +99,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer", :zone => nil)
   end
 
+  def miq_alert_status_purge_timer
+    queue_work(:class_name => "MiqAlertStatus", :method_name => "purge_timer", :zone => nil)
+  end
+
   def miq_report_result_purge_timer
     queue_work(:class_name => "MiqReportResult", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -204,6 +204,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:binary_blob_purge_timer)
     end
 
+    # Schedule - Prune old miq alert status Timer
+    every = worker_settings[:miq_alert_status_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue :miq_alert_status_purge_timer
+    end
+
     # Schedule every 24 hours
     at = worker_settings[:storage_file_collection_time_utc]
     if Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc) < Time.now.utc

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -925,6 +925,10 @@
   :history:
     :keep_archived_entities: 6.months
     :purge_window_size: 1000
+:miq_alert_status:
+  :history:
+    :keep_miq_alert_statuses: 6.months
+    :purge_window_size: 1000
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
@@ -1194,6 +1198,7 @@
       :policy_events_purge_interval: 1.day
       :poll: 15.seconds
       :report_result_purge_interval: 1.week
+      :miq_alert_status_purge_interval: 1.week
       :server_log_stats_interval: 5.minutes
       :server_stats_interval: 60.seconds
       :service_retired_interval: 10.minutes


### PR DESCRIPTION
Purging miq_alert_statuses will allow removing the `dependent_destroy` and having history for deleted entities (for example container node).

Originally submitted in https://github.com/ManageIQ/manageiq/pull/13430
Was reopened here since I do not have permissions to reopen that PR.