### PR TITLE
Fix reason scope for MiqRequest

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -114,7 +114,7 @@ class MiqRequest < ApplicationRecord
   def self.with_reason_like(reason)
     # Reason string uses * wildcard, scope is required to convert it into % wildcard for LIKE statement
     reason = reason.match(/\A(?<start>\*?)(?<content>.*?)(?<end>\*?)\z/)
-    where("reason LIKE (?)", "#{reason[:start] ? '%' : ''}#{sanitize_sql_like(reason[:content])}#{reason[:end] ? '%' : ''}")
+    joins(:miq_approvals).where("miq_approvals.reason LIKE (?)", "#{reason[:start] ? '%' : ''}#{sanitize_sql_like(reason[:content])}#{reason[:end] ? '%' : ''}")
   end
 
   # Supports old-style requests where specific request was a seperate table connected as a resource


### PR DESCRIPTION
Fix the reason scope introduced in https://github.com/ManageIQ/manageiq/pull/16843. It was wrong and not respecting the field delegation. My bad.

Tests are included in https://github.com/ManageIQ/manageiq-ui-classic/pull/3274, which is covering also the use case.

cc @martinpovolny 