### PR TITLE
Allow OrchestrationTemplate subclass to customize md5 calculation

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -42,7 +42,8 @@ class OrchestrationTemplate < ApplicationRecord
         create!(hash.except(:md5)) # always create a new template if it is a draft
         true
       else
-        md5s << calc_md5(with_universal_newline(hash[:content]))
+        klass = hash[:type].present? ? hash[:type].constantize : self
+        md5s << klass.calc_md5(with_universal_newline(hash[:content]))
         false
       end
     end

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -36,6 +36,23 @@ describe OrchestrationTemplate do
         expect(@existing_record).not_to eq(OrchestrationTemplate.find_or_create_by_contents(@query_hash)[0])
         expect(OrchestrationTemplate.count).to eq(2)
       end
+
+      it "uses subclass if type is present" do
+        expect(ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate).to receive(:calc_md5).at_least(:once)
+        expect(described_class).not_to receive(:calc_md5)
+
+        @query_hash[:draft] = false
+        @query_hash[:type] = ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.name
+        OrchestrationTemplate.find_or_create_by_contents(@query_hash)
+      end
+
+      it "uses parent if type is not present" do
+        expect(described_class).to receive(:calc_md5).at_least(:once)
+
+        @query_hash[:draft] = false
+        @query_hash[:type] = nil
+        OrchestrationTemplate.find_or_create_by_contents(@query_hash)
+      end
     end
   end
 


### PR DESCRIPTION
Currently, md5 checksum is forcibly calculated on entire orchestration template text content:

```
OrchestrationTemplate.calc_md5(text)
```

But this is not always feasible. VMware vCloud, for example, yields randomly ordered elements in XML even when describing the very same orchestration template, hence the MD5 checksum differs. Therefore we need to be able to customize the way the MD5 checksum is calculated.

With this commit we make sure that calc_md5 function from the subclass is used:

```
ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate.calc_md5(text)
```

Only this way we're able to customize what part of the XML will actually be used to calculate MD5 checksum.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1553699

@miq-bot assign @Ladas 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @bzwei @agrare @gberginc 

