### PR TITLE
Add GraphQL API engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,6 +172,10 @@ group :rest_api, :manageiq_default do
   manageiq_plugin "manageiq-api"
 end
 
+group :graphql_api, :manageiq_default do
+  manageiq_plugin "manageiq-graphql"
+end
+
 group :scheduler, :manageiq_default do
   # Modified gems (forked on Github)
   gem "rufus-scheduler", "=3.1.10.2", :git => "https://github.com/ManageIQ/rufus-scheduler.git", :require => false, :tag => "v3.1.10-2"


### PR DESCRIPTION
This adds the [manageiq-graphql](https://github.com/ManageIQ/manageiq-graphql) project to ManageIQ `master`, which is currently targeted for the Hammer release.

Note that the GraphQL API is considered extremely alpha and while you're welcome to tinker around with it, ManageIQ developers shouldn't be building anything on top of it yet. The main reason this should be merged now is that we actually need it available to run CI in the project (and changing CI to use our own custom branch isn't really worth the trouble).

I will make an announcement on manageiq.org and/or the forum once we're finished more of our foundation phase of development.