### PR TITLE
Update vm transformation status in a plan

### DIFF
--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -201,7 +201,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
   def update_and_notify_parent(*args)
     prev_state = state
     super
-    task_finished if state == "finished" && prev_state != "finished"
+    try("task_#{state}") if prev_state != state
   end
 
   def task_finished

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -11,7 +11,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     service_resources.find_by(:resource_type => 'TransformationMapping').resource
   end
 
-  def vm_requests
+  def vm_resources
     service_resources.where(:resource_type => 'VmOrTemplate')
   end
 

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -1,18 +1,18 @@
 class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   TASK_DESCRIPTION = 'VM Transformations'.freeze
 
-  delegate :transformation_mapping, :vm_requests, :to => :source
+  delegate :transformation_mapping, :vm_resources, :to => :source
 
   def requested_task_idx
-    vm_requests.where(:status => 'Approved')
+    vm_resources.where(:status => 'Approved')
   end
 
-  def customize_request_task_attributes(req_task_attrs, vm_request)
-    req_task_attrs[:source] = vm_request.resource
+  def customize_request_task_attributes(req_task_attrs, vm_resource)
+    req_task_attrs[:source] = vm_resource.resource
   end
 
   def source_vms
-    vm_requests.where(:status => %w(Queued Failed)).pluck(:resource_id)
+    vm_resources.where(:status => %w(Queued Failed)).pluck(:resource_id)
   end
 
   def validate_vm(_vm_id)
@@ -21,6 +21,6 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   end
 
   def approve_vm(vm_id)
-    vm_requests.find_by(:resource_id => vm_id).update_attributes!(:status => 'Approved')
+    vm_resources.find_by(:resource_id => vm_id).update_attributes!(:status => 'Approved')
   end
 end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -19,4 +19,19 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     options[:progress] = (options[:progress] || {}).merge(progress)
     save
   end
+
+  def task_finished
+    # update the status of vm transformation status in the plan
+    vm_request.update_attributes(:status => status == 'Ok' ? 'Completed' : 'Failed')
+  end
+
+  def task_active
+    vm_request.update_attributes(:status => 'Active')
+  end
+
+  private
+
+  def vm_request
+    miq_request.vm_requests.find_by(:resource => source)
+  end
 end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -22,16 +22,16 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def task_finished
     # update the status of vm transformation status in the plan
-    vm_request.update_attributes(:status => status == 'Ok' ? 'Completed' : 'Failed')
+    vm_resource.update_attributes(:status => status == 'Ok' ? 'Completed' : 'Failed')
   end
 
   def task_active
-    vm_request.update_attributes(:status => 'Active')
+    vm_resource.update_attributes(:status => 'Active')
   end
 
   private
 
-  def vm_request
-    miq_request.vm_requests.find_by(:resource => source)
+  def vm_resource
+    miq_request.vm_resources.find_by(:resource => source)
   end
 end

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -36,8 +36,8 @@ describe ServiceTemplateTransformationPlan do
 
       expect(service_template.name).to eq('Transformation Plan')
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
-      expect(service_template.vm_requests.collect(&:resource)).to match_array([vm1, vm2])
-      expect(service_template.vm_requests.collect(&:status)).to eq(%w(Queued Queued))
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
+      expect(service_template.vm_resources.collect(&:status)).to eq(%w(Queued Queued))
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -62,14 +62,14 @@ describe ServiceTemplateTransformationPlanTask do
     describe 'task_active' do
       it 'sets vm_request status to Started' do
         task.task_active
-        expect(plan.vm_requests.first.status).to eq('Active')
+        expect(plan.vm_resources.first.status).to eq('Active')
       end
     end
 
     describe 'task_finished' do
       it 'sets vm_request status to Completed' do
         task.task_finished
-        expect(plan.vm_requests.first.status).to eq('Completed')
+        expect(plan.vm_resources.first.status).to eq('Completed')
       end
     end
   end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -15,6 +15,7 @@ describe ServiceTemplateTransformationPlanTask do
   context 'populated request and task' do
     let(:src) { FactoryGirl.create(:ems_cluster) }
     let(:dst) { FactoryGirl.create(:ems_cluster) }
+    let(:vm)  { FactoryGirl.create(:vm_or_template) }
     let(:mapping) do
       FactoryGirl.create(
         :transformation_mapping,
@@ -28,7 +29,7 @@ describe ServiceTemplateTransformationPlanTask do
         :description => 'a description',
         :config_info => {
           :transformation_mapping_id => mapping.id,
-          :vm_ids                    => [FactoryGirl.create(:vm_or_template).id],
+          :vm_ids                    => [vm.id],
         }
       }
     end
@@ -36,7 +37,7 @@ describe ServiceTemplateTransformationPlanTask do
     let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
 
     let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
-    let(:task) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan') }
+    let(:task) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
 
     describe '#resource_action' do
       it 'has a resource action points to the entry point for transformation' do
@@ -55,6 +56,20 @@ describe ServiceTemplateTransformationPlanTask do
       it 'saves the progress in options' do
         task.update_transformation_progress(:vm_percent => '80')
         expect(task.options[:progress]).to eq(:vm_percent => '80')
+      end
+    end
+
+    describe 'task_active' do
+      it 'sets vm_request status to Started' do
+        task.task_active
+        expect(plan.vm_requests.first.status).to eq('Active')
+      end
+    end
+
+    describe 'task_finished' do
+      it 'sets vm_request status to Completed' do
+        task.task_finished
+        expect(plan.vm_requests.first.status).to eq('Completed')
       end
     end
   end


### PR DESCRIPTION
Each selected vm in a transformation plan has status column needs to be updated. This work enables the status update during the course of miq_request_task execution.
