### PR TITLE
Add documentation for db layout of metrics and metric_rollups

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,3 +1,37 @@
+# Note on the database layout of `metrics` and `metrics_rollups`
+#
+# In the database, the `metrics` table leverages [PostgreSQL table inheritance]
+# and [PostgreSQL table partioning].
+#
+# Table inheritance is used to create child tables with the same structure as
+# the parent.  As columns are added or removed from the parent table, they are
+# automatically added and removed from the child tables.  The `metrics` table,
+# which is used for "realtime" data, has 24 child tables, one per hour.  The
+# `metrics_rollups` table, which is used for long term "rollup" data, has 12
+# child tables, one per month.
+#
+# Table partitioning is used to divert inserts and deletes from the parent table
+# to a specific child table, and to allow queries to search across the various
+# child tables and return the results as if they were in a single table.  This
+# is accomplished using triggers on the parent table, which look at the hour of
+# the timestamp for `metrics` or the month of the timestamp for
+# `metric_rollups`, and then diverting to the corresponding child table.
+# Additionally, a shared sequence is used from the parent table for the primary
+# key, so that when queries blend the rows together the primary key constraint
+# is satisfied.
+#
+# The reason for all of this is because of read/write contention.  The metrics
+# table is mostly an append-only table, so writes happen at the end of data.
+# Purges on the other hand, happen on record at the beginning of the table.
+# Additonally, the purge time frame causes those deletes to be very far away
+# from the inserts.  When all of the records are in a single table, these
+# deletes from purges have a negative performance effect on inserts.  However,
+# putting the records into separate tables allows inserts to occur in one table,
+# while deletes occur in a completely different table, eliminating the
+# read/write contention.
+#
+# [PostgreSQL table inheritance]: https://www.postgresql.org/docs/9.6/static/tutorial-inheritance.html
+# [PostgreSQL table partioning]: https://www.postgresql.org/docs/9.6/static/ddl-partitioning.html
 class Metric < ApplicationRecord
   BASE_COLS = ["id", "timestamp", "capture_interval_name", "resource_type", "resource_id", "resource_name", "tag_names", "parent_host_id", "parent_ems_cluster_id", "parent_ems_id", "parent_storage_id"]
 

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -1,3 +1,4 @@
+# @see Metric
 class MetricRollup < ApplicationRecord
   include Metric::Common
   include_concern 'Metric::ChargebackHelper'


### PR DESCRIPTION
@gtanzillo @cben Please review

One thing I left out was what we referred to as the swiss cheese effect.  This was a problem when both metrics and metrics rollups live in a single table. 
 In that case, realtime and rollup rows were interleaved in the Postgres data pages.  Since they have different purge time frames, purging would cause "holes" in the Postgres data pages.  The problem was those holes would cause autovacuum to never actually clean up the page, causing a TON of bloat.  This is what led to us separating into metrics and metrics_rollups tables.  After the table split was when we noticed the read/write contention as listed in the documentation, and went with the table partitions.

I left this out because it only describes why we split into metrics and metrics_rollups, but I'm not sure that's useful, but maybe it is?  What do you think?  Should I add it into the comment here anyway?

cc @kbrock @NickLaMuro 

