### PR TITLE
[WIP] Use config 1.7.0 to be able to reset values to nil.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "ancestry",                       "~>2.2.1",       :require => false
 gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"
-gem "config",                         "~>1.6.0",       :require => false
+gem "config",                         "~>1.7.0",       :require => false
 gem "dalli",                          "~>2.7.4",       :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -141,11 +141,11 @@
     :image_name: manageiq/embedded-ansible
     :image_tag: latest
     :service_account: miq-privileged
-:ems:
 # provider specific settings are nested here, but they are in the provider repos
 # e.g.:
-#  :ems_<provider_name>:
-#    :use_feature: false
+# :ems:
+#    :ems_<provider_name>:
+#      :use_feature: false
 :event_streams:
   :history:
     :keep_events: 6.months


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1444048

Note, we can't have keys with no values for keys that are overridden
in sub-settings.

When we merge in nils from different configuration sources, nils from
settings.yml or any source "later" in the chain will override existing
values with nil.

For example, if we have the sources below, anything near the end that
sets a key found in a prior yml to nil will override these values:

```
  #<Config::Sources.../gems/manageiq-providers-vmware-d8c04f7b07d7/config/settings/development.yml">
  #<Config::Sources.../gems/manageiq-providers-vmware-d8c04f7b07d7/config/environments/development.yml">
  #<Config::Sources.../gems/manageiq-automation_engine-2b8a271ad41d/config/settings.yml">
  #<Config::Sources.../gems/manageiq-automation_engine-2b8a271ad41d/config/settings/development.yml">
  #<Config::Sources.../gems/manageiq-automation_engine-2b8a271ad41d/config/environments/development.yml">
  #<Config::Sources.../gems/manageiq-api-f257e71ea7c7/config/settings.yml">
  #<Config::Sources.../gems/manageiq-api-f257e71ea7c7/config/settings/development.yml">
  #<Config::Sources.../gems/manageiq-api-f257e71ea7c7/config/environments/development.yml">
  #<Config::Sources.../gems/manageiq-graphql-334da8c9270b/config/settings.yml">
  #<Config::Sources.../gems/manageiq-graphql-334da8c9270b/config/settings/development.yml">
  #<Config::Sources.../gems/manageiq-graphql-334da8c9270b/config/environments/development.yml">
  #<Config::Sources.../gems/manageiq-content-684d7b1440dc/config/settings.yml">
  #<Config::Sources.../gems/manageiq-content-684d7b1440dc/config/settings/development.yml">
  #<Config::Sources.../gems/manageiq-content-684d7b1440dc/config/environments/development.yml">
  #<Config::Sources.../gems/manageiq-consumption-a833d356caec/config/settings.yml">
  #<Config::Sources.../gems/manageiq-consumption-a833d356caec/config/settings/development.yml">
  #<Config::Sources.../gems/manageiq-consumption-a833d356caec/config/environments/development.yml">
  #<Config::Sources.../gems/manageiq-ui-classic-4c51685f3095/config/settings.yml">
  #<Config::Sources.../gems/manageiq-ui-classic-4c51685f3095/config/settings/development.yml">
  #<Config::Sources.../ruby/2.4.3/bundler/gems/manageiq-ui-classic-4c51685f3095/config/environments/development.yml">
  #<Config::Sources.../manageiq/config/settings.yml">
```
