### PR TITLE
Fully qualify Network references

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -47,7 +47,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :vms,               :foreign_key => :ems_id, :inverse_of => :ext_management_system
   has_many :operating_systems, :through => :vms_and_templates
   has_many :hardwares,         :through => :vms_and_templates
-  has_many :networks,          :through => :hardwares
+  has_many :networks,          :through => :hardwares, :class_name => '::Network'
   has_many :disks,             :through => :hardwares
 
   has_many :storages,       -> { distinct },          :through => :hosts

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -5,7 +5,7 @@ class Hardware < ApplicationRecord
   belongs_to  :host
   belongs_to  :computer_system
 
-  has_many    :networks, :dependent => :destroy
+  has_many    :networks, :dependent => :destroy, :class_name => '::Network'
   has_many    :firmwares, :as => :resource, :dependent => :destroy
 
   has_many    :disks, -> { order(:location) }, :dependent => :destroy

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -51,7 +51,7 @@ class Host < ApplicationRecord
   has_many                  :switches, :through => :host_switches
   has_many                  :lans,     :through => :switches
   has_many                  :subnets,  :through => :lans
-  has_many                  :networks, :through => :hardware
+  has_many                  :networks, :through => :hardware, :class_name => '::Network'
   has_many                  :patches, :dependent => :destroy
   has_many                  :system_services, :dependent => :destroy
   has_many                  :host_services, :class_name => "SystemService", :foreign_key => "host_id", :inverse_of => :host

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -16,7 +16,7 @@ module ManageIQ::Providers
     has_many :switches, -> { distinct },  :through => :hosts
     has_many :lans, -> { distinct },      :through => :hosts
     has_many :subnets, -> { distinct },   :through => :lans
-    has_many :networks,                   :through => :hardwares
+    has_many :networks,                   :through => :hardwares, :class_name => '::Network'
     has_many :guest_devices,              :through => :hardwares
 
     class << model_name

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -82,7 +82,7 @@ module ScanningMixin
     # Find out what XML file document we are being passed.
     case xml_node.root.name
     when "miq"
-      for element_class in [OperatingSystem, Account, SystemService, GuestApplication, Patch, Network]
+      for element_class in [OperatingSystem, Account, SystemService, GuestApplication, Patch, ::Network]
         begin
           element_class.add_elements(self, xml_node)
           updated = true

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1617,7 +1617,7 @@ class VmOrTemplate < ApplicationRecord
   # Called from integrate ws to kick off scan for vdi VMs
   def self.vms_by_ipaddress(ipaddress)
     ipaddresses = ipaddress.split(',')
-    Network.where("ipaddress in (?)", ipaddresses).each do |network|
+    ::Network.where("ipaddress in (?)", ipaddresses).each do |network|
       begin
         vm = network.hardware.vm
         yield(vm)

--- a/spec/models/manager_refresh/persister/targeted_refresh_spec_helper.rb
+++ b/spec/models/manager_refresh/persister/targeted_refresh_spec_helper.rb
@@ -65,7 +65,7 @@ module TargetedRefreshSpecHelper
       :disk                          => Disk.count,
       :guest_device                  => GuestDevice.count,
       :hardware                      => Hardware.count,
-      :network                       => Network.count,
+      :network                       => ::Network.count,
       :operating_system              => OperatingSystem.count,
       :snapshot                      => Snapshot.count,
       :system_service                => SystemService.count,

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -783,7 +783,7 @@ describe ManagerRefresh::SaveInventory do
       :manager_ref => %i(hardware device_name)
     )
     @data[:networks] = ::ManagerRefresh::InventoryCollection.new(
-      :model_class => Network,
+      :model_class => ::Network,
       :parent      => @ems,
       :association => :networks,
       :manager_ref => %i(hardware description)


### PR DESCRIPTION
01c00c6 introduced a `ManageIQ::Network` module that has name
conflicts with `::Network`.

First reaction was to rename that module, but since there is also a
`Docker::Network`, and ui-classic has a `Network` mixin, it seems that
it will be a loosing battle.

This is fully qualifying the global to avoid some of the confusion.

reproduction:

```
ExtManagementSystem.all.map { |ems| ems.networks.count }
NoMethodError: undefined method `relation_delegate_class' for ManageIQ::Network:Module
# or
MiqExpression.build_relats(ManageIQ::Providers::InfraManager)
```

references:
- #16916 PR from @gildub that introduced the module /cc @bdunne 
- #16993 issue from @lpichler 
- #16994 Alternative implementation from @d-m-u 
- No BZ, this is a bug on master only