### PR TITLE
Fix supports_launch_vnc_console? for VMWare VMs

### DIFF
--- a/app/models/vm/operations.rb
+++ b/app/models/vm/operations.rb
@@ -36,7 +36,7 @@ module Vm::Operations
     end
 
     supports :launch_vnc_console do
-      if vendor == 'vmware' && ext_management_system.api_version.to_f >= 6.5
+      if vendor == 'vmware' && ext_management_system.try(:api_version).to_f >= 6.5
         unsupported_reason_add(:launch_vnc_console, _('VNC consoles are unsupported on VMware ESXi 6.5 and later.'))
       elsif power_state != 'on'
         unsupported_reason_add(:launch_vnc_console, _('The web-based VNC console is not available because the VM is not powered on'))

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -108,6 +108,14 @@ describe 'VM::Operations' do
       allow(@vm).to receive(:ext_management_system).and_return(@ems_double)
     end
 
+    it 'returns the correct error message if the vm vendor is vmware and it does not have an ext_management_system' do
+      allow(@vm).to receive(:ext_management_system).and_return(nil)
+      allow(@vm).to receive(:power_state).and_return('off')
+
+      expect(@vm.supports_launch_vnc_console?).to be_falsey
+      expect(@vm.unsupported_reason(:launch_vnc_console)).to include('the VM is not powered on')
+    end
+
     it 'does not support if vendor is vmware and api version is >= 6.5' do
       allow(@ems_double).to receive(:api_version).and_return('6.5')
       allow(@vm).to receive(:vendor).and_return('vmware')


### PR DESCRIPTION
The `supports_launch_vnc_console?` method checks `api_version` on `ext_management_system` but not all of these VMs have an ems, resulting in an internal error showing up in the unsupported reason for vnc_console.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1539429

@miq-bot assign @gtanzillo 
@miq-bot add_label blocker, bug, gaprindashvili/yes 
