### PR TITLE
Binary blob refactoring

### DIFF
--- a/app/models/binary_blob.rb
+++ b/app/models/binary_blob.rb
@@ -12,11 +12,7 @@ class BinaryBlob < ApplicationRecord
 
   # Get binary file from database into a raw String
   def binary
-    # TODO: Change this to collect the binary_blob_parts in batches, so we are not pulling in every row into memory at once
-    data = binary_blob_parts.inject("") do |d, b|
-      d << b.data
-      d
-    end
+    data = binary_blob_parts.pluck(:data).join
     unless size.nil? || size == data.bytesize
       raise _("size of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
     end

--- a/app/models/binary_blob_part.rb
+++ b/app/models/binary_blob_part.rb
@@ -1,4 +1,6 @@
 class BinaryBlobPart < ApplicationRecord
+  validates :data, :presence => true
+
   def self.default_part_size
     @default_part_size ||= 1.megabyte
   end
@@ -18,24 +20,5 @@ class BinaryBlobPart < ApplicationRecord
     iv.chomp!(", ")
     iv.rstrip!
     "#{to_s.chop}#{iv}>"
-  end
-
-  def data
-    val = read_attribute(:data)
-    unless size.nil? || size == val.bytesize
-      raise _("size of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
-    end
-    unless md5.nil? || md5 == Digest::MD5.hexdigest(val)
-      raise _("md5 of %{name} id [%{number}] is incorrect") % {:name => self.class.name, :number => id}
-    end
-    val
-  end
-
-  def data=(val)
-    raise ArgumentError, "data cannot be set to nil" if val.nil?
-    write_attribute(:data, val)
-    self.md5 = Digest::MD5.hexdigest(val)
-    self.size = val.bytesize
-    self
   end
 end

--- a/spec/models/binary_blob_part_spec.rb
+++ b/spec/models/binary_blob_part_spec.rb
@@ -2,15 +2,13 @@
 
 describe BinaryBlobPart do
   context "#data= and #data" do
-    before(:each) do
-      @part = FactoryGirl.build(:binary_blob_part)
-    end
+    let(:part) { FactoryGirl.build(:binary_blob_part) }
 
     subject do
-      @part.data = @data
-      @part.save
-      @part.reload
-      @part.data
+      part.data = @data
+      part.save
+      part.reload
+      part.data
     end
 
     it "without UTF-8 data" do

--- a/spec/models/binary_blob_part_spec.rb
+++ b/spec/models/binary_blob_part_spec.rb
@@ -3,7 +3,7 @@
 describe BinaryBlobPart do
   context "#data= and #data" do
     before(:each) do
-      @part = FactoryGirl.create(:binary_blob_part)
+      @part = FactoryGirl.build(:binary_blob_part)
     end
 
     subject do


### PR DESCRIPTION
Improve performance of storing and retrieving `BinaryBlobParts`.
- It's the responsibility of the database to ensure that the data read is the same as the data written.  We don't need to double check all of the `BinaryBlobPart`s with a md5 sum that we currently store on the same record.  We want to keep the md5sum on `BinaryBlob` since that is the md5sum for the entire blob that was stored.
- Also, we don't need to load the entire `BinaryBlobPart` object when reconstructing the `BinaryBlob`.  We only need the data, which we pluck directly from the database reducing the number of objects loaded into memory.