### PR TITLE
Added rkerberos gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.2.0",       :require => false
+gem "rkerberos",                      "~>0.1.5",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.1",       :require => false
 gem "rugged",                         "~>0.25.0",      :require => false


### PR DESCRIPTION
This PR aims at adding the `rkerberos` gem to the dependencies of ManageIQ. Any Ruby code leveraging Kerberos authentication could use it without installing it manually on all instances.

Links
----------------

* [[RFE] Add rkerberos gem](#6315)