### PR TITLE
Add nil check to serializer for invalid categories

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -23,7 +23,7 @@ class DialogFieldSerializer < Serializer
 
     if dialog_field.type == "DialogFieldTagControl"
       category = Category.find_by(:id => dialog_field.category)
-      dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
+      dialog_field.options.merge!(:category_name => category.name, :category_description => category.description) if category
     end
     included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)
   end


### PR DESCRIPTION
Fixes issue with dialog editor not loading on import of dialogs with invalid tag controls. 

Fixes 1/2 of https://bugzilla.redhat.com/show_bug.cgi?id=1540713

This bz is two issues: the editor won't load because https://github.com/ManageIQ/manageiq/blob/master/app/models/dialog_field_serializer.rb#L26 returns nil for non-valid categories which this PR fixes, and the editor doesn't correctly save changed, valid categories which is an editor problem (because I can replicate it with the import piece taken out, that is, creating a new dialog with a tag control that has a category, saving it, then editing that dialog and changing the category results in the new category not saving as it should.)