### PR TITLE
Avoiding duplicated physical provider connection

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -89,6 +89,12 @@ class ExtManagementSystem < ApplicationRecord
     existing_hostnames = (self.class.all - [self]).map(&:hostname).compact.map(&:downcase)
 
     errors.add(:hostname, N_("has to be unique per provider type")) if existing_hostnames.include?(hostname.downcase)
+
+    # if hostname is ipaddress check against dicovered ipaddress in database too
+    if hostname.ipaddress?
+      existing_ipaddress = (self.class.all - [self]).map(&:ipaddress).compact.map { |ipaddress| ipaddress.gsub(/\/$/, '') }
+      errors.add(:ipaddress, N_("has to be unique per provider type")) if existing_ipaddress.include?(hostname)
+    end
   end
 
   def hostname_format_valid?


### PR DESCRIPTION
**This PR fix:**
https://bugzilla.redhat.com/show_bug.cgi?id=1505610

**This PR:**
* Disregards the slash at the end of hostname on the uniqueness validation;
* Checks if hostname is an ipaddress, if true check if there isn't any discovered ipaddress on database with the same value;
* If is a duplicated ipaddress, show the following message to user:
![image](https://user-images.githubusercontent.com/8550928/35826033-51fdeb3a-0a96-11e8-9e17-2f129c5c2ca2.png)

