### PR TITLE
Bump ripper ruby parser for 2.5 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "rails",                          "~>5.0.2"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
-gem "ripper_ruby_parser",             "~>1.1.2",       :require => false
+gem "ripper_ruby_parser",             "~>1.2.0",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.1",       :require => false
 gem "rugged",                         "~>0.25.0",      :require => false


### PR DESCRIPTION
Fixes an issue parsing our ruby code on the now released ruby 2.5.0:
https://github.com/mvz/ripper_ruby_parser/issues/35

According to the changelog below and basic sanity tests the changes
should not break ruby 2.3 or 2.4:
https://github.com/mvz/ripper_ruby_parser/blob/master/CHANGELOG.md#120--2018-01-12