### PR TITLE
Fix filename when downloading pdf from Flavor summary

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -785,6 +785,10 @@ en:
       ManageIQ::Providers::Azure::CloudManager::Vm:                         Instance (Microsoft Azure)
       ManageIQ::Providers::Amazon::CloudManager::Vm:                        Instance (Amazon)
       ManageIQ::Providers::Vmware::CloudManager::Vm:                        Instance (VMware vCloud)
+      ManageIQ::Providers::Amazon::CloudManager::Flavor:                    Flavor (Amazon)
+      ManageIQ::Providers::Google::CloudManager::Flavor:                    Flavor (Google)
+      ManageIQ::Providers::Azure::CloudManager::Flavor:                     Flavor (Microsoft Azure)
+      ManageIQ::Providers::Openstack::CloudManager::Flavor:                 Flavor (OpenStack)
       ManageIQ::Providers::CloudManager::Template:                          Image
       ManageIQ::Providers::Amazon::CloudManager::Template:                  Image (Amazon)
       ManageIQ::Providers::CloudManager::VirtualTemplate:                   Resourceless Server Template


### PR DESCRIPTION
Filename before:
ManageIQ_Providers_Openstack_Cloud Manager_Flavor_m1.large_summary_2018_02_02.pdf

Filename after:
Flavor (OpenStack)_m1.large_summary_2018_02_02.pdf

@miq-bot add_labels providers/cloud, bug, blocker

https://bugzilla.redhat.com/show_bug.cgi?id=1540601