### PR TITLE
Use join_key while building relation sql

### DIFF
--- a/lib/extensions/virtual_total.rb
+++ b/lib/extensions/virtual_total.rb
@@ -109,9 +109,8 @@ module VirtualTotal
 
         foreign_table = reflection.klass.arel_table
         # need db access for the keys, so delaying all this lookup until call time
-        local_key   = reflection.active_record_primary_key
-        foreign_key = reflection.foreign_key
-        query       = query.where(t[local_key].eq(foreign_table[foreign_key]))
+        join_keys = reflection.join_keys(reflection.klass)
+        query       = query.where(t[join_keys.foreign_key].eq(foreign_table[join_keys.key]))
 
         arel_column = if method_name == :size
                         Arel.star.count

--- a/spec/lib/extensions/virtual_total_spec.rb
+++ b/spec/lib/extensions/virtual_total_spec.rb
@@ -344,11 +344,15 @@ describe VirtualTotal do
     # it can not sort by virtual
 
     it "calculates totals locally" do
-      expect(model_with_children(0).total_vms).to eq(0)
-      expect(model_with_children(2).total_vms).to eq(2)
+      expect(model_with_children(0).v_total_vms).to eq(0)
+      expect(model_with_children(2).v_total_vms).to eq(2)
     end
 
     it "is not defined in sql" do
+      expect(base_model.attribute_supported_by_sql?(:v_total_vms)).to be(false)
+    end
+
+    it "alias is not defined in sql" do
       expect(base_model.attribute_supported_by_sql?(:total_vms)).to be(false)
     end
 


### PR DESCRIPTION
For virtual_attributes, we build sql to allow us to avoid N+1 queries and bring back attributes in models. This sql is auto generated using our `virtual_delegate` and `virtual_total` methods.

### Before

special logic determining the keys to use for joining when building the sql for `has_many` or `belongs_to` virtual attributes (use in virtual_delegates).

### After

Just use ActiveRecord's `join_key` method so we can use the same code for `has_many` and `belongs_to` sql generation.

### Confidence

This is scary stuff. So confidence needs to be addressed

1. I added `puts` to ensure both code paths were followed.
2. We have a pretty high coverage of tests for virtual attributes. feel pretty good here.

/cc @Ladas hope this helps us add support for `virtual_totals` with `:through`
/cc @NickLaMuro If we get the `:through` working, then we may be able to get the aggregation with those fields working (your current BZ)