### PR TITLE
Delete #retire_now since it has been moved to shared code

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -3,11 +3,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
 
   require_nested :Status
 
-  def retire_now(requester = nil)
-    update_attributes(:retirement_requester => requester)
-    finish_retirement
-  end
-
   # Intend to be called by UI to display stdout. The stdout is stored in MiqTask#task_results or #message if error
   # Since the task_results may contain a large block of data, it is desired to remove the task upon receiving the data
   def raw_stdout_via_worker(userid, format = 'txt')

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -3,11 +3,6 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
 
   it_behaves_like 'ansible job'
 
-  it 'processes retire_now properly' do
-    expect(job).to receive(:finish_retirement).once
-    job.retire_now
-  end
-
   describe '#raw_stdout_via_worker' do
     before do
       EvmSpecHelper.create_guid_miq_server_zone


### PR DESCRIPTION
The code has been moved to another [repository](https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/66) so it can be safely deleted.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1468635

Depends on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/66