### PR TITLE
Fix Deleting Snapshot on Smartstate Cancel

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -248,7 +248,7 @@ class VmScan < Job
                 (vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) && vm.require_snapshot_for_scan?)
             vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
           else
-            delete_snapshot(mor)
+            delete_snapshot(mor, vm)
           end
         rescue => err
           _log.error(err.to_s)
@@ -505,7 +505,7 @@ class VmScan < Job
         mor = context[:snapshot_mor]
         context[:snapshot_mor] = nil
         set_status("Deleting snapshot before aborting job")
-        delete_snapshot(mor)
+        delete_snapshot(mor, vm)
       end
       if vm
         inputs = {:vm => vm, :host => vm.host}

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -505,14 +505,7 @@ class VmScan < Job
         mor = context[:snapshot_mor]
         context[:snapshot_mor] = nil
         set_status("Deleting snapshot before aborting job")
-        if vm.kind_of?(ManageIQ::Providers::Openstack::CloudManager::Vm)
-          vm.ext_management_system.vm_delete_evm_snapshot(vm, mor)
-        elsif vm.kind_of?(ManageIQ::Providers::Microsoft::InfraManager::Vm) ||
-              (vm.kind_of?(ManageIQ::Providers::Azure::CloudManager::Vm) && vm.require_snapshot_for_scan?)
-          vm.ext_management_system.vm_delete_evm_snapshot(vm, :snMor => mor)
-        else
-          delete_snapshot(mor)
-        end
+        delete_snapshot(mor)
       end
       if vm
         inputs = {:vm => vm, :host => vm.host}

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -493,7 +493,6 @@ class VmScan < Job
   end
 
   def process_delete_evm_snapshot(vm)
-    vm = VmOrTemplate.find_by(:id => target_id)
     unless context[:snapshot_mor].nil?
       mor = context[:snapshot_mor]
       context[:snapshot_mor] = nil


### PR DESCRIPTION
Cancelling a Smartstate Analysis job is supposed to delete the
snapshot created if necessary.  The code attempted to call an
incorrectly named method for the provider in the case of Azure and SCVMM.
This resulted in the snapshot being left and consequently the next
attempt to run Smartstate on the same VM failed because it seemed as if
there was an active analysis job running already.

@roliveri @hsong-rh please review this blocker fix.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538347

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1538347

Steps for Testing/QA [Optional]
-------------------------------

Run Smartstate Analysis on either an Azure or SCVMM VM.  Once the snapshot has been taken and scanning has commenced, select the "Cancel Job" button.  The job should be cancelled and the snapshot should be deleted.  
If you attempt to run another Smartstate Analysis job on the same VM it should not fail because the Snapshot already exists.