### PR TITLE
Remove chargeback rate from metering reports

### DIFF
--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -2,7 +2,7 @@ module Metering
   extend ActiveSupport::Concern
 
   included do
-    DISALLOWED_SUFFIXES = %w(_cost).freeze
+    DISALLOWED_SUFFIXES = %w(_cost chargeback_rates).freeze
 
     def self.attribute_names
       super.reject { |x| x.ends_with?(*DISALLOWED_SUFFIXES) }

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -1,4 +1,14 @@
 module Metering
+  extend ActiveSupport::Concern
+
+  included do
+    DISALLOWED_SUFFIXES = %w(_cost).freeze
+
+    def self.attribute_names
+      super.reject { |x| x.ends_with?(*DISALLOWED_SUFFIXES) }
+    end
+  end
+
   def calculate_costs(consumption, _)
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
     self.metering_used_metric = consumption.metering_used_fields_present if consumption.metering_used_fields_present

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -933,7 +933,6 @@ class MiqExpression
       model.constantize.try(:refresh_dynamic_metric_columns)
       md = model_details(model, :include_model => false, :include_tags => true).select do |c|
         allowed_suffixes = ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES
-        allowed_suffixes -= ['_cost'] if model.starts_with?('Metering')
         c.last.ends_with?(*allowed_suffixes)
       end
       td = if TAG_CLASSES.include?(cb_model)

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -98,4 +98,38 @@ describe MeteringVm do
       end
     end
   end
+
+  let(:allowed_attributes) do
+    %w(start_date
+       end_date
+       interval_name
+       display_range
+       entity
+       tag_name
+       label_name
+       fixed_compute_metric
+       id
+       vm_id
+       vm_name
+       vm_uid
+       vm_guid
+       owner_name
+       provider_name
+       provider_uid
+       cpu_allocated_metric
+       cpu_used_metric
+       disk_io_used_metric
+       memory_allocated_metric
+       memory_used_metric
+       net_io_used_metric
+       storage_allocated_metric
+       storage_used_metric
+       metering_used_metric
+       existence_hours_metric
+  )
+  end
+
+  it 'lists proper attributes' do
+    expect(described_class.attribute_names).to match_array(allowed_attributes)
+  end
 end


### PR DESCRIPTION
Column Chargeback Rate is removed from available fields in report definition for metering reports

@miq-bot add_label bug, chargeback

Links 
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1514626

@miq-bot assign @gtanzillo 