### PR TITLE
[EUWE] Workaround failed VCR for vCloud NetworkManager

### DIFF
--- a/spec/models/manageiq/providers/vmware/network_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/vmware/network_manager/refresher_spec.rb
@@ -43,6 +43,12 @@ describe ManageIQ::Providers::Vmware::NetworkManager::Refresher do
   end
 
   it "will perform a full refresh" do
+    # NOTE: cloud inventoring has been slightly changed therefore vApp Template collection fails (VCR cassette doesn't
+    # match anymore). Since we're only testing networking in this example, we can simply prevent vApp Templates from
+    # being fetched instead of re-recording the whole thing. Also, the NetworkManager has been reimplemented, therefore
+    # it makes no real sense to dive into fixing this obsolete VCR cassette.
+    allow_any_instance_of(ManageIQ::Providers::Vmware::CloudManager::RefreshParser).to receive(:get_vapp_templates)
+
     2.times do # Run twice to verify that a second run with existing data does not change anything
       @ems.reload
       @ems_network.reload


### PR DESCRIPTION
With this commit we fix failing test in legacy EUWE branch by avoiding unrelated API requests to collect vApp Templates. We simply skip vApp Template collection at all, since vApp Templates are not even tested here.

@miq-bot assign @agrare 