### PR TITLE
Fix single security group in provisioning

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -179,6 +179,7 @@
           :required: false
           :display: :edit
           :data_type: :array_integer
+          :auto_select_single: false
         :floating_ip_address:
           :values_from:
             :method: :allowed_floating_ip_addresses


### PR DESCRIPTION
This PR fixes issue with selecting security groups in provisioning. Security groups are not required to perform provisioning and it is not possible to leave field empty when there was only one security group in list. Requires restarting memcached and running bin/update.
<img width="1133" alt="screen shot 2018-03-06 at 16 59 40" src="https://user-images.githubusercontent.com/20123872/37043002-e433f5aa-215f-11e8-92da-bba77d0fdff4.png">
https://github.com/ManageIQ/manageiq-providers-openstack/issues/178