### PR TITLE
Bad skipping of assert in production env

### DIFF
--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -73,7 +73,7 @@ module ManagerRefresh
           # TODO(lsmola) lazy_find will support only hash, then we can remove the _by variant
           # TODO(lsmola) this method should return lazy too, the rest of the finders should be deprecated
           return if reference.nil?
-          return unless assert_index(reference, ref)
+          assert_index(reference, ref)
 
           reference = inventory_collection.build_reference(reference, ref)
 
@@ -103,7 +103,7 @@ module ManagerRefresh
           # access the data
           # TODO(lsmola) lazy_find will support only hash, then we can remove the _by variant
           return if manager_uuid.nil?
-          return unless assert_index(manager_uuid, ref)
+          assert_index(manager_uuid, ref)
 
           ::ManagerRefresh::InventoryObjectLazy.new(inventory_collection,
                                                     manager_uuid,
@@ -203,8 +203,6 @@ module ManagerRefresh
             # Assert the that possible relation is nil or InventoryObject or InventoryObjectlazy class
             assert_relation_keys({named_ref(ref).first => manager_uuid}, ref)
           end
-
-          true
         rescue => e
           _log.error("Error when asserting index: #{manager_uuid}, with ref: #{ref} of: #{inventory_collection}")
           raise e


### PR DESCRIPTION
Bad skipping of assert in production env, the return was causing
lazy_find to behave badly in production env.