### PR TITLE
Support for hidden columns in reports and views

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -181,6 +181,16 @@ class MiqReport < ApplicationRecord
     sortby ? col_order.index(sortby.first) : 0
   end
 
+  def column_is_hidden?(col)
+    return false unless col_options
+
+    @hidden_cols ||= col_options.keys.each_with_object([]) do |c, a|
+      a << c if col_options[c][:hidden]
+    end
+
+    @hidden_cols.include?(col.to_s)
+  end
+
   def self.from_hash(h)
     new(h)
   end

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -45,7 +45,7 @@ module MiqReport::Generator::Html
         row = 1 - row
 
         col_order.each_with_index do |c, c_idx|
-          next if col_options[c].try(:has_key?, :hidden) && col_options[c][:hidden]
+          next if column_is_hidden?(c)
 
           build_html_col(output, c, self.col_formats[c_idx], d.data)
         end

--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -45,6 +45,8 @@ module MiqReport::Generator::Html
         row = 1 - row
 
         col_order.each_with_index do |c, c_idx|
+          next if col_options[c].try(:has_key?, :hidden) && col_options[c][:hidden]
+
           build_html_col(output, c, self.col_formats[c_idx], d.data)
         end
 

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -94,7 +94,7 @@ module Vmdb
       unless report.headers.nil?
         report.headers.each_with_index do |h, i|
           col = report.col_order[i]
-          next if report.col_options[col].try(:has_key?, :hidden) && report.col_options[col][:hidden]
+          next if report.column_is_hidden?(col)
 
           html << "<th>" << CGI.escapeHTML(_(h.to_s)) << "</th>"
         end

--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -92,7 +92,10 @@ module Vmdb
 
       # table headings
       unless report.headers.nil?
-        report.headers.each do |h|
+        report.headers.each_with_index do |h, i|
+          col = report.col_order[i]
+          next if report.col_options[col].try(:has_key?, :hidden) && report.col_options[col][:hidden]
+
           html << "<th>" << CGI.escapeHTML(_(h.to_s)) << "</th>"
         end
         html << "</tr>"

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -847,6 +847,26 @@ describe MiqReport do
     end
   end
 
+  describe "#column_is_hidden?" do
+    let(:report) do
+      MiqReport.new(
+        :name        => "VMs",
+        :title       => "Virtual Machines",
+        :db          => "Vm",
+        :cols        => %w(name guid hostname ems_ref vendor),
+        :col_order   => %w(name hostname vendor guid emf_ref),
+        :headers     => %w(Name Host Vendor Guid EMS),
+        :col_options => {"guid" => {:hidden => true}, "ems_ref" => {:hidden => true}}
+      )
+    end
+
+    it "detects hidden columns defined in #col_options" do
+      expect(report.column_is_hidden?(:guid)).to be_truthy
+      expect(report.column_is_hidden?(:ems_ref)).to be_truthy
+      expect(report.column_is_hidden?(:vendor)).to be_falsey
+    end
+  end
+
   context "chargeback reports" do
     let(:hourly_rate) { 0.01 }
     let(:hourly_variable_tier_rate) { {:variable_rate => hourly_rate.to_s} }


### PR DESCRIPTION
Columns, including headers, with MiqReport#col_options[<column_name>][:hidden] == true should not
are included in html, pdf, text output formats and only be included in csv

UI changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/3564

/cc @dclarizio 