### PR TITLE
Report datetime columns(begining and end of resource's existence) in metering report of VMs

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -10,8 +10,6 @@ class Chargeback
       #   2) We cannot charge for future hours (i.e. weekly report on Monday, should charge just monday)
       #   3) We cannot charge for hours after the resource has been retired.
       @consumed_hours_in_interval ||= begin
-                                        consumption_start = [@start_time, born_at].compact.max
-                                        consumption_end = [Time.current, @end_time, resource.try(:retires_on)].compact.min
                                         consumed = (consumption_end - consumption_start).round / 1.hour
                                         consumed > 0 ? consumed : 0
                                       end
@@ -21,6 +19,14 @@ class Chargeback
       # If the interval is monthly, we have use exact number of days in interval (i.e. 28, 29, 30, or 31)
       # othewise (for weekly and daily intervals) we assume month equals to 30 days
       monthly? ? hours_in_interval : (1.month / 1.hour)
+    end
+
+    def consumption_start
+      [@start_time, born_at].compact.max
+    end
+
+    def consumption_end
+      [Time.current, @end_time, resource.try(:retires_on)].compact.min
     end
 
     private

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -13,6 +13,8 @@ module Metering
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
     self.metering_used_metric = consumption.metering_used_fields_present if consumption.metering_used_fields_present
     self.existence_hours_metric = consumption.consumed_hours_in_interval
+    self.beginning_of_resource_existence_in_report_interval = consumption.consumption_start
+    self.end_of_resource_existence_in_report_interval = consumption.consumption_end
 
     relevant_fields.each do |field|
       next unless self.class.report_col_options.include?(field)

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,7 +1,9 @@
 class MeteringContainerImage < ChargebackContainerImage
   set_columns_hash(
-    :metering_used_metric   => :integer,
-    :existence_hours_metric => :integer
+    :metering_used_metric                               => :integer,
+    :existence_hours_metric                             => :integer,
+    :beginning_of_resource_existence_in_report_interval => :datetime,
+    :end_of_resource_existence_in_report_interval       => :datetime
   )
 
   include Metering

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,7 +1,9 @@
 class MeteringContainerProject < ChargebackContainerProject
   set_columns_hash(
-    :metering_used_metric   => :integer,
-    :existence_hours_metric => :integer
+    :metering_used_metric                               => :integer,
+    :existence_hours_metric                             => :integer,
+    :beginning_of_resource_existence_in_report_interval => :datetime,
+    :end_of_resource_existence_in_report_interval       => :datetime
   )
 
   include Metering

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,7 +1,9 @@
 class MeteringVm < ChargebackVm
   set_columns_hash(
-    :metering_used_metric   => :integer,
-    :existence_hours_metric => :integer
+    :metering_used_metric                               => :integer,
+    :existence_hours_metric                             => :integer,
+    :beginning_of_resource_existence_in_report_interval => :datetime,
+    :end_of_resource_existence_in_report_interval       => :datetime
   )
 
   include Metering

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -919,6 +919,7 @@ class MiqExpression
       model.constantize.try(:refresh_dynamic_metric_columns)
       md = model_details(model, :include_model => false, :include_tags => true).select do |c|
         allowed_suffixes = ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES
+        allowed_suffixes += ReportController::Reports::Editor::METERING_VM_ALLOWED_FIELD_SUFFIXES if model.starts_with?('Metering')
         c.last.ends_with?(*allowed_suffixes)
       end
       td = if TAG_CLASSES.include?(cb_model)

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -58,6 +58,8 @@ describe MeteringContainerImage do
       expect(subject.memory_allocated_metric).to eq(@container.limit_memory_bytes / 1.megabytes)
       expect(subject.cpu_cores_allocated_metric).to eq(@container.limit_cpu_cores)
       expect(subject.cpu_cores_allocated_metric).to eq(@container.limit_memory_bytes / 1.megabytes)
+      expect(subject.beginning_of_resource_existence_in_report_interval).to eq(month_beginning)
+      expect(subject.end_of_resource_existence_in_report_interval).to eq(month_beginning + 1.month)
     end
   end
 

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -62,6 +62,8 @@ describe MeteringContainerProject do
       expect(subject.metering_used_metric).to eq(count_of_metric_rollup)
       expect(subject.existence_hours_metric).to eq(month_beginning.end_of_month.day * 24)
       expect(subject.net_io_used_metric).to eq(net_usage_rate_average * count_of_metric_rollup)
+      expect(subject.beginning_of_resource_existence_in_report_interval).to eq(month_beginning)
+      expect(subject.end_of_resource_existence_in_report_interval).to eq(month_beginning + 1.month)
     end
   end
 

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -76,6 +76,21 @@ describe MeteringVm do
       expect(subject.net_io_used_metric).to eq(net_usage_rate_average * count_of_metric_rollup)
       expect(subject.storage_allocated_metric).to eq(derived_vm_allocated_disk_storage)
       expect(subject.storage_used_metric).to eq(derived_vm_used_disk_storage * count_of_metric_rollup)
+      expect(subject.beginning_of_resource_existence_in_report_interval).to eq(month_beginning)
+      expect(subject.end_of_resource_existence_in_report_interval).to eq(month_beginning + 1.month)
+    end
+
+    context "vm started later then beginning of report interval and it was retired earlier then end of report interval " do
+      let(:beginning_of_resource_existence) { month_beginning + 5.days }
+      let(:end_of_resource_existence)       { month_beginning + 20.days }
+
+      it 'uses datetime from Vm#created_on and Vm#retires_on' do
+        vm.update_attributes(:created_on => beginning_of_resource_existence, :retires_on => end_of_resource_existence)
+        vm.metric_rollups.each { |mr| mr.update_attributes(:timestamp => beginning_of_resource_existence) }
+
+        expect(subject.beginning_of_resource_existence_in_report_interval).to eq(beginning_of_resource_existence)
+        expect(subject.end_of_resource_existence_in_report_interval).to eq(end_of_resource_existence)
+      end
     end
 
     context 'count of used hours is different than count of metric rollups' do
@@ -127,6 +142,8 @@ describe MeteringVm do
        metering_used_metric
        existence_hours_metric
        tenant_name
+       beginning_of_resource_existence_in_report_interval
+       end_of_resource_existence_in_report_interval
   )
   end
 


### PR DESCRIPTION
New columns are named:

```
Beginning Of Resource Existence In Report Interval
End Of Resource Existence In Report Interval
```
Maybe we can find better names. @Loicavenel  @gtanzillo 

![screen shot 2018-03-07 at 14 53 40](https://user-images.githubusercontent.com/14937244/37095862-5a904cc8-2217-11e8-918e-284df3734f61.png)


Links
----------------
* part of https://bugzilla.redhat.com/show_bug.cgi?id=1505115

@miq-bot assign @gtanzillo 
@miq-bot add_label gaprindashvili/yes, enhancement
