### PR TITLE
[FINE] Change the way active_provisions are calculated.

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -275,26 +275,13 @@ module MiqProvisionQuotaMixin
   end
 
   def quota_find_active_prov_request(_options)
-    prov_req_ids = []
-    MiqQueue
-      .where(:method_name => 'create_request_tasks', :state => 'dequeue', :class_name => %w(MiqProvisionRequest ServiceTemplateProvisionRequest))
-      .each do |q|
-        prov_req_ids << q.instance_id
-      end
-
-    prov_ids = []
-    MiqQueue
-      .where(:method_name => 'deliver', :state => %w(ready dequeue), :class_name => 'MiqAeEngine')
-      .where("task_id like ?", '%_provision_%')
-      .each do |q|
-        if q.args
-          args = q.args.first
-          prov_ids << args[:object_id] if args[:object_type].include?('Provision') && !args[:object_id].blank?
-        end
-      end
-    prov_req_ids += MiqRequestTask.where(:id => prov_ids).pluck("miq_request_id")
-
-    MiqRequest.where(:id => prov_req_ids.compact.uniq)
+    MiqRequest.where(
+      :approval_state => 'approved',
+      :type           => %w(MiqProvisionRequest ServiceTemplateProvisionRequest),
+      :request_state  => %w(active queued pending),
+      :status         => 'Ok',
+      :process        => true
+    ).where.not(:id => id)
   end
 
   def vm_quota_values(pr, result)

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -146,49 +146,20 @@ describe MiqProvisionRequest do
         end
 
         context "for cloud and infra providers," do
-          def create_task(user, request)
-            FactoryGirl.create(:miq_request_task, :miq_request => request, :miq_request_id => request.id, :type => 'MiqProvision', :description => "task", :tenant => user.current_tenant)
-          end
-
           def create_request(user, vm_template, prov_options)
-            FactoryGirl.create(:miq_provision_request, :requester   => user,
-                                                       :description => "request",
-                                                       :tenant      => user.current_tenant,
-                                                       :source      => vm_template,
-                                                       :src_vm_id   => vm_template.id,
-                                                       :options     => prov_options.merge(:owner_email => user.email, :requester_group => user.miq_groups.first.description))
+            FactoryGirl.create(:miq_provision_request, :requester      => user,
+                                                       :description    => "request",
+                                                       :tenant         => user.current_tenant,
+                                                       :source         => vm_template,
+                                                       :status         => 'Ok',
+                                                       :process        => true,
+                                                       :request_state  => 'active',
+                                                       :approval_state => 'approved',
+                                                       :src_vm_id      => vm_template.id,
+                                                       :options        => prov_options.merge(:owner_email => user.email, :requester_group => user.miq_groups.first.description))
           end
 
-          def request_queue_entry(request)
-            FactoryGirl.create(:miq_queue,
-                               :state       => MiqQueue::STATE_DEQUEUE,
-                               :instance_id => request.id,
-                               :class_name  => 'MiqProvisionRequest',
-                               :method_name => 'create_request_tasks')
-          end
-
-          def task_queue_entry(task)
-            FactoryGirl.create(:miq_queue,
-                               :state       => MiqQueue::STATE_DEQUEUE,
-                               :args        => [{:object_type => "Provision", :object_id => task.id}],
-                               :task_id     => 'miq_provision_task',
-                               :class_name  => 'MiqAeEngine',
-                               :method_name => 'deliver')
-          end
-
-          def create_test_task(user, template)
-            request = create_request(user, template, {})
-            create_task(user, request)
-            request
-          end
-
-          def queue(requests)
-            requests.each do |request|
-              request.miq_request_tasks.empty? ? request_queue_entry(request) : task_queue_entry(request.miq_request_tasks.first)
-            end
-          end
-
-          let(:vmware_tasks) do
+          let(:create_requests) do
             ems = FactoryGirl.create(:ems_vmware)
             vmware_tenant = FactoryGirl.create(:tenant)
             group = FactoryGirl.create(:miq_group, :tenant => vmware_tenant)
@@ -199,16 +170,10 @@ describe MiqProvisionRequest do
                                                   :ext_management_system => ems,
                                                   :hardware              => hardware)
             prov_options = {:number_of_vms => [2, '2'], :vm_memory => [1024, '1024'], :number_of_cpus => [2, '2']}
-            requests = []
-            2.times { requests << create_request(@vmware_user1, @vmware_template, prov_options) }
-            create_task(@vmware_user1, requests.first)
+            2.times { create_request(@vmware_user1, @vmware_template, prov_options) }
 
-            2.times { requests << create_request(@vmware_user2, @vmware_template, prov_options) }
-            create_task(@vmware_user2, requests.last)
-            requests
-          end
+            2.times { create_request(@vmware_user2, @vmware_template, prov_options) }
 
-          let(:google_tasks) do
             ems = FactoryGirl.create(:ems_google_with_authentication,
                                      :availability_zones => [FactoryGirl.create(:availability_zone_google)])
             google_tenant = FactoryGirl.create(:tenant)
@@ -220,26 +185,21 @@ describe MiqProvisionRequest do
                                         :cpus => 4, :cpu_cores => 1, :memory => 1024)
             prov_options = {:number_of_vms => 1, :src_vm_id => vm_template.id, :boot_disk_size => ["10.GB", "10 GB"],
                             :placement_auto => [true, 1], :instance_type => [flavor.id, flavor.name]}
-            requests = []
-            2.times { requests << create_request(@google_user1, @google_template, prov_options) }
-            create_task(@google_user1, requests.first)
+            2.times { create_request(@google_user1, @google_template, prov_options) }
 
-            2.times { requests << create_request(@google_user2, @google_template, prov_options) }
-            create_task(@google_user2, requests.last)
-            requests
+            2.times { create_request(@google_user2, @google_template, prov_options) }
           end
 
           shared_examples_for "check_quota" do
             it "check" do
-              load_queue
+              create_requests
               stats = request.check_quota(quota_method)
               expect(stats).to include(counts_hash)
             end
           end
 
           context "active_provisions," do
-            let(:load_queue) { queue(vmware_tasks | google_tasks) }
-            let(:request) { create_test_task(@vmware_user1, @vmware_template) }
+            let(:request) { create_request(@vmware_user1, @vmware_template, {}) }
             let(:quota_method) { :active_provisions }
             let(:counts_hash) do
               {:count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 44.gigabytes}
@@ -248,8 +208,7 @@ describe MiqProvisionRequest do
           end
 
           context "infra," do
-            let(:load_queue) { queue(vmware_tasks | google_tasks) }
-            let(:request) { create_test_task(@vmware_user1, @vmware_template) }
+            let(:request) { create_request(@vmware_user1, @vmware_template, {}) }
             let(:counts_hash) do
               {:count => 8, :memory => 8.gigabytes, :cpu => 16, :storage => 4.gigabytes}
             end
@@ -272,7 +231,7 @@ describe MiqProvisionRequest do
               it_behaves_like "check_quota"
 
               it "fails without owner_email option" do
-                load_queue
+                create_requests
                 request.options = {}
                 expect { request.check_quota(quota_method) }.to raise_error(NoMethodError)
               end
@@ -280,8 +239,7 @@ describe MiqProvisionRequest do
           end
 
           context "cloud," do
-            let(:load_queue) { queue(vmware_tasks | google_tasks) }
-            let(:request) { create_test_task(@google_user1, @google_template) }
+            let(:request) { create_request(@google_user1, @google_template, {}) }
             let(:counts_hash) do
               {:count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes}
             end

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -5,10 +5,6 @@ describe ServiceTemplateProvisionRequest do
   let(:admin) { FactoryGirl.create(:user_admin) }
   context "quota methods" do
     context "for cloud and infra providers," do
-      def create_task(user, request)
-        FactoryGirl.create(:service_template_provision_task, :miq_request => request, :miq_request_id => request.id, :type => 'ServiceTemplateProvisionTask', :description => "task", :tenant => user.current_tenant)
-      end
-
       def create_request(user, template, prov_options = {})
         FactoryGirl.create(:service_template_provision_request, :requester   => user,
                                                                 :description => "request",
@@ -19,33 +15,8 @@ describe ServiceTemplateProvisionRequest do
                                                                 :options     => prov_options.merge(:owner_email => user.email))
       end
 
-      def request_queue_entry(request)
-        FactoryGirl.create(:miq_queue,
-                           :state       => MiqQueue::STATE_DEQUEUE,
-                           :instance_id => request.id,
-                           :class_name  => 'ServiceTemplateProvisionRequest',
-                           :method_name => 'create_request_tasks')
-      end
-
-      def task_queue_entry(task)
-        FactoryGirl.create(:miq_queue,
-                           :state       => MiqQueue::STATE_DEQUEUE,
-                           :args        => [{:object_type => "ServiceTemplateProvisionRequest", :object_id => task.id}],
-                           :task_id     => 'service_template_provision_task',
-                           :class_name  => 'MiqAeEngine',
-                           :method_name => 'deliver')
-      end
-
-      def create_test_task(user, service_template)
-        request = create_request(user, service_template)
-        create_task(user, request)
-        request
-      end
-
-      def queue(requests)
-        requests.each do |request|
-          request.miq_request_tasks.empty? ? request_queue_entry(request) : task_queue_entry(request.miq_request_tasks.first)
-        end
+      def create_test_request(user, service_template)
+        create_request(user, service_template)
       end
 
       def create_service_bundle(user, items, options = {})
@@ -59,14 +30,14 @@ describe ServiceTemplateProvisionRequest do
 
       shared_examples_for "check_quota" do
         it "check" do
-          load_queue
+          load_requests
           stats = request.check_quota(quota_method)
           expect(stats).to include(counts_hash)
         end
       end
 
       context "infra," do
-        let(:vmware_tasks) do
+        let(:vmware_requests) do
           ems = FactoryGirl.create(:ems_vmware)
           group = FactoryGirl.create(:miq_group, :tenant => FactoryGirl.create(:tenant))
           @vmware_user1 = FactoryGirl.create(:user_with_email, :miq_groups => [group])
@@ -83,11 +54,9 @@ describe ServiceTemplateProvisionRequest do
           requests << build_vmware_service_item
 
           requests << create_service_bundle(@user, [@vmware_template], @vmware_prov_options)
-          create_task(@user, requests.last)
 
           @user = @vmware_user2
           requests << build_vmware_service_item
-          create_task(@user, requests.last)
 
           requests << create_service_bundle(@user, [@vmware_template], @vmware_prov_options)
 
@@ -95,8 +64,8 @@ describe ServiceTemplateProvisionRequest do
           requests
         end
 
-        let(:load_queue) { queue(vmware_tasks) }
-        let(:request) { create_test_task(@vmware_user1, @vmware_template) }
+        let(:load_requests) { vmware_requests }
+        let(:request) { create_test_request(@vmware_user1, @vmware_template) }
         let(:counts_hash) do
           {:count => 6, :memory => 6.gigabytes, :cpu => 16, :storage => 3.gigabytes}
         end
@@ -106,7 +75,7 @@ describe ServiceTemplateProvisionRequest do
           it_behaves_like "check_quota"
 
           it "invalid service_template does not raise error" do
-            requests = load_queue
+            requests = load_requests
             requests.first.update_attributes(:service_template => nil)
             expect { request.check_quota(quota_method) }.not_to raise_error
           end
@@ -125,7 +94,7 @@ describe ServiceTemplateProvisionRequest do
           it_behaves_like "check_quota"
 
           it "fails without requester.email" do
-            load_queue
+            load_requests
             @vmware_user1.update_attributes(:email => nil)
             expect { request.check_quota(quota_method) }.to raise_error(NoMethodError)
           end
@@ -142,7 +111,7 @@ describe ServiceTemplateProvisionRequest do
           @service_request = build_service_template_request("google_service_item", @user, :dialog => {"test" => "dialog"})
         end
 
-        let(:google_tasks) do
+        let(:google_requests) do
           ems = FactoryGirl.create(:ems_google_with_authentication,
                                    :availability_zones => [FactoryGirl.create(:availability_zone_google)])
           group = FactoryGirl.create(:miq_group, :tenant => FactoryGirl.create(:tenant))
@@ -162,11 +131,9 @@ describe ServiceTemplateProvisionRequest do
           requests << build_google_service_item
 
           requests << create_service_bundle(@user, [@google_template], @google_prov_options)
-          create_task(@user, requests.last)
 
           @user = @google_user2
           requests << build_google_service_item
-          create_task(@user, requests.last)
 
           requests << create_service_bundle(@user, [@google_template], @google_prov_options)
 
@@ -174,8 +141,8 @@ describe ServiceTemplateProvisionRequest do
           requests
         end
 
-        let(:load_queue) { queue(google_tasks) }
-        let(:request) { create_test_task(@google_user1, @google_template) }
+        let(:load_requests) { google_requests }
+        let(:request) { create_test_request(@google_user1, @google_template) }
         let(:counts_hash) do
           {:count => 4, :memory => 4096, :cpu => 16, :storage => 40.gigabytes}
         end

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -96,6 +96,9 @@ module Spec
                            :type           => 'ServiceTemplateProvisionRequest',
                            :request_type   => 'clone_to_service',
                            :approval_state => 'approved',
+                           :status         => 'Ok',
+                           :process        => true,
+                           :request_state  => 'active',
                            :source_id      => root.id,
                            :requester      => user,
                            :options        => options)


### PR DESCRIPTION
The current quota implementation has some limitations regarding the active provision calculations.
Changed the quota_find_active_prov_requests method to use MiqRequests instead of MiqQueue entries for for a more accurate count of active provisions.

We now calculate active provisions based on the following MiqRequests:
approval_state: = approved
request_state = active/queued/pending
type = MiqProvisionRequest/ServiceTemplateProvisionRequest
status = 'Ok'
process = true

Original PR
https://github.com/ManageIQ/manageiq/pull/16831

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1489507