### PR TITLE
Graph refresh enhance parallel safe strategies

### DIFF
--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -95,7 +95,7 @@ module ManagerRefresh
                                                     :ref => ref, :key => key, :default => default)
         end
 
-        def named_ref(ref)
+        def named_ref(ref = primary_index_ref)
           all_refs[ref]
         end
 

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -14,6 +14,10 @@ module ManagerRefresh
         @stringified_reference = self.class.build_stringified_reference(full_reference, keys)
       end
 
+      def primary?
+        ref == :manager_ref
+      end
+
       def to_hash
       end
 

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -3,13 +3,14 @@ module ManagerRefresh
     class Reference
       include Vmdb::Logging
 
-      attr_reader :full_reference, :ref, :stringified_reference
+      attr_reader :full_reference, :keys, :ref, :stringified_reference
 
       delegate :[], :to => :full_reference
 
       def initialize(data, ref, keys)
         @full_reference = build_full_reference(data, keys)
         @ref            = ref
+        @keys           = keys
 
         @stringified_reference = self.class.build_stringified_reference(full_reference, keys)
       end

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -72,6 +72,15 @@ module ManagerRefresh::SaveCollection
 
       delegate :build_stringified_reference, :build_stringified_reference_for_record, :to => :inventory_collection
 
+      def values_for_database!(all_attribute_keys, attributes)
+        all_attribute_keys.each do |key|
+          if (type = serializable_keys[key])
+            attributes[key] = type.serialize(attributes[key])
+          end
+        end
+        attributes
+      end
+
       private
 
       attr_reader :unique_index_keys, :unique_index_keys_to_s, :select_keys, :unique_db_primary_keys, :unique_db_indexes,

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
@@ -1,6 +1,8 @@
 module ManagerRefresh::SaveCollection
   module Saver
     class ConcurrentSafe < ManagerRefresh::SaveCollection::Saver::Base
+      # TODO(lsmola) this strategy does not make much sense, it's better to use concurent_safe_batch and make batch size
+      # configurable
       private
 
       def update_record!(record, hash, inventory_object)
@@ -23,13 +25,31 @@ module ManagerRefresh::SaveCollection
 
       def create_record!(hash, inventory_object)
         all_attribute_keys = hash.keys
-        hash               = inventory_collection.model_class.new(hash).attributes.symbolize_keys
-        assign_attributes_for_create!(hash, time_now)
+        data               = inventory_collection.model_class.new(hash).attributes.symbolize_keys
 
-        result_id = ActiveRecord::Base.connection.insert_sql(
-          build_insert_query(all_attribute_keys, [hash])
+        # TODO(lsmola) abstract common behavior into base class
+        all_attribute_keys << :created_at if supports_created_at?
+        all_attribute_keys << :updated_at if supports_updated_at?
+        all_attribute_keys << :created_on if supports_created_on?
+        all_attribute_keys << :updated_on if supports_updated_on?
+        hash_for_creation = if inventory_collection.use_ar_object?
+                              record = inventory_collection.model_class.new(data)
+                              values_for_database!(all_attribute_keys,
+                                                   record.attributes.symbolize_keys)
+                            elsif serializable_keys?
+                              values_for_database!(all_attribute_keys,
+                                                   data)
+                            else
+                              data
+                            end
+
+        assign_attributes_for_create!(hash_for_creation, time_now)
+
+        result_id = ActiveRecord::Base.connection.execute(
+          build_insert_query(all_attribute_keys, [hash_for_creation])
         )
-        inventory_object.id = result_id
+
+        inventory_object.id = result_id.to_a.try(:first).try(:[], "id")
         inventory_collection.store_created_records(inventory_object)
       end
     end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -242,15 +242,6 @@ module ManagerRefresh::SaveCollection
         end
       end
 
-      def values_for_database!(all_attribute_keys, attributes)
-        all_attribute_keys.each do |key|
-          if (type = serializable_keys[key])
-            attributes[key] = type.serialize(attributes[key])
-          end
-        end
-        attributes
-      end
-
       def map_ids_to_inventory_objects(indexed_inventory_objects, all_attribute_keys, hashes, result)
         # The remote_data_timestamp is adding a WHERE condition to ON CONFLICT UPDATE. As a result, the RETURNING
         # clause is not guaranteed to return all ids of the inserted/updated records in the result. In that case


### PR DESCRIPTION
Enhancing parallel safe strategies and making skeletal pre-create work properly.

We can add our first specs to k8s and OpenShift once we have the DB indexes.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/16741