### PR TITLE
Fix memory leak with ruby/require/autoload_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -90,15 +90,15 @@ module Vmdb
     # Customize any additional options below...
 
     config.autoload_paths += config.eager_load_paths
-    config.autoload_paths << Rails.root.join("app", "models", "aliases")
-    config.autoload_paths << Rails.root.join("app", "models", "mixins")
-    config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models")
-    config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models", "mixins")
-    config.autoload_paths << Rails.root.join("app", "controllers", "mixins")
-    config.autoload_paths << Rails.root.join("lib")
-    config.autoload_paths << Rails.root.join("lib", "services")
+    config.autoload_paths << Rails.root.join("app", "models", "aliases").to_s
+    config.autoload_paths << Rails.root.join("app", "models", "mixins").to_s
+    config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models").to_s
+    config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models", "mixins").to_s
+    config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
+    config.autoload_paths << Rails.root.join("lib").to_s
+    config.autoload_paths << Rails.root.join("lib", "services").to_s
 
-    config.autoload_once_paths << Rails.root.join("lib", "vmdb", "console_methods.rb")
+    config.autoload_once_paths << Rails.root.join("lib", "vmdb", "console_methods.rb").to_s
 
     # config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled.
     # Defaults to every folder in the app directory of the application.


### PR DESCRIPTION
In ruby versions less than 2.5.0, it was found that if you have `Pathname` objects in the `$LOAD_PATH` instead of regular strings, it messes with ruby's internals and causes a memory leak.

In most ruby applications, this wouldn't be much of an issue, but there are a significant number of deferred require statements that we do in `manageiq` that cause this to leak overtime.  Further more, this seems to be an issue that presents itself even if the file has been loaded previously (mostly a no-op for `require`).

Replication of this issue can be done using a simple ruby script:

```ruby
require 'pathname'
require 'fileutils'

puts Process.pid

Dir.mkdir("foo") unless Dir.exists?("foo")
$LOAD_PATH.unshift(Pathname.new("foo"))

FileUtils.touch("empty.rb")
1500.times { 1500.times { require "empty" }; print "."; GC.start; }
```

By simply running the application with the Pathnames converted to strings, this should be a proper and low cost workaround for us until it is patched in ruby or we update `manageiq` to >= ruby 2.5.0.


This will also need to be done in the provider repos as well that happen to add to the `autoload_paths` in their engines as well.  Should only be the `manageiq-api`, `manageiq-ui-classic`, and the `manageiq-automation_engine` (PRs for those to come shortly, and will be linked below)


Links
-----

* https://github.com/ManageIQ/manageiq-api/pull/288
* https://github.com/ManageIQ/manageiq-automation_engine/pull/146
* https://github.com/ManageIQ/manageiq-ui-classic/pull/3266
* https://github.com/ManageIQ/manageiq-graphql/pull/34
* https://bugs.ruby-lang.org/issues/14372

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1535720

TODO:  Add links for the following

- [x] Additional PRs for the provider repos
- [x] Link to ruby bug
- [ ] Relavent BZs once we determine which workers this helps fix completely


Steps for Testing/QA
--------------------

Running the script above should replicate the issue on any system.

Additionally, we are testing this collection of patches on multiple appliances to confirm that the leak is removed.

Finally, once all these are merged (or by applying these patches locally), you can run a `bin/rails console` and confirm that nothing in the `$LOAD_PATH` is a `Pathname`:

```ruby
irb> $LOAD_PATH.select {|path| path.class == Pathname }
#=> []
```