### PR TITLE
Don't dependent => destroy child managers

### DIFF
--- a/app/models/mixins/cinder_manager_mixin.rb
+++ b/app/models/mixins/cinder_manager_mixin.rb
@@ -7,8 +7,7 @@ module CinderManagerMixin
     has_one  :cinder_manager,
              :foreign_key => :parent_ems_id,
              :class_name  => "ManageIQ::Providers::StorageManager::CinderManager",
-             :autosave    => true,
-             :dependent   => :destroy
+             :autosave    => true
 
     delegate :cloud_volumes,
              :cloud_volume_snapshots,

--- a/app/models/mixins/has_network_manager_mixin.rb
+++ b/app/models/mixins/has_network_manager_mixin.rb
@@ -5,8 +5,7 @@ module HasNetworkManagerMixin
     has_one :network_manager,
             :foreign_key => :parent_ems_id,
             :class_name  => "ManageIQ::Providers::NetworkManager",
-            :autosave    => true,
-            :dependent   => :destroy
+            :autosave    => true
 
     delegate :floating_ips,
              :security_groups,

--- a/app/models/mixins/swift_manager_mixin.rb
+++ b/app/models/mixins/swift_manager_mixin.rb
@@ -5,8 +5,7 @@ module SwiftManagerMixin
     has_one  :swift_manager,
              :foreign_key => :parent_ems_id,
              :class_name  => "ManageIQ::Providers::StorageManager::SwiftManager",
-             :autosave    => true,
-             :dependent   => :destroy
+             :autosave    => true
 
     delegate :cloud_object_store_containers,
              :cloud_object_store_objects,


### PR DESCRIPTION
Destroying child_managers is orchestrated by the parent and destroying
them prematurely leads to issues when the endpoints are shared between
the two managers.

Example failure: https://travis-ci.org/ManageIQ/manageiq-providers-openstack/jobs/332446792#L2079-L2091

Other PRs:

- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/208
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/401