### PR TITLE
Add lans as a virtual relationship to ems_cluster

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -34,6 +34,8 @@ class EmsCluster < ApplicationRecord
 
   virtual_has_many :storages,       :uses => {:hosts => :storages}
   virtual_has_many :resource_pools, :uses => :all_relationships
+  virtual_has_many :lans,           :uses => {:hosts => :lans}
+
   has_many :failover_hosts, -> { failover }, :class_name => "Host"
 
   include SerializedEmsRefObjMixin

--- a/app/models/mixins/aggregation_mixin/methods.rb
+++ b/app/models/mixins/aggregation_mixin/methods.rb
@@ -47,5 +47,11 @@ module AggregationMixin
 
       hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
     end
+
+    def lans
+      hosts = all_hosts
+      MiqPreloader.preload(hosts, :lans)
+      hosts.flat_map(&:lans).compact.uniq
+    end
   end
 end


### PR DESCRIPTION
Lans need to be exposed via the API for the creation of transformation mappings. By adding this virtual relationship, they are able to be queried via `/api/clusters/:id?attributes=lans`

cc: @bzwei, @priley86
@miq-bot assign @gtanzillo 

@miq-bot add_label transformation

