### PR TITLE
Raise a notification when registration fails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "hamlit",                         "~>2.7.0"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "kubeclient",                     "~>2.4.0",       :require => false # For scaling pods at runtime
-gem "linux_admin",                    "~>1.2.0",       :require => false
+gem "linux_admin",                    "~>1.2.1",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.1.0",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"

--- a/app/models/miq_server/update_management.rb
+++ b/app/models/miq_server/update_management.rb
@@ -63,6 +63,10 @@ module MiqServer::UpdateManagement
     configure_yum_proxy
     # HACK: #enable_repos is not always successful immediately after #attach_products, retry to ensure they are enabled.
     5.times { repos_enabled? ? break : enable_repos }
+  rescue LinuxAdmin::SubscriptionManagerError => e
+    _log.error("Registration Failed: #{e.message}")
+    Notification.create(:type => "server_registration_error", :options => {:server_name => MiqServer.my_server.name})
+    raise
   end
 
   def register

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -254,3 +254,8 @@
   :expires_in: 24.hours
   :level: :error
   :audience: global
+- :name: server_registration_error
+  :message: 'Registration failed for server %{server_name}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: superadmin

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -89,6 +89,17 @@ describe MiqServer do
 
       @server.attempt_registration
     end
+
+    it "should raise a notification if registration fails" do
+      NotificationType.seed
+      result = AwesomeSpawn::CommandResult.new("stuff", "things", "more things", 1)
+      err = LinuxAdmin::SubscriptionManagerError.new("things", result)
+      expect(@server).to receive(:register).and_raise(err)
+      expect { @server.attempt_registration }.to raise_error(LinuxAdmin::SubscriptionManagerError)
+
+      note = Notification.find_by(:notification_type_id => NotificationType.find_by(:name => "server_registration_error").id)
+      expect(note.options.keys).to include(:server_name)
+    end
   end
 
   context "#register" do


### PR DESCRIPTION
This adds a new notification type and creates a notification of
this type when we fail to execute any of the steps of the
Subscription Manager registration process.

https://bugzilla.redhat.com/show_bug.cgi?id=1518801

Requires https://github.com/ManageIQ/linux_admin/pull/199