### PR TITLE
Make all public images be visible for provisioning.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -122,6 +122,13 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     n_('Image', 'Images', number)
   end
 
+  def self.tenant_id_clause(user_or_group)
+    template_tenant_ids = MiqTemplate.accessible_tenant_ids(user_or_group, Rbac.accessible_tenant_ids_strategy(self))
+    return if template_tenant_ids.empty?
+
+    ["(vms.template = true AND (vms.tenant_id IN (?) OR vms.publicly_available = true))", template_tenant_ids]
+  end
+
   private
 
   def raise_created_event

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -718,6 +718,38 @@ describe Rbac::Filterer do
             expect(results).to match_array []
           end
         end
+
+        context "searching CloudTemplate" do
+          let(:group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) } # T1
+          let(:admin_user) { FactoryGirl.create(:user, :role => "super_administrator") }
+          let!(:cloud_template_root) { FactoryGirl.create(:template_cloud, :publicly_available => false) }
+
+          it 'returns all cloud templates when user is admin' do
+            results = described_class.filtered(TemplateCloud, :user => admin_user)
+            expect(results).to match_array(TemplateCloud.all)
+          end
+
+          context "when user is restricted user" do
+            let(:tenant_2) { FactoryGirl.create(:tenant, :parent => default_tenant, :source_type => 'CloudTenant') } # T2
+            let(:group_2) { FactoryGirl.create(:miq_group, :tenant => tenant_2) } # T1
+            let(:user_2) { FactoryGirl.create(:user, :miq_groups => [group_2]) }
+            let(:tenant_3) { FactoryGirl.create(:tenant, :parent => tenant_2) } # T3
+            let!(:cloud_template) { FactoryGirl.create(:template_cloud, :tenant => tenant_3, :publicly_available => true) }
+
+            it "returns all public cloud templates" do
+              results = described_class.filtered(TemplateCloud, :user => user_2)
+              expect(results).to match_array([cloud_template, cloud_template_root])
+            end
+
+            context "should ignore" do
+              let!(:cloud_template) { FactoryGirl.create(:template_cloud, :tenant => tenant_3, :publicly_available => false) }
+              it "private cloud templates" do
+                results = described_class.filtered(TemplateCloud, :user => user_2)
+                expect(results).to match_array([cloud_template_root])
+              end
+            end
+          end
+        end
       end
 
       context "tenant 0" do


### PR DESCRIPTION
This PR makes all public images visible for tenants. The issue is that when we have MiQ user with visibility to 1 cloud tenant public images of admin user are not visible.
https://bugzilla.redhat.com/show_bug.cgi?id=1524368

ping @aufi