### PR TITLE
Support setting var type with configure_server_settings.rb

### DIFF
--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -63,7 +63,7 @@ keys.each { |p| path = path[p.to_sym] }
 if opts[:force]
   puts "Change [#{opts[:path]}], old class: [#{path[key].class}], new class: [#{newval.class}]"
 elsif path[key] && path[key].class != newval.class
-  STDERR.puts "The new value's class #{newval.class} does not match the prior one's #{path[key].class}.  Use -f to force update, this may break things!"
+  STDERR.puts "The new value's class #{newval.class} does not match the prior one's #{path[key].class}. Use -t to specify the type for the provided value. Use -f to force changing this value. Note, -f may break things! See -h for examples."
   exit 1
 end
 

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -27,6 +27,8 @@ Trollop.die :path,     "is required" unless opts[:path_given]
 Trollop.die :value,    "is required" unless opts[:value_given]
 Trollop.die :type,     "must be one of #{TYPES.inspect}" unless TYPES.include?(opts[:type])
 
+newval = ''
+
 # Grab the value that we have set and translate to appropriate var class
 case opts[:type]
 when "integer"

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -2,7 +2,7 @@
 require File.expand_path("../config/environment", __dir__)
 require 'trollop'
 
-TYPES = %w{ string integer boolean symbol float }
+TYPES = %w(string integer boolean symbol float).freeze
 
 opts = Trollop.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -6,10 +6,10 @@ TYPES = %w(string integer boolean symbol float).freeze
 
 opts = Trollop.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \
-         "Example (String): #{__FILE__} -d -s 1 -p reporting/history/keep_reports -v 42\n" \
+         "Example (String): #{__FILE__} -s 1 -p reporting/history/keep_reports -v 42\n" \
          "Example (Integer): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
          "Example (Boolean): #{__FILE__} -s 1 -p ui/mark_translated_strings -v true -t boolean\n" \
-         "Example (Symbol): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/poll_method -v :escalate -t symbol\n" \
+         "Example (Symbol): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/poll_method -v escalate -t symbol\n" \
          "Example (Float): #{__FILE__} -s 1 -p capacity/profile/1/vcpu_commitment_ratio -v 1.5 -t float"
 
   opt :dry_run,  "Dry Run",                                  :short => "d"
@@ -31,6 +31,8 @@ newval = ''
 
 # Grab the value that we have set and translate to appropriate var class
 case opts[:type]
+when "string"
+  newval = opts[:value]
 when "integer"
   newval = opts[:value].to_i
 when "boolean"

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -4,19 +4,26 @@ require 'trollop'
 
 opts = Trollop.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \
-         "Example: #{__FILE__} -d -s 1 -p reporting/history/keep_reports -v 42"
+         "Example: #{__FILE__} -d -s 1 -p reporting/history/keep_reports -v 42\n" \
+         "Example: #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 4 -i"
 
   opt :dry_run,  "Dry Run",                            :short => "d"
-  opt :serverid, "Server Id",                          :short => "s", :default => 0
-  opt :path,     "Path within advanced settings hash", :short => "p", :default => ""
-  opt :value,    "New value for setting",              :short => "v", :default => ""
+  opt :serverid, "Server Id",                          :short => "s", :type => :integer, :required => true
+  opt :path,     "Path within advanced settings hash", :short => "p", :type => :string, :required => true
+  opt :value,    "New Value for setting",              :short => "v", :type => :string, :required => true
+  opt :integer,  "Value Provided is an Integer",       :short => "i", :type => :boolean, :default => false
+
+  depends :path, :serverid, :value
 end
 
 puts opts.inspect
 
-Trollop.die :serverid, "is required" unless opts[:serverid_given]
-Trollop.die :path,     "is required" unless opts[:path_given]
-Trollop.die :value,    "is required" unless opts[:value_given]
+# Grab the value that we have set
+if opts[:integer]
+  newval = opts[:value].to_i
+else
+  newval = opts[:value]
+end
 
 server = MiqServer.where(:id => opts[:serverid]).take
 unless server
@@ -32,7 +39,7 @@ key = keys.pop.to_sym
 keys.each { |p| path = path[p.to_sym] }
 
 puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{opts[:value]}]"
-path[key] = opts[:value]
+path[key] = newval
 
 valid, errors = VMDB::Config::Validator.new(settings).validate
 unless valid

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -9,8 +9,8 @@ opts = Trollop.options(ARGV) do
 
   opt :dry_run,  "Dry Run",                            :short => "d"
   opt :serverid, "Server Id",                          :short => "s", :type => :integer, :required => true
-  opt :path,     "Path within advanced settings hash", :short => "p", :type => :string, :required => true
-  opt :value,    "New Value for setting",              :short => "v", :type => :string, :required => true
+  opt :path,     "Path within advanced settings hash", :short => "p", :type => :string,  :required => true
+  opt :value,    "New Value for setting",              :short => "v", :type => :string,  :required => true
   opt :integer,  "Value Provided is an Integer",       :short => "i", :type => :boolean, :default => false
 
   depends :path, :serverid, :value

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -6,7 +6,7 @@ TYPES = %w(string integer boolean symbol float).freeze
 
 opts = Trollop.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \
-         "Example (String): #{__FILE__} -s 1 -p reporting/history/keep_reports -v 42\n" \
+         "Example (String): #{__FILE__} -s 1 -p reporting/history/keep_reports -v 3.months\n" \
          "Example (Integer): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
          "Example (Boolean): #{__FILE__} -s 1 -p ui/mark_translated_strings -v true -t boolean\n" \
          "Example (Symbol): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/poll_method -v escalate -t symbol\n" \
@@ -27,25 +27,24 @@ Trollop.die :path,     "is required" unless opts[:path_given]
 Trollop.die :value,    "is required" unless opts[:value_given]
 Trollop.die :type,     "must be one of #{TYPES.inspect}" unless TYPES.include?(opts[:type])
 
-newval = ''
-
 # Grab the value that we have set and translate to appropriate var class
-case opts[:type]
-when "string"
-  newval = opts[:value]
-when "integer"
-  newval = opts[:value].to_i
-when "boolean"
-  if opts[:value].downcase == "true"
-    newval = true
-  elsif opts[:value].downcase == "false"
-    newval = false
+newval =
+  case opts[:type]
+  when "string"
+    opts[:value]
+  when "integer"
+    opts[:value].to_i
+  when "boolean"
+    if opts[:value].downcase == "true"
+      true
+    elsif opts[:value].downcase == "false"
+      false
+    end
+  when "symbol"
+    opts[:value].to_sym
+  when "float"
+    opts[:value].to_f
   end
-when "symbol"
-  newval = opts[:value].to_sym
-when "float"
-  newval = opts[:value].to_f
-end
 
 server = MiqServer.where(:id => opts[:serverid]).take
 unless server

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -9,13 +9,15 @@ opts = Trollop.options(ARGV) do
          "Example (String): #{__FILE__} -d -s 1 -p reporting/history/keep_reports -v 42\n" \
          "Example (Integer): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
          "Example (Boolean): #{__FILE__} -s 1 -p ui/mark_translated_strings -v true -t boolean\n" \
+         "Example (Symbol): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/poll_method -v :escalate -t symbol\n" \
          "Example (Float): #{__FILE__} -s 1 -p capacity/profile/1/vcpu_commitment_ratio -v 1.5 -t float"
 
   opt :dry_run,  "Dry Run",                                  :short => "d"
   opt :serverid, "Server Id",                                :short => "s", :type => :integer, :required => true
   opt :path,     "Path within advanced settings hash",       :short => "p", :type => :string,  :required => true
   opt :value,    "New Value for setting",                    :short => "v", :type => :string,  :required => true
-  opt :type,     "Type of value provided, #{TYPES.inspect}", :short => "t", :type => :string,  :default => "string"
+  opt :force,    "Force change value regardless of type",    :short => "f", :type => :boolean, :default  => false
+  opt :type,     "Type of value provided, #{TYPES.inspect}", :short => "t", :type => :string,  :default  => "string"
 end
 
 puts opts.inspect
@@ -25,7 +27,7 @@ Trollop.die :path,     "is required" unless opts[:path_given]
 Trollop.die :value,    "is required" unless opts[:value_given]
 Trollop.die :type,     "must be one of #{TYPES.inspect}" unless TYPES.include?(opts[:type])
 
-# Grab the value that we have set
+# Grab the value that we have set and translate to appropriate var class
 case opts[:type]
 when "integer"
   newval = opts[:value].to_i
@@ -53,6 +55,15 @@ path = settings.config
 keys = opts[:path].split("/")
 key = keys.pop.to_sym
 keys.each { |p| path = path[p.to_sym] }
+
+# allow user to escape if the new value's class is not the same as the original,
+# such as setting a String where it was previously an Integer
+if opts[:force]
+  puts "Change [#{opts[:path]}], old class: [#{path[key].class}], new class: [#{newval.class}]"
+elsif path[key] && path[key].class != newval.class
+  STDERR.puts "The new value's class #{newval.class} does not match the prior one's #{path[key].class}.  Use -f to force update, this may break things!"
+  exit 1
+end
 
 puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{opts[:value]}]"
 path[key] = newval


### PR DESCRIPTION
Changing the worker count across our environment for `ems_metrics_collector_worker` from 2 to 4 caused C & U to stop function because the value was change from `2` to `'4'`. Subsequently `miq_worker.rb:149` was trying to compare current workers [0] to ['4'] and throwing a string comparison exception.

Here is the view in the advanced config screen before the fix

![screen shot 2018-02-22 at 5 52 49 pm](https://user-images.githubusercontent.com/5966/36592166-a13e5610-1862-11e8-8888-02997cb96809.png)

and after

![screen shot 2018-02-22 at 5 57 30 pm](https://user-images.githubusercontent.com/5966/36592171-a51c7406-1862-11e8-90e8-8f48124af73e.png)

Steps for Testing/QA
---------------------

This will break with both the new code and the existing code.

- `./tools/configure_server_settings.rb -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 4`

The following will cast the the value as an integer and it will update the configuration accordingly.

- `./tools/configure_server_settings.rb -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 4 -t integer`