### PR TITLE
[FINE] Truncate realtime metrics instead of purging

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -2,4 +2,12 @@ class Metric < ApplicationRecord
   BASE_COLS = ["id", "timestamp", "capture_interval_name", "resource_type", "resource_id", "resource_name", "tag_names", "parent_host_id", "parent_ems_cluster_id", "parent_ems_id", "parent_storage_id"]
 
   include Metric::Common
+
+  # @param time [ActiveSupport::TimeWithZone, Time, Integer, nil] the hour to run (default: 1 hour from now)
+  # @return the table for the given hour
+  # Unfortunatly, Integer responds_to :hour, so :strftime was used instead.
+  def self.reindex_table_name(time = Time.now.utc.hour + 1)
+    hour = (time.respond_to?(:strftime) ? time.hour : time) % 24
+    "metrics_%02d" % hour
+  end
 end

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -95,6 +95,7 @@ describe Metric::Purging do
         end
         expect(Metric.count).to eq(17)
         # keep metric for 05:13 - 09:13
+        # note: old metrics will delete metrics at 09:14..09:59 - the new metrics will keep those
         described_class.purge_realtime(4.hours.ago)
         expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [5, 6, 7, 8, 9]
         expect(Metric.count).to eq(5)

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -83,4 +83,107 @@ describe Metric::Purging do
       end
     end
   end
+
+  context "#purge_realtime" do
+    before { EvmSpecHelper.create_guid_miq_server_zone }
+    let(:vm1) { FactoryGirl.create(:vm_vmware) }
+
+    it "deletes mid day" do
+      Timecop.freeze('2018-02-01T09:12:00Z') do
+        (0..16).each do |hours|
+          FactoryGirl.create(:metric_vm_rt, :resource_id => vm1.id, :timestamp => (hours.hours.ago + 1.minute))
+        end
+        expect(Metric.count).to eq(17)
+        # keep metric for 05:13 - 09:13
+        described_class.purge_realtime(4.hours.ago)
+        expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [5, 6, 7, 8, 9]
+        expect(Metric.count).to eq(5)
+      end
+    end
+
+    it "deletes just after midnight" do
+      Timecop.freeze('2018-02-01T02:12:00Z') do
+        (0..16).each do |hours|
+          FactoryGirl.create(:metric_vm_rt, :resource_id => vm1.id, :timestamp => (hours.hours.ago + 1.minute))
+        end
+        expect(Metric.count).to eq(17)
+        # keep metric for 22:13 - 02:13
+        described_class.purge_realtime(4.hours.ago)
+        expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [0, 1, 2, 22, 23]
+        expect(Metric.count).to eq(5)
+      end
+    end
+
+    it "deletes just after new years" do
+      EvmSpecHelper.create_guid_miq_server_zone
+
+      Timecop.freeze('2018-01-01T02:12:00Z') do
+        (0..16).each do |hours|
+          FactoryGirl.create(:metric_vm_rt, :resource_id => vm1.id, :timestamp => (hours.hours.ago + 1.minute))
+        end
+        expect(Metric.count).to eq(17)
+        # keep metric for 22:13 - 02:13
+        described_class.purge_realtime(4.hours.ago)
+        expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [0, 1, 2, 22, 23]
+        expect(Metric.count).to eq(5)
+      end
+    end
+
+    it "deletes just after daylight savings (spring forward)" do
+      EvmSpecHelper.create_guid_miq_server_zone
+      Timecop.freeze('2017-03-12T08:12:00Z') do # 2:00am+05 EST is time of change
+        # this is overkill. since we prune every 21 minutes, there will only be ~1 table with data
+        (0..16).each do |hours|
+          FactoryGirl.create(:metric_vm_rt, :resource_id => vm1.id, :timestamp => (hours.hours.ago + 1.minute))
+        end
+        expect(Metric.count).to eq(17)
+        # keep metric for 04:13 - 08:13
+        described_class.purge_realtime(4.hours.ago)
+        expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [4, 5, 6, 7, 8]
+        expect(Metric.count).to eq(5)
+      end
+    end
+
+    it "deletes just after daylight savings (fallback)" do
+      EvmSpecHelper.create_guid_miq_server_zone
+      Timecop.freeze('2017-11-05T08:12:00Z') do # 2:00am+05 EST is time of change
+        # this is overkill. since we prune every 21 minutes, there will only be ~1 table with data
+        (0..16).each do |hours|
+          FactoryGirl.create(:metric_vm_rt, :resource_id => vm1.id, :timestamp => (hours.hours.ago + 1.minute))
+        end
+        expect(Metric.count).to eq(17)
+        # keep metric for 04:13 - 08:13
+        described_class.purge_realtime(4.hours.ago)
+        expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [4, 5, 6, 7, 8]
+        expect(Metric.count).to eq(5)
+      end
+    end
+
+    context "with 8 hour retention" do
+      # since the window duration is passed into the queue / this method, this config change will not matter
+      let(:settings) do
+        {
+          :performance => {
+            :history => {
+              :keep_realtime_performance => "8.hours",
+              :purge_window_size         => 10,
+            }
+          }
+        }
+      end
+
+      it "deletes just after midnight" do
+        Timecop.freeze('2018-02-01T02:12:00Z') do
+          (0..23).each do |hours|
+            FactoryGirl.create(:metric_vm_rt, :resource_id => vm1.id, :timestamp => (hours.hours.ago + 1.minute))
+          end
+          expect(Metric.count).to eq(24)
+          # keep metric for 18:13 - 02:13
+          described_class.purge_realtime(8.hours.ago)
+          expect(Metric.all.map { |metric| metric.timestamp.hour }.sort).to eq [0, 1, 2, 18, 19, 20, 21, 22, 23]
+          expect(Metric.count).to eq(9)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1169,6 +1169,34 @@ describe Metric do
     end
   end
 
+  context "#reindex_table_name" do
+    it "defaults to 1 hour from now" do
+      Timecop.freeze("2017-01-30T09:20UTC") do
+        expect(Metric.reindex_table_name).to eq("metrics_10")
+      end
+    end
+
+    it "pads table to 2 digits" do
+      Timecop.freeze("2017-01-30T03:20UTC") do
+        expect(Metric.reindex_table_name).to eq("metrics_04")
+      end
+    end
+
+    it "provides hour wrap around" do
+      Timecop.freeze("2017-01-30T23:20UTC") do
+        expect(Metric.reindex_table_name).to eq("metrics_00")
+      end
+    end
+
+    it "allows time to be passed in" do
+      expect(Metric.reindex_table_name(Time.parse("2017-01-30T23:20Z").utc)).to eq("metrics_23")
+    end
+
+    it "allows hour integer to be passed in" do
+      expect(Metric.reindex_table_name(23)).to eq("metrics_23")
+    end
+  end
+
   private
 
   def assert_queued_rollup(q_item, instance_id, class_name, args, deliver_on, method = "perf_rollup")


### PR DESCRIPTION
Manual backport of:
    https://github.com/ManageIQ/manageiq/pull/17017
    https://github.com/ManageIQ/manageiq/pull/17051
    https://github.com/ManageIQ/manageiq/pull/17050
    
Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1553473