### PR TITLE
Prefer default_value_for to set zone and name

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -31,6 +31,9 @@ class MiqServer < ApplicationRecord
 
   virtual_column :zone_description, :type => :string
 
+  default_value_for(:name, "EVM")
+  default_value_for(:zone) { Zone.default_zone }
+
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
   delegate :description, :to => :zone, :prefix => true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1004,7 +1004,6 @@
   :mks_classid: 338095E4-1806-4BA3-AB51-38A3179200E9
   :mks_version: 2.1.0.0
   :monitor_poll: 5.seconds
-  :name: EVM
   :prefetch_max_per_worker: 10
   :prefetch_max_per_worker_dequeue: 100
   :prefetch_min_per_worker_dequeue: 10
@@ -1035,7 +1034,6 @@
       :value: 60
     :sync_interval: 30.minutes
     :wait_for_started_timeout: 10.minutes
-  :zone: default
 :session:
   :interval: 60
   :memcache_server: 127.0.0.1:11211


### PR DESCRIPTION
I'd like to get rid of these from settings entirely, but I'm sure QE relies on them and I'm not sure there is API functionality to set them yet.

cc @psav @Fryguy @abellotti 