### PR TITLE
Provider generator: fix hardcoded 'DUMMY_PROVIDER'

### DIFF
--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher/runner.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/event_catcher/runner.rb
@@ -23,8 +23,8 @@ class ManageIQ::Providers::<%= class_name %>::CloudManager::EventCatcher::Runner
 
   def event_to_hash(event, ems_id)
     {
-      :event_type => "DUMMY_PROVIDER_#{event[:name]}",
-      :source     => 'DUMMY_PROVIDER',
+      :event_type => "<%= provider_name.upcase %>#{event[:name]}",
+      :source     => '<%= provider_name.upcase %>',
       :timestamp  => event[:timestamp],
       :vm_ems_ref => event[:vm_ems_ref],
       :full_data  => event,


### PR DESCRIPTION
A bug in the templating of `event_catcher/runner.rb`