### PR TITLE
Remove options request helper

### DIFF
--- a/spec/support/options_request.rb
+++ b/spec/support/options_request.rb
@@ -1,5 +1,0 @@
-module ActionDispatch::Integration::RequestHelpers
-  def options(path, headers = nil)
-    process :options, path, :headers => headers
-  end
-end


### PR DESCRIPTION
This method is no longer being used by the API. ✂️ 

Thanks for finding this @bdunne 

@miq-bot assign @bdunne 
@miq-bot add_label cleanup 