### PR TITLE
Update users' current_group on group  deletion

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -22,6 +22,7 @@ class MiqGroup < ApplicationRecord
   validates :description, :presence => true, :unique_within_region => true
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
+  after_destroy :reset_current_group_for_users
 
   # For REST API compatibility only; Don't use otherwise!
   accepts_nested_attributes_for :entitlement
@@ -273,19 +274,14 @@ class MiqGroup < ApplicationRecord
     id == current_user_group.try(:id)
   end
 
-  def current_group_for_any_user?
-    users.where(:current_group_id => id).count != 0
-  end
-
   def ensure_can_be_destroyed
     raise _("The login group cannot be deleted") if current_user_group?
     raise _("The group has users assigned that do not belong to any other group") if single_group_users?
     raise _("A tenant default group can not be deleted") if tenant_group? && referenced_by_tenant?
     raise _("A read only group cannot be deleted.") if system_group?
-    reset_current_group_for_users if current_group_for_any_user?
   end
 
   def reset_current_group_for_users
-    users.where(:current_group_id => id).each(&:change_current_group)
+    User.where(:id => user_ids, :current_group_id => id).each(&:change_current_group)
   end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -286,6 +286,6 @@ class MiqGroup < ApplicationRecord
   end
 
   def reset_current_group_for_users
-    users.where(:current_group_id => id).each {|u| u.change_current_group(id)}
+    users.where(:current_group_id => id).each { |u| u.change_current_group(id) }
   end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -286,6 +286,6 @@ class MiqGroup < ApplicationRecord
   end
 
   def reset_current_group_for_users
-    User.where(:current_group_id => id).each {|u| u.change_current_group(id)}
+    users.where(:current_group_id => id).each {|u| u.change_current_group(id)}
   end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -286,6 +286,6 @@ class MiqGroup < ApplicationRecord
   end
 
   def reset_current_group_for_users
-    users.where(:current_group_id => id).each { |u| u.change_current_group(id) }
+    users.where(:current_group_id => id).each(&:change_current_group)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,7 @@ class User < ApplicationRecord
     user_groups = miq_group_ids
     user_groups.delete(id)
     self.current_group = MiqGroup.find_by(:id => user_groups.first)
-    self.save!
+    save!
   end
 
   def admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,6 +206,7 @@ class User < ApplicationRecord
   def change_current_group(id)
     user_groups = miq_group_ids
     user_groups.delete(id)
+    raise _("The user's loging group cannot be changed.") if user_groups.empty?
     self.current_group = MiqGroup.find_by(:id => user_groups.first)
     save!
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -205,7 +205,7 @@ class User < ApplicationRecord
 
   def change_current_group
     user_groups = miq_group_ids
-    user_groups.delete(current_group.id)
+    user_groups.delete(current_group_id)
     raise _("The user's current group cannot be changed because the user does not belong to any other group") if user_groups.empty?
     self.current_group = MiqGroup.find_by(:id => user_groups.first)
     save!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,10 +203,10 @@ class User < ApplicationRecord
     self.current_group = groups.first if current_group.nil? || !groups.include?(current_group)
   end
 
-  def change_current_group(id)
+  def change_current_group
     user_groups = miq_group_ids
-    user_groups.delete(id)
-    raise _("The user's loging group cannot be changed.") if user_groups.empty?
+    user_groups.delete(current_group.id)
+    raise _("The user's current group cannot be changed because the user does not belong to any other group") if user_groups.empty?
     self.current_group = MiqGroup.find_by(:id => user_groups.first)
     save!
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -203,6 +203,13 @@ class User < ApplicationRecord
     self.current_group = groups.first if current_group.nil? || !groups.include?(current_group)
   end
 
+  def change_current_group(id)
+    user_groups = miq_group_ids
+    user_groups.delete(id)
+    self.current_group = MiqGroup.find_by(:id => user_groups.first)
+    self.save!
+  end
+
   def admin?
     self.class.admin?(userid)
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -530,7 +530,7 @@ describe MiqGroup do
       testgroup3 = FactoryGirl.create(:miq_group)
       user1 = FactoryGirl.create(:user, :miq_groups => [testgroup1, testgroup2], :current_group => testgroup2)
       user2 = FactoryGirl.create(:user, :miq_groups => [testgroup1, testgroup3], :current_group => testgroup3)
-      expect{ testgroup2.destroy }.not_to raise_error
+      expect { testgroup2.destroy }.not_to raise_error
       expect(User.find_by(:id => user1.id).current_group.id).to eq(testgroup1.id)
       expect(User.find_by(:id => user2.id).current_group.id).to eq(testgroup3.id)
     end
@@ -541,10 +541,9 @@ describe MiqGroup do
       testgroup3 = FactoryGirl.create(:miq_group)
       user1 = FactoryGirl.create(:user, :miq_groups => [testgroup1, testgroup2], :current_group => testgroup2)
       user2 = FactoryGirl.create(:user, :miq_groups => [testgroup3], :current_group => testgroup3)
-      expect{ testgroup1.destroy }.not_to raise_error
+      expect { testgroup1.destroy }.not_to raise_error
       expect(User.find_by(:id => user1).current_group.id).to eq(testgroup2.id)
       expect(User.find_by(:id => user2).current_group.id).to eq(testgroup3.id)
     end
   end
 end
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -547,6 +547,23 @@ describe User do
     end
   end
 
+  describe "#change_current_group" do
+    let(:group1) { FactoryGirl.create(:miq_group) }
+    let(:group2) { FactoryGirl.create(:miq_group) }
+
+    it "changes the user to a group other than the current one" do
+      user = FactoryGirl.create(:user, :miq_groups => [group1, group2], :current_group => group1)
+      user.change_current_group
+      expect(user.current_group).to eq(group2)
+    end
+
+    it "raises an error if there is no group other than the current one to switch to" do
+      user = FactoryGirl.create(:user, :miq_groups => [group1], :current_group => group1)
+      expect { user.change_current_group }
+        .to raise_error(RuntimeError, /The user's current group cannot be changed because the user does not belong to any other group/)
+    end
+  end
+
   context ".super_admin" do
     it "has super_admin" do
       FactoryGirl.create(:miq_group, :role => "super_administrator")


### PR DESCRIPTION
When deleting a group, update the current_group for users that have the deleted group as the current_group

Links 
---------
https://bugzilla.redhat.com/show_bug.cgi?id=1264967


Steps for Testing/QA 
-------------------------------
1. Create 1 new group
2. Create 1 or  new 2 users and assign them to the newly created group plus one additional group each.
3. Make sure the new group is the current group for at least one of the users.
4. Delete the group create in step1. 

The user that had the current_group set to the new group can log in with the changes in this PR, as its new current_group is the second group it belonged to. 