### PR TITLE
Fix active_provision quota check for infra VM request with invalid vm_template.

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -282,6 +282,10 @@ module MiqProvisionQuotaMixin
       :status         => 'Ok',
       :process        => true
     ).where.not(:id => id)
+              .where(%{source_type IS NULL OR
+       (source_type = 'VmOrTemplate' AND source_id IN (SELECT id FROM vms)) OR
+       (source_type = 'ServiceTemplate' AND source_id IN (SELECT id FROM service_templates))
+     })
   end
 
   def vm_quota_values(pr, result)

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -201,6 +201,12 @@ describe MiqProvisionRequest do
               {:count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 44.gigabytes}
             end
             it_behaves_like "check_quota"
+
+            it "invalid vm_template does not raise error" do
+              create_requests
+              MiqRequest.first.update_attributes(:vm_template => nil)
+              expect { request.check_quota(quota_method) }.not_to raise_error
+            end
           end
 
           context "infra," do


### PR DESCRIPTION
Quota uses 'active' MiqRequests in its calculations for active provisions. Previously, quota used the MiqQueue entries to calculate active provisions. The MiqRequest approach is much more accurate, but is susceptible to old and/or invalid MiqRequests that appear to be 'active'.  

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1554989

Check for valid request.vm_template for VM infra provisioned storage calculations to avoid the following error caused by an invalid MIqRequest.

task_id([miq_provision_6000000002384]) <AutomationEngine> MiqAeServiceModelBase.ar_method raised: <NoMethodError>: <undefined method `provisioned_storage' for nil:NilClass
[----] E, [2018-03-13T05:06:49.201944 #19065:d0efbc] ERROR -- : Q-task_id([miq_provision_6000000002384]) <AutomationEngine> /var/www/miq/vmdb/app/models/mixins/miq_provision_quota_mixin.rb:378:in `storage'
[----] E, [2018-03-13T05:06:49.204481 #19065:6749c70] ERROR -- : Q-task_id([miq_provision_6000000002384]) <AutomationEngine> <AEMethod vmware_best_fit_with_scope> The following error occurred during method evaluation:
[----] E, [2018-03-13T05:06:49.205527 #19065:6749c70] ERROR -- : Q-task_id([miq_provision_6000000002384]) <AutomationEngine> <AEMethod vmware_best_fit_with_scope>   NoMethodError: undefined method `provisioned_storage' for nil:NilClass
[----] E, [2018-03-13T05:06:49.206780 #19065:6749c70] ERROR -- : Q-task_id([miq_provision_6000000002384]) <AutomationEngine> <AEMethod vmware_best_fit_with_scope>   (druby://127.0.0.1:34153) /var/www/miq/vmdb/app/models/mixins/miq_provis



