### PR TITLE
Add support for alert labels

### DIFF
--- a/app/models/miq_alert_status.rb
+++ b/app/models/miq_alert_status.rb
@@ -3,11 +3,12 @@ class MiqAlertStatus < ApplicationRecord
 
   belongs_to :miq_alert
   belongs_to :resource, :polymorphic => true
-  belongs_to :ext_management_system
+  belongs_to :ext_management_system, :foreign_key => 'ems_id', :inverse_of => :miq_alert_statuses
   belongs_to :assignee, :class_name => 'User'
   has_many :miq_alert_status_actions, -> { order("created_at") }, :dependent => :destroy
   virtual_column :assignee, :type => :string
   virtual_column :hidden, :type => :boolean
+  virtual_column :labels, :type => :string # This is actually an array of `MiqAlertStatusLabel` objects.
 
   validates :severity, :acceptance => { :accept => SEVERITY_LEVELS }
 
@@ -17,5 +18,22 @@ class MiqAlertStatus < ApplicationRecord
 
   def hidden?
     miq_alert_status_actions.where(:action_type => %w(hide show)).last.try(:action_type) == 'hide'
+  end
+
+  #
+  # Returns the labels associated to this alert status.
+  #
+  # @return [Array<MiqAlertStatusLabel>] The array of labels.
+  #
+  def labels
+    @labels ||= fetch_labels
+  end
+
+  private
+
+  def fetch_labels
+    ems = ext_management_system
+    return [] unless ems&.supports_alert_labels?
+    ems.alert_labels(self)
   end
 end

--- a/app/models/miq_alert_status_label.rb
+++ b/app/models/miq_alert_status_label.rb
@@ -1,0 +1,8 @@
+#
+# This class represents a name/value pair used to store alert labels. Currently this isn't persisted to a table, but
+# fetched using the `alert_labels` method of the providers that support the alert labels feature.
+#
+class MiqAlertStatusLabel
+  attr_accessor :name
+  attr_accessor :value
+end

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -61,6 +61,7 @@ module SupportsFeatureMixin
     :add_host                            => 'Add Host',
     :add_interface                       => 'Add Interface',
     :add_security_group                  => 'Add Security Group',
+    :alert_labels                        => 'Alert Labels',
     :associate_floating_ip               => 'Associate a Floating IP',
     :clone                               => 'Clone',
     # FIXME: this is just a internal helper and should be refactored

--- a/spec/factories/miq_alert_status_label.rb
+++ b/spec/factories/miq_alert_status_label.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :miq_alert_status_label do
+    name 'mylabelname'
+    value 'mylabelvalue'
+
+    # By default `FactoryGirl` calls the `save!` method when the instance is created, but we don't
+    # want to do that for this class because it isn't persisted to any table, and it doesn't have
+    # that `save!` method.
+    skip_create
+  end
+end

--- a/spec/models/miq_alert_status_spec.rb
+++ b/spec/models/miq_alert_status_spec.rb
@@ -17,6 +17,12 @@ describe MiqAlertStatus do
   let(:show_action) do
     FactoryGirl.create(:miq_alert_status_action, :action_type => 'show', :user => user1, :miq_alert_status => alert)
   end
+  let(:labels) do
+    [
+      FactoryGirl.create(:miq_alert_status_label, :name => 'myfistlabelname', :value => 'myfistlabelvalue'),
+      FactoryGirl.create(:miq_alert_status_label, :name => 'mysecondlabelname', :value => 'mysecondlabelvalue'),
+    ]
+  end
 
   describe "Validation" do
     it "should reject unexpected severities" do
@@ -125,6 +131,26 @@ describe MiqAlertStatus do
     it "returns false after show action" do
       alert.miq_alert_status_actions = [assignment_action, hide_action, show_action]
       expect(alert.hidden?).to be_falsey
+    end
+  end
+
+  describe "#labels" do
+    it "returns an empty array if not connected to a ext_management_system" do
+      expect(alert).to receive(:ext_management_system).and_return(nil)
+      expect(alert.labels).to eq([])
+    end
+
+    it "returns an empty array if the ext_management_system does not support alert labels" do
+      expect(ems).to receive(:supports_alert_labels?).and_return(false)
+      expect(alert).to receive(:ext_management_system).and_return(ems)
+      expect(alert.labels).to eq([])
+    end
+
+    it "returns the labels fetched by the ext_management_system" do
+      expect(ems).to receive(:supports_alert_labels?).and_return(true)
+      expect(ems).to receive(:alert_labels).and_return(labels)
+      expect(alert).to receive(:ext_management_system).and_return(ems)
+      expect(alert.labels).to eq(labels)
     end
   end
 end


### PR DESCRIPTION
This patch adds support for a new `label` virtual column in the
`MiqAlertStatus` class. This new column will be an array of
`MiqAlertStatusLabel` objects. The column will not be persisted to the
database, but calculated by the providers that support it. This is
mostly intended to support the _label_ concept used by Prometheus
alerts.

Fixes https://bugzilla.redhat.com/1520125