### PR TITLE
Add tagging feature for Ansible Playbooks

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4776,6 +4776,10 @@
         :description: Ansible Playbooks Refresh
         :feature_type: control
         :identifier: embedded_configuration_script_payload_refresh
+      - :name: Edit Tags
+        :description: Edit Tags for the selected Ansible Playbooks
+        :feature_type: control
+        :identifier: embedded_configuration_script_payload_tag
 
   - :name: Credentials
     :description: Everything under Credentials


### PR DESCRIPTION
**More in:** https://bugzilla.redhat.com/show_bug.cgi?id=1526218
**UI PR:** https://github.com/ManageIQ/manageiq-ui-classic/pull/3522

This PR is a part of work, with another one PR in UI repo (link above), completes adding tagging support for _Ansible Playbooks_ (in _Automation > Ansible > Playbooks_). It needs to be merged first (before the UI, to remain everything work properly).