### PR TITLE
Add MiqRequest factory with MiqApproval

### DIFF
--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -12,5 +12,15 @@ FactoryGirl.define do
     factory :miq_provision_request,              :class => "MiqProvisionRequest" do
       source { create(:miq_template) }
     end
+
+    trait :with_approval do
+      transient do
+        reason ""
+      end
+
+      after(:create) do |request, evaluator|
+        request.miq_approvals << FactoryGirl.create(:miq_approval, :reason => evaluator.reason)
+      end
+    end
   end
 end


### PR DESCRIPTION
Provide a MiqRequest factory which has an MiqApproval. Required to test that `report_data` is capable to query based on `reason`.  

Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/3274