### PR TITLE
Adding missing Product Feature for viewing a single container

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4552,6 +4552,10 @@
         :description: Display Lists of Containers
         :feature_type: view
         :identifier: container_show_list
+      - :name: Show
+        :description: Display Individual Containers
+        :feature_type: view
+        :identifier: container_show
       - :name: Timeline
         :description: Display Timelines for Containers
         :feature_type: view


### PR DESCRIPTION

We were missing the Product feature for container_show.

This is required for: https://github.com/ManageIQ/manageiq-api/pull/332
