### PR TITLE
Make resource groups taggable

### DIFF
--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -1,4 +1,5 @@
 class ResourceGroup < ApplicationRecord
+  acts_as_miq_taggable
   alias_attribute :images, :templates
 
   has_many :vm_or_templates


### PR DESCRIPTION
Resource groups are not currently taggable, making it difficult to limit their visibility or otherwise manage them via RBAC. This PR makes them taggable.