### PR TITLE
Fix LinuxAdmin::Rhn deprecation warning... kinda

### DIFF
--- a/app/models/registration_system.rb
+++ b/app/models/registration_system.rb
@@ -74,7 +74,7 @@ module RegistrationSystem
 
   def self.verify_credentials(options = {})
     LinuxAdmin::SubscriptionManager.validate_credentials(assemble_options(options))
-  rescue NotImplementedError, LinuxAdmin::CredentialError
+  rescue NotImplementedError, LinuxAdmin::CredentialError, AwesomeSpawn::NoSuchFileError
     false
   end
 

--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -91,7 +91,15 @@ describe RegistrationSystem do
     end
 
     it "should rescue NotImplementedError" do
-      allow_any_instance_of(LinuxAdmin::Rhn).to receive_messages(:registered? => true)
+      if Gem::Version.new(LinuxAdmin::VERSION) > Gem::Version.new("1.2.1")
+        raise "Hey, this test can be changed now"
+        # To fix, just simply remove the `rhn_double`, and following two
+        # `allow` stubs, along with this if block.
+      end
+      rhn_double = double("LinuxAdmin::Rhn")
+      allow(LinuxAdmin::Rhn).to receive_messages(:new => rhn_double)
+      allow(rhn_double).to      receive_messages(:registered? => false)
+      allow_any_instance_of(LinuxAdmin::SubscriptionManager).to receive_messages(:registered? => true)
       expect(RegistrationSystem.verify_credentials(creds)).to be_falsey
     end
 


### PR DESCRIPTION
Atomically fix the deprecation warnings in the specs, but in reality, the fix probably also need to happen in `linux_admin`... and then here again (the gift that keeps on giving)

Long Winded Explanation
-----------------------

So there is a whole mess of WTF going on here, but I will try and explain as best (and briefly) as possible:

To start off, the deprecation warning from `linux_admin` was added here:

https://github.com/ManageIQ/linux_admin/pull/198

There was little to go off of for a "why", except that it was, in fact, deprecated.  So there is that.

Our codebase as well wasn't using `LinuxAdmin::Rhn` anywhere as well, and was only referenced in the specs.  So just change `LinuxAdmin::Rhn` to `LinuxAdmin::SubscriptionManager` and we are good, right?

WRONG!

So that causes two issues:

1. First, the `LinuxAdmin::SubscriptionManager` doesn't fail with the same error as `LinuxAdmin::Rhn` did in this test.  So as a quick solution, I just made it so that `RegistrationSystem.verify_credentials` now rescues the `AwesomeSpawn::NoSuchFileError` that gets thrown when it calls it's `run!` method.
  
  But even with that fix, and changing the stub, there is still a deprecation warning?  What gives.

2. Well, that is the second, and much more obnoxious part with the whole ordeal.  Thanks to some "totally obvious and not confusing" metaprogramming happening in the base class of SubscriptionManager, the class method version of `.verify_credentials` is actually called via the `LinuxAdmin::RegistrationSystem.method_missing`, which will eventually call on `LinuxAdmin::Rhn.new.registered?` prior to calling that on `LinuxAdmin::SubscriptionManager.new.registered?`

What truly heinous about this is not that we are deprecating `Rhn`, but that we are doing so, and providing no way to have the user avoid the deprecation warning in `Rhn.new` because we still favor the old code in inner workings of these public APIs class methods.  Which doesn't seem to make much sense since it is deprecated... but who am I to judge...

**Resolution**

Anyway, for now, the quick fix done here is to stub out the `.new` method for `LinuxAdmin::Rhn` with a double, and have that return `false` for `#registered?`.  Really, this should be a change to `LinuxAdmin` to make `SubscriptionManager` the default.  With that said, added a "future proof" version check as well in that spec that will make the test break when this klugy-ness is no longer needed.


Links
-----

* [Where I foolish accept this quest](https://gitter.im/ManageIQ/manageiq?at=5aa7eebc8f1c77ef3ab73232)
* https://github.com/ManageIQ/linux_admin/pull/198


Steps for Testing/QA
--------------------

Just do a `ctrl-f` for "`[DEPRECATION] 'LinuxAdmin::Rhn'`" in the travis output and confirm there is no instances of it.