### PR TITLE
Bump manageiq-smartstate gem to 0.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,7 +183,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.2",       :require => false
+  gem "manageiq-smartstate",            "~>0.2.7",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Force the manageiq main repo to pick up at least 0.2.7 of the manageiq-smartstate gem.

Pick up the latest manageiq-smartstate so that we will be using the Managed Disk Read Semantics change for Smartstate on Azure for https://bugzilla.redhat.com/show_bug.cgi?id=1508154

@roliveri @hsong-rh please review.  Requested by our build overlord.