### PR TITLE
Remove options[:user_message] during miq_request_task creation.

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -559,6 +559,7 @@ class MiqRequest < ApplicationRecord
   def clean_up_keys_for_request_task
     req_task_attributes = attributes.dup
     (req_task_attributes.keys - MiqRequestTask.column_names + REQUEST_UNIQUE_KEYS).each { |key| req_task_attributes.delete(key) }
+    req_task_attributes["options"].delete(:user_message)
 
     _log.debug("#{self.class.name} Attributes: [#{req_task_attributes.inspect}]...")
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -314,6 +314,12 @@ describe MiqRequest do
         cleaned_attribs = request.send(:clean_up_keys_for_request_task)
         expect(cleaned_attribs).to_not match_array(removable_keys)
       end
+
+      it '#clean_up_keys_for_request_task removes options user_message' do
+        request.update_attributes!(:options => {:user_message => 'doesntmatter'})
+        cleaned_attribs = request.send(:clean_up_keys_for_request_task)
+        expect(cleaned_attribs["options"]).to_not include(:user_message)
+      end
     end
 
     it 'non VM provisioning' do


### PR DESCRIPTION
The miq_request options[:user_message] gets added when an Automate
 method calls the user_message method during approval. 
The request options are copied to each miq_request_task at task creation which
causes a problem during update_and_notify_parent.
Removing the task options[:user_message] resolves the issue.

calls the update_and_notify_parent with the display_message method:
https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request_task.rb#L85

uses the user_message, if available: 
https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/miq_request_mixin.rb#L13

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1482197

@miq-bot assign @gmcculloug
@miq-bot add_label bug, fine/yes, gaprindashvili/yes
