### PR TITLE
[WIP] MiqQueue.miq_callback to support pre and post callbacks

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -184,14 +184,7 @@ module EmsRefresh
                   task.id
                 end
 
-      unless task_id.nil?
-        item[:miq_callback] = {
-          :class_name  => 'MiqTask',
-          :method_name => :queue_callback,
-          :instance_id => task_id,
-          :args        => ['Finished']
-        }
-      end
+      item[:miq_callback] = MiqTask.generic_action_callbacks(task_id) if task_id
       item.merge(
         :data        => targets,
         :task_id     => task_id,

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -92,6 +92,9 @@ module Metric::CiMixin::Capture
           qi.delete(:state)
           if cb && item_interval == "realtime"
             qi[:miq_callback] = cb
+            if task_id
+              cb.merge(MiqTask.generic_action_callbacks(task_id))
+            end
           end
           qi
         elsif msg.state == "ready" && (task_id || MiqQueue.higher_priority?(priority, msg.priority))


### PR DESCRIPTION
And use the pre-post callbacks to support `miq_task` life cycles.

This PR would handle all the known cases
* Ansible operations
* Refresh
* Metric rollups

As an alternate approach to https://github.com/ManageIQ/manageiq/pull/16872

**Showing started**
![screen shot 2018-02-06 at 2 17 23 pm](https://user-images.githubusercontent.com/2421248/35879206-9f1f651c-0b48-11e8-9213-1443a275f04d.png)

**Showing finished**
![screen shot 2018-02-06 at 2 17 48 pm](https://user-images.githubusercontent.com/2421248/35879201-9cf01f7a-0b48-11e8-9692-3ab3ee1fcb7e.png)
