### PR TITLE
configure_server_settings loses integer values

### DIFF
--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -30,6 +30,7 @@ path = settings.config
 keys = opts[:path].split("/")
 key = keys.pop.to_sym
 keys.each { |p| path = path[p.to_sym] }
+opts[:value] = opts[:value].to_i if !!(opts[:value].match /^(\d)+$/ )
 
 puts "Setting [#{opts[:path]}], old value: [#{path[key]}](#{path[key].class}), new value: [#{opts[:value]}](#{opts[:value].class})"
 path[key] = opts[:value]

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -31,7 +31,7 @@ keys = opts[:path].split("/")
 key = keys.pop.to_sym
 keys.each { |p| path = path[p.to_sym] }
 
-puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{opts[:value]}]"
+puts "Setting [#{opts[:path]}], old value: [#{path[key]}](#{path[key].class}), new value: [#{opts[:value]}](#{opts[:value].class})"
 path[key] = opts[:value]
 
 valid, errors = VMDB::Config::Validator.new(settings).validate


### PR DESCRIPTION
* Print the value's class before and after setting it (for clarity)
* If STDIN strings are really integers, convert them

Although, we do special handling of "100.megabytes" strings, etc. later
when consuming the settings such as in worker_settings using
to_i_with_method, it makes sense to check for integers here at the point
in which the user provides them so we can store them "correctly".

Note, one could argue we should handle floats or other datatypes but
99.9% of our settings are strings or integers.

http://talk.manageiq.org/t/tune-workers-via-cli/3107/4452dd84


**Before the fix**
```
$ ./tools/configure_server_settings.rb -s 1 -p workers/worker_base/queue_worker_base/generic_worker/count -v 3
...
{:dry_run=>false, :serverid=>1, :path=>"workers/worker_base/queue_worker_base/generic_worker/count", :value=>"3", :help=>false, :serverid_given=>true, :path_given=>true, :value_given=>true}
Setting [workers/worker_base/queue_worker_base/generic_worker/count], old value: [2] (Integer), new value: [3](String)
Done
```

**After**
```
$ ./tools/configure_server_settings.rb -s 1 -p workers/worker_base/queue_worker_base/generic_worker/count -v 1
...
{:dry_run=>false, :serverid=>1, :path=>"workers/worker_base/queue_worker_base/generic_worker/count", :value=>"1", :help=>false, :serverid_given=>true, :path_given=>true, :value_given=>true}
Setting [workers/worker_base/queue_worker_base/generic_worker/count], old value: [3](Integer), new value: [1](Integer)
Done
```