### PR TITLE
Re-check the provider authentication if the API is responding

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -23,6 +23,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
   def do_work
     embedded_ansible.start if !embedded_ansible.alive? && !embedded_ansible.running?
+    provider.authentication_check if embedded_ansible.alive? && !provider.authentication_status_ok?
   end
 
   def before_exit(*_)
@@ -37,7 +38,6 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
 
   def update_embedded_ansible_provider
     server   = MiqServer.my_server(true)
-    provider = ManageIQ::Providers::EmbeddedAnsible::Provider.first_or_initialize
 
     provider.name = "Embedded Ansible"
     provider.zone = server.zone
@@ -64,6 +64,10 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def message_sync_config(*_args); end
 
   private
+
+  def provider
+    @provider ||= ManageIQ::Providers::EmbeddedAnsible::Provider.first_or_initialize
+  end
 
   def provider_url
     URI::Generic.build(provider_uri_hash).to_s


### PR DESCRIPTION
This fixes an issue where we hit a race condition when the ansible API is not ready yet, but is technically "alive".

Before we would see that it was alive, but would never re-check the credentials so we would never get refresh workers.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1539782