### PR TITLE
Loosen kubeclient to >=2.4 <3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.7.0"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
-gem "kubeclient",                     "~>2.4.0",       :require => false # For scaling pods at runtime
+gem "kubeclient",                     "~>2.4",         :require => false # For scaling pods at runtime
 gem "linux_admin",                    "~>1.2.1",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.1.0",       :require => false


### PR DESCRIPTION
The goal is picking up kubeclient 2.5.2.  This PR can be merged alone, but kubeclient version won't change until https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/232 and https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/26 land.

This brings 2 fixes we need:

- Prevent EBADF exception escaping when closing a watch worker
  https://bugzilla.redhat.com/show_bug.cgi?id=1507528
- Watch return RecursiveOpenStruct inside arrays too.
  We were already effectively running the new code via [a monkey patch](https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/2), better to run the new code from kubeclient.

See https://github.com/abonas/kubeclient/blob/master/CHANGELOG.md for full changelog.

@miq-bot add-label bug, gaprindashvili/yes

(On master, we'll later upgrade to kubeclient 3.0.0, need to resolve a version conflict first.  On gaprindashvili, we'll stay with 2.5.)

@pkliczewski @masayag @jhernand please review.