### PR TITLE
Remove new fields from export if empty

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -60,7 +60,10 @@ class MiqAeMethod < ApplicationRecord
   end
 
   def to_export_yaml
-    export_attributes
+    export_attributes.tap do |hash|
+      hash.delete('options') if options.empty?
+      hash.delete('embedded_methods') if embedded_methods.empty?
+    end
   end
 
   def method_inputs

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -142,7 +142,8 @@ describe MiqAeMethod do
 
     expect(result['name']).to eql('foo_method')
     expect(result['location']).to eql('inline')
-    expect(result['options']).to be_nil
-    expect(result['embedded_methods']).to be_nil
+    keys = result.keys
+    expect(keys.exclude?('options')).to be_truthy
+    expect(keys.exclude?('embedded_methods')).to be_truthy
   end
 end

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -127,4 +127,22 @@ describe MiqAeMethod do
                             :location => "inline")
     expect(m1.domain.name).to eql('dom1')
   end
+
+  it "#to_export_yaml" do
+    d1 = FactoryGirl.create(:miq_ae_system_domain, :name => 'dom1', :priority => 10)
+    n1 = FactoryGirl.create(:miq_ae_namespace, :name => 'ns1', :parent_id => d1.id)
+    c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    m1 = FactoryGirl.create(:miq_ae_method,
+                            :class_id => c1.id,
+                            :name     => "foo_method",
+                            :scope    => "instance",
+                            :language => "ruby",
+                            :location => "inline")
+    result = m1.to_export_yaml
+
+    expect(result['name']).to eql('foo_method')
+    expect(result['location']).to eql('inline')
+    expect(result['options']).to be_nil
+    expect(result['embedded_methods']).to be_nil
+  end
 end


### PR DESCRIPTION
To stay backward compatible with old importers, if the 2 new attributes from G release

1. **options**
2. **embedded_methods**

are empty, then we should not export it. This would help if we try
to export the Automate model from newer versions, which dont have
 

1. Embedded Methods or
2.  Embedded Ansible methods, which use options


into an older system. The old importer wouldn't be aware of these new attributes.

Issue found when back porting fixes to Fine release PR # https://github.com/ManageIQ/manageiq-content/pull/256