### PR TITLE
Update gettext_i18n_rails_js to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"
-gem "gettext_i18n_rails_js",          "~>1.1.0"
+gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.7.0"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false


### PR DESCRIPTION
This version supports extracting gettext strings from both `.js` and `.jsx` files (needed for v2v).