### PR TITLE
Reverts change to cloud network list without RBAC

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -26,9 +26,11 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def allowed_cloud_networks(_options = {})
-    source = load_ar_obj(get_source_vm)
-    targets = get_targets_for_source(source, :cloud_filter, CloudNetwork, 'cloud_network_id')
-    allowed_ci(:cloud_network, [:availability_zone], targets.map(&:id))
+    return {} unless (src_obj = provider_or_tenant_object)
+
+    src_obj.all_cloud_networks.each_with_object({}) do |cn, hash|
+      hash[cn.id] = cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
+    end
   end
 
   def allowed_guest_access_key_pairs(_options = {})
@@ -86,20 +88,6 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   def allowed_ci(ci, relats, filtered_ids = nil)
     return {} if (sources = resources_for_ui).blank?
     super(ci, relats, sources, filtered_ids)
-  end
-
-  def availability_zone_to_cloud_network(src)
-    if src[:availability_zone]
-      load_ar_obj(src[:availability_zone]).cloud_subnets.each_with_object({}) do |cs, hash|
-        cn = cs.cloud_network
-        hash[cn.id] = cn.name
-      end
-    else
-      return {} unless load_ar_obj(src[:ems]).cloud_subnets
-      load_ar_obj(src[:ems]).cloud_subnets.collect(&:cloud_network).each_with_object({}) do |cn, hash|
-        hash[cn.id] = cn.name
-      end
-    end
   end
 
   def get_source_and_targets(refresh = false)

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -124,18 +124,6 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
                                               :ext_management_system => ems.network_manager)
     end
 
-    context "#allowed_cloud_networks" do
-      it "without a zone", :skip_before do
-        expect(workflow.allowed_cloud_networks.length).to be_zero
-      end
-
-      it "with a zone" do
-        workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
-        expect(workflow.allowed_cloud_networks.length).to eq(1)
-        expect(workflow.allowed_cloud_networks).to eq(@cn1.id => @cn1.name)
-      end
-    end
-
     context "#allowed_cloud_subnets" do
       it "without a cloud_network", :skip_before do
         expect(workflow.allowed_cloud_subnets.length).to be_zero


### PR DESCRIPTION
Per discussion of https://github.com/ManageIQ/manageiq/pull/16804, I think this should be reverted to the way it was before 16688 broke the provider subclass code.

Previously, cloud network list was only updated after selection of security group, or change of tab, or a select set of other actions that completely voided the list of parameters passed to the filtering method. This adds a change so that availability zone updates the selection of cloud network, preventing incorrect cloud networks from showing up in the after the zone dropdown changes. This code should live in the specific provider that needs it though and that seems to only be Amazon afaik so this replaces that change with the code that worked for all providers save Amazon. 

Should fix broken test in main and [UI issue that Roman brought up](https://github.com/ManageIQ/manageiq/pull/16804) (that 16804 also fixes but probably not correctly)

## related to:
https://github.com/ManageIQ/manageiq-providers-amazon/pull/391