### PR TITLE
Refactor VM naming method in provisioning task to support call from automate

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -59,11 +59,14 @@ class MiqProvision < MiqProvisionTask
   end
 
   def after_request_task_create
-    vm_name                      = get_next_vm_name
-    options[:vm_target_name]     = vm_name
-    options[:vm_target_hostname] = get_hostname(vm_name)
-    self.description             = self.class.get_description(self, vm_name)
-    save
+    update_vm_name(get_next_vm_name)
+  end
+
+  def update_vm_name(new_name, update_request: true)
+    options[:vm_target_name]     = new_name
+    options[:vm_target_hostname] = get_hostname(new_name)
+
+    update_attributes(:description => self.class.get_description(self, new_name), :options => options)
   end
 
   def after_ae_delivery(ae_result)

--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -59,14 +59,16 @@ class MiqProvision < MiqProvisionTask
   end
 
   def after_request_task_create
-    update_vm_name(get_next_vm_name)
+    update_vm_name(get_next_vm_name, :update_request => false)
   end
 
   def update_vm_name(new_name, update_request: true)
+    new_name = self.class.get_vm_full_name(new_name, self, true)
     options[:vm_target_name]     = new_name
     options[:vm_target_hostname] = get_hostname(new_name)
 
     update_attributes(:description => self.class.get_description(self, new_name), :options => options)
+    miq_request.update_description_from_tasks if update_request
   end
 
   def after_ae_delivery(ae_result)

--- a/app/models/miq_provision/automate.rb
+++ b/app/models/miq_provision/automate.rb
@@ -1,6 +1,20 @@
 module MiqProvision::Automate
   extend ActiveSupport::Concern
 
+  module ClassMethods
+    def vm_name_from_automate(prov_obj)
+      prov_obj.save
+      attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'}
+      MiqAeEngine.set_automation_attributes_from_objects([prov_obj.get_user], attrs)
+      MiqAeEngine.resolve_automation_object("REQUEST",
+                                            prov_obj.get_user,
+                                            attrs,
+                                            :vmdb_object => prov_obj).root("vmname").tap do
+        prov_obj.reload
+      end
+    end
+  end
+
   def get_placement_via_automate
     attrs = automate_attributes('get_placement')
     ws = MiqAeEngine.resolve_automation_object("REQUEST", get_user, attrs, :vmdb_object => self)

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -6,13 +6,7 @@ module MiqProvision::Naming
 
   module ClassMethods
     def get_next_vm_name(prov_obj, determine_index = true)
-      prov_obj.save
-      attrs = {'request' => 'UI_PROVISION_INFO', 'message' => 'get_vmname'}
-      MiqAeEngine.set_automation_attributes_from_objects([prov_obj.get_user], attrs)
-      ws = MiqAeEngine.resolve_automation_object("REQUEST", prov_obj.get_user, attrs, :vmdb_object => prov_obj)
-
-      unresolved_vm_name = ws.root("vmname")
-      prov_obj.reload
+      unresolved_vm_name = vm_name_from_automate(prov_obj)
 
       # Check if we need to force a unique target name
       if prov_obj.get_option(:miq_force_unique_name) == true && unresolved_vm_name !~ NAME_SEQUENCE_REGEX

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -61,8 +61,12 @@ class MiqProvisionRequest < MiqRequest
   end
 
   def post_create_request_tasks
+    update_description_from_tasks
+  end
+
+  def update_description_from_tasks
     return unless requested_task_idx.length == 1
-    update_attributes(:description => miq_request_tasks.first.description)
+    update_attributes(:description => miq_request_tasks.reload.first.description)
   end
 
   def my_role

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -13,6 +13,8 @@ describe MiqProvision do
       }
     end
 
+    let(:miq_region) { MiqRegion.create }
+
     context "with VMware infrastructure" do
       before(:each) do
         @ems         = FactoryGirl.create(:ems_vmware_with_authentication)
@@ -54,7 +56,7 @@ describe MiqProvision do
         end
 
         it "should create a valid target_name and hostname" do
-          MiqRegion.seed
+          expect(MiqRegion).to receive(:my_region).and_return(miq_region).twice
           ae_workspace = double("ae_workspace")
           expect(ae_workspace).to receive(:root).and_return(@target_vm_name)
           expect(MiqAeEngine).to receive(:resolve_automation_object).and_return(ae_workspace).exactly(3).times
@@ -78,11 +80,40 @@ describe MiqProvision do
           expect(@vm_prov.get_option(:vm_target_hostname)).to eq(name_002.gsub(/ +|_+/, "-"))
         end
 
+        context "#update_vm_name" do
+          it "does not modify a fully resolved vm_name" do
+            @vm_prov.update_vm_name(@target_vm_name)
+            expect(@vm_prov.get_option(:vm_target_name)).to eq(@target_vm_name)
+          end
+
+          it "Enumerates vm_name that contains the naming sequence characters" do
+            expect(MiqRegion).to receive(:my_region).and_return(miq_region)
+
+            @vm_prov.update_vm_name("#{@target_vm_name}$n{3}")
+            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}001")
+          end
+
+          it "Updates the request description with only name parameter passed" do
+            expect(@pr).to receive(:update_description_from_tasks).and_call_original
+
+            @vm_prov.update_vm_name(@target_vm_name)
+
+            expect(@vm_prov.description).to eq("Provision from [template1] to [clone test]")
+            expect(@pr.description).to eq(@vm_prov.description)
+          end
+
+          it "Does not update the request description when `update_request` parameter is false" do
+            expect(@pr).not_to receive(:update_description_from_tasks)
+
+            @vm_prov.update_vm_name(@target_vm_name, :update_request => false)
+          end
+        end
+
         context "when auto naming sequence exceeds the range" do
           before do
-            region = MiqRegion.seed
-            region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
-            region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
+            expect(MiqRegion).to receive(:my_region).exactly(3).times.and_return(miq_region)
+            miq_region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
+            miq_region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
           end
 
           it "should advance to next range but based on the existing sequence number for the new range" do


### PR DESCRIPTION
VM naming during provisioning runs when the provision task is initially created.  This is generally not an issue with Lifecycle provisioning.  For Service provisioning this can be an issue because the dialog field data gets pushed down to the tasks after they are created (seems obvious) and therefore after the naming method has run.  

Therefore it is difficult for the dialog field data to be used as part of the VM naming.  

Furthermore, the naming logic at task creation supports an auto-incrementing feature, with synchronization to ensure uniqueness, which is not available from other calls.

This PR **does not** change the location of when the naming code runs, it make the vm_naming method available to an external caller so they can generate the name at a later time in the provisioning process and take advantage of the auto-incrementing name feature.

Note: The first commit is refactoring.  The main changes are in the second commit.


Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1455002
* Related to PR https://github.com/ManageIQ/manageiq-automation_engine/pull/153

Steps for Testing/QA [Optional]
-------------------------------

In automate override one of the VM provisioning state-machine methods, like the `Provision` method and to call the newly exposed `update_vm_name` method and pass any name.  It can contain the enumeration sequence (`$n{#}`) used to auto-increment the name.  For example, "clone_test_$n{4}" should generate a VM with a name like "clone_test_0001".