### PR TITLE
Do not divide recipients to subgroup when sending attached report

### DIFF
--- a/app/models/miq_report/notification.rb
+++ b/app/models/miq_report/notification.rb
@@ -43,34 +43,16 @@ module MiqReport::Notification
       end
     end
 
-    # Avoid ActionMailer bug where the email headers get corrupted when the total length in bytes of all the recipients exceeds approx 150 bytes.
-    # When this happens, the addresses on the end spill over into the headers and cause the content and mime information to be ignored.
-    #
-    # Split recipient list into groups whose total length in bytes is around 100 bytes or the configured limit
-    cut_off = ::Settings.smtp.recipient_address_byte_limit
-    sub_group = []
-    grouped_tos = to.uniq.inject([]) do |g, t|
-      sub_group << t
-      if sub_group.join.length >= cut_off || to.index(t) == (to.length - 1)
-        g << sub_group
-        sub_group = []
-      end
-      g
-    end
-    #
-
     begin
-      grouped_tos.each do |group_of_tos|
-        _log.info("Queuing email user: [#{user.name}] report results: [#{result.name}] to: #{group_of_tos.inspect}")
-        options = {
-          :to         => group_of_tos,
-          :from       => from,
-          :subject    => subject,
-          :body       => body,
-          :attachment => attachments,
-        }
-        GenericMailer.deliver_queue(:generic_notification, options)
-      end
+      _log.info("Queuing email user: [#{user.name}] report results: [#{result.name}] to: #{to.inspect}")
+      options = {
+        :to         => to,
+        :from       => from,
+        :subject    => subject,
+        :body       => body,
+        :attachment => attachments,
+      }
+      GenericMailer.deliver_queue(:generic_notification, options)
     rescue => err
       _log.error("Queuing email user: [#{user.name}] report results: [#{result.name}] failed with error: [#{err.class.name}] [#{err}]")
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1049,7 +1049,6 @@
   :host: localhost
   :password: ''
   :port: '25'
-  :recipient_address_byte_limit: 100
   :user_name: evmadmin
 :snapshots:
   :create_free_percent: 100


### PR DESCRIPTION
**Issue**:
When sending report by e-mail If list if recipients is long (more than some customizable value), we are dividing recipients to sub-groups and sending separate e-mails(with attached report) to each sub-group.
It works fine for the first subgroup. Attempt to send report to second group will throw `[Couldn't find BinaryBlob with 'id'=...]` error, since we are deleting record in BinaryBlob table after report was sent.   
 BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=1547846

**Solution**:
Do not divide recipients to subgroups.
It looks like it is OK now to have list of recipients longer than 150 bytes

@miq-bot add-label bug, reporting  
\cc @gtanzillo 
