### PR TITLE
Fix event linking to a disconnected VM

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -118,13 +118,11 @@ class EmsEvent < EventStream
   def self.process_vm_in_event!(event, options = {})
     prefix           = options[:prefix]
     options[:id_key] = "#{prefix}vm_or_template_id".to_sym
+    uid_ems          = event.delete(:vm_uid_ems)
     process_object_in_event!(Vm, event, options)
 
     if options[:id_key] == :vm_or_template_id && event[:vm_or_template_id].nil?
-      # uid_ems is used for non-VC events, and should be nil for VC events.
-      uid_ems = event.fetch_path(:full_data, :vm, :uid_ems)
-      vm      = VmOrTemplate.find_by(:uid_ems => uid_ems) unless uid_ems.nil?
-
+      vm = VmOrTemplate.find_by(:uid_ems => uid_ems) unless uid_ems.nil?
       unless vm.nil?
         event[:vm_or_template_id] = vm.id
         event[:vm_name] ||= vm.name

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -252,6 +252,37 @@ describe EmsEvent do
     end
   end
 
+  context ".add" do
+    let(:ems) { FactoryGirl.create(:ext_management_system) }
+    context "with a VM" do
+      let(:vm) { FactoryGirl.create(:vm, :uid_ems => '3ace5197-3d6a-4cb3-aeb2-e8348e428775', :ems_ref => 'vm-123') }
+      let(:event) do
+        {
+          :ems_id     => ems.id,
+          :event_type => 'VmDestroyedEvent',
+          :vm_ems_ref => vm.ems_ref,
+          :vm_uid_ems => vm.uid_ems,
+        }
+      end
+
+      context "with a connected VM" do
+        before { vm.update_attributes(:ems_id => ems.id) }
+
+        it "should link the event to the vm" do
+          ems_event = EmsEvent.add(ems.id, event)
+          expect(ems_event.vm_or_template_id).to eq(vm.id)
+        end
+      end
+
+      context "with a disconnected VM" do
+        it "should link the event to the vm" do
+          ems_event = EmsEvent.add(ems.id, event)
+          expect(ems_event.vm_or_template_id).to eq(vm.id)
+        end
+      end
+    end
+  end
+
   context '.event_groups' do
     let(:provider_event) { 'SomeSpecialProviderEvent' }
 


### PR DESCRIPTION
When linking events to a VM we first try [ems_id, ems_ref] which fails
to find a disconnected VM because the ems_id is nullified.  Next we try
by uid_ems but no one was setting the field that we were using so this
standardizes on an event key :vm_uid_ems (similar to :vm_location) which
can be set by the EventParser to allow events to be connected to VMs
after they are disconnected.

Depends:
- [x] https://github.com/ManageIQ/vmware_web_service/pull/32
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/179
 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538996