### PR TITLE
Add hostname to Vm

### DIFF
--- a/db/migrate/20180215131608_add_hostname_to_vm.rb
+++ b/db/migrate/20180215131608_add_hostname_to_vm.rb
@@ -1,0 +1,5 @@
+class AddHostnameToVm < ActiveRecord::Migration[5.0]
+  def change
+    add_column :vms, :hostname, :string
+  end
+end


### PR DESCRIPTION
This migration adds attribute `hostname` to `Vm`. For example
virtual machine in Vmware provider has attribute computer name
and now we will be able to render it into hostname.