### PR TITLE
Fix vim_broker_worker targeted folder refresh spec

### DIFF
--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -270,12 +270,14 @@ describe MiqVimBrokerWorker::Runner do
           }
 
           expected_folder_hash = {
-            :folder => {
-              :type        => klass,
-              :ems_ref     => mor,
-              :ems_ref_obj => mor,
-              :uid_ems     => mor
-            }
+            :folders => [
+              {
+                :type        => klass,
+                :ems_ref     => mor,
+                :ems_ref_obj => mor,
+                :uid_ems     => mor
+              }
+            ]
           }
 
           @vim_broker_worker.instance_variable_get(:@queue).enq(event.dup)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-vmware/pull/166 fixed the
folder hash that was being returned to match save_ems_inventory hashes
format but the broker spec tests were still checking for the old format.