### PR TITLE
Add tagging feature for Ansible Credentials

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4803,6 +4803,10 @@
         :description: Ansible Credentials Refresh
         :feature_type: control
         :identifier: embedded_automation_manager_credentials_refresh
+      - :name: Edit Tags
+        :description: Edit Tags for the selected Ansible Credentials
+        :feature_type: control
+        :identifier: ansible_credential_tag
 
 # Automation Manager
 - :name: Ansible Tower


### PR DESCRIPTION
**More in:** https://bugzilla.redhat.com/show_bug.cgi?id=1526219

This PR is a part of making tagging support work in _Ansible Credentials_, and also with another PR in UI repo, completes adding tagging support for Ansible Credentials (in _Automation > Ansible > Credentials_). It needs to be merged first (before the UI, to remain everything work properly).

