### PR TITLE
[WIP] remove ar_virtual bad AR polymorphic error

### DIFF
--- a/app/models/metric/common.rb
+++ b/app/models/metric/common.rb
@@ -181,7 +181,7 @@ module Metric::Common
     end
 
     def with_resource
-      where.not(:resource => nil)
+      where.not(:resource => {})
     end
   end
 end

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -563,14 +563,14 @@ module VirtualFields
     def remove_virtual_fields(associations)
       case associations
       when String, Symbol
-        virtual_field?(associations) ? nil : associations
+        virtual_field?(associations) ? {} : associations
       when Array
         associations.collect { |association| remove_virtual_fields(association) }.compact
       when Hash
         associations.each_with_object({}) do |(parent, child), h|
           next if virtual_field?(parent)
           reflection = reflect_on_association(parent.to_sym)
-          h[parent] = reflection.options[:polymorphic] ? nil : reflection.klass.remove_virtual_fields(child) if reflection
+          h[parent] = reflection.options[:polymorphic] ? {} : reflection.klass.remove_virtual_fields(child) if reflection
         end
       else
         associations

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -8,10 +8,9 @@ describe MetricRollup do
           .includes(:resource => {}, :time_profile => {})
           .references(:time_profile => {}).last
       end.not_to raise_error
+    end
 
-      # TODO: Also, there is a bug that exists in only the manageiq repo and not rails
-      # TODO: that causes the error "ActiveRecord::ConfigurationError: nil"
-      # TODO: instead of the expected "ActiveRecord::EagerLoadPolymorphicError" error.
+    it "raises eager load polymorphic error when referencing bogus table" do
       expect do
         Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table => {}).to_a
       end.to raise_error ActiveRecord::EagerLoadPolymorphicError


### PR DESCRIPTION
Going through pending tests again...

comment in 8615ffe points to issue with
requiring a polymorphic association.

This change gets us closer. It no longer has a configuration error when
requiring a bogus association.

one thing for sure: It was changing many associations while creating queries. Think this is going in the right route, but not totally sure about implications