### PR TITLE
#1518279 For all roles that have sui product features adds sui_notifications

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -91,6 +91,7 @@
   - vm_cloud_explorer
   - vm_infra_explorer
   - sui_services
+  - sui_notifications
 
 - :name: EvmRole-approver
   :read_only: true
@@ -181,6 +182,7 @@
   - sui_vm_web_console
   - sui_vm_tags
   - sui_orders_view
+  - sui_notifications
 
 - :name: EvmRole-auditor
   :read_only: true
@@ -273,6 +275,7 @@
   - sui_vm_console
   - sui_vm_web_console
   - sui_vm_tags
+  - sui_notifications
 
 - :name: EvmRole-desktop
   :read_only: true
@@ -341,6 +344,7 @@
   - sui_vm_suspend
   - sui_orders_view
   - sui_orders_operations
+  - sui_notifications
 
 - :name: EvmRole-operator
   :read_only: true
@@ -469,6 +473,7 @@
   - sui_vm_start
   - sui_vm_stop
   - sui_vm_suspend
+  - sui_notifications
 
 - :name: EvmRole-security
   :read_only: true
@@ -554,6 +559,7 @@
   - sui_vm_snapshot_create
   - sui_vm_snapshot_delete
   - sui_vm_tags
+  - sui_notifications
 
 - :name: EvmRole-support
   :read_only: true
@@ -641,6 +647,7 @@
   - sui_vm_console
   - sui_vm_web_console
   - sui_vm_tags
+  - sui_notifications
 
 - :name: EvmRole-user
   :read_only: true
@@ -728,6 +735,7 @@
   - sui_vm_tags
   - sui_orders_view
   - sui_orders_operations
+  - sui_notifications
 
 - :name: EvmRole-user_limited_self_service
   :read_only: true
@@ -921,6 +929,7 @@
   - sui_vm_suspend
   - sui_orders_view
   - sui_orders_operations
+  - sui_notifications
 
 - :name: EvmRole-tenant_administrator
   :read_only: true
@@ -987,6 +996,7 @@
   - vm_cloud_explorer
   - vm_infra_explorer
   - sui_services
+  - sui_notifications
 
 - :name: EvmRole-tenant_quota_administrator
   :read_only: true
@@ -1044,6 +1054,7 @@
   - vm_cloud_explorer
   - vm_infra_explorer
   - sui_services
+  - sui_notifications
 
 - :name: EvmRole-consumption_administrator
   :read_only: true
@@ -1256,3 +1267,4 @@
   - vm_view
   - sui_services_view
   - sui_orders_view
+  - sui_notifications


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1518279

Those roles with `sui` or `sui_core` don't require this product feature to ensure consistent behavior.
This pr has a sister in the sui repo, these combined close thhe bz: https://github.com/ManageIQ/manageiq-ui-service/pull/1293