### PR TITLE
Fix replication validation for not saved subscriptions

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -91,7 +91,7 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def validate(new_connection_params = {})
-    find_password
+    find_password if new_connection_params['password'].blank?
     connection_hash = attributes.merge(new_connection_params.delete_blanks)
     MiqRegionRemote.validate_connection_settings(connection_hash['host'],
                                                  connection_hash['port'],

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -406,6 +406,15 @@ describe PglogicalSubscription do
         .with("my.example.com", nil, "root", "thepassword", "vmdb_production")
       sub.validate
     end
+
+    it "validates connection parameters without accessing database or initializing subscription parameters" do
+      sub = described_class.new
+
+      expect(pglogical).not_to receive(:subscription_show_status)
+      expect(MiqRegionRemote).to receive(:validate_connection_settings)
+        .with("my.example.com", nil, "root", "mypass", "vmdb_production")
+      sub.validate('host' => "my.example.com", 'user' => "root", 'password' => "mypass", 'dbname' => "vmdb_production")
+    end
   end
 
   describe "#backlog" do


### PR DESCRIPTION
**Issue:**
While setting-up replication nodes on global region, validation throws errors if 'pglogical' schema not created first:
``/usr/local/lib/ruby/gems/2.3.0/gems/pg-pglogical-2.1.2/lib/pg/pglogical/client.rb:344:in `async_exec'
/usr/local/lib/ruby/gems/2.3.0/gems/pg-pglogical-2.1.2/lib/pg/pglogical/client.rb:344:in `typed_exec'
/usr/local/lib/ruby/gems/2.3.0/gems/pg-pglogical-2.1.2/lib/pg/pglogical/client.rb:228:in `subscription_show_status'
/var/www/miq/vmdb/app/models/pglogical_subscription.rb:211:in `find_password'
/var/www/miq/vmdb/app/models/pglogical_subscription.rb:94:in `validate'
/usr/local/lib/ruby/gems/2.3.0/bundler/gems/manageiq-ui-classic-02e1a7098b58/app/controllers/ops_controller/settings/common.rb:239:in `pglogical_validate_subscription'
``

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544911

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/36168707-fc328b9c-10c7-11e8-820c-35980e1a2a56.png)

@miq-bot add-label bug, replication, gaprindashvili/yes
