### PR TITLE
Declare Kubevirt's template as eligible for provision

### DIFF
--- a/app/models/manageiq/providers/infra_manager/template.rb
+++ b/app/models/manageiq/providers/infra_manager/template.rb
@@ -2,7 +2,10 @@ class ManageIQ::Providers::InfraManager::Template < MiqTemplate
   default_value_for :cloud, false
 
   def self.eligible_for_provisioning
-    super.where(:type => %w(ManageIQ::Providers::Redhat::InfraManager::Template ManageIQ::Providers::Vmware::InfraManager::Template ManageIQ::Providers::Microsoft::InfraManager::Template))
+    super.where(:type => %w(ManageIQ::Providers::Redhat::InfraManager::Template
+                            ManageIQ::Providers::Vmware::InfraManager::Template
+                            ManageIQ::Providers::Microsoft::InfraManager::Template
+                            ManageIQ::Providers::Kubevirt::InfraManager::Template))
   end
 
   private


### PR DESCRIPTION
Kubevirt is a virtualization provider that allows to create virtual
machines.

For that purpose, the kubevirt's template should be added to the
eligible for provision list of templates.
Kubevirt is a virtualization provider that allows to create virtual
machines. Currently, it is pretty limited and not fully defined,
therefore the initial dialog allows the user to specific the VM memory
only.

The provider PR that adds the vm provision dialog:
https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/25