### PR TITLE
Add uniqueness of service for generation chargeback report for SSUI

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -372,11 +372,11 @@ class Service < ApplicationRecord
   end
 
   def chargeback_report_name
-    "Chargeback-Vm-Monthly-#{name}"
+    "Chargeback-Vm-Monthly-#{name}-#{id}"
   end
 
   def generate_chargeback_report(options = {})
-    _log.info("Generation of chargeback report for service #{name} started...")
+    _log.info("Generation of chargeback report for service #{name} with #{id} started...")
     MiqReportResult.where(:name => chargeback_report_name).destroy_all
     report = MiqReport.new(chargeback_yaml)
     options[:report_sync] = true

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -442,7 +442,7 @@ describe Service do
 
     describe "#chargeback_report_name" do
       it "creates chargeback report's name" do
-        expect(@service.chargeback_report_name).to eq "Chargeback-Vm-Monthly-Test_Service_1"
+        expect(@service.chargeback_report_name).to eq "Chargeback-Vm-Monthly-Test_Service_1-#{@service.id}"
       end
     end
 


### PR DESCRIPTION
Chargeback report in summary dashboard screen is calculated
from data from this API request:
```
/api/services?expand=resources&filter[]=service_id%3Dnil&attributes=chargeback_report
```

and this request is returing data from each service let's say in this structure:
(Assume that we 3 different service with same name but with different ID)
```
service1:
  chargeback_data_for_service_my_service

service2:
  chargeback_data_for_service_my_service

service3:
  chargeback_data_for_service_my_service
```

but for each service has been used
same name of report because services could be
named by same name.

So when there is generated result for `service3` and
this result is empty then in final API request
will have all services empty result too because
report results from service1 and service2 have been
overwritten by empty result from service 3 -
thanks to the distinguishing by just name.

So I am adding Service#id for distiguishing and
ensuring uniqueness to fetch correct chargeback 
report result for each service.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1551113


@miq-bot assign @gtanzillo 

@yrudman can you review it please ?


@miq-bot add_label chargeback, bug, gaprindashvili/yes

