### PR TITLE
Rename network module to not overrun network class

### DIFF
--- a/lib/manageiq/network_discovery/discovery.rb
+++ b/lib/manageiq/network_discovery/discovery.rb
@@ -1,14 +1,14 @@
 require 'net/ping'
 
 module ManageIQ
-  module Network
+  module NetworkDiscovery
     module IPMI
-      autoload :Discovery, 'manageiq/network/ipmi/discovery'
+      autoload :Discovery, 'manageiq/network_discovery/ipmi/discovery'
     end
 
     module Discovery
       PROVIDERS_BY_TYPE = {
-        :ipmi            => "ManageIQ::Network::IPMI::Discovery",
+        :ipmi            => "ManageIQ::NetworkDiscovery::IPMI::Discovery",
         :msvirtualserver => "ManageIQ::Providers::Microsoft::Discovery",
         :mswin           => "ManageIQ::Providers::Microsoft::Discovery",
         :scvmm           => "ManageIQ::Providers::Microsoft::Discovery",

--- a/lib/manageiq/network_discovery/ipmi/discovery.rb
+++ b/lib/manageiq/network_discovery/ipmi/discovery.rb
@@ -1,7 +1,7 @@
 require 'util/miq-ipmi'
 
 module ManageIQ
-  module Network
+  module NetworkDiscovery
     module IPMI
       class Discovery
         def self.probe(ost)

--- a/lib/manageiq/network_discovery/port.rb
+++ b/lib/manageiq/network_discovery/port.rb
@@ -2,7 +2,7 @@ require 'timeout'
 require 'socket'
 
 module ManageIQ
-  module Network
+  module NetworkDiscovery
     class Port
       def self.all_open?(ost, ports)
         ports.all? { |port| open?(ost, port) }

--- a/spec/lib/network_discovery/discovery_spec.rb
+++ b/spec/lib/network_discovery/discovery_spec.rb
@@ -1,8 +1,8 @@
-require 'manageiq/network/discovery'
+require 'manageiq/network_discovery/discovery'
 require 'ostruct'
 require 'util/miq-ipmi'
 
-RSpec.describe ManageIQ::Network::Discovery do
+RSpec.describe ManageIQ::NetworkDiscovery::Discovery do
   context '#scan_host' do
     let(:ost) { OpenStruct.new(:discover_types => [:ipmi], :ipaddr => '127.0.0.1', :hypervisor => []) }
     it 'hypervisor is ipmi when available' do

--- a/spec/lib/network_discovery/port_spec.rb
+++ b/spec/lib/network_discovery/port_spec.rb
@@ -1,8 +1,8 @@
-require 'manageiq/network/discovery'
+require 'manageiq/network_discovery/discovery'
 require 'ostruct'
 require 'benchmark'
 
-RSpec.describe ManageIQ::Network::Port do
+RSpec.describe ManageIQ::NetworkDiscovery::Port do
   before do
     @ost = OpenStruct.new
     @ost.ipaddr = '172.16.254.1'


### PR DESCRIPTION
This addresses the concern [here](https://github.com/ManageIQ/manageiq/issues/16993) wherein  ManageIQ::Network is conflicting with ::Network...in particular on the has_many :networks relationship on ExtManagementSystem (or possibly ManageIQ::Providers::InfraManager, which strangely redefines has_many :networks), an issue which was created [here](https://github.com/ManageIQ/manageiq/pull/16916)