### PR TITLE
truncate realtime metrics instead of purging

### DIFF
--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -94,6 +94,7 @@ describe Metric::Purging do
         end
         expect(Metric.count).to eq(17)
         # keep metric for 05:13 - 09:13
+        # note: old metrics will delete metrics at 09:14..09:59 - the new metrics will keep those
         described_class.purge_realtime(4.hours.ago)
         expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [5, 6, 7, 8, 9]
         expect(Metric.count).to eq(5)


### PR DESCRIPTION
extracted:

- [x] #17050 introduce metrics purging tests
- [x] #17051 fix for `reindex_table_name`

### Background

The `metrics` table holds realtime metrics and is separated into sub tables: `metrics_00` - `metrics_23`, one table per hour. A trigger on `metrics` will put into the corresponding table based upon the `timestamp` column.

Every 21 minutes, the scheduler calls `Metric::Purging#purge_realtime_timer` to delete all metrics older than 4 hours old. So only 5 tables should be populated at a time (note: rounding of time makes it 5 tables not 4).

The purging is taking too long, and `metrics` is growing. This causes the query to run even slower.

### Before

Deleting from the parent table, `metrics`, delegating the deletes to the child tables (e.g.: `metrics_23`). We delete in batches of 1,000 by default.
The batching for these deletes doesn't quite work with the multi table abstraction and causes ~23x23 queries per delete.

For each run, we run `# records / 1,000` of the above query.

### After

The purging process is aware of the delegation. It truncates the hourly table not
associated with dates in the retain window. This removes the need for batching.
Also, truncate is a more streamlined procedure.

Constant number of queries.

The purging will not pickup all older records, only those with hour numbers more than 4 hours ago. We run this every 21 minutes, so this is not a problem.

### Tweaking the interval and purge window:

If you run this every night at midnight, it will never purge hours 18-24. So those tables will grow and never be purged. This will need to be run at least once from 4am - 8pm for the purging to work.

The safe rule of thumb is: `interval + window < 12 hours`. The current defaults `21.minutes + 4.hours < 12 hours` is well within these limits. Increasing interval to `1.hour` may even be better

### Numbers

Metric.count = 84,110, batch size = 1,000

|        ms |      bytes |  objects |query |   qry ms |     rows |`comments`
|       ---:|        ---:|      ---:|  ---:|      ---:|      ---:| ---
|  30,612.2 | 4,923,487 |  412,321 |   85 | 30,442.2 |     (85) |before
|     173.4 |   585,229 |    5,702 |   23 |    130.9 |     (23) |after


### Extrapolated numbers

For the db with an issue, there are many more records. metrics_21 alone has 6,184,590. All metrics is 32,778,292 records.
Since each query takes ~10 minutes - and it would need to perform ~330 of them, it will take 2 1/4 days to delete a days worth of metrics. We'd never get out.

The new process takes closer to 1 minute on an appliance

- https://bugzilla.redhat.com/show_bug.cgi?id=1537733
