### PR TITLE
Add comments and specs around the ruby 'require leak patch' (see #16837)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -90,6 +90,15 @@ module Vmdb
     # Customize any additional options below...
 
     config.autoload_paths += config.eager_load_paths
+
+    # NOTE:  If you are going to make changes to autoload_paths, please make
+    # sure they are all strings.  Rails will push these paths into the
+    # $LOAD_PATH.
+    #
+    # More info can be found in the ruby-lang bug:
+    #
+    #   https://bugs.ruby-lang.org/issues/14372
+    #
     config.autoload_paths << Rails.root.join("app", "models", "aliases").to_s
     config.autoload_paths << Rails.root.join("app", "models", "mixins").to_s
     config.autoload_paths << Rails.root.join("lib", "miq_automation_engine", "models").to_s

--- a/lib/generators/provider/templates/lib/manageiq/providers/%provider_name%/engine.rb
+++ b/lib/generators/provider/templates/lib/manageiq/providers/%provider_name%/engine.rb
@@ -3,6 +3,23 @@ module ManageIQ
     module <%= class_name %>
       class Engine < ::Rails::Engine
         isolate_namespace ManageIQ::Providers::<%= class_name %>
+
+        # NOTE:  If you are going to make changes to autoload_paths, please make
+        # sure they are all strings.  Rails will push these paths into the
+        # $LOAD_PATH.
+        #
+        # More info can be found in the ruby-lang bug:
+        #
+        #   https://bugs.ruby-lang.org/issues/14372
+        #
+        # If you have no need to add any autoload_paths in this manageiq
+        # plugin, feel free to delete this section.
+        #
+        # Examples:
+        #
+        # config.autoload_paths << root.join("app", "models").to_s
+        # config.autoload_paths << root.join("lib", "my_provider").to_s
+        # config.autoload_paths << Rails.root.join("app", "models", "aliases").to_s
       end
     end
   end

--- a/spec/lib/ruby_require_leak_spec.rb
+++ b/spec/lib/ruby_require_leak_spec.rb
@@ -1,0 +1,48 @@
+describe "Ruby 'require' leak with Pathnames" do
+  context "to prevent" do
+    # If this test fails, then either this repo, or one of the provider repos
+    # has added a entry to `config.autoload_paths` that is a Pathname instead
+    # of a raw string.  Until we upgrade to ruby >= 2.5, all Pathnames in the
+    # autoload_paths/$LOAD_PATH should be converted to Strings.
+    #
+    # You can use the code in the expect block as a way of testing this in a
+    # `bin/rails console`:
+    #
+    #     irb> $LOAD_PATH.select { |p| p.class == Pathname }
+    #     #=> []
+    #
+    # More info can be found here:
+    #
+    #     * https://bugs.ruby-lang.org/issues/14372
+    #
+    it "has no Pathnames in the $LOAD_PATH" do
+      expect($LOAD_PATH.select { |p| p.class == Pathname }).to be_empty
+    end
+  end
+
+  if ENV["TRAVIS"] && ENV["TRAVIS_ALLOW_FAILURE"] != "true"
+    context "this file can be removed when" do
+      # If this test fails, then the ManageIQ project has been upgraded to a
+      # version of ruby that no longer requires converting Pathnames in the
+      # autoload_paths/$LOAD_PATH to strings.  This means this file can be
+      # deleted and the changes in the the config/application.rb and
+      # lib/manageiq/**/engine.rb files can be re-evaluated to see if changing
+      # them back to Pathnames makes sense. See the following PRs for examples
+      # of what was changed:
+      #
+      #     * https://github.com/ManageIQ/manageiq/pull/16837
+      #     * https://github.com/ManageIQ/manageiq-api/pull/288
+      #     * https://github.com/ManageIQ/manageiq-automation_engine/pull/146
+      #     * https://github.com/ManageIQ/manageiq-ui-classic/pull/3266
+      #     * https://github.com/ManageIQ/manageiq-graphql/pull/34
+      #
+      it "is running on ruby >= 2.5.0" do
+        current_ruby_version = Gem::Version.new(RbConfig::CONFIG["ruby_version"])
+        ruby_2_5_0_version   = Gem::Version.new("2.5.0")
+        err_msg              = "expected ruby to be less than 2.5.0"
+
+        expect(current_ruby_version).to be < ruby_2_5_0_version, err_msg
+      end
+    end
+  end
+end

--- a/spec/tools/environment_builders/openstack/tests/interaction_methods_spec.rb
+++ b/spec/tools/environment_builders/openstack/tests/interaction_methods_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../interaction_methods'
 
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 describe Openstack::InteractionMethods do
   let(:host1_data) { {:name => "name1", :connection_state => 'connection_state1', :settings => {}} }

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth/auth_model"
 require "fix_auth/auth_config_model"

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth/auth_model"
 require "fix_auth/auth_config_model"

--- a/spec/tools/fix_auth/cli_spec.rb
+++ b/spec/tools/fix_auth/cli_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth/cli"
 

--- a/spec/tools/fix_auth/fix_auth_spec.rb
+++ b/spec/tools/fix_auth/fix_auth_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth"
 

--- a/spec/tools/fix_auth/models_spec.rb
+++ b/spec/tools/fix_auth/models_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth"
 require "tempfile"

--- a/spec/tools/miqldap_to_sssd/authconfig_spec.rb
+++ b/spec/tools/miqldap_to_sssd/authconfig_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
 
 require "authconfig"
 

--- a/spec/tools/miqldap_to_sssd/cli_spec.rb
+++ b/spec/tools/miqldap_to_sssd/cli_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "miqldap_to_sssd/cli"
 

--- a/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
 
 require "configure_apache"
 require "tempfile"

--- a/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
 
 require "configure_appliance_settings"
 

--- a/spec/tools/miqldap_to_sssd/configure_selinux_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_selinux_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd")
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
 
 require "configure_selinux"
 

--- a/spec/tools/pg_inspector/active_connections_to_human_spec.rb
+++ b/spec/tools/pg_inspector/active_connections_to_human_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require 'pg_inspector'
 

--- a/spec/tools/server_settings_replicator/server_settings_replicator_spec.rb
+++ b/spec/tools/server_settings_replicator/server_settings_replicator_spec.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 
 require "server_settings_replicator/server_settings_replicator"
 

--- a/tools/replicate_server_settings.rb
+++ b/tools/replicate_server_settings.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require File.expand_path("../config/environment", __dir__)
-$LOAD_PATH << Rails.root.join("tools")
+$LOAD_PATH << Rails.root.join("tools").to_s
 require 'trollop'
 require 'server_settings_replicator/server_settings_replicator'
 


### PR DESCRIPTION
Provides comments and info regarding the changes to the `autoload_paths`, and adds some specs to notify us when this changes, and steps to resolve.

Included in those specs is also a check to see if we are greater than ruby 2.5.0, and if so, fail so this spec can then be removed.


Links
-----

* Original PR: https://github.com/ManageIQ/manageiq/pull/16837
* Adding comments in other repos:
  - https://github.com/ManageIQ/manageiq-automation_engine/pull/148
  - https://github.com/ManageIQ/manageiq-ui-classic/pull/3276
  - https://github.com/ManageIQ/manageiq-graphql/pull/36
  - API done in original leak fix PR:  https://github.com/ManageIQ/manageiq-api/pull/288

Steps for Testing/QA
--------------------

I have tested this on ruby 2.5.0 locally, and the spec fails as expected.  As soon as all of the PRs mentioned in https://github.com/ManageIQ/manageiq/pull/16837 are merged, then the specs in this PR should also pass.