### PR TITLE
Adding classifications for V2V

### DIFF
--- a/db/fixtures/classifications.yml
+++ b/db/fixtures/classifications.yml
@@ -1022,3 +1022,51 @@
   :parent_id: 0
   :default: true
   :single_value: "1"
+- :description: V2V - Transformation Host
+  :entries:
+  - :description: True
+    :read_only: "0"
+    :syntax: string
+    :name: "true"
+    :example_text:
+    :default: true
+    :single_value: "1"
+  - :description: False
+    :read_only: "0"
+    :syntax: string
+    :name: "false"
+    :example_text:
+    :default: true
+    :single_value: "1"
+  :read_only: "0"
+  :syntax: string
+  :show: true
+  :name: v2v_transformation_host
+  :example_text: Transformation Host role enabled for V2V.
+  :parent_id: 0
+  :default: true
+  :single_value: "1"
+- :description: V2V - Transformation Method
+  :entries:
+  - :description: VDDK
+    :read_only: "0"
+    :syntax: string
+    :name: vddk
+    :example_text:
+    :default: true
+    :single_value: "1"
+  - :description: SSH
+    :read_only: "0"
+    :syntax: string
+    :name: ssh
+    :example_text:
+    :default: true
+    :single_value: "1"
+  :read_only: "0"
+  :syntax: string
+  :show: true
+  :name: v2v_transformation_method
+  :example_text: Transformation methods supported for V2V.
+  :parent_id: 0
+  :default: true
+  :single_value: "0"


### PR DESCRIPTION
When transforming a VM from on provider to another, we configure some machines as transformation hosts. This consists in installing some mandatory packages, such as virt-v2v, nbdkit-plugin-vddk, etc..., as well as creating some filesystem tree where the transformation temporary files will be stored. This is done using Ansible playbooks and on enablement / disablement, we set tags on the transformation hosts.

Currently, we use two tags:
 - `v2v_transformation_host` that is a boolean to identify the machine as a transformation host
 - `v2v_transformation_method` that is a multi-value tag to store the available transformation methods on this host, i.e. the ones deployed via the playbook.
