### PR TITLE
ConfigurationScriptSource to have last_updated_on column

### DIFF
--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -28,7 +28,7 @@ module ManagerRefresh::Inventory::Core
         :manager_ref                 => [:manager_ref],
         :inventory_object_attributes => %i(
           name description scm_type scm_url scm_branch scm_clean scm_delete_on_update
-          scm_update_on_launch authentication status
+          scm_update_on_launch authentication status last_updated_on
         ),
       }.merge(options))
     end


### PR DESCRIPTION
For the RFE: store Tower project's last_updated time

https://bugzilla.redhat.com/show_bug.cgi?id=1536144

Related to: 
 - schema change https://github.com/ManageIQ/manageiq-schema/pull/172
 - Tower refresh change https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/59

