### PR TITLE
[GAPRINDASHVILI] On task screen show created_on date if started_on was not initialized

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -50,8 +50,16 @@ class MiqTask < ApplicationRecord
   scope :no_status_selected,      ->           { running.where.not(:status => %(Ok Error Warn)) }
   scope :with_status_in,          ->(s, *rest) { rest.reduce(MiqTask.send(s)) { |chain, r| chain.or(MiqTask.send(r)) } }
 
+  def started_on
+    self._started_on || created_on
+  end
+
+  def _started_on
+    read_attribute(:started_on)
+  end
+
   def ensure_started
-    self.started_on ||= Time.now.utc if state == STATE_ACTIVE
+    self.started_on = Time.now.utc if state == STATE_ACTIVE && self._started_on.nil?
   end
 
   def self.update_status_for_timed_out_active_tasks

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -395,7 +395,7 @@ describe Job do
         end
 
         it "updates 'started_on' attribute of miq_task if job's 'started_on' attribute was updated" do
-          expect(@task.started_on).to be nil
+          expect(@task._started_on).to be nil
           time = Time.new.utc.change(:usec => 0)
           @job.update_attributes(:started_on => time)
           expect(@task.reload.started_on).to eq time

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -335,10 +335,10 @@ describe MiqTask do
       let(:task) { FactoryGirl.create(:miq_task_plain) }
 
       it "initilizes 'started_on' attribute if task become Active " do
-        expect(task.started_on).to be nil
+        expect(task._started_on).to be nil
         Timecop.freeze do
           task.update_attributes!(:state => MiqTask::STATE_ACTIVE)
-          expect(task.started_on).to eq Time.now.utc
+          expect(task._started_on).to eq Time.now.utc
         end
       end
     end
@@ -350,22 +350,22 @@ describe MiqTask do
     context "to 'Active' state" do
       it "sets 'started_on => Time.now.utc' if 'started_on' is nil" do
         Timecop.freeze do
-          expect(miq_task.started_on).to be nil
+          expect(miq_task._started_on).to be nil
           miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
-          expect(miq_task.started_on).to eq Time.now.utc
+          expect(miq_task._started_on).to eq Time.now.utc
         end
       end
 
       it "does not set 'started_on' if passed state is not 'active'" do
         miq_task.update_status("Any state", MiqTask::STATUS_OK, "")
-        expect(miq_task.started_on).to be nil
+        expect(miq_task._started_on).to be nil
       end
 
       it "does not changed 'started_on' if task already has 'started-on' attribute set" do
         some_time = Time.now.utc - 5.hours
         miq_task.update_attributes!(:started_on => some_time)
         miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
-        expect(miq_task.started_on).to eq some_time
+        expect(miq_task._started_on).to eq some_time
       end
 
       it "sets 'miq_server' association" do
@@ -381,9 +381,9 @@ describe MiqTask do
 
     it "sets 'started_on => Time.now.utc' if 'started_on' is nil" do
       Timecop.freeze do
-        expect(miq_task.started_on).to be nil
+        expect(miq_task._started_on).to be nil
         miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
-        expect(miq_task.started_on).to eq Time.now.utc
+        expect(miq_task._started_on).to eq Time.now.utc
       end
     end
 
@@ -391,7 +391,7 @@ describe MiqTask do
       some_time = Time.now.utc - 5.hours
       miq_task.update_attributes!(:started_on => some_time)
       miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "")
-      expect(miq_task.started_on).to eq some_time
+      expect(miq_task._started_on).to eq some_time
     end
 
     it "sets 'miq_server' association" do


### PR DESCRIPTION
In `fine` release `Started` column was linked to `MiqTask#created_on`
In `gaprindashvili` we have added new visible column 'Queued' on task screen (it is the same screen for jobs and tasks) and linked that column to `MiqTask#created_on`. `Started` column was linked to new db column `MiqTask#started_on`.

**before:** some tasks do not have value in `Started` column
https://bugzilla.redhat.com/show_bug.cgi?id=1536126

**after:**
 temporary (before implementing proper fix):  show in the `Started`column `MiqTask.created_on` if `started_on` was not initialized.

NOTE: I am not sure if this PR should go, since  even after implementing proper fix (set task "Active" when task started) there will be empty `Started` on old tasks. I would rather added to list of "known issues" for 5.9.0

**BEFORE:**
<img width="1096" alt="before1" src="https://user-images.githubusercontent.com/6556758/35355607-d5b28fd2-011b-11e8-90d6-26dddb004faf.png">

**AFTER:**
<img width="1163" alt="after" src="https://user-images.githubusercontent.com/6556758/35356585-d9a8835a-011e-11e8-9432-ac563d52f65d.png">


@miq-bot add-label gaprindashvili, blocker, bug, core