### PR TITLE
Fix policy_events relationship on VmOrTemplate

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -122,7 +122,7 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :ems_events_src,  :class_name => "EmsEvent"
   has_many                  :ems_events_dest, :class_name => "EmsEvent", :foreign_key => :dest_vm_or_template_id
 
-  has_many                  :policy_events, -> { where(["target_id = ? OR target_class = 'VmOrTemplate'", id]).order(:timestamp) }, :class_name => "PolicyEvent"
+  has_many                  :policy_events, ->(vm) { where(["target_id = ? AND target_class = 'VmOrTemplate'", vm.id]).order(:timestamp) }, :foreign_key => "target_id"
 
   has_many                  :miq_events, :as => :target, :dependent => :destroy
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1229,4 +1229,12 @@ describe VmOrTemplate do
       expect(Vm.new(:location => "test location", :storage => storage).v_datastore_path).to eq("storage name/test location")
     end
   end
+
+  context "#policy_events" do
+    it "returns the policy events with target class of VmOrTemplate and target_id of the vm" do
+      policy_event = FactoryGirl.create(:policy_event, :target_class => "VmOrTemplate", :target_id => vm.id)
+
+      expect(vm.policy_events).to eq([policy_event])
+    end
+  end
 end


### PR DESCRIPTION
Currently (back to Fine), the `policy_events` relationship on `VmOrTemplate` is not working, and even if "fixed" to resolve the current internal server error, it does not appear to do what I *think* it was intended to be doing, which is simply returning all policy events with a `target_type` of `VmOrTemplate`

Here's the step by step (although most of it is probably obvious):
```
:policy_events, -> { where(["target_id = ? OR target_class = 'VmOrTemplate'", id]).order(:timestamp) }, :class_name => "PolicyEvent"
```

does not work because it is referencing "id" which is an invalid reference, resulting in:
```
NameError: undefined local variable or method `id' for #<PolicyEvent::ActiveRecord_Relation:0x007fe7489066b8>
```

Adjusting the query to reference the VmOrTemplate id:
```
:policy_events, ->(vmt) { where(["target_id = ? OR target_class = 'VmOrTemplate'", vmt.id]).order(:timestamp) }, :class_name => "PolicyEvent"
```
Still does not work, because it is expecting the `foreign_key` to be `vm_or_template_id`. Even if that is fixed, it is doing an `AND` on the foreign_key and this `where` clause, which would not return what this `where` is expecting. 

I got to this point and realized I think that this query is simply attempting to return all `policy_events` where the `target_class` is `VmOrTemplate`? But it is difficult to tell when the query was not working/does not make much sense in the first place

Sanity check for what this query was *supposed* to be doing?

@miq-bot assign @gtanzillo 
@miq-bot add_label bug, gaprindashvili/yes, fine/yes 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546995
