### PR TITLE
Lookup a category_id if a tag control passes it in

### DIFF
--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -31,13 +31,16 @@ class DialogFieldImporter
   private
 
   def set_category_for_tag_control(dialog_field, dialog_field_attributes)
-    category_name = dialog_field_attributes["options"][:category_name]
-    if category_name
-      category_description = dialog_field_attributes["options"][:category_description]
-      category = Category.find_by_name(category_name)
-      dialog_field.category = category.try(:description) == category_description ? category.id.to_s : nil
-    else
-      dialog_field.category = dialog_field_attributes["options"][:category_id]
-    end
+    dialog_field.category = adjust_category(dialog_field_attributes['options'])
+  end
+
+  def adjust_category(opts)
+    return nil if opts[:category_description].nil?
+    category = if opts[:category_id]
+                 Category.find(opts[:category_id])
+               elsif opts[:category_name]
+                 Category.find_by_name(opts[:category_name])
+               end
+    category.try(:description) == opts[:category_description] ? category.try(:id).to_s : nil
   end
 end

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -78,10 +78,9 @@ describe DialogFieldImporter do
     context "when the type of the dialog field is a tag control" do
       let(:type) { "DialogFieldTagControl" }
 
-      context "when the import file contains a category name" do
+      context "when the import file contains a category name with no category_id" do
         let(:options) do
           {
-            :category_id          => "123",
             :category_name        => "best_category",
             :category_description => category_description
           }
@@ -123,12 +122,38 @@ describe DialogFieldImporter do
         end
       end
 
-      context "when the import file only contains a category id" do
-        let(:options) { {:category_id => "123"} }
+      context "when the import file contains a category id a category name and a description" do
+        before do
+          @existing_category = Category.create!(:name => "best_category", :description => "best_category")
+        end
+        let(:options) do
+          {
+            :category_id          => @existing_category.id,
+            :category_name        => @existing_category.name,
+            :category_description => @existing_category.description
+          }
+        end
 
         it "uses the category id provided" do
           dialog_field_importer.import_field(dialog_field)
-          expect(DialogFieldTagControl.first.category).to eq("123")
+          expect(DialogFieldTagControl.first.category).to eq(@existing_category.id.to_s)
+        end
+      end
+
+      context "when the import file contains a category id with a different description" do
+        before do
+          @existing_category = Category.create!(:name => "best_category", :description => "best_category")
+        end
+        let(:options) do
+          {
+            :category_id          => @existing_category.id,
+            :category_description => "bad description"
+          }
+        end
+
+        it "returns nil" do
+          dialog_field_importer.import_field(dialog_field)
+          expect(DialogFieldTagControl.first.category).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
When editing a tag control for service dialogs, we were always looking up by the name
coming in from the dialog.  For a new record this sufficed, for an edit it caused edits to fail.

This changes the order of lookups to first check the category_id if it comes in,
and to fallback to the name if there is no category_id

https://bugzilla.redhat.com/show_bug.cgi?i

