### PR TITLE
MiqExpression::Field#virtual_reflection?

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -40,7 +40,7 @@ class MiqExpression::Field < MiqExpression::Target
   end
 
   def attribute_supported_by_sql?
-    !custom_attribute_column? && target.attribute_supported_by_sql?(column)
+    !custom_attribute_column? && target.attribute_supported_by_sql?(column) && reflection_supported_by_sql?
   end
 
   def custom_attribute_column?

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -48,6 +48,10 @@ class MiqExpression::Target
     [:has_many, :has_and_belongs_to_many].include?(reflections.last.macro)
   end
 
+  def reflection_supported_by_sql?
+    model.follow_associations(associations).present?
+  end
+
   def reflections
     klass = model
     associations.collect do |association|

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -235,13 +235,21 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
-  describe "sql detection" do
+  describe "#attribute_supported_by_sql?" do
     it "detects if column is supported by sql with custom_attribute" do
       expect(MiqExpression::Field.parse("Vm-virtual_custom_attribute_example").attribute_supported_by_sql?).to be_falsey
     end
 
     it "detects if column is supported by sql with regular column" do
       expect(MiqExpression::Field.parse("Vm-name").attribute_supported_by_sql?).to be_truthy
+    end
+
+    it "detects if column is supported by sql through regular association" do
+      expect(MiqExpression::Field.parse("Host.vms-name").attribute_supported_by_sql?).to be_truthy
+    end
+
+    it "detects if column is supported by sql through virtual association" do
+      expect(MiqExpression::Field.parse("Vm.service-name").attribute_supported_by_sql?).to be_falsey
     end
   end
 
@@ -282,6 +290,20 @@ RSpec.describe MiqExpression::Field do
 
     it "detects string as non-numeric" do
       expect(MiqExpression::Field.parse("Vm-name")).not_to be_numeric
+    end
+  end
+
+  describe "#reflection_supported_by_sql?" do
+    it "detects if column is accessed directly" do
+      expect(MiqExpression::Field.parse("Host-name")).to be_reflection_supported_by_sql
+    end
+
+    it "detects if column is accessed through regular association" do
+      expect(MiqExpression::Field.parse("Host.vms-name")).to be_reflection_supported_by_sql
+    end
+
+    it "detects if column is accessed through regular virtual association" do
+      expect(MiqExpression::Field.parse("Vm.service-name")).not_to be_reflection_supported_by_sql
     end
   end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -406,6 +406,21 @@ describe MiqExpression do
       expect(sql).to eq("\"vms\".\"id\" IN (SELECT DISTINCT \"guest_applications\".\"vm_or_template_id\" FROM \"guest_applications\" WHERE \"guest_applications\".\"name\" = 'foo')")
     end
 
+    it "cant generates the SQL for a CONTAINS expression with association.association-field" do
+      sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.guest_applications.host-name", "value" => "foo"}).to_sql
+      expect(sql).to be_nil
+    end
+
+    it "cant generat the SQL for a CONTAINS expression virtualassociation" do
+      sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.processes-name", "value" => "foo"}).to_sql
+      expect(sql).to be_nil
+    end
+
+    it "cant generat the SQL for a CONTAINS expression with [association.virtualassociation]" do
+      sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.users.active_vms-name", "value" => "foo"}).to_sql
+      expect(sql).to be_nil
+    end
+
     it "generates the SQL for a CONTAINS expression with field containing a scope" do
       sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.users-name", "value" => "foo"}).to_sql
       expected = "\"vms\".\"id\" IN (SELECT DISTINCT \"accounts\".\"vm_or_template_id\" FROM \"accounts\" "\


### PR DESCRIPTION
Extracted from #13446

### High Level Goal

Move ActiveRecord metadata logic out of `MiqExpression` and into `MiqExpression::Field`
More verbiage in #13446

### Goal of this PR

#### Before

`MiqExpression::Field#attribute_supported_by_sql? == true` even if it is referenced through a virtual reflection. `Field` is expected to take into account the whole picture, and whether a field is referenced through a virtual association.

The code checks both the reflection path and field. [[ref]](https://github.com/kbrock/manageiq/blob/miq_expression_column_type/lib/miq_expression.rb#L478).

#### After

Introduce `MiqExpression::Field#reflection_supported_by_sql?` so `attribute_supported_by_sql?` will return the correct value and full picture.

The parent PR introduces this method into `get_col_info`.

