### PR TITLE
Inventory task

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -678,6 +678,21 @@ class ExtManagementSystem < ApplicationRecord
     User.super_admin.tap { |u| u.current_group = tenant.default_miq_group }
   end
 
+  def self.inventory_status
+    data = includes(:zone)
+           .select(:id, :zone_id, :name, :total_hosts, :total_vms, :total_clusters)
+           .map do |ems|
+             [
+               ems.region_id, ems.zone.name, ems.name,
+               ems.total_clusters, ems.total_hosts, ems.total_vms, ems.total_storages
+             ]
+           end
+    return if data.empty?
+    data = data.sort_by { |e| [e[0], e[1], e[2], e[3]] }
+
+    data.unshift %w(region zone ems clusters hosts vms storages)
+  end
+
   private
 
   def build_connection(options = {})

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -689,7 +689,7 @@ class ExtManagementSystem < ApplicationRecord
            end
     return if data.empty?
     data = data.sort_by { |e| [e[0], e[1], e[2], e[3]] }
-
+    data = data.map { |row| row.map { |col| col.to_s == "0" ? nil : col } }
     data.unshift %w(region zone ems clusters hosts vms storages)
   end
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -153,7 +153,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_total  :total_miq_templates,     :miq_templates
   virtual_total  :total_hosts,             :hosts
   virtual_total  :total_storages,          :storages
-  virtual_total  :total_clusters,          :clusters
+  virtual_total  :total_clusters,          :ems_clusters
   virtual_column :zone_name,               :type => :string, :uses => :zone
   virtual_column :total_vms_on,            :type => :integer
   virtual_column :total_vms_off,           :type => :integer

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -146,7 +146,7 @@ class Host < ApplicationRecord
   virtual_has_many   :event_logs,                                   :uses => {:operating_system => :event_logs}
   virtual_has_many   :firewall_rules,                               :uses => {:operating_system => :firewall_rules}
 
-  virtual_total :v_total_storages, :storages
+  virtual_total :v_total_storages, :host_storages
   virtual_total :v_total_vms, :vms
   virtual_total :v_total_miq_templates, :miq_templates
 

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -50,6 +50,12 @@ namespace :evm do
     EvmApplication.status(true)
   end
 
+  desc "Describe inventory of the ManageIQ EVM Application"
+  task :inventory => :environment do
+    inventory = ExtManagementSystem.inventory_status
+    puts inventory.tableize if inventory.present?
+  end
+
   desc "Write a remote region id to this server's REGION file"
   task :join_region => :environment do
     configured_region = ApplicationRecord.region_number_from_sequence.to_i

--- a/spec/lib/extensions/virtual_total_spec.rb
+++ b/spec/lib/extensions/virtual_total_spec.rb
@@ -362,21 +362,23 @@ describe VirtualTotal do
     end
   end
 
-  describe ".virtual_total (with through relation (host#v_total_storages)" do
-    let(:base_model) { Host }
+  describe ".virtual_total (with through relation (ems#total_storages)" do
+    let(:base_model) { ExtManagementSystem }
 
     it "calculates totals locally" do
-      expect(model_with_children(0).v_total_storages).to eq(0)
-      expect(model_with_children(2).v_total_storages).to eq(2)
+      expect(model_with_children(0).total_storages).to eq(0)
+      expect(model_with_children(2).total_storages).to eq(2)
     end
 
     it "is not defined in sql" do
-      expect(base_model.attribute_supported_by_sql?(:v_total_storages)).to be(false)
+      expect(base_model.attribute_supported_by_sql?(:total_storages)).to be(false)
     end
 
     def model_with_children(count)
-      FactoryGirl.create(:host).tap do |host|
-        count.times { host.storages.create(FactoryGirl.attributes_for(:storage)) }
+      FactoryGirl.create(:ext_management_system).tap do |ems|
+        ems.hosts.create(FactoryGirl.attributes_for(:host)).tap do |host|
+          count.times { host.storages.create(FactoryGirl.attributes_for(:storage)) }
+        end
       end.reload
     end
   end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -495,4 +495,18 @@ describe ExtManagementSystem do
       expect(ManageIQ::Providers::Amazon::CloudManager.raw_connect?).to eq(true)
     end
   end
+
+  describe ".inventory_status" do
+    it "works with infra providers" do
+      ems = FactoryGirl.create(:ems_infra)
+      host = FactoryGirl.create(:host, :ext_management_system => ems)
+      FactoryGirl.create(:vm_infra, :ext_management_system => ems, :host => host)
+      FactoryGirl.create(:vm_infra, :ext_management_system => ems, :host => host)
+
+      result = ExtManagementSystem.inventory_status
+      expect(result.size).to eq(2)
+      expect(result[0]).to eq(%w(region zone ems clusters hosts vms storages))
+      expect(result[1][3..-1]).to eq([0, 1, 2, 0])
+    end
+  end
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -505,8 +505,18 @@ describe ExtManagementSystem do
 
       result = ExtManagementSystem.inventory_status
       expect(result.size).to eq(2)
-      expect(result[0]).to eq(%w(region zone ems clusters hosts vms storages))
-      expect(result[1][3..-1]).to eq([0, 1, 2, 0])
+      expect(result[0]).to eq(%w(region zone kind ems hosts vms))
+      expect(result[1][4..-1]).to eq([1, 2])
+    end
+
+    it "works with container providers" do
+      ems = FactoryGirl.create(:ems_container)
+      FactoryGirl.create(:container, :ems_id => ems.id)
+      FactoryGirl.create(:container, :ems_id => ems.id)
+      result = ExtManagementSystem.inventory_status
+      expect(result.size).to eq(2)
+      expect(result[0]).to eq(%w(region zone kind ems containers))
+      expect(result[1][4..-1]).to eq([2])
     end
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -375,7 +375,6 @@ describe Host do
       host = FactoryGirl.create(:host)
       host.storages.create(FactoryGirl.attributes_for(:storage))
       expect(host.v_total_storages).to eq(1)
-      expect(Host.attribute_supported_by_sql?(:v_total_storages)).to be false
     end
   end
 


### PR DESCRIPTION
When support wants a quick snapshot of an installation, they just want to know
the general layout for regions, zones, and emses. The numbers for the size of the ems installations as well.

This adds the `evm:inventory` task to display the current inventory
This also fixed 2 virtual columns that were not executing in sql, but rather in ruby. storages_count is still an N+1 query.


```bash
rake evm:inventory

 region | zone           | kind            | ems                                 | clusters | hosts | vms | storages | containers
--------+----------------+-----------------+-------------------------------------+----------+-------+-----+----------+------------
      0 | Amazon Zone    | Amazon          | Amazon                              |          |       |  19 |          |
      0 | Amazon Zone    | Amazon          | Amazon Network Manager              |          |       |  19 |          |
      0 | Amazon Zone    | StorageManager  | Amazon EBS Storage Manager          |          |       |     |          |
      0 | Azure Zone     | Azure           | Azure (East US)                     |          |       |  68 |          |
      0 | Azure Zone     | Azure           | Azure (East US) Network Manager     |          |       |  68 |          |
      0 | Config Zone    | AnsibleTower    | Ansible Tower Automation Manager    |          |       |     |          |
      0 | Config Zone    | EmbeddedAnsible | Embedded Ansible Automation Manager |          |       |     |          |
      0 | Config Zone    | Foreman         | Satellite 6 Configuration Manager   |          |       |     |          |
      0 | Config Zone    | Foreman         | Satellite 6 Provisioning Manager    |          |       |     |          |
      0 | Config Zone    | Lenovo          | Lenovo xClarity                     |          |     6 | 118 |          |
      0 | Google Zone    | Google          | Google (Eastern US)                 |          |       |   3 |          |
      0 | Google Zone    | Google          | Google (Eastern US) Network Manager |          |       |   3 |          |
      0 | HyperV Zone    | Microsoft       | HyperV                              |          |     3 |   6 |        6 |
      0 | Nuage Zone     | Nuage           | Network Manager                     |          |       |     |          |
      0 | OpenShift Zone | Openshift       | OCP 3.6 QE                          |          |       |     |          | 22
      0 | OpenShift Zone | Openshift       | OpenShift 3.7                       |          |       |     |          | 76
      0 | OpenShift Zone | Openshift       | OpenShift 3.7 Monitoring Manager    |          |       |     |          |
      0 | OpenStack Zone | Openstack       | OpenStack                           |          |       |  20 |          |
      0 | OpenStack Zone | Openstack       | OpenStack Director                  |        2 |     3 |     |          |
      0 | OpenStack Zone | Openstack       | OpenStack Director Network Manager  |          |       |     |          |
      0 | OpenStack Zone | Openstack       | OpenStack Network Manager           |          |       |  20 |          |
      0 | OpenStack Zone | StorageManager  | OpenStack Cinder Manager            |          |       |     |          |
      0 | OpenStack Zone | StorageManager  | OpenStack Swift Manager             |          |       |     |          |
      0 | RHV Zone       | Redhat          | RHV                                 |        2 |     3 |  78 |        5 |
      0 | VMware Zone    | Vmware          | vCenter                             |        1 |     3 |  98 |        4 |
```