### PR TITLE
Allow ems to prevent EventCatcher worker from running

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -158,7 +158,7 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
 
     tid = Thread.new do
       begin
-        monitor_events
+        can_monitor? ? monitor_events : wait_silently
       rescue EventCatcherHandledException
         Thread.exit
       rescue TemporaryFailure
@@ -176,6 +176,18 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
     _log.info("#{log_prefix} Started Event Monitor Thread")
 
     tid
+  end
+
+  def wait_silently
+    _log.info("#{log_prefix} Event Monitor Thread waiting silently")
+    until @exit_requested
+      event_monitor_running
+      sleep 5
+    end
+  end
+
+  def can_monitor?
+    true
   end
 
   def drain_queue


### PR DESCRIPTION
Some providers (VMware, Nuage) support option "None" for eventing which indicates that event catching should be turned off:

![capture](https://user-images.githubusercontent.com/8102426/35613608-f264e4b2-066c-11e8-8599-335cfacf99de.PNG)

But currently, even if "None" option is selected, the EventCatcher thread is started. It dies immediately due to lack of credentials, of course, but MIQ is smart enough to detect this - and restarts it. We end up with EventCatcher thread restarting every second...

With this commit we prevent such behavior by allowing ems to conditionally run "dummy" event catcher which basically sleeps forever. This way we prevent annoying continous restarting every second. Ems is supposed to override function `can_monitor?` to decide whether real EventCatcher should be run or just its dummy counterpart (e.g. when "None" option is selected).

Followup PR: https://github.com/ManageIQ/manageiq-providers-nuage/pull/63
@miq-bot assign @juliancheal 
@miq-bot add_label enhancement

/cc @bronaghs 