### PR TITLE
Allow usage of string factories

### DIFF
--- a/spec/support/missing_factory_helper.rb
+++ b/spec/support/missing_factory_helper.rb
@@ -3,17 +3,21 @@ module Spec
   module Support
     module MissingFactoryHelper
       def build(factory, *args, &block)
-        registered_factory_symbols.include?(factory) ? super : class_from_symbol(factory).new(*args)
+        factory_exists?(factory) ? super : class_from_symbol(factory).new(*args)
       end
 
       def create(factory, *args, &block)
-        registered_factory_symbols.include?(factory) ? super : class_from_symbol(factory).create!(*args)
+        factory_exists?(factory) ? super : class_from_symbol(factory).create!(*args)
       end
 
       private
 
       def class_from_symbol(symbol)
         symbol.to_s.classify.constantize
+      end
+
+      def factory_exists?(factory)
+        registered_factory_symbols.include?(factory.to_sym)
       end
 
       def registered_factory_symbols


### PR DESCRIPTION
Currently using `FactoryGirl.create(:abc)` works, but `FactoryGirl.create("abc")` does not.  This PR allows the usage of strings or symbols.  I'm not sure if it is intentional that this works in FactoryGirl, but we take advantage of it in several repos.

follow up to https://github.com/ManageIQ/manageiq/pull/16768 [kbrock edit]