### PR TITLE
[FINE] Allow for specifying of subcollection as attribute

### DIFF
--- a/app/controllers/api/base_controller/renderer.rb
+++ b/app/controllers/api/base_controller/renderer.rb
@@ -195,7 +195,24 @@ module Api
       end
 
       def expand_subcollection?(sc, target)
-        respond_to?(target) && (@req.expand?(sc) || collection_config.show?(sc))
+        return false unless respond_to?(target) # If there's no query method, no need to go any further
+        expand_resources?(sc) || expand_action_resource?(sc) || resource_requested?(sc)
+      end
+
+      # Expand if: expand='resources' && no attributes specified && subcollection is configured
+      def expand_resources?(sc)
+        collection_config.show?(sc) && (@req.c_id || @req.expand?('resources')) && @req.attributes.empty?
+      end
+
+      # Expand if: resource is being returned and subcollection is configured
+      # IE an update to /service_catalogs expects service_templates as part of its resource
+      def expand_action_resource?(sc)
+        @req.method != :get && collection_config.show?(sc)
+      end
+
+      # Expand if: explicitly requested
+      def resource_requested?(sc)
+        @req.expand?(sc)
       end
 
       #

--- a/spec/requests/api/service_catalogs_spec.rb
+++ b/spec/requests/api/service_catalogs_spec.rb
@@ -24,6 +24,22 @@ describe "Service Catalogs API" do
     st_id ? "#{st_base}/#{st_id}" : st_base
   end
 
+  describe "GET /api/service_catalogs/:id?attributes=service_templates" do
+    it "returns the service templates for a service catalog" do
+      catalog = FactoryGirl.create(:service_template_catalog)
+      template = FactoryGirl.create(:service_template, :service_template_catalog => catalog)
+      api_basic_authorize action_identifier(:service_catalogs, :read, :resource_actions, :get)
+
+      run_get("#{service_catalogs_url(catalog.id)}?attributes=service_templates")
+
+      expected = {
+        "service_templates" => [a_hash_including("id" => template.id)]
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(expected)
+    end
+  end
+
   describe "Service Catalogs create" do
     it "rejects resource creation without appropriate role" do
       api_basic_authorize


### PR DESCRIPTION
Calling
`GET /api/service_catalogs/:id?attributes=service_templates`

Results in
```
{
    "error": {
        "kind": "bad_request",
        "message": "Cannot expand subcollection service_templates by name and virtual attribute",
        "klass": "Api::BadRequestError"
    }
}
```

Users should be able to specify an attribute (even if it is a subcollection, too) via `attributes`. This takes some methods added to Gaprindashvili, adjusts them for Fine, to resolve this issue

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546942

@miq-bot add_label api
@miq-bot assign @abellotti 
