### PR TITLE
Add ServiceTemplate.pre_creation_check for api use

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -103,6 +103,14 @@ class ServiceTemplate < ApplicationRecord
     end
   end
 
+  # options should be the same as the one in .create_catalog_item
+  # returns a hash
+  #   :status => 'Ok' / 'Error'
+  #   :reason => {} # optional. reason can be a well structured hash to itemize details
+  def self.pre_creation_check(options)
+    raise NotImplementedError, _("pre_creation_check method is not implemented")
+  end
+
   def update_catalog_item(options, auth_user = nil)
     config_info = validate_update_config_info(options)
     unless config_info


### PR DESCRIPTION
A new API method is needed to validate whether a service template can be created with a given config_info. The return should give the caller very detailed validation message so that the caller can correct the problems before actually creating the service template.

This is intended to be used by the v2v project. The base implementation is not given this time. `ServiceTemplateTransformationPlan` will first implement this method. Other subtypes can add their own implementation in the future as needed.