### PR TITLE
MiqServer refactoring

### DIFF
--- a/app/models/miq_automate.rb
+++ b/app/models/miq_automate.rb
@@ -2,7 +2,7 @@ class MiqAutomate
   def self.async_datastore_reset
     task = MiqTask.create(:name => "Automate Datastore Reset")
 
-    if MiqServer.find_all_started_servers.detect { |s| s.has_active_role?("automate") }.nil?
+    if MiqServer.active_miq_servers.detect { |s| s.has_active_role?("automate") }.nil?
       task.update_status("Finished", "Error", "No Server has Automate Role enabled")
     else
       MiqQueue.submit_job(

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -33,6 +33,7 @@ class MiqServer < ApplicationRecord
 
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
+  delegate :description, :to => :zone, :prefix => true
 
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze
@@ -547,10 +548,6 @@ class MiqServer < ApplicationRecord
 
   def self.my_zone(force_reload = false)
     my_server(force_reload).my_zone
-  end
-
-  def zone_description
-    zone.try(:description)
   end
 
   def self.my_roles(force_reload = false)

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -31,6 +31,7 @@ class MiqServer < ApplicationRecord
 
   virtual_column :zone_description, :type => :string
 
+  scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
 
   STATUS_STARTING       = 'starting'.freeze
@@ -46,10 +47,6 @@ class MiqServer < ApplicationRecord
   STATUSES_ALIVE   = STATUSES_ACTIVE + [STATUS_RESTARTING, STATUS_QUIESCE]
 
   RESTART_EXIT_STATUS = 123
-
-  def self.active_miq_servers
-    where(:status => STATUSES_ACTIVE)
-  end
 
   def hostname
     h = super

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -501,10 +501,6 @@ class MiqServer < ApplicationRecord
     true
   end
 
-  def state
-    "on"
-  end
-
   def started?
     status == "started"
   end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -578,15 +578,6 @@ class MiqServer < ApplicationRecord
     my_zone == zone_name
   end
 
-  CONDITION_CURRENT = {:status => ["starting", "started"]}
-  def self.find_started_in_my_region
-    in_my_region.where(CONDITION_CURRENT)
-  end
-
-  def self.find_all_started_servers
-    where(CONDITION_CURRENT)
-  end
-
   def find_other_started_servers_in_region
     MiqRegion.my_region.active_miq_servers.to_a.delete_if { |s| s.id == id }
   end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -594,10 +594,6 @@ class MiqServer < ApplicationRecord
     self.class.where(:zone_id => zone_id).where.not(:id => id).to_a
   end
 
-  def log_prefix
-    @log_prefix ||= "MIQ(#{self.class.name})"
-  end
-
   def display_name
     "#{name} [#{id}]"
   end

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -579,19 +579,19 @@ class MiqServer < ApplicationRecord
   end
 
   def find_other_started_servers_in_region
-    MiqRegion.my_region.active_miq_servers.to_a.delete_if { |s| s.id == id }
+    self.class.active_miq_servers.in_my_region.where.not(:id => id).to_a
   end
 
   def find_other_servers_in_region
-    MiqRegion.my_region.miq_servers.to_a.delete_if { |s| s.id == id }
+    self.class.active_miq_servers.where.not(:id => id).to_a
   end
 
   def find_other_started_servers_in_zone
-    zone.active_miq_servers.to_a.delete_if { |s| s.id == id }
+    self.class.active_miq_servers.where(:zone_id => zone_id).where.not(:id => id).to_a
   end
 
   def find_other_servers_in_zone
-    zone.miq_servers.to_a.delete_if { |s| s.id == id }
+    self.class.where(:zone_id => zone_id).where.not(:id => id).to_a
   end
 
   def log_prefix

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -90,7 +90,7 @@ module MiqServer::ServerSmartProxy
           timeout_adj = 8
         end
       end
-      $log.debug("#{log_prefix}: queuing call to #{self.class.name}##{ost.method_name}")
+      _log.debug("queuing call to #{self.class.name}##{ost.method_name}")
       # Queue call to scan_metadata or sync_metadata.
       MiqQueue.submit_job(
         :service     => "smartproxy",
@@ -136,7 +136,7 @@ module MiqServer::ServerSmartProxy
     klass  = ost.target_type.constantize
     target = klass.find(ost.target_id)
     job    = Job.find_by(:guid => ost.taskid)
-    _log.debug("#{log_prefix}: #{target.name} (#{target.class.name})")
+    _log.debug("#{target.name} (#{target.class.name})")
     begin
       target.perform_metadata_sync(ost)
     rescue Exception => err

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -935,7 +935,7 @@ class VmOrTemplate < ApplicationRecord
 
   def log_proxies_format_instance(object)
     return 'Nil' if object.nil?
-    "#{object.class.name}:#{object.id}-#{object.name}:#{object.state}"
+    "#{object.class.name}:#{object.id}-#{object.name}:#{object.try(:state)}"
   end
 
   def storage2hosts

--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -124,7 +124,7 @@ class VmdbDatabaseConnection < ApplicationRecord
   end
 
   def miq_server
-    @miq_server ||= miq_worker.try(:miq_server) || MiqServer.find_started_in_my_region.find_by(:sql_spid => spid)
+    @miq_server ||= miq_worker.try(:miq_server) || MiqServer.active_miq_servers.in_my_region.find_by(:sql_spid => spid)
   end
 
   def zone


### PR DESCRIPTION
- Make .active_miq_servers a scope
- Remove unused method
- Delegate description to zone
- Remove duplicate code
- Instantiate fewer ruby objects when searching for servers
- Remove unnecessary #log_prefix method