### PR TITLE
Move qpid_proton dependency to Nuage provider's gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,10 +118,6 @@ group :nuage, :manageiq_default do
   manageiq_plugin "manageiq-providers-nuage"
 end
 
-group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.19.0",      :require => false
-end
-
 group :openshift, :manageiq_default do
   manageiq_plugin "manageiq-providers-openshift"
   gem "htauth",                         "2.0.0",         :require => false # used by container deployment


### PR DESCRIPTION
With this commit we're removing qpid_proton gem dependency from top-level Gemfile into Nuage's gemspec. Since Nuage provider is the only provider using this gem, no issues should arise.

Main reason for this migration is that we want to be able to be shifting gem's version without creating PRs to core, and rather do it on Nuage repo directly.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1554771
(BZ above is the reason why we want to shift qpid proton version, and we want to do it on Nuage repo, not here)

Depends on: https://github.com/ManageIQ/manageiq-providers-nuage/pull/77

@miq-bot assign @juliancheal
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @gberginc