### PR TITLE
Require graphiql-rails gem in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -218,6 +218,7 @@ end
 unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
+    gem "graphiql-rails",   "~>1.4"
     gem "haml_lint",        "~>0.20.0", :require => false
     gem "rubocop",          "~>0.52.1", :require => false
     # ruby_parser is required for i18n string extraction

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,8 @@ Vmdb::Application.routes.draw do
     logger.level = Logger.const_get(::Settings.log.level_websocket.upcase)
     mount WebsocketServer.new(:logger => logger) => '/ws'
   end
+
+  if Rails.env.development?
+    mount GraphiQL::Rails::Engine, :at => "/graphql/explorer", :graphql_path => "/graphql"
+  end
 end


### PR DESCRIPTION
This needs to be required here because of the peculiarities of how
engines hook into the rails application. Essentially, requiring an
engine within an engine will cause this to fail - although the library
is loaded correctly, the app code never gets loaded causing a 404
error when performing a GET to /graphql/explorer.