### PR TITLE
Bump manageiq-smartstate to 0.2.10 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,7 +182,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.2.8",       :require => false
+  gem "manageiq-smartstate",            "~>0.2.10",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Pick up several changes to the manageiq-smartstate gem.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553295 

at least.

Links [Optional]
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1553295

@roliveri @hsong-rh please review and merge.  Thanks.