### PR TITLE
Backend enhancements for transformation plan request to better support UI

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -97,14 +97,13 @@ class MiqRequest < ApplicationRecord
         :automation => N_("Automation")
       }
     },
-    :Transformation => {
-      :ServiceTemplateTransformationPlanRequest => {
-        :transformation_plan => N_("Transformation Plan")
-      }
-    }
   }.freeze
 
-  REQUEST_TYPES_BACKEND_ONLY = {:MiqProvisionRequestTemplate => {:template => "VM Provision Template"}}
+  REQUEST_TYPES_BACKEND_ONLY = {
+    :MiqProvisionRequestTemplate              => {:template            => "VM Provision Template"},
+    :ServiceTemplateTransformationPlanRequest => {:transformation_plan => "Transformation Plan"}
+  }
+
   REQUEST_TYPES = MODEL_REQUEST_TYPES.values.each_with_object(REQUEST_TYPES_BACKEND_ONLY) { |i, h| i.each { |k, v| h[k] = v } }
   REQUEST_TYPE_TO_MODEL = MODEL_REQUEST_TYPES.values.each_with_object({}) do |i, h|
     i.each { |k, v| v.keys.each { |vk| h[vk] = k } }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -3,8 +3,13 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     ServiceTemplateTransformationPlanTask
   end
 
+  def self.get_description(req_obj)
+    source_name = req_obj.source.name
+    req_obj.kind_of?(ServiceTemplateTransformationPlanRequest) ? source_name : "Transforming VM [#{source_name}]"
+  end
+
   def after_request_task_create
-    update_attributes(:description => "Transforming VM #{source.name}")
+    update_attributes(:description => get_description)
   end
 
   def resource_action

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -72,5 +72,15 @@ describe ServiceTemplateTransformationPlanTask do
         expect(plan.vm_resources.first.status).to eq('Completed')
       end
     end
+
+    describe '.get_description' do
+      it 'describes a task' do
+        expect(described_class.get_description(task)).to include("Transforming VM")
+      end
+
+      it 'describes a request' do
+        expect(described_class.get_description(request)).to eq(plan.name)
+      end
+    end
   end
 end


### PR DESCRIPTION
Small enhancements to transformation plan request
1. Treat `ServiceTemplateTransformationPlanRequest` as backend only so that it does not show on the service requests screen
2. Set the request's description the same as plan's name. The migration UI shows the request by description. The description can link to the plan.