### PR TITLE
Handle group names with encoded special characters

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -120,7 +120,7 @@ module Authenticator
                     :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
                     :email     => request.headers['X-REMOTE-USER-EMAIL'],
                     :domain    => request.headers['X-REMOTE-USER-DOMAIN']}
-      [user_attrs, (CGI.unescape(request.headers['X-REMOTE-USER-GROUPS']) || '').split(/[;:,]/)]
+      [user_attrs, (CGI.unescape(request.headers['X-REMOTE-USER-GROUPS'] || '')).split(/[;:,]/)]
     end
 
     def user_attrs_from_external_directory(username)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -120,7 +120,7 @@ module Authenticator
                     :lastname  => request.headers['X-REMOTE-USER-LASTNAME'],
                     :email     => request.headers['X-REMOTE-USER-EMAIL'],
                     :domain    => request.headers['X-REMOTE-USER-DOMAIN']}
-      [user_attrs, (request.headers['X-REMOTE-USER-GROUPS'] || '').split(/[;:,]/)]
+      [user_attrs, (CGI.unescape(request.headers['X-REMOTE-USER-GROUPS']) || '').split(/[;:,]/)]
     end
 
     def user_attrs_from_external_directory(username)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -570,6 +570,34 @@ describe Authenticator::Httpd do
           authenticate
         end
       end
+
+      context "when there are no group names" do
+        let(:config) { {:httpd_role => true} }
+        let(:headers) do
+          {
+            'X-Remote-User'           => username,
+            'X-Remote-User-FullName'  => 'Test User',
+            'X-Remote-User-FirstName' => 'Alice',
+            'X-Remote-User-LastName'  => 'Aardvark',
+            'X-Remote-User-Email'     => 'testuser@example.com',
+            'X-Remote-User-Domain'    => 'example.com',
+            'X-Remote-User-Groups'    => nil,
+          }
+        end
+        let(:user_attrs) do
+          { :username  => "testuser",
+            :fullname  => "Test User",
+            :firstname => "Alice",
+            :lastname  => "Aardvark",
+            :email     => "testuser@example.com",
+            :domain    => "example.com" }
+        end
+
+        it "handles nil group names" do
+          expect(subject).to receive(:find_external_identity).with(username, user_attrs, [])
+          authenticate
+        end
+      end
     end
   end
 end

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -550,6 +550,26 @@ describe Authenticator::Httpd do
           authenticate
         end
       end
+
+      context "when group names have escaped special characters" do
+        let(:config) { {:httpd_role => true} }
+        let(:headers) do
+          super().merge('X-Remote-User-Groups' => CGI.escape('spécial_char@fqdn:moré@fqdn'))
+        end
+        let(:user_attrs) do
+          { :username  => "testuser",
+            :fullname  => "Test User",
+            :firstname => "Alice",
+            :lastname  => "Aardvark",
+            :email     => "testuser@example.com",
+            :domain    => "example.com" }
+        end
+
+        it "handles group names with escaped special characters" do
+          expect(subject).to receive(:find_external_identity).with(username, user_attrs, ["spécial_char@fqdn", "moré@fqdn"])
+          authenticate
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1469589

Group names in the headers at index X-REMOTE-USER-GROUPS need to
be decoded in order to handle special characters.

Steps for Testing/QA
-------------------------------

1. Configure appliance to use SAML or other external auth.
2. Create user who has a custom group like "SR-APP-EPM-Membre-équipe"
3. Add custom group to MiQ and assign role.
4. log in with user.
