### PR TITLE
Add << method to MulticastLogger

### DIFF
--- a/lib/vmdb/loggers/multicast_logger.rb
+++ b/lib/vmdb/loggers/multicast_logger.rb
@@ -24,6 +24,12 @@ module Vmdb::Loggers
       true
     end
 
+    def <<(msg)
+      msg = msg.strip
+      loggers.each { |l| l.send(:<<, msg) }
+      msg.size
+    end
+
     def reopen(_logdev = nil)
       raise NotImplementedError, "#{self.class.name} should not be reopened since it is backed by multiple loggers."
     end

--- a/spec/lib/vmdb/loggers/multicast_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/multicast_logger_spec.rb
@@ -26,4 +26,18 @@ describe Vmdb::Loggers::MulticastLogger do
     subject.level = 3
     [logger1, logger2, subject].each { |l| expect(l.level).to eq(3) }
   end
+
+  context "#<<" do
+    it "forwards to the other loggers" do
+      expect(logger1).to receive(:<<).with("test message")
+      expect(logger2).to receive(:<<).with("test message")
+
+      subject << "test message"
+    end
+
+    it "returns the size of the logged message" do
+      expect(subject << "test message").to eql(12)
+      expect(subject << "test message   ").to eql(12)
+    end
+  end
 end


### PR DESCRIPTION
At the moment, nothing is being logged in the $azure_log. Under the hood, the azure-armrest gem is using the rest-client library (at least for now). The rest-client library relies on `<<` internally for backwards compatibility. Since this isn't defined in the MulticastLogger, nothing is getting logged.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1539677

https://github.com/rest-client/rest-client/issues/34 for more information.

To test, add an Azure provider and inspect the azure.log file during/after a refresh.