### PR TITLE
Add scopes for MiqRequest

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -56,7 +56,6 @@ class MiqRequest < ApplicationRecord
   scope :with_approval_state, ->(state)      { where(:approval_state => state) }
   scope :with_type,           ->(type)       { where(:type => type) }
   scope :with_request_type,   ->(type)       { where(:request_type => type) }
-  scope :with_reason,         ->(op, reason) { where("reason #{op} ?", reason) }
   scope :with_requester,      ->(id)         { where(:requester_id => User.with_same_userid(id).collect(&:id)) }
 
   MODEL_REQUEST_TYPES = {
@@ -98,7 +97,7 @@ class MiqRequest < ApplicationRecord
         :automation => N_("Automation")
       }
     }
-  }
+  }.freeze
 
   REQUEST_TYPES_BACKEND_ONLY = {:MiqProvisionRequestTemplate => {:template => "VM Provision Template"}}
   REQUEST_TYPES = MODEL_REQUEST_TYPES.values.each_with_object(REQUEST_TYPES_BACKEND_ONLY) { |i, h| i.each { |k, v| h[k] = v } }
@@ -110,6 +109,12 @@ class MiqRequest < ApplicationRecord
     request_type = (data[:__request_type__] || data[:request_type]).try(:to_sym)
     model_symbol = REQUEST_TYPE_TO_MODEL[request_type] || raise(ArgumentError, "Invalid request_type")
     model_symbol.to_s.constantize
+  end
+
+  def self.with_reason_like(reason)
+    # Reason string uses * wildcard, scope is required to convert it into % wildcard for LIKE statement
+    reason = reason.match(/\A(?<start>\*?)(?<content>.*?)(?<end>\*?)\z/)
+    where("reason LIKE (?)", "#{reason[:start] ? '%' : ''}#{sanitize_sql_like(reason[:content])}#{reason[:end] ? '%' : ''}")
   end
 
   # Supports old-style requests where specific request was a seperate table connected as a resource

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -52,6 +52,13 @@ class MiqRequest < ApplicationRecord
 
   include MiqRequestMixin
 
+  scope :created_recently,    ->(days_ago)   { where("created_on > ?", days_ago.days.ago) }
+  scope :with_approval_state, ->(state)      { where(:approval_state => state) }
+  scope :with_type,           ->(type)       { where(:type => type) }
+  scope :with_request_type,   ->(type)       { where(:request_type => type) }
+  scope :with_reason,         ->(op, reason) { where("reason #{op} ?", reason) }
+  scope :with_requester,      ->(id)         { where(:requester_id => User.with_same_userid(id).collect(&:id)) }
+
   MODEL_REQUEST_TYPES = {
     :Service        => {
       :MiqProvisionRequest                 => {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,8 @@ class User < ApplicationRecord
   serialize     :settings, Hash   # Implement settings column as a hash
   default_value_for(:settings) { Hash.new }
 
+  scope :with_same_userid, ->(id) { where(:userid => User.find(id).userid) }
+
   def self.with_allowed_roles_for(user_or_group)
     includes(:miq_groups => :miq_user_role).where.not(:miq_user_roles => {:name => user_or_group.disallowed_roles})
   end


### PR DESCRIPTION
In order to fetch MiqRequest via `report_data` properly, it's required to get rid of `filter` and use `scope`s instead. For more info please consult the dependent PR.

Required by: https://github.com/ManageIQ/manageiq-ui-classic/pull/3274