### PR TITLE
Fix errors in help message

### DIFF
--- a/spec/tools/miqldap_to_sssd/cli_spec.rb
+++ b/spec/tools/miqldap_to_sssd/cli_spec.rb
@@ -4,7 +4,7 @@ require "miqldap_to_sssd/cli"
 
 describe MiqLdapToSssd::Cli do
   before do
-    @all_options = :tls_cacert, :tls_cacertdir, :basedn_domain, :only_change_userids, :skip_post_coversion_userid_change
+    @all_options = :tls_cacert, :tls_cacertdir, :domain, :only_change_userids, :skip_post_conversion_userid_change
     stub_const("LOGGER", double)
     allow(LOGGER).to receive(:debug)
   end
@@ -12,12 +12,12 @@ describe MiqLdapToSssd::Cli do
   describe "#parse" do
     it "should assign defaults" do
       opts = described_class.new.parse([]).options.slice(*@all_options)
-      expect(opts).to eq(:only_change_userids => false, :skip_post_coversion_userid_change => false)
+      expect(opts).to eq(:only_change_userids => false, :skip_post_conversion_userid_change => false)
     end
 
     it "should parse base DN domain names" do
-      opts = described_class.new.parse(%w(-d example.com)).options.slice(:basedn_domain)
-      expect(opts).to eq(:basedn_domain => "example.com")
+      opts = described_class.new.parse(%w(-d example.com)).options.slice(:domain)
+      expect(opts).to eq(:domain => "example.com")
     end
 
     it "should parse bind DN" do
@@ -37,12 +37,12 @@ describe MiqLdapToSssd::Cli do
 
     it "can only updating the userids" do
       opts = described_class.new.parse(%w(-n)).options.slice(*@all_options)
-      expect(opts).to eq(:only_change_userids => true, :skip_post_coversion_userid_change => false)
+      expect(opts).to eq(:only_change_userids => true, :skip_post_conversion_userid_change => false)
     end
 
     it "can skip updating the userids after the conversion" do
       opts = described_class.new.parse(%w(-s)).options.slice(*@all_options)
-      expect(opts).to eq(:only_change_userids => false, :skip_post_coversion_userid_change => true)
+      expect(opts).to eq(:only_change_userids => false, :skip_post_conversion_userid_change => true)
     end
   end
 end

--- a/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_apache_spec.rb
@@ -39,7 +39,7 @@ describe MiqLdapToSssd::ConfigureApache do
     end
 
     before do
-      @initial_settings = {:basedn_domain => "bob.your.uncle.com"}
+      @initial_settings = {:domain => "bob.your.uncle.com"}
 
       @test_dir = "#{Dir.tmpdir}/#{@spec_name}"
       @template_dir = "#{@test_dir}/TEMPLATE"

--- a/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
+++ b/spec/tools/miqldap_to_sssd/miqldap_configuration_spec.rb
@@ -4,11 +4,11 @@ require "miqldap_to_sssd"
 
 describe MiqLdapToSssd::MiqLdapConfiguration do
   describe '#retrieve_initial_settings' do
-    let(:settings) { {:tls_cacert => 'cert', :basedn_domain => "example.com"} }
+    let(:settings) { {:tls_cacert => 'cert', :domain => "example.com"} }
 
     it 'raises an error when the basedn domain can not be determined' do
       expect(MiqLdapToSssd::LOGGER).to receive(:fatal)
-      subject = described_class.new(settings.merge(:basedn => nil, :basedn_domain => nil))
+      subject = described_class.new(settings.merge(:basedn => nil, :domain => nil))
       expect { subject.retrieve_initial_settings }.to raise_error(MiqLdapToSssd::MiqLdapConfigurationArgumentError)
     end
 
@@ -36,14 +36,14 @@ describe MiqLdapToSssd::MiqLdapConfiguration do
       expect { subject.retrieve_initial_settings }.to_not raise_error
     end
 
-    it 'does not modify basedn_domain if provided' do
-      subject = described_class.new(settings.merge(:basedn_domain => "example.com"))
-      expect(subject.retrieve_initial_settings[:basedn_domain]).to eq("example.com")
+    it 'does not modify domain if provided' do
+      subject = described_class.new(settings.merge(:domain => "example.com"))
+      expect(subject.retrieve_initial_settings[:domain]).to eq("example.com")
     end
 
-    it 'sets basedn_domain from mixed case basedn' do
+    it 'sets domain from mixed case basedn' do
       subject = described_class.new(settings.merge(:basedn => "CN=Users,DC=Example,DC=COM"))
-      expect(subject.retrieve_initial_settings[:basedn_domain]).to eq("example.com")
+      expect(subject.retrieve_initial_settings[:domain]).to eq("example.com")
     end
   end
 end

--- a/tools/miqldap_to_sssd/cli.rb
+++ b/tools/miqldap_to_sssd/cli.rb
@@ -12,8 +12,8 @@ module MiqLdapToSssd
       self.options = Trollop.options(args) do
         banner "Usage: ruby #{$PROGRAM_NAME} [options]\n"
 
-        opt :basedn_domain,
-            "The Base DN domain name, e.g. example.com",
+        opt :domain,
+            "The domain name for the Base DN, e.g. example.com",
             :short   => "d",
             :default => nil,
             :type    => :string
@@ -25,7 +25,7 @@ module MiqLdapToSssd
             :type    => :string
 
         opt :bind_pwd,
-            "The Base DN domain name, e.g. example.com",
+            "The password for the Bind DN.",
             :short   => "p",
             :default => nil,
             :type    => :string
@@ -42,7 +42,7 @@ module MiqLdapToSssd
             :default => false,
             :type    => :flag
 
-        opt :skip_post_coversion_userid_change,
+        opt :skip_post_conversion_userid_change,
             "Do the MiqLdap to SSSD conversion but skip the normalizing of the userids",
             :short   => "s",
             :default => false,

--- a/tools/miqldap_to_sssd/configure_apache.rb
+++ b/tools/miqldap_to_sssd/configure_apache.rb
@@ -43,7 +43,7 @@ module MiqLdapToSssd
 
       begin
         miq_ext_auth = File.read("#{HTTPD_CONF_DIR}/manageiq-external-auth.conf")
-        miq_ext_auth[/(\s*)KrbAuthRealms(\s*)(.*)/, 3] = initial_settings[:basedn_domain]
+        miq_ext_auth[/(\s*)KrbAuthRealms(\s*)(.*)/, 3] = initial_settings[:domain]
         File.write("#{HTTPD_CONF_DIR}/manageiq-external-auth.conf", miq_ext_auth)
       rescue Errno::ENOENT, IndexError => err
         LOGGER.fatal(err.message)

--- a/tools/miqldap_to_sssd/converter.rb
+++ b/tools/miqldap_to_sssd/converter.rb
@@ -19,7 +19,7 @@ module MiqLdapToSssd
       LOGGER.debug("Running #{$PROGRAM_NAME}")
 
       do_conversion unless initial_settings[:only_change_userids]
-      ConfigureDatabase.new.change_userids_to_upn unless initial_settings[:skip_post_coversion_userid_change]
+      ConfigureDatabase.new.change_userids_to_upn unless initial_settings[:skip_post_conversion_userid_change]
 
       Services.restart
 

--- a/tools/miqldap_to_sssd/miqldap_configuration.rb
+++ b/tools/miqldap_to_sssd/miqldap_configuration.rb
@@ -27,8 +27,8 @@ module MiqLdapToSssd
 
     private
 
-    def check_for_basedn_domain
-      if initial_settings[:basedn_domain].nil? && initial_settings[:basedn].nil?
+    def check_for_domain
+      if initial_settings[:domain].nil? && initial_settings[:basedn].nil?
         LOGGER.fatal(NO_BASE_DN_DOMAIN)
         raise MiqLdapConfigurationArgumentError, NO_BASE_DN_DOMAIN
       end
@@ -65,11 +65,11 @@ module MiqLdapToSssd
     end
 
     def derive_domain
-      check_for_basedn_domain
+      check_for_domain
 
       # If the caller did not provide a base DN domain name derive it from the configured Base DN.
-      if initial_settings[:basedn_domain].nil?
-        initial_settings[:basedn_domain] = initial_settings[:basedn].downcase.split(",").collect do |p|
+      if initial_settings[:domain].nil?
+        initial_settings[:domain] = initial_settings[:basedn].downcase.split(",").collect do |p|
           p.split('dc=')[1]
         end.compact.join('.')
       end

--- a/tools/miqldap_to_sssd/sssd_conf.rb
+++ b/tools/miqldap_to_sssd/sssd_conf.rb
@@ -37,8 +37,8 @@ module MiqLdapToSssd
       File.open(SSSD_CONF_FILE, "w") do |f|
         sssd_conf_contents.each do |section, values|
           if section == :domain
-            f.write("\n[domain/#{initial_settings[:basedn_domain]}]\n")
-            f.write("\n[application/#{initial_settings[:basedn_domain]}]\n")
+            f.write("\n[domain/#{initial_settings[:domain]}]\n")
+            f.write("\n[application/#{initial_settings[:domain]}]\n")
           else
             f.write("\n[#{section}]\n")
           end

--- a/tools/miqldap_to_sssd/sssd_conf/sssd.rb
+++ b/tools/miqldap_to_sssd/sssd_conf/sssd.rb
@@ -15,11 +15,11 @@ module MiqLdapToSssd
     end
 
     def default_domain_suffix
-      initial_settings[:basedn_domain]
+      initial_settings[:domain]
     end
 
     def domains
-      initial_settings[:basedn_domain]
+      initial_settings[:domain]
     end
 
     def sbus_timeout


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1545861

The help message for miqldap_to_sssd had three issue that this PR addresses.

Update bind-pwd description in help message
Change basedn-domain to domain
Fix spelling error coversion to conversion for skip-post-conversion-userid-change


Steps for Testing/QA 
-------------------------------
Simply run `miqldap_to_sssd --help` the output should look like the following:

```
miq> miqldap_to_sssd --help
Usage: ruby tools/miqldap_to_sssd.rb [options]
  -d, --domain=<s>                           The domain name for the Base DN, e.g. example.com
  -b, --bind-dn=<s>                          The Bind DN, credential to use to authenticate against LDAP e.g.
                                             cn=Manager,dc=example,dc=com
  -p, --bind-pwd=<s>                         The password for the Bind DN.
  -c, --tls-cacert=<s>                       Path to certificate file
  -n, --only-change-userids                  normalize the userids then exit
  -s, --skip-post-coversion-userid-change    Do the MiqLdap to SSSD conversion but skip the normalizing of the userids
  -h, --help                                 Show this message

```