### PR TITLE
Return a task when queueing chargeback report generation for services

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -392,14 +392,23 @@ class Service < ApplicationRecord
   end
 
   def queue_chargeback_report_generation(options = {})
+    task = MiqTask.create(
+      :name    => "Generating chargeback report with id: #{id}",
+      :state   => MiqTask::STATE_QUEUED,
+      :status  => MiqTask::STATUS_OK,
+      :message => "Queueing Chargeback of #{self.class.name} with id: #{id}"
+    )
+
     MiqQueue.submit_job(
       :service     => "reporting",
       :class_name  => self.class.name,
       :instance_id => id,
+      :task_id     => task.id,
       :method_name => "generate_chargeback_report",
       :args        => options
     )
     _log.info("Added to queue: generate_chargeback_report for service #{name}")
+    task
   end
 
   #

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -453,7 +453,7 @@ describe Service do
                                   :method_name => "generate_chargeback_report",
                                   :args        => {:report_source => "Test Run"})
         end
-        @service.queue_chargeback_report_generation(:report_source => "Test Run")
+        expect(@service.queue_chargeback_report_generation(:report_source => "Test Run")).to be_kind_of(MiqTask)
       end
     end
 


### PR DESCRIPTION
When chargeback report generation is queued, it should send back a task. This is being added to the API, and the task needs to be returned to allow the user to see the status of it.

Needed for https://github.com/ManageIQ/manageiq-api/pull/301

@miq-bot add_label enhancement, services