### PR TITLE
[FINE] Fix spec failure on edits of current users

### DIFF
--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -193,11 +193,11 @@ RSpec.describe "users API" do
       request = {
         "action"    => "edit",
         "resources" => [{
-          "href"          => api_user_url(nil, user1),
+          "href"          => users_url(user1.id),
           "current_group" => {}
         }]
       }
-      post(api_users_url, :params => request)
+      run_post(users_url, request)
 
       expected = {
         'error' => a_hash_including(


### PR DESCRIPTION
Fixes spec failure caused by backport of 
https://github.com/ManageIQ/manageiq-api/pull/329#issuecomment-370874153

@miq-bot assign @simaishi 