### PR TITLE
[EUWE] Hide the VMware MKS console support as it relies on the NPAPI

### DIFF
--- a/app/controllers/ops_controller/settings/common.rb
+++ b/app/controllers/ops_controller/settings/common.rb
@@ -956,7 +956,7 @@ module OpsController::Settings::Common
       @edit[:current].config[:server][:role] = @edit[:current].config[:server][:role] ? @edit[:current].config[:server][:role].split(",").sort.join(",") : ""
       @edit[:current].config[:server][:timezone] = "UTC" if @edit[:current].config[:server][:timezone].blank?
       @edit[:current].config[:server][:locale] = "default" if @edit[:current].config[:server][:locale].blank?
-      @edit[:current].config[:server][:remote_console_type] ||= "MKS"
+      @edit[:current].config[:server][:remote_console_type] ||= "VNC"
       @edit[:current].config[:smtp][:enable_starttls_auto] = GenericMailer.default_for_enable_starttls_auto if @edit[:current].config[:smtp][:enable_starttls_auto].nil?
       @edit[:current].config[:smtp][:openssl_verify_mode] ||= nil
       @edit[:current].config[:ntp] ||= {}

--- a/app/views/ops/_settings_server_tab.html.haml
+++ b/app/views/ops/_settings_server_tab.html.haml
@@ -127,23 +127,11 @@
         = _("Use")
       .col-md-8
         = select_tag('console_type',
-                    options_for_select([[_("VMware MKS Plugin"), "MKS"], [_("VNC"), "VNC"], [_("VMware VMRC Plugin"), "VMRC"]],
+                    options_for_select([[_("VNC"), "VNC"], [_("VMware VMRC Plugin"), "VMRC"]],
                     @edit[:new][:server][:remote_console_type]),
                     :class    => "selectpicker")
       :javascript
         miqSelectPickerEvent('console_type', "#{url}")
-
-    - if @edit[:new][:server][:remote_console_type] == "MKS"
-      .form-group
-        %label.col-md-2.control-label
-          = _("VMware MKS Plugin Version")
-        .col-md-8
-          = select_tag('server_mks_version',
-                        options_for_select(MKS_VERSIONS,
-                        @edit[:new][:server][:mks_version]),
-                        :class    => "selectpicker")
-      :javascript
-        miqSelectPickerEvent('server_mks_version', "#{url}")
   %hr
   %h3
     = _("NTP Servers")


### PR DESCRIPTION
NPAPI support has been dropped from all major browsers and VMware no longer supports this console type. The feature has been already dropped from [fine](https://github.com/ManageIQ/manageiq-ui-classic/pull/1052) and [later](https://github.com/ManageIQ/manageiq-ui-classic/pull/979).

https://bugzilla.redhat.com/show_bug.cgi?id=1513592

