### PR TITLE
Singularize plural model

### DIFF
--- a/app/models/asset_detail.rb
+++ b/app/models/asset_detail.rb
@@ -3,5 +3,5 @@ class AssetDetail < ApplicationRecord
 
   acts_as_miq_taggable
 
-  belongs_to :physical_server, :polymorphic => true
+  belongs_to :resource, :polymorphic => true
 end

--- a/app/models/asset_detail.rb
+++ b/app/models/asset_detail.rb
@@ -1,4 +1,4 @@
-class AssetDetails < ApplicationRecord
+class AssetDetail < ApplicationRecord
   include NewWithTypeStiMixin
 
   acts_as_miq_taggable

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -47,7 +47,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
                 []
               end
 
-    child_keys = [:computer_system, :asset_details, :hosts]
+    child_keys = [:computer_system, :asset_detail, :hosts]
     save_inventory_multi(ems.physical_servers, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_servers, hashes, :ems_ref)
   end
@@ -69,8 +69,8 @@ module EmsRefresh::SaveInventoryPhysicalInfra
   #
   # Saves asset details information of a resource
   #
-  def save_asset_details_inventory(parent, hash)
+  def save_asset_detail_inventory(parent, hash)
     return if hash.nil?
-    save_inventory_single(:asset_details, parent, hash)
+    save_inventory_single(:asset_detail, parent, hash)
   end
 end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -22,7 +22,7 @@ class PhysicalServer < ApplicationRecord
   has_one :computer_system, :as => :managed_entity, :dependent => :destroy
   has_one :hardware, :through => :computer_system
   has_one :host, :inverse_of => :physical_server
-  has_one :asset_details, :as => :resource, :dependent => :destroy
+  has_one :asset_detail, :as => :resource, :dependent => :destroy
 
   scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
 

--- a/spec/factories/asset_details.rb
+++ b/spec/factories/asset_details.rb
@@ -1,4 +1,3 @@
 FactoryGirl.define do
-  factory :asset_details do
-  end
+  factory :asset_detail
 end


### PR DESCRIPTION
The model was created as a plural, luckily the table name appears to be correct so we don't need a schema migration.

Added in https://github.com/ManageIQ/manageiq/pull/14749
Found because of https://github.com/ManageIQ/manageiq/pull/16768#issuecomment-357765761