### PR TITLE
Core changes for azure targeted refresh

### DIFF
--- a/app/models/load_balancer_pool.rb
+++ b/app/models/load_balancer_pool.rb
@@ -8,6 +8,7 @@ class LoadBalancerPool < ApplicationRecord
 
   has_many :load_balancer_listener_pools, :dependent => :destroy
   has_many :load_balancer_listeners, :through => :load_balancer_listener_pools
+  has_many :load_balancers, :through => :load_balancer_listeners
   has_many :load_balancer_pool_member_pools, :dependent => :destroy
   has_many :load_balancer_pool_members, :through => :load_balancer_pool_member_pools
 

--- a/app/models/manager_refresh/inventory_collection_default/network_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/network_manager.rb
@@ -8,7 +8,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         :parent_inventory_collections => [:vms, :network_ports, :load_balancers],
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.cloud_subnet_network_ports.references(:network_ports).where(
           :network_ports => {:ems_ref => manager_uuids}
@@ -114,7 +114,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         }
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_pools.where(:ems_ref => manager_uuids)
       end
@@ -132,10 +132,10 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         }
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_pool_members
-                            .joins(:load_balancer_pool_member_pools => :load_balancer_pool)
+                            .joins(:load_balancer_pool_member_pools => :load_balancler_pool)
                             .where(:load_balancer_pool_member_pools => {'load_balancer_pools' => {:ems_ref => manager_uuids}})
                             .distinct
       end
@@ -151,7 +151,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         :parent_inventory_collections => [:load_balancers]
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_pool_member_pools
                             .references(:load_balancer_pools)
@@ -173,7 +173,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         }
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_listeners.joins(:load_balancer).where(
           :load_balancers => {:ems_ref => manager_uuids}
@@ -191,7 +191,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         :parent_inventory_collections => [:load_balancers]
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_listener_pools.joins(:load_balancer_pool).where(
           :load_balancer_pools => {:ems_ref => manager_uuids}
@@ -211,7 +211,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         }
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_health_checks.where(:ems_ref => manager_uuids)
       end
@@ -227,7 +227,7 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
         :parent_inventory_collections => [:load_balancers],
       }
 
-      extra_attributes[:targeted_arel] = lambda do |inventory_collection|
+      attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_health_check_members.references(:load_balancer_health_checks).where(
           :load_balancer_health_checks => {:ems_ref => manager_uuids}

--- a/app/models/manager_refresh/inventory_collection_default/network_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/network_manager.rb
@@ -116,7 +116,10 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.load_balancer_pools.where(:ems_ref => manager_uuids)
+        inventory_collection.parent.load_balancer_pools
+          .joins(:load_balancers)
+          .where(:load_balancers => {:ems_ref => manager_uuids})
+          .distinct
       end
 
       attributes.merge!(extra_attributes)
@@ -135,9 +138,14 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_pool_members
-                            .joins(:load_balancer_pool_member_pools => :load_balancler_pool)
-                            .where(:load_balancer_pool_member_pools => {'load_balancer_pools' => {:ems_ref => manager_uuids}})
-                            .distinct
+          .joins(:load_balancer_pool_member_pools => [:load_balancer_pool => :load_balancers])
+          .where(:load_balancer_pool_member_pools => {
+            'load_balancer_pools' => {
+              'load_balancers' => {
+                :ems_ref => manager_uuids
+              }
+            }
+          }).distinct
       end
 
       attributes.merge!(extra_attributes)
@@ -154,8 +162,8 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
         inventory_collection.parent.load_balancer_pool_member_pools
-                            .references(:load_balancer_pools)
-                            .where(:load_balancer_pools => {:ems_ref => manager_uuids})
+                            .joins(:load_balancer_pool => :load_balancers)
+                            .where(:load_balancer_pools => {'load_balancers' => {:ems_ref => manager_uuids}})
                             .distinct
       end
 
@@ -175,9 +183,10 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.load_balancer_listeners.joins(:load_balancer).where(
-          :load_balancers => {:ems_ref => manager_uuids}
-        )
+        inventory_collection.parent.load_balancer_listeners
+          .joins(:load_balancer)
+          .where(:load_balancers => {:ems_ref => manager_uuids})
+          .distinct
       end
 
       attributes.merge!(extra_attributes)
@@ -193,9 +202,10 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.load_balancer_listener_pools.joins(:load_balancer_pool).where(
-          :load_balancer_pools => {:ems_ref => manager_uuids}
-        )
+        inventory_collection.parent.load_balancer_listener_pools
+          .joins(:load_balancer_pool => :load_balancers)
+          .where(:load_balancer_pools => {'load_balancers' => {:ems_ref => manager_uuids}})
+          .distinct
       end
 
       attributes.merge!(extra_attributes)
@@ -213,7 +223,10 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.load_balancer_health_checks.where(:ems_ref => manager_uuids)
+        inventory_collection.parent.load_balancer_health_checks
+          .joins(:load_balancer)
+          .where(:load_balancers => {:ems_ref => manager_uuids})
+          .distinct
       end
 
       attributes.merge!(extra_attributes)
@@ -229,9 +242,10 @@ class ManagerRefresh::InventoryCollectionDefault::NetworkManager < ManagerRefres
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
         manager_uuids = inventory_collection.parent_inventory_collections.flat_map { |c| c.manager_uuids.to_a }
-        inventory_collection.parent.load_balancer_health_check_members.references(:load_balancer_health_checks).where(
-          :load_balancer_health_checks => {:ems_ref => manager_uuids}
-        )
+        inventory_collection.parent.load_balancer_health_check_members
+          .joins(:load_balancer_health_check => :load_balancer)
+          .where(:load_balancer_health_checks => {'load_balancers' => {:ems_ref => manager_uuids}})
+          .distinct
       end
 
       attributes.merge!(extra_attributes)


### PR DESCRIPTION
Correct targeted_arel joined with load_balancer
    
Correct targeted_arel joined with load_balancer. For AWS,it was ok to join to pool, which had the same ems_ref as lb. But for Azure, the pool has different ems_ref, so we need to correctly join every table to load_balancers table and filter there
    
And do not write into extra attributes, since that can leak into other settings.

Partially fixes
https://bugzilla.redhat.com/show_bug.cgi?id=1487602

Passes all specs for all Providers locally
