### PR TITLE
Fix call to get_targets_for_source to be correct scope name

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
   def allowed_cloud_networks(_options = {})
     return {} unless (src = provider_or_tenant_object)
-    targets = get_targets_for_source(src, :cloud_filter, CloudNetwork, 'cloud_networks')
+    targets = get_targets_for_source(src, :cloud_filter, CloudNetwork, 'all_cloud_networks')
     allowed_ci(:cloud_network, [:availability_zone], targets.map(&:id))
   end
 
@@ -95,7 +95,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
         hash[cn.id] = cn.name
       end
     else
-      load_ar_obj(src[:ems]).cloud_subnets.collect(&:cloud_network).each_with_object({}) do |cn, hash|
+      load_ar_obj(src[:ems]).all_cloud_networks.each_with_object({}) do |cn, hash|
         hash[cn.id] = cn.name
       end
     end


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/16811 and https://github.com/ManageIQ/manageiq/pull/16688 broke openstack provisioning because the call needs the all_cloud_networks which was taken out in https://github.com/ManageIQ/manageiq/pull/16688. The all_cloud_networks includes the shared networks set up in the openstack provider specs [here](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/spec/models/manageiq/providers/openstack/cloud_manager/provision_workflow_spec.rb#L288).

Fixes issue caused by fix of https://bugzilla.redhat.com/show_bug.cgi?id=1533277
(Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535189)

## Related to:
https://github.com/ManageIQ/manageiq-providers-openstack/pull/202
https://github.com/ManageIQ/manageiq-providers-google/pull/43

### related external provider tests:
(which, since this and the above two are blockers, should maybe wait until the code is merged?)
https://github.com/ManageIQ/manageiq-providers-amazon/pull/394
https://github.com/ManageIQ/manageiq-providers-azure/pull/199

