### PR TITLE
Symbolize keys in options hash

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -549,6 +549,10 @@ class MiqRequest < ApplicationRecord
     "#{self.class::SOURCE_CLASS_NAME}:#{requested_task_idx.inspect}"
   end
 
+  def options=(hash)
+    write_attribute(:options, hash.symbolize_keys)
+  end
+
   private
 
   def clean_up_keys_for_request_task

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -550,7 +550,7 @@ class MiqRequest < ApplicationRecord
   end
 
   def options=(hash)
-    write_attribute(:options, hash.symbolize_keys)
+    self[:options] = hash.symbolize_keys
   end
 
   private

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -203,7 +203,7 @@ class MiqRequestTask < ApplicationRecord
   end
 
   def options=(hash)
-    write_attribute(:options, hash.symbolize_keys)
+    self[:options] = hash.symbolize_keys
   end
 
   private

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -202,6 +202,10 @@ class MiqRequestTask < ApplicationRecord
     end
   end
 
+  def options=(hash)
+    write_attribute(:options, hash.symbolize_keys)
+  end
+
   private
 
   def validate_request_type

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -209,6 +209,15 @@ describe MiqProvision do
     end
   end
 
+  describe "options" do
+    let(:miq_provision) { FactoryGirl.build(:miq_provision, :options => {'a' => "1"}) }
+    context 'converted' do
+      it 'symbols' do
+        expect(miq_provision.options[:a]).to eq("1")
+      end
+    end
+  end
+
   describe "#placement_auto" do
     let(:miq_provision) { FactoryGirl.build(:miq_provision, :options => {:placement_auto => placement_option}) }
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -430,6 +430,22 @@ describe MiqRequest do
     end
   end
 
+  context "options" do
+    before do
+      allow(MiqServer).to receive(:my_zone).and_return("New York")
+    end
+
+    let(:request) do
+      FactoryGirl.create(:miq_provision_request,
+                         :requester => fred,
+                         :options   => {'abc' => "1"})
+    end
+
+    it 'strings are symbolized' do
+      expect(request.options[:abc]).to eq("1")
+    end
+  end
+
   context "#update_request" do
     before do
       allow(MiqServer).to receive(:my_zone).and_return("New York")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1542661

Symbolize the first level keys in the options hash.

Symbols are only supported in Ruby, when a options hash (dictionary) is sent from other languages via the REST API, they send the keys as strings.

This PR saves the options keys as symbols.