### PR TITLE
[WIP] Don't define DISALLOWED_SUFFIXES if already defined

### DIFF
--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -1,9 +1,8 @@
 module Metering
   extend ActiveSupport::Concern
+  DISALLOWED_SUFFIXES = %w(_cost chargeback_rates).freeze
 
   included do
-    DISALLOWED_SUFFIXES = %w(_cost chargeback_rates).freeze
-
     def self.attribute_names
       super.reject { |x| x.ends_with?(*DISALLOWED_SUFFIXES) }
     end


### PR DESCRIPTION
Prevents this warning while running specs, and might be good in general:

`/app/models/metering.rb:5: warning: already initialized constant Metering::DISALLOWED_SUFFIXES`