### PR TITLE
Add acts_as_miq_taggable to AuthPrivateKey

### DIFF
--- a/app/models/auth_private_key.rb
+++ b/app/models/auth_private_key.rb
@@ -1,2 +1,3 @@
 class AuthPrivateKey < Authentication
+  acts_as_miq_taggable
 end

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -33,7 +33,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
 
   def allowed_guest_access_key_pairs(_options = {})
     source = load_ar_obj(get_source_vm)
-    targets = get_targets_for_ems(source, :cloud_filter, ManageIQ::Providers, 'key_pairs')
+    targets = get_targets_for_ems(source, :cloud_filter, ManageIQ::Providers::CloudManager::AuthKeyPair, 'key_pairs')
     targets.each_with_object({}) { |kp, h| h[kp.id] = kp.name }
   end
 

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -74,7 +74,10 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
       FactoryGirl.create(:classification_cost_center_with_tags)
       admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
                                                                          'belongsto' => []})
-
+      2.times do |i|
+        kp = ManageIQ::Providers::CloudManager::AuthKeyPair.create(:name => "auth_#{i}")
+        ems.key_pairs << kp
+      end
       2.times { FactoryGirl.create(:availability_zone, :ems_id => ems.id) }
       2.times do
         FactoryGirl.create(:security_group, :name                  => "sgb_1",
@@ -84,11 +87,23 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
                                         :supports_64_bit => true)
       ems.flavors << FactoryGirl.create(:flavor, :name => "m1.large", :supports_32_bit => false,
                                         :supports_64_bit => true)
-
+      tagged_key_pair = ems.key_pairs.first
       tagged_zone = ems.availability_zones.first
       tagged_flavor = ems.flavors.first
       Classification.classify(tagged_zone, 'cc', '001')
       Classification.classify(tagged_flavor, 'cc', '001')
+      Classification.classify(tagged_key_pair, 'cc', '001')
+    end
+
+    context "key_pairs" do
+      it "#get_targets_for_ems" do
+        expect(ems.key_pairs.size).to eq(2)
+        expect(ems.key_pairs.first.tags.size).to eq(1)
+        expect(ems.key_pairs.last.tags.size).to eq(0)
+        filtered = workflow.send(:get_targets_for_ems, ems, :cloud_filter, ManageIQ::Providers::CloudManager::AuthKeyPair,
+                                 'key_pairs')
+        expect(filtered.size).to eq(1)
+      end
     end
 
     context "availability_zones" do


### PR DESCRIPTION
The RBAC filtering was not 100% applied to the AuthPrivate key class which
caused tagging to fail.  This change allows `key_pairs` to return correctly when
run through RBAC when being tagged

https://bugzilla.redhat.com/show_bug.cgi?id=1514237
