### PR TITLE
[WIP] Add purging for notifications using expires_in

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -95,6 +95,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "EventStream", :method_name => "purge_timer", :zone => nil)
   end
 
+  def notification_purge_timer
+    queue_work(:class_name => "Notification", :method_name => "purge_timer", :zone => nil)
+  end
+
   def policy_event_purge_timer
     queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -203,6 +203,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:binary_blob_purge_timer)
     end
 
+    every = worker_settings[:notifications_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue(:notification_purge_timer)
+    end
+
     every = worker_settings[:vim_performance_states_purge_interval]
     scheduler.schedule_every(every, :first_in => every) do
       enqueue(:vim_performance_states_purge_timer)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,6 @@
 class Notification < ApplicationRecord
+  include_concern 'Purging'
+
   belongs_to :notification_type
   belongs_to :initiator, :class_name => User, :foreign_key => 'user_id'
   belongs_to :subject, :polymorphic => true

--- a/app/models/notification/purging.rb
+++ b/app/models/notification/purging.rb
@@ -1,0 +1,68 @@
+class Notification
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        nil
+      end
+
+      def purge_window_size
+        ::Settings.notifications.history.purge_window_size
+      end
+
+      # Collects the notifications that have expired based on the expires_in
+      # value for each notification type.  The "older_than" value is not used
+      # for this function, so it is named as `_`.
+      #
+      # First, this collects all of the notification_types and groups them by
+      # expires_in value (we only seed 3 different types currently).
+      #
+      # It then builds a single query that matches against each
+      # notification_type and if it has expired that specific expires_in for
+      # that type.
+      def purge_scope(_)
+        query = nil
+
+        # Make a query to collect the expires_in and id columns for all of the
+        # NotificationTypes, and then put them into a hash with the key being
+        # the expires_in column, and the values being all of the ids matching
+        # the expires_in value.
+        expire_ids = NotificationType.pluck(:expires_in, :id)
+        expire_ids = expire_ids.each_with_object({}) do |(key, id), result|
+          result[key] ||= []
+          result[key] << id
+        end
+
+        # Create a query that matches on the notification on expires_in for
+        # specific ids that have that exact same expires_in time. So something
+        # like:
+        #
+        #   SELECT *
+        #   FROM "notifications"
+        #   WHERE ((("notifications"."notification_type_id" IN (1,2,3)
+        #          AND "notifications"."created_at" < [[1.days.ago.utc]])
+        #      OR ("notifications"."notification_type_id" IN (4,5,6)
+        #          AND "notifications"."created_at" < [[7.days.ago.utc]]))
+        #      OR ("notifications"."notification_type_id" IN (7,8,9)
+        #          AND "notifications"."created_at" < [[14.days.ago.utc]]))
+        #
+        expire_ids.each do |expires_in, type_ids|
+          new_condition = arel_table.grouping(
+            arel_table[:notification_type_id].in(type_ids).and(
+              arel_table[:created_at].lt(expires_in.seconds.ago.utc)
+            )
+          )
+          query = query.nil? ? new_condition : query.or(new_condition)
+        end
+
+        where(query)
+      end
+
+      def purge_associated_records(ids)
+        NotificationRecipient.where(:notification_id => ids).delete_all
+      end
+    end
+  end
+end

--- a/app/models/notification/purging.rb
+++ b/app/models/notification/purging.rb
@@ -15,49 +15,9 @@ class Notification
       # Collects the notifications that have expired based on the expires_in
       # value for each notification type.  The "older_than" value is not used
       # for this function, so it is named as `_`.
-      #
-      # First, this collects all of the notification_types and groups them by
-      # expires_in value (we only seed 3 different types currently).
-      #
-      # It then builds a single query that matches against each
-      # notification_type and if it has expired that specific expires_in for
-      # that type.
       def purge_scope(_)
-        query = nil
-
-        # Make a query to collect the expires_in and id columns for all of the
-        # NotificationTypes, and then put them into a hash with the key being
-        # the expires_in column, and the values being all of the ids matching
-        # the expires_in value.
-        expire_ids = NotificationType.pluck(:expires_in, :id)
-        expire_ids = expire_ids.each_with_object({}) do |(key, id), result|
-          result[key] ||= []
-          result[key] << id
-        end
-
-        # Create a query that matches on the notification on expires_in for
-        # specific ids that have that exact same expires_in time. So something
-        # like:
-        #
-        #   SELECT *
-        #   FROM "notifications"
-        #   WHERE ((("notifications"."notification_type_id" IN (1,2,3)
-        #          AND "notifications"."created_at" < [[1.days.ago.utc]])
-        #      OR ("notifications"."notification_type_id" IN (4,5,6)
-        #          AND "notifications"."created_at" < [[7.days.ago.utc]]))
-        #      OR ("notifications"."notification_type_id" IN (7,8,9)
-        #          AND "notifications"."created_at" < [[14.days.ago.utc]]))
-        #
-        expire_ids.each do |expires_in, type_ids|
-          new_condition = arel_table.grouping(
-            arel_table[:notification_type_id].in(type_ids).and(
-              arel_table[:created_at].lt(expires_in.seconds.ago.utc)
-            )
-          )
-          query = query.nil? ? new_condition : query.or(new_condition)
-        end
-
-        where(query)
+        Notification.joins(:notification_type)
+                    .where("notifications.created_at + notification_types.expires_in * INTERVAL '1 second' < now()")
       end
 
       def purge_associated_records(ids)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -915,6 +915,9 @@
   :level_websocket: info
   :level_vcloud: info
   :level_nuage: info
+:notifications:
+  :history:
+    :purge_window_size: 1000
 :ntp:
   :server:
   - 0.pool.ntp.org
@@ -1222,6 +1225,7 @@
       :log_database_statistics_interval: 1.days
       :memory_threshold: 500.megabytes
       :nice_delta: 3
+      :notifications_purge_interval: 6.hours
       :orchestration_stack_retired_interval: 10.minutes
       :performance_collection_interval: 3.minutes
       :performance_collection_start_delay: 5.minutes

--- a/spec/models/notification/purging_spec.rb
+++ b/spec/models/notification/purging_spec.rb
@@ -1,0 +1,178 @@
+describe Notification do
+  context "::Purging" do
+    describe "purge_scope" do
+      # Defined at the bottom
+      before { seed_notification_types_and_users }
+
+      let(:type_1_day)  { NotificationType.where(:name => "1 day").first }
+      let(:type_7_day)  { NotificationType.where(:name => "7 days").first }
+      let(:type_14_day) { NotificationType.where(:name => "14 days").first }
+
+      it "creates a query for every notification_type expire_in value" do
+        Timecop.freeze(Time.current) do
+          db_strftime = "%Y-%m-%d %H:%M:%S.%6N"
+          type_1_day_expires  = type_1_day.expires_in.seconds.ago.utc.strftime(db_strftime)
+          type_7_day_expires  = type_7_day.expires_in.seconds.ago.utc.strftime(db_strftime)
+          type_14_day_expires = type_14_day.expires_in.seconds.ago.utc.strftime(db_strftime)
+
+          expected_sql = <<-SQL.lines.map(&:strip).join(" ")
+            SELECT "notifications".*
+            FROM "notifications"
+            WHERE ((("notifications"."notification_type_id" IN (#{type_1_day.id})
+                   AND "notifications"."created_at" < '#{type_1_day_expires}')
+               OR ("notifications"."notification_type_id" IN (#{type_7_day.id})
+                   AND "notifications"."created_at" < '#{type_7_day_expires}'))
+               OR ("notifications"."notification_type_id" IN (#{type_14_day.id})
+                   AND "notifications"."created_at" < '#{type_14_day_expires}'))
+          SQL
+
+          expect(described_class.purge_scope(nil).to_sql).to eq(expected_sql)
+        end
+      end
+    end
+
+    describe ".purge_by_date" do
+      # Defined at the bottom
+      before { seed_notification_types_and_users }
+
+      let(:notification_type) { NotificationType.where(:name => type_name).first }
+      let(:new_notification) do
+        FactoryGirl.create(:notification, :notification_type => notification_type)
+      end
+
+      let(:semi_old_notification) do
+        Timecop.freeze(notification_type.expires_in.seconds.ago + 6.hours) do
+          FactoryGirl.create(:notification, :notification_type => notification_type)
+        end
+      end
+
+      let(:old_notification) do
+        Timecop.freeze(notification_type.expires_in.seconds.ago - 6.hours) do
+          FactoryGirl.create(:notification, :notification_type => notification_type)
+        end
+      end
+
+      context "for 24.hour notification types" do
+        let(:type_name) { "1 day" }
+
+        it "purges notifications older than a day" do
+          expect(described_class.all).to match_array([new_notification, semi_old_notification, old_notification])
+          expect(NotificationRecipient.count).to eq(6)
+          count = described_class.purge_by_date(described_class.purge_date)
+          expect(described_class.all).to match_array([new_notification, semi_old_notification])
+          expect(NotificationRecipient.count).to eq(4)
+          expect(count).to eq(1)
+        end
+      end
+
+      context "for 7.day notification types" do
+        let(:type_name) { "7 days" }
+
+        it "purges notifications older than a week" do
+          expect(described_class.all).to match_array([new_notification, semi_old_notification, old_notification])
+          expect(NotificationRecipient.count).to eq(6)
+          count = described_class.purge_by_date(described_class.purge_date)
+          expect(described_class.all).to match_array([new_notification, semi_old_notification])
+          expect(NotificationRecipient.count).to eq(4)
+          expect(count).to eq(1)
+        end
+      end
+
+      context "for 14.day notification types" do
+        let(:type_name) { "14 days" }
+
+        it "purges notifications older than two weeks" do
+          expect(described_class.all).to match_array([new_notification, semi_old_notification, old_notification])
+          expect(NotificationRecipient.count).to eq(6)
+          count = described_class.purge_by_date(described_class.purge_date)
+          expect(described_class.all).to match_array([new_notification, semi_old_notification])
+          expect(NotificationRecipient.count).to eq(4)
+          expect(count).to eq(1)
+        end
+      end
+
+      context "for mixed notification types" do
+        # Using the existing let for this type, "7 days" and "14 days" will be
+        # built custom for this test.
+        let(:type_name)   { "1 day" }
+        let(:type_7_day)  { NotificationType.where(:name => "7 days").first }
+        let(:type_14_day) { NotificationType.where(:name => "14 days").first }
+
+        let(:new_7_day_notification) do
+          FactoryGirl.create(:notification, :notification_type => type_7_day)
+        end
+
+        let(:new_14_day_notification) do
+          FactoryGirl.create(:notification, :notification_type => type_7_day)
+        end
+
+        let(:old_7_day_notification) do
+          Timecop.freeze(type_7_day.expires_in.seconds.ago - 6.hours) do
+            FactoryGirl.create(:notification, :notification_type => type_7_day)
+          end
+        end
+
+        let(:old_14_day_notification) do
+          Timecop.freeze(type_14_day.expires_in.seconds.ago - 6.hours) do
+            FactoryGirl.create(:notification, :notification_type => type_14_day)
+          end
+        end
+
+        let(:all_notifcations) do
+          [
+            new_notification,
+            semi_old_notification,
+            old_notification,
+            new_7_day_notification,
+            old_7_day_notification,
+            new_14_day_notification,
+            old_14_day_notification
+          ]
+        end
+
+        let(:kept_notifcations) do
+          [
+            new_notification,
+            semi_old_notification,
+            new_7_day_notification,
+            new_14_day_notification
+          ]
+        end
+
+        it "purges notifications older than two weeks" do
+          expect(described_class.all).to match_array(all_notifcations)
+          expect(NotificationRecipient.count).to eq(14)
+          count = described_class.purge_by_date(described_class.purge_date)
+          expect(described_class.all).to match_array(kept_notifcations)
+          expect(NotificationRecipient.count).to eq(8)
+          expect(count).to eq(3)
+        end
+      end
+    end
+
+    describe ".purge_timer" do
+      it "queues the correct purge method" do
+        EvmSpecHelper.local_miq_server
+        described_class.purge_timer
+        q = MiqQueue.first
+        expect(q).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date")
+      end
+    end
+
+    def seed_notification_types_and_users
+      # Seed different notification types
+      [1.day, 7.days, 14.days].each do |expire|
+        type_attrs = {
+          :name       => expire.inspect, # example: "1 day"
+          :audience   => NotificationType::AUDIENCE_GLOBAL,
+          :expires_in => expire.to_i
+        }
+        FactoryGirl.create(:notification_type, type_attrs)
+      end
+
+      # Create some recipients
+      FactoryGirl.create(:user)
+      FactoryGirl.create(:user)
+    end
+  end
+end


### PR DESCRIPTION
- Purges based on the expires_in for the given notification_type on a notification
  * This requires 1 extra query, but I think Keenan will survive (trust me, I tried to make this work in a single query... but gave up)
- Puring runs every six hours (clears out 24 hour notifications faster)
- Clears out notification recipients as well

This is a alternative to https://github.com/ManageIQ/manageiq/pull/17046 in which a global setting was used to determine when to clear up notifications.  This could still be done in here as a well, but I left it only using the `expires_in` for now.


Info on the `.purge_scope` query
--------------------------------

The query for the `Notification.purge_scope` is a little complex, so let me walk through it:

- First, it collects all of the `notification_types` and groups the ids by the `expires_in` value
- From there, it builds a where clause as a collection of "OR" statements for each `expires_in`/`type_ids` group.  An example sub-condition looks like:
  
  ```sql
  (notification_type_id IN (type_ids) AND created_at < {{expires_in_value}})
  ```

The full query looks something like this:

```sql
SELECT *
FROM "notifications"
WHERE ((("notifications"."notification_type_id" IN (1,2,3)
       AND "notifications"."created_at" < '2000-01-13 00:00:00.000000')
   OR ("notifications"."notification_type_id" IN (4,5,6)
       AND "notifications"."created_at" < '2000-01-07 00:00:00.000000'))
   OR ("notifications"."notification_type_id" IN (7,8,9)
       AND "notifications"."created_at" < '2000-01-01 00:00:00.000000'))
```

Hopefully it isn't terribly unoptimized doing that, but it might need an index to scale properly...


Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1544890
* Still pretty much a copy-pasta of this PR:  https://github.com/ManageIQ/manageiq/pull/16754
  - (minus using the orphan purger)
* Original Attempt:  https://github.com/ManageIQ/manageiq/pull/17046