### PR TITLE
[Gaprindashvili] - Added missing key, to prevent nil error while building features tree

### DIFF
--- a/config/permissions.tmpl.yml
+++ b/config/permissions.tmpl.yml
@@ -11,6 +11,7 @@
 - :conf
 - :help
 - :inf
+- :mdl
 - :monitor
 - :monitor_alerts
 - :dwh


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1533391

We don't need this change on upstream because Middleware section was removed from upstream in https://github.com/ManageIQ/manageiq-ui-classic/pull/3142

@lgalis Please review/test. This can be tested by copying permissions.tmpl.yml to permission.yml on gaprindashvili branch.

