### PR TITLE
Make db restore more reliable

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -94,12 +94,14 @@ class EvmDatabaseOps
 
       prepare_for_restore(db_opts[:local_file])
 
-      backup = PostgresAdmin.restore(db_opts)
+      # remove all the connections before we restore; AR will reconnect on the next query
+      ActiveRecord::Base.connection_pool.disconnect!
+      backup_file = PostgresAdmin.restore(db_opts)
     ensure
       session.disconnect if session
     end
 
-    uri ||= backup
+    uri ||= backup_file
     _log.info("[#{db_opts[:dbname]}] database has been restored from file: [#{uri}]")
     uri
   end

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -194,7 +194,7 @@ namespace :evm do
 
     namespace :restore do
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a local backup file'
-      task :local do
+      task :local => :environment do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
           opt :local_file, "Destination file", :type => :string, :required => true
@@ -215,7 +215,7 @@ namespace :evm do
       end
 
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a remote backup file'
-      task :remote do
+      task :remote => :environment do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
           opt :uri,              "Destination depot URI",       :type => :string, :required => true

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -55,6 +55,7 @@ describe EvmDatabaseOps do
       allow_any_instance_of(MiqSmbSession).to receive(:settings_mount_point).and_return(Rails.root.join("tmp"))
       allow(PostgresAdmin).to receive(:runcmd_with_logging)
       allow(PostgresAdmin).to receive(:pg_dump_file?).and_return(true)
+      allow(PostgresAdmin).to receive(:base_backup_file?).and_return(false)
     end
 
     it "from local backup" do


### PR DESCRIPTION
This PR moves much of the logic around how what to check for when we do a database restore into `EvmDatabaseOps` rather than `PostgresAdmin`

This allows us to use the models and native PG connections to do things like remove pglogical and check for connections to the database with particular application names.

This also brings all of the connection checking into one class (and repo) rather than doing some checking in the console, then some other checking in `PostgresAdmin` and also sometimes failing in `db:drop`

This change also fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540686 which was caused by this confusing handling for different backup types.