### PR TITLE
Remove modify options from a physical server

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5867,19 +5867,6 @@
       :description: Display Timelines for Physical Servers
       :feature_type: view
       :identifier: physical_server_timeline
-  - :name: Modify
-    :description: Modify Physical Servers
-    :feature_type: admin
-    :identifier: physical_server_admin
-    :children:
-    - :name: Remove
-      :description: Remove Physical Server(s)
-      :feature_type: admin
-      :identifier: physical_server_delete
-    - :name: Edit
-      :description: Edit a Physical Server
-      :feature_type: admin
-      :identifier: physical_server_edit
   - :name: Operate
     :description: Perform Operations on Physical Servers
     :feature_type: control


### PR DESCRIPTION
Edit Physical Servers is pointless since all info are retrieved from a refresh.
So if I delete a physical server, it will be retrieved again in the next refresh