### PR TITLE
Fix RBAC for User and enable tagging for Tenants

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -251,8 +251,8 @@ class MiqGroup < ApplicationRecord
     in_my_region.non_tenant_groups
   end
 
-  def self.with_current_user_groups
-    current_user = User.current_user
+  def self.with_current_user_groups(user = nil)
+    current_user = user || User.current_user
     current_user.admin_user? ? all : where(:id => current_user.miq_group_ids)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -285,8 +285,9 @@ class User < ApplicationRecord
     Thread.current[:user] ||= find_by_userid(current_userid)
   end
 
-  def self.with_current_user_groups
-    current_user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => current_user.miq_group_ids})
+  def self.with_current_user_groups(user = nil)
+    user ||= current_user
+    user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => user.miq_group_ids})
   end
 
   def self.missing_user_features(db_user)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -463,6 +463,7 @@ module Rbac
 
         if MiqUserRole != klass
           filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, managed_filters))
+          scope = scope.with_current_user_groups(user)
         end
 
         scope_by_ids(scope, filtered_ids)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -52,7 +52,7 @@ module Rbac
       VmOrTemplate
     )
 
-    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User)
+    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User Tenant)
 
     NETWORK_MODELS_FOR_BELONGSTO_FILTER = %w(
       CloudNetwork
@@ -499,6 +499,9 @@ module Rbac
         scope_by_parent_ids(associated_class, scope, filtered_ids)
       elsif [MiqUserRole, MiqGroup, User].include?(klass)
         scope_for_user_role_group(klass, scope, miq_group, user, rbac_filters['managed'])
+      elsif klass == Tenant
+        filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, rbac_filters['managed']))
+        scope_by_ids(scope, filtered_ids)
       else
         scope
       end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -635,13 +635,14 @@ describe Rbac::Filterer do
         end
       end
 
-      it "returns all users" do
+      it "returns users from current user's groups" do
+        other_user.miq_groups << group
         get_rbac_results_for_and_expect_objects(User, [user, other_user])
       end
 
-      it "returns all groups" do
+      it "returns user's groups" do
         _expected_groups = [group, other_group] # this will create more groups than 2
-        get_rbac_results_for_and_expect_objects(MiqGroup, MiqGroup.all)
+        get_rbac_results_for_and_expect_objects(MiqGroup, user.miq_groups)
       end
 
       context "with self-service user" do
@@ -1593,8 +1594,10 @@ describe Rbac::Filterer do
     end
 
     context "with group's VMs" do
+      let(:group_user) { FactoryGirl.create(:user, :miq_groups => [group2, group]) }
+      let(:group2) { FactoryGirl.create(:miq_group, :role => 'support') }
+
       before(:each) do
-        group2 = FactoryGirl.create(:miq_group, :role => 'support')
         4.times do |i|
           FactoryGirl.create(:vm_vmware,
                              :name             => "Test VM #{i}",
@@ -1611,12 +1614,12 @@ describe Rbac::Filterer do
             value: connected
             field: MiqGroup.vms-connection_state
         '
-        results, attrs = described_class.search(:class          => "MiqGroup",
-                                                :filter         => filter,
-                                                :miq_group      => group)
 
-        expect(results.length).to eq(2)
-        expect(attrs[:auth_count]).to eq(2)
+        User.with_user(group_user) do
+          results, attrs = described_class.search(:class => "MiqGroup", :filter => filter, :miq_group => group)
+          expect(results.length).to eq(2)
+          expect(attrs[:auth_count]).to eq(2)
+        end
       end
 
       it "when filtering on a virtual column (FB15509)" do
@@ -1627,11 +1630,11 @@ describe Rbac::Filterer do
             value: false
             field: MiqGroup.vms-disconnected
         '
-        results, attrs = described_class.search(:class          => "MiqGroup",
-                                                :filter         => filter,
-                                                :miq_group      => group)
-        expect(results.length).to eq(2)
-        expect(attrs[:auth_count]).to eq(2)
+        User.with_user(group_user) do
+          results, attrs = described_class.search(:class => "MiqGroup", :filter => filter, :miq_group => group)
+          expect(results.length).to eq(2)
+          expect(attrs[:auth_count]).to eq(2)
+        end
       end
     end
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -158,6 +158,17 @@ describe Rbac::Filterer do
           expect(results).to match_array [host_aggregate]
         end
       end
+
+      context "searching for tenants" do
+        before do
+          owner_tenant.tag_with('/managed/environment/prod', :ns => '*')
+        end
+
+        it 'list tagged tenants' do
+          results = described_class.search(:class => Tenant, :user => user).first
+          expect(results).to match_array [owner_tenant]
+        end
+      end
     end
 
     context 'with virtual custom attributes' do

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -78,8 +78,10 @@ describe ResourceSharer do
       let(:resource_to_be_shared) { FactoryGirl.build(:miq_group) }
 
       it "is invalid" do
-        expect(subject).not_to be_valid
-        expect(subject.errors.full_messages).to include(a_string_including("Resource is not sharable"))
+        User.with_user(user) do
+          expect(subject).not_to be_valid
+          expect(subject.errors.full_messages).to include(a_string_including("Resource is not sharable"))
+        end
       end
     end
 


### PR DESCRIPTION
There are two things in this PR:

###  1) Fix RBAC for User:
**before fix:**
Restricted user was able to see all groups and all users.
**after fix:**
Restricted user can see only his groups and users from his groups

###  2) Enable tagging for Tenants
Tenants are taggable but this was not included in RBAC.

### How it is related to chargeback BZ?
in filter tab, there are list of tenants and users(owners) (select box **Show costs by**). And these lists will be visible after UI fix for this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1544875) stated below.

Links
----------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1544875
* https://bugzilla.redhat.com/show_bug.cgi?id=1549137

@miq-bot assign @gtanzillo 
@miq-bot add_label bug, rbac

@miq-bot add_label gaprindashvili/yes