### PR TITLE
Add sui_product_features method to miq_group

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -17,6 +17,7 @@ class MiqGroup < ApplicationRecord
 
   virtual_column :miq_user_role_name, :type => :string,  :uses => :miq_user_role
   virtual_column :read_only,          :type => :boolean
+  virtual_has_one :sui_product_features, :class_name => "Array"
 
   delegate :self_service?, :limited_self_service?, :disallowed_roles, :to => :miq_user_role, :allow_nil => true
 
@@ -259,6 +260,13 @@ class MiqGroup < ApplicationRecord
     group_user_ids = user_ids
     return false if group_user_ids.empty?
     users.includes(:miq_groups).where(:id => group_user_ids).where.not(:miq_groups => {:id => id}).count != group_user_ids.size
+  end
+
+  def sui_product_features
+    return [] unless miq_user_role.allows?(:identifier => 'sui')
+    MiqProductFeature.feature_all_children('sui').each_with_object([]) do |sui_feature, sui_features|
+      sui_features << sui_feature if miq_user_role.allows?(:identifier => sui_feature)
+    end
   end
 
   private

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -546,4 +546,28 @@ describe MiqGroup do
       expect(User.find_by(:id => user2).current_group.id).to eq(testgroup3.id)
     end
   end
+
+  describe "#sui_product_features" do
+    let(:role) { double }
+
+    before do
+      allow(subject).to receive(:miq_user_role).and_return(role)
+    end
+
+    it "Returns an empty array for roles without sui support" do
+      allow(role).to receive(:allows?).with(:identifier => 'sui').and_return(false)
+
+      expect(subject.sui_product_features).to be_empty
+    end
+
+    it "Returns the expected sui roles" do
+      allow(MiqProductFeature).to receive(:feature_all_children).with('sui').and_return(%w(sui_role_a sui_role_b sui_role_c))
+      %w(sui sui_role_a sui_role_c).each do |ident|
+        allow(role).to receive(:allows?).with(:identifier => ident).and_return(true)
+      end
+      allow(role).to receive(:allows?).with(:identifier => 'sui_role_b').and_return(false)
+
+      expect(subject.sui_product_features).to eq(%w(sui_role_a sui_role_c))
+    end
+  end
 end


### PR DESCRIPTION
The SUI needs the ability to see what SUI product features are available to the user before changing groups. (Needed for https://github.com/ManageIQ/manageiq-api/pull/311 / https://bugzilla.redhat.com/show_bug.cgi?id=1540733). This adds it as a virtual attribute.

Returning *all* product features can result in very large payloads (2MB) depending on how many groups a user belongs to. This reduces that size by only returning the feature identifiers specifically for the SUI.

@miq-bot assign @gtanzillo 
cc: @abellotti 
