### PR TITLE
Fix failing test now that vCloud supports destroy

### DIFF
--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -534,7 +534,7 @@ describe VmOrTemplate do
 
   context "#supports_terminate?" do
     let(:ems_does_vm_destroy) { FactoryGirl.create(:ems_vmware) }
-    let(:ems_doesnot_vm_destroy) { FactoryGirl.create(:ems_vmware_cloud) }
+    let(:ems_doesnot_vm_destroy) { FactoryGirl.create(:ems_cloud) }
     let(:host) { FactoryGirl.create(:host) }
 
     it "returns true for a VM not terminated" do


### PR DESCRIPTION
A test confirming that supports_terminate returns false was using VMware vCloud as the EMS.

Recently in https://github.com/ManageIQ/manageiq-providers-vmware/pull/184 vCloud added support for vm_destroy so we need to use something else.