### PR TITLE
Allow users already in UPN format

### DIFF
--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -83,6 +83,44 @@ describe Authenticator::Httpd do
     end
   end
 
+  describe '#find_or_initialize_user' do
+    let(:user_attrs_simple) do
+      { :username  => "sal",
+        :fullname  => "Test User Sal",
+        :firstname => "Salvadore",
+        :lastname  => "Bigs",
+        :email     => "sal_email@example.com",
+        :domain    => "example.com" }
+    end
+
+    let(:identity_simple) { [user_attrs_simple, %w(mumble bumble bee)] }
+
+    let(:user_attrs_upn) do
+      { :username  => "sal@example.com",
+        :fullname  => "Test User Sal",
+        :firstname => "Salvadore",
+        :lastname  => "Bigs",
+        :email     => "sal_email@example.com",
+        :domain    => "example.com" }
+    end
+
+    let(:identity_upn) { [user_attrs_upn, %w(mumble bumble bee)] }
+
+    let(:upn_sal) { FactoryGirl.create(:user, :userid => 'sal@example.com') }
+
+    before do
+      upn_sal
+    end
+
+    it "Returns UPN username when passed UPN username" do
+      expect(subject.find_or_initialize_user(identity_upn, 'sal@example.com')).to match_array(["sal@example.com", upn_sal])
+    end
+
+    it "Returns UPN username when passed simple username" do
+      expect(subject.find_or_initialize_user(identity_simple, 'sal')).to match_array(["sal@example.com", upn_sal])
+    end
+  end
+
   describe '#authenticate' do
     def authenticate
       subject.authenticate(username, nil, request)


### PR DESCRIPTION
The Classic UI peels the domain from the userid before authenticating.
The SSUI does not.

These changes will make username matching more robust by supporting both a username with and without the domain portion.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1424618

Related PRs:

* Converting userids to UPN format to avoid duplicate user records [15535](https://github.com/ManageIQ/manageiq/pull/15535)

* Add support for the domain user attribute [127](https://github.com/ManageIQ/manageiq-appliance/pull/127)

* Document support for the domain user attribute [424](https://github.com/ManageIQ/manageiq_docs/pull/424)


* Add support for the external auth domain user attribute [250](https://github.com/ManageIQ/manageiq-gems-pending/pull/250)

* [FINE] Do not downcase the amazon IAM username [#15959](https://github.com/ManageIQ/manageiq/pull/15959)

* If the userid is not found in the DB do a case insensitive search [15904](https://github.com/ManageIQ/manageiq/pull/15904)



Steps for Testing/QA
-------------------------------

1. Log into classic ui as short usernme: testuser1 then log out.
1. Confirm that the userid of testuser1 is still testuser1@example.com  
1. Log into SSUI as UPN username:testuser1@example.com
1. Confirm that the userid of testuser1 is still testuser1@example.com  