### PR TITLE
Exclude Service::AGGREGATE_ALL_VM_ATTRS from MiqExp.to_sql

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -482,9 +482,13 @@ class MiqExpression
   end
 
   def self.exclude_col_by_preprocess_options?(field, options)
-    return false unless options.kind_of?(Hash)
-    return false unless options[:vim_performance_daily_adhoc]
-    Metric::Rollup.excluded_col_for_expression?(field.column.to_sym)
+    if options.kind_of?(Hash) && options[:vim_performance_daily_adhoc]
+      Metric::Rollup.excluded_col_for_expression?(field.column.to_sym)
+    elsif field.target == Service
+      Service::AGGREGATE_ALL_VM_ATTRS.include?(field.column.to_sym)
+    else
+      false
+    end
   end
 
   def lenient_evaluate(obj, tz = nil)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -476,15 +476,15 @@ class MiqExpression
       result[:format_sub_type] = f.sub_type
       result[:virtual_column] = model.virtual_attribute?(col.to_s)
       result[:sql_support] = !result[:virtual_reflection] && model.attribute_supported_by_sql?(col.to_s)
-      result[:excluded_by_preprocess_options] = exclude_col_by_preprocess_options?(col, options)
+      result[:excluded_by_preprocess_options] = exclude_col_by_preprocess_options?(f, options)
     end
     result
   end
 
-  def self.exclude_col_by_preprocess_options?(col, options)
+  def self.exclude_col_by_preprocess_options?(field, options)
     return false unless options.kind_of?(Hash)
     return false unless options[:vim_performance_daily_adhoc]
-    Metric::Rollup.excluded_col_for_expression?(col.to_sym)
+    Metric::Rollup.excluded_col_for_expression?(field.column.to_sym)
   end
 
   def lenient_evaluate(obj, tz = nil)


### PR DESCRIPTION
These calls, while they are Arel and could be converted, would most likely be used in "filter" type scenarios, and would not be good candidates for that since they would perform horribly when used on more than one record at a time (which filtering would do that).

Instead of preventing these records from showing up as a filter option, just make sure they can't be used with SQL when they are.  That said, they will cause N+1 hell, so they really shouldn't be filtered on...  but...

¯\\(°_o)/¯

Alternative solution explanation
------------------------------

This is one possible solution for this BZ.  The other would be wrapping the `arel_attribute` values in the `MiqExpression#to_arel` method with a `Arel::Nodes::Grouping` call, which would allow `eq` calls to be done on these, and the other arel-based `MiqExpression` operators.  This solution was proposed first because of the concerns raised in https://github.com/ManageIQ/manageiq/pull/11502 which add the `Service::AGGREGATE_ALL_VM_ATTRS` `virtual_attributes`:

> These are DEFINITELY not queries that you want to run in a index type fashion, as they will not scale. This is because the nested selects will individually run for each service record returned. In this case, it will end up in a tying up a process, so these methods need to be used with care.

As mentioned above, this means if a user does decide to filter based on these columns, it will most likely be slow, but it will be a bunch of short queries to the DB instead of a single massive and crippling one.  Ideally these filters just shouldn't be used for filtering Services.


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1539710
* https://github.com/ManageIQ/manageiq/pull/11502
* https://github.com/ManageIQ/manageiq/commit/251de4e

Steps for Testing/QA
--------------------

I will add some tests in another commit/rebased commit, but for now, you can test with that the following doesn't raise an error in a `bin/rails c`:

```ruby
irb> MiqExpression.new("=" => {"field" => "Service-aggregate_all_vm_cpus", "value" => "454"}).to_sql
#=> [nil, nil, {:supported_by_sql=>false}]
```