### PR TITLE
Fix for differing behavior in DialogFieldTagControl multi/single drop downs

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -23,7 +23,10 @@ class DialogFieldSerializer < Serializer
 
     if dialog_field.type == "DialogFieldTagControl"
       category = Category.find_by(:id => dialog_field.category)
-      dialog_field.options.merge!(:category_name => category.name, :category_description => category.description) if category
+      if category
+        dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
+        dialog_field.options[:force_single_value] = dialog_field.options[:force_single_value] || category.single_value
+      end
     end
     included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)
   end

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -125,13 +125,18 @@ describe DialogFieldSerializer do
 
     context "when the dialog_field is a tag control type" do
       let(:dialog_field) do
-        DialogFieldTagControl.new(expected_serialized_values.merge(:resource_action => resource_action, :dialog_field_responders => dialog_field_responders))
+        DialogFieldTagControl.new(expected_serialized_values.merge(
+          :resource_action         => resource_action,
+          :dialog_field_responders => dialog_field_responders
+        ))
       end
 
       let(:type) { "DialogFieldTagControl" }
-      let(:options) { {:category_id => "123"} }
+      let(:options) { {:category_id => "123", :force_single_value => false} }
       let(:dynamic) { false }
-      let(:category) { double("Category", :name => "best category ever", :description => "best category ever") }
+      let(:category) do
+        double("Category", :name => "best category ever", :description => "best category ever", :single_value => true)
+      end
 
       before do
         allow(Category).to receive(:find_by).with(:id => "123").and_return(category)
@@ -149,7 +154,8 @@ describe DialogFieldSerializer do
                    "options"                 => {
                      :category_id          => "123",
                      :category_name        => "best category ever",
-                     :category_description => "best category ever"
+                     :category_description => "best category ever",
+                     :force_single_value   => true
                    },
                    "default_value"           => "[\"one\", \"two\"]"
           ))


### PR DESCRIPTION
This will ensure that any data coming back from the API serializes the `force_single_value` correctly since the value should not simply take into account how it is set on the dialog but also if the category that is selected is a single value category.

This is related to https://bugzilla.redhat.com/show_bug.cgi?id=1540273 and was found during testing of it.

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @gmcculloug 
