### PR TITLE
Moves NetworkDiscovery:IPMI to Util::IPMI

### DIFF
--- a/lib/manageiq/network_discovery/discovery.rb
+++ b/lib/manageiq/network_discovery/discovery.rb
@@ -2,13 +2,9 @@ require 'net/ping'
 
 module ManageIQ
   module NetworkDiscovery
-    module IPMI
-      autoload :Discovery, 'manageiq/network_discovery/ipmi/discovery'
-    end
-
     module Discovery
       PROVIDERS_BY_TYPE = {
-        :ipmi            => "ManageIQ::NetworkDiscovery::IPMI::Discovery",
+        :ipmi            => "ManageIQ::Util::IPMI::Discovery",
         :msvirtualserver => "ManageIQ::Providers::Microsoft::Discovery",
         :mswin           => "ManageIQ::Providers::Microsoft::Discovery",
         :scvmm           => "ManageIQ::Providers::Microsoft::Discovery",

--- a/lib/manageiq/util/ipmi/discovery.rb
+++ b/lib/manageiq/util/ipmi/discovery.rb
@@ -1,7 +1,7 @@
 require 'util/miq-ipmi'
 
 module ManageIQ
-  module NetworkDiscovery
+  module Util
     module IPMI
       class Discovery
         def self.probe(ost)


### PR DESCRIPTION
This moves IPMI discovery probe from the core discovery code. All the probes have been move to their respective providers as https://github.com/ManageIQ/manageiq-network_discovery/issues/8
Meanwhile IPMI doesn't have a per say providers the best place is to belong to existing Util::IPMI class as used by 'util/miq-ipmi.rb' in 'manageiq-gems-pending`.