### PR TITLE
Use correct comparison for multi-value default value inclusion rules

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -55,4 +55,18 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     return super unless force_multi_value
     MiqAeEngine.create_automation_attribute_array_key(super)
   end
+
+  private
+
+  def default_value_included?(values_list)
+    if force_multi_value
+      return false if default_value.blank?
+      converted_values_list = values_list.collect { |value_pair| value_pair[0].send(value_modifier) }
+      converted_default_values = JSON.parse(default_value).collect { |value| value.send(value_modifier) }
+      overlap = converted_values_list & converted_default_values
+      !overlap.empty?
+    else
+      super(values_list)
+    end
+  end
 end

--- a/spec/models/dialog/orchestration_template_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_service_dialog_spec.rb
@@ -25,14 +25,14 @@ describe Dialog::OrchestrationTemplateServiceDialog do
     context "when allowed values are given" do
       let(:param_options) do
         constraint = OrchestrationTemplate::OrchestrationParameterAllowed.new(:allowed_values => %w(val1 val2), :allow_multiple => true)
-        {:default_value => 'val1', :constraints => [constraint]}
+        {:default_value => '["val1"]', :constraints => [constraint]}
       end
 
       it "creates a dropdown field with pairs of values" do
         assert_field(test_field(dialog),
                      DialogFieldDropDownList,
                      :name              => "param_user",
-                     :default_value     => "val1",
+                     :default_value     => "[\"val1\"]",
                      :values            => [%w(val1 val1), %w(val2 val2)],
                      :reconfigurable    => true,
                      :force_multi_value => true)

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -136,33 +136,65 @@ describe DialogFieldDropDownList do
       end
     end
 
-    context "#initialize_with_values" do
-      before(:each) do
-        @df.values = [%w(3 X), %w(2 Y), %w(1 Z)]
-        @df.load_values_on_init = true
-      end
+    it "#automate_key_name" do
+      expect(@df.automate_key_name).to eq("dialog_drop_down_list")
+    end
+  end
+
+  describe "#initialize_with_values" do
+    let(:dialog_field) { described_class.new(:options => {:force_multi_value => force_multi_value}) }
+
+    before do
+      dialog_field.values = [%w(3 X), %w(2 Y), %w(1 Z)]
+      dialog_field.load_values_on_init = true
+    end
+
+    context "when force_multi_value is not true" do
+      let(:force_multi_value) { false }
 
       it "uses the nil as the default value" do
-        @df.default_value = nil
-        @df.initialize_with_values({})
-        expect(@df.value).to eq(nil)
+        dialog_field.default_value = nil
+        dialog_field.initialize_with_values({})
+        expect(dialog_field.value).to eq(nil)
       end
 
       it "with default value" do
-        @df.default_value = "1"
-        @df.initialize_with_values({})
-        expect(@df.value).to eq("1")
+        dialog_field.default_value = "1"
+        dialog_field.initialize_with_values({})
+        expect(dialog_field.value).to eq("1")
       end
 
       it "uses the nil when there is a non-matching default value" do
-        @df.default_value = "4"
-        @df.initialize_with_values({})
-        expect(@df.value).to eq(nil)
+        dialog_field.default_value = "4"
+        dialog_field.initialize_with_values({})
+        expect(dialog_field.value).to eq(nil)
       end
     end
 
-    it "#automate_key_name" do
-      expect(@df.automate_key_name).to eq("dialog_drop_down_list")
+    context "when force_multi_value is true" do
+      let(:force_multi_value) { true }
+
+      context "when the default values are included in the value list" do
+        before do
+          dialog_field.default_value = "[\"3\", \"2\"]"
+        end
+
+        it "uses the default value" do
+          dialog_field.initialize_with_values({})
+          expect(dialog_field.value).to eq("[\"3\", \"2\"]")
+        end
+      end
+
+      context "when the default values are not included in the value list" do
+        before do
+          dialog_field.default_value = "[\"4\"]"
+        end
+
+        it "uses nil" do
+          dialog_field.initialize_with_values({})
+          expect(dialog_field.value).to eq(nil)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1531316, found while I was testing with a multi-value drop down. The default value was being set correctly but the actual drop down wasn't displaying the default. It was because it was trying to see if the default value existed within the list of values. When it's a multi-value drop down, something like `"[\"1\", \"2\"]"` is not going to be one of the values, we have to parse it first and then check to see if there is any overlap.

@miq-bot assign @gmcculloug 
@miq-bot add_label gaprindashvili/yes, bug, blocker

/cc @romanblanco 

@d-m-u Can you review, please?