### PR TITLE
Support mixed case basedn.

### DIFF
--- a/spec/tools/miqldap_to_sssd/authconfig_spec.rb
+++ b/spec/tools/miqldap_to_sssd/authconfig_spec.rb
@@ -1,13 +1,8 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
+$LOAD_PATH << Rails.root.join("tools").to_s
 
-require "authconfig"
+require "miqldap_to_sssd"
 
 describe MiqLdapToSssd::AuthConfig do
-  before do
-    stub_const("LOGGER", double)
-    allow(LOGGER).to receive(:debug)
-  end
-
   describe '#run_auth_config' do
     before do
       @initial_settings = {:mode => "bob", :ldaphost => ["hostname"], :ldapport => 22}
@@ -32,7 +27,7 @@ describe MiqLdapToSssd::AuthConfig do
     end
 
     it 'handles authconfig failures' do
-      expect(LOGGER).to receive(:fatal)
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
       expect(AwesomeSpawn).to receive(:run)
         .and_return(double(:command_line => "authconfig", :failure? => true, :error => "malfunction"))
       expect { described_class.new(@initial_settings).run_auth_config }.to raise_error(MiqLdapToSssd::AuthConfigError)

--- a/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
@@ -1,13 +1,11 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
+$LOAD_PATH << Rails.root.join("tools").to_s
 
-require "configure_apache"
+require "miqldap_to_sssd"
 require "tempfile"
 require "fileutils"
 
 describe MiqLdapToSssd::ConfigureApache do
   before do
-    stub_const("LOGGER", double)
-    allow(LOGGER).to receive(:debug)
     @spec_name = File.basename(__FILE__).split(".rb").first.freeze
   end
 
@@ -77,13 +75,13 @@ describe MiqLdapToSssd::ConfigureApache do
 
     it 'raises an error when a TEMPLATE file is missing' do
       FileUtils.rm_f("#{@pam_template_dir}/httpd-auth")
-      expect(LOGGER).to receive(:fatal)
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
       expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureApacheError)
     end
 
     it 'raises an error when KrbAuthRealms is missing from manageiq-external-auth.conf' do
       File.open("#{@httpd_template_dir}/manageiq-external-auth.conf.erb", "w") { |f| f.write("hello walls") }
-      expect(LOGGER).to receive(:fatal)
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
       expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureApacheError)
     end
   end

--- a/spec/tools/miqldap_to_sssd/configure_selinux_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_selinux_spec.rb
@@ -1,13 +1,8 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
+$LOAD_PATH << Rails.root.join("tools").to_s
 
-require "configure_selinux"
+require "miqldap_to_sssd"
 
 describe MiqLdapToSssd::ConfigureSELinux do
-  before do
-    stub_const("LOGGER", double)
-    allow(LOGGER).to receive(:debug)
-  end
-
   describe '#configure' do
     before do
       @initial_settings = {:ldapport => '22'}
@@ -36,7 +31,7 @@ describe MiqLdapToSssd::ConfigureSELinux do
     end
 
     it 'handles semanage already defined result' do
-      expect(LOGGER).to_not receive(:fatal)
+      expect(MiqLdapToSssd::LOGGER).to_not receive(:fatal)
       expect(AwesomeSpawn).to receive(:run).once
         .and_return(double(:command_line => "semanage", :failure? => true, :error => "malfunction already defined"))
 
@@ -54,14 +49,14 @@ describe MiqLdapToSssd::ConfigureSELinux do
     end
 
     it 'handles semanage failures' do
-      expect(LOGGER).to receive(:fatal).with("semanage failed with: malfunction")
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal).with("semanage failed with: malfunction")
       expect(AwesomeSpawn).to receive(:run)
         .and_return(double(:command_line => "semanage", :failure? => true, :error => "malfunction"))
       expect { described_class.new(@initial_settings).configure }.to raise_error(MiqLdapToSssd::ConfigureSELinuxError)
     end
 
     it 'handles setsebool failures' do
-      expect(LOGGER).to receive(:fatal).with("setsebool failed with: malfunction")
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal).with("setsebool failed with: malfunction")
       expect(AwesomeSpawn).to receive(:run).once
         .with("semanage",
               :params => {nil => "port",

--- a/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
+++ b/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
@@ -1,16 +1,15 @@
-$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
+$LOAD_PATH << Rails.root.join("tools").to_s
 
-require "miqldap_configuration"
+require "miqldap_to_sssd"
 
 describe MiqLdapToSssd::MiqLdapConfiguration do
   before do
-    stub_const("LOGGER", double)
-    allow(LOGGER).to receive(:debug)
+    allow(MiqLdapToSssd::LOGGER).to receive(:debug)
   end
 
   describe '#retrieve_initial_settings' do
     it 'raises an error when the basedn domain can not be determined' do
-      expect(LOGGER).to receive(:fatal)
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
       subject = described_class.new(:basedn => nil, :basedn_domain => nil)
       expect { subject.retrieve_initial_settings }.to raise_error(MiqLdapToSssd::MiqLdapConfigurationArgumentError)
     end

--- a/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
+++ b/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
@@ -1,0 +1,28 @@
+$LOAD_PATH << Rails.root.join("tools", "miqldap_to_sssd").to_s
+
+require "miqldap_configuration"
+
+describe MiqLdapToSssd::MiqLdapConfiguration do
+  before do
+    stub_const("LOGGER", double)
+    allow(LOGGER).to receive(:debug)
+  end
+
+  describe '#retrieve_initial_settings' do
+    it 'raises an error when the basedn domain can not be determined' do
+      expect(LOGGER).to receive(:fatal)
+      subject = described_class.new(:basedn => nil, :basedn_domain => nil)
+      expect { subject.retrieve_initial_settings }.to raise_error(MiqLdapToSssd::MiqLdapConfigurationArgumentError)
+    end
+
+    it 'does not modify basedn_domain if providedn' do
+      subject = described_class.new(:basedn_domain => "example.com")
+      expect(subject.retrieve_initial_settings[:basedn_domain]).to eq("example.com")
+    end
+
+    it 'sets basedn_domain from mixed case basedn' do
+      subject = described_class.new(:basedn => "CN=Users,DC=Example,DC=COM")
+      expect(subject.retrieve_initial_settings[:basedn_domain]).to eq("example.com")
+    end
+  end
+end

--- a/tools/miqldap_to_sssd.rb
+++ b/tools/miqldap_to_sssd.rb
@@ -5,10 +5,8 @@
 # upgrades authentication mode from LDAP(s) to External Auth with SSSD
 # Alternatively, it will update all user records to have a userid in UPN format
 
-if __FILE__ == $PROGRAM_NAME
-  $LOAD_PATH.push(File.expand_path(__dir__))
-  $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(miqldap_to_sssd))))
-end
+$LOAD_PATH.push(File.expand_path(__dir__))
+$LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(miqldap_to_sssd))))
 
 require File.expand_path('../config/environment', __dir__)
 

--- a/tools/miqldap_to_sssd/miqldap_configuration.rb
+++ b/tools/miqldap_to_sssd/miqldap_configuration.rb
@@ -47,7 +47,7 @@ module MiqLdapToSssd
 
       # If the caller did not provide a base DN domain name derive it from the configured Base DN.
       if initial_settings[:basedn_domain].nil?
-        initial_settings[:basedn_domain] = initial_settings[:basedn].split(",").collect do |p|
+        initial_settings[:basedn_domain] = initial_settings[:basedn].downcase.split(",").collect do |p|
           p.split('dc=')[1]
         end.compact.join('.')
       end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536663

This PR addresses an issue where the miqldap_to_sssd conversion tool did not
properly generate the basedn domain name from a mixed case basedn



Steps for Testing/QA [Optional]
-------------------------------

- Configure MIQLDAP for LDAP, specifying the basedn in mixed case, e.g.: "CN=Users,DC=Example,DC=COM"
- Test that user can log in and shows up in users table.
- Take snapshot of VM per docs.
- In ssh shell run miqldap_to_sssd with no parameters. 
