### PR TITLE
Move "give me a cloud_network_manager" logic from UI to NetworkManager base class

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -86,5 +86,14 @@ module ManageIQ::Providers
     def name
       "#{parent_manager.try(:name)} Network Manager"
     end
+
+    def self.cloud_network_managers
+      # filter out openstack undercloud
+      ids = ::ManageIQ::Providers::Openstack::NetworkManager.joins(:parent_manager).where(:parent_managers_ext_management_systems=>{:type=>'ManageIQ::Providers::Openstack::CloudManager'}).pluck(:id)
+
+      ids += ::ManageIQ::Providers::Redhat::NetworkManager.pluck(:id)
+
+      ::ManageIQ::Providers::NetworkManager.where(:id => ids.uniq)
+    end
   end
 end


### PR DESCRIPTION
The idea is that this kind of provider-specific logic should definitely not live in the UI.

It should not live in core either, but that's a step in moving this to provider code ;).

Right now, all the forms which give you a list of network managers to pick in the UI go via this piece of UI code:

```ruby
  def network_managers
    ems_clouds = ManageIQ::Providers::Openstack::NetworkManager.joins(:parent_manager).where(:parent_managers_ext_management_systems=>{:type=>'ManageIQ::Providers::Openstack::CloudManager'})
    openstack_network_manager = Rbac::Filterer.filtered(ems_clouds).select(:id, :name, :parent_ems_id)
    redhat_network_manager = Rbac::Filterer.filtered(ManageIQ::Providers::Redhat::NetworkManager).select(:id, :name, :parent_ems_id)
    openstack_network_manager + redhat_network_manager
  end
```

(`app/controllers/application_controller/network.rb`)


The code gives you non-undercloud Openstack network managers and Ovirt/Redhat network managers. Presumably that's all currently supported "cloud" network managers.

So, `NetworkManager` is definitely a better place for this kind of logic than UI code, but ideally, this should really be asking the specific providers (I'm just doing the first step though, sorry :).)

Cc @Ladas 
