### PR TITLE
Network-discovery core

### DIFF
--- a/lib/manageiq/network/discovery.rb
+++ b/lib/manageiq/network/discovery.rb
@@ -7,7 +7,7 @@ module ManageIQ
     end
 
     module Discovery
-  	  PROVIDERS_BY_TYPE = {
+      PROVIDERS_BY_TYPE = {
         :ipmi            => "ManageIQ::Network::IPMI::Discovery",
         :msvirtualserver => "ManageIQ::Providers::Microsoft::Discovery",
         :mswin           => "ManageIQ::Providers::Microsoft::Discovery",
@@ -17,7 +17,7 @@ module ManageIQ
         :esx             => "ManageIQ::Providers::Vmware::Discovery",
         :virtualcenter   => "ManageIQ::Providers::Vmware::Discovery",
         :vmwareserver    => "ManageIQ::Providers::Vmware::Discovery"
-      }
+      }.freeze
 
       def self.scan_host(ost)
         ost.os = []
@@ -37,9 +37,9 @@ module ManageIQ
           ost.discover_types.each do |type|
             next unless PROVIDERS_BY_TYPE.include?(type)
             klass = Object.const_get(PROVIDERS_BY_TYPE[type])
-            $log.info "#{klass}: probing ip = #{ost.ipaddr}" if $log
+            $log&.info("#{klass}: probing ip = #{ost.ipaddr}")
             klass.probe(ost)
-            $log.info "#{klass}: probe of ip = #{ost.ipaddr} complete" if $log
+            $log&.info("#{klass}: probe of ip = #{ost.ipaddr} complete")
           end
         end
       end

--- a/lib/manageiq/network/discovery.rb
+++ b/lib/manageiq/network/discovery.rb
@@ -1,0 +1,48 @@
+require 'net/ping'
+
+module ManageIQ
+  module Network
+    module IPMI
+      autoload :Discovery, 'manageiq/network/ipmi/discovery'
+    end
+
+    module Discovery
+  	  PROVIDERS_BY_TYPE = {
+        :ipmi            => "ManageIQ::Network::IPMI::Discovery",
+        :msvirtualserver => "ManageIQ::Providers::Microsoft::Discovery",
+        :mswin           => "ManageIQ::Providers::Microsoft::Discovery",
+        :scvmm           => "ManageIQ::Providers::Microsoft::Discovery",
+        :openstack_infra => "ManageIQ::Providers::Openstack::Discovery",
+        :rhevm           => "ManageIQ::Providers::Redhat::Discovery",
+        :esx             => "ManageIQ::Providers::Vmware::Discovery",
+        :virtualcenter   => "ManageIQ::Providers::Vmware::Discovery",
+        :vmwareserver    => "ManageIQ::Providers::Vmware::Discovery"
+      }
+
+      def self.scan_host(ost)
+        ost.os = []
+        ost.hypervisor = []
+
+        # If the ping flag is set we try to ping the box first
+        # and skip scanning if the ping fails.
+        ping = true
+        begin
+          ping = Net::Ping::External.new(ost.ipaddr).ping if ost.ping
+        rescue Timeout::Error
+          ping = false
+        end
+
+        if ping
+          # Trigger probes
+          ost.discover_types.each do |type|
+            next unless PROVIDERS_BY_TYPE.include?(type)
+            klass = Object.const_get(PROVIDERS_BY_TYPE[type])
+            $log.info "#{klass}: probing ip = #{ost.ipaddr}" if $log
+            klass.probe(ost)
+            $log.info "#{klass}: probe of ip = #{ost.ipaddr} complete" if $log
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/network/ipmi/discovery.rb
+++ b/lib/manageiq/network/ipmi/discovery.rb
@@ -1,0 +1,13 @@
+require 'util/miq-ipmi'
+
+module ManageIQ
+  module Network
+    module IPMI
+      class Discovery
+        def self.probe(ost)
+          ost.hypervisor << :ipmi if MiqIPMI.is_available?(ost.ipaddr)
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/network/port.rb
+++ b/lib/manageiq/network/port.rb
@@ -1,0 +1,49 @@
+require 'timeout'
+require 'socket'
+
+module ManageIQ
+  module Network
+    class Port
+      def self.all_open?(ost, ports)
+        ports.each { |port| return false unless any_open?(ost, port) }
+        true
+      endf
+
+      def self.any_open?(ost, ports)
+        ports = [ports] unless ports.kind_of?(Array)
+        ports.each { |port| return true if open?(ost, port) }
+        false
+      end
+
+      def self.open?(ost, port)
+        ost.timeout ||= 10
+        begin
+          Timeout.timeout(ost.timeout) do
+            s = TCPSocket.open(ost.ipaddr, port)
+            s.close
+            $log.debug("Port: IP = #{ost.ipaddr}, port = #{port}, Open") if $log
+            true
+          end
+        rescue Timeout::Error => err
+          $log.debug("Port scan timeout: ip = #{ost.ipaddr}, port = #{port}, #{err}") if $log
+          false
+        rescue StandardError => err
+          $log.debug("Port scan error: ip = #{ost.ipaddr}, port = #{port}, #{err}") if $log
+          false
+        end
+      end
+
+      def self.scan_array(ost, ports)
+        ports_found = []
+        ports.each { |port| ports_found << port if open?(ost, port) }
+        ports_found
+      end
+
+      def self.scan_range(ost, start_port, end_port)
+        ports_found = []
+        start_port.upto(end_port) { |port| ports_found << port if open?(ost, port) }
+        ports_found
+      end
+    end
+  end
+end

--- a/spec/lib/network/discovery_spec.rb
+++ b/spec/lib/network/discovery_spec.rb
@@ -1,0 +1,22 @@
+require 'manageiq/network/discovery'
+require 'ostruct'
+require 'util/miq-ipmi'
+
+RSpec.describe ManageIQ::Network::Discovery do
+  context "#scan_host" do
+    let(:ost) { OpenStruct.new(:discover_types => [:ipmi], :ipaddr => "127.0.0.1", :hypervisor => []) }
+    it "hypervisor is ipmi when available" do
+      allow(MiqIPMI).to receive(:is_available?).and_return(true)
+      described_class.scan_host(ost)
+
+      expect(ost.hypervisor).to eql([:ipmi])
+    end
+
+    it "no hypervisor if ipmi isn't available" do
+      allow(MiqIPMI).to receive(:is_available?).and_return(false)
+      described_class.scan_host(ost)
+
+      expect(ost.hypervisor).to eql([])
+    end
+  end
+end

--- a/spec/lib/network/discovery_spec.rb
+++ b/spec/lib/network/discovery_spec.rb
@@ -3,16 +3,16 @@ require 'ostruct'
 require 'util/miq-ipmi'
 
 RSpec.describe ManageIQ::Network::Discovery do
-  context "#scan_host" do
-    let(:ost) { OpenStruct.new(:discover_types => [:ipmi], :ipaddr => "127.0.0.1", :hypervisor => []) }
-    it "hypervisor is ipmi when available" do
+  context '#scan_host' do
+    let(:ost) { OpenStruct.new(:discover_types => [:ipmi], :ipaddr => '127.0.0.1', :hypervisor => []) }
+    it 'hypervisor is ipmi when available' do
       allow(MiqIPMI).to receive(:is_available?).and_return(true)
       described_class.scan_host(ost)
 
       expect(ost.hypervisor).to eql([:ipmi])
     end
 
-    it "no hypervisor if ipmi isn't available" do
+    it 'no hypervisor unless ipmi is available' do
       allow(MiqIPMI).to receive(:is_available?).and_return(false)
       described_class.scan_host(ost)
 

--- a/spec/lib/network/port_spec.rb
+++ b/spec/lib/network/port_spec.rb
@@ -3,23 +3,23 @@ require 'ostruct'
 require 'benchmark'
 
 RSpec.describe ManageIQ::Network::Port do
-  before(:each) do
+  before do
     @ost = OpenStruct.new
-    @ost.ipaddr = "192.168.252.2" # yoda (ESX)
+    @ost.ipaddr = '172.16.254.1'
   end
 
-  context "#open?" do
-    it "with an open port" do
+  context '#open?' do
+    it 'with an open port' do
       expect(TCPSocket).to receive(:open).and_return(StringIO.new)
       expect(described_class.open?(@ost, 903)).to be_truthy
     end
 
-    it "with a closed port" do
+    it 'with a closed port' do
       expect(TCPSocket).to receive(:open).and_raise(Timeout::Error)
       expect(described_class.open?(@ost, 904)).to be_falsey
     end
 
-    it "with a changed timeout value" do
+    it 'with a changed timeout value' do
       @ost.timeout = 0.001
       allow(TCPSocket).to receive(:open) { sleep 1 }
       ts = Benchmark.realtime do
@@ -29,29 +29,20 @@ RSpec.describe ManageIQ::Network::Port do
     end
   end
 
-  context ".scan_array" do
-    before(:each) do
+  context '#scan_open' do
+    before do
       allow(described_class).to receive(:open?).with(@ost, 902).and_return(true)
-      allow(described_class).to receive(:open?).with(@ost, 903).and_return(true)
-      allow(described_class).to receive(:open?).with(@ost, 904).and_return(false)
+      allow(described_class).to receive(:open?).with(@ost, 903).and_return(false)
+      allow(described_class).to receive(:open?).with(@ost, 904).and_return(true)
       allow(described_class).to receive(:open?).with(@ost, 905).and_return(false)
     end
 
-    it("with all open ports")  { expect(described_class.scan_array(@ost, [902, 903])).to eq([902, 903]) }
-    it("with some open ports") { expect(described_class.scan_array(@ost, [903, 904])).to eq([903]) }
-    it("with no open ports")   { expect(described_class.scan_array(@ost, [904, 905])).to eq([]) }
-  end
-
-  context ".scan_range" do
-    before(:each) do
-      allow(described_class).to receive(:open?).with(@ost, 902).and_return(true)
-      allow(described_class).to receive(:open?).with(@ost, 903).and_return(true)
-      allow(described_class).to receive(:open?).with(@ost, 904).and_return(false)
-      allow(described_class).to receive(:open?).with(@ost, 905).and_return(false)
+    it 'has some open with array of ports' do
+      expect(described_class.scan_open(@ost, [902, 903, 904, 905])).to eq([902, 904])
     end
 
-    it("with all open ports")  { expect(described_class.scan_range(@ost, 902, 903)).to eq([902, 903]) }
-    it("with some open ports") { expect(described_class.scan_range(@ost, 903, 904)).to eq([903]) }
-    it("with no open ports")   { expect(described_class.scan_range(@ost, 904, 905)).to eq([]) }
+    it 'has some open with range of ports' do
+      expect(described_class.scan_open(@ost, 902..905)).to eq([902, 904])
+    end
   end
 end

--- a/spec/lib/network/port_spec.rb
+++ b/spec/lib/network/port_spec.rb
@@ -1,0 +1,57 @@
+require 'manageiq/network/discovery'
+require 'ostruct'
+require 'benchmark'
+
+RSpec.describe ManageIQ::Network::Port do
+  before(:each) do
+    @ost = OpenStruct.new
+    @ost.ipaddr = "192.168.252.2" # yoda (ESX)
+  end
+
+  context "#open?" do
+    it "with an open port" do
+      expect(TCPSocket).to receive(:open).and_return(StringIO.new)
+      expect(described_class.open?(@ost, 903)).to be_truthy
+    end
+
+    it "with a closed port" do
+      expect(TCPSocket).to receive(:open).and_raise(Timeout::Error)
+      expect(described_class.open?(@ost, 904)).to be_falsey
+    end
+
+    it "with a changed timeout value" do
+      @ost.timeout = 0.001
+      allow(TCPSocket).to receive(:open) { sleep 1 }
+      ts = Benchmark.realtime do
+        expect(described_class.open?(@ost, 123)).to be_falsey
+      end
+      expect(ts).to be < 0.5
+    end
+  end
+
+  context ".scan_array" do
+    before(:each) do
+      allow(described_class).to receive(:open?).with(@ost, 902).and_return(true)
+      allow(described_class).to receive(:open?).with(@ost, 903).and_return(true)
+      allow(described_class).to receive(:open?).with(@ost, 904).and_return(false)
+      allow(described_class).to receive(:open?).with(@ost, 905).and_return(false)
+    end
+
+    it("with all open ports")  { expect(described_class.scan_array(@ost, [902, 903])).to eq([902, 903]) }
+    it("with some open ports") { expect(described_class.scan_array(@ost, [903, 904])).to eq([903]) }
+    it("with no open ports")   { expect(described_class.scan_array(@ost, [904, 905])).to eq([]) }
+  end
+
+  context ".scan_range" do
+    before(:each) do
+      allow(described_class).to receive(:open?).with(@ost, 902).and_return(true)
+      allow(described_class).to receive(:open?).with(@ost, 903).and_return(true)
+      allow(described_class).to receive(:open?).with(@ost, 904).and_return(false)
+      allow(described_class).to receive(:open?).with(@ost, 905).and_return(false)
+    end
+
+    it("with all open ports")  { expect(described_class.scan_range(@ost, 902, 903)).to eq([902, 903]) }
+    it("with some open ports") { expect(described_class.scan_range(@ost, 903, 904)).to eq([903]) }
+    it("with no open ports")   { expect(described_class.scan_range(@ost, 904, 905)).to eq([]) }
+  end
+end


### PR DESCRIPTION
Replaces, with minimum impact, manageiq-network_discovery.

The new approach moves only core files `discovery.rb` and `port.rb` (and spec) files to manageiq core.
They are the hook to allow providers supported discovery, where all the modules/probes are moved to.  

The reduce impact, the new discovery uses `ManageIQ::Network::Discovery` and `ManageIQ::Network::Port` name spaces.

https://github.com/ManageIQ/manageiq-network_discovery/issues/8