### PR TITLE
Adding request id to evm log

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -138,6 +138,10 @@ class MiqRequest < ApplicationRecord
     self.class.name
   end
 
+  def tracking_label_id
+    "r#{id}_#{self.class.name.underscore}_#{id}"
+  end
+
   def initialize_attributes
     self.approval_state ||= "pending_approval"
     miq_approvals << build_default_approval if miq_approvals.empty?
@@ -397,7 +401,7 @@ class MiqRequest < ApplicationRecord
       :method_name    => "create_request_tasks",
       :zone           => options.fetch(:miq_zone, my_zone),
       :role           => my_role,
-      :tracking_label => "#{self.class.name.underscore}_#{id}",
+      :tracking_label => tracking_label_id,
       :msg_timeout    => 3600,
       :deliver_on     => deliver_on
     )

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -146,7 +146,7 @@ class MiqRequestTask < ApplicationRecord
         :args           => [args],
         :role           => 'automate',
         :zone           => options.fetch(:miq_zone, zone),
-        :tracking_label => my_task_id,
+        :tracking_label => tracking_label_id,
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else
@@ -172,7 +172,7 @@ class MiqRequestTask < ApplicationRecord
       :method_name    => "execute",
       :zone           => options.fetch(:miq_zone, zone),
       :role           => miq_request.my_role,
-      :tracking_label => my_task_id,
+      :tracking_label => tracking_label_id,
       :deliver_on     => deliver_on,
       :miq_callback   => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )

--- a/app/models/miq_request_task/post_install_callback.rb
+++ b/app/models/miq_request_task/post_install_callback.rb
@@ -25,7 +25,7 @@ module MiqRequestTask::PostInstallCallback
       :method_name    => 'provision_completed',
       :zone           => my_zone,
       :role           => my_role,
-      :tracking_label => my_task_id,
+      :tracking_label => tracking_label_id,
     )
   end
 

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -3,7 +3,7 @@ module MiqRequestTask::StateMachine
   delegate :my_zone, :to => :source,      :allow_nil => true
 
   def my_task_id
-    "#{self.class.base_model.name.underscore}_#{id}"
+    "#{miq_request_id}_#{self.class.base_model.name.underscore}_#{id}"
   end
 
   def signal_abort

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -2,8 +2,8 @@ module MiqRequestTask::StateMachine
   delegate :my_role, :to => :miq_request
   delegate :my_zone, :to => :source,      :allow_nil => true
 
-  def my_task_id
-    "#{miq_request_id}_#{self.class.base_model.name.underscore}_#{id}"
+  def tracking_label_id
+    "r#{miq_request_id}_#{self.class.base_model.name.underscore}_#{id}"
   end
 
   def signal_abort
@@ -56,7 +56,7 @@ module MiqRequestTask::StateMachine
       :args           => args,
       :zone           => my_zone,
       :role           => my_role,
-      :tracking_label => my_task_id,
+      :tracking_label => tracking_label_id,
     )
   end
 
@@ -77,7 +77,7 @@ module MiqRequestTask::StateMachine
       :deliver_on     => 10.seconds.from_now.utc,
       :zone           => my_zone,
       :role           => my_role,
-      :tracking_label => my_task_id,
+      :tracking_label => tracking_label_id,
       :miq_callback => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )
   end

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -43,7 +43,7 @@ class ServiceReconfigureTask < MiqRequestTask
         :args           => [args],
         :role           => 'automate',
         :zone           => zone,
-        :tracking_label => "#{self.class.name.underscore}_#{id}"
+        :tracking_label => my_task_id
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else

--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -43,7 +43,7 @@ class ServiceReconfigureTask < MiqRequestTask
         :args           => [args],
         :role           => 'automate',
         :zone           => zone,
-        :tracking_label => my_task_id
+        :tracking_label => tracking_label_id
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -98,7 +98,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
       :instance_id    => id,
       :method_name    => "do_post_provision",
       :deliver_on     => 1.minutes.from_now.utc,
-      :tracking_label => "#{self.class.name.underscore}_#{id}",
+      :tracking_label => my_task_id,
       :miq_callback   => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )
   end
@@ -150,7 +150,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
         :args           => [args],
         :role           => 'automate',
         :zone           => options.fetch(:miq_zone, zone),
-        :tracking_label => "#{self.class.name.underscore}_#{id}"
+        :tracking_label => my_task_id
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -98,7 +98,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
       :instance_id    => id,
       :method_name    => "do_post_provision",
       :deliver_on     => 1.minutes.from_now.utc,
-      :tracking_label => my_task_id,
+      :tracking_label => tracking_label_id,
       :miq_callback   => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )
   end
@@ -150,7 +150,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
         :args           => [args],
         :role           => 'automate',
         :zone           => options.fetch(:miq_zone, zone),
-        :tracking_label => my_task_id
+        :tracking_label => tracking_label_id
       )
       update_and_notify_parent(:state => "pending", :status => "Ok",  :message => "Automation Starting")
     else

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -88,7 +88,8 @@ describe ServiceReconfigureTask do
           :args           => [automate_args],
           :role           => 'automate',
           :zone           => nil,
-          :tracking_label => "service_reconfigure_task_#{task.id}")
+          :tracking_label => "r#{request.id}_service_reconfigure_task_#{task.id}"
+        )
         task.deliver_to_automate
       end
 

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -25,6 +25,8 @@ describe ServiceTemplateProvisionTask do
       @task_3.miq_request_task   =  @task_0
     end
 
+    let(:tracking_label) { "r#{@request.id}_service_template_provision_task_#{@task_0.id}" }
+
     def create_stp(description, state = 'pending', prov_index = nil, scaling_max = nil)
       if prov_index && scaling_max
         options = {:service_resource_id => service_resource_id(prov_index, scaling_max)}
@@ -100,7 +102,8 @@ describe ServiceTemplateProvisionTask do
           :args           => [automate_args],
           :role           => 'automate',
           :zone           => 'special',
-          :tracking_label => "service_template_provision_task_#{@task_0.id}")
+          :tracking_label => tracking_label
+        )
         @task_0.deliver_to_automate
       end
 
@@ -126,7 +129,7 @@ describe ServiceTemplateProvisionTask do
           :method_name    => 'execute',
           :role           => 'ems_operations',
           :zone           => 'a_zone',
-          :tracking_label => "service_template_provision_task_#{@task_0.id}",
+          :tracking_label => tracking_label,
           :deliver_on     => nil,
           :miq_callback   => miq_callback)
         @task_0.execute_queue


### PR DESCRIPTION
We are adding the letter `r` plus `request_id` as a prefix of `tracking_label`. With this change we are able to find all related tasks in the log by a single request_id.

## Logs:
**before:**
![screenshot from 2018-03-28 05-51-11](https://user-images.githubusercontent.com/19405716/38007947-57109522-324c-11e8-96e1-320187e5efd1.png)
![screenshot from 2018-03-28 05-51-29](https://user-images.githubusercontent.com/19405716/38007950-5bf85d18-324c-11e8-9f85-684af3fa8bbe.png)

**after:**
![screenshot from 2018-03-28 04-59-27](https://user-images.githubusercontent.com/19405716/38006376-133612a2-3245-11e8-9c08-07d96a3989bd.png)
![screenshot from 2018-03-28 04-59-45](https://user-images.githubusercontent.com/19405716/38006380-1746ae06-3245-11e8-8a4e-a0ab14a4d4f0.png)
**filter command:** grep "Q-task_id(\\[.*\\])" log/evm.log


