### PR TITLE
Adding persistent_volumes_show_list as a feature.

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4357,9 +4357,12 @@
     :identifier: persistent_volume_view
     :children:
     - :name: List
-      :description: Display Lists of Persistent Volumes
+      :description: Display all Persistent Volumes
       :feature_type: view
       :identifier: persistent_volume_show_list
+    - :name: List
+      :description: Display a list of Persistent Volumes
+      :identifier: persistent_volumes_show_list
     - :name: Show
       :description: Display Individual Persistent Volume
       :feature_type: view


### PR DESCRIPTION
This is to support Pod to PV relationship: It is needed so that we can add this relationship in the UI. (see: https://github.com/ManageIQ/manageiq-ui-classic/pull/3299).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1435235

cc: @zeari @cben 
