### PR TITLE
[WIP] Assert we put valid InventoryObject into a relation

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -674,6 +674,14 @@ module ManagerRefresh
       end
     end
 
+    def association_to_class_mapping
+      return {} unless model_class
+
+      @association_to_class_mapping ||= model_class.reflect_on_all_associations.each_with_object({}) do |x, obj|
+        obj[x.name] = x.klass unless x.polymorphic?
+      end
+    end
+
     def foreign_keys
       return [] unless model_class
 


### PR DESCRIPTION
Assert we put valid InventoryObject into a relation. With easy
check, e.g. if hardware has define 'belongs_to :vm_or_template'
Then we can check that that only VmOrTemplate and subclasses
are assigned there in a parser.

WIP: check all consequences of this