### PR TITLE
Add miq_product_features to miq_group

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -13,6 +13,7 @@ class MiqGroup < ApplicationRecord
   has_many   :miq_report_results, :dependent => :nullify
   has_many   :miq_widget_contents, :dependent => :destroy
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
+  has_many   :miq_product_features, :through => :miq_user_role
 
   virtual_column :miq_user_role_name, :type => :string,  :uses => :miq_user_role
   virtual_column :read_only,          :type => :boolean


### PR DESCRIPTION
This adds `miq_product_features` to `miq_group`. This is needed for both https://github.com/ManageIQ/manageiq-api/pull/311 as well as to expose the miq_groups via the api such as `/api/groups/:id?attributes=miq_product_features`

@miq-bot assign @gtanzillo 
cc: @abellotti 