### PR TITLE
Enhance logging around remove snapshot operations

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -63,6 +63,8 @@ module VmOrTemplate::Operations::Snapshot
     snapshot = snapshots.find_by(:id => snapshot_id)
     raise _("Requested VM snapshot not found, unable to remove snapshot") unless snapshot
     begin
+      _log.info("removing snapshot ID: [#{snapshot.id}] uid_ems: [#{snapshot.uid_ems}] ems_ref: [#{snapshot.ems_ref}] name: [#{snapshot.name}] description [#{snapshot.description}]")
+
       run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
     rescue => err
       create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "remove")


### PR DESCRIPTION
Prior to removing a snapshot log the id, uid_ems, ems_ref, name, and
description to aid in diagnosing errors.

Related: 

- ~~https://github.com/ManageIQ/vmware_web_service/pull/34~~
- ~~https://github.com/ManageIQ/manageiq-smartstate/pull/56~~

https://bugzilla.redhat.com/show_bug.cgi?id=1549299