### PR TITLE
Eval value passed to configure_server settings

### DIFF
--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -32,7 +32,7 @@ key = keys.pop.to_sym
 keys.each { |p| path = path[p.to_sym] }
 
 puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{opts[:value]}]"
-path[key] = opts[:value]
+path[key] = eval(opts[:value])
 
 valid, errors = VMDB::Config::Validator.new(settings).validate
 unless valid


### PR DESCRIPTION
Currently configure_server_settings.rb stores value argument as strings. The problem is that not all settings can handled as string, for example:
`tools/configure_server_settings.rb -s 2 -p authentication/httpd_role -v false`
This will result in:
```
:authentication:
  :httpd_role: 'false'
```
ManageIQ will treat it as 'true'. Not to mention other cases, such as ingtegers and lists.

Using 'eval' command is quick and dirty solution, better option maybe will be parsing a json\yaml file to a dict and merge it to existing settings. Thoughts?