### PR TITLE
Migrate model display names from locale/en.yml to models

### DIFF
--- a/app/models/auth_private_key.rb
+++ b/app/models/auth_private_key.rb
@@ -1,3 +1,7 @@
 class AuthPrivateKey < Authentication
   acts_as_miq_taggable
+
+  def self.display_name(number = 1)
+    n_('Private Key', 'Private Keys', number)
+  end
 end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -3,4 +3,8 @@ class AuthToken < Authentication
     @auth_changed = true if val != auth_key
     super(val)
   end
+
+  def self.display_name(number = 1)
+    n_('Authentication Token', 'Authentication Tokens', number)
+  end
 end

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -8,4 +8,8 @@ class AuthUseridPassword < Authentication
     @auth_changed = true if val != userid
     super(val)
   end
+
+  def self.display_name(number = 1)
+    n_('Password', 'Passwords', number)
+  end
 end

--- a/app/models/authentication_allow_all.rb
+++ b/app/models/authentication_allow_all.rb
@@ -1,2 +1,5 @@
 class AuthenticationAllowAll < Authentication
+  def self.display_name(number = 1)
+    n_('Authentication (Allow All)', 'Authentications (Allow All)', number)
+  end
 end

--- a/app/models/authentication_github.rb
+++ b/app/models/authentication_github.rb
@@ -1,2 +1,5 @@
 class AuthenticationGithub < Authentication
+  def self.display_name(number = 1)
+    n_('Authentication (GitHub)', 'Authentications (GitHub)', number)
+  end
 end

--- a/app/models/authentication_google.rb
+++ b/app/models/authentication_google.rb
@@ -1,2 +1,5 @@
 class AuthenticationGoogle < Authentication
+  def self.display_name(number = 1)
+    n_('Authentication (Google)', 'Authentications (Google)', number)
+  end
 end

--- a/app/models/authentication_htpasswd.rb
+++ b/app/models/authentication_htpasswd.rb
@@ -1,2 +1,5 @@
 class AuthenticationHtpasswd < Authentication
+  def self.display_name(number = 1)
+    n_('Authentication (HTTP Password)', 'Authentications (HTTP Password)', number)
+  end
 end

--- a/app/models/authentication_ldap.rb
+++ b/app/models/authentication_ldap.rb
@@ -6,4 +6,8 @@ class AuthenticationLdap < Authentication
     end
     super(hash)
   end
+
+  def self.display_name(number = 1)
+    n_('Authentication (LDAP)', 'Authentications (LDAP)', number)
+  end
 end

--- a/app/models/authentication_open_id.rb
+++ b/app/models/authentication_open_id.rb
@@ -1,2 +1,5 @@
 class AuthenticationOpenId < Authentication
+  def self.display_name(number = 1)
+    n_('Authentication (OpenID)', 'Authentications (OpenID)', number)
+  end
 end

--- a/app/models/authentication_rhsm.rb
+++ b/app/models/authentication_rhsm.rb
@@ -1,2 +1,5 @@
 class AuthenticationRhsm < Authentication
+  def self.display_name(number = 1)
+    n_('Authentication (RHSM)', 'Authentications (RHSM)', number)
+  end
 end

--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -113,6 +113,10 @@ class ChargebackContainerImage < Chargeback
     }
   end
 
+  def self.display_name(number = 1)
+    n_('Chargeback for Image', 'Chargebacks for Image', number)
+  end
+
   private
 
   def init_extra_fields(consumption, _region)

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -72,6 +72,10 @@ class ChargebackContainerProject < Chargeback
     }
   end
 
+  def self.display_name(number = 1)
+    n_('Chargeback for Projects', 'Chargebacks for Projects', number)
+  end
+
   private
 
   def init_extra_fields(consumption, _region)

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -188,6 +188,10 @@ class ChargebackVm < Chargeback
       end
   end
 
+  def self.display_name(number = 1)
+    n_('Chargeback for VMs', 'Chargebacks for VMs', number)
+  end
+
   private
 
   def init_extra_fields(consumption, region)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -466,6 +466,10 @@ class Classification < ApplicationRecord
     name.downcase.tr('^a-z0-9_:', '_')[0, NAME_MAX_LENGTH]
   end
 
+  def self.display_name(number = 1)
+    n_('Category', 'Categories', number)
+  end
+
   private
 
   def self.add_entries_from_hash(cat, entries)

--- a/app/models/compliance.rb
+++ b/app/models/compliance.rb
@@ -112,4 +112,8 @@ class Compliance < ApplicationRecord
       end
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Compliance History', 'Compliance Histories', number)
+  end
 end

--- a/app/models/configuration_script_source.rb
+++ b/app/models/configuration_script_source.rb
@@ -6,4 +6,8 @@ class ConfigurationScriptSource < ApplicationRecord
   belongs_to  :manager, :class_name => "ExtManagementSystem"
 
   virtual_total :total_payloads, :configuration_script_payloads
+
+  def self.display_name(number = 1)
+    n_('Repository', 'Repositories', number)
+  end
 end

--- a/app/models/container_env_var.rb
+++ b/app/models/container_env_var.rb
@@ -1,3 +1,6 @@
 class ContainerEnvVar < ApplicationRecord
   belongs_to :container
+  def self.display_name(number = 1)
+    n_('Container Environment Variable', 'Container Environment Variables', number)
+  end
 end

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -95,4 +95,8 @@ class ContainerGroup < ApplicationRecord
     self.deleted_on = Time.now.utc
     save
   end
+
+  def self.display_name(number = 1)
+    n_('Pod', 'Pods', number)
+  end
 end

--- a/app/models/container_group_performance.rb
+++ b/app/models/container_group_performance.rb
@@ -2,4 +2,8 @@ class ContainerGroupPerformance < MetricRollup
   default_scope { where("resource_type = 'ContainerGroup' and resource_id IS NOT NULL") }
 
   belongs_to :container_group, :foreign_key => :resource_id, :class_name => ContainerGroup.name
+
+  def self.display_name(number = 1)
+    n_('Pod Performance', 'Pod Performances', number)
+  end
 end

--- a/app/models/container_node_performance.rb
+++ b/app/models/container_node_performance.rb
@@ -2,4 +2,8 @@ class ContainerNodePerformance < MetricRollup
   default_scope { where("resource_type = 'ContainerNode' and resource_id IS NOT NULL") }
 
   belongs_to :container_node, :foreign_key => :resource_id, :class_name => ContainerNode.name
+
+  def self.display_name(number = 1)
+    n_('Container Node Performance', 'Container Nodes Performances', number)
+  end
 end

--- a/app/models/container_performance.rb
+++ b/app/models/container_performance.rb
@@ -2,4 +2,8 @@ class ContainerPerformance < MetricRollup
   default_scope { where("resource_type = 'Container' and resource_id IS NOT NULL") }
 
   belongs_to :container_node, :foreign_key => :resource_id, :class_name => Container.name
+
+  def self.display_name(number = 1)
+    n_('Performance - Container', 'Performance - Containers', number)
+  end
 end

--- a/app/models/container_project_performance.rb
+++ b/app/models/container_project_performance.rb
@@ -2,4 +2,8 @@ class ContainerProjectPerformance < MetricRollup
   default_scope { where("resource_type = 'ContainerProject' and resource_id IS NOT NULL") }
 
   belongs_to :container_node, :foreign_key => :resource_id, :class_name => ContainerProject.name
+
+  def self.display_name(number = 1)
+    n_('Performance - Container Project', 'Performance - Container Projects', number)
+  end
 end

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -197,4 +197,8 @@ class CustomButton < ApplicationRecord
     options[:guid] = SecureRandom.uuid
     options.each_with_object(dup) { |(k, v), button| button.send("#{k}=", v) }.tap(&:save!)
   end
+
+  def self.display_name(number = 1)
+    n_('Button', 'Buttons', number)
+  end
 end

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -76,4 +76,8 @@ class CustomButtonSet < ApplicationRecord
       custom_buttons.each { |cb| cbs.add_member(cb.copy(:applies_to => options[:owner])) }
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Button Group', 'Button Groups', number)
+  end
 end

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -338,4 +338,8 @@ class EmsCluster < ApplicationRecord
   def openstack_cluster?
     ext_management_system.class == ManageIQ::Providers::Openstack::InfraManager
   end
+
+  def self.display_name(number = 1)
+    n_('Cluster / Deployment Role', 'Clusters / Deployment Roles', number)
+  end
 end

--- a/app/models/ems_cluster_performance.rb
+++ b/app/models/ems_cluster_performance.rb
@@ -2,4 +2,8 @@ class EmsClusterPerformance < MetricRollup
   default_scope { where("resource_type = 'EmsCluster' and resource_id IS NOT NULL") }
 
   belongs_to :ems_cluster, :foreign_key => :resource_id
+
+  def self.display_name(number = 1)
+    n_('Cluster Performance', 'Cluster Performances', number)
+  end
 end

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -220,6 +220,10 @@ class EmsEvent < EventStream
     ext_management_system.class::EventTargetParser.new(self).parse
   end
 
+  def self.display_name(number = 1)
+    n_('Management Event', 'Management Events', number)
+  end
+
   private
 
   def self.event_allowed_ems_ref_keys

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -181,6 +181,10 @@ class EmsFolder < ApplicationRecord
     child_folder_paths_recursive(subtree, options)
   end
 
+  def self.display_name(number = 1)
+    n_('Folder', 'Folders', number)
+  end
+
   # Helper method for building the child folder paths given an arranged subtree.
   def self.child_folder_paths_recursive(subtree, options = {})
     options[:prefix] ||= ""

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -708,6 +708,10 @@ class ExtManagementSystem < ApplicationRecord
     data
   end
 
+  def self.display_name(number = 1)
+    n_('Manager', 'Managers', number)
+  end
+
   private
 
   def build_connection(options = {})

--- a/app/models/ext_management_system_performance.rb
+++ b/app/models/ext_management_system_performance.rb
@@ -2,4 +2,8 @@ class ExtManagementSystemPerformance < MetricRollup
   default_scope { where("resource_type = 'ExtManagementSystem' and resource_id IS NOT NULL") }
 
   belongs_to :ext_management_system, :foreign_key => :resource_id
+
+  def self.display_name(number = 1)
+    n_('Performance - Provider', 'Performance - Providers', number)
+  end
 end

--- a/app/models/file_depot_ftp.rb
+++ b/app/models/file_depot_ftp.rb
@@ -90,6 +90,10 @@ class FileDepotFtp < FileDepot
     false
   end
 
+  def self.display_name(number = 1)
+    n_('FTP', 'FTPs', number)
+  end
+
   private
 
   def create_directory_structure(directory_path)

--- a/app/models/file_depot_ftp_anonymous.rb
+++ b/app/models/file_depot_ftp_anonymous.rb
@@ -2,4 +2,8 @@ class FileDepotFtpAnonymous < FileDepotFtp
   def login_credentials
     ["anonymous", "anonymous"]
   end
+
+  def self.display_name(number = 1)
+    n_('Anonymous FTP', 'Anonymous FTPs', number)
+  end
 end

--- a/app/models/file_depot_smb.rb
+++ b/app/models/file_depot_smb.rb
@@ -14,4 +14,8 @@ class FileDepotSmb < FileDepot
   def verify_credentials(_auth_type = nil, cred_hash = nil)
     self.class.validate_settings(cred_hash.merge(:uri => uri))
   end
+
+  def self.display_name(number = 1)
+    n_('Samba', 'Sambas', number)
+  end
 end

--- a/app/models/floating_ip.rb
+++ b/app/models/floating_ip.rb
@@ -23,4 +23,8 @@ class FloatingIp < ApplicationRecord
     # TODO: use a factory on ExtManagementSystem side to return correct class for each provider
     ext_management_system && ext_management_system.class::FloatingIp
   end
+
+  def self.display_name(number = 1)
+    n_('Floating IP', 'Floating IPs', number)
+  end
 end

--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -147,6 +147,10 @@ class GenericObjectDefinition < ApplicationRecord
     CustomButton.buttons_for("GenericObject")
   end
 
+  def self.display_name(number = 1)
+    n_('Generic Object Class', 'Generic Object Classes', number)
+  end
+
   private
 
   def get_objects_of_association(attr, values)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1778,4 +1778,8 @@ class Host < ApplicationRecord
   def validate_destroy
     {:available => true, :message => nil}
   end
+
+  def self.display_name(number = 1)
+    n_('Host / Node', 'Hosts / Nodes', number)
+  end
 end

--- a/app/models/host_performance.rb
+++ b/app/models/host_performance.rb
@@ -3,4 +3,8 @@ class HostPerformance < MetricRollup
 
   belongs_to :ems_cluster, :foreign_key => :parent_ems_cluster_id
   belongs_to :host,        :foreign_key => :resource_id
+
+  def self.display_name(number = 1)
+    n_('Performance - Host', 'Performance - Hosts', number)
+  end
 end

--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -44,4 +44,8 @@ class IsoDatastore < ApplicationRecord
     _log.info("Synchronizing images on #{log_for}...Complete")
   rescue ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error
   end
+
+  def self.display_name(number = 1)
+    n_('ISO Datastore', 'ISO Datastores', number)
+  end
 end

--- a/app/models/iso_image.rb
+++ b/app/models/iso_image.rb
@@ -3,4 +3,8 @@ class IsoImage < ApplicationRecord
   belongs_to :pxe_image_type
 
   has_many :customization_templates, :through => :pxe_image_type
+
+  def self.display_name(number = 1)
+    n_('ISO Image', 'ISO Images', number)
+  end
 end

--- a/app/models/manageiq/providers/automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/automation_manager/authentication.rb
@@ -1,2 +1,5 @@
 class ManageIQ::Providers::AutomationManager::Authentication < Authentication
+  def self.display_name(number = 1)
+    n_('Credential', 'Credentials', number)
+  end
 end

--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -41,4 +41,8 @@ module ManageIQ::Providers
       {}
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Manager', 'Managers', number)
+  end
 end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -137,5 +137,9 @@ module ManageIQ::Providers
     def create_cloud_tenant(options)
       CloudTenant.create_cloud_tenant(self, options)
     end
+
+    def self.display_name(number = 1)
+      n_('Cloud Manager', 'Cloud Managers', number)
+    end
   end
 end

--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -60,4 +60,8 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::AuthPrivateKey
   def delete_key_pair
     raw_delete_key_pair
   end
+
+  def self.display_name(number = 1)
+    n_('Key Pair', 'Key Pairs', number)
+  end
 end

--- a/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_stack.rb
@@ -23,4 +23,8 @@ class ManageIQ::Providers::CloudManager::OrchestrationStack < ::OrchestrationSta
   def self.orchestration_stack_class_factory(orchestration_manager, template)
     "#{orchestration_manager.class.name}::#{template.stack_type}".constantize
   end
+
+  def self.display_name(number = 1)
+    n_('Orchestration Stack', 'Orchestration Stacks', number)
+  end
 end

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -118,6 +118,10 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
      :message   => _("%{message} is not available for %{name}.") % {:message => message_prefix, :name => name}}
   end
 
+  def self.display_name(number = 1)
+    n_('Image', 'Images', number)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -273,6 +273,10 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     vm.evacuate(options)
   end
 
+  def self.display_name(number = 1)
+    n_('Instance', 'Instances', number)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -21,4 +21,8 @@ class ManageIQ::Providers::ConfigurationManager < ManageIQ::Providers::BaseManag
   def total_configured_systems
     Rbac.filtered(configured_systems).count
   end
+
+  def self.display_name(number = 1)
+    n_('Configuration Manager', 'Configuration Managers', number)
+  end
 end

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -110,4 +110,8 @@ module ManageIQ::Providers
       virtualization_endpoint_destroyed(role) if respond_to?(:virtualization_endpoint_destroyed)
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Containers Manager', 'Containers Managers', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AmazonCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Amazon)', 'Credentials (Amazon)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -1,4 +1,8 @@
 # This corresponds to Ansible Tower's Azure Resource Manager (azure_rm) type credential
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Microsoft Azure)', 'Credentials (Microsoft Azure)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -4,4 +4,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::TowerApi
 
   FRIENDLY_NAME = "Ansible Automation Inside Project".freeze
+
+  def self.display_name(number = 1)
+    n_('Repository (Embedded Ansible)', 'Repositories (Embedded Ansible)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::GoogleCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Google)', 'Credentials (Google)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential <
   ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::MachineCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Machine)', 'Credentials (Machine)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::NetworkCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Network)', 'Credentials (Network)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::OpenstackCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (OpenStack)', 'Credentials (OpenStack)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -20,6 +20,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook <
     job_template_klass.raw_create_in_provider(manager, jt_options)
   end
 
+  def self.display_name(number = 1)
+    n_('Playbook (Embedded Ansible)', 'Playbooks (Embedded Ansible)', number)
+  end
+
   private
 
   def build_parameter_list(options)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/refresher.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/refresher.rb
@@ -1,4 +1,8 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
   include ::EmsRefresh::Refreshers::EmsRefresherMixin
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Refresher
+
+  def self.display_name(number = 1)
+    n_('Credential (Rackspace)', 'Credentials (Rackspace)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ScmCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (SCM)', 'Credentials (SCM)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VaultCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (Vault)', 'Credentials (Vault)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::VmwareCredential
+
+  def self.display_name(number = 1)
+    n_('Credential (VMware)', 'Credentials (VMware)', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/authentication.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAutomationManager::Authentication <
   ManageIQ::Providers::AutomationManager::Authentication
+
+  def self.display_name(number = 1)
+    n_('Credential', 'Credentials', number)
+  end
 end

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_script_source.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource <
   ManageIQ::Providers::AutomationManager::ConfigurationScriptSource
+
+  def self.display_name(number = 1)
+    n_('Repository', 'Repositories', number)
+  end
 end

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -54,4 +54,8 @@ module ManageIQ::Providers
       hosts.where(:ems_cluster => nil)
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Infrastructure Manager', 'Infrastructure Managers', number)
+  end
 end

--- a/app/models/manageiq/providers/infra_manager/template.rb
+++ b/app/models/manageiq/providers/infra_manager/template.rb
@@ -8,6 +8,10 @@ class ManageIQ::Providers::InfraManager::Template < MiqTemplate
                             ManageIQ::Providers::Kubevirt::InfraManager::Template))
   end
 
+  def self.display_name(number = 1)
+    n_('Template', 'Templates', number)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/infra_manager/vm.rb
+++ b/app/models/manageiq/providers/infra_manager/vm.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::InfraManager::Vm < ::Vm
     super
   end
 
+  def self.display_name(number = 1)
+    n_('Virtual Machine', 'Virtual Machines', number)
+  end
+
   private
 
   def raise_created_event

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -87,4 +87,8 @@ module ManageIQ::Providers
       "#{parent_manager.try(:name)} Network Manager"
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Network Manager', 'Network Managers', number)
+  end
 end

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -59,5 +59,9 @@ module ManageIQ::Providers
     def console_url
       raise MiqException::Error, _("Console not supported")
     end
+
+    def self.display_name(number = 1)
+      n_('Physical Infrastructure Manager', 'Physical Infrastructure Managers', number)
+    end
   end
 end

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -16,6 +16,10 @@ module ManageIQ::Providers
                :class_name  => "ManageIQ::Providers::BaseManager",
                :autosave    => true
 
+    def self.display_name(number = 1)
+      n_('Storage Manager', 'Storage Managers', number)
+    end
+
     class << model_name
       define_method(:route_key) { "ems_storages" }
       define_method(:singular_route_key) { "ems_storage" }

--- a/app/models/manageiq/providers/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager.rb
@@ -67,4 +67,8 @@ class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::
   def supports_provider_id?
     true
   end
+
+  def self.display_name(number = 1)
+    n_('Storage Manager (Cinder)', 'Storage Managers (Cinder)', number)
+  end
 end

--- a/app/models/manageiq/providers/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager.rb
@@ -67,4 +67,8 @@ class ManageIQ::Providers::StorageManager::SwiftManager < ManageIQ::Providers::S
   def self.event_monitor_class
     ManageIQ::Providers::StorageManager::SwiftManager::EventCatcher
   end
+
+  def self.display_name(number = 1)
+    n_('Storage Manager (Swift)', 'Storage Managers (Swift)', number)
+  end
 end

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -24,4 +24,8 @@ class MeteringContainerImage < ChargebackContainerImage
   def self.build_results_for_report_MeteringContainerImage(options)
     build_results_for_report_ChargebackContainerImage(options)
   end
+
+  def self.display_name(number = 1)
+    n_('Metering for Image', 'Metering for Images', number)
+  end
 end

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -22,4 +22,8 @@ class MeteringContainerProject < ChargebackContainerProject
   def self.build_results_for_report_MeteringContainerProject(options)
     build_results_for_report_ChargebackContainerProject(options)
   end
+
+  def self.display_name(number = 1)
+    n_('Metering for Project', 'Metering for Projects', number)
+  end
 end

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -27,4 +27,8 @@ class MeteringVm < ChargebackVm
   def self.build_results_for_report_MeteringVm(options)
     build_results_for_report_ChargebackVm(options)
   end
+
+  def self.display_name(number = 1)
+    n_('Metering for VM', 'Metering for VMs', number)
+  end
 end

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -986,6 +986,10 @@ class MiqAction < ApplicationRecord
     FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end
 
+  def self.display_name(number = 1)
+    n_('Action', 'Actions', number)
+  end
+
   private
 
   def invoke_or_queue(

--- a/app/models/miq_action_set.rb
+++ b/app/models/miq_action_set.rb
@@ -1,3 +1,7 @@
 class MiqActionSet < ApplicationRecord
   acts_as_miq_set
+
+  def self.display_name(number = 1)
+    n_('Action Set', 'Action Sets', number)
+  end
 end

--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -155,6 +155,10 @@ class MiqAeClass < ApplicationRecord
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Automate Class', 'Automate Classes', number)
+  end
+
   private
 
   def self.sub_namespaces(ns_obj, ids)

--- a/app/models/miq_ae_field.rb
+++ b/app/models/miq_ae_field.rb
@@ -102,6 +102,10 @@ class MiqAeField < ApplicationRecord
 
   delegate :editable?, :to => :ae_class
 
+  def self.display_name(number = 1)
+    n_('Automation Field', 'Automation Fields', number)
+  end
+
   private
 
   def set_default_value(value)

--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -136,6 +136,10 @@ class MiqAeInstance < ApplicationRecord
     MiqAeDatastore.get_homonymic_across_domains(user, ::MiqAeInstance, fqname, enabled)
   end
 
+  def self.display_name(number = 1)
+    n_('Automate Instance', 'Automate Instances', number)
+  end
+
   private
 
   def validate_field(field)

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -128,4 +128,8 @@ class MiqAeMethod < ApplicationRecord
     ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(name)
     ::MiqAeMethod.where(ae_method_filter).where(:class_id => class_id).first
   end
+
+  def self.display_name(number = 1)
+    n_('Automate Method', 'Automate Methods', number)
+  end
 end

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -113,4 +113,8 @@ class MiqAeNamespace < ApplicationRecord
   def domain?
     parent_id.nil? && name != '$'
   end
+
+  def self.display_name(number = 1)
+    n_('Automate Namespace', 'Automate Namespaces', number)
+  end
 end

--- a/app/models/miq_ae_value.rb
+++ b/app/models/miq_ae_value.rb
@@ -33,4 +33,8 @@ class MiqAeValue < ApplicationRecord
   def value=(value)
     write_attribute(:value, (ae_field.datatype == "password") ? MiqAePassword.encrypt(value) : value)
   end
+
+  def self.display_name(number = 1)
+    n_('Automation Value', 'Automation Values', number)
+  end
 end

--- a/app/models/miq_ae_workspace.rb
+++ b/app/models/miq_ae_workspace.rb
@@ -23,6 +23,10 @@ class MiqAeWorkspace < ApplicationRecord
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Automation Workspace', 'Automation Workspaces', number)
+  end
+
   def self.workspace_from_token(token)
     ws = MiqAeWorkspace.find_by(:guid => token)
     raise MiqAeException::WorkspaceNotFound, "Workspace Not Found for token=[#{token}]" if ws.nil?

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -33,10 +33,6 @@ class MiqAlert < ApplicationRecord
     BASE_TABLES
   end
 
-  def self.display_name
-    "Alert"
-  end
-
   acts_as_miq_set_member
 
   ASSIGNMENT_PARENT_ASSOCIATIONS = [:host, :ems_cluster, :ext_management_system, :my_enterprise]
@@ -859,5 +855,9 @@ class MiqAlert < ApplicationRecord
       _a, stat = import_from_hash(e[name])
       stat
     end
+  end
+
+  def self.display_name(number = 1)
+    n_('Alert', 'Alerts', number)
   end
 end

--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -51,6 +51,10 @@ class MiqAlertSet < ApplicationRecord
     File.open(fixture_file) { |fd| MiqAlertSet.import_from_yaml(fd, :save => true) }
   end
 
+  def self.display_name(number = 1)
+    n_('Alert Profile', 'Alert Profiles', number)
+  end
+
   private
 
   def default_name_to_description

--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -18,4 +18,8 @@ class MiqAlertStatus < ApplicationRecord
   def hidden?
     miq_alert_status_actions.where(:action_type => %w(hide show)).last.try(:action_type) == 'hide'
   end
+
+  def self.display_name(number = 1)
+    n_('Alert Status', 'Alert Statuses', number)
+  end
 end

--- a/app/models/miq_alert_status_action.rb
+++ b/app/models/miq_alert_status_action.rb
@@ -33,4 +33,8 @@ class MiqAlertStatusAction < ApplicationRecord
   def update_status_assignee
     miq_alert_status.update_attributes!(:assignee => assignee) if %w(assign unassign).include?(action_type)
   end
+
+  def self.display_name(number = 1)
+    n_('Alert Status Action', 'Alert Status Actions', number)
+  end
 end

--- a/app/models/miq_approval.rb
+++ b/app/models/miq_approval.rb
@@ -46,6 +46,10 @@ class MiqApproval < ApplicationRecord
     false
   end
 
+  def self.display_name(number = 1)
+    n_('Approval', 'Approvals', number)
+  end
+
   private
 
   def execute_approval(user)

--- a/app/models/miq_database.rb
+++ b/app/models/miq_database.rb
@@ -88,4 +88,8 @@ class MiqDatabase < ApplicationRecord
   def registration_organization_name
     registration_organization_display_name || registration_organization
   end
+
+  def self.display_name(number = 1)
+    n_('Database', 'Databases', number)
+  end
 end

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -49,4 +49,8 @@ class MiqDialog < ApplicationRecord
       create(item)
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Dialog', 'Dialogs', number)
+  end
 end

--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -103,4 +103,8 @@ class MiqEnterprise < ApplicationRecord
   end
   alias_method :perf_capture_enabled, :perf_capture_enabled?
   Vmdb::Deprecation.deprecate_methods(self, :perf_capture_enabled => :perf_capture_enabled?)
+
+  def self.display_name(number = 1)
+    n_('Enterprise', 'Enterprises', number)
+  end
 end # class MiqEnterprise

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -176,4 +176,8 @@ class MiqEvent < EventStream
     source_event_id = full_data.fetch_path(:source_event_id)
     @source_event = EventStream.find_by(:id => source_event_id) if source_event_id
   end
+
+  def self.display_name(number = 1)
+    n_('Event', 'Events', number)
+  end
 end

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -170,4 +170,8 @@ class MiqEventDefinition < ApplicationRecord
       end
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Event Definition', 'Event Definitions', number)
+  end
 end # class MiqEventDefinition

--- a/app/models/miq_event_definition_set.rb
+++ b/app/models/miq_event_definition_set.rb
@@ -23,4 +23,8 @@ class MiqEventDefinitionSet < ApplicationRecord
   def self.fixture_path
     FIXTURE_DIR.join("#{to_s.pluralize.underscore}.csv")
   end
+
+  def self.display_name(number = 1)
+    n_('Event Definition Set', 'Event Definition Sets', number)
+  end
 end

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -267,6 +267,10 @@ class MiqGroup < ApplicationRecord
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Group', 'Groups', number)
+  end
+
   private
 
   # if this tenant is changing, make sure this is not a default group

--- a/app/models/miq_host_provision.rb
+++ b/app/models/miq_host_provision.rb
@@ -42,4 +42,8 @@ class MiqHostProvision < MiqRequestTask
   end
 
   delegate :name, :to => :host, :prefix => true
+
+  def self.display_name(number = 1)
+    n_('Host Provision', 'Host Provisions', number)
+  end
 end

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -84,10 +84,6 @@ class MiqPolicy < ApplicationRecord
     attrs
   end
 
-  def self.display_name
-    "Policy"
-  end
-
   def copy(new_fields)
     npolicy = self.class.new(self.class.clean_attrs(attributes).merge(new_fields))
     npolicy.conditions = conditions
@@ -182,6 +178,11 @@ class MiqPolicy < ApplicationRecord
       MiqEventDefinition.find_by(:name => event)
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Policy', 'Policies', number)
+  end
+
   private_class_method :find_event_def
 
   def self.evaluate_conditions(plist, target, mode, inputs, result)

--- a/app/models/miq_policy_content.rb
+++ b/app/models/miq_policy_content.rb
@@ -30,4 +30,8 @@ class MiqPolicyContent < ApplicationRecord
     h["MiqAction"] = miq_action.export_to_array.first["MiqAction"] if miq_action
     [self.class.to_s => h]
   end
+
+  def self.display_name(number = 1)
+    n_('Policy Content', 'Policy Contents', number)
+  end
 end

--- a/app/models/miq_policy_set.rb
+++ b/app/models/miq_policy_set.rb
@@ -85,6 +85,10 @@ class MiqPolicySet < ApplicationRecord
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Policy Profile', 'Policy Profiles', number)
+  end
+
   private
 
   def default_name_to_description

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -220,4 +220,8 @@ class MiqProductFeature < ApplicationRecord
       )
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Product Feature', 'Product Features', number)
+  end
 end

--- a/app/models/miq_product_features_share.rb
+++ b/app/models/miq_product_features_share.rb
@@ -1,4 +1,8 @@
 class MiqProductFeaturesShare < ApplicationRecord
   belongs_to :miq_product_feature
   belongs_to :share
+
+  def self.display_name(number = 1)
+    n_('Product Features Share', 'Product Features Shares', number)
+  end
 end

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -96,4 +96,8 @@ class MiqProvision < MiqProvisionTask
                                                     :name    => prov_obj.vm_template.name,
                                                     :vm_name => vm_name}
   end
+
+  def self.display_name(number = 1)
+    n_('Provision', 'Provisions', number)
+  end
 end

--- a/app/models/miq_provision_task.rb
+++ b/app/models/miq_provision_task.rb
@@ -13,4 +13,8 @@ class MiqProvisionTask < MiqRequestTask
   def do_request
     signal :run_provision
   end
+
+  def self.display_name(number = 1)
+    n_('Provision Task', 'Provision Tasks', number)
+  end
 end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -541,6 +541,10 @@ class MiqQueue < ApplicationRecord
     find_by(:task_id => task_id).try(:get_worker)
   end
 
+  def self.display_name(number = 1)
+    n_('Queue', 'Queues', number)
+  end
+
   private
 
   def activate_miq_task(args)

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -305,6 +305,10 @@ class MiqRegion < ApplicationRecord
     @perf_capture_always = options.freeze
   end
 
+  def self.display_name(number = 1)
+    n_('Region', 'Regions', number)
+  end
+
   private
 
   def clear_my_region_cache

--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -105,4 +105,8 @@ class MiqRegionRemote < ApplicationRecord
       remove_connection
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Region Remote', 'Region Remotes', number)
+  end
 end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -233,6 +233,10 @@ class MiqReport < ApplicationRecord
     headers[column_index]
   end
 
+  def self.display_name(number = 1)
+    n_('Report', 'Reports', number)
+  end
+
   private
 
   def va_sql_cols

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -345,6 +345,10 @@ class MiqReportResult < ApplicationRecord
             miq_report_results.miq_report_id")
   end
 
+  def self.display_name(number = 1)
+    n_('Report Result', 'Report Results', number)
+  end
+
   private
 
   def user_timezone

--- a/app/models/miq_report_result_detail.rb
+++ b/app/models/miq_report_result_detail.rb
@@ -1,3 +1,7 @@
 class MiqReportResultDetail < ApplicationRecord
   belongs_to  :miq_report_result
+
+  def self.display_name(number = 1)
+    n_('Report Result Detail', 'Report Result Details', number)
+  end
 end

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -588,6 +588,10 @@ class MiqRequest < ApplicationRecord
     "#{self.class::SOURCE_CLASS_NAME}:#{requested_task_idx.inspect}"
   end
 
+  def self.display_name(number = 1)
+    n_('Request', 'Requests', number)
+  end
+
   private
 
   def clean_up_keys_for_request_task

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -202,6 +202,10 @@ class MiqRequestTask < ApplicationRecord
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Request Task', 'Request Tasks', number)
+  end
+
   private
 
   def validate_request_type

--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -85,4 +85,8 @@ class MiqRetireTask < MiqRequestTask
       end
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Retire Task', 'Retire Tasks', number)
+  end
 end

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -441,4 +441,8 @@ class MiqSchedule < ApplicationRecord
     return "" if zone.nil?
     zone.name
   end
+
+  def self.display_name(number = 1)
+    n_('Schedule', 'Schedules', number)
+  end
 end # class MiqSchedule

--- a/app/models/miq_scsi_lun.rb
+++ b/app/models/miq_scsi_lun.rb
@@ -1,3 +1,7 @@
 class MiqScsiLun < ApplicationRecord
   belongs_to :miq_scsi_target
+
+  def self.display_name(number = 1)
+    n_('SCSI LUN', 'SCSI LUNs', number)
+  end
 end

--- a/app/models/miq_scsi_target.rb
+++ b/app/models/miq_scsi_target.rb
@@ -3,4 +3,8 @@ class MiqScsiTarget < ApplicationRecord
 
   belongs_to :guest_device
   has_many :miq_scsi_luns, :dependent => :destroy
+
+  def self.display_name(number = 1)
+    n_('SCSI Target', 'SCSI Targets', number)
+  end
 end

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -105,4 +105,8 @@ class MiqSearch < ApplicationRecord
       end
     end
   end
+
+  def self.display_name(number = 1)
+    n_('Search', 'Searches', number)
+  end
 end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -615,4 +615,8 @@ class MiqServer < ApplicationRecord
   def miq_region
     ::MiqRegion.my_region
   end
+
+  def self.display_name(number = 1)
+    n_('Server', 'Servers', number)
+  end
 end # class MiqServer

--- a/app/models/miq_shortcut.rb
+++ b/app/models/miq_shortcut.rb
@@ -55,4 +55,8 @@ class MiqShortcut < ApplicationRecord
   def self.start_pages
     where(:startup => true).sort_by { |s| s.sequence.to_i }.collect { |s| [s.url, s.description, s.rbac_feature_name] }
   end
+
+  def self.display_name(number = 1)
+    n_('Shortcut', 'Shortcuts', number)
+  end
 end

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -354,6 +354,10 @@ class MiqTask < ApplicationRecord
     end
   end
 
+  def self.display_name(number = 1)
+    n_('Task', 'Tasks', number)
+  end
+
   private
 
   def initialize_attributes

--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -37,4 +37,8 @@ class MiqTemplate < VmOrTemplate
   end
 
   def active?; false; end
+
+  def self.display_name(number = 1)
+    n_('Template and Image', 'Templates and Images', number)
+  end
 end

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -119,4 +119,8 @@ class MiqUserRole < ApplicationRecord
   def self.default_tenant_role
     find_by(:name => DEFAULT_TENANT_ROLE_NAME)
   end
+
+  def self.display_name(number = 1)
+    n_('Role', 'Roles', number)
+  end
 end

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -576,6 +576,10 @@ class MiqWidget < ApplicationRecord
     options.fetch(:timezone_matters, true)
   end
 
+  def self.display_name(number = 1)
+    n_('Widget', 'Widgets', number)
+  end
+
   private
 
   def content_generator

--- a/app/models/miq_widget_content.rb
+++ b/app/models/miq_widget_content.rb
@@ -1,4 +1,8 @@
 class MiqWidgetContent < ApplicationRecord
   belongs_to  :miq_widget
   belongs_to  :miq_report_result
+
+  def self.display_name(number = 1)
+    n_('Widget Content', 'Widget Contents', number)
+  end
 end

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -74,4 +74,8 @@ class MiqWidgetSet < ApplicationRecord
     recs = where(:id => ids).index_by(&:id)
     ids.map { |id| recs[id.to_i] }
   end
+
+  def self.display_name(number = 1)
+    n_('Dashboard', 'Dashboards', number)
+  end
 end

--- a/app/models/miq_widget_shortcut.rb
+++ b/app/models/miq_widget_shortcut.rb
@@ -1,4 +1,8 @@
 class MiqWidgetShortcut < ApplicationRecord
   belongs_to :miq_widget
   belongs_to :miq_shortcut
+
+  def self.display_name(number = 1)
+    n_('Widget Shortcut', 'Widget Shortcuts', number)
+  end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -633,5 +633,10 @@ class MiqWorker < ApplicationRecord
     delta = worker_settings[:nice_delta]
     delta.kind_of?(Integer) ? delta.to_s : "+10"
   end
+
+  def self.display_name(number = 1)
+    n_('Worker', 'Workers', number)
+  end
+
   private_class_method :nice_increment
 end

--- a/app/models/pxe_image.rb
+++ b/app/models/pxe_image.rb
@@ -59,6 +59,10 @@ class PxeImage < ApplicationRecord
     pxe_server.delete_file(filepath)
   end
 
+  def self.display_name(number = 1)
+    n_('PXE Image', 'PXE Images', number)
+  end
+
   private
 
   def update_pxe_content_option(options, key, value)

--- a/app/models/pxe_image_type.rb
+++ b/app/models/pxe_image_type.rb
@@ -30,4 +30,8 @@ class PxeImageType < ApplicationRecord
   def esx?
     name.to_s.downcase == 'esx'
   end
+
+  def self.display_name(number = 1)
+    n_('Image Type', 'Image Types', number)
+  end
 end

--- a/app/models/pxe_menu.rb
+++ b/app/models/pxe_menu.rb
@@ -71,4 +71,8 @@ class PxeMenu < ApplicationRecord
 
     _log.info("Synchronizing Menu Items in Menu [#{file_name}] on PXE Server [#{pxe_server.name}]... Complete - #{stats.inspect}")
   end
+
+  def self.display_name(number = 1)
+    n_('PXE Menu', 'PXE Menus', number)
+  end
 end

--- a/app/models/pxe_menu_ipxe.rb
+++ b/app/models/pxe_menu_ipxe.rb
@@ -65,4 +65,8 @@ class PxeMenuIpxe < PxeMenu
     end
     items
   end
+
+  def self.display_name(number = 1)
+    n_('PXE Menu (iPXE)', 'PXE Menus (iPXE)', number)
+  end
 end

--- a/app/models/pxe_menu_pxelinux.rb
+++ b/app/models/pxe_menu_pxelinux.rb
@@ -48,4 +48,8 @@ class PxeMenuPxelinux < PxeMenu
     options.reject! { |o| o.blank? || rejects.any? { |r| o.starts_with?(r) } }
     return options.join(' '), initrd
   end
+
+  def self.display_name(number = 1)
+    n_('PXE Menu (pxelinux)', 'PXE Menus (pxelinux)', number)
+  end
 end

--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -197,4 +197,8 @@ class PxeServer < ApplicationRecord
     end
     _log.info("#{log_message}...Complete")
   end
+
+  def self.display_name(number = 1)
+    n_('PXE Server', 'PXE Servers', number)
+  end
 end

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -82,6 +82,10 @@ class RssFeed < ApplicationRecord
     Tag.where("name like '/managed/roles/%'").pluck(:name).collect { |n| n.split("/").last }
   end
 
+  def self.display_name(number = 1)
+    n_('RSS Feed', 'RSS Feeds', number)
+  end
+
   private
 
   def self.eval_item_attr(script, rec)

--- a/app/models/scan_item_set.rb
+++ b/app/models/scan_item_set.rb
@@ -1,3 +1,7 @@
 class ScanItemSet < ApplicationRecord
   acts_as_miq_set
+
+  def self.display_name(number = 1)
+    n_('Analysis Profile', 'Analysis Profiles', number)
+  end
 end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -412,6 +412,10 @@ class ServiceTemplate < ApplicationRecord
     set_service_type
   end
 
+  def self.display_name(number = 1)
+    n_('Service Catalog Item', 'Service Catalog Items', number)
+  end
+
   private
 
   def update_service_resources(config_info, auth_user = nil)

--- a/app/models/service_template_catalog.rb
+++ b/app/models/service_template_catalog.rb
@@ -7,4 +7,8 @@ class ServiceTemplateCatalog < ApplicationRecord
   has_many  :service_templates, :dependent => :nullify
 
   acts_as_miq_taggable
+
+  def self.display_name(number = 1)
+    n_('Catalog', 'Catalogs', number)
+  end
 end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -848,4 +848,8 @@ class Storage < ApplicationRecord
   def self.supports?(store_type)
     Storage::SUPPORTED_STORAGE_TYPES.include?(store_type)
   end
+
+  def self.display_name(number = 1)
+    n_('Datastore', 'Datastores', number)
+  end
 end

--- a/app/models/storage_file.rb
+++ b/app/models/storage_file.rb
@@ -70,4 +70,8 @@ class StorageFile < ApplicationRecord
   def v_size_numeric
     size.to_i
   end
+
+  def self.display_name(number = 1)
+    n_('Datastore File', 'Datastore Files', number)
+  end
 end

--- a/app/models/storage_performance.rb
+++ b/app/models/storage_performance.rb
@@ -2,4 +2,8 @@ class StoragePerformance < MetricRollup
   default_scope { where("resource_type = 'Storage' and resource_id IS NOT NULL") }
 
   belongs_to :storage, :foreign_key => :resource_id
+
+  def self.display_name(number = 1)
+    n_('Performance - Datastore', 'Performance - Datastores', number)
+  end
 end

--- a/app/models/vim_performance_trend.rb
+++ b/app/models/vim_performance_trend.rb
@@ -269,4 +269,8 @@ class VimPerformanceTrend < ActsAsArModel
 
     title
   end
+
+  def self.display_name(number = 1)
+    n_('Performance Trend', 'Performance Trends', number)
+  end
 end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -133,6 +133,10 @@ class Vm < VmOrTemplate
     vm_as_resources.all? { |rsc| rsc.status == ServiceResource::STATUS_FAILED } ? TransformationMapping::VM_VALID : TransformationMapping::VM_IN_OTHER_PLAN
   end
 
+  def self.display_name(number = 1)
+    n_('VM and Instance', 'VMs and Instances', number)
+  end
+
   private
 
   def vnc_support

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1736,6 +1736,10 @@ class VmOrTemplate < ApplicationRecord
     parent
   end
 
+  def self.display_name(number = 1)
+    n_('VM or Template', 'VMs or Templates', number)
+  end
+
   private
 
   def set_tenant_from_group

--- a/app/models/vm_performance.rb
+++ b/app/models/vm_performance.rb
@@ -5,4 +5,8 @@ class VmPerformance < MetricRollup
   belongs_to :ems_cluster, :foreign_key => :parent_ems_cluster_id
   belongs_to :storage,     :foreign_key => :parent_storage_id
   belongs_to :vm,          :foreign_key => :resource_id, :class_name => 'VmOrTemplate'
+
+  def self.display_name(number = 1)
+    n_('Performance - VM', 'Performance - VMs', number)
+  end
 end

--- a/app/models/vmdb_database.rb
+++ b/app/models/vmdb_database.rb
@@ -76,4 +76,8 @@ class VmdbDatabase < ApplicationRecord
   def self.report_client_connections
     connection.client_connections if connection.respond_to?(:client_connections)
   end
+
+  def self.display_name(number = 1)
+    n_('Database', 'Databases', number)
+  end
 end

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -134,4 +134,8 @@ class VmdbDatabaseConnection < ApplicationRecord
   def pid
     @pid ||= (miq_worker || miq_server).try(:pid)
   end
+
+  def self.display_name(number = 1)
+    n_('Database Connection', 'Database Connections', number)
+  end
 end

--- a/app/models/vmdb_database_lock.rb
+++ b/app/models/vmdb_database_lock.rb
@@ -8,6 +8,10 @@ class VmdbDatabaseLock < ApplicationRecord
       .find_by(['pid != ?', pid])
   end
 
+  def self.display_name(number = 1)
+    n_('Database Lock', 'Database Locks', number)
+  end
+
   private
 
   def blocking_lock_relation

--- a/app/models/vmdb_database_metric.rb
+++ b/app/models/vmdb_database_metric.rb
@@ -3,4 +3,8 @@ class VmdbDatabaseMetric < ApplicationRecord
 
   VmdbMetric # Eager load VmdbMetric class to allow access to VmdbMetric::Purging
   include_concern 'VmdbMetric::Purging'
+
+  def self.display_name(number = 1)
+    n_('Database Metric', 'Database Metrics', number)
+  end
 end

--- a/app/models/vmdb_database_setting.rb
+++ b/app/models/vmdb_database_setting.rb
@@ -23,4 +23,8 @@ class VmdbDatabaseSetting < ApplicationRecord
     desc += "  #{extra_desc}" unless extra_desc.nil?
     desc
   end
+
+  def self.display_name(number = 1)
+    n_('Database Setting', 'Database Settings', number)
+  end
 end

--- a/app/models/vmdb_index.rb
+++ b/app/models/vmdb_index.rb
@@ -15,4 +15,8 @@ class VmdbIndex < ApplicationRecord
   def my_metrics
     vmdb_metrics
   end
+
+  def self.display_name(number = 1)
+    n_('Index', 'Indexes', number)
+  end
 end

--- a/app/models/vmdb_metric.rb
+++ b/app/models/vmdb_metric.rb
@@ -31,4 +31,8 @@ class VmdbMetric < ApplicationRecord
     # Create new daily record...
     metric.update_attributes(:rows => rows, :size => size, :wasted_bytes => wasted_bytes, :percent_bloat => percent_bloat)
   end
+
+  def self.display_name(number = 1)
+    n_('Metric', 'Metrics', number)
+  end
 end

--- a/app/models/vmdb_table.rb
+++ b/app/models/vmdb_table.rb
@@ -15,4 +15,8 @@ class VmdbTable < ApplicationRecord
   def my_metrics
     vmdb_metrics
   end
+
+  def self.display_name(number = 1)
+    n_('Table', 'Tables', number)
+  end
 end

--- a/app/models/windows_image.rb
+++ b/app/models/windows_image.rb
@@ -3,4 +3,8 @@ class WindowsImage < ApplicationRecord
   belongs_to :pxe_image_type
 
   has_many :customization_templates, :through => :pxe_image_type
+
+  def self.display_name(number = 1)
+    n_('Windows Image', 'Windows Images', number)
+  end
 end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -215,4 +215,15 @@ namespace :locale do
     Rake::Task['gettext:po_to_json'].invoke
     system "rm -rf #{combined_dir}"
   end
+
+  desc "Create display names for models"
+  task "model_display_names" => :environment do
+    f = File.open(Rails.root.join("config/model_display_names.rb"), "w+")
+    Rails.application.eager_load!
+    ApplicationRecord.descendants.sort_by(&:display_name).collect do |model|
+      next if model.model_name.singular.titleize != model.display_name || model.display_name.start_with?('ManageIQ')
+      f.puts "n_('#{model.display_name}', '#{model.display_name 2}', n)"
+    end
+    f.close
+  end
 end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -142,9 +142,10 @@ namespace :locale do
     Rake::Task['locale:store_dictionary_strings'].invoke
     Rake::Task['locale:run_store_model_attributes'].invoke
     Rake::Task['locale:extract_yaml_strings'].invoke(Rails.root)
+    Rake::Task['locale:model_display_names'].invoke
     Rake::Task['gettext:find'].invoke
 
-    Dir["config/dictionary_strings.rb", "config/model_attributes.rb", "config/yaml_strings.rb", "locale/**/*.edit.po", "locale/**/*.po.time_stamp"].each do |file|
+    Dir["config/dictionary_strings.rb", "config/model_attributes.rb", "config/model_display_names.rb", "config/yaml_strings.rb", "locale/**/*.edit.po", "locale/**/*.po.time_stamp"].each do |file|
       File.unlink(file)
     end
   end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from `locale/en.yml` into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

The strings were migrated automatically and adjusted where needed (incorrect plurals and such), some of the display names were changed:
```
EVM Audit Event -> Audit Event
Chargeback for Vms -> Chargeback for VMs
Host / Nodes -> Hosts / Nodes
EVM Group -> Group
EVM User -> User
VMDB Table -> Table
```

Next step would be to switch `ui_lookup()` and `Dictionary.gettext()` to use `display_name()` rather than `I18n.t()` and `locale.en.yml`.

Plugin PRs:
https://github.com/ManageIQ/manageiq-automation_engine/pull/145
https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/55
https://github.com/ManageIQ/manageiq-providers-amazon/pull/398
https://github.com/ManageIQ/manageiq-providers-azure/pull/200
https://github.com/ManageIQ/manageiq-providers-foreman/pull/16
https://github.com/ManageIQ/manageiq-providers-google/pull/42
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/218
https://github.com/ManageIQ/manageiq-providers-lenovo/pull/126
https://github.com/ManageIQ/manageiq-providers-openshift/pull/84
https://github.com/ManageIQ/manageiq-providers-openstack/pull/200
https://github.com/ManageIQ/manageiq-providers-scvmm/pull/60
https://github.com/ManageIQ/manageiq-providers-vmware/pull/174
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/197

gaprindashvili/no