### PR TITLE
Fix ambiguous created_recently scope

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -52,7 +52,7 @@ class MiqRequest < ApplicationRecord
 
   include MiqRequestMixin
 
-  scope :created_recently,    ->(days_ago)   { where("created_on > ?", days_ago.days.ago) }
+  scope :created_recently,    ->(days_ago)   { where("miq_requests.created_on > ?", days_ago.days.ago) }
   scope :with_approval_state, ->(state)      { where(:approval_state => state) }
   scope :with_type,           ->(type)       { where(:type => type) }
   scope :with_request_type,   ->(type)       { where(:request_type => type) }


### PR DESCRIPTION
When used in combination with `with_reason_like` scope, the scope
`create_recently` becomes ambiguous.

Related (fixes issue introduced by): https://github.com/ManageIQ/manageiq/pull/16843

@miq-bot add_label bug, gaprindashvili/no

@martinpovolny, some love for you :arrow_up:  :tada: 