### PR TITLE
Fix rake `evm:status` and `evm:status_full`

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -93,9 +93,9 @@ class EvmApplication
   def self.output_workers_status(servers)
     data = []
     servers.each do |s|
-      mb_usage = w.proportional_set_size || w.memory_usage
-      mb_threshold = w.worker_settings[:memory_threshold]
       s.miq_workers.order(:type).each do |w|
+        mb_usage = w.proportional_set_size || w.memory_usage
+        mb_threshold = w.worker_settings[:memory_threshold]
         data <<
           [w.type,
            w.status.sub("stopping", "stop pending"),


### PR DESCRIPTION
After a botched rebase (allegedly), the evm status commands became unusable since the scope for the `mb_usage` and `mb_threshold` was in the incorrect block.

This fixes that, as well as adds some tests to make this quicker to catch instead of letting our users find out for themselves.


Links
-----
* Offending PR:  https://github.com/ManageIQ/manageiq/pull/17016


Steps for Testing/QA
--------------------

Confirm we aren't crazy by trying to run `rake evm:status` on master, then checkout these changes and do the same.