### PR TITLE
Added before_save to MiqTask to initialize MiqTask#started_on when task become active

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -27,8 +27,8 @@ class MiqTask < ApplicationRecord
   before_validation :initialize_attributes, :on => :create
 
   before_destroy :check_active, :check_associations
-  before_save :started
-  
+  before_save :ensure_started
+
   virtual_has_one :task_results
   virtual_attribute :state_or_status, :string, :arel => (lambda do |t|
     t.grouping(Arel::Nodes::Case.new(t[:state]).when(STATE_FINISHED).then(t[:status]).else(t[:state]))
@@ -50,7 +50,7 @@ class MiqTask < ApplicationRecord
   scope :no_status_selected,      ->           { running.where.not(:status => %(Ok Error Warn)) }
   scope :with_status_in,          ->(s, *rest) { rest.reduce(MiqTask.send(s)) { |chain, r| chain.or(MiqTask.send(r)) } }
 
-  def started
+  def ensure_started
     self.started_on ||= Time.now.utc if state == STATE_ACTIVE
   end
 

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -330,6 +330,20 @@ describe MiqTask do
     end
   end
 
+  context "before save callback" do
+    describe "#started" do
+      let(:task) { FactoryGirl.create(:miq_task_plain) }
+
+      it "initilizes 'started_on' attribute if task become Active " do
+        expect(task.started_on).to be nil
+        Timecop.freeze do
+          task.update_attributes!(:state => MiqTask::STATE_ACTIVE)
+          expect(task.started_on).to eq Time.now.utc
+        end
+      end
+    end
+  end
+
   describe "#update_status" do
     let(:miq_task) { FactoryGirl.create(:miq_task_plain) }
 


### PR DESCRIPTION
**Before:**
`MiqTask#started_on` was not set if `state` attribute updated directly (like `task.update_attributes(:state => MiqTask::STATE_ACTIVE)`)
related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1536126

**After:**
 Added `before_save` callback to initialize `#started_on` when `state` set to "Active" 

@miq-bot add-label core, technical debt

\cc @gtanzillo @jameswnl 