### PR TITLE
Create trait for service template with resource action and dialog

### DIFF
--- a/spec/factories/resource_action.rb
+++ b/spec/factories/resource_action.rb
@@ -1,4 +1,7 @@
 FactoryGirl.define do
   factory :resource_action do
+    trait :with_dialog do
+      dialog
+    end
   end
 end

--- a/spec/factories/service_template.rb
+++ b/spec/factories/service_template.rb
@@ -4,4 +4,15 @@ FactoryGirl.define do
   factory :service_template_ansible_playbook, :class => 'ServiceTemplateAnsiblePlaybook', :parent => :service_template
   factory :service_template_container_template, :class => 'ServiceTemplateContainerTemplate', :parent => :service_template
   factory :service_template_transformation_plan, :class => 'ServiceTemplateTransformationPlan', :parent => :service_template
+
+  trait :with_provision_resource_action_and_dialog do
+    after(:create) do |x|
+      x.resource_actions << FactoryGirl.create(:resource_action, :with_dialog, :action => 'Provision')
+    end
+  end
+
+  trait :orderable do
+    display true
+    service_template_catalog
+  end
 end


### PR DESCRIPTION
The setup for creating service templates with resource actions and dialogs (and "orderable") is done repetitively in the API, this can be cleaned up and made more clear through traits.

@miq-bot assign @chrisarcand 
