### PR TITLE
Differentiate being in a container vs running in OpenShift/k8s

### DIFF
--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -124,7 +124,7 @@ module Authenticator
     end
 
     def user_attrs_from_external_directory(username)
-      if MiqEnvironment::Command.is_container?
+      if MiqEnvironment::Command.is_podified?
         user_attrs_from_external_directory_via_dbus_api_service(username)
       else
         user_attrs_from_external_directory_via_dbus(username)

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -74,7 +74,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   end
 
   def provider_uri_hash
-    if MiqEnvironment::Command.is_container?
+    if MiqEnvironment::Command.is_podified?
       {:scheme => "https", :host => ContainerEmbeddedAnsible::ANSIBLE_SERVICE_NAME, :path => "/api/v1"}
     elsif Rails.env.development?
       {:scheme => "http", :host => "localhost", :path => "/api/v1", :port => 54321}

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -135,7 +135,7 @@ class MiqGroup < ApplicationRecord
   end
 
   def self.get_httpd_groups_by_user(user)
-    if MiqEnvironment::Command.is_container?
+    if MiqEnvironment::Command.is_podified?
       get_httpd_groups_by_user_via_dbus_api_service(user)
     else
       get_httpd_groups_by_user_via_dbus(user)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -92,7 +92,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def check_not_responding(class_name = nil)
-    return [] if MiqEnvironment::Command.is_container?
+    return [] if MiqEnvironment::Command.is_podified?
     processed_workers = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)

--- a/app/models/miq_server/worker_management/monitor/system_limits.rb
+++ b/app/models/miq_server/worker_management/monitor/system_limits.rb
@@ -9,13 +9,13 @@ module MiqServer::WorkerManagement::Monitor::SystemLimits
   }
 
   def kill_workers_due_to_resources_exhausted?
-    return false if MiqEnvironment::Command.is_container?
+    return false if MiqEnvironment::Command.is_podified?
     options = worker_monitor_settings[:kill_algorithm].merge(:type => :kill)
     invoke_algorithm(options)
   end
 
   def enough_resource_to_start_worker?(worker_class)
-    return true if MiqEnvironment::Command.is_container?
+    return true if MiqEnvironment::Command.is_podified?
     # HACK, sync_config is done in the server, while this method is called from miq_worker
     # This method should move to the worker and the server should pass the settings.
     sync_config if worker_monitor_settings.nil? || child_worker_settings.nil?

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -2,7 +2,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
   extend ActiveSupport::Concern
 
   def validate_worker(w)
-    return true if MiqEnvironment::Command.is_container?
+    return true if MiqEnvironment::Command.is_podified?
     time_threshold   = get_time_threshold(w)
     restart_interval = get_restart_interval(w)
     memory_threshold = get_memory_threshold(w)

--- a/app/models/miq_ui_worker/runner.rb
+++ b/app/models/miq_ui_worker/runner.rb
@@ -3,6 +3,6 @@ class MiqUiWorker::Runner < MiqWorker::Runner
 
   def prepare
     super
-    MiqApache::Control.start if MiqEnvironment::Command.is_container?
+    MiqApache::Control.start if MiqEnvironment::Command.is_podified?
   end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -370,7 +370,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.containerized_worker?
-    MiqEnvironment::Command.is_container? && supports_container?
+    MiqEnvironment::Command.is_podified? && supports_container?
   end
 
   def containerized_worker?
@@ -525,7 +525,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def status_update
-    return if MiqEnvironment::Command.is_container?
+    return if MiqEnvironment::Command.is_podified?
 
     begin
       pinfo = MiqProcess.processInfo(pid)

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -6,7 +6,7 @@ module MiqEnvironment
 
     def self.supports_memcached?
       return @supports_memcached unless @supports_memcached.nil?
-      @supports_memcached = is_linux? && is_appliance? && !is_container? && supports_command?('memcached') && supports_command?('memcached-tool') && supports_command?('service')
+      @supports_memcached = is_linux? && is_appliance? && !is_podified? && supports_command?('memcached') && supports_command?('memcached-tool') && supports_command?('service')
     end
 
     def self.supports_apache?
@@ -22,6 +22,11 @@ module MiqEnvironment
     def self.is_container?
       return @is_container unless @is_container.nil?
       @is_container = ENV["CONTAINER"] == "true"
+    end
+
+    def self.is_podified?
+      return @is_podified unless @is_podified.nil?
+      @is_podified = is_container? && ContainerOrchestrator.available?
     end
 
     def self.is_appliance?

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -103,7 +103,7 @@ describe EmbeddedAnsibleWorker::Runner do
 
       context "in a container" do
         before do
-          expect(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
+          expect(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
         end
 
         it "creates the provider with the service name for the URL" do


### PR DESCRIPTION
Before this change we would try to start worker containers in the monolithic image, which we don't want to be doing.