### PR TITLE
Add setting to spawn instead of fork a worker

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -343,11 +343,11 @@ class MiqWorker < ApplicationRecord
   end
 
   def start_runner
-    if ENV['MIQ_SPAWN_WORKERS'] || !Process.respond_to?(:fork)
-      start_runner_via_spawn
-    else
-      start_runner_via_fork
-    end
+    spawn_worker? ? start_runner_via_spawn : start_runner_via_fork
+  end
+
+  def spawn_worker?
+    ENV['MIQ_SPAWN_WORKERS'] || !Process.respond_to?(:fork) || worker_settings[:spawn_worker]
   end
 
   def start_runner_via_fork

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1083,6 +1083,7 @@
       :poll_escalate_max: 30.seconds
       :poll_method: :normal
       :restart_interval: 0.hours
+      :spawn_worker: false
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
     :embedded_ansible_worker:
@@ -1227,6 +1228,7 @@
       :nice_delta: 3
       :poll: 1.seconds
       :reconnect_retry_interval: 5.minutes
+      :spawn_worker: true
       :vim_broker_status_interval: 15.minutes
       :vim_broker_update_interval: 0.seconds
       :vim_broker_max_wait: 60


### PR DESCRIPTION
Add a config setting per worker type to force the worker to be spawned
instead of forked.

This will allow us to force certain provider workers to be spawned
instead of forked to work around possible shared thread object ID
issues.