### PR TITLE
Add miq_v2v_ui plugin to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -196,6 +196,10 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
   gem "jquery-rjs",                   "=0.1.1",                       :git => "https://github.com/ManageIQ/jquery-rjs.git", :tag => "v0.1.1-1"
 end
 
+group :v2v, :ui_dependencies do
+  gem "miq_v2v_ui", :git => "https://github.com/priley86/miq_v2v_ui_plugin.git", :branch => "master"
+end
+
 group :web_server, :manageiq_default do
   gem "puma",                           "~>3.7.0"
   gem "responders",                     "~>2.0"


### PR DESCRIPTION
Add `miq_v2v_ui` plugin to Gemfile. As it's under development it's located outside ManageIQ.

How to test:
Run `bin/update`
There should be new navigation tabs and screens(not fully functional).
![image](https://user-images.githubusercontent.com/9210860/37350066-29a34226-26d8-11e8-8430-33007467dd6a.png)

cc: @ohadlevy 

@miq-bot add_label gaprindashvili/no
