### PR TITLE
Add encryption key validation rake task

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -56,6 +56,12 @@ namespace :evm do
     puts inventory.tableize if inventory.present?
   end
 
+  desc "Determine if the configured encryption key is valid"
+  task :validate_encryption_key => :environment do
+    raise "Invalid encryption key" unless EvmApplication.encryption_key_valid?
+    puts "Encryption key valid"
+  end
+
   desc "Write a remote region id to this server's REGION file"
   task :join_region => :environment do
     configured_region = ApplicationRecord.region_number_from_sequence.to_i

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -143,10 +143,11 @@ class EvmApplication
   end
 
   def self.encryption_key_valid?
-    # if we're a new deployment we won't even be able to get the database row, so just return true
+    # if we're a new deployment we won't even be able to get the database row
+    # and if there is no database row, allow this key to be used
     return true if deployment_status == "new_deployment"
+    return true unless (db = MiqDatabase.first)
 
-    db = MiqDatabase.first
     # both of these should raise if we have the wrong key
     db.session_secret_token
     db.csrf_secret_token

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -142,6 +142,20 @@ class EvmApplication
     region_file.write(new_region)
   end
 
+  def self.encryption_key_valid?
+    # if we're a new deployment we won't even be able to get the database row, so just return true
+    return true if deployment_status == "new_deployment"
+
+    db = MiqDatabase.first
+    # both of these should raise if we have the wrong key
+    db.session_secret_token
+    db.csrf_secret_token
+
+    true
+  rescue MiqPassword::MiqPasswordError
+    false
+  end
+
   def self.deployment_status
     return "new_deployment" if ActiveRecord::Migrator.current_version.zero?
     return "new_replica"    if MiqServer.my_server.nil?

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -206,4 +206,10 @@ describe EvmApplication do
       expect(described_class.deployment_status).to eq("redeployment")
     end
   end
+
+  describe ".encryption_key_valid?" do
+    it "returns true when we are using the correct encryption key" do
+      expect(described_class.encryption_key_valid?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This task will use the currently configured encryption key to
attempt to decrypt the seeded values from the miq_databases entry.

If the database is not migrated and seeded yet, it will return true

https://bugzilla.redhat.com/show_bug.cgi?id=1544854