### PR TITLE
Pass target object when evaluating expression for Generic Object

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -14,7 +14,6 @@ class GenericObject < ApplicationRecord
            :type_cast,
            :property_association_defined?,
            :property_methods, :property_method_defined?,
-           :custom_actions, :custom_action_buttons,
            :to => :generic_object_definition, :allow_nil => true
 
   delegate :name, :to => :generic_object_definition, :prefix => true, :allow_nil => false
@@ -25,6 +24,14 @@ class GenericObject < ApplicationRecord
     attributes = (attributes || {}).symbolize_keys
     attributes = attributes.slice(:generic_object_definition).merge(attributes.except(:generic_object_definition))
     super
+  end
+
+  def custom_actions
+    generic_object_definition&.custom_actions(self)
+  end
+
+  def custom_action_buttons
+    generic_object_definition&.custom_action_buttons(self)
   end
 
   def property_attributes=(options)

--- a/spec/models/generic_object_spec.rb
+++ b/spec/models/generic_object_spec.rb
@@ -353,4 +353,23 @@ describe GenericObject do
       expect(service.generic_objects).to be_blank
     end
   end
+
+  context "custom buttons" do
+    let(:service_template) { FactoryGirl.create(:service_template) }
+    let(:service) { FactoryGirl.create(:service, :service_template => service_template) }
+
+    describe "#custom_actions" do
+      it "returns list of custom actions retrived linked GenericObjectDefinition" do
+        expect(definition).to receive(:custom_actions).with(go)
+        go.custom_actions
+      end
+    end
+
+    describe "#custom_action_buttons" do
+      it "returns list of custom action buttons retrived linked GenericObjectDefinition" do
+        expect(definition).to receive(:custom_action_buttons).with(go)
+        go.custom_action_buttons
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Issue*: 
call to`GenericObject#custom_actions` was delegated to `GenericObjectDefinition`. As a result, evaluating expression defined on `GenericObject` would get `GenericObjectDefinition` as target (instead of `GenericObject`)

There was similar issue with evaluating expression for `Service` addressed here: https://github.com/ManageIQ/manageiq/pull/16770
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1505988

\cc @gtanzillo @gmcculloug
