### PR TITLE
Scope the default zone to the current region

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -74,7 +74,7 @@ class Zone < ApplicationRecord
   end
 
   def self.default_zone
-    find_by(:name => "default")
+    in_my_region.find_by(:name => "default")
   end
 
   def remote_cockpit_ws_miq_server

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -191,4 +191,14 @@ describe Zone do
       ).to eq(1)
     end
   end
+
+  context "validate multi region" do
+    let!(:other_region_id)         { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
+    let!(:default_in_other_region) { described_class.create(:name => "default", :description => "Default Zone", :id => other_region_id) }
+    let!(:default_in_my_region)    { described_class.create(:name => "default", :description => "Default Zone") }
+
+    it ".default_zone returns a zone in the current region" do
+      expect(described_class.default_zone).to eq(default_in_my_region)
+    end
+  end
 end


### PR DESCRIPTION
This addresses the case where a new server is added to a DB containing multiple regions and the default
zone from a remote region is assigned

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552231
