### PR TITLE
[WIP] Replace argument to association with .reload method.

### DIFF
--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -281,7 +281,7 @@ module EmsRefresh::SaveInventoryNetwork
   def save_load_balancer_pool_members_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.load_balancer_pool_members(true)
+    ems.load_balancer_pool_members.reload
     deletes = if target == ems
                 ems.load_balancer_pool_members.dup
               else
@@ -298,7 +298,7 @@ module EmsRefresh::SaveInventoryNetwork
   def save_load_balancer_pools_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.load_balancer_pools(true)
+    ems.load_balancer_pools.reload
     deletes = if target == ems
                 ems.load_balancer_pools.dup
               else
@@ -330,7 +330,7 @@ module EmsRefresh::SaveInventoryNetwork
   def save_load_balancer_listeners_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.load_balancer_listeners(true)
+    ems.load_balancer_listeners.reload
     deletes = if target == ems
                 ems.load_balancer_listeners.dup
               else
@@ -368,7 +368,7 @@ module EmsRefresh::SaveInventoryNetwork
   def save_load_balancer_health_checks_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.load_balancer_health_checks(true)
+    ems.load_balancer_health_checks.reload
     deletes = if target == ems
                 ems.load_balancer_health_checks.dup
               else


### PR DESCRIPTION
Attempts to fix this warning:

`Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call 'reload' on the result collection proxy instead.`