### PR TITLE
Dropping azure classic and rackspace credential types

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -4,13 +4,11 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :Credential
   require_nested :AmazonCredential
   require_nested :AzureCredential
-  require_nested :AzureClassicCredential
   require_nested :CloudCredential
   require_nested :GoogleCredential
   require_nested :MachineCredential
   require_nested :NetworkCredential
   require_nested :OpenstackCredential
-  require_nested :RackspaceCredential
   require_nested :ScmCredential
   require_nested :VmwareCredential
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_classic_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_classic_credential.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureClassicCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::AzureClassicCredential
-end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rackspace_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rackspace_credential.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RackspaceCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
-  include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::RackspaceCredential
-end


### PR DESCRIPTION
Dropped by Tower 3.2 http://docs.ansible.com/ansible-tower/latest/html/upgrade-migration-guide/release_notes.html#ansible-tower-version-3-2-0

Depending on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/58

(For issue https://github.com/ManageIQ/manageiq-providers-ansible_tower/issues/53)

Bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1542182