### PR TITLE
openscap report filter fixup

### DIFF
--- a/product/reports/170_Configuration Management - Containers/130_Images by Failed OpenSCAP Rule Results.yaml
+++ b/product/reports/170_Configuration Management - Containers/130_Images by Failed OpenSCAP Rule Results.yaml
@@ -22,7 +22,16 @@ headers:
 - Rule Name
 - Result
 - Severity
-conditions:
+conditions: !ruby/object:MiqExpression
+  exp:
+    and:
+    - not:
+        "=":
+          field: ContainerImage.openscap_rule_results-result
+          value: pass
+    - IS NOT EMPTY:
+        field: ContainerImage.openscap_rule_results-name
+  context_type:
 order: Ascending
 sortby:
 - name
@@ -46,16 +55,7 @@ col_formats:
 -
 tz:
 time_profile_id:
-display_filter: !ruby/object:MiqExpression
-  exp:
-    and:
-    - not:
-        "=":
-          field: ContainerImage.openscap_rule_results-result
-          value: pass
-    - IS NOT EMPTY:
-        field: ContainerImage.openscap_rule_results-name
-  context_type:
+display_filter:
 col_options: {}
 rpt_options:
   :pdf:


### PR DESCRIPTION
use `conditions` instead of `display_filter` for reports. especially when the report can be run in sql

|        ms |       bytes |    objects |query |   qry ms |     rows |`comments`
|       ---:|         ---:|        ---:|  ---:|      ---:|      ---:| ---
|  20,749.0 | 531,274,786*| 45,026,195 |    2 |  2,620.0 |   76,196 |`before`
|     219.7 |  22,729,400 |    308,144 |    2 |     59.5 |    1,140 |`after`
| 99% | 96% | 99% | 0 | 98% | 99% | delta

\* Memory usage does not reflect 20,135,448 freed objects.

Running `rpt._generate_table` generated the same `@data` value for both on MBU database