### PR TITLE
Reconfigure options must be with_indifferent_access

### DIFF
--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -41,7 +41,7 @@ class VmReconfigureTask < MiqRequestTask
   end
 
   def do_request
-    config = vm.build_config_spec(options)
+    config = vm.build_config_spec(options.with_indifferent_access)
     dump_obj(config, "#{_log.prefix} Config spec: ", $log, :info)
     vm.spec_reconfigure(config)
 


### PR DESCRIPTION
Reconfigure options provided by the API should be made with_indifferent_access to work with the providers.

See https://github.com/ManageIQ/manageiq-api/issues/260

Without this fix, all reconfigure attempts using the API (add and remove disk) will fail.