### PR TITLE
Add the artemis auth info as env variables in worker containers

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -58,12 +58,15 @@ class ContainerOrchestrator
 
     def default_environment
       [
+        {:name => "ARTEMIS_USER",            :value => ENV["ARTEMIS_USER"]},
         {:name => "DATABASE_SERVICE_NAME",   :value => ENV["DATABASE_SERVICE_NAME"]},
         {:name => "GUID",                    :value => MiqServer.my_guid},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
+        {:name      => "ARTEMIS_PASSWORD",
+         :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "artemis-password"}}},
         {:name      => "DATABASE_URL",
          :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "database-url"}}},
         {:name      => "V2_KEY",


### PR DESCRIPTION
Requires https://github.com/ManageIQ/manageiq-pods/pull/268

\cc @agrare 