### PR TITLE
Soft[ish] removal of custom `have_attributes`

### DIFF
--- a/spec/support/custom_matchers/have_attributes.rb
+++ b/spec/support/custom_matchers/have_attributes.rb
@@ -19,9 +19,14 @@ RSpec::Matchers.define :have_attributes do |attrs|
           end
 
         matcher = if actual.respond_to?(:acts_like_time?) && expected.respond_to?(:acts_like_time?)
-                    be_within(0.1).of(expected)
-                  elsif expected.kind_of?(RSpec::Matchers::BuiltIn::Match)
-                    match(expected.expected)
+                    if expected == actual
+                      eq(expected)
+                    else
+                      @depending_on_custom_approximation = true
+                      be_within(0.1).of(expected)
+                    end
+                  elsif expected.kind_of?(RSpec::Matchers::BuiltIn::BaseMatcher)
+                    expected
                   else
                     eq(expected)
                   end
@@ -30,18 +35,42 @@ RSpec::Matchers.define :have_attributes do |attrs|
           name_key = [:name, :id, :object_id].detect { |k| obj.respond_to?(k) }
           @err_msg ||= "with #{obj.class.name} #{name_key}:#{obj.send(name_key).inspect}\n\n"
           @err_msg << "testing attribute: \"#{attr}\"\n#{matcher.failure_message}\n\n"
+
+          if @depending_on_custom_approximation
+            msg = <<~MESSAGE
+              \nUse of approximate time matching in `have_attributes` is removed.
+              If you expected the values to match here, this could actually be a bug in your code,
+              though due to precision discrepancies you should be using approximate times or
+              rounding your times with 'to_i' anyway.
+
+              To match approximate times, use RSpec's composable matchers.
+              e.g.: expect(thing).to have_attributes(:timestamp => a_value_within(0.1).of(expected))
+              For more info, see https://github.com/ManageIQ/manageiq/pull/11474
+
+              Spec failed with the following message:
+              #{@err_msg}
+
+              #{"Called from " + called_from if called_from}
+            MESSAGE
+
+            raise msg
+          end
         end
       end
     end
 
 
     if @array_access_used
-      puts <<-MESSAGE
-\nWARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
-If you're matching attributes in hashes, use appropriate hash matchers instead (`include`, `eq`).
-#{"Called from " + called_from if called_from}
+      msg = <<~MESSAGE
+        \nUse of `have_attributes` with array access (:[]) is removed.
+        If you're matching attributes in hashes, use appropriate hash matchers instead (`include`, `eq`).
+        For more info, see https://github.com/ManageIQ/manageiq/pull/11474
+        #{"Called from " + called_from if called_from}
       MESSAGE
+
+      raise msg
     end
+
     @err_msg.nil?
   end
 


### PR DESCRIPTION
This effectively removes the custom `have_attributes` matcher.  It now raises if you use `have_attributes` in a way that isn't compatible with the normal RSpec one.

This has been deprecated a really long time but I bet there's still callers out there that use it. As I pity anyone who has to deal with time failures that just randomly now occur, let's leave this in the codebase for a week as it'll give all CI runs a change to helpfully force people to fix their test suites before *really* confusing errors occur.

### TODO

- [ ] Fix manageiq-providers-ansible_tower 's shared examples utilizing the time approximations in have_attributes to make these tests pass.