### PR TITLE
Allow EMS to prevent worker from starting

### DIFF
--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -18,7 +18,11 @@ module PerEmsWorkerMixin
     end
 
     def all_valid_ems_in_zone
-      all_ems_in_zone.select {|e| e.enabled && e.authentication_status_ok?}
+      all_ems_in_zone.select do |e|
+        next(false) unless e.enabled && e.authentication_status_ok?
+        next(e.worker_wanted?(name)) if e.respond_to?(:worker_wanted?)
+        true
+      end
     end
 
     def desired_queue_names


### PR DESCRIPTION
With this commit we allow EMS to decide whether it wants to prevent its worker from being run. This is useful in case when worker depends on user input when adding EMS. E.g. user can opt-in to pick "None" option for EventMonitoring and in such case EMS can now prevent EventCatcher worker from spawning.

![capture](https://user-images.githubusercontent.com/8102426/35729662-c0ef5fbc-080f-11e8-81bd-01279d85d6bc.PNG)

Previously, workers were spawned no matter what which is both uneffective and causes troubles when such "invalid" worker is continously failing.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1527209
Followup PR: https://github.com/ManageIQ/manageiq-providers-nuage/pull/63

@miq-bot assign @agrare 
@miq-bot add_label enhancement