### PR TITLE
Only update zone if found

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -35,8 +35,8 @@ module MiqServer::ConfigurationManagement
     end
 
     unless data.zone.nil?
-      self.zone = Zone.in_my_region.find_by(:name => data.zone)
-      save
+      zone = Zone.in_my_region.find_by(:name => data.zone)
+      update_attributes(:zone => zone) if zone
     end
     update_capabilities
 

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -68,6 +68,14 @@ describe MiqServer, "::ConfigurationManagement" do
 
         expect(miq_server.reload.zone).to eq(zone)
       end
+
+      it "does not overwrite the servers zone_id if the config value is invalid" do
+        _guid, miq_server, zone = EvmSpecHelper.local_guid_miq_server_zone
+
+        miq_server.send(:immediately_reload_settings)
+
+        expect(MiqServer.my_server.zone).to eq(zone)
+      end
     end
   end
 end


### PR DESCRIPTION
In trying to remove an unnecessary stub from a test, I found that the zone was unexpectedly being removed from the server.  It turns out that the settings reload was trying to set the zone to the default zone since the default config has `:server => {:zone => "default"}`.  I only found this because it was the test environment and I didn't have a "default" zone.  If someone enters something invalid in this section of the config they would also have the same problem.

I'll link PR's for:
- [The line I was trying to delete from a test](https://github.com/ManageIQ/manageiq-ui-classic/pull/3582)
- [Why is the zone default a server setting (and name too for that matter)?](https://github.com/ManageIQ/manageiq/pull/17140)