### PR TITLE
Add support for bind dn and bind pwd on the command line.

### DIFF
--- a/spec/tools/miqldap_to_sssd/cli_spec.rb
+++ b/spec/tools/miqldap_to_sssd/cli_spec.rb
@@ -20,6 +20,16 @@ describe MiqLdapToSssd::Cli do
       expect(opts).to eq(:basedn_domain => "example.com")
     end
 
+    it "should parse bind DN" do
+      opts = described_class.new.parse(%w(-b cn=Manager,dc=example,dc=com)).options.slice(:bind_dn)
+      expect(opts).to eq(:bind_dn => "cn=Manager,dc=example,dc=com")
+    end
+
+    it "should parse bind pwd" do
+      opts = described_class.new.parse(%w(-p password)).options.slice(:bind_pwd)
+      expect(opts).to eq(:bind_pwd => "password")
+    end
+
     it "should parse TLS cacert path and directory" do
       opts = described_class.new.parse(%w(-c /a/path/to/a/cacert)).options.slice(:tls_cacert, :tls_cacertdir)
       expect(opts).to eq(:tls_cacert => "/a/path/to/a/cacert", :tls_cacertdir => "/a/path/to/a")

--- a/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
+++ b/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
@@ -4,19 +4,45 @@ require "miqldap_to_sssd"
 
 describe MiqLdapToSssd::MiqLdapConfiguration do
   describe '#retrieve_initial_settings' do
+    let(:settings) { {:tls_cacert => 'cert', :basedn_domain => "example.com"} }
+
     it 'raises an error when the basedn domain can not be determined' do
       expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
-      subject = described_class.new(:basedn => nil, :basedn_domain => nil)
+      subject = described_class.new(settings.merge(:basedn => nil, :basedn_domain => nil))
       expect { subject.retrieve_initial_settings }.to raise_error(MiqLdapToSssd::MiqLdapConfigurationArgumentError)
     end
 
-    it 'does not modify basedn_domain if providedn' do
-      subject = described_class.new(:basedn_domain => "example.com")
+    it 'when mode is ldap and bind dn is nil raises an error' do
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
+      subject = described_class.new(settings.merge(:mode => 'ldap', :bind_pwd => nil))
+      expect { subject.retrieve_initial_settings }.to raise_error(MiqLdapToSssd::MiqLdapConfigurationArgumentError)
+    end
+
+    it 'when mode is ldaps and bind dn is nil does not raises an error' do
+      expect(MiqLdapToSssd::LOGGER).to_not receive(:fatal)
+      subject = described_class.new(settings.merge(:mode => 'ldaps', :bind_dn => nil))
+      expect { subject.retrieve_initial_settings }.to_not raise_error
+    end
+
+    it 'when mode is ldap and bind pwd is nil raises an error' do
+      expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
+      subject = described_class.new(settings.merge(:mode => 'ldap', :bind_pwd => nil))
+      expect { subject.retrieve_initial_settings }.to raise_error(MiqLdapToSssd::MiqLdapConfigurationArgumentError)
+    end
+
+    it 'when mode is ldaps and bind pwd is nil does not raises an error' do
+      expect(MiqLdapToSssd::LOGGER).to_not receive(:fatal)
+      subject = described_class.new(settings.merge(:mode => 'ldaps', :bind_pwd => nil))
+      expect { subject.retrieve_initial_settings }.to_not raise_error
+    end
+
+    it 'does not modify basedn_domain if provided' do
+      subject = described_class.new(settings.merge(:basedn_domain => "example.com"))
       expect(subject.retrieve_initial_settings[:basedn_domain]).to eq("example.com")
     end
 
     it 'sets basedn_domain from mixed case basedn' do
-      subject = described_class.new(:basedn => "CN=Users,DC=Example,DC=COM")
+      subject = described_class.new(settings.merge(:basedn => "CN=Users,DC=Example,DC=COM"))
       expect(subject.retrieve_initial_settings[:basedn_domain]).to eq("example.com")
     end
   end

--- a/tools/miqldap_to_sssd/cli.rb
+++ b/tools/miqldap_to_sssd/cli.rb
@@ -18,6 +18,18 @@ module MiqLdapToSssd
             :default => nil,
             :type    => :string
 
+        opt :bind_dn,
+            "The Bind DN, credential to use to authenticate against LDAP e.g. cn=Manager,dc=example,dc=com",
+            :short   => "b",
+            :default => nil,
+            :type    => :string
+
+        opt :bind_pwd,
+            "The Base DN domain name, e.g. example.com",
+            :short   => "p",
+            :default => nil,
+            :type    => :string
+
         opt :tls_cacert,
             "Path to certificate file",
             :short   => "c",

--- a/tools/miqldap_to_sssd/miqldap_configuration.rb
+++ b/tools/miqldap_to_sssd/miqldap_configuration.rb
@@ -6,6 +6,12 @@ module MiqLdapToSssd
     NO_BASE_DN_DOMAIN = "Unable to determine base DN domain name\nA Base DN domain name must be " <<
                         "specified on the command line when a Base DN is not already configured.".freeze
 
+    NO_BIND_DN        = "Unable to determine bind DN\nA Bind DN must be specified on the command " <<
+                        "line when a bind DN is not already configured.".freeze
+
+    NO_BIND_PWD       = "Unable to determine bind pwd\nA Bind pwd must be specified on the command " <<
+                        "line when a bind pwd is not already configured.".freeze
+
     attr_accessor :initial_settings
 
     def initialize(options = {})
@@ -14,6 +20,8 @@ module MiqLdapToSssd
 
     def retrieve_initial_settings
       check_for_tls_certs
+      check_for_bind_dn
+      check_for_bind_pwd
       derive_domain
     end
 
@@ -23,6 +31,20 @@ module MiqLdapToSssd
       if initial_settings[:basedn_domain].nil? && initial_settings[:basedn].nil?
         LOGGER.fatal(NO_BASE_DN_DOMAIN)
         raise MiqLdapConfigurationArgumentError, NO_BASE_DN_DOMAIN
+      end
+    end
+
+    def check_for_bind_dn
+      if initial_settings[:bind_dn].nil? && initial_settings[:mode] == "ldap"
+        LOGGER.fatal(NO_BIND_DN)
+        raise MiqLdapConfigurationArgumentError, NO_BIND_DN
+      end
+    end
+
+    def check_for_bind_pwd
+      if initial_settings[:bind_pwd].nil? && initial_settings[:mode] == "ldap"
+        LOGGER.fatal(NO_BIND_PWD)
+        raise MiqLdapConfigurationArgumentError, NO_BIND_PWD
       end
     end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1538813

When mode is ldap, bind dn and bind pwd must be provided, either
in the authentication settings or on the command line.

Steps for Testing/QA 
-------------------------------

1. Configure MIQLDAP for **Mode: LDAP** (not Mode: LDAPS)
2. Do not get groups from LDAP
3. Manually create users in UPN username format.
4. Run SSSD conversion
 e.g.:
```bash
miqldap_to_sssd -b "cn=Manager,dc=example,dc=com" -p "password" -d "example.com"
```