### PR TITLE
Rename new guest device pages

### DIFF
--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -15,6 +15,8 @@ class GuestDevice < ApplicationRecord
   has_many :firmwares, :dependent => :destroy
   has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
 
+  alias_attribute :name, :device_name
+
   def self.with_ethernet_type
     where(:device_type => "ethernet")
   end

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -14,4 +14,8 @@ class GuestDevice < ApplicationRecord
 
   has_many :firmwares, :dependent => :destroy
   has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
+
+  def self.with_ethernet_type
+    where(:device_type => "ethernet")
+  end
 end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -23,6 +23,7 @@ class PhysicalServer < ApplicationRecord
   has_one :hardware, :through => :computer_system
   has_one :host, :inverse_of => :physical_server
   has_one :asset_detail, :as => :resource, :dependent => :destroy
+  has_many :guest_devices, :through => :hardware
 
   scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
 

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -735,6 +735,7 @@ en:
       GenericObject:            Generic Object
       GenericObjectDefinition:  Generic Object Class
       GuestApplication:         Guest Application
+      GuestDevice:              Network Device
       Host:                     Host / Node
       HostPerformance:          Performance - Host
       IsoDatastore:             ISO Datastore


### PR DESCRIPTION
This PR renames the new guest device pages introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/3398 to network device pages. Also, a filter method was added to the guest device model for displaying only ethernet devices. In addition, the physical server model was updated with an association to guest devices.