### PR TITLE
Add #orderable? as alias method

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -18,6 +18,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   def validate_order
     true
   end
+  alias orderable? validate_order
 
   def self.default_provisioning_entry_point(_service_type)
     '/Transformation/StateMachines/VMTransformation/Transformation'

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -12,6 +12,7 @@ describe ServiceTemplateTransformationPlan do
   describe '#validate_order' do
     it 'always allows a plan to be ordered' do
       expect(subject.validate_order).to be_truthy
+      expect(subject.orderable?).to be_truthy # alias
     end
   end
 


### PR DESCRIPTION
`orderable?` is alias method of `validate_order` in `ServiceTemplate`.
Need to declare it as an alias again when overriding `validate_order` in `ServiceTemplateMigrationPlan`.