### PR TITLE
Update the  human description for "cpu_used_delta_summation"

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -90,7 +90,7 @@ en:
         cpu_ready_delta_summation:     CPU - Time Spent In Ready State (ms)
         cpu_system_delta_summation:    CPU - Time Spent in System State (ms)
         cpu_usagemhz_rate_average:     CPU - Usage Rate for Collected Intervals (MHz)
-        cpu_used_delta_summation:      CPU - Time Used (ms)
+        cpu_used_delta_summation:      CPU - Total time usage (VMware) (ms)
         cpu_wait_delta_summation:      CPU - Time Spent in Wait State (ms)
         derived_cpu_available:         CPU - Total - from VM Analysis (MHz)
         derived_cpu_reserved:          CPU - Reserved (MHz)


### PR DESCRIPTION
Update the  human description for "cpu_used_delta_summation" to allow the correct selection of performance field for alerts.

Links
---------
https://bugzilla.redhat.com/show_bug.cgi?id=1495209