### PR TITLE
Add display name for Amazon Network Router

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -842,6 +842,7 @@ en:
       ManageIQ::Providers::Azure::CloudManager::OrchestrationStack:         Orchestration Stack (Microsoft Azure)
       ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack:        Orchestration Stack (Amazon)
       ManageIQ::Providers::Amazon::NetworkManager::NetworkPort:             Network Port (Amazon)
+      ManageIQ::Providers::Amazon::NetworkManager::NetworkRouter:           Network Router (Amazon)
       ManageIQ::Providers::Azure::NetworkManager:                           Network Manager (Microsoft Azure)
       ManageIQ::Providers::Azure::NetworkManager::NetworkPort:              Network Port (Microsoft Azure)
       ManageIQ::Providers::Openstack::NetworkManager::NetworkPort:          Network Port (OpenStack)


### PR DESCRIPTION
Before:
![nr-before](https://user-images.githubusercontent.com/6648365/35573705-28aaf75e-05d8-11e8-99d2-ee17614b0e1a.jpg)


After:
![nr-after](https://user-images.githubusercontent.com/6648365/35573723-2d5f0506-05d8-11e8-9f61-f93ea8953538.jpg)


https://bugzilla.redhat.com/show_bug.cgi?id=1540199