### PR TITLE
Allow individual tables to be specified for metrics

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -3,7 +3,11 @@ class Metric < ApplicationRecord
 
   include Metric::Common
 
-  def self.reindex_table_name
-    "metrics_#{Time.now.utc.hour + 1}"
+  # @param time [ActiveSupport::TimeWithZone, Time, Integer, nil] the hour to run (default: 1 hour from now)
+  # @return the table for the given hour
+  # Unfortunatly, Integer responds_to :hour, so :strftime was used instead.
+  def self.reindex_table_name(time = Time.now.utc.hour + 1)
+    hour = (time.respond_to?(:strftime) ? time.hour : time) % 24
+    "metrics_%02d" % hour
   end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1181,6 +1181,34 @@ describe Metric do
     end
   end
 
+  context "#reindex_table_name" do
+    it "defaults to 1 hour from now" do
+      Timecop.freeze("2017-01-30T09:20UTC") do
+        expect(Metric.reindex_table_name).to eq("metrics_10")
+      end
+    end
+
+    it "pads table to 2 digits" do
+      Timecop.freeze("2017-01-30T03:20UTC") do
+        expect(Metric.reindex_table_name).to eq("metrics_04")
+      end
+    end
+
+    it "provides hour wrap around" do
+      Timecop.freeze("2017-01-30T23:20UTC") do
+        expect(Metric.reindex_table_name).to eq("metrics_00")
+      end
+    end
+
+    it "allows time to be passed in" do
+      expect(Metric.reindex_table_name(Time.parse("2017-01-30T23:20Z").utc)).to eq("metrics_23")
+    end
+
+    it "allows hour integer to be passed in" do
+      expect(Metric.reindex_table_name(23)).to eq("metrics_23")
+    end
+  end
+
   private
 
   def assert_queued_rollup(q_item, instance_id, class_name, args, deliver_on, method = "perf_rollup")


### PR DESCRIPTION
pulled out of #17017

Allows us to specify which metrics table we want to use (still defaulting to an hour from now)

functionality added in #16929

This also fixes 2 bugs:
- metrics table name `metrics_1` should be `metrics_01`
- metrics table name `metrics_24` should be `metrics_00`
