### PR TITLE
Implement #configuration_script because of virtual_has_one relationship

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -435,6 +435,9 @@ class Service < ApplicationRecord
     parent_service.remove_resource(self)
   end
 
+  def configuration_script
+  end
+
   private
 
   def apply_dialog_settings

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -840,4 +840,8 @@ describe Service do
       end
     end
   end
+
+  describe '#configuration_script' do
+    it { expect(subject.configuration_script).to be_nil }
+  end
 end


### PR DESCRIPTION
Class `Service` needs to implement `#configuration_script` because of the [virtual_has_one](https://github.com/bzwei/manageiq/blob/a6558c4723d83c2f00df8b26d4b0b7fd96751eaf/app/models/service.rb#L51) relationship.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540250