### PR TITLE
Add missing role for container user groups

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -1096,6 +1096,7 @@
   - redhat_access_insights_admin
   - ems_container_ad_hoc_metrics
   - monitor
+  - monitor_alerts
   - alert_status
   - alert_action
   - ems_infra
@@ -1140,6 +1141,7 @@
   - vm_view
   - ems_container_ad_hoc_metrics
   - monitor
+  - monitor_alerts
   - alert_status
   - alert_action
   - ems_infra


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1494963

We would like users belonging to each of these groups to have access to the monitoring screens;
- EvmGroup-container_administrator
- EvmGroup-container_operator

Tested this allows members of both groups to enter both monitoring screens, and add a comment in the alert list screen.

See:
[Main Menu](https://github.com/ManageIQ/manageiq-ui-classic/blob/06dca5f8eebf462af8228f9e0180e97fa763eb7d/app/presenters/menu/default_menu.rb#L238-L239)
[Product Feature](https://github.com/ManageIQ/manageiq/blob/ca66301eac096b322395629d89ea24e74ca64e0a/db/fixtures/miq_product_features.yml#L6515)
