### PR TITLE
Bump manageiq-smartstate gem to 0.2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,7 +183,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.2.7",       :require => false
+  gem "manageiq-smartstate",            "~>0.2.8",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
In order to pick up https://github.com/ManageIQ/manageiq-smartstate/pull/52
bump the manageiq-smartstate gem in the Gemfile to 0.2.8

Describe the rationale and use case for this pull request.  Provide any background, examples, and images that provide further information to accurately describe what it is that you are adding to the repo.  Add subsections as necessary to organize and feel free to link and reference other PRs as necessary, but also include them in the links section below as a quick reference.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1519555

@roliveri @hsong-rh please review and merge.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1519555
* https://github.com/ManageIQ/manageiq-smartstate/pull/52

Steps for Testing/QA
-------------------------------

THis is a particularly difficult fix to test.  We happen to have one instance of this issue showing up in a customer location and we were able to test it onsite but it would be difficult to do so programatically.