### PR TITLE
[FINE] Raise error on editing of miq_groups

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -54,6 +54,7 @@ module Api
     end
 
     def parse_set_group(data)
+      raise BadRequestError, "Cannot specify 'miq_groups', must use 'group'" if data.key?("miq_groups")
       group = parse_fetch_group(data.delete("group"))
       data["miq_groups"] = Array(group) if group
     end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -203,6 +203,18 @@ RSpec.describe "users API" do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "rejects edits of miq_groups" do
+      api_basic_authorize collection_action_identifier(:users, :edit)
+
+      run_post(users_url(user1.id), gen_request(:edit, "miq_groups" => {}))
+
+      expected = {
+        "error" => a_hash_including("message" => "Cannot specify 'miq_groups', must use 'group'")
+      }
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body).to include(expected)
+    end
+
     it "supports single user edit" do
       api_basic_authorize collection_action_identifier(:users, :edit)
 


### PR DESCRIPTION
Direct edits of miq_groups was not supported in 5.8. This adds in an error message that tells the user to use the "group" key instead.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549085

@miq-bot add_label bug
@miq-bot assign @abellotti 
