### PR TITLE
Only set encryption option to net-ldap when needed.

### DIFF
--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -46,8 +46,11 @@ class MiqLdap
     options[:host] ||= ::Settings.authentication.ldaphost
     options[:port] ||= ::Settings.authentication.ldapport
     options[:host] = resolve_host(options[:host], options[:port])
-    options[:encryption] = mode == "ldaps" ? {:method => :simple_tls} : {}
-    options.store_path(:encryption, :tls_options, :verify_mode, OpenSSL::SSL::VERIFY_NONE) if options[:host].ipaddress?
+
+    if mode == "ldaps"
+      options[:encryption] = {:method => :simple_tls}
+      options.store_path(:encryption, :tls_options, :verify_mode, OpenSSL::SSL::VERIFY_NONE) if options[:host].ipaddress?
+    end
 
     # Make sure we do NOT log the clear-text password
     log_options = Vmdb::Settings.mask_passwords!(options.deep_clone)

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -120,19 +120,41 @@ describe MiqLdap do
     expect(MiqLdap.sid_to_s(data)).to eq("S-1-5-21-4106323499-3255682937-2389761597-1183")
   end
 
-  it 'returns a hostname when a hostname is availble and does not set verify mode' do
-    allow(TCPSocket).to receive(:gethostbyname).and_return(["testhostname", "aliases", "type", "192.168.252.20"])
-    allow(TCPSocket).to receive(:new)
-    ldap = MiqLdap.new(:host => ["testhostname", "localhost", "dummy", @host])
-    expect(ldap.ldap.host).to eq("testhostname")
-    expect(ldap.ldap.instance_variable_get(:@encryption).try(:has_key_path?, :tls_options, :verify_mode)).to be_falsey
+  context 'when a hostname is available' do
+    before do
+      allow(TCPSocket).to receive(:gethostbyname).and_return(["testhostname", "aliases", "type", "192.168.252.20"])
+      allow(TCPSocket).to receive(:new)
+    end
+
+    it 'returns a hostname and does not set verify_mode when mode is ldaps' do
+      ldap = MiqLdap.new(:mode => "ldaps", :host => ["testhostname", "localhost", "dummy", @host])
+      expect(ldap.ldap.host).to eq("testhostname")
+      expect(ldap.ldap.instance_variable_get(:@encryption).try(:has_key_path?, :tls_options, :verify_mode)).to be_falsey
+    end
+
+    it 'returns a hostname when a hostname is availble and does not set encryption options' do
+      ldap = MiqLdap.new(:mode => "ldap", :host => ["testhostname", "localhost", "dummy", @host])
+      expect(ldap.ldap.host).to eq("testhostname")
+      expect(ldap.ldap.instance_variable_get(:@encryption)).to be_falsey
+    end
   end
 
-  it 'returns an IPAddress and disables verify mode when only an IPAddress is availble' do
-    expect(TCPSocket).not_to receive(:gethostbyname)
-    allow(TCPSocket).to receive(:new)
-    ldap = MiqLdap.new(:host => ["192.168.254.15", "localhost", "dummy", @host])
-    expect(ldap.ldap.host).to eq("192.168.254.15")
-    expect(ldap.ldap.instance_variable_get(:@encryption).fetch_path(:tls_options, :verify_mode)).to eq(OpenSSL::SSL::VERIFY_NONE)
+  context 'when only an IPAddress is available' do
+    before do
+      expect(TCPSocket).not_to receive(:gethostbyname)
+      allow(TCPSocket).to receive(:new)
+    end
+
+    it 'returns an IPAddress and disables verify_mode when mode is ldaps' do
+      ldap = MiqLdap.new(:mode => "ldaps", :host => ["192.168.254.15", "localhost", "dummy", @host])
+      expect(ldap.ldap.host).to eq("192.168.254.15")
+      expect(ldap.ldap.instance_variable_get(:@encryption).fetch_path(:tls_options, :verify_mode)).to eq(OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    it 'returns an IPAddress and does not set encryption options when mode is ldap' do
+      ldap = MiqLdap.new(:mode => "ldap", :host => ["192.168.254.15", "localhost", "dummy", @host])
+      expect(ldap.ldap.host).to eq("192.168.254.15")
+      expect(ldap.ldap.instance_variable_get(:@encryption)).to be_falsey
+    end
   end
 end

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -126,16 +126,16 @@ describe MiqLdap do
       allow(TCPSocket).to receive(:new)
     end
 
-    it 'returns a hostname and does not set verify_mode when mode is ldaps' do
+    it 'when mode is ldaps returns a hostname and does not set verify_mode' do
       ldap = MiqLdap.new(:mode => "ldaps", :host => ["testhostname", "localhost", "dummy", @host])
       expect(ldap.ldap.host).to eq("testhostname")
       expect(ldap.ldap.instance_variable_get(:@encryption).try(:has_key_path?, :tls_options, :verify_mode)).to be_falsey
     end
 
-    it 'returns a hostname when a hostname is availble and does not set encryption options' do
+    it 'when mode is ldap returns a hostname and does not set encryption options' do
       ldap = MiqLdap.new(:mode => "ldap", :host => ["testhostname", "localhost", "dummy", @host])
       expect(ldap.ldap.host).to eq("testhostname")
-      expect(ldap.ldap.instance_variable_get(:@encryption)).to be_falsey
+      expect(ldap.ldap.instance_variable_get(:@encryption)).to be_nil
     end
   end
 
@@ -145,16 +145,16 @@ describe MiqLdap do
       allow(TCPSocket).to receive(:new)
     end
 
-    it 'returns an IPAddress and disables verify_mode when mode is ldaps' do
+    it 'when mode is ldaps returns an IPAddress and disables verify_mode' do
       ldap = MiqLdap.new(:mode => "ldaps", :host => ["192.168.254.15", "localhost", "dummy", @host])
       expect(ldap.ldap.host).to eq("192.168.254.15")
       expect(ldap.ldap.instance_variable_get(:@encryption).fetch_path(:tls_options, :verify_mode)).to eq(OpenSSL::SSL::VERIFY_NONE)
     end
 
-    it 'returns an IPAddress and does not set encryption options when mode is ldap' do
+    it 'when mode is ldap returns an IPAddress and does not set encryption options' do
       ldap = MiqLdap.new(:mode => "ldap", :host => ["192.168.254.15", "localhost", "dummy", @host])
       expect(ldap.ldap.host).to eq("192.168.254.15")
-      expect(ldap.ldap.instance_variable_get(:@encryption)).to be_falsey
+      expect(ldap.ldap.instance_variable_get(:@encryption)).to be_nil
     end
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1542222

The net-ldap gem, which implements authentication mode ldaps and ldap, requires
encryption options when doing secure ldapS but can not handle empty
encryption options when doing unsecure ldap. 

This PR ensure no encryption options, empty or otherwise, are passed to net-ldap
when the encryption options are unneeded.

Links
----------------

* https://github.com/ManageIQ/manageiq/pull/16850 inadvertently introduced the
issue this PR addresses.

Steps for Testing/QA
-------------------------------

Configure an appliance for Authentication Mode: LDAP
Attempt to log in with a  valid user should succeed.
