### PR TITLE
Miq expression column parsing

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -448,28 +448,8 @@ class MiqExpression
       return result
     end
 
-    model = f.model
-    cur_incl = result[:include]
-
-    f.associations.each do |assoc|
-      assoc = assoc.to_sym
-      ref = model.reflection_with_virtual(assoc)
-      result[:virtual_reflection] = true if model.virtual_reflection?(assoc)
-
-      unless ref
-        result[:virtual_reflection] = true
-        result[:sql_support] = false
-        result[:virtual_column] = true
-        return result
-      end
-
-      unless result[:virtual_reflection]
-        cur_incl[assoc] ||= {}
-        cur_incl = cur_incl[assoc]
-      end
-
-      model = ref.klass
-    end
+    f.collect_reflections.map(&:name).inject(result[:include]) { |a, p| a[p] ||= {} }
+    result[:virtual_reflection] = !f.reflection_supported_by_sql?
 
     if f.column
       result[:data_type] = f.column_type

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -52,14 +52,16 @@ class MiqExpression::Target
     model.follow_associations(associations).present?
   end
 
+  # AR or virtual reflections
   def reflections
-    klass = model
-    associations.collect do |association|
-      klass.reflection_with_virtual(association).tap do |reflection|
-        raise ArgumentError, "One or more associations are invalid: #{associations.join(", ")}" unless reflection
-        klass = reflection.klass
-      end
-    end
+    model.collect_reflections_with_virtual(associations) ||
+      raise(ArgumentError, "One or more associations are invalid: #{associations.join(", ")}")
+  end
+
+  # only AR reflections
+  def collect_reflections
+    model.collect_reflections(associations) ||
+      raise(ArgumentError, "One or more associations are invalid: #{associations.join(", ")}")
   end
 
   def target

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -876,7 +876,9 @@ describe VirtualFields do
     # Vms.belongs_to :host
     # Vms.virtual_has_many :processes
     it "stops at virtual reflections" do
-      expect(ExtManagementSystem.collect_reflections(%w(vms processes))).to be_nil
+      expect(ExtManagementSystem.collect_reflections(%w(vms processes))).to eq(
+        [ExtManagementSystem.reflect_on_association(:vms)]
+      )
     end
   end
 


### PR DESCRIPTION
Extracted from #13446 -- see for more information

**PROTIP:** Use `diff` for each of the 2 commits.

# Goal

This PR removes logic from `MiqExpression#get_col_info` and uses the logic in `MiqExpression::Field`, instead. This is part of the goal of removing model introspection from `MiqExpression`.

### Before

1. `get_col_info` directly parses fields.
2. `get_col_info` directly traverse the relations.
3. `get_col_info` directly introspects fields.
4. `ArVirtual#collect_reflections` unused

### After

1. `get_col_info` uses `MiqExpression::Field` to parse a field.
2. `get_col_info` uses Field to traverse relations. Consolidates relation traversal logic in `MiqExpression#get_col_info`, `ArVirtual#collect_reflections` and `Target#reflections`.
3. `get_col_info` uses `Field` to determine a field's attributes.

