### PR TITLE
Remove redundant destroy

### DIFF
--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -31,7 +31,7 @@ class ContainerNode < ApplicationRecord
   has_many :metrics, :as => :resource
   has_many :metric_rollups, :as => :resource
   has_many :vim_performance_states, :as => :resource
-  has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
+  has_many :miq_alert_statuses, :as => :resource
 
   virtual_column :ready_condition_status, :type => :string, :uses => :container_conditions
   virtual_column :system_distribution, :type => :string


### PR DESCRIPTION
All alerts that belong to a container node must also belong to their ems[1] so when deleting the ems they will be deleted. While the ems exists, the nodes will never be deleted but might be archived.
In that case we would want to keep the alerts.

The reason for that is we have a screen planned that shows stats on alerts over time i.e "this alert fired 20 times this week" where we would want to show alert even on archived entities.

[1] https://github.com/ManageIQ/manageiq/blob/4fb6c9be4f0a4dc532740318d5146b4e5f9c5c4d/app/models/miq_alert.rb#L252