### PR TITLE
make the default endpoint be saved first for container managers

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -55,6 +55,14 @@ module ManageIQ::Providers
 
     virtual_column :port_show, :type => :string
 
+    before_create :sort_endpoints_default_first
+
+    def sort_endpoints_default_first
+      to_sort = endpoints
+      self.endpoints = []
+      self.endpoints = to_sort.sort { |x| x.role == 'default' ? -1 : 1 }
+    end
+
     supports :external_logging do
       unless respond_to?(:external_logging_route_name)
         unsupported_reason_add(:external_logging, _('This provider type does not support external_logging'))


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1535941

In some cases other endpoints(alerts, virtualization) can be dependent of the default endpoint so we need to save the default endpoint first. 

@cben @elad661 @moolitayer  Please review