### PR TITLE
Corrected tests evaluating MiqExpression for Custom Button

### DIFF
--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -50,20 +50,24 @@ describe ServiceTemplate do
       false_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "bar"})
       FactoryGirl.create(:custom_button,
                          :name                  => "visible button",
-                         :applies_to_class      => "Service",
+                         :applies_to_class      => "ServiceTemplate",
+                         :applies_to_id         => service_template.id,
                          :visibility_expression => true_expression)
       FactoryGirl.create(:custom_button,
                          :name                  => "hidden button",
-                         :applies_to_class      => "Service",
+                         :applies_to_class      => "ServiceTemplate",
+                         :applies_to_id         => service_template.id,
                          :visibility_expression => false_expression)
-      FactoryGirl.create(:custom_button_set).tap do |group|
+      service_template.custom_button_sets << FactoryGirl.create(:custom_button_set).tap do |group|
         group.add_member(FactoryGirl.create(:custom_button,
                                             :name                  => "visible button in group",
-                                            :applies_to_class      => "Service",
+                                            :applies_to_class      => "ServiceTemplate",
+                                            :applies_to_id         => service_template.id,
                                             :visibility_expression => true_expression))
         group.add_member(FactoryGirl.create(:custom_button,
                                             :name                  => "hidden button in group",
-                                            :applies_to_class      => "Service",
+                                            :applies_to_class      => "ServiceTemplate",
+                                            :applies_to_id         => service_template.id,
                                             :visibility_expression => false_expression))
       end
 
@@ -143,8 +147,9 @@ describe ServiceTemplate do
 
     it "serializes the enablement" do
       service_template = FactoryGirl.create(:service_template, :name => "foo")
-      true_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "foo"})
-      false_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "bar"})
+      service = FactoryGirl.create(:service, :name => "bar", :service_template => service_template)
+      true_expression = MiqExpression.new("=" => {"field" => "Service-name", "value" => "bar"})
+      false_expression = MiqExpression.new("=" => {"field" => "Service-name", "value" => "foo"})
       FactoryGirl.create(:custom_button,
                          :name                  => "enabled button",
                          :applies_to_class      => "Service",
@@ -178,7 +183,7 @@ describe ServiceTemplate do
           )
         ]
       }
-      expect(service_template.custom_actions).to match(expected)
+      expect(service_template.custom_actions(service)).to match(expected)
     end
   end
 
@@ -188,18 +193,22 @@ describe ServiceTemplate do
       true_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "foo"})
       false_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "bar"})
       visible_button = FactoryGirl.create(:custom_button,
-                                          :applies_to_class      => "Service",
+                                          :applies_to_class      => "ServiceTemplate",
+                                          :applies_to_id         => service_template.id,
                                           :visibility_expression => true_expression)
       _hidden_button = FactoryGirl.create(:custom_button,
-                                          :applies_to_class      => "Service",
+                                          :applies_to_class      => "ServiceTemplate",
+                                          :applies_to_id         => service_template.id,
                                           :visibility_expression => false_expression)
       visible_button_in_group = FactoryGirl.create(:custom_button,
-                                                   :applies_to_class      => "Service",
+                                                   :applies_to_class      => "ServiceTemplate",
+                                                   :applies_to_id         => service_template.id,
                                                    :visibility_expression => true_expression)
       hidden_button_in_group = FactoryGirl.create(:custom_button,
-                                                  :applies_to_class      => "Service",
+                                                  :applies_to_class      => "ServiceTemplate",
+                                                  :applies_to_id         => service_template.id,
                                                   :visibility_expression => false_expression)
-      FactoryGirl.create(:custom_button_set).tap do |group|
+      service_template.custom_button_sets << FactoryGirl.create(:custom_button_set).tap do |group|
         group.add_member(visible_button_in_group)
         group.add_member(hidden_button_in_group)
       end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -45,7 +45,7 @@ describe ServiceTemplate do
     end
 
     it "does not show hidden buttons" do
-      service_template = FactoryGirl.create(:service_template, :name => "bar")
+      service_template = FactoryGirl.create(:service_template)
       service = FactoryGirl.create(:service, :name => "foo", :service_template => service_template)
       true_expression = MiqExpression.new("=" => {"field" => "Service-name", "value" => "foo"})
       false_expression = MiqExpression.new("=" => {"field" => "Service-name", "value" => "labar"})

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -45,29 +45,26 @@ describe ServiceTemplate do
     end
 
     it "does not show hidden buttons" do
-      service_template = FactoryGirl.create(:service_template, :name => "foo")
-      true_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "foo"})
-      false_expression = MiqExpression.new("=" => {"field" => "ServiceTemplate-name", "value" => "bar"})
+      service_template = FactoryGirl.create(:service_template, :name => "bar")
+      service = FactoryGirl.create(:service, :name => "foo", :service_template => service_template)
+      true_expression = MiqExpression.new("=" => {"field" => "Service-name", "value" => "foo"})
+      false_expression = MiqExpression.new("=" => {"field" => "Service-name", "value" => "labar"})
       FactoryGirl.create(:custom_button,
                          :name                  => "visible button",
-                         :applies_to_class      => "ServiceTemplate",
-                         :applies_to_id         => service_template.id,
+                         :applies_to_class      => "Service",
                          :visibility_expression => true_expression)
       FactoryGirl.create(:custom_button,
                          :name                  => "hidden button",
-                         :applies_to_class      => "ServiceTemplate",
-                         :applies_to_id         => service_template.id,
+                         :applies_to_class      => "Service",
                          :visibility_expression => false_expression)
-      service_template.custom_button_sets << FactoryGirl.create(:custom_button_set).tap do |group|
+      FactoryGirl.create(:custom_button_set).tap do |group|
         group.add_member(FactoryGirl.create(:custom_button,
                                             :name                  => "visible button in group",
-                                            :applies_to_class      => "ServiceTemplate",
-                                            :applies_to_id         => service_template.id,
+                                            :applies_to_class      => "Service",
                                             :visibility_expression => true_expression))
         group.add_member(FactoryGirl.create(:custom_button,
                                             :name                  => "hidden button in group",
-                                            :applies_to_class      => "ServiceTemplate",
-                                            :applies_to_id         => service_template.id,
+                                            :applies_to_class      => "Service",
                                             :visibility_expression => false_expression))
       end
 
@@ -83,7 +80,7 @@ describe ServiceTemplate do
           )
         ]
       }
-      expect(service_template.custom_actions).to match(expected)
+      expect(service_template.custom_actions(service)).to match(expected)
     end
 
     context "expression evaluation" do


### PR DESCRIPTION
When Custom button created `CustomButton#applies_to_class` initialized with model name to which this button applies. The same model used to build `MiqExpression` and evaluate it.

**Before**:
For tests with expression evaluation model name in `MiqExpression` was not the same as `CustomButton#applies_to_class` attribute

**After**:
`CustomButton#applies_to_class` attribute represents model  which will be used to evaluate `MiqExpression` attached to CustomButton.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1505988

@miq-bot add-label technical debt, test

\cc @gtanzillo @imtayadeway  