### PR TITLE
Graph refresh skeletal precreate

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -76,7 +76,7 @@ module ManagerRefresh
                 :internal_attributes, :delete_method, :dependency_attributes, :manager_ref, :create_only,
                 :association, :complete, :update_only, :transitive_dependency_attributes, :check_changed, :arel,
                 :inventory_object_attributes, :name, :saver_strategy, :manager_uuids, :builder_params,
-                :skeletal_manager_uuids, :targeted_arel, :targeted, :manager_ref_allowed_nil, :use_ar_object,
+                :targeted_arel, :targeted, :manager_ref_allowed_nil, :use_ar_object,
                 :created_records, :updated_records, :deleted_records,
                 :custom_reconnect_block, :batch_extra_attributes, :references_storage
 
@@ -402,7 +402,6 @@ module ManagerRefresh
       @manager_uuids                = Set.new.merge(manager_uuids)
       @all_manager_uuids            = all_manager_uuids
       @parent_inventory_collections = parent_inventory_collections
-      @skeletal_manager_uuids       = Set.new.merge(manager_uuids)
       @targeted_arel                = targeted_arel
       @targeted                     = !!targeted
 
@@ -528,7 +527,7 @@ module ManagerRefresh
     def noop?
       # If this InventoryCollection doesn't do anything. it can easily happen for targeted/batched strategies.
       if targeted?
-        if parent_inventory_collections.nil? && manager_uuids.blank? && skeletal_manager_uuids.blank? &&
+        if parent_inventory_collections.nil? && manager_uuids.blank? &&
            all_manager_uuids.nil? && parent_inventory_collections.blank? && custom_save_block.nil? &&
            skeletal_primary_index.blank?
           # It's a noop Parent targeted InventoryCollection
@@ -751,12 +750,12 @@ module ManagerRefresh
           targeted_arel.call(self)
         elsif manager_ref.count > 1
           # TODO(lsmola) optimize with ApplicationRecordIterator
-          hashes = extract_references(manager_uuids + skeletal_manager_uuids)
+          hashes = extract_references(manager_uuids)
           full_collection_for_comparison.where(build_multi_selection_condition(hashes))
         else
           ManagerRefresh::ApplicationRecordIterator.new(
             :inventory_collection => self,
-            :manager_uuids_set    => (manager_uuids + skeletal_manager_uuids).to_a.flatten.compact
+            :manager_uuids_set    => manager_uuids.to_a.flatten.compact
           )
         end
       else

--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -73,7 +73,7 @@ module ManagerRefresh
     attr_accessor :parent_inventory_collections
 
     attr_reader :model_class, :strategy, :attributes_blacklist, :attributes_whitelist, :custom_save_block, :parent,
-                :internal_attributes, :delete_method, :dependency_attributes, :manager_ref,
+                :internal_attributes, :delete_method, :dependency_attributes, :manager_ref, :create_only,
                 :association, :complete, :update_only, :transitive_dependency_attributes, :check_changed, :arel,
                 :inventory_object_attributes, :name, :saver_strategy, :manager_uuids, :builder_params,
                 :skeletal_manager_uuids, :targeted_arel, :targeted, :manager_ref_allowed_nil, :use_ar_object,
@@ -367,7 +367,7 @@ module ManagerRefresh
     def initialize(model_class: nil, manager_ref: nil, association: nil, parent: nil, strategy: nil,
                    custom_save_block: nil, delete_method: nil, dependency_attributes: nil,
                    attributes_blacklist: nil, attributes_whitelist: nil, complete: nil, update_only: nil,
-                   check_changed: nil, arel: nil, builder_params: {},
+                   check_changed: nil, arel: nil, builder_params: {}, create_only: nil,
                    inventory_object_attributes: nil, name: nil, saver_strategy: nil,
                    parent_inventory_collections: nil, manager_uuids: [], all_manager_uuids: nil, targeted_arel: nil,
                    targeted: nil, manager_ref_allowed_nil: nil, secondary_refs: {}, use_ar_object: nil,
@@ -387,6 +387,7 @@ module ManagerRefresh
       @internal_attributes    = %i(__feedback_edge_set_parent __parent_inventory_collections)
       @complete               = complete.nil? ? true : complete
       @update_only            = update_only.nil? ? false : update_only
+      @create_only            = create_only.nil? ? false : create_only
       @builder_params         = builder_params
       @name                   = name || association || model_class.to_s.demodulize.tableize
       @saver_strategy         = process_saver_strategy(saver_strategy)
@@ -487,6 +488,10 @@ module ManagerRefresh
 
     def create_allowed?
       !update_only?
+    end
+
+    def create_only?
+      create_only
     end
 
     def saved?

--- a/app/models/manager_refresh/inventory_collection/data_storage.rb
+++ b/app/models/manager_refresh/inventory_collection/data_storage.rb
@@ -74,10 +74,9 @@ module ManagerRefresh
         # since that one is not being saved.
         uuid = ::ManagerRefresh::InventoryCollection::Reference.build_stringified_reference(hash, named_ref)
         inventory_object = skeletal_primary_index.delete(uuid)
-        if inventory_object
-          # We want to update the skeletal record with actual data
-          inventory_object.assign_attributes(hash)
-        end
+
+        # We want to update the skeletal record with actual data
+        inventory_object&.assign_attributes(hash)
 
         # Build the InventoryObject
         inventory_object ||= new_inventory_object(enrich_data(hash))

--- a/app/models/manager_refresh/inventory_collection/data_storage.rb
+++ b/app/models/manager_refresh/inventory_collection/data_storage.rb
@@ -10,8 +10,7 @@ module ManagerRefresh
 
       delegate :each, :size, :to => :data
 
-      delegate :find,
-               :primary_index,
+      delegate :primary_index,
                :build_primary_index_for,
                :build_secondary_indexes_for,
                :named_ref,
@@ -32,7 +31,7 @@ module ManagerRefresh
       end
 
       def <<(inventory_object)
-        unless primary_index.find(inventory_object.manager_uuid)
+        if inventory_object.manager_uuid.present? && !primary_index.find(inventory_object.manager_uuid)
           data << inventory_object
 
           # TODO(lsmola) Maybe we do not need the secondary indexes here?
@@ -54,29 +53,31 @@ module ManagerRefresh
       end
 
       def find_or_build_by(manager_uuid_hash)
-        if !manager_uuid_hash.keys.all? { |x| manager_ref.include?(x) } || manager_uuid_hash.keys.size != manager_ref.size
-          raise "Allowed find_or_build_by keys are #{manager_ref}"
+        find_in_data(manager_uuid_hash) || build(manager_uuid_hash)
+      end
+
+      def find_in_data(hash)
+        hash = enrich_data(hash)
+
+        if manager_ref.any? { |x| !hash.key?(x) }
+          raise "Needed find_or_build_by keys are: #{manager_ref}, data provided: #{hash}"
         end
 
-        build(manager_uuid_hash)
+        uuid = ::ManagerRefresh::InventoryCollection::Reference.build_stringified_reference(hash, named_ref)
+        primary_index.find(uuid)
       end
 
       def build(hash)
-        hash = builder_params.merge(hash)
-
-        # Faster way to build uuid than inventory_object.manager_uuid
-        uuid = ::ManagerRefresh::InventoryCollection::Reference.build_stringified_reference(hash, named_ref)
-
-        # Each InventoryObject must be able to build an UUID, return nil if it can't
-        return nil if uuid.blank?
-        # Return existing InventoryObject if we have it
-        return primary_index.find(uuid) if primary_index.find(uuid)
-
         # Build the InventoryObject
-        inventory_object = new_inventory_object(hash)
+        inventory_object = new_inventory_object(enrich_data(hash))
         # Store new InventoryObject and return it
         push(inventory_object)
-        inventory_object
+
+        return inventory_object unless inventory_object.nil?
+
+        # TODO(lsmola) prepare for changing behavior, build will return nil if it can't build or the record is already
+        # there. Maybe we should even make build a private method.
+        find_in_data(enrich_data(hash))
       end
 
       def to_a
@@ -125,6 +126,13 @@ module ManagerRefresh
             end
           end
         end
+      end
+
+      private
+
+      def enrich_data(hash)
+        # This is 25% faster than builder_params.merge(hash)
+        {}.merge!(builder_params).merge!(hash)
       end
     end
   end

--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -75,9 +75,9 @@ module ManagerRefresh
           when :local_db_find_references, :local_db_cache_all
             local_db_index_find(reference)
           when :local_db_find_missing_references
-            data_index_find(reference) || local_db_index_find(reference)
+            find_in_data_or_skeletal_index(reference) || local_db_index_find(reference)
           else
-            data_index_find(reference)
+            find_in_data_or_skeletal_index(reference)
           end
         end
 
@@ -112,10 +112,25 @@ module ManagerRefresh
 
         delegate :association_to_foreign_key_mapping,
                  :build_stringified_reference,
+                 :parallel_safe?,
                  :strategy,
                  :to => :inventory_collection
 
         attr_reader :all_refs, :data_indexes, :inventory_collection, :primary_ref, :local_db_indexes, :secondary_refs
+
+        def find_in_data_or_skeletal_index(reference)
+          if parallel_safe?
+            # With parallel safe strategies, we create skeletal nodes that we can look for
+            data_index_find(reference) || skeletal_index_find(reference)
+          else
+            data_index_find(reference)
+          end
+        end
+
+        def skeletal_index_find(reference)
+          # Find in skeletal index, but we are able to create skeletal index only for primary indexes
+          skeletal_primary_index.find(reference.stringified_reference) if reference.primary?
+        end
 
         def data_index_find(reference)
           data_index(reference.ref).find(reference.stringified_reference)

--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -4,6 +4,8 @@ module ManagerRefresh
       class Proxy
         include Vmdb::Logging
 
+        attr_reader :skeletal_primary_index
+
         def initialize(inventory_collection, secondary_refs = {})
           @inventory_collection = inventory_collection
 
@@ -28,6 +30,13 @@ module ManagerRefresh
               @data_indexes[index_name]
             )
           end
+
+          @skeletal_primary_index = ManagerRefresh::InventoryCollection::Index::Type::Skeletal.new(
+            inventory_collection,
+            :skeletal_primary_index_ref,
+            named_ref,
+            primary_index
+          )
         end
 
         def build_primary_index_for(inventory_object)

--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -95,7 +95,7 @@ module ManagerRefresh
                                                     :ref => ref, :key => key, :default => default)
         end
 
-        def named_ref(ref)
+        def named_ref(ref = primary_index_ref)
           all_refs[ref]
         end
 

--- a/app/models/manager_refresh/inventory_collection/index/type/skeletal.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/skeletal.rb
@@ -1,0 +1,63 @@
+module ManagerRefresh
+  class InventoryCollection
+    module Index
+      module Type
+        class Skeletal < ManagerRefresh::InventoryCollection::Index::Type::Base
+          def initialize(inventory_collection, index_name, attribute_names, primary_index)
+            super
+
+            @primary_index = primary_index
+          end
+
+          delegate :builder_params,
+                   :new_inventory_object,
+                   :named_ref,
+                   :to => :inventory_collection
+
+          delegate :each,
+                   :to => :index
+
+          # Find value based on index_value
+          #
+          # @param index_value [String] a index_value of the InventoryObject we search for
+          # @return [InventoryObject|nil] Returns found value or nil
+          def find(index_value)
+            index[index_value]
+          end
+
+          # Deletes and returns the value on the index_value
+          #
+          # @param index_value [String] a index_value of the InventoryObject we search for
+          # @return [InventoryObject|nil] Returns found value or nil
+          def delete(index_value)
+            index.delete(index_value)
+          end
+
+          # Builds index record with skeletal InventoryObject and returns it, or returns nil if it's already present
+          # in primary_index or skeletal_primary_index
+          # @param attributes [Hash] Skeletal data of the index, must contain unique index keys and everything else
+          #        needed for creating the record in the Database
+          # @return [InventoryObject|nil] Returns built value or nil
+          def build(attributes)
+            attributes = {}.merge!(builder_params).merge!(attributes)
+
+            # If the primary index is already filled, we don't want populate skeletal index
+            uuid = ::ManagerRefresh::InventoryCollection::Reference.build_stringified_reference(attributes, named_ref)
+            return if primary_index.find(uuid)
+
+            # Return if skeletal index already exists
+            return if index[uuid]
+
+            # We want to populate a new skeletal index
+            inventory_object                     = new_inventory_object(attributes)
+            index[inventory_object.manager_uuid] = inventory_object
+          end
+
+          private
+
+          attr_reader :primary_index
+        end
+      end
+    end
+  end
+end

--- a/app/models/manager_refresh/inventory_collection/index/type/skeletal.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/skeletal.rb
@@ -14,7 +14,8 @@ module ManagerRefresh
                    :named_ref,
                    :to => :inventory_collection
 
-          delegate :each,
+          delegate :blank?,
+                   :each,
                    :to => :index
 
           # Find value based on index_value

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -14,6 +14,10 @@ module ManagerRefresh
         @stringified_reference = self.class.build_stringified_reference(full_reference, keys)
       end
 
+      def primary?
+        ref == :manager_ref
+      end
+
       def to_hash
       end
 

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -3,13 +3,14 @@ module ManagerRefresh
     class Reference
       include Vmdb::Logging
 
-      attr_reader :full_reference, :ref, :stringified_reference
+      attr_reader :full_reference, :keys, :ref, :stringified_reference
 
       delegate :[], :to => :full_reference
 
       def initialize(data, ref, keys)
         @full_reference = build_full_reference(data, keys)
         @ref            = ref
+        @keys           = keys
 
         @stringified_reference = self.class.build_stringified_reference(full_reference, keys)
       end

--- a/app/models/manager_refresh/inventory_collection/scanner.rb
+++ b/app/models/manager_refresh/inventory_collection/scanner.rb
@@ -45,7 +45,6 @@ module ManagerRefresh
                :parent_inventory_collections,
                :parent_inventory_collections=,
                :references,
-               :skeletal_manager_uuids,
                :transitive_dependency_attributes,
                :to => :inventory_collection
 

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -82,11 +82,6 @@ module ManagerRefresh
       # the given :arel scope, we will always attempt to create the recod, so we need unique index to avoid duplication
       # of records.
       return unless %i(concurrent_safe concurrent_safe_batch).include?(saver_strategy)
-      # Allow skeletal pre-create only for targeted refresh, full refresh should have all edges connected
-      # TODO(lsmola) actually this is not true, e.g. cloud have several full refreshes, where e.g. storage manager
-      # records can have missing edges to cloud manager records. For this to drop, we need build method to call
-      # assign_attributes, or use everywhere find_or_build(hash).assign_attributes(hash)
-      return unless targeted?
       # Pre-create only for strategies that will be persisting data, i.e. are not saved already
       return if saved?
       # We can only do skeletal pre-create for primary index reference, since that is needed to create DB unique index

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -94,10 +94,6 @@ module ManagerRefresh
       return if keys.any? { |x| full_reference[x].blank? }
 
       skeletal_primary_index.build(full_reference)
-
-      # TODO(lsmola) what do I need this for? Skeletal record can break :key, since the record won't be fetched by DB
-      # strategy and :key is missing in skeletal record. Write spec!
-      # value_inventory_collection.skeletal_manager_uuids << value.stringified_reference
     end
 
     def load_object_with_key

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -68,7 +68,7 @@ module ManagerRefresh
 
     private
 
-    delegate :saved?, :saver_strategy, :targeted?, :to => :inventory_collection
+    delegate :parallel_safe?, :saved?, :saver_strategy, :skeletal_primary_index, :targeted?, :to => :inventory_collection
     delegate :full_reference, :keys, :primary?, :to => :reference
 
 
@@ -81,7 +81,7 @@ module ManagerRefresh
       # We can do skeletal pre-create only for strategies using unique indexes. Since this can build records out of
       # the given :arel scope, we will always attempt to create the recod, so we need unique index to avoid duplication
       # of records.
-      return unless %i(concurrent_safe concurrent_safe_batch).include?(saver_strategy)
+      return unless parallel_safe?
       # Pre-create only for strategies that will be persisting data, i.e. are not saved already
       return if saved?
       # We can only do skeletal pre-create for primary index reference, since that is needed to create DB unique index
@@ -93,7 +93,7 @@ module ManagerRefresh
       # TODO(lsmola) for composite keys, it's still valid to have one of the keys nil, figure out how to allow this
       return if keys.any? { |x| full_reference[x].blank? }
 
-      inventory_collection.build(full_reference)
+      skeletal_primary_index.build(full_reference)
 
       # TODO(lsmola) what do I need this for? Skeletal record can break :key, since the record won't be fetched by DB
       # strategy and :key is missing in skeletal record. Write spec!

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -11,6 +11,10 @@ module ManagerRefresh
       @reference            = inventory_collection.build_reference(index_data, ref)
       @key                  = key
       @default              = default
+
+      # We do not support skeletal pre-create for :key, since :key will not be available, we want to use local_db_find
+      # instead.
+      skeletal_precreate! unless @key
     end
 
     # TODO(lsmola) do we need this method?
@@ -63,6 +67,43 @@ module ManagerRefresh
     end
 
     private
+
+    delegate :saved?, :saver_strategy, :targeted?, :to => :inventory_collection
+    delegate :full_reference, :keys, :primary?, :to => :reference
+
+
+    # Instead of loading the reference from the DB, we'll add the skeletal InventoryObject (having manager_ref and
+    # info from the builder_params) to the correct InventoryCollection. Which will either be found in the DB or
+    # created as a skeletal object. The later refresh of the object will then fill the rest of the data, while not
+    # touching the reference.
+    # @return [ManagerRefresh::InventoryObject| Returns pre-created InvetoryObject or nil
+    def skeletal_precreate!
+      # We can do skeletal pre-create only for strategies using unique indexes. Since this can build records out of
+      # the given :arel scope, we will always attempt to create the recod, so we need unique index to avoid duplication
+      # of records.
+      return unless %i(concurrent_safe concurrent_safe_batch).include?(saver_strategy)
+      # Allow skeletal pre-create only for targeted refresh, full refresh should have all edges connected
+      # TODO(lsmola) actually this is not true, e.g. cloud have several full refreshes, where e.g. storage manager
+      # records can have missing edges to cloud manager records. For this to drop, we need build method to call
+      # assign_attributes, or use everywhere find_or_build(hash).assign_attributes(hash)
+      return unless targeted?
+      # Pre-create only for strategies that will be persisting data, i.e. are not saved already
+      return if saved?
+      # We can only do skeletal pre-create for primary index reference, since that is needed to create DB unique index
+      return unless primary?
+      # Full reference must be present
+      return if full_reference.blank?
+
+      # To avoid pre-creating invalid records all fields of a primary key must have value
+      # TODO(lsmola) for composite keys, it's still valid to have one of the keys nil, figure out how to allow this
+      return if keys.any? { |x| full_reference[x].blank? }
+
+      inventory_collection.build(full_reference)
+
+      # TODO(lsmola) what do I need this for? Skeletal record can break :key, since the record won't be fetched by DB
+      # strategy and :key is missing in skeletal record. Write spec!
+      # value_inventory_collection.skeletal_manager_uuids << value.stringified_reference
+    end
 
     def load_object_with_key
       # TODO(lsmola) Log error if we are accessing path that is present in blacklist or not present in whitelist

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -71,7 +71,6 @@ module ManagerRefresh
     delegate :parallel_safe?, :saved?, :saver_strategy, :skeletal_primary_index, :targeted?, :to => :inventory_collection
     delegate :full_reference, :keys, :primary?, :to => :reference
 
-
     # Instead of loading the reference from the DB, we'll add the skeletal InventoryObject (having manager_ref and
     # info from the builder_params) to the correct InventoryCollection. Which will either be found in the DB or
     # created as a skeletal object. The later refresh of the object will then fill the rest of the data, while not

--- a/app/models/manager_refresh/save_collection/saver/base.rb
+++ b/app/models/manager_refresh/save_collection/saver/base.rb
@@ -72,6 +72,15 @@ module ManagerRefresh::SaveCollection
 
       delegate :build_stringified_reference, :build_stringified_reference_for_record, :to => :inventory_collection
 
+      def values_for_database!(all_attribute_keys, attributes)
+        all_attribute_keys.each do |key|
+          if (type = serializable_keys[key])
+            attributes[key] = type.serialize(attributes[key])
+          end
+        end
+        attributes
+      end
+
       private
 
       attr_reader :unique_index_keys, :unique_index_keys_to_s, :select_keys, :unique_db_primary_keys, :unique_db_indexes,

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe.rb
@@ -1,6 +1,8 @@
 module ManagerRefresh::SaveCollection
   module Saver
     class ConcurrentSafe < ManagerRefresh::SaveCollection::Saver::Base
+      # TODO(lsmola) this strategy does not make much sense, it's better to use concurent_safe_batch and make batch size
+      # configurable
       private
 
       def update_record!(record, hash, inventory_object)
@@ -23,13 +25,31 @@ module ManagerRefresh::SaveCollection
 
       def create_record!(hash, inventory_object)
         all_attribute_keys = hash.keys
-        hash               = inventory_collection.model_class.new(hash).attributes.symbolize_keys
-        assign_attributes_for_create!(hash, time_now)
+        data               = inventory_collection.model_class.new(hash).attributes.symbolize_keys
 
-        result_id = ActiveRecord::Base.connection.insert_sql(
-          build_insert_query(all_attribute_keys, [hash])
+        # TODO(lsmola) abstract common behavior into base class
+        all_attribute_keys << :created_at if supports_created_at?
+        all_attribute_keys << :updated_at if supports_updated_at?
+        all_attribute_keys << :created_on if supports_created_on?
+        all_attribute_keys << :updated_on if supports_updated_on?
+        hash_for_creation = if inventory_collection.use_ar_object?
+                              record = inventory_collection.model_class.new(data)
+                              values_for_database!(all_attribute_keys,
+                                                   record.attributes.symbolize_keys)
+                            elsif serializable_keys?
+                              values_for_database!(all_attribute_keys,
+                                                   data)
+                            else
+                              data
+                            end
+
+        assign_attributes_for_create!(hash_for_creation, time_now)
+
+        result_id = ActiveRecord::Base.connection.execute(
+          build_insert_query(all_attribute_keys, [hash_for_creation])
         )
-        inventory_object.id = result_id
+
+        inventory_object.id = result_id.to_a.try(:first).try(:[], "id")
         inventory_collection.store_created_records(inventory_object)
       end
     end

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -242,15 +242,6 @@ module ManagerRefresh::SaveCollection
         end
       end
 
-      def values_for_database!(all_attribute_keys, attributes)
-        all_attribute_keys.each do |key|
-          if (type = serializable_keys[key])
-            attributes[key] = type.serialize(attributes[key])
-          end
-        end
-        attributes
-      end
-
       def map_ids_to_inventory_objects(indexed_inventory_objects, all_attribute_keys, hashes, result)
         # The remote_data_timestamp is adding a WHERE condition to ON CONFLICT UPDATE. As a result, the RETURNING
         # clause is not guaranteed to return all ids of the inserted/updated records in the result. In that case

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -66,10 +66,14 @@ module ManagerRefresh::SaveCollection
 
         _log.debug("Processing #{inventory_collection} of size #{inventory_collection.size}...")
 
-        update_or_destroy_records!(batch_iterator(association), inventory_objects_index, attributes_index, all_attribute_keys)
+        unless inventory_collection.create_only?
+          update_or_destroy_records!(batch_iterator(association), inventory_objects_index, attributes_index, all_attribute_keys)
+        end
 
-        unless inventory_collection.custom_reconnect_block.nil?
-          inventory_collection.custom_reconnect_block.call(inventory_collection, inventory_objects_index, attributes_index)
+        unless inventory_collection.create_only?
+          unless inventory_collection.custom_reconnect_block.nil?
+            inventory_collection.custom_reconnect_block.call(inventory_collection, inventory_objects_index, attributes_index)
+          end
         end
 
         all_attribute_keys << :type if supports_sti?

--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -101,7 +101,7 @@ module ManagerRefresh::SaveCollection
             end
 
             skeletal_inventory_objects_index.each_slice(batch_size_for_persisting) do |batch|
-              create_records!(all_attribute_keys, batch, skeletal_attributes_index)
+              create_records!(all_attribute_keys, batch, skeletal_attributes_index, :on_conflict => :do_nothing)
             end
           end
         end
@@ -231,7 +231,7 @@ module ManagerRefresh::SaveCollection
         get_connection.execute(query)
       end
 
-      def create_records!(all_attribute_keys, batch, attributes_index)
+      def create_records!(all_attribute_keys, batch, attributes_index, on_conflict: nil)
         indexed_inventory_objects = {}
         hashes                    = []
         create_time               = time_now
@@ -259,7 +259,7 @@ module ManagerRefresh::SaveCollection
         return if hashes.blank?
 
         result = get_connection.execute(
-          build_insert_query(all_attribute_keys, hashes)
+          build_insert_query(all_attribute_keys, hashes, :on_conflict => on_conflict)
         )
         inventory_collection.store_created_records(result)
         if inventory_collection.dependees.present?


### PR DESCRIPTION
Skeletal precreate is when we use graph edges to build skeletal nodes. Combining with unique indexes, we can use this to easily build the graph in parallel. Or build the graph out of order e.g. with targeted refresh, that would remove the need to scanning e.g. all Vms relations, to make sure it's being saved in the right order.

