### PR TITLE
Add a 'Container Project Discovered' event

### DIFF
--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -22,6 +22,7 @@ class ContainerProject < ApplicationRecord
   has_many :container_templates
   has_many :archived_container_groups, :foreign_key => "old_container_project_id", :class_name => "ContainerGroup"
   has_many :persistent_volume_claims
+  has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
 
   # Needed for metrics
   has_many :metrics,                :as => :resource

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -26,6 +26,7 @@ class MiqAlert < ApplicationRecord
     ExtManagementSystem
     MiqServer
     ContainerNode
+    ContainerProject
   )
 
   def self.base_tables

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -17,7 +17,7 @@ class MiqEvent < EventStream
   SUPPORTED_POLICY_AND_ALERT_CLASSES = [Host, VmOrTemplate, Storage,
                                         EmsCluster, ResourcePool, MiqServer,
                                         ExtManagementSystem,
-                                        ContainerReplicator, ContainerGroup,
+                                        ContainerReplicator, ContainerGroup, ContainerProject,
                                         ContainerNode, ContainerImage, PhysicalServer].freeze
 
   def self.raise_evm_event(target, raw_event, inputs = {}, options = {})

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -217,6 +217,8 @@ containerreplicator_compliance_check,Replicator Compliance Check,Default,complia
 containerreplicator_compliance_passed,Replicator Compliance Passed,Default,compliance
 containerreplicator_compliance_failed,Replicator Compliance Failed,Default,compliance
 
+containerproject_created,Container Project Discovered,Default,container_operations
+
 #
 # Physical Server Operations
 #


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1469138
Completed by:
 https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/226
https://github.com/ManageIQ/manageiq-ui-classic/pull/3360

This is the exact same implementation as 'Container Image Discovered'
If we like this type `Discovered` events then ill refactor this and the code for `ContainerImage` into a `DiscoveredEventMixin`.


@cben @moolitayer @Ladas PTAL
cc @oourfali 

@miq-bot add_label providers/containers, bug 

