### PR TITLE
Make sure Containers Exist Before Processing

### DIFF
--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresh_parser.rb
@@ -123,8 +123,8 @@ module ManageIQ::Providers
     end
 
     def cleanup
-      @data[:cloud_object_store_containers].each { |c| c.delete(:tenant_id) }
-      @data[:cloud_object_store_objects].each    { |c| c.delete(:tenant_id) }
+      @data[:cloud_object_store_containers]&.each { |c| c.delete(:tenant_id) }
+      @data[:cloud_object_store_objects]&.each    { |c| c.delete(:tenant_id) }
     end
   end
 end

--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresh_parser/cross_linkers/openstack.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresh_parser/cross_linkers/openstack.rb
@@ -11,11 +11,11 @@ module ManageIQ::Providers::StorageManager::SwiftManager::RefreshParser::CrossLi
     end
 
     def cross_link
-      @data[:cloud_object_store_containers].each do |container_hash|
+      @data[:cloud_object_store_containers]&.each do |container_hash|
         link_to_tenant(container_hash)
       end
 
-      @data[:cloud_object_store_objects].each do |object_hash|
+      @data[:cloud_object_store_objects]&.each do |object_hash|
         link_to_tenant(object_hash)
       end
     end


### PR DESCRIPTION
The crosslink code for the Swift Manager refresh parser
attempts to loop through the set of containers for the
manager without checking if any exist first.
Fix by checking first.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538501

@roliveri @hsong-rh please review.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1538501