### PR TITLE
No longer assume that a value is an array

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -155,7 +155,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
         f[:notes] = vm_description
       when :vlan
         get_field(:vlan)
-        vlan ||= @values[fn].first
+        vlan ||= Array(@values[fn]).first
         set_value_from_list(fn, f, vlan, allowed_vlans)
       end
     end


### PR DESCRIPTION
We found a situation where an ||= was failing because the result was nil as opposed to an array.
Adding a .try to the lookup allows us to pass nil in these specific cases.

https://bugzilla.redhat.com/show_bug.cgi?id=1540326
