### PR TITLE
Remove GCE regions from factories

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -292,9 +292,7 @@ FactoryGirl.define do
   factory :ems_google,
           :aliases => ["manageiq/providers/google/cloud_manager"],
           :class   => "ManageIQ::Providers::Google::CloudManager",
-          :parent  => :ems_cloud do
-    provider_region "us-central1"
-  end
+          :parent  => :ems_cloud
 
   factory :ems_google_with_authentication,
           :parent => :ems_google do
@@ -306,9 +304,7 @@ FactoryGirl.define do
   factory :ems_google_network,
           :aliases => ["manageiq/providers/google/network_manager"],
           :class   => "ManageIQ::Providers::Google::NetworkManager",
-          :parent  => :ems_network do
-    provider_region "us-central1"
-  end
+          :parent  => :ems_network
 
   # Leaf classes for ems_container
 


### PR DESCRIPTION
A cleanup after GCE regions removal

Requires: https://github.com/ManageIQ/manageiq-providers-google/pull/52

@miq-bot add_label cleanup, providers/cloud, test