### PR TITLE
[FINE] Add the Authentication class to the RBAC filtered list

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -6,6 +6,7 @@ module Rbac
     # 2. Tagging has been enabled in the UI
     # 3. Class contains acts_as_miq_taggable
     CLASSES_THAT_PARTICIPATE_IN_RBAC = %w(
+      Authentication
       AvailabilityZone
       CloudNetwork
       CloudSubnet


### PR DESCRIPTION
The Authentication class is needed in the `CLASSES_THAT_PARTICIPATE_IN_RBAC`
array in order for the AuthPrivateKey class to participate in RBAC.

PR where this was introduced: https://github.com/ManageIQ/manageiq/pull/16828

Original PR that added `Authentication` to `CLASSES_THAT_PARTICIPATE_IN_RBAC`
https://github.com/ManageIQ/manageiq/pull/15359
