### PR TITLE
Check for roles required by the worker when using `run_single_worker`

### DIFF
--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -59,6 +59,12 @@ ENV["BUNDLER_GROUPS"] = MIQ_WORKER_TYPES[worker_class].join(',')
 require File.expand_path("../../../config/environment", __dir__)
 
 worker_class = worker_class.constantize
+missing_roles = ServerRole.where(:name => worker_class.required_roles) - MiqServer.my_server.active_roles
+unless missing_roles.empty?
+  puts "ERR:  Server roles are not sufficient for `#{worker_class}` worker. Missing: #{missing_roles.collect(&:name)}"
+  exit 1
+end
+
 worker_class.before_fork
 unless options[:dry_run]
   create_options = {:pid => Process.pid}

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -35,6 +35,10 @@ opt_parser = OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  opts.on("-f", "--force", "Ignore missing server roles and run anyway") do
+    options[:force] = true
+  end
 end
 opt_parser.parse!
 worker_class = ARGV[0]
@@ -62,7 +66,7 @@ worker_class = worker_class.constantize
 missing_roles = ServerRole.where(:name => worker_class.required_roles) - MiqServer.my_server.active_roles
 unless missing_roles.empty?
   STDERR.puts "ERR:  Server roles are not sufficient for `#{worker_class}` worker. Missing: #{missing_roles.collect(&:name)}"
-  exit 1
+  exit 1 unless options[:force]
 end
 
 worker_class.before_fork

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -48,7 +48,7 @@ end
 opt_parser.abort(opt_parser.help) unless worker_class
 
 unless ::MIQ_WORKER_TYPES.keys.include?(worker_class)
-  puts "ERR:  `#{worker_class}` WORKER CLASS NOT FOUND!  Please run with `-l` to see possible worker class names."
+  STDERR.puts "ERR:  `#{worker_class}` WORKER CLASS NOT FOUND!  Please run with `-l` to see possible worker class names."
   exit 1
 end
 
@@ -61,7 +61,7 @@ require File.expand_path("../../../config/environment", __dir__)
 worker_class = worker_class.constantize
 missing_roles = ServerRole.where(:name => worker_class.required_roles) - MiqServer.my_server.active_roles
 unless missing_roles.empty?
-  puts "ERR:  Server roles are not sufficient for `#{worker_class}` worker. Missing: #{missing_roles.collect(&:name)}"
+  STDERR.puts "ERR:  Server roles are not sufficient for `#{worker_class}` worker. Missing: #{missing_roles.collect(&:name)}"
   exit 1
 end
 


### PR DESCRIPTION
Add a check for roles of the `MiqServer` when running a worker via `run_sinle_worker.rb`.

For example when running a refresh worker, the `ems_inventory` role is missing and `MiqQueue.get()` would always return empty array. With this change the worker is not allowed to start unless the requirements are met. User is notified about the missing roles:

```
ERR:  Server roles are not sufficient for `ManageIQ::Providers::Azure::CloudManager::RefreshWorker` worker. Missing: ["ems_inventory"]
```