### PR TITLE
Add a Physical Rack model

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -64,6 +64,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :resource_pools, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :customization_specs, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :storage_profiles,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :physical_racks,      :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :physical_servers,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :customization_scripts, :foreign_key => "manager_id", :dependent => :destroy, :inverse_of => :ext_management_system
 

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers
   class PhysicalInfraManager < BaseManager
     include SupportsFeatureMixin
 
+    virtual_total :total_physical_racks,      :physical_racks
     virtual_total :total_physical_servers,    :physical_servers
     virtual_column :total_hosts,              :type => :integer
     virtual_column :total_vms,                :type => :integer

--- a/app/models/physical_rack.rb
+++ b/app/models/physical_rack.rb
@@ -1,0 +1,5 @@
+class PhysicalRack < ApplicationRecord
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_racks
+
+  has_many :physical_servers, :dependent => :nullify, :inverse_of => :physical_rack
+end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -17,7 +17,8 @@ class PhysicalServer < ApplicationRecord
   }.freeze
 
   validates :vendor, :inclusion =>{:in => VENDOR_TYPES}
-  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhysicalInfraManager"
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_servers
+  belongs_to :physical_rack, :inverse_of => :physical_servers
 
   has_one :computer_system, :as => :managed_entity, :dependent => :destroy
   has_one :hardware, :through => :computer_system


### PR DESCRIPTION
This PR is able to add a PhysicalRack model to ManageIQ.
Today, providers are able to access all physical server directly, although this change relate physical servers to physical racks instead providers, i wanted to keep a possible way to access physical servers through providers so this change won't break most providers out there.

To be merged with: https://github.com/ManageIQ/manageiq-providers-lenovo/pull/147