### PR TITLE
Add InventoryObject interface automatically

### DIFF
--- a/app/models/manager_refresh/inventory_object.rb
+++ b/app/models/manager_refresh/inventory_object.rb
@@ -151,6 +151,48 @@ module ManagerRefresh
 
     private
 
+    def allowed_writers
+      return [] unless model_class
+
+      # Get all writers of a model
+      @allowed_writers ||= (model_class.new.methods - Object.methods).grep(/^[\w]+?\=$/)
+    end
+
+    def allowed_readers
+      return [] unless model_class
+
+      # Get all readers inferred from writers of a model
+      @allowed_readers ||= allowed_writers.map { |x| x.to_s.delete("=").to_sym }
+    end
+
+    def method_missing(method_name, *arguments, &block)
+      if allowed_writers.include?(method_name)
+        self.class.define_data_writer(method_name)
+        public_send(method_name, arguments[0])
+      elsif allowed_readers.include?(method_name)
+        self.class.define_data_reader(method_name)
+        public_send(method_name)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, _include_private = false)
+      allowed_writers.include?(method_name) || allowed_readers.include?(method_name) || super
+    end
+
+    def self.define_data_writer(data_key)
+      define_method(data_key) do |value|
+        public_send(:[]=, data_key.to_s.delete("=").to_sym, value)
+      end
+    end
+
+    def self.define_data_reader(data_key)
+      define_method(data_key) do
+        public_send(:[], data_key)
+      end
+    end
+
     def association?(inventory_collection_scope, key)
       # Is the key an association on inventory_collection_scope model class?
       !inventory_collection_scope.association_to_foreign_key_mapping[key].nil?


### PR DESCRIPTION
Add InventoryObject interface automatically, without need to
specify it in :inventory_object_attributes