### PR TITLE
Stop container workers cleanly

### DIFF
--- a/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -35,7 +35,10 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
     @quiesce_loop_timeout = @worker_monitor_settings[:quiesce_loop_timeout] || 5.minutes
     worker_monitor_poll = (@worker_monitor_settings[:poll] || 1.seconds).to_i_with_method
 
-    miq_workers.each { |w| stop_worker(w) }
+    miq_workers.each do |w|
+      MiqEnvironment::Command.is_podified? && w.containerized_worker? ? w.delete_container_objects : stop_worker(w)
+    end
+
     loop do
       reload # Reload from SQL this MiqServer AND its miq_workers association
       break if self.workers_quiesced?

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -47,18 +47,26 @@ class ContainerOrchestrator
     scale(name, 0)
     connection.delete_deployment_config(name, my_namespace)
     delete_replication_controller(rc.metadata.name) if rc
+  rescue KubeException => e
+    raise unless e.message =~ /not found/
   end
 
   def delete_replication_controller(name)
     kube_connection.delete_replication_controller(name, my_namespace)
+  rescue KubeException => e
+    raise unless e.message =~ /not found/
   end
 
   def delete_service(name)
     kube_connection.delete_service(name, my_namespace)
+  rescue KubeException => e
+    raise unless e.message =~ /not found/
   end
 
   def delete_secret(name)
     kube_connection.delete_secret(name, my_namespace)
+  rescue KubeException => e
+    raise unless e.message =~ /not found/
   end
 
   private


### PR DESCRIPTION
Before this, when #stop_worker was called, we would attempt to scale the deployment. This would work if we had a different number (or zero) workers configured in the settings, but we don't shut workers down like that when shutting down the server to preserve the user's settings for the next startup.

This resulted in worker pods not exiting when the orchestrator pod stopped and much confusion when the next orchestrator started up.

Additionally, this PR implements some error catching for the `ContainerOrchestrator` which we need because requests to remove resources from OpenShift are asynchronous.
