### PR TITLE
Calculate totals for hours of exitstence in metering reports

### DIFF
--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -10,6 +10,7 @@ class MeteringContainerImage < ChargebackContainerImage
     {
       "cpu_cores_allocated_metric" => {:grouping => [:total]},
       "cpu_cores_used_metric"      => {:grouping => [:total]},
+      "existence_hours_metric"     => {:grouping => [:total]},
       "fixed_compute_metric"       => {:grouping => [:total]},
       "memory_allocated_metric"    => {:grouping => [:total]},
       "memory_used_metric"         => {:grouping => [:total]},

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -8,11 +8,12 @@ class MeteringContainerProject < ChargebackContainerProject
 
   def self.report_col_options
     {
-      "cpu_cores_used_metric" => {:grouping => [:total]},
-      "fixed_compute_metric"  => {:grouping => [:total]},
-      "memory_used_metric"    => {:grouping => [:total]},
-      "metering_used_metric"  => {:grouping => [:total]},
-      "net_io_used_metric"    => {:grouping => [:total]},
+      "cpu_cores_used_metric"  => {:grouping => [:total]},
+      "existence_hours_metric" => {:grouping => [:total]},
+      "fixed_compute_metric"   => {:grouping => [:total]},
+      "memory_used_metric"     => {:grouping => [:total]},
+      "metering_used_metric"   => {:grouping => [:total]},
+      "net_io_used_metric"     => {:grouping => [:total]},
     }
   end
 

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -11,6 +11,7 @@ class MeteringVm < ChargebackVm
       "cpu_allocated_metric"     => {:grouping => [:total]},
       "cpu_used_metric"          => {:grouping => [:total]},
       "disk_io_used_metric"      => {:grouping => [:total]},
+      "existence_hours_metric"   => {:grouping => [:total]},
       "fixed_compute_metric"     => {:grouping => [:total]},
       "memory_allocated_metric"  => {:grouping => [:total]},
       "memory_used_metric"       => {:grouping => [:total]},

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -4,6 +4,7 @@ describe MeteringContainerImage do
   let(:hourly_rate)       { 0.01 }
   let(:count_hourly_rate) { 1.00 }
   let(:starting_date) { Time.parse('2012-09-01 23:59:59Z').utc }
+  let(:options) { base_options }
   let(:ts) { starting_date.in_time_zone(Metric::Helper.get_time_zone(options[:ext_options])) }
   let(:report_run_time) { month_end }
   let(:month_beginning) { ts.beginning_of_month.utc }
@@ -58,5 +59,22 @@ describe MeteringContainerImage do
       expect(subject.cpu_cores_allocated_metric).to eq(@container.limit_cpu_cores)
       expect(subject.cpu_cores_allocated_metric).to eq(@container.limit_memory_bytes / 1.megabytes)
     end
+  end
+
+  let(:report_col_options) do
+    {
+      "cpu_cores_allocated_metric" => {:grouping => [:total]},
+      "cpu_cores_used_metric"      => {:grouping => [:total]},
+      "existence_hours_metric"     => {:grouping => [:total]},
+      "fixed_compute_metric"       => {:grouping => [:total]},
+      "memory_allocated_metric"    => {:grouping => [:total]},
+      "memory_used_metric"         => {:grouping => [:total]},
+      "metering_used_metric"       => {:grouping => [:total]},
+      "net_io_used_metric"         => {:grouping => [:total]},
+    }
+  end
+
+  it 'sets grouping settings for all related columns' do
+    expect(described_class.report_col_options).to eq(report_col_options)
   end
 end

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -64,4 +64,19 @@ describe MeteringContainerProject do
       expect(subject.net_io_used_metric).to eq(net_usage_rate_average * count_of_metric_rollup)
     end
   end
+
+  let(:report_col_options) do
+    {
+      "cpu_cores_used_metric"  => {:grouping => [:total]},
+      "existence_hours_metric" => {:grouping => [:total]},
+      "fixed_compute_metric"   => {:grouping => [:total]},
+      "memory_used_metric"     => {:grouping => [:total]},
+      "metering_used_metric"   => {:grouping => [:total]},
+      "net_io_used_metric"     => {:grouping => [:total]},
+    }
+  end
+
+  it 'sets grouping settings for all related columns' do
+    expect(described_class.report_col_options).to eq(report_col_options)
+  end
 end

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -133,4 +133,24 @@ describe MeteringVm do
   it 'lists proper attributes' do
     expect(described_class.attribute_names).to match_array(allowed_attributes)
   end
+
+  let(:report_col_options) do
+    {
+      "cpu_allocated_metric"     => {:grouping => [:total]},
+      "cpu_used_metric"          => {:grouping => [:total]},
+      "disk_io_used_metric"      => {:grouping => [:total]},
+      "existence_hours_metric"   => {:grouping => [:total]},
+      "fixed_compute_metric"     => {:grouping => [:total]},
+      "memory_allocated_metric"  => {:grouping => [:total]},
+      "memory_used_metric"       => {:grouping => [:total]},
+      "metering_used_metric"     => {:grouping => [:total]},
+      "net_io_used_metric"       => {:grouping => [:total]},
+      "storage_allocated_metric" => {:grouping => [:total]},
+      "storage_used_metric"      => {:grouping => [:total]},
+    }
+  end
+
+  it 'sets grouping settings for all related columns' do
+    expect(described_class.report_col_options).to eq(report_col_options)
+  end
 end


### PR DESCRIPTION
`existence_hours_metric` columns have not been included in option hash about grouping.
This changed need to re-save report definition.

**before**
![screen shot 2018-03-01 at 15 47 48](https://user-images.githubusercontent.com/14937244/36850787-f115f08a-1d67-11e8-84ee-cd887daefdb1.png)

**after**
![screen shot 2018-03-01 at 15 47 31](https://user-images.githubusercontent.com/14937244/36850792-f3084956-1d67-11e8-9a00-02f18ea674cd.png)

@miq-bot assign @gtanzillo 

@miq-bot add_label chargeback, bug, gaprindashvili/yes


