### PR TITLE
Add reindex to job scheduler 

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -2,4 +2,8 @@ class Metric < ApplicationRecord
   BASE_COLS = ["id", "timestamp", "capture_interval_name", "resource_type", "resource_id", "resource_name", "tag_names", "parent_host_id", "parent_ems_cluster_id", "parent_ems_id", "parent_storage_id"]
 
   include Metric::Common
+
+  def self.reindex_table_name
+    "metrics_#{Time.now.utc.hour + 1}"
+  end
 end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -143,6 +143,12 @@ class MiqScheduleWorker::Jobs
     end
   end
 
+  def database_maintenance_reindex_timer
+    ::Settings.database.maintenance.reindex_tables.each do |class_name|
+      queue_work(:class_name => class_name, :method_name => "reindex", :role => "database_operations", :zone => nil)
+    end
+  end
+
   def check_for_stuck_dispatch(threshold_seconds)
     class_n = "JobProxyDispatcher"
     method_n = "dispatch"

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -280,6 +280,13 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       :tags => [:database_operations, :database_metrics_purge_schedule],
     ) { enqueue(:metric_purge_all_timer) }
 
+    sched = ::Settings.database.maintenance.reindex_schedule
+    _log.info("database_maintenance_reindex_schedule: #{sched}")
+    scheduler.schedule_cron(
+      sched,
+      :tags => %i(database_operations database_maintenance_reindex_schedule),
+    ) { enqueue(:database_maintenance_reindex_timer) }
+
     @schedules[:database_operations]
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -83,6 +83,12 @@
   :scanning_job_timeout: 20.minutes
   :concurrent_per_ems: 3
 :database:
+  :maintenance:
+    :reindex_schedule: "1 * * * *"
+    :reindex_tables:
+    - Metric
+    - MiqQueue
+    - MiqWorker
   :metrics_collection:
     :collection_schedule: "1 * * * *"
     :daily_rollup_schedule: "23 0 * * *"

--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -10,5 +10,15 @@ module ActiveRecord
     def self.truncate
       connection.truncate(table_name, "#{name} Truncate")
     end
+
+    def self.reindex
+      _log.info("Reindexing table #{reindex_table_name}")
+      connection.reindex_table(reindex_table_name)
+      _log.info("Reindexing table #{reindex_table_name}")
+    end
+
+    def self.reindex_table_name
+      table_name
+    end
   end
 end


### PR DESCRIPTION
This adds a reindex of `Metric`, `MiqQueue`, `MiqWorker` to run hourly via the job scheduler. At present, this is configured on the appliance console and done via cron jobs on the database appliance. 

Will be following up with scheduling of vacuum on tables.

@miq-bot add_label wip
@miq-bot assign @carbonin 
