### PR TITLE
Handle Vault Credential for an Ansible Playbook Service

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -107,7 +107,12 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
     [:credential, :cloud_credential, :network_credential].each do |credential|
       cred_sym = "#{credential}_id".to_sym
-      params[credential] = Authentication.find(info[cred_sym]).manager_ref if info[cred_sym]
+      if info[cred_sym] && Authentication.find(info[cred_sym]).match("VaultCredential")
+        params[:vault_credential] = Authentication.find(info[cred_sym]).manager_ref if info[cred_sym]
+        params[credential] = nil
+      elsif info[cred_sym]
+        params[credential] = Authentication.find(info[cred_sym]).manager_ref
+      end
     end
 
     [tower, params.compact]


### PR DESCRIPTION
This is a WIP example of forcing a Vault Credential attribute `vault_credential` when calling an Embedded Ansible 3.2.x instance using the v1 api.

This is WIP for the simple reason that I cannot prove an Miq Service will launch a job_template because of errors with the version of Embedded Ansible I was working with on my appliance.

However, when testing this change via a `rails console` using `AnsibleTowerClient` I'm able to prove that I can update a `VaultCredential` and Launch the `JobTemplate`, it just fails with sundry errors about project update status, on a project that does not have the `scm_update_on_launch` attribute set.
