### PR TITLE
Two small fixes to tools/miqssh

### DIFF
--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -5,7 +5,7 @@
 
 TAIL_NUMBER=3
 ALL_TAIL_NUMBER=999999999999999
-NAME=$(basename $(realpath $0))
+NAME=$(basename $0)
 DIR=$(dirname $0)
 miqhosts_cmd="$DIR/miqhosts.rb"
 miqhosts_file="$DIR/miqhosts"

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -495,7 +495,13 @@ then
       "miqssh") ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$ARGS" ;;
       "miqscp") ansible all -i $HOSTS -f $PARALLELISM -m copy -a "src=$1 dest=$2" ;;
       "miqcollect") ansible all -i $HOSTS -f $PARALLELISM -m fetch -a "src=$1 dest=$2/$(basename $1)-{{ inventory_hostname }} flat=yes" ;;
-      "miqgrep") ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP \"$PATTERN\" $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE ;;
+      "miqgrep")
+        if [ -n "$PATTERN" ]
+        then
+          ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP \"$PATTERN\" $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE
+        else
+          ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE
+        fi ;;
     esac
 
   else


### PR DESCRIPTION
Remove realpath for determining NAME in miqssh.  This was a poor attempt to allow aliases of old names.

Fix miqgrep when used with nogrep option and ansible transport.