### PR TITLE
Add detail and name to the new update event group

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -781,6 +781,9 @@
       - USER_UPDATE_STORAGE_POOL_FAILED
       :detail: []
       :name: Storage
+    :update:
+      :detail: []
+      :name: Update
   :task_final_events:
     :ClusterCreatedEvent:
     - CreateClusterEx


### PR DESCRIPTION
A new event group "update" was added for the amazon provider [0], we need to
also add the name and detail properties to the group in the main repo.

[0] https://github.com/ManageIQ/manageiq-providers-amazon/pull/415