### PR TITLE
[WIP] [FINE] Enhances matching for TripleO role names in Infra

### DIFF
--- a/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openstack/infra_manager/refresh_parser.rb
@@ -86,7 +86,7 @@ module ManageIQ
           # Filtering just server resources which is important to us for getting Purpose of the node
           # (compute, controller, etc.).
           resources += all_stack_server_resources(stack).select do |x|
-            %w(OS::TripleO::Server OS::Nova::Server).include?(x["resource_type"])
+            [/OS::TripleO::\w*Server$/, /OS::Nova::Server/].any?{ |type| x["resource_type"] =~ type}
           end
         end
         @all_server_resources = resources
@@ -143,7 +143,7 @@ module ManageIQ
         indexed_servers = {}
         servers.each { |s| indexed_servers[s.id] = s }
 
-        # Indexed Heat resources, we are interested only in OS::Nova::Server/OS::TripleO::Server
+        # Indexed Heat resources, we are interested only in OS::Nova::Server/OS::TripleO::#{role}Server
         indexed_resources = {}
         all_server_resources.each { |p| indexed_resources[p['physical_resource_id']] = p }
 
@@ -349,7 +349,7 @@ module ManageIQ
           next unless uid
 
           nova_server = stack[:resources].detect do |r|
-            %w(OS::TripleO::Server OS::Nova::Server).include?(r[:resource_category])
+            [/OS::TripleO::\w*Server$/, /OS::Nova::Server/].any?{ |role| r[:resource_category] =~ role}
           end
           next unless nova_server
 


### PR DESCRIPTION
This reflect the change in tripleo-heat-templates that enables Pluggable
server type per Role -
https://github.com/openstack/tripleo-heat-templates/commit/87ce5d457489f1c89ef47add8b5c7d5be094cf9c

Solves https://bugzilla.redhat.com/show_bug.cgi?id=1540579

Steps for Testing/QA
-------------------------------
Have a TripleO setup with OSP12 using quickstart with updated new resource types.
After refresh without this patch you will see no deployment role / cluster in Infra provider for Undercloud. With this patch deployment roles are present and so the matching with physical nodes works.