### PR TITLE
Fix automate specs after MulticastLogger changes

### DIFF
--- a/spec/support/workflow_spec_helper.rb
+++ b/spec/support/workflow_spec_helper.rb
@@ -40,9 +40,10 @@ module Spec
       end
 
       def stub_automate_workspace(url, user, *result)
-        workspace_stub = double
+        workspace_stub = double("Double for #stub_automate_workspace")
         expect(workspace_stub).to receive(:instantiate).with(url, user, nil)
         expect(workspace_stub).to receive(:root).and_return(*result)
+        allow(workspace_stub).to  receive(:to_expanded_xml).and_return(*result)
         expect(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:new).and_return(workspace_stub)
       end
     end


### PR DESCRIPTION
Specs that used `stub_automate_workspace` would fail no because, previously, the calls to `resolve_automation_object`:

```ruby
def self.resolve_automation_object(uri, user_obj, attr = nil, options = {}, readonly = false)
  raise "User object not passed in" unless user_obj.kind_of?(User)
  uri = create_automation_object(uri, attr, options) if attr
  options[:uri] = uri
  MiqAeWorkspaceRuntime.instantiate(uri, user_obj, :readonly => readonly).tap do |ws|
    $miq_ae_logger.debug { ws.to_expanded_xml }
  end
end
```

Would trigger the `$miq_ae_logger.debug` line and just no-op, because the underlying logger would be set to info.

This change allows the `double` that is instantiated in `stub_automate_workspace` to also receive `#to_expanded_xml` optionally, so that line won't cause failures.


Links
-----

* PR exposing the issue:  https://github.com/ManageIQ/manageiq/pull/16990
* PR with an example of the issue:  https://github.com/ManageIQ/manageiq-providers-amazon/pull/410


Steps for Testing/QA
--------------------

This probably needs to be merged into master to allow https://github.com/ManageIQ/manageiq-providers-amazon/pull/410 to pass and be a proper QA, but you can check out that branches' changes by doing the following:

```console
$ cd /path/to/manageiq-providers-amazon
$ git apply <(curl -L https://github.com/ManageIQ/manageiq-providers-amazon/pull/410.patch)
```

And then update the manageiq spec helper by doing the following

```console
$ cd spec/manageiq
$ git apply <(curl -L https://github.com/ManageIQ/manageiq/pull/17001.patch)
```