### PR TITLE
Renamed method to delete cloud object store for consistency reasons

### DIFF
--- a/app/models/cloud_object_store_object/operations.rb
+++ b/app/models/cloud_object_store_object/operations.rb
@@ -1,7 +1,7 @@
 module CloudObjectStoreObject::Operations
   extend ActiveSupport::Concern
 
-  def delete_cloud_object_store_object
+  def cloud_object_store_object_delete
     raw_delete
   end
 


### PR DESCRIPTION
Renamed method introduced in https://github.com/ManageIQ/manageiq/commit/81072dbb020#diff-ddea025797d4c84804a87a85c2db89a8R4 for consistency reasons.

The change allows me to generalize the `case` statement introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/498/files/524fe8c31aecc5becabedc4db880987214aeb240#r106942728

Links
----------------

* https://github.com/ManageIQ/manageiq-providers-amazon/pull/419
* ManageIQ/manageiq-ui-classic#3607

cc @miha-plesko 