### PR TITLE
Adds purging for notifications

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -95,6 +95,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "EventStream", :method_name => "purge_timer", :zone => nil)
   end
 
+  def notification_purge_timer
+    queue_work(:class_name => "Notification", :method_name => "purge_timer", :zone => nil)
+  end
+
   def policy_event_purge_timer
     queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -203,6 +203,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:binary_blob_purge_timer)
     end
 
+    every = worker_settings[:notifications_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue(:notification_purge_timer)
+    end
+
     every = worker_settings[:vim_performance_states_purge_interval]
     scheduler.schedule_every(every, :first_in => every) do
       enqueue(:vim_performance_states_purge_timer)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,6 @@
 class Notification < ApplicationRecord
+  include_concern 'Purging'
+
   belongs_to :notification_type
   belongs_to :initiator, :class_name => User, :foreign_key => 'user_id'
   belongs_to :subject, :polymorphic => true

--- a/app/models/notification/purging.rb
+++ b/app/models/notification/purging.rb
@@ -1,0 +1,24 @@
+class Notification
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.notifications.history.keep_notifications.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.notifications.history.purge_window_size
+      end
+
+      def purge_scope(older_than)
+        where(arel_table[:created_at].lt(older_than))
+      end
+
+      def purge_associated_records(ids)
+        NotificationRecipient.where(:notification_id => ids).delete_all
+      end
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -915,6 +915,10 @@
   :level_websocket: info
   :level_vcloud: info
   :level_nuage: info
+:notifications:
+  :history:
+    :purge_window_size: 1000
+    :keep_notifications: 1.week
 :ntp:
   :server:
   - 0.pool.ntp.org
@@ -1222,6 +1226,7 @@
       :log_database_statistics_interval: 1.days
       :memory_threshold: 500.megabytes
       :nice_delta: 3
+      :notifications_purge_interval: 1.day
       :orchestration_stack_retired_interval: 10.minutes
       :performance_collection_interval: 3.minutes
       :performance_collection_start_delay: 5.minutes

--- a/spec/models/notification/purging_spec.rb
+++ b/spec/models/notification/purging_spec.rb
@@ -1,0 +1,40 @@
+describe Notification do
+  context "::Purging" do
+    describe ".purge_by_date" do
+      it "purges old notifications" do
+        FactoryGirl.create(:user)
+        FactoryGirl.create(:user)
+        type = FactoryGirl.create(:notification_type, :audience => NotificationType::AUDIENCE_GLOBAL)
+
+        # Notification and recipients that will not be purged
+        new_notification = FactoryGirl.create(:notification, :notification_type => type)
+
+        old_notification, semi_old_notification = nil
+        Timecop.freeze(6.days.ago) do
+          semi_old_notification = FactoryGirl.create(:notification, :notification_type => type)
+        end
+
+        Timecop.freeze(8.days.ago) do
+          # Notification and recipients that will be purged
+          old_notification = FactoryGirl.create(:notification, :notification_type => type)
+        end
+
+        expect(described_class.all).to match_array([new_notification, semi_old_notification, old_notification])
+        expect(NotificationRecipient.count).to eq(6)
+        count = described_class.purge_by_date(described_class.purge_date)
+        expect(described_class.all).to match_array([new_notification, semi_old_notification])
+        expect(NotificationRecipient.count).to eq(4)
+        expect(count).to eq(1)
+      end
+    end
+
+    describe ".purge_timer" do
+      it "queues the correct purge method" do
+        EvmSpecHelper.local_miq_server
+        described_class.purge_timer
+        q = MiqQueue.first
+        expect(q).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date")
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Sets notifications that are older than a week to be purged by default.
* Purging is run daily
* Clears out notification recipients as well


Links
-----
* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544890
* Pretty much a copy-pasta of this PR:  https://github.com/ManageIQ/manageiq/pull/16754
  - (minus using the orphan purger)