### PR TITLE
Many things rely on authentications, check it first

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -33,11 +33,11 @@ class MiqScheduleWorker::Jobs
   end
 
   def host_authentication_check_schedule
-    queue_work_on_each_zone(:class_name  => "Host", :method_name => "authentication_check_schedule")
+    queue_work_on_each_zone(:class_name  => "Host", :method_name => "authentication_check_schedule", :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def ems_authentication_check_schedule
-    queue_work_on_each_zone(:class_name  => "ExtManagementSystem", :method_name => "authentication_check_schedule")
+    queue_work_on_each_zone(:class_name  => "ExtManagementSystem", :method_name => "authentication_check_schedule", :priority => MiqQueue::HIGH_PRIORITY)
   end
 
   def session_check_session_timeout


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1534631

We can get stuck if:
* Automate event processing queues refresh and waits
* Refresh workers aren't running because credentials are temporarily bad
* Authentication checks don't get processed because they are normal priority,
which is lower than an event storm of automate messages at high priority