### PR TITLE
Remove empty array associations created via UI from association list

### DIFF
--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -57,7 +57,7 @@ class DialogImportValidator
 
   def check_dialog_associations_for_validity(dialog_fields)
     associations = {}
-    dialog_fields.each { |df| associations.merge!(df["name"] => df["dialog_field_responders"]) unless df["dialog_field_responders"].nil? }
+    dialog_fields.each { |df| associations.merge!(df["name"] => df["dialog_field_responders"]) if df["dialog_field_responders"].present? }
     unless associations.blank?
       circular_references = @dialog_field_association_validator.circular_references(associations)
       raise DialogFieldAssociationCircularReferenceError, circular_references if circular_references


### PR DESCRIPTION
This check needs to be a present because it needs to remove associations whose values are merely an empty array, which present does but the existing code won't. 