### PR TITLE
[WIP] Don't queue refresh with invalid credentials

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -131,6 +131,7 @@
   :foreman_provisioning:
     :refresh_interval: 1.hour
   :full_refresh_threshold: 100
+  :invalid_authentication_grace_period: 15.minutes
   :raise_vm_snapshot_complete_if_created_within: 15.minutes
   :refresh_interval: 24.hours
   :scvmm:

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -2,7 +2,7 @@ describe EmsRefresh do
   context ".queue_refresh" do
     before(:each) do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-      @ems = FactoryGirl.create(:ems_vmware, :zone => zone)
+      @ems = FactoryGirl.create(:ems_vmware_with_valid_authentication, :zone => zone)
     end
 
     it "with Ems" do
@@ -48,8 +48,8 @@ describe EmsRefresh do
   context ".queue_refresh_task" do
     before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
-      @ems  = FactoryGirl.create(:ems_vmware, :zone => zone)
-      @ems2 = FactoryGirl.create(:ems_vmware, :zone => zone)
+      @ems  = FactoryGirl.create(:ems_vmware_with_valid_authentication, :zone => zone)
+      @ems2 = FactoryGirl.create(:ems_vmware_with_valid_authentication, :zone => zone)
     end
 
     context "with a refresh already on the queue" do


### PR DESCRIPTION
If the provider credentials have been invalid for longer than a
configurable grace period (default here of 15 minutes) then don't queue
a refresh since a full will be run when the workers start back up.