### PR TITLE
Remove outdated cloud network identifiers 

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6088,17 +6088,6 @@
           :feature_type: control
           :identifier: miq_template_snapshot_revert
 
-# CloudNetworks
-- :name: Cloud Networks
-  :description: Get Cloud Networks
-  :feature_type: node
-  :identifier: miq_cloud_networks
-  :children:
-  - :name: View
-    :description: Show Cloud Networks
-    :feature_type: view
-    :identifier: miq_cloud_networks_view
-
 # EmsStorage
 - :name: Storage Managers
   :description: Everything under Storage Managers


### PR DESCRIPTION
The product features are no longer used and have been replaced in the API by the [correct identifiers](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_product_features.yml#L4388-L4406)

@miq-bot add_label cleanup 
cc: @lpichler @abellotti 
