### PR TITLE
[FINE] Fix tool tip while setting the ownership for VMs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -56,12 +56,14 @@
     "spin.js": "~2.3.2",
     "sprintf": "~1.0.3",
     "tota11y": "~0.1.6",
-    "xml_display": "~0.1.1"
+    "xml_display": "~0.1.1",
+    "bootstrap-select": "1.12.2"
   },
   "resolutions": {
     "patternfly-bootstrap-treeview": "~2.1.1",
     "moment": ">=2.10.5",
     "d3": "~3.5.0",
-    "jquery": "~2.2.4"
+    "jquery": "~2.2.4",
+    "bootstrap-select": "1.12.2"
   }
 }


### PR DESCRIPTION
**BZ** https://bugzilla.redhat.com/show_bug.cgi?id=1549723
**UI PR:** https://github.com/ManageIQ/manageiq-ui-classic/pull/3619

Fix tool tip which displayed html code while setting the ownership
for multiple VMs, in _Compute > Infrastructure > Virtual Machines_.

**Note:** The bug was originally fixed for master by updating PatternFly to v3.31.1:#2989, and I was told that we did not want to backport the whole PR to Fine, so I created this PR with only the changes really needed for the fix. **This PR needs to merge with the UI one, to fix the bug completely.**

**Note 2**: run `bower install --save bootstrap-select@1.12.2` (in the UI repo and also in main miq repo)

---

**Before:**
User dropdown (the same for Group dropdown):
![ble](https://user-images.githubusercontent.com/13417815/37397390-c4291ade-277b-11e8-9eea-4f8c6c1f818e.png)

**After:**
User dropdown (the same for Group dropdown):
![tool_tip_fixed](https://user-images.githubusercontent.com/13417815/37406923-aeecebf6-2798-11e8-967c-99be7b8e0067.png)