### PR TITLE
Added Embedded Ansible Content plugin

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -7,6 +7,7 @@ module Vmdb
     def initialize
       @registered_automate_domains = []
       @registered_provider_plugin_map = {}
+      @registered_ansible_content = []
       @vmdb_plugins = []
     end
 
@@ -27,6 +28,7 @@ module Vmdb
       @vmdb_plugins << engine
 
       register_automate_domains(engine)
+      register_ansible_content(engine)
       register_provider_plugin(engine)
 
       # make sure STI models are recognized
@@ -54,9 +56,21 @@ module Vmdb
       end
     end
 
+    def registered_content_directories(engine, subfolder)
+      Dir.glob(engine.root.join("content", subfolder, "*")).each do |content_directory|
+        yield content_directory
+      end
+    end
+
     def register_automate_domains(engine)
-      Dir.glob(engine.root.join("content", "automate", "*")).each do |domain_directory|
+      registered_content_directories(engine, "automate") do |domain_directory|
         @registered_automate_domains << AutomateDomain.new(domain_directory)
+      end
+    end
+
+    def register_ansible_content(engine)
+      registered_content_directories(engine, "ansible") do |content_directory|
+        @registered_ansible_content << AnsibleContent.new(content_directory)
       end
     end
   end

--- a/lib/vmdb/plugins/ansible_content.rb
+++ b/lib/vmdb/plugins/ansible_content.rb
@@ -1,0 +1,15 @@
+module Vmdb
+  class Plugins
+    class AnsibleContent
+      attr_reader :datastores_path
+      attr_reader :name
+      attr_reader :path
+
+      def initialize(path)
+        raise "#{path} does not exist" unless File.directory?(path)
+        @roles_path = Pathname.new(path)
+        @path = @roles_path.split.first
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new Vmdb plugin for `AnsibleContent`.

The registered plugin contains the following paths: `@path` and `@roles_path`

```
Vmdb::Plugins.instance.instance_variable_get(:@registered_ansible_content)
 => [#<Vmdb::Plugins::AnsibleContent:0x007fb45d9c6170 @roles_path=#<Pathname:/Users/dbomhof/syncrou/manageiq-content/content/ansible/roles>, @path=#<Pathname:/Users/dbomhof/syncrou/manageiq-content/content/ansible>>]
```

Dependent on: https://github.com/ManageIQ/manageiq-content/pull/254

Thanks to @gmcculloug for helping with the refactor of the Automate and EmbeddedAnsible registration methods