### PR TITLE
Add back the missing IP address range in Virtual Private Cloud name.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -88,15 +88,19 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
     super(ci, relats, sources, filtered_ids)
   end
 
+  def cloud_network_display_name(cn)
+    cn.cidr.blank? ? cn.name : "#{cn.name} (#{cn.cidr})"
+  end
+
   def availability_zone_to_cloud_network(src)
     if src[:availability_zone]
       load_ar_obj(src[:availability_zone]).cloud_subnets.each_with_object({}) do |cs, hash|
         cn = cs.cloud_network
-        hash[cn.id] = cn.name
+        hash[cn.id] = cloud_network_display_name(cn)
       end
     else
       load_ar_obj(src[:ems]).all_cloud_networks.each_with_object({}) do |cn, hash|
-        hash[cn.id] = cn.name
+        hash[cn.id] = cloud_network_display_name(cn)
       end
     end
   end

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -125,7 +125,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
       @az2 = FactoryGirl.create(:availability_zone, :ext_management_system => ems)
       @az3 = FactoryGirl.create(:availability_zone, :ext_management_system => ems)
 
-      @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager)
+      @cn1 = FactoryGirl.create(:cloud_network, :ext_management_system => ems.network_manager, :cidr => "10.0.0./8")
 
       @cs1 = FactoryGirl.create(:cloud_subnet, :cloud_network         => @cn1,
                                                :availability_zone     => @az1,
@@ -149,7 +149,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
       it "with a zone" do
         workflow.values[:placement_availability_zone] = [@az1.id, @az1.name]
         expect(workflow.allowed_cloud_networks.length).to eq(1)
-        expect(workflow.allowed_cloud_networks).to eq(@cn1.id => @cn1.name)
+        expect(workflow.allowed_cloud_networks).to eq(@cn1.id => "#{@cn1.name} (#{@cn1.cidr})")
       end
     end
 


### PR DESCRIPTION
IP address range in Virtual Private Cloud name was accidentally removed [here](https://github.com/ManageIQ/manageiq/pull/16688).

Includes https://github.com/ManageIQ/manageiq-providers-openstack/pull/211.
Includes https://github.com/ManageIQ/manageiq-providers-google/pull/46.

https://bugzilla.redhat.com/show_bug.cgi?id=1538696

@miq-bot add_label bug, gaprindashvili/yes
@miq-bot assign @gmcculloug 

cc @bronaghs 