### PR TITLE
Add tagging feature for Ansible Repositories

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4746,6 +4746,10 @@
         :description: Ansible Repositories Refresh
         :feature_type: control
         :identifier: embedded_configuration_script_source_refresh
+      - :name: Edit Tags
+        :description: Edit Tags for the selected Ansible Repositories
+        :feature_type: control
+        :identifier: ansible_repository_tag
   - :name: Playbooks
     :description: Everything under Playbooks
     :feature_type: node


### PR DESCRIPTION
More in: https://bugzilla.redhat.com/show_bug.cgi?id=1526217

This PR is a part of making tagging support work in Ansible Repositories. More PRs (to manageiq-ui-classic repo and also for Ansible Playbooks) are coming soon.