### PR TITLE
Fix alerts based on hourly timer for container entities

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -8,17 +8,22 @@ class Zone < ApplicationRecord
 
   has_many :miq_servers
   has_many :ext_management_systems
+  has_many :container_managers, :class_name => "ManageIQ::Providers::ContainerManager"
   has_many :miq_schedules, :dependent => :destroy
   has_many :ldap_regions
   has_many :providers
 
-  has_many :hosts,               :through => :ext_management_systems
-  has_many :clustered_hosts,     :through => :ext_management_systems
-  has_many :non_clustered_hosts, :through => :ext_management_systems
-  has_many :vms_and_templates,   :through => :ext_management_systems
-  has_many :vms,                 :through => :ext_management_systems
-  has_many :miq_templates,       :through => :ext_management_systems
-  has_many :ems_clusters,        :through => :ext_management_systems
+  has_many :hosts,                 :through => :ext_management_systems
+  has_many :clustered_hosts,       :through => :ext_management_systems
+  has_many :non_clustered_hosts,   :through => :ext_management_systems
+  has_many :vms_and_templates,     :through => :ext_management_systems
+  has_many :vms,                   :through => :ext_management_systems
+  has_many :miq_templates,         :through => :ext_management_systems
+  has_many :ems_clusters,          :through => :ext_management_systems
+  has_many :container_nodes,       :through => :container_managers
+  has_many :container_groups,      :through => :container_managers
+  has_many :container_replicators, :through => :container_managers
+  has_many :containers,            :through => :container_managers
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
 
   before_destroy :check_zone_in_use_on_destroy

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -454,6 +454,7 @@ describe MiqAlert do
       @miq_server = EvmSpecHelper.local_miq_server
       @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
       @ems_other  = FactoryGirl.create(:ems_vmware, :zone => FactoryGirl.create(:zone, :name => 'other'))
+      @ems_kub    = FactoryGirl.create(:ems_kubernetes, :zone => @miq_server.zone)
       @alert      = FactoryGirl.create(:miq_alert, :responds_to_events => "_hourly_timer_")
       @alert_prof = FactoryGirl.create(:miq_alert_set, :alerts => [@alert])
     end
@@ -464,6 +465,7 @@ describe MiqAlert do
       @alert_prof.assign_to_objects(@ems.id, "ExtManagementSystem")
 
       expect(MiqAlert).to receive(:evaluate_alerts).with(@ems, "_hourly_timer_")
+      expect(MiqAlert).to receive(:evaluate_alerts).with(@ems_kub, "_hourly_timer_")
       MiqAlert.evaluate_hourly_timer
     end
 
@@ -502,6 +504,17 @@ describe MiqAlert do
       expect(MiqAlert).to receive(:evaluate_alerts).once.with(storage_no_ems, "_hourly_timer_")
       expect(MiqAlert).not_to receive(:evaluate_alerts).with(storage_in_another, "_hourly_timer_")
       MiqAlert.evaluate_hourly_timer
+    end
+
+    it "evaluates for container entities" do
+      [:container_node, :container_group, :container_replicator, :container].each do |entity|
+        container_entity_in_zone = FactoryGirl.create(entity, :ext_management_system => @ems_kub)
+        @alert.update_attributes(:db => entity.to_s.camelize)
+        @alert_prof.mode = container_entity_in_zone.class.base_model.name
+        @alert_prof.assign_to_objects(container_entity_in_zone.id, entity.to_s.camelize)
+        expect(MiqAlert).to receive(:evaluate_alerts).once.with(container_entity_in_zone, "_hourly_timer_")
+        MiqAlert.evaluate_hourly_timer
+      end
     end
   end
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1496838

Alerts driven by hourly timer that evaluate an expression would fail for container entities that had no relationship to `Zone`. Added ~~`ContainerProject`~~, `ContainerNode`, `ContainerReplicator`, `Container`, `ContainerGroup`. 

@cben @moolitayer PTAL
cc @oourfali 

@miq-bot add_label bug, providers/containers