### PR TITLE
Display thresholds in evm_status for workers

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -94,7 +94,7 @@ class EvmApplication
     data = []
     servers.each do |s|
       mb_usage = w.proportional_set_size || w.memory_usage
-      mb_threshold =  w.worker_settings[:memory_threshold]
+      mb_threshold = w.worker_settings[:memory_threshold]
       s.miq_workers.order(:type).each do |w|
         data <<
           [w.type,

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -93,6 +93,8 @@ class EvmApplication
   def self.output_workers_status(servers)
     data = []
     servers.each do |s|
+      mb_usage = w.proportional_set_size || w.memory_usage
+      mb_threshold =  w.worker_settings[:memory_threshold]
       s.miq_workers.order(:type).each do |w|
         data <<
           [w.type,
@@ -104,7 +106,7 @@ class EvmApplication
            w.queue_name || w.uri,
            w.started_on && w.started_on.iso8601,
            w.last_heartbeat && w.last_heartbeat.iso8601,
-           (mem = (w.unique_set_size || w.memory_usage)).nil? ? "" : mem / 1.megabyte]
+           mb_usage ? "#{mb_usage / 1.megabyte}/#{mb_threshold / 1.megabyte}" : ""]
       end
     end
 


### PR DESCRIPTION
`rake evm:status_full` displays process data

This displays the threshold, so problems can be quickly identified

new output:
please look at the last column

 Worker Type                  | Status  |   ID |   PID | SPID  | Server id | Queue Name / URL      | Started On           | Last Heartbeat       | MB Usage
------------------------------|---------|------|-------|-------|-----------|-----------------------|----------------------|----------------------|----------
 MiqEmsMetricsProcessorWorker | started | 1657 |  5932 | 5956  |         1 | ems_metrics_processor | 2018-02-16T14:15:11Z | 2018-02-16T19:55:04Z | 248/600
 MiqEmsMetricsProcessorWorker | started | 1656 |  5923 | 5952  |         1 | ems_metrics_processor | 2018-02-16T14:15:11Z | 2018-02-16T19:55:04Z | 251/600
 MiqGenericWorker             | started | 1705 | 26571 | 26580 |         1 | generic               | 2018-02-16T19:12:50Z | 2018-02-16T19:55:04Z | 301/500
 MiqGenericWorker             | started | 1710 | 29366 | 29375 |         1 | generic               | 2018-02-16T19:54:20Z | 2018-02-16T19:55:06Z | 270/500
 MiqPriorityWorker            | started | 1708 | 28558 | 28568 |         1 | generic               | 2018-02-16T19:42:29Z | 2018-02-16T19:55:06Z | 498/600
 MiqPriorityWorker            | started | 1709 | 28752 | 28762 |         1 | generic               | 2018-02-16T19:45:32Z | 2018-02-16T19:55:06Z | 541/600
 MiqScheduleWorker            | started | 1658 |  5941 | 5955  |         1 |                       | 2018-02-16T14:15:12Z | 2018-02-16T19:54:59Z | 258/500
 MiqUiWorker                  | started | 1617 | 20047 |       |         1 | http://127.0.0.1:3000 | 2018-02-16T01:49:10Z | 2018-02-16T19:54:59Z | 252/1024
 MiqWebServiceWorker          | started | 1618 | 20056 |       |         1 | http://127.0.0.1:4000 | 2018-02-16T01:49:10Z | 2018-02-16T19:54:59Z | 252/1024
