### PR TITLE
Add PowerOnMultiVM_Task to task_final_events

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -796,6 +796,7 @@
     - DrsMigrateVM_Task
     :DrsVmPoweredOnEvent:
     - PowerOnVM_Task
+    - PowerOnMultiVM_Task
     :EnteredMaintenanceModeEvent:
     - EnterMaintenanceMode_Task
     :ExitMaintenanceModeEvent:
@@ -825,6 +826,7 @@
     - PowerOffVM_Task
     :VmPoweredOnEvent:
     - PowerOnVM_Task
+    - PowerOnMultiVM_Task
     - ResetVM_Task
     :VmReconfiguredEvent:
     - ReconfigVM_Task


### PR DESCRIPTION
VMware 6.5 seems to use PowerOnMultiVM even for staring a single vm now.
Add it to the list of task_final_events to look for.

https://bugzilla.redhat.com/show_bug.cgi?id=1441515