### PR TITLE
Change get_targets_for_source to use correct params

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -26,8 +26,8 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def allowed_cloud_networks(_options = {})
-    source = load_ar_obj(get_source_vm)
-    targets = get_targets_for_source(source, :cloud_filter, CloudNetwork, 'cloud_network_id')
+    return {} unless (src = provider_or_tenant_object)
+    targets = get_targets_for_source(src, :cloud_filter, CloudNetwork, 'cloud_networks')
     allowed_ci(:cloud_network, [:availability_zone], targets.map(&:id))
   end
 
@@ -95,7 +95,6 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
         hash[cn.id] = cn.name
       end
     else
-      return {} unless load_ar_obj(src[:ems]).cloud_subnets
       load_ar_obj(src[:ems]).cloud_subnets.collect(&:cloud_network).each_with_object({}) do |cn, hash|
         hash[cn.id] = cn.name
       end

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -3,6 +3,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
   let(:admin) { FactoryGirl.create(:user_with_group) }
   let(:ems) { FactoryGirl.create(:ems_cloud) }
+  let(:network_manager) { FactoryGirl.create(:ems_network, :parent_ems_id => ems.id) }
   let(:template) { FactoryGirl.create(:miq_template, :name => "template", :ext_management_system => ems) }
   let(:workflow) do
     stub_dialog
@@ -117,7 +118,6 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
       @cs2 = FactoryGirl.create(:cloud_subnet, :cloud_network         => @cn1,
                                                :availability_zone     => @az2,
                                                :ext_management_system => ems.network_manager)
-
       @ip1 = FactoryGirl.create(:floating_ip, :cloud_network_only    => true,
                                               :ext_management_system => ems.network_manager)
       @ip2 = FactoryGirl.create(:floating_ip, :cloud_network_only    => false,
@@ -126,6 +126,8 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
     context "#allowed_cloud_networks" do
       it "without a zone", :skip_before do
+        network_manager
+
         expect(workflow.allowed_cloud_networks.length).to be_zero
       end
 


### PR DESCRIPTION
Source needs to be src and the last param in this call needs to be the correct association name.

Previously, cloud network list was only updated after selection of security group, or change of tab, or a select set of other actions that completely voided the list of parameters passed to the filtering method. This issue was fixed in https://github.com/ManageIQ/manageiq/pull/16688. Unfortunately I also introduced an issue where get_targets_for_source was not returning the right things because I wasn't calling it correctly, which this PR should fix. 

## Related to:
https://github.com/ManageIQ/manageiq-content/pull/241
https://bugzilla.redhat.com/show_bug.cgi?id=1518847