### PR TITLE
Downgrade dalli to 2.7.6 to fix issues with session in the UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.6.0",       :require => false
-gem "dalli",                          "~>2.7.4",       :require => false
+gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false


### PR DESCRIPTION
With Dalli 2.7.7 it's impossible to create a new session because of some missing params in the random number generation. This ends up the UI with the following error:
```
Error caught: [TypeError] nil can't be coerced into Integer
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/session/abstract/id.rb:258:in `**'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/session/abstract/id.rb:258:in `generate_sid'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/dalli-2.7.7/lib/rack/session/dalli.rb:171:in `generate_sid_with'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/dalli-2.7.7/lib/rack/session/dalli.rb:98:in `block in get_session'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/dalli-2.7.7/lib/dalli/client.rb:263:in `with'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/dalli-2.7.7/lib/rack/session/dalli.rb:178:in `with_block'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/dalli-2.7.7/lib/rack/session/dalli.rb:96:in `get_session'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/dalli-2.7.7/lib/rack/session/dalli.rb:126:in `find_session'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/rack-2.0.4/lib/rack/session/abstract/id.rb:280:in `load_session'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/session/abstract_store.rb:56:in `block in load_session'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/session/abstract_store.rb:64:in `stale_session_check!'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/middleware/session/abstract_store.rb:56:in `load_session'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/request/session.rb:216:in `load!'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/request/session.rb:212:in `load_for_write!'
/home/skateman/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/actionpack-5.0.6/lib/action_dispatch/request/session.rb:114:in `[]='
/home/skateman/Repositories/ManageIQ/manageiq-ui-classic/app/controllers/application_controller/tenancy.rb:17:in `set_session_tenant'
```

Downgrading to 2.7.6 fixes the issue...