### PR TITLE
[WIP] Virtual Aggregates use :through

### DIFF
--- a/lib/extensions/virtual_total.rb
+++ b/lib/extensions/virtual_total.rb
@@ -91,7 +91,7 @@ module VirtualTotal
     end
 
     def virtual_aggregate_arel(reflection, method_name, column)
-      return unless reflection && reflection.macro == :has_many && !reflection.options[:through]
+      return unless reflection && reflection.macro == :has_many && !reflection.options[:through] ## fix
       lambda do |t|
         query = if reflection.scope
                   reflection.klass.instance_exec(nil, &reflection.scope)

--- a/spec/lib/extensions/virtual_total_spec.rb
+++ b/spec/lib/extensions/virtual_total_spec.rb
@@ -370,9 +370,18 @@ describe VirtualTotal do
       expect(model_with_children(2).v_total_storages).to eq(2)
     end
 
-    it "is not defined in sql" do
-      expect(base_model.attribute_supported_by_sql?(:v_total_storages)).to be(false)
-    end
+    # it "is defined in sql" do # TODO
+    #   expect(base_model.attribute_supported_by_sql?(:v_total_storages)).to be(true)
+    # end
+
+    # it "sorts by total" do
+    #   host0 = model_with_children(0)
+    #   host2 = model_with_children(2)
+    #   host1 = model_with_children(1)
+
+    #   expect(base_model.order(:v_total_storages).pluck(:id))
+    #     .to eq([host0, host1, host2].map(&:id))
+    # end
 
     def model_with_children(count)
       FactoryGirl.create(:host).tap do |host|


### PR DESCRIPTION
extracted

- [ ] #16927

Goal is to allow virtual_aggregation to use :through.
Want to use virtual_aggregation / virtual_total for the aggregation mixins

Sorry. currently a place holder


also want to fix:

https://github.com/Ladas/manageiq/blob/742b0d68bf0d0a251fe226f81fde719dfac1086a/app/models/manageiq/providers/network_manager.rb#L40


getting through working
