### PR TITLE
Removed unused method for vm power state validation

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -115,10 +115,6 @@ module VmOrTemplate::Operations
     validate_vm_control_power_state(true)
   end
 
-  def validate_vm_control_not_powered_on
-    validate_vm_control_power_state(false)
-  end
-
   def validate_vm_control_power_state(check_powered_on)
     unless supports_control?
       return {:available => false, :message => unsupported_reason(:control)}


### PR DESCRIPTION
It seems the method is unused. I couldn't find any place where it would be called, so I'm removing it. :scissors: 