### PR TITLE
Rescue attempt to get backlog for remote db in PglogicalSubscription#backlog

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -102,6 +102,9 @@ class PglogicalSubscription < ActsAsArModel
 
   def backlog
     connection.xlog_location_diff(remote_node_lsn, remote_replication_lsn)
+  rescue PG::Error => e
+    _log.error(e.message)
+    nil
   end
 
   # translate the output from the pglogical stored proc to our object columns

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -423,5 +423,11 @@ describe PglogicalSubscription do
 
       expect(described_class.first.backlog).to eq(12_120)
     end
+
+    it "returns nill if error raised inside" do
+      expect(MiqRegionRemote).to receive(:with_remote_connection).and_raise(PG::Error)
+
+      expect(described_class.first.backlog).to be nil
+    end
   end
 end


### PR DESCRIPTION
**Issue**:
Replication management screen on global region throws Error when any of subscribed DB is down.
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533958

@miq-bot add-label bug

\cc @carbonin 



