### PR TITLE
Close open connections from parent after fork

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -314,6 +314,7 @@ class MiqWorker < ApplicationRecord
   def self.after_fork
     close_pg_sockets_inherited_from_parent
     DRb.stop_service
+    close_drb_pool_connections
     renice(Process.pid)
   end
 
@@ -327,6 +328,23 @@ class MiqWorker < ApplicationRecord
         _log.info("Closing socket: #{socket}")
         IO.for_fd(socket).close
       end
+    end
+  end
+
+  # Close all open DRb connections so that connections in the parent's memory space
+  # which is shared due to forking the child process do not pollute the child's DRb
+  # connection pool.  This can lead to errors when the children connect to a server
+  # and get an incorrect response back.
+  #
+  # ref: https://bugs.ruby-lang.org/issues/2718
+  def self.close_drb_pool_connections
+    require 'drb'
+
+    # HACK: DRb doesn't provide an interface to close open pool connections.
+    #
+    # Once that is added this should be replaced.
+    DRb::DRbConn.instance_variable_get(:@mutex).synchronize do
+      DRb::DRbConn.instance_variable_get(:@pool).each(&:close)
     end
   end
 


### PR DESCRIPTION
DRb::DRbConn keeps a global pool of open connections which is shared by
child processes when they are forked from a parent.  If this parent
executes a DRb call prior to forking a child process the child picks up
this open connection and uses it which can cause replies from the server
to go to the wrong DRb client.

The connection pool in question is [here](https://github.com/ruby/ruby/blob/9f4e80ef179d1297dcb2fc16028b134563dea8d4/lib/drb/drb.rb#L1205-L1243)

There is a long standing ruby bug https://bugs.ruby-lang.org/issues/2718
which describes the issue and has reproducer code attached.

This is the reproducer code that we used: https://gist.github.com/agrare/d9484884bd297b1615814128129cfc5c

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1385038