### PR TITLE
Consolidate Azure refresh workers

### DIFF
--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -11,7 +11,6 @@ MIQ_WORKER_TYPES = {
   "ManageIQ::Providers::Azure::CloudManager::EventCatcher"                      => %i(manageiq_default),
   "ManageIQ::Providers::Azure::CloudManager::MetricsCollectorWorker"            => %i(manageiq_default),
   "ManageIQ::Providers::Azure::CloudManager::RefreshWorker"                     => %i(manageiq_default),
-  "ManageIQ::Providers::Azure::NetworkManager::RefreshWorker"                   => %i(manageiq_default),
   "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::EventCatcher"       => %i(manageiq_default),
   "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RefreshWorker"      => %i(manageiq_default),
   "ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker"           => %i(manageiq_default),


### PR DESCRIPTION
Depending PR merges both Azure refresh workers so it can be performed in one worker.  

Depends on: https://github.com/ManageIQ/manageiq-providers-azure/pull/216
Related discussion: https://github.com/ManageIQ/manageiq/pull/16465, https://github.com/ManageIQ/manageiq-providers-openstack/pull/154

One of many requirements for: https://bugzilla.redhat.com/show_bug.cgi?id=1487602

@miq-bot add_label gaprindashvili/yes
cc @Ladas 