### PR TITLE
Add method to copy current user's tags to taggable object

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -269,6 +269,18 @@ class MiqGroup < ApplicationRecord
     end
   end
 
+  def add_managed_filters_to(object)
+    group_tags = get_managed_filters
+
+    return if group_tags.empty?
+
+    group_tags.each do |category_tags|
+      _, _, classification = Classification.tag_name_to_objects(category_tags.first)
+      next unless classification
+      classification.assign_entry_to(object, false)
+    end
+  end
+
   private
 
   # if this tenant is changing, make sure this is not a default group

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -205,4 +205,12 @@ module ActsAsTaggable
   def perf_tags
     tag_list(:ns => '/managed').split.join("|")
   end
+
+  def add_current_user_tags
+    user = User.current_user
+    return if user.nil?
+    return if user.super_admin_user?
+
+    user.try(:current_group).try(:add_managed_filters_to, self)
+  end
 end


### PR DESCRIPTION
method can be used on [places](https://github.com/ManageIQ/manageiq-ui-classic/pull/3497)  where when ems or any object
is created by tag-restricted user - bug was about that
that such newly created object was hidden for current user
- so this fix will copy tags from current user's current group
to ems or any passed object.

When we have more then one tags from same category assigned to
group then it will copy only first.(Object can have only one tag from
one category)

scenario from UI PR:
**Before/After**
User's group have 3 tags:
![screen shot 2018-02-19 at 19 38 19](https://user-images.githubusercontent.com/14937244/36392628-781b73e8-15ac-11e8-8194-e43edbcd625c.png)


**Before**
![ctdmwphybh](https://user-images.githubusercontent.com/14937244/36392593-4bfb42d4-15ac-11e8-9db2-4c1936c29de1.gif)


**After**
![ynux7otlnt](https://user-images.githubusercontent.com/14937244/36392452-7fe62e16-15ab-11e8-8948-ab458a7dbc6b.gif)

@miq-bot assign @gtanzillo 

@miq-bot add_label bug

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1552681