### PR TITLE
When using http only, set env variable to allow insecure sessions

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -10,7 +10,7 @@ else
 
   session_options = {}
   if MiqEnvironment::Command.is_appliance?
-    session_options[:secure]   = true unless MiqEnvironment::Command.is_container?
+    session_options[:secure]   = true unless ENV["ALLOW_INSECURE_SESSION"]
     session_options[:httponly] = true
   end
 


### PR DESCRIPTION
Replaces #16656 
Depends on https://github.com/ManageIQ/manageiq-pods/pull/261