### PR TITLE
Follow up to update_vm_name for Service template provisioning

### DIFF
--- a/app/models/miq_provision.rb
+++ b/app/models/miq_provision.rb
@@ -68,7 +68,7 @@ class MiqProvision < MiqProvisionTask
     options[:vm_target_hostname] = get_hostname(new_name)
 
     update_attributes(:description => self.class.get_description(self, new_name), :options => options)
-    miq_request.update_description_from_tasks if update_request
+    miq_request.try(:update_description_from_tasks) if update_request
   end
 
   def after_ae_delivery(ae_result)

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -107,6 +107,17 @@ describe MiqProvision do
 
             @vm_prov.update_vm_name(@target_vm_name, :update_request => false)
           end
+
+          it "When task is part of a ServiceTemplateProvisionRequest the description should not update" do
+            request_descripton = "Service Name Test"
+            service_provision_request = FactoryGirl.create(:service_template_provision_request, :description => request_descripton)
+            @vm_prov.update_attributes(:miq_request_id => service_provision_request.id)
+
+            expect(service_provision_request).not_to receive(:update_description_from_tasks)
+            @vm_prov.update_vm_name(@target_vm_name, :update_request => true)
+
+            expect(service_provision_request.description).to eq(request_descripton)
+          end
         end
 
         context "when auto naming sequence exceeds the range" do


### PR DESCRIPTION
When provisioning a VM as part of a service the miq_provision task gets associated to a `service_template_provision_request` which does not have an `update_description_from_tasks` method.  In this case we want to skip calling the `update_description_from_tasks` method if the request object does not expose it.

Links
----------------

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1455002
* https://github.com/ManageIQ/manageiq/pull/16897

cc @syncrou 