### PR TITLE
Activate network discovery refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem "linux_admin",                    "~>1.2.0",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
-gem "manageiq-network_discovery",     "~>0.1.2",       :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>2.6.1",       :path => File.expand_path("mime-types-redirector", __dir__)
 gem "more_core_extensions",           "~>3.5"

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -830,7 +830,7 @@ class Host < ApplicationRecord
       end
 
       discover_options = {:ipaddr         => ipaddr,
-                          :usePing        => options[:ping],
+                          :ping           => options[:ping],
                           :timeout        => options[:timeout],
                           :discover_types => options[:discover_types],
                           :credentials    => options[:credentials]
@@ -924,11 +924,11 @@ class Host < ApplicationRecord
   end
 
   def rediscover(ipaddr, discover_types = [:esx])
-    require 'manageiq-network_discovery'
-    ost = OpenStruct.new(:usePing => true, :discover_types => discover_types, :ipaddr => ipaddr)
+    require 'manageiq/network_discovery/discovery'
+    ost = OpenStruct.new(:ping => true, :discover_types => discover_types, :ipaddr => ipaddr)
     _log.info("Rediscovering Host: #{ipaddr} with types: #{discover_types.inspect}")
     begin
-      ManageIQ::NetworkDiscovery.scanHost(ost)
+      ManageIQ::NetworkDiscovery::Discovery.scan_host(ost)
       _log.info("Rediscovering Host: #{ipaddr} raw results: #{self.class.ost_inspect(ost)}")
 
       unless ost.hypervisor.empty?
@@ -944,11 +944,11 @@ class Host < ApplicationRecord
   end
 
   def self.discoverHost(options)
-    require 'manageiq-network_discovery'
+    require 'manageiq/network_discovery/discovery'
     ost = OpenStruct.new(Marshal.load(options))
     _log.info("Discovering Host: #{ost_inspect(ost)}")
     begin
-      ManageIQ::NetworkDiscovery.scanHost(ost)
+      ManageIQ::NetworkDiscovery::Discovery.scan_host(ost)
 
       if ost.hypervisor.empty?
         _log.info("NOT Discovered: #{ost_inspect(ost)}")


### PR DESCRIPTION
- Remove network discovery gem `manageiq-network_discovery` which is done on dependent PR https://github.com/ManageIQ/manageiq/pull/16916

- Modify `Hosts` to use new discovery.

Please refer to https://github.com/ManageIQ/manageiq-network_discovery/issues/8 for more details.

This is needed for https://bugzilla.redhat.com/show_bug.cgi?id=1212947 which https://github.com/ManageIQ/manageiq/pull/16318 depends on.