### PR TITLE
[FINE] Add service model for MiqTask which is needed by event state machine.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_task.rb
@@ -1,0 +1,4 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqTask < MiqAeServiceModelBase
+  end
+end


### PR DESCRIPTION
Blocks https://github.com/ManageIQ/manageiq-content/pull/256.

Follow up of https://github.com/ManageIQ/manageiq-content/pull/243.

https://bugzilla.redhat.com/show_bug.cgi?id=1550725

@miq-bot add_label bug, fine/yes
cc @gmcculloug 
