### PR TITLE
Upgrade net-ldap to 0.16.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>2.6.1",       :path => File.expand_path("mime-types-redirector", __dir__)
 gem "more_core_extensions",           "~>3.5"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
-gem "net-ldap",                       "~>0.14.0",      :require => false
+gem "net-ldap",                       "~>0.16.1",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false
 gem "openscap",                       "~>0.4.3",       :require => false
 gem "pg",                             "~>0.18.2",      :require => false

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -119,4 +119,20 @@ describe MiqLdap do
     data = "\001\005\000\000\000\000\000\005\025\000\000\000+\206\301\364y\307\r\302=\336p\216\237\004\000\000"
     expect(MiqLdap.sid_to_s(data)).to eq("S-1-5-21-4106323499-3255682937-2389761597-1183")
   end
+
+  it 'returns a hostname when a hostname is availble and does not set verify mode' do
+    allow(TCPSocket).to receive(:gethostbyname).and_return(["testhostname", "aliases", "type", "192.168.252.20"])
+    allow(TCPSocket).to receive(:new)
+    ldap = MiqLdap.new(:host => ["testhostname", "localhost", "dummy", @host])
+    expect(ldap.ldap.host).to eq("testhostname")
+    expect(ldap.ldap.instance_variable_get(:@encryption).try(:has_key_path?, :tls_options, :verify_mode)).to be_falsey
+  end
+
+  it 'returns an IPAddress and disables verify mode when only an IPAddress is availble' do
+    expect(TCPSocket).not_to receive(:gethostbyname)
+    allow(TCPSocket).to receive(:new)
+    ldap = MiqLdap.new(:host => ["192.168.254.15", "localhost", "dummy", @host])
+    expect(ldap.ldap.host).to eq("192.168.254.15")
+    expect(ldap.ldap.instance_variable_get(:@encryption).fetch_path(:tls_options, :verify_mode)).to eq(OpenSSL::SSL::VERIFY_NONE)
+  end
 end


### PR DESCRIPTION
Addresses #3486

The MiqLdap driver needed to be updated to pass a hostname to net-ldap when
possible to take advantage of improvements in the net-ldap gem.

Changes from 0.14 to 0.16.1 are:

Net::LDAP 0.16.1

* Send DN and newPassword with password_modify request #271

Net::LDAP 0.16.0

* Sasl fix #281

* enable TLS hostname validation #279

* update rubocop to 0.42.0 #278

Net::LDAP 0.15.0

* Respect connect_timeout when establishing SSL connections #273

Steps for Testing/QA [Optional]
-------------------------------

**Test 1**

- Configure an appliance for **_Authentication Mode: LDAP_**, specifying the **_IPAddr_** of the LDAP server
- for LDAP Host Names.
- Confirm ability to log in to the appliance with an LDAP configured user.

**Test 2**

- Configure an appliance for **_Authentication Mode: LDAPS_**, specifying the **_IPAddr_** of the LDAP server
- for LDAP Host Names.
- Confirm ability to log in to the appliance with an LDAP configured user.

**Test 3**

- Configure an appliance for **_Authentication Mode: LDAP_**, specifying the **_hostname_** of the LDAP server
- for LDAP Host Names.
- Confirm ability to log in to the appliance with an LDAP configured user.


**Test 4**

- Configure an appliance for **_Authentication Mode: LDAPS_**, specifying the **_hostname_** of the LDAP server
- for LDAP Host Names.
- Confirm ability to log in to the appliance with an LDAP configured user.





