### PR TITLE
Use handled_list to get Cinder backups for all accessible tenants

### DIFF
--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_parser.rb
@@ -53,7 +53,8 @@ module ManageIQ::Providers
     end
 
     def get_backups
-      process_collection(@cinder_service&.list_backups_detailed.body["backups"],
+      process_collection(@cinder_service.handled_list(:list_backups_detailed,
+                                                      :__request_body_index => "backups"),
                          :cloud_volume_backups) { |backup| parse_backup(backup) }
     end
 


### PR DESCRIPTION
The Cinder refresh parser should use `handled_list` to collect backups so that they are collected for all accessible tenants and not just the ones that the default tenant sees. This brings backups into line with the way that volumes and snapshots are collected.

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1552129