### PR TITLE
Use vm_ems_ref to reconnect events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -222,8 +222,13 @@ class EmsEvent < EventStream
 
   private
 
+  def self.event_allowed_ems_ref_keys
+    %w(vm_ems_ref dest_vm_ems_ref)
+  end
+  private_class_method :event_allowed_ems_ref_keys
+
   def self.create_event(event)
-    event.delete_if { |k,| k.to_s.ends_with?("_ems_ref") }
+    event.delete_if { |k,| k.to_s.ends_with?("_ems_ref") && !event_allowed_ems_ref_keys.include?(k.to_s) }
 
     new_event = EmsEvent.create(event) unless EmsEvent.exists?(
       :event_type  => event[:event_type],
@@ -270,6 +275,7 @@ class EmsEvent < EventStream
         :host_id           => source_event.host_id,
         :vm_name           => source_event.vm_name,
         :vm_location       => source_event.vm_location,
+        :vm_ems_ref        => source_event.vm_ems_ref,
         :vm_or_template_id => source_event.vm_or_template_id
       }
       new_event[:username] = event.username unless event.username.blank?
@@ -284,6 +290,7 @@ class EmsEvent < EventStream
           :dest_host_id           => dest_event.host_id,
           :dest_vm_name           => dest_event.send("#{dest_key}vm_name"),
           :dest_vm_location       => dest_event.send("#{dest_key}vm_location"),
+          :dest_vm_ems_ref        => dest_event.send("#{dest_key}vm_ems_ref"),
           :dest_vm_or_template_id => dest_event.send("#{dest_key}vm_or_template_id")
         )
       end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -823,19 +823,19 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def reconnect_events
-    events = EmsEvent.where("(vm_location = ? AND vm_or_template_id IS NULL) OR (dest_vm_location = ? AND dest_vm_or_template_id IS NULL)", path, path)
+    events = EmsEvent.where("ems_id = ? AND ((vm_ems_ref = ? AND vm_or_template_id IS NULL) OR (dest_vm_ems_ref = ? AND dest_vm_or_template_id IS NULL))", ext_management_system.id, ems_ref, ems_ref)
     events.each do |e|
       do_save = false
 
       src_vm = e.src_vm_or_template
-      if src_vm.nil? && e.vm_location == path
+      if src_vm.nil? && e.vm_ems_ref == ems_ref
         src_vm = self
         e.vm_or_template_id = src_vm.id
         do_save = true
       end
 
       dest_vm = e.dest_vm_or_template
-      if dest_vm.nil? && e.dest_vm_location == path
+      if dest_vm.nil? && e.dest_vm_ems_ref == ems_ref
         dest_vm = self
         e.dest_vm_or_template_id = dest_vm.id
         do_save = true


### PR DESCRIPTION
Events delivered early in a VM's lifecycle often do not contain the
vmPathName yet and therefore cannot be connected to VMs which are saved
after the events are processed.  It is much more reliable to use the
VM's ems_ref since that is available in all tasks and events except the
initial CreateVM_Task/CloneVM_Task (since the target VM hasn't been
created yet it isn't possible to link these to a VM anyway).

https://bugzilla.redhat.com/show_bug.cgi?id=1428797

Depends on:
https://github.com/ManageIQ/manageiq-schema/pull/176