### PR TITLE
Fix physical server and topology access rights for EvmRole-operator

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -383,7 +383,8 @@
   - ems_physical_infra_refresh
   - ems_physical_infra_tag
   - ems_physical_infra_view
-  - physical_server_timeline
+  - physical_server_view
+  - physical_infra_topology_view
   - host_new
   - host_analyze
   - host_compare


### PR DESCRIPTION
Gives EvmRole-operator the rights to access physical server and physical infra topology pages.

Fixes issues:
* https://bugzilla.redhat.com/show_bug.cgi?id=1505618.
* https://bugzilla.redhat.com/show_bug.cgi?id=1530680.
