### PR TITLE
removing :each from before and after

### DIFF
--- a/spec/lib/ems_event_helper_spec.rb
+++ b/spec/lib/ems_event_helper_spec.rb
@@ -1,6 +1,6 @@
 describe EmsEventHelper do
   context "fb12322 - MiqAeEvent.build_evm_event blows up expecting inputs[:policy] to be an instance of MiqPolicy, but it is a hash of { :vmdb_class => 'MiqPolicy', :vmdb_id => 42}" do
-    before(:each) do
+    before do
       [Zone, ExtManagementSystem, Host, Vm, Storage, EmsEvent, MiqEventDefinition, MiqPolicy, MiqAction, MiqPolicyContent, MiqPolicySet].each(&:delete_all)
 
       @zone      = FactoryGirl.create(:zone)

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -1,7 +1,7 @@
 require 'util/runcmd'
 describe EvmDatabaseOps do
   context "#backup" do
-    before(:each) do
+    before do
       @connect_opts = {:username => 'blah', :password => 'blahblah', :uri => "smb://myserver.com/share"}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
       allow(MiqSmbSession).to receive(:runcmd)
@@ -47,7 +47,7 @@ describe EvmDatabaseOps do
   end
 
   context "#restore" do
-    before(:each) do
+    before do
       @connect_opts = {:username => 'blah', :password => 'blahblah'}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
       allow(MiqSmbSession).to receive(:runcmd)

--- a/spec/lib/extensions/ar_extract_objects_spec.rb
+++ b/spec/lib/extensions/ar_extract_objects_spec.rb
@@ -1,6 +1,6 @@
 describe "ArExtractObjects" do
   context "ArExtractObjectsTest" do
-    before(:each) do
+    before do
       vms = (0...2).collect { FactoryGirl.create(:vm_vmware) }
       @vm1, @vm2 = *vms
       @id1, @id2 = vms.collect(&:id)

--- a/spec/lib/extensions/ar_nested_count_by_spec.rb
+++ b/spec/lib/extensions/ar_nested_count_by_spec.rb
@@ -1,6 +1,6 @@
 describe "AR Nested Count By extension" do
   context "miq_queue with messages" do
-    before(:each) do
+    before do
       @zone = EvmSpecHelper.local_miq_server.zone
 
       FactoryGirl.create(:miq_queue, :zone => @zone.name, :state => MiqQueue::STATE_DEQUEUE,  :role => "role1", :priority => 20)

--- a/spec/lib/extensions/ar_taggable_spec.rb
+++ b/spec/lib/extensions/ar_taggable_spec.rb
@@ -1,5 +1,5 @@
 describe ActsAsTaggable do
-  before(:each) do
+  before do
     @host1 = FactoryGirl.create(:host, :name => "HOST1")
     @host1.tag_with("red blue yellow", :ns => "/test", :cat => "tags")
     @host2 = FactoryGirl.create(:host, :name => "HOST2")

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -1,6 +1,6 @@
 describe VirtualFields do
   context "TestClass" do
-    before(:each) do
+    before do
       class TestClassBase < ActiveRecord::Base
         self.abstract_class = true
 
@@ -35,7 +35,7 @@ describe VirtualFields do
       end
     end
 
-    after(:each) do
+    after do
       TestClassBase.remove_connection
       Object.send(:remove_const, :TestClass)
       Object.send(:remove_const, :TestClassBase)
@@ -222,7 +222,7 @@ describe VirtualFields do
     end
 
     context "with virtual columns" do
-      before(:each) do
+      before do
         TestClass.virtual_column :vcol1, :type => :string
         TestClass.virtual_column :vcol2, :type => :string
 
@@ -240,7 +240,7 @@ describe VirtualFields do
             virtual_column :vcolsub1, :type => :string
           end
         end
-        before(:each) do
+        before do
           test_sub_class
           @vcols_sub_strs = @vcols_strs + ["vcolsub1"]
           @vcols_sub_syms = @vcols_syms + [:vcolsub1]
@@ -438,7 +438,7 @@ describe VirtualFields do
     end
 
     context "with virtual reflections" do
-      before(:each) do
+      before do
         TestClass.virtual_has_one :vref1
         TestClass.virtual_has_one :vref2
 
@@ -456,7 +456,7 @@ describe VirtualFields do
             virtual_has_one :vrefsub1
           end
         end
-        before(:each) do
+        before do
           test_sub_class
           @vrefs_sub_syms = @vrefs_syms + [:vrefsub1]
           @refs_sub_syms  = @vrefs_sub_syms + [:ref1, :ref2]
@@ -468,7 +468,7 @@ describe VirtualFields do
     end
 
     context "with both virtual columns and reflections" do
-      before(:each) do
+      before do
         TestClass.virtual_column  :vcol1, :type => :string
         TestClass.virtual_has_one :vref1
       end
@@ -613,7 +613,7 @@ describe VirtualFields do
       end
 
       context "with relation in foreign table" do
-        before(:each) do
+        before do
           class TestOtherClass < ActiveRecord::Base
             def self.connection
               TestClassBase.connection
@@ -624,7 +624,7 @@ describe VirtualFields do
           end
         end
 
-        after(:each) do
+        after do
           TestOtherClass.remove_connection
           Object.send(:remove_const, :TestOtherClass)
         end
@@ -906,7 +906,7 @@ describe VirtualFields do
   end
 
   context "preloading" do
-    before(:each) do
+    before do
       FactoryGirl.create(:vm_vmware,
                          :hardware         => FactoryGirl.create(:hardware),
                          :operating_system => FactoryGirl.create(:operating_system),

--- a/spec/lib/extensions/database_configuration_spec.rb
+++ b/spec/lib/extensions/database_configuration_spec.rb
@@ -2,7 +2,7 @@ describe "DatabaseConfiguration patch" do
   let(:db_config_path) { File.expand_path "../../../config/database.yml", __dir__ }
   let(:fake_db_config) { Pathname.new("does/not/exist") }
 
-  before(:each) do
+  before do
     allow(ManageIQ).to receive_messages(:env => ActiveSupport::StringInquirer.new("production"))
 
     @app = Vmdb::Application.new
@@ -10,7 +10,7 @@ describe "DatabaseConfiguration patch" do
   end
 
   context "ERB in the template" do
-    before(:each) do
+    before do
       database_config = StringIO.new "---\nvalue: <%= 1 %>\n"
       allow(database_config).to receive(:exist?).and_return(true)
       allow(Pathname).to receive(:new).and_return(database_config)

--- a/spec/lib/extensions/virtual_total_spec.rb
+++ b/spec/lib/extensions/virtual_total_spec.rb
@@ -1,5 +1,5 @@
 describe VirtualTotal do
-  before(:each) do
+  before do
     # rubocop:disable Style/SingleLineMethods, Layout/EmptyLineBetweenDefs, Naming/AccessorMethodName
     class VitualTotalTestBase < ActiveRecord::Base
       self.abstract_class = true
@@ -71,7 +71,7 @@ describe VirtualTotal do
     # rubocop:enable Style/SingleLineMethods, Layout/EmptyLineBetweenDefs, Naming/AccessorMethodName
   end
 
-  after(:each) do
+  after do
     VitualTotalTestBase.remove_connection
     Object.send(:remove_const, :VtAuthor)
     Object.send(:remove_const, :VtBook)
@@ -160,7 +160,7 @@ describe VirtualTotal do
     end
 
     context "with order clauses in the relation" do
-      before(:each) do
+      before do
         # Monkey patching VtAuthor for these specs
         class VtAuthor < VitualTotalTestBase
           has_many :recently_published_books, -> { published.order(:created_on => :desc) },
@@ -217,7 +217,7 @@ describe VirtualTotal do
     end
 
     context "with a special books class" do
-      before(:each) do
+      before do
         class SpecialVtBook < VtBook
           default_scope { where(:special => true) }
 
@@ -236,7 +236,7 @@ describe VirtualTotal do
         end
       end
 
-      after(:each) do
+      after do
         Object.send(:remove_const, :SpecialVtBook)
       end
 

--- a/spec/lib/manageiq_spec.rb
+++ b/spec/lib/manageiq_spec.rb
@@ -15,7 +15,7 @@ describe ManageIQ do
   end
 
   describe ".env" do
-    before(:each) do
+    before do
       ManageIQ.instance_variable_set(:@_env, nil)
     end
 
@@ -45,7 +45,7 @@ describe ManageIQ do
   end
 
   describe ".root" do
-    before(:each) do
+    before do
       ManageIQ.instance_variable_set(:@_root, nil)
     end
 

--- a/spec/lib/miq_cockpit_spec.rb
+++ b/spec/lib/miq_cockpit_spec.rb
@@ -1,5 +1,5 @@
 describe MiqCockpit::WS do
-  before(:each) do
+  before do
     @server = FactoryGirl.create(:miq_server, :hostname => "hostname")
     @miq_server = EvmSpecHelper.local_miq_server
     @miq_server.ipaddress = "10.0.0.1"
@@ -104,7 +104,7 @@ describe MiqCockpit::WS do
   end
 
   describe 'update_config' do
-    before(:each) do
+    before do
       @login_command = Rails.root.join("tools", "cockpit", "cockpit-auth-miq")
     end
 

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -1,11 +1,11 @@
 describe MiqEnvironment do
   context "with linux platform" do
-    before(:each) do
+    before do
       @old_impl = Sys::Platform::IMPL
       silence_warnings { Sys::Platform::IMPL = :linux }
     end
 
-    after(:each) do
+    after do
       silence_warnings { Sys::Platform::IMPL = @old_impl } if @old_impl
     end
 

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -37,7 +37,7 @@ describe MiqExpression do
         let(:volume_2_type_field_cost) { "#{model}-storage_allocated_#{volume_2.volume_type}_cost" }
         let(:volume_3_type_field_cost) { "#{model}-storage_allocated_#{volume_3.volume_type}_cost" }
 
-        before(:each) do
+        before do
           volume_1
           volume_2
         end

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -1,7 +1,7 @@
 # encoding: US-ASCII
 
 describe MiqLdap do
-  before(:each) do
+  before do
     @host     = 'mycompany.com'
 
     # TODO: Use an actual user so this test actually tests something in the CI server

--- a/spec/lib/pid_file_spec.rb
+++ b/spec/lib/pid_file_spec.rb
@@ -1,5 +1,5 @@
 describe PidFile do
-  before(:each) do
+  before do
     @fname = 'foo.bar'
     @pid_file = PidFile.new(@fname)
   end
@@ -11,7 +11,7 @@ describe PidFile do
     end
 
     context "file does exist" do
-      before(:each) do
+      before do
         allow(File).to receive(:file?).with(@fname).and_return(true)
       end
 
@@ -68,7 +68,7 @@ describe PidFile do
     end
 
     context "#pid returns valid value" do
-      before(:each) do
+      before do
         @pid = 42
         allow(@pid_file).to receive(:pid).and_return(@pid)
       end
@@ -84,7 +84,7 @@ describe PidFile do
       end
 
       context "MiqProcess.command_line returns valid value" do
-        before(:each) do
+        before do
           @cmd_line = "my favorite program"
           allow(MiqProcess).to receive(:command_line).and_return(@cmd_line)
         end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -521,7 +521,7 @@ describe Rbac::Filterer do
     end
 
     context "for Metrics::Rollup" do
-      before(:each) do
+      before do
         vm = FactoryGirl.create(:vm_vmware)
         FactoryGirl.create(
           :metric_rollup_vm_daily,
@@ -571,7 +571,7 @@ describe Rbac::Filterer do
     let(:group) { FactoryGirl.create(:miq_group, :tenant => default_tenant) }
     let(:user)  { FactoryGirl.create(:user, :miq_groups => [group]) }
 
-    before(:each) do
+    before do
       @tags = {
         2 => "/managed/environment/prod",
         3 => "/managed/environment/dev",
@@ -668,7 +668,7 @@ describe Rbac::Filterer do
       end
 
       context "with self-service user" do
-        before(:each) do
+        before do
           allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
         end
 
@@ -725,13 +725,13 @@ describe Rbac::Filterer do
 
     context "with Hosts" do
       let(:hosts) { [@host1, @host2] }
-      before(:each) do
+      before do
         @host1 = FactoryGirl.create(:host, :name => "Host1", :hostname => "host1.local")
         @host2 = FactoryGirl.create(:host, :name => "Host2", :hostname => "host2.local")
       end
 
       context "having Metric data" do
-        before(:each) do
+        before do
           @timestamps = [
             ["2010-04-14T20:52:30Z", 100.0],
             ["2010-04-14T21:51:10Z", 1.0],
@@ -754,7 +754,7 @@ describe Rbac::Filterer do
         end
 
         context "with only managed filters" do
-          before(:each) do
+          before do
             group.entitlement = Entitlement.new
             group.entitlement.set_managed_filters([["/managed/environment/prod"], ["/managed/service_level/silver"]])
             group.entitlement.set_belongsto_filters([])
@@ -796,7 +796,7 @@ describe Rbac::Filterer do
         end
 
         context "with only belongsto filters" do
-          before(:each) do
+          before do
             group.entitlement = Entitlement.new
             group.entitlement.set_belongsto_filters(["/belongsto/ExtManagementSystem|ems1"])
             group.entitlement.set_managed_filters([])
@@ -834,7 +834,7 @@ describe Rbac::Filterer do
       end
 
       context "with VMs and Templates" do
-        before(:each) do
+        before do
           @ems = FactoryGirl.create(:ems_vmware, :name => 'ems1')
           @host1.update_attributes(:ext_management_system => @ems)
           @host2.update_attributes(:ext_management_system => @ems)
@@ -866,7 +866,7 @@ describe Rbac::Filterer do
         end
 
         context "search on EMSes" do
-          before(:each) do
+          before do
             @ems2 = FactoryGirl.create(:ems_vmware, :name => 'ems2')
           end
 
@@ -1020,7 +1020,7 @@ describe Rbac::Filterer do
       end
 
       context "when applying a filter to the host and it's cluster (FB17114)" do
-        before(:each) do
+        before do
           @ems = FactoryGirl.create(:ems_vmware, :name => 'ems')
           @ems_folder_path = "/belongsto/ExtManagementSystem|#{@ems.name}"
           @root = FactoryGirl.create(:ems_folder, :name => "Datacenters")
@@ -1151,7 +1151,7 @@ describe Rbac::Filterer do
     end
 
     context "with services" do
-      before(:each) do
+      before do
         @service1 = FactoryGirl.create(:service)
         @service2 = FactoryGirl.create(:service)
         @service3 = FactoryGirl.create(:service, :evm_owner => user)
@@ -1168,7 +1168,7 @@ describe Rbac::Filterer do
         end
 
         context "with self-service user" do
-          before(:each) do
+          before do
             allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
           end
 
@@ -1189,7 +1189,7 @@ describe Rbac::Filterer do
         end
 
         context "with limited self-service user" do
-          before(:each) do
+          before do
             allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
             allow_any_instance_of(MiqGroup).to receive_messages(:limited_self_service? => true)
           end
@@ -1418,7 +1418,7 @@ describe Rbac::Filterer do
     context "with tagged VMs" do
       let(:ems) { FactoryGirl.create(:ext_management_system) }
 
-      before(:each) do
+      before do
         [
           FactoryGirl.create(:host, :name => "Host1", :hostname => "host1.local"),
           FactoryGirl.create(:host, :name => "Host2", :hostname => "host2.local"),
@@ -1450,7 +1450,7 @@ describe Rbac::Filterer do
         end
 
         context "with self-service user" do
-          before(:each) do
+          before do
             allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
           end
 
@@ -1478,7 +1478,7 @@ describe Rbac::Filterer do
         end
 
         context "with limited self-service user" do
-          before(:each) do
+          before do
             allow_any_instance_of(MiqGroup).to receive_messages(:self_service? => true)
             allow_any_instance_of(MiqGroup).to receive_messages(:limited_self_service? => true)
           end
@@ -1559,7 +1559,7 @@ describe Rbac::Filterer do
       end
 
       context "with only managed filters (FB9153, FB11442)" do
-        before(:each) do
+        before do
           group.entitlement = Entitlement.new
           group.entitlement.set_managed_filters([["/managed/environment/prod"], ["/managed/service_level/silver"]])
           group.save!
@@ -1619,7 +1619,7 @@ describe Rbac::Filterer do
       let(:group_user) { FactoryGirl.create(:user, :miq_groups => [group2, group]) }
       let(:group2) { FactoryGirl.create(:miq_group, :role => 'support') }
 
-      before(:each) do
+      before do
         4.times do |i|
           FactoryGirl.create(:vm_vmware,
                              :name             => "Test VM #{i}",

--- a/spec/lib/task_helpers/exports/alert_sets_spec.rb
+++ b/spec/lib/task_helpers/exports/alert_sets_spec.rb
@@ -30,12 +30,12 @@ describe TaskHelpers::Exports::AlertSets do
     }
   end
 
-  before(:each) do
+  before do
     FactoryGirl.create(:miq_alert_set_vm, alert_set_create_attrs)
     @export_dir = Dir.mktmpdir('miq_exp_dir')
   end
 
-  after(:each) do
+  after do
     FileUtils.remove_entry @export_dir
   end
 

--- a/spec/lib/task_helpers/exports/alerts_spec.rb
+++ b/spec/lib/task_helpers/exports/alerts_spec.rb
@@ -28,12 +28,12 @@ describe TaskHelpers::Exports::Alerts do
     }
   end
 
-  before(:each) do
+  before do
     FactoryGirl.create(:miq_alert, alert_create_attrs)
     @export_dir = Dir.mktmpdir('miq_exp_dir')
   end
 
-  after(:each) do
+  after do
     FileUtils.remove_entry(@export_dir)
   end
 

--- a/spec/lib/task_helpers/exports_spec.rb
+++ b/spec/lib/task_helpers/exports_spec.rb
@@ -45,11 +45,11 @@ describe TaskHelpers::Exports do
   describe '.validate_directory' do
     let(:export_dir2) { Dir.tmpdir + "/thisdoesntexist" }
 
-    before(:each) do
+    before do
       @export_dir = Dir.mktmpdir('miq_exp_dir')
     end
 
-    after(:each) do
+    after do
       FileUtils.remove_entry @export_dir
     end
 

--- a/spec/lib/task_helpers/imports_spec.rb
+++ b/spec/lib/task_helpers/imports_spec.rb
@@ -1,13 +1,13 @@
 describe TaskHelpers::Imports do
   describe '.validate_source' do
-    before(:each) do
+    before do
       @import_dir = Dir.mktmpdir('miq_imp_dir')
       @import_dir2 = Dir.mktmpdir('miq_imp_dir')
       FileUtils.remove_entry @import_dir2
       @import_file = Tempfile.new('miq_imp_file')
     end
 
-    after(:each) do
+    after do
       FileUtils.remove_entry @import_dir
       @import_file.close!
     end

--- a/spec/lib/vmdb/loggers/fog_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/fog_logger_spec.rb
@@ -1,5 +1,5 @@
 describe Vmdb::Loggers::FogLogger do
-  before(:each) do
+  before do
     @log_stream = StringIO.new
     @log = described_class.new(@log_stream)
     @log.level = VMDBLogger::DEBUG

--- a/spec/lib/websocket_server_spec.rb
+++ b/spec/lib/websocket_server_spec.rb
@@ -1,5 +1,5 @@
 describe WebsocketServer do
-  before(:each) do
+  before do
     allow(logger).to receive(:info)
     @server = described_class.new(:logger => logger)
     Thread.list.reject { |t| t == Thread.current }.each(&:kill)
@@ -41,7 +41,7 @@ describe WebsocketServer do
   describe '#cleanup' do
     subject { @server.send(:cleanup, error) }
 
-    before(:each) do
+    before do
       pairing.merge!(
         left  => WebsocketServer::Pairing.new(true, proxy),
         right => WebsocketServer::Pairing.new(false, proxy)

--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -1,5 +1,5 @@
 describe GenericMailer do
-  before(:each) do
+  before do
     @miq_server = EvmSpecHelper.local_miq_server
     @args = {
       :to      => "you@bedrock.gov",

--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -1,6 +1,6 @@
 describe AssignedServerRole do
   context "and Server Role seeded for 1 Region/Zone" do
-    before(:each) do
+    before do
       @miq_server = EvmSpecHelper.local_miq_server
     end
 
@@ -76,7 +76,7 @@ describe AssignedServerRole do
   end
 
   context "and Server Roles seeded for 1 Region and 2 Zones" do
-    before(:each) do
+    before do
       @miq_region = FactoryGirl.create(:miq_region, :region => 1)
       allow(MiqRegion).to receive(:my_region).and_return(@miq_region)
 

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -102,12 +102,12 @@ describe AsyncDeleteMixin do
   end
 
   context "with zone and server" do
-    before(:each) do
+    before do
       EvmSpecHelper.local_miq_server
     end
 
     context "with 3 ems clusters" do
-      before(:each) do
+      before do
         @objects, @obj = common_setup(:ems_cluster)
       end
 
@@ -123,7 +123,7 @@ describe AsyncDeleteMixin do
     end
 
     context "with 3 ems" do
-      before(:each) do
+      before do
         @objects, @obj = common_setup(:ems_vmware)
       end
 
@@ -139,7 +139,7 @@ describe AsyncDeleteMixin do
     end
 
     context "with 3 hosts" do
-      before(:each) do
+      before do
         @objects, @obj = common_setup(:host)
       end
 
@@ -155,7 +155,7 @@ describe AsyncDeleteMixin do
     end
 
     context "with 3 resource pools" do
-      before(:each) do
+      before do
         @objects, @obj = common_setup(:resource_pool)
       end
 
@@ -171,7 +171,7 @@ describe AsyncDeleteMixin do
     end
 
     context "with 3 storages" do
-      before(:each) do
+      before do
         @objects, @obj = common_setup(:storage)
       end
 

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -7,7 +7,7 @@ describe Authentication do
   end
 
   context "with miq events seeded" do
-    before(:each) do
+    before do
       MiqEventDefinitionSet.seed
       MiqEventDefinition.seed
     end

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -12,7 +12,7 @@ describe Authenticator::Httpd do
     ActionDispatch::Request.new(Rack::MockRequest.env_for("/", env))
   end
 
-  before(:each) do
+  before do
     # If anything goes looking for the currently configured
     # Authenticator during any of these tests, we'd really rather they
     # found the one we're working on.
@@ -25,7 +25,7 @@ describe Authenticator::Httpd do
     allow(User).to receive(:authenticator).and_return(subject)
   end
 
-  before(:each) do
+  before do
     FactoryGirl.create(:miq_group, :description => 'wibble')
     FactoryGirl.create(:miq_group, :description => 'wobble')
 

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -39,7 +39,7 @@ describe Authenticator::Ldap do
     end
   end
 
-  before(:each) do
+  before do
     # If anything goes looking for the currently configured
     # Authenticator during any of these tests, we'd really rather they
     # found the one we're working on.
@@ -52,7 +52,7 @@ describe Authenticator::Ldap do
     allow(User).to receive(:authenticator).and_return(subject)
   end
 
-  before(:each) do
+  before do
     FactoryGirl.create(:miq_group, :description => 'wibble')
     FactoryGirl.build_stubbed(:miq_group, :description => 'wobble')
   end
@@ -111,7 +111,7 @@ describe Authenticator::Ldap do
     }
   end
 
-  before(:each) do
+  before do
     allow(MiqLdap).to receive(:new) { FakeLdap.new(user_data) }
     allow(MiqLdap).to receive(:using_ldap?) { true }
   end
@@ -233,7 +233,7 @@ describe Authenticator::Ldap do
 
       context "using external authorization" do
         let(:config) { super().merge(:ldap_role => true) }
-        before(:each) { allow(subject).to receive(:authorize_queue?).and_return(false) }
+        before { allow(subject).to receive(:authorize_queue?).and_return(false) }
 
         context "with an LDAP user" do
           before { allow(subject).to receive(:run_task) }
@@ -397,7 +397,7 @@ describe Authenticator::Ldap do
 
       context "using external authorization" do
         let(:config) { super().merge(:ldap_role => true) }
-        before(:each) { allow(subject).to receive(:authorize_queue?).and_return(false) }
+        before { allow(subject).to receive(:authorize_queue?).and_return(false) }
 
         it "enqueues an authorize task" do
           expect(subject).to receive(:authorize_queue).and_return(123)

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -1,6 +1,6 @@
 describe AutomationRequest do
   let(:admin) { FactoryGirl.create(:user, :role => "admin") }
-  before(:each) do
+  before do
     allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
     @zone        = FactoryGirl.create(:zone, :name => "fred")
     @approver    = FactoryGirl.create(:user_miq_request_approver)
@@ -169,7 +169,7 @@ describe AutomationRequest do
 
   context "#approve" do
     context "an unapproved request with a single approver" do
-      before(:each) do
+      before do
         @ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
         @reason = "Why Not?"
       end
@@ -209,7 +209,7 @@ describe AutomationRequest do
   end
 
   context "#create_request_tasks" do
-    before(:each) do
+    before do
       @ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
       root = {'ae_result' => 'ok'}
       @ws = double('ws')

--- a/spec/models/automation_task_spec.rb
+++ b/spec/models/automation_task_spec.rb
@@ -1,5 +1,5 @@
 describe AutomationTask do
-  before(:each) do
+  before do
     allow(MiqServer).to receive(:my_zone).and_return("default")
     @admin       = FactoryGirl.create(:user_admin)
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -107,7 +107,7 @@ describe ChargebackVm do
 
       context "by service" do
         let(:options) { base_options.merge(:interval => 'monthly', :interval_size => 4, :service_id => @service.id) }
-        before(:each) do
+        before do
           @service = FactoryGirl.create(:service)
           @service << @vm1
           @service.save
@@ -416,7 +416,7 @@ describe ChargebackVm do
         let(:derived_vm_numvcpus_tenant_5) { 1 }
         let(:cpu_usagemhz_rate_average_tenant_5) { 50 }
 
-        before(:each) do
+        before do
           add_metric_rollups_for([vm_1_1, vm_2_1], month_beginning...month_end, 8.hours, metric_rollup_params.merge!(:derived_vm_numvcpus => 1, :cpu_usagemhz_rate_average => 50))
           add_metric_rollups_for([vm_1_2, vm_2_2], month_beginning...month_end, 8.hours, metric_rollup_params.merge!(:derived_vm_numvcpus => 1, :cpu_usagemhz_rate_average => 50))
           add_metric_rollups_for([vm_1_3, vm_2_3], month_beginning...month_end, 8.hours, metric_rollup_params.merge!(:derived_vm_numvcpus => 1, :cpu_usagemhz_rate_average => 50))

--- a/spec/models/container_deployment_spec.rb
+++ b/spec/models/container_deployment_spec.rb
@@ -1,5 +1,5 @@
 describe ContainerDeployment do
-  before(:each) do
+  before do
     @container_deployment = FactoryGirl.create(:container_deployment,
                                                :method_type => "non_managed",
                                                :version     => "v2",
@@ -74,7 +74,7 @@ variant: openshift-enterprise
   end
 
   context "#cockpit_url" do
-    before(:each) do
+    before do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         cockpit_ws,Cockpit,1,false,zone
@@ -130,7 +130,7 @@ variant: openshift-enterprise
   end
 
   context "authentication yml generation" do
-    before(:each) do
+    before do
       @container_deployment.authentications.destroy_all
     end
     it "parse allow all correctly" do

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -42,7 +42,7 @@ describe ContainerLabelTagMapping do
   end
 
   context "with 2 mappings for same label" do
-    before(:each) do
+    before do
       FactoryGirl.create(:container_label_tag_mapping, :only_nodes, :label_value => 'value-1', :tag => tag1)
       FactoryGirl.create(:container_label_tag_mapping, :only_nodes, :label_value => 'value-1', :tag => tag2)
     end
@@ -54,7 +54,7 @@ describe ContainerLabelTagMapping do
   end
 
   context "with any-value and specific-value mappings" do
-    before(:each) do
+    before do
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag1)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value-1', :tag => tag2)
@@ -151,7 +151,7 @@ describe ContainerLabelTagMapping do
   end
 
   context "with 2 any-value mappings onto same category" do
-    before(:each) do
+    before do
       FactoryGirl.create(:container_label_tag_mapping, :label_name => 'name1', :tag => cat_tag)
       FactoryGirl.create(:container_label_tag_mapping, :label_name => 'name2', :tag => cat_tag)
     end
@@ -183,7 +183,7 @@ describe ContainerLabelTagMapping do
   # seemed the simplest well-defined behavior...
 
   context "with any-type and specific-type mappings" do
-    before(:each) do
+    before do
       FactoryGirl.create(:container_label_tag_mapping, :only_nodes, :label_value => 'value', :tag => tag1)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value', :tag => tag2)
     end
@@ -198,7 +198,7 @@ describe ContainerLabelTagMapping do
   end
 
   context "any-type specific-value vs specific-type any-value" do
-    before(:each) do
+    before do
       FactoryGirl.create(:container_label_tag_mapping, :only_nodes, :tag => cat_tag)
       FactoryGirl.create(:container_label_tag_mapping, :label_value => 'value', :tag => tag2)
     end
@@ -217,7 +217,7 @@ describe ContainerLabelTagMapping do
       instance_double(ManagerRefresh::InventoryObject, :id => tag.id)
     end
 
-    before(:each) do
+    before do
       # For tag1, tag2 to be controlled by the mapping, though current implementation doesn't care.
       FactoryGirl.create(:container_label_tag_mapping, :tag => cat_tag)
       tag1

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -34,7 +34,7 @@ describe CustomButton do
     end
 
     context "when I create a button via save_as_button class method" do
-      before(:each) do
+      before do
         @button_name   = "Power ON"
         @button_text   = "Power ON during Business Hours ONLY"
         @button_number = 3
@@ -71,7 +71,7 @@ describe CustomButton do
       end
 
       context "when invoking for a particular VM" do
-        before(:each) do
+        before do
           @vm    = FactoryGirl.create(:vm_vmware)
           @user2 = FactoryGirl.create(:user_with_group)
           EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
@@ -137,7 +137,7 @@ describe CustomButton do
   end
 
   context "validates uniqueness" do
-    before(:each) do
+    before do
       @vm = FactoryGirl.create(:vm_vmware)
       @default_name = @default_description = "boom"
     end

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -2,7 +2,7 @@ describe DatabaseBackup do
   context "region" do
     let!(:region) { FactoryGirl.create(:miq_region, :region => 3) }
 
-    before(:each) do
+    before do
       allow(described_class).to receive_messages(:my_region_number => region.region)
     end
 
@@ -24,7 +24,7 @@ describe DatabaseBackup do
   end
 
   context "schedule" do
-    before(:each) do
+    before do
       EvmSpecHelper.local_miq_server
 
       @name = "adhoc schedule"

--- a/spec/models/dialog_field_date_time_control_spec.rb
+++ b/spec/models/dialog_field_date_time_control_spec.rb
@@ -5,7 +5,7 @@ describe DialogFieldDateTimeControl do
     end
 
     context "with UTC timezone" do
-      before(:each) do
+      before do
         allow(user).to receive(:get_timezone).and_return("UTC")
       end
 
@@ -26,7 +26,7 @@ describe DialogFieldDateTimeControl do
     end
 
     context "with HST timezone" do
-      before(:each) do
+      before do
         allow(user).to receive(:get_timezone).and_return("HST")
       end
 

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -8,7 +8,7 @@ describe DialogFieldTagControl do
   end
 
   context "dialog field tag control without options hash" do
-    before(:each) do
+    before do
       @df = FactoryGirl.create(:dialog_field_tag_control, :label => 'test tag category', :name => 'test tag category')
     end
 
@@ -62,7 +62,7 @@ describe DialogFieldTagControl do
   end
 
   context "dialog field tag control with with options hash and category" do
-    before(:each) do
+    before do
       @df = FactoryGirl.create(:dialog_field_tag_control, :label => 'test tag category', :name => 'test tag category',
             :options => {:force_single_value => true, :category_id => 1, :category_name => 'category', :category_description => 'description'}
                               )
@@ -86,7 +86,7 @@ describe DialogFieldTagControl do
   end
 
   context "dialog field with tag control hash and tag categories" do
-    before(:each) do
+    before do
       @cat = FactoryGirl.create(:classification, :description => "Auto Approve - Max CPU", :name => "prov_max_cpu", :single_value => 1)
       @df  = FactoryGirl.create(:dialog_field_tag_control, :label => 'test tag category', :name => 'test tag category',
             :options => {:category_id => @cat.id, :category_name => 'category', :category_description => 'description'}
@@ -106,7 +106,7 @@ describe DialogFieldTagControl do
   end
 
   context "dialog field tag control and Classification seeded" do
-    before(:each) do
+    before do
       cat = FactoryGirl.create(:classification, :description => "Environment", :name => "environment",  :single_value => true,  :parent_id => 0)
       add_entry(cat, :name => "dev",  :description => "Development")
       add_entry(cat, :name => "test", :description => "Test")
@@ -127,7 +127,7 @@ describe DialogFieldTagControl do
     end
 
     context "with dialog field tag control without options hash" do
-      before(:each) do
+      before do
         @df  = FactoryGirl.create(:dialog_field_tag_control, :label => 'test tag', :name => 'test tag', :options => {:force_single_select => true})
       end
 

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -62,7 +62,7 @@ describe Dialog do
   end
 
   context "#destroy" do
-    before(:each) do
+    before do
       @dialog = FactoryGirl.create(:dialog, :label => 'dialog')
     end
 
@@ -81,7 +81,7 @@ describe Dialog do
   end
 
   describe "dialog structures" do
-    before(:each) do
+    before do
       @dialog       = FactoryGirl.build(:dialog, :label => 'dialog')
       @dialog_tab   = FactoryGirl.create(:dialog_tab, :label => 'tab')
       @dialog_group = FactoryGirl.create(:dialog_group, :label => 'group')
@@ -133,7 +133,7 @@ describe Dialog do
   end
 
   context "#remove_all_resources" do
-    before(:each) do
+    before do
       @dialog       = FactoryGirl.create(:dialog, :label => 'dialog')
       @dialog_tab   = FactoryGirl.create(:dialog_tab, :label => 'tab')
       @dialog_group = FactoryGirl.create(:dialog_group, :label => 'group')
@@ -163,7 +163,7 @@ describe Dialog do
   end
 
   context "remove resources" do
-    before(:each) do
+    before do
       @dialog             = FactoryGirl.create(:dialog,       :label => 'dialog')
       @dialog_tab         = FactoryGirl.create(:dialog_tab,   :label => 'tab')
       @dialog_group       = FactoryGirl.create(:dialog_group, :label => 'group')
@@ -208,7 +208,7 @@ describe Dialog do
   end
 
   context "#each_field" do
-    before(:each) do
+    before do
       @dialog        = FactoryGirl.create(:dialog, :label => 'dialog')
       @dialog_tab    = FactoryGirl.create(:dialog_tab, :label => 'tab')
       @dialog_group  = FactoryGirl.create(:dialog_group, :label => 'group')
@@ -331,7 +331,7 @@ describe Dialog do
   end
 
   context "#dialog_fields" do
-    before(:each) do
+    before do
       @dialog        = FactoryGirl.create(:dialog, :label => 'dialog')
       @dialog_tab    = FactoryGirl.create(:dialog_tab, :label => 'tab')
       @dialog_group  = FactoryGirl.create(:dialog_group, :label => 'group')

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -1,7 +1,7 @@
 # this is basically copied from miq_report_result/purging.rb
 describe DriftState do
   context "::Purging" do
-    before(:each) do
+    before do
       @vmdb_config = {
         :drift_states => {
           :history => {
@@ -43,7 +43,7 @@ describe DriftState do
     end
 
     context "#purge_queue" do
-      before(:each) do
+      before do
         EvmSpecHelper.create_guid_miq_server_zone
         described_class.purge_queue(:remaining, 1)
       end

--- a/spec/models/ems_cluster/capacity_planning_spec.rb
+++ b/spec/models/ems_cluster/capacity_planning_spec.rb
@@ -1,5 +1,5 @@
 describe EmsCluster::CapacityPlanning do
-  before(:each) do
+  before do
     @cluster = FactoryGirl.create(:ems_cluster)
   end
 
@@ -159,7 +159,7 @@ describe EmsCluster::CapacityPlanning do
     end
 
     context "with effective_resource not set" do
-      before(:each) do
+      before do
         allow(@cluster).to receive(:effective_cpu).and_return(nil)
       end
 
@@ -188,7 +188,7 @@ describe EmsCluster::CapacityPlanning do
       end
 
       context "and HA enabled" do
-        before(:each) do
+        before do
           @cluster.update_attribute(:ha_enabled, true)
         end
 
@@ -266,7 +266,7 @@ describe EmsCluster::CapacityPlanning do
   end
 
   context "#capacity_resources_per_vm_with_min_max" do
-    before(:each) do
+    before do
       allow(@cluster).to receive(:capacity_resources_per_vm).and_return(3.530)
     end
 

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -1,6 +1,6 @@
 describe EmsCluster do
   context("VMware") do
-    before(:each) do
+    before do
       @cluster = FactoryGirl.create(:ems_cluster)
       @host1 = FactoryGirl.create(:host, :ems_cluster => @cluster)
       @host2 = FactoryGirl.create(:host, :ems_cluster => @cluster)
@@ -60,7 +60,7 @@ describe EmsCluster do
   end
 
   context("RedHat") do
-    before(:each) do
+    before do
       @cluster = FactoryGirl.create(:ems_cluster)
       @host1 = FactoryGirl.create(:host, :ems_cluster => @cluster)
       @host2 = FactoryGirl.create(:host, :ems_cluster => @cluster)
@@ -177,7 +177,7 @@ describe EmsCluster do
   end
 
   context "#node_types" do
-    before(:each) do
+    before do
       @ems1 = FactoryGirl.create(:ems_vmware)
       @ems2 = FactoryGirl.create(:ems_openstack_infra)
     end

--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -1,6 +1,6 @@
 describe EmsFolder do
   context "with folder tree" do
-    before(:each) do
+    before do
       @root = FactoryGirl.create(:ems_folder, :name => "root")
 
       @dc   = FactoryGirl.create(:ems_folder, :name => "dc")

--- a/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -1,6 +1,6 @@
 describe EmsRefresh::MetadataRelats do
   context ".vmdb_relats" do
-    before(:each) do
+    before do
       @zone        = FactoryGirl.create(:zone)
       @ems         = FactoryGirl.create(:ems_vmware, :zone => @zone)
 
@@ -44,7 +44,7 @@ describe EmsRefresh::MetadataRelats do
     end
 
     context "with an invalid relats tree" do
-      before(:each) do
+      before do
         @rp2 = FactoryGirl.create(:resource_pool, :ext_management_system => @ems)
         @host.set_child(@rp2)
         @host_folder.add_host(@host)

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -11,7 +11,7 @@ context "save_tags_inventory" do
     entry.tag
   end
 
-  before(:each) do
+  before do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
 

--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -110,7 +110,7 @@ describe EmsRefresh::SaveInventoryInfra do
   end
 
   context ".save_hosts_inventory" do
-    before(:each) do
+    before do
       @zone   = FactoryGirl.create(:zone)
       @ems    = FactoryGirl.create(:ems_vmware, :zone => @zone)
     end

--- a/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_spec.rb
@@ -1,12 +1,12 @@
 describe EmsRefresh::SaveInventory do
   context "save_vms_inventory handling duplicate uids" do
-    before(:each) do
+    before do
       @zone = FactoryGirl.create(:zone)
       @ems  = FactoryGirl.create(:ems_vmware, :zone => @zone)
     end
 
     context "check save_ems_inventory_no_disconnect" do
-      before(:each) do
+      before do
         @zone = FactoryGirl.create(:zone)
         @ems = FactoryGirl.create(:ems_redhat, :zone => @zone)
         FactoryGirl.create(:resource_pool,
@@ -103,7 +103,7 @@ describe EmsRefresh::SaveInventory do
     end
 
     context "with no dups in the database" do
-      before(:each) do
+      before do
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
         @vm2 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
       end
@@ -150,7 +150,7 @@ describe EmsRefresh::SaveInventory do
     end
 
     context "with dups in the database" do
-      before(:each) do
+      before do
         @uid = SecureRandom.uuid
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
         @vm2 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
@@ -198,7 +198,7 @@ describe EmsRefresh::SaveInventory do
     end
 
     context "with disconnected dups in the database" do
-      before(:each) do
+      before do
         @uid = SecureRandom.uuid
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => nil,  :uid_ems => @uid)
         @vm2 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
@@ -247,7 +247,7 @@ describe EmsRefresh::SaveInventory do
     end
 
     context "with non-dup on a different EMS in the database" do
-      before(:each) do
+      before do
         @ems2 = FactoryGirl.create(:ems_vmware)
         @uid  = SecureRandom.uuid
         @vm1  = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems2, :uid_ems => @uid)
@@ -273,7 +273,7 @@ describe EmsRefresh::SaveInventory do
     end
 
     context "with disconnected non-dup in the database" do
-      before(:each) do
+      before do
         @uid  = SecureRandom.uuid
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => nil, :uid_ems => @uid)
         @vm2 = FactoryGirl.build(:vm_with_ref, :ext_management_system => @ems, :uid_ems => @uid)
@@ -293,7 +293,7 @@ describe EmsRefresh::SaveInventory do
     end
 
     context "with no dups in the database, but with nil ems_refs (after upgrade)" do
-      before(:each) do
+      before do
         @vm1 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
         @vm2 = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems)
 

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -1,6 +1,6 @@
 describe EmsRefresh do
   context ".queue_refresh" do
-    before(:each) do
+    before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems = FactoryGirl.create(:ems_vmware, :zone => zone)
     end
@@ -46,7 +46,7 @@ describe EmsRefresh do
   end
 
   context "stopping targets unbounded growth" do
-    before(:each) do
+    before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
       @ems = FactoryGirl.create(:ems_vmware, :zone => zone)
     end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -239,7 +239,7 @@ describe ExtManagementSystem do
   end
 
   context "with two small envs" do
-    before(:each) do
+    before do
       @zone1 = FactoryGirl.create(:small_environment)
       @zone2 = FactoryGirl.create(:small_environment)
     end
@@ -260,7 +260,7 @@ describe ExtManagementSystem do
   end
 
   context "with virtual totals" do
-    before(:each) do
+    before do
       @ems = FactoryGirl.create(:ems_vmware)
       2.times do
         FactoryGirl.create(:vm_vmware,

--- a/spec/models/guest_device_spec.rb
+++ b/spec/models/guest_device_spec.rb
@@ -1,5 +1,5 @@
 describe GuestDevice do
-  before(:each) do
+  before do
     @vm_gd = FactoryGirl.create(:guest_device_nic)
     @vm    = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :guest_devices => [@vm_gd]))
 

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -39,7 +39,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
     end
 
     context "With a zone, server, ems, hosts, vmware vms" do
-      before(:each) do
+      before do
         server = EvmSpecHelper.local_miq_server(:is_master => true, :name => "test_server_main_server")
         (NUM_OF_SERVERS - 1).times do |i|
           FactoryGirl.create(:miq_server, :zone => server.zone, :name => "test_server_#{i}")
@@ -61,7 +61,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
       end
 
       context "and a scan job for each vm" do
-        before(:each) do
+        before do
           allow(MiqVimBrokerWorker).to receive(:available_in_zone?).and_return(true)
 
           @jobs = @vms.collect(&:raw_scan)
@@ -100,7 +100,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
         end
 
         context "and embedded scans on hosts" do
-          before(:each) do
+          before do
             allow(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:scan_via_ems?).and_return(false)
           end
 

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -2,7 +2,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
@@ -12,20 +12,20 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
-      before(:each) do
+      before do
         @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 
       context "with a vm scan job, " do
-        before(:each) do
+        before do
           @job = @vm.raw_scan
           @jpd.instance_of?(JobProxyDispatcher) ? @jpd.instance_variable_set(:@vm, @vm) : @jpd.send(:class_variable_set, :@@vm, @vm)
           @jpd.instance_variable_set(:@vm, @vm)
         end
 
         context "and the vm attached to the job was not found, so @vm is nil, " do
-          before(:each) do
+          before do
             @jpd.instance_of?(JobProxyDispatcher) ? @jpd.instance_variable_set(:@vm, nil) : @jpd.send(:class_variable_set, :@@vm, nil)
           end
 
@@ -35,7 +35,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
         end
 
         context "vm on unsupported storage type, " do
-          before(:each) do
+          before do
             store = @vm.storage
             store.store_type = "VMFS2"
             store.save
@@ -47,7 +47,7 @@ describe "JobProxyDispatcherGetEligibleProxiesForJob" do
         end
 
         context "with no proxies for job, " do
-          before(:each) do
+          before do
             allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive_messages(:proxies4job => {:proxies => [], :message => "blah"})
           end
 

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -18,12 +18,12 @@ describe JobProxyDispatcher do
 
   let(:dispatcher) { JobProxyDispatcher.new }
 
-  before(:each) do
+  before do
     @server = EvmSpecHelper.local_miq_server(:name => "test_server_main_server")
   end
 
   context "With a default zone, server, with hosts with a miq_proxy, vmware vms on storages" do
-    before(:each) do
+    before do
       (NUM_SERVERS - 1).times do |i|
         FactoryGirl.create(:miq_server, :zone => @server.zone, :name => "test_server_#{i}")
       end
@@ -62,7 +62,7 @@ describe JobProxyDispatcher do
         end
 
         context "with a vm without a storage" do
-          before(:each) do
+          before do
             # Test a vm without a storage (ie, removed from VC but retained in the VMDB)
             allow(MiqVimBrokerWorker).to receive(:available_in_zone?).and_return(true)
             @vm = @vms.first
@@ -78,7 +78,7 @@ describe JobProxyDispatcher do
         end
 
         context "with a Microsoft vm without a storage" do
-          before(:each) do
+          before do
             # Test a Microsoft vm without a storage
             allow(MiqVimBrokerWorker).to receive(:available_in_zone?).and_return(true)
             @vm = @vms.first
@@ -94,7 +94,7 @@ describe JobProxyDispatcher do
         end
 
         context "with a Microsoft vm with a Microsoft storage" do
-          before(:each) do
+          before do
             # Test a Microsoft vm without a storage
             allow(MiqVimBrokerWorker).to receive(:available_in_zone?).and_return(true)
             @vm = @vms.first
@@ -110,7 +110,7 @@ describe JobProxyDispatcher do
         end
 
         context "with a Microsoft vm with an invalid storage" do
-          before(:each) do
+          before do
             # Test a Microsoft vm without a storage
             allow(MiqVimBrokerWorker).to receive(:available_in_zone?).and_return(true)
             @vm = @vms.first
@@ -128,7 +128,7 @@ describe JobProxyDispatcher do
       end
 
       context "with jobs, a default smartproxy for repo scanning" do
-        before(:each) do
+        before do
           allow(MiqVimBrokerWorker).to receive(:available?).and_return(true)
           @repo_proxy = @proxies.last
           if @repo_proxy
@@ -173,7 +173,7 @@ describe JobProxyDispatcher do
 
     context "with container and vms jobs" do
       let (:container_image_classes) { ContainerImage.descendants.collect(&:name).append('ContainerImage') }
-      before(:each) do
+      before do
         @jobs = (@vms + @repo_vms).collect(&:raw_scan)
         User.current_user = FactoryGirl.create(:user)
         @jobs += @container_images.map { |img| img.ext_management_system.raw_scan_job_create(img.class, img.id) }
@@ -278,7 +278,7 @@ describe JobProxyDispatcher do
 
   context "limiting number of smart state analysis running on one server" do
     let(:job) { Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello - 1") }
-    before(:each) do
+    before do
       Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello - 2")
          .update_attributes(:dispatch_status => "active")
       Job.create_job("VmScan", :miq_server_id => @server.id, :name => "Hello - 3")
@@ -329,7 +329,7 @@ describe JobProxyDispatcher do
     let(:ems_id) { 1 }
     let(:job) { Job.create_job("VmScan", :name => "Hello, World") }
 
-    before(:each) do
+    before do
       dispatcher.instance_variable_set(:@zone, @server.my_zone)
       dispatcher.instance_variable_set(:@active_container_scans_by_zone_and_ems, @server.my_zone => {ems_id => 0})
     end

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -2,20 +2,20 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
-      before(:each) do
+      before do
         @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 
       context "with a started server, vix disk enabled, in same zone as a vmware vm with a host, " do
-        before(:each) do
+        before do
         end
 
         it "should return both servers" do
@@ -27,7 +27,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with main server stopped, " do
-        before(:each) do
+        before do
           @server1.status = "stopped"
           @server1.save
         end
@@ -37,7 +37,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with no vix disk enabled servers, " do
-        before(:each) do
+        before do
           allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => false)
         end
         it "should return no servers" do
@@ -46,7 +46,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with only a server in a different zone than the vm, " do
-        before(:each) do
+        before do
           @vms_zone = FactoryGirl.create(:zone, :description => "Zone 1", :name => "zone1")
           @server2.zone = @vms_zone
           @server2.save
@@ -58,7 +58,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with repository vm(a vm without a host), " do
-        before(:each) do
+        before do
           @vm.host = nil
           @vm.save
         end
@@ -68,7 +68,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with a vm without a storage, " do
-        before(:each) do
+        before do
           @vm.storage = nil
           @vm.save
         end
@@ -78,7 +78,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with the vm's host with vm scan affinity, " do
-        before(:each) do
+        before do
           host = @vm.host
           host.vm_scan_affinity = [@server2]
         end
@@ -88,7 +88,7 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
       end
 
       context "with vm's host does not have scan affinity and main server has vm scan affinity for a different host, " do
-        before(:each) do
+        before do
           host = @hosts.find { |h| h != @vm.host }
           @server1.vm_scan_host_affinity = [host]
         end

--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -2,20 +2,20 @@ describe "JobProxyDispatcherVmProxies4Job" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
-      before(:each) do
+      before do
         _hosts, _proxies, _storages, @vms = build_entities
         @vm = @vms.first
       end
 
       context "with available active proxy" do
-        before(:each) do
+        before do
           allow(@vm).to receive_messages(:storage2proxies => [@server1])
           allow(@vm).to receive_messages(:storage2active_proxies => [@server1])
         end
@@ -26,12 +26,12 @@ describe "JobProxyDispatcherVmProxies4Job" do
       end
 
       context "with no eligible active proxies, " do
-        before(:each) do
+        before do
           allow(@vm).to receive_messages(:storage2active_proxies => [])
         end
 
         context "with @server1 in list of all eligible proxies before filtering, " do
-          before(:each) do
+          before do
             allow(@vm).to receive_messages(:storage2proxies => [@server1])
           end
 
@@ -41,7 +41,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
         end
 
         context "with empty list of all eligible proxies before filtering, " do
-          before(:each) do
+          before do
             allow(@vm).to receive_messages(:storage2proxies => [])
           end
 
@@ -52,7 +52,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
       end
 
       context "with a vm scan job, with no eligible proxies, " do
-        before(:each) do
+        before do
           @job = @vm.raw_scan
           allow(@vm).to receive_messages(:storage2proxies => [])
           allow(@vm).to receive_messages(:storage2activeproxies => [])
@@ -64,7 +64,7 @@ describe "JobProxyDispatcherVmProxies4Job" do
         end
 
         context "with VmAmazon, " do
-          before(:each) do
+          before do
             @vm.type = "ManageIQ::Providers::Amazon::CloudManager::Vm"
             @vm.save
             @vm = VmOrTemplate.find(@vm.id)

--- a/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2hosts_spec.rb
@@ -2,26 +2,26 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
-      before(:each) do
+      before do
         @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 
       context "with vm's repository host as the last host, " do
-        before(:each) do
+        before do
           @repo_host = @hosts.last
           allow(@vm).to receive_messages(:myhost => @repo_host)
         end
 
         context "with a host-less vm and it's storage having hosts, " do
-          before(:each) do
+          before do
             vm_storage = @vm.storage
             vm_storage.hosts | [@hosts.first]
             vm_storage.save
@@ -32,7 +32,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
         end
 
         context "with host-less vm and it's storage without hosts, " do
-          before(:each) do
+          before do
             vm_storage = @vm.storage
             vm_storage.hosts = []
             vm_storage.save
@@ -44,7 +44,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
         end
 
         context "with a non KVM vm tied to a host and it's storage having hosts, " do
-          before(:each) do
+          before do
             @vm.host = @hosts.first
             @vm.save
             vm_storage = @vm.storage
@@ -58,7 +58,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
         end
 
         context "with a non KVM vm tied to a host and it's storage without hosts, " do
-          before(:each) do
+          before do
             @vm.host = @hosts.first
             @vm.save
             vm_storage = @vm.storage
@@ -72,7 +72,7 @@ describe "JobProxyDispatcherVmStorage2Hosts" do
         end
 
         context "with a vmware vm on a non-vmware host which is also the only host on the vm's storage, " do
-          before(:each) do
+          before do
             @host = @hosts.first
             @host.vmm_vendor = "microsoft"
             @host.save

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -2,26 +2,26 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "two vix disk enabled servers," do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
       allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "hosts with proxy and vmware vms," do
-      before(:each) do
+      before do
         @hosts, @proxies, @storages, @vms = build_entities
         @vm = @vms.first
       end
 
       context "the vm having a repository host," do
-        before(:each) do
+        before do
           @repo_host = @hosts.last
           allow(@vm).to receive_messages(:myhost => @repo_host)
         end
 
         context "removing proxy from a host" do
-          before(:each) do
+          before do
             @host = @hosts.first
             @host.save
             @repo_host.save
@@ -38,7 +38,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
         end
 
         context "vm's storage having no hosts," do
-          before(:each) do
+          before do
             store = @vm.storage
             store.hosts = []
             store.save
@@ -50,7 +50,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
           end
 
           context "'smartproxy' server and roles deactivated" do
-            before(:each) do
+            before do
               FactoryGirl.create(:server_role, :name => "smartproxy", :max_concurrent => 0)
 
               @server1.deactivate_all_roles
@@ -76,13 +76,13 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
           end
 
           context "with server proxies active," do
-            before(:each) do
+            before do
               allow_any_instance_of(MiqServer).to receive_messages(:is_proxy_active? => true)
               allow(@vm).to receive(:my_zone).and_return(@server1.zone.name)
             end
 
             context "a vm template and invalid VC authentication" do
-              before(:each) do
+              before do
                 allow_any_instance_of(ManageIQ::Providers::Vmware::InfraManager).to receive_messages(:missing_credentials? => true)
                 allow(@vm).to receive_messages(:template? => true)
                 @ems1 = FactoryGirl.create(:ems_vmware, :name => "Ems1")
@@ -95,7 +95,7 @@ describe "JobProxyDispatcherVmStorage2Proxies" do
             end
 
             context "a vm and invalid host authentication" do
-              before(:each) do
+              before do
                 allow_any_instance_of(Host).to receive_messages(:missing_credentials? => true)
                 allow(@vm).to receive_messages(:template? => false)
               end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -1,6 +1,6 @@
 describe Job do
   context "With a single scan job," do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)
       @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
 
@@ -17,7 +17,7 @@ describe Job do
     end
 
     context "where job is dispatched but never started" do
-      before(:each) do
+      before do
         @job.update_attribute(:dispatch_status, "active")
 
         Timecop.travel 5.minutes
@@ -25,12 +25,12 @@ describe Job do
         Job.check_jobs_for_timeout
       end
 
-      after(:each) do
+      after do
         Timecop.return
       end
 
       context "after queue message is processed" do
-        before(:each) do
+        before do
           @msg = MiqQueue.get(:role => "smartstate", :zone => @zone.name)
           status, message, result = @msg.deliver
           @msg.delivered(status, message, result)
@@ -61,7 +61,7 @@ describe Job do
     end
 
     context "where job is for a repository VM (no zone)" do
-      before(:each) do
+      before do
         @job.update_attributes(:state => "scanning", :dispatch_status => "active", :zone => nil)
 
         Timecop.travel 5.minutes
@@ -75,7 +75,7 @@ describe Job do
         @job.reload
       end
 
-      after(:each) do
+      after do
         Timecop.return
       end
 
@@ -88,7 +88,7 @@ describe Job do
     end
 
     context "where job is for a VM that disappeared" do
-      before(:each) do
+      before do
         @job.update_attributes(:state => "scanning", :dispatch_status => "active", :zone => nil)
 
         @vm.destroy
@@ -104,7 +104,7 @@ describe Job do
         @job.reload
       end
 
-      after(:each) do
+      after do
         Timecop.return
       end
 
@@ -117,7 +117,7 @@ describe Job do
     end
 
     context "where 2 VMs in 2 Zones have an EVM Snapshot" do
-      before(:each) do
+      before do
         scan_type   = nil
         build       = '12345'
         description = "Snapshot for scan job: #{@job.guid}, EVM Server build: #{build} #{scan_type} Server Time: #{Time.now.utc.iso8601}"
@@ -153,7 +153,7 @@ describe Job do
       end
 
       context "where job is not found and the snapshot timestamp is less than an hour old with default job_not_found_delay" do
-        before(:each) do
+        before do
           @job.destroy
           Job.check_for_evm_snapshots
         end
@@ -164,7 +164,7 @@ describe Job do
       end
 
       context "where job is not found and the snapshot timestamp is less than an hour old with job_not_found_delay from worker settings" do
-        before(:each) do
+        before do
           @job.destroy
           Job.check_for_evm_snapshots(@schedule_worker_settings[:evm_snapshot_delete_delay_for_job_not_found])
         end
@@ -175,13 +175,13 @@ describe Job do
       end
 
       context "where job is not found and the snapshot timestamp is more than an hour old with job_not_found_delay from worker settings" do
-        before(:each) do
+        before do
           @job.destroy
           Timecop.travel 61.minutes
           Job.check_for_evm_snapshots(@schedule_worker_settings[:evm_snapshot_delete_delay_for_job_not_found])
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -191,13 +191,13 @@ describe Job do
       end
 
       context "where job is not found and job_not_found_delay passed with 5 minutes and the snapshot timestamp is more than an 5 minutes old" do
-        before(:each) do
+        before do
           @job.destroy
           Timecop.travel 6.minutes
           Job.check_for_evm_snapshots(5.minutes)
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -207,7 +207,7 @@ describe Job do
       end
 
       context "where job is not found and the snapshot timestamp is nil" do
-        before(:each) do
+        before do
           @job.destroy
           @snapshot.update_attribute(:description, "Foo")
           Job.check_for_evm_snapshots
@@ -219,7 +219,7 @@ describe Job do
       end
 
       context "where job is active" do
-        before(:each) do
+        before do
           @job.update_attribute(:state, "active")
           Job.check_for_evm_snapshots
         end
@@ -230,7 +230,7 @@ describe Job do
       end
 
       context "where job is finished" do
-        before(:each) do
+        before do
           @job.update_attribute(:state, "finished")
           Job.check_for_evm_snapshots
         end
@@ -246,7 +246,7 @@ describe Job do
     end
 
     context "where scan jobs exist for both vms and container images" do
-      before(:each) do
+      before do
         User.current_user = FactoryGirl.create(:user)
         @ems_k8s = FactoryGirl.create(
           :ems_kubernetes, :hostname => "test.com", :zone => @zone, :port => 8443,
@@ -287,7 +287,7 @@ describe Job do
     end
 
     describe ".check_jobs_for_timeout" do
-      before(:each) do
+      before do
         @job.update_attributes(:state => "active")
         @queue_item = MiqQueue.put(:task_id => @job.guid)
       end
@@ -328,7 +328,7 @@ describe Job do
   end
 
   context "before_destroy callback" do
-    before(:each) do
+    before do
       @job = Job.create_job("VmScan", :name => "Hello, World!")
     end
 

--- a/spec/models/manageiq/providers/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::CloudManager::Provision do
     let(:template) { FactoryGirl.create(:template_cloud, :ext_management_system => provider) }
     let(:vm) { FactoryGirl.create(:vm_cloud, :ext_management_system => provider, :ems_ref => "vm_1") }
 
-    before(:each) do
+    before do
       subject.source = template
     end
 

--- a/spec/models/manager_refresh/target_collection_spec.rb
+++ b/spec/models/manager_refresh/target_collection_spec.rb
@@ -1,5 +1,5 @@
 describe ManagerRefresh::TargetCollection do
-  before(:each) do
+  before do
     @zone               = FactoryGirl.create(:zone)
     @ems                = FactoryGirl.create(:ems_cloud, :zone => @zone, :name => "ems_name")
     @ems_physical_infra = FactoryGirl.create(:ems_physical_infra, :zone => @zone)

--- a/spec/models/manager_refresh/target_spec.rb
+++ b/spec/models/manager_refresh/target_spec.rb
@@ -1,5 +1,5 @@
 describe ManagerRefresh::Target do
-  before(:each) do
+  before do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_cloud, :zone => @zone)
 

--- a/spec/models/message_timeout_handling_spec.rb
+++ b/spec/models/message_timeout_handling_spec.rb
@@ -1,5 +1,5 @@
 describe "Message Timeout Handling" do
-  before(:each) do
+  before do
     @guid = SecureRandom.uuid
     allow(MiqServer).to receive(:my_guid).and_return(@guid)
 
@@ -11,7 +11,7 @@ describe "Message Timeout Handling" do
   end
 
   context "A Worker Handling a Message with a timeout of 3600 seconds" do
-    before(:each) do
+    before do
       MiqQueue.put(
         :msg_timeout => 3600,
         :class_name  => "Vm",
@@ -33,7 +33,7 @@ describe "Message Timeout Handling" do
   end
 
   context "An MiqServer monitoring Workers, with a Message Queued with a timeout of 3600 seconds" do
-    before(:each) do
+    before do
       @worker.update_attributes(:last_heartbeat => Time.now.utc, :status => 'started')
       @msg = MiqQueue.put(
         :msg_timeout => 3600,

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1,5 +1,5 @@
 describe Metric do
-  before(:each) do
+  before do
     MiqRegion.seed
 
     _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
@@ -11,7 +11,7 @@ describe Metric do
     end
 
     context "with enabled and disabled targets" do
-      before(:each) do
+      before do
         storages = []
         2.times { storages << FactoryGirl.create(:storage_target_vmware) }
 
@@ -46,7 +46,7 @@ describe Metric do
       end
 
       context "executing perf_capture_timer" do
-        before(:each) do
+        before do
           stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
@@ -68,7 +68,7 @@ describe Metric do
         end
 
         context "executing capture_targets for realtime targets with parent objects" do
-          before(:each) do
+          before do
             @expected_targets = Metric::Targets.capture_targets
           end
 
@@ -171,7 +171,7 @@ describe Metric do
       end
 
       context "executing perf_capture_gap" do
-        before(:each) do
+        before do
           t = Time.now.utc
           Metric::Capture.perf_capture_gap(t - 7.days, t - 5.days)
         end
@@ -189,7 +189,7 @@ describe Metric do
       end
 
       context "executing perf_capture_realtime_now" do
-        before(:each) do
+        before do
           @vm = Vm.first
           @vm.perf_capture_realtime_now
         end
@@ -204,7 +204,7 @@ describe Metric do
         end
 
         context "with an existing queue item at a lower priority" do
-          before(:each) do
+          before do
             MiqQueue.first.update_attribute(:priority, MiqQueue::NORMAL_PRIORITY)
             @vm.perf_capture_realtime_now
           end
@@ -220,7 +220,7 @@ describe Metric do
         end
 
         context "with an existing queue item at a higher priority" do
-          before(:each) do
+          before do
             MiqQueue.first.update_attribute(:priority, MiqQueue::MAX_PRIORITY)
             @vm.perf_capture_realtime_now
           end
@@ -238,12 +238,12 @@ describe Metric do
     end
 
     context "with a vm" do
-      before(:each) do
+      before do
         @vm = FactoryGirl.create(:vm_perf, :ext_management_system => @ems_vmware)
       end
 
       context "queueing up realtime rollups to parent" do
-        before(:each) do
+        before do
           MiqQueue.delete_all
           @vm.perf_rollup_to_parents("realtime", "2010-04-14T21:51:10Z", "2010-04-14T22:50:50Z")
         end
@@ -255,7 +255,7 @@ describe Metric do
         end
 
         context "twice" do
-          before(:each) do
+          before do
             @vm.perf_rollup_to_parents("realtime", "2010-04-14T21:51:10Z", "2010-04-14T22:50:50Z")
           end
 
@@ -268,7 +268,7 @@ describe Metric do
       end
 
       context "executing perf_capture_now?" do
-        before(:each) do
+        before do
           stub_settings(:performance => {:capture_threshold => {:vm => 10}, :capture_threshold_with_alerts => {:vm => 2}})
         end
 
@@ -301,7 +301,7 @@ describe Metric do
     end
 
     context "with a small environment and time_profile" do
-      before(:each) do
+      before do
         @vm1 = FactoryGirl.create(:vm_vmware)
         @vm2 = FactoryGirl.create(:vm_vmware, :hardware => FactoryGirl.create(:hardware, :cpu1x2, :memory_mb => 4096))
         @host1 = FactoryGirl.create(:host, :hardware => FactoryGirl.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
@@ -317,7 +317,7 @@ describe Metric do
       end
 
       context "with Vm realtime performances" do
-        before(:each) do
+        before do
           cases = [
             "2010-04-14T20:52:30Z", 100.0,
             "2010-04-14T21:51:10Z", 1.0,
@@ -343,7 +343,7 @@ describe Metric do
         end
 
         context "calling perf_rollup to hourly on the Vm" do
-          before(:each) do
+          before do
             @vm1.perf_rollup("2010-04-14T21:00:00Z", 'hourly')
           end
 
@@ -371,7 +371,7 @@ describe Metric do
       end
 
       context "with Vm hourly performances" do
-        before(:each) do
+        before do
           cases = [
             "2010-04-13T21:00:00Z", 100.0,
             "2010-04-14T18:00:00Z", 1.0,
@@ -411,7 +411,7 @@ describe Metric do
         end
 
         context "calling perf_rollup to daily on the Vm" do
-          before(:each) do
+          before do
             @vm1.perf_rollup("2010-04-14T00:00:00Z", 'daily', @time_profile.id)
           end
 
@@ -447,7 +447,7 @@ describe Metric do
         end
 
         context "calling perf_rollup_range to daily on the Vm" do
-          before(:each) do
+          before do
             @vm1.perf_rollup_range("2010-04-13T00:00:00Z", "2010-04-15T00:00:00Z", 'daily', @time_profile.id)
           end
 
@@ -460,7 +460,7 @@ describe Metric do
         end
 
         context "with Vm daily performances" do
-          before(:each) do
+          before do
             @perf = FactoryGirl.create(:metric_rollup_vm_daily,
                                        :timestamp    => "2010-04-14T00:00:00Z",
                                        :time_profile => @time_profile
@@ -489,7 +489,7 @@ describe Metric do
         end
 
         context "and Host realtime performances" do
-          before(:each) do
+          before do
             cases = [
               "2010-04-14T20:52:40Z", 100.0,
               "2010-04-14T21:51:20Z", 2.0,
@@ -528,7 +528,7 @@ describe Metric do
           end
 
           context "calling perf_rollup to hourly on the Host" do
-            before(:each) do
+            before do
               @host1.perf_rollup("2010-04-14T21:00:00Z", 'hourly')
             end
 
@@ -551,7 +551,7 @@ describe Metric do
           end
 
           context "calling perf_rollup_range to realtime on the parent Cluster" do
-            before(:each) do
+            before do
               @ems_cluster.perf_rollup_range("2010-04-14T21:51:20Z", "2010-04-14T21:52:40Z", 'realtime')
             end
 
@@ -582,7 +582,7 @@ describe Metric do
           end
 
           context "executing perf_rollup_gap_queue" do
-            before(:each) do
+            before do
               @args = [2.days.ago.utc, Time.now.utc, 'daily', @time_profile.id]
               Metric::Rollup.perf_rollup_gap_queue(*@args)
             end
@@ -603,7 +603,7 @@ describe Metric do
           end
 
           context "executing perf_rollup_gap" do
-            before(:each) do
+            before do
               @args = [2.days.ago.utc, Time.now.utc, 'daily', @time_profile.id]
               Metric::Rollup.perf_rollup_gap(*@args)
             end
@@ -693,7 +693,7 @@ describe Metric do
     end
 
     context "with a full rollup chain and time profile" do
-      before(:each) do
+      before do
         @host = FactoryGirl.create(:host, :ext_management_system => @ems_vmware)
         @vm = FactoryGirl.create(:vm_vmware, :ext_management_system => @ems_vmware, :host => @host)
         @ems_cluster = FactoryGirl.create(:ems_cluster, :ext_management_system => @ems_vmware)
@@ -996,7 +996,7 @@ describe Metric do
     end
 
     context "with enabled and disabled targets" do
-      before(:each) do
+      before do
         @availability_zone = FactoryGirl.create(:availability_zone_target)
         @ems_openstack.availability_zones << @availability_zone
         @vms_in_az = []
@@ -1018,7 +1018,7 @@ describe Metric do
       end
 
       context "executing perf_capture_timer" do
-        before(:each) do
+        before do
           stub_settings(:performance => {:history => {:initial_capture_days => 7}})
           Metric::Capture.perf_capture_timer
         end
@@ -1034,12 +1034,12 @@ describe Metric do
     end
 
     context "with a vm" do
-      before(:each) do
+      before do
         @vm = FactoryGirl.create(:vm_perf_openstack, :ext_management_system => @ems_openstack)
       end
 
       context "queueing up realtime rollups to parent" do
-        before(:each) do
+        before do
           MiqQueue.delete_all
           @vm.perf_rollup_to_parents("realtime", "2010-04-14T21:51:10Z", "2010-04-14T22:50:50Z")
         end
@@ -1051,7 +1051,7 @@ describe Metric do
         end
 
         context "twice" do
-          before(:each) do
+          before do
             @vm.perf_rollup_to_parents("realtime", "2010-04-14T21:51:10Z", "2010-04-14T22:50:50Z")
           end
 
@@ -1065,7 +1065,7 @@ describe Metric do
     end
 
     context "with a full rollup chain and time profile" do
-      before(:each) do
+      before do
         @availability_zone = FactoryGirl.create(:availability_zone, :ext_management_system => @ems_openstack)
         @vm = FactoryGirl.create(:vm_openstack, :ext_management_system => @ems_openstack, :availability_zone => @availability_zone)
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -1,6 +1,6 @@
 describe MiqAction do
   describe "#invoke_or_queue" do
-    before(:each) do
+    before do
       @action = MiqAction.new
     end
 
@@ -12,7 +12,7 @@ describe MiqAction do
   end
 
   context "#action_custom_automation" do
-    before(:each) do
+    before do
       tenant = FactoryGirl.create(:tenant)
       group  = FactoryGirl.create(:miq_group, :tenant => tenant)
       @user = FactoryGirl.create(:user, :userid => "test", :miq_groups => [group])
@@ -86,7 +86,7 @@ describe MiqAction do
   end
 
   context "#raise_automation_event" do
-    before(:each) do
+    before do
       @vm   = FactoryGirl.create(:vm_vmware)
       allow(@vm).to receive(:my_zone).and_return("vm_zone")
       FactoryGirl.create(:miq_event_definition, :name => "raise_automation_event")
@@ -133,7 +133,7 @@ describe MiqAction do
   end
 
   context "#action_ems_refresh" do
-    before(:each) do
+    before do
       FactoryGirl.create(:miq_action, :name => "ems_refresh")
       @action = MiqAction.find_by(:name => "ems_refresh")
       expect(@action).not_to be_nil

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -82,7 +82,7 @@ describe MiqAeClass do
       ns.update_attributes!(:priority => value)
     end
 
-    before(:each) do
+    before do
       @user = FactoryGirl.create(:user_with_group, 'name' => 'Fred')
       model_data_dir = Rails.root.join("spec/models/miq_ae_class/data")
       EvmSpecHelper.import_yaml_model(File.join(model_data_dir, 'domain1'), "DOMAIN1")
@@ -292,7 +292,7 @@ describe MiqAeClass do
   end
 
   context "state_machine_class tests" do
-    before(:each) do
+    before do
       n1 = FactoryGirl.create(:miq_ae_system_domain, :name => 'ns1', :priority => 10)
       @c1 = FactoryGirl.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     end

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -40,7 +40,7 @@ describe MiqAeField do
   end
 
   context "legacy tests" do
-    before(:each) do
+    before do
       @c1 = MiqAeClass.create(:namespace => "TEST", :name => "fields_test")
       @user = FactoryGirl.create(:user_with_group)
     end

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -1,6 +1,6 @@
 describe MiqAeInstance do
   context "legacy tests" do
-    before(:each) do
+    before do
       @user = FactoryGirl.create(:user_with_group)
       @c1 = MiqAeClass.create(:namespace => "TEST", :name => "instance_test")
       @fname1 = "field1"

--- a/spec/models/miq_alert_eval_internal_spec.rb
+++ b/spec/models/miq_alert_eval_internal_spec.rb
@@ -1,11 +1,11 @@
 describe "MiqAlert Evaluation Internal" do
   context "With VM as a target," do
-    before(:each) do
+    before do
       @vm = FactoryGirl.create(:vm_vmware)
     end
 
     context "evaluating an event threshold alert" do
-      before(:each) do
+      before do
         @events = []
         @events << FactoryGirl.create(:ems_event, :vm_or_template_id => @vm.id, :event_type => "MigrateVM_Task_Complete", :timestamp => Time.now.utc)
         @events << FactoryGirl.create(:ems_event, :vm_or_template_id => @vm.id, :event_type => "MigrateVM_Task_Complete", :timestamp => 1.day.ago.utc)
@@ -32,7 +32,7 @@ describe "MiqAlert Evaluation Internal" do
     end
 
     context "evaluating a realtime performance alert" do
-      before(:each) do
+      before do
         t = 2.minutes.ago.utc
         6.times do |i|
           FactoryGirl.create(:metric_vm_rt, :resource_id => @vm.id, :timestamp => t, :mem_vmmemctl_absolute_average => (250 + (i * 10)))
@@ -62,7 +62,7 @@ describe "MiqAlert Evaluation Internal" do
     end
 
     context "evaluating a changed vm value alert" do
-      before(:each) do
+      before do
         # TODO: create drift for test
         expression = {
           :eval_method => "changed_vm_value",
@@ -83,7 +83,7 @@ describe "MiqAlert Evaluation Internal" do
     end
 
     context "evaluating a reconfigured hardware value alert" do
-      before(:each) do
+      before do
         # TODO: create drift for test
         expression = {
           :eval_method => "reconfigured_hardware_value",
@@ -104,7 +104,7 @@ describe "MiqAlert Evaluation Internal" do
     end
 
     context "evaluating a VM event log threshold alert" do
-      before(:each) do
+      before do
         # TODO: Create factories with event_logs
         expression = {
           :eval_method => "event_log_threshold",
@@ -131,7 +131,7 @@ describe "MiqAlert Evaluation Internal" do
     end
 
     context "evaluating a VM Alarm alert" do
-      before(:each) do
+      before do
         expression = {
           :eval_method => "ems_alarm",
           :mode        => "internal",
@@ -154,12 +154,12 @@ describe "MiqAlert Evaluation Internal" do
   end
 
   context "With Host as a target," do
-    before(:each) do
+    before do
       @host = FactoryGirl.create(:host)
     end
 
     context "evaluating a hostd log threshold alert" do
-      before(:each) do
+      before do
         # TODO: Create factories with event_logs
         expression = {
           :eval_method => "hostd_log_threshold",
@@ -185,12 +185,12 @@ describe "MiqAlert Evaluation Internal" do
   end
 
   context "With MiqServer as a target," do
-    before(:each) do
+    before do
       @server = FactoryGirl.create(:miq_server, :zone => FactoryGirl.create(:zone))
     end
 
     context "evaluating an alert with no expression" do
-      before(:each) do
+      before do
         expression = {:eval_method => "nothing"}
         @alert = FactoryGirl.create(:miq_alert_vm, :expression => expression)
         @alert_prof = FactoryGirl.create(:miq_alert_set, :mode => @server.class.name)

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -247,7 +247,7 @@ describe MiqAlert do
       end
 
       context "with the alert now evaluated to false" do
-        before  do
+        before do
           @alert.evaluate([@vm.class.base_class.name, @vm.id])
           allow(@alert).to receive_messages(:eval_expression => false)
           @alert.options.store_path(:notifications, :delay_next_evaluation, 0)

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -1,6 +1,6 @@
 describe MiqAlert do
   context "With single server with a single generic worker with the notifier role," do
-    before(:each) do
+    before do
       @miq_server = EvmSpecHelper.local_miq_server(:role => 'notifier')
       @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
       @vm     = FactoryGirl.create(:vm_vmware)
@@ -23,7 +23,7 @@ describe MiqAlert do
     end
 
     context "where a vm_scan_complete event is raised for a VM" do
-      before(:each) do
+      before do
         MiqAlert.all.each { |a| a.update_attribute(:enabled, true) } # enable out of the box alerts
         MiqAlert.evaluate_alerts(@vm, "vm_scan_complete")
       end
@@ -39,7 +39,7 @@ describe MiqAlert do
     end
 
     context "where a vm_scan_complete event is raised for a VM" do
-      before(:each) do
+      before do
         MiqAlert.all.each { |a| a.update_attribute(:enabled, true) } # enable out of the box alerts
         @events_to_alerts.each do |arr|
           MiqAlert.evaluate_alerts([@vm.class.base_class.name, @vm.id], arr.first)
@@ -61,7 +61,7 @@ describe MiqAlert do
     end
 
     context "where all alerts are disabled" do
-      before(:each) do
+      before do
         MiqAlert.all.each { |a| a.update_attribute(:enabled, false) }
         MiqAlert.evaluate_alerts([@vm.class.base_class.name, @vm.id], "vm_scan_complete")
       end
@@ -73,12 +73,12 @@ describe MiqAlert do
     end
 
     context "with a single alert, not evaluated" do
-      before(:each) do
+      before do
         @alert = MiqAlert.find_by(:description => "VM Unregistered")
       end
 
       context "with a delay_next_evaluation value of 5 minutes" do
-        before(:each) do
+        before do
           @alert.options ||= {}
           @alert.options.store_path(:notifications, :delay_next_evaluation, 5.minutes)
         end
@@ -92,7 +92,7 @@ describe MiqAlert do
     end
 
     context "with a single alert, evaluated to true" do
-      before(:each) do
+      before do
         @alert = MiqAlert.find_by(:description => "VM Unregistered")
         allow(@alert).to receive_messages(:eval_expression => true)
       end
@@ -247,7 +247,7 @@ describe MiqAlert do
       end
 
       context "with the alert now evaluated to false" do
-        before(:each)  do
+        before  do
           @alert.evaluate([@vm.class.base_class.name, @vm.id])
           allow(@alert).to receive_messages(:eval_expression => false)
           @alert.options.store_path(:notifications, :delay_next_evaluation, 0)
@@ -272,7 +272,7 @@ describe MiqAlert do
       end
 
       context "with a delay_next_evaluation value of 5 minutes" do
-        before(:each) do
+        before do
           @alert.evaluate([@vm.class.base_class.name, @vm.id])
           @alert.options ||= {}
           @alert.options.store_path(:notifications, :delay_next_evaluation, 5.minutes)
@@ -294,7 +294,7 @@ describe MiqAlert do
     end
 
     context "where all alerts are unassigned" do
-      before(:each) do
+      before do
         @original_assigned     = MiqAlert.assigned_to_target(@vm, "vm_perf_complete") # force cache load
         @original_assigned_all = MiqAlert.assigned_to_target(@vm)                     # force cache load
         MiqAlertSet.all.each(&:remove_all_assigned_tos)

--- a/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
+++ b/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
@@ -1,6 +1,6 @@
 describe MiqCockpitWsWorker::Authenticator do
   describe '#authenticate_for_host' do
-    before(:each) do
+    before do
       @auth = MiqCockpitWsWorker::Authenticator
       @user = FactoryGirl.create(:user, :userid => 1)
       @token = Api::Environment.user_token_service.generate_token(1, "api")

--- a/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
+++ b/spec/models/miq_ems_refresh_core_worker/runner_spec.rb
@@ -1,5 +1,5 @@
 describe MiqEmsRefreshCoreWorker::Runner do
-  before(:each) do
+  before do
     _guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => zone)
 
@@ -15,7 +15,7 @@ describe MiqEmsRefreshCoreWorker::Runner do
 
   context "#process_update" do
     context "against a ManageIQ::Providers::Vmware::InfraManager::Vm" do
-      before(:each) do
+      before do
         Timecop.travel(1.day.ago) do
           @vm = FactoryGirl.create(:vm_with_ref, :ext_management_system => @ems, :raw_power_state => "unknown")
         end
@@ -87,7 +87,7 @@ describe MiqEmsRefreshCoreWorker::Runner do
         end
 
         context "and networks already persisted" do
-          before(:each) do
+          before do
             @hw = FactoryGirl.create(:hardware, :vm_or_template => @vm)
             @nics = (1..2).collect { FactoryGirl.create(:guest_device_nic_with_network, :hardware => @hw) }.sort_by(&:address)
             @expected_addresses = @nics.collect { |n| [n.network.ipaddress, n.network.ipv6address] }
@@ -144,7 +144,7 @@ describe MiqEmsRefreshCoreWorker::Runner do
     end
 
     context "against a ManageIQ::Providers::Vmware::InfraManager::Template" do
-      before(:each) do
+      before do
         Timecop.travel(1.day.ago) do
           @template = FactoryGirl.create(:template_vmware_with_ref, :ext_management_system => @ems)
         end

--- a/spec/models/miq_enterprise_spec.rb
+++ b/spec/models/miq_enterprise_spec.rb
@@ -30,7 +30,7 @@ describe MiqEnterprise do
   end
 
   context "with some existing records" do
-    before(:each) do
+    before do
       @ems  = FactoryGirl.create(:ems_vmware)
     end
 

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -62,7 +62,7 @@ describe MiqEvent do
     end
 
     context ".raise_evm_event" do
-      before(:each) do
+      before do
         @cluster    = FactoryGirl.create(:ems_cluster)
         @miq_server = EvmSpecHelper.local_miq_server
         @zone       = @miq_server.zone

--- a/spec/models/miq_host_provision_request_spec.rb
+++ b/spec/models/miq_host_provision_request_spec.rb
@@ -4,7 +4,7 @@ describe MiqHostProvisionRequest do
   end
 
   context "with a valid userid and host," do
-    before(:each) do
+    before do
       @user = FactoryGirl.create(:user, :role => "admin")
       # approver is also an admin
       @approver = FactoryGirl.create(:user_miq_request_approver, :miq_groups => @user.miq_groups)
@@ -35,7 +35,7 @@ describe MiqHostProvisionRequest do
     end
 
     context "when calling call_automate_event_queue" do
-      before(:each) do
+      before do
         EvmSpecHelper.local_miq_server(:zone => Zone.seed)
         @pr.miq_request.call_automate_event_queue("request_created")
       end
@@ -52,7 +52,7 @@ describe MiqHostProvisionRequest do
     end
 
     context "after MiqRequest is deleted," do
-      before(:each) do
+      before do
         @pr.miq_request.destroy
       end
 

--- a/spec/models/miq_host_provision_spec.rb
+++ b/spec/models/miq_host_provision_spec.rb
@@ -22,7 +22,7 @@ describe MiqHostProvision do
   end
 
   context "with default server and zone" do
-    before(:each) do
+    before do
       @miq_server = EvmSpecHelper.local_miq_server
     end
 

--- a/spec/models/miq_host_provision_workflow_spec.rb
+++ b/spec/models/miq_host_provision_workflow_spec.rb
@@ -6,7 +6,7 @@ describe MiqHostProvisionWorkflow do
 
   context "seeded" do
     context "After setup," do
-      before(:each) do
+      before do
         @server = EvmSpecHelper.local_miq_server
 
         FactoryGirl.create(:user_admin)
@@ -29,7 +29,7 @@ describe MiqHostProvisionWorkflow do
       end
 
       context "With a Valid IPMI Host," do
-        before(:each) do
+        before do
           ems = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => @server.zone)
           FactoryGirl.create(:host_with_ipmi, :ext_management_system => ems)
           pxe_server = FactoryGirl.create(:pxe_server,

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -5,7 +5,7 @@ describe MiqPolicy do
     # test verifies that changing things under the covers doesn't affect
     # calling conditions.
 
-    before(:each) do
+    before do
       @ps = FactoryGirl.create(:miq_policy_set, :name => "ps")
       @p  = FactoryGirl.create(:miq_policy)
       @ps.add_member(@p)

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -1,6 +1,6 @@
 describe MiqProvision do
   context "A new provision request," do
-    before(:each) do
+    before do
       @os = OperatingSystem.new(:product_name => 'Microsoft Windows')
       @admin = FactoryGirl.create(:user_with_group, :role => "admin")
       @target_vm_name = 'clone test'
@@ -16,14 +16,14 @@ describe MiqProvision do
     let(:miq_region) { MiqRegion.create }
 
     context "with VMware infrastructure" do
-      before(:each) do
+      before do
         @ems         = FactoryGirl.create(:ems_vmware_with_authentication)
         @vm_template = FactoryGirl.create(:template_vmware, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
         @vm          = FactoryGirl.create(:vm_vmware, :name => "vm1", :location => "abc/def.vmx")
       end
 
       context "with a valid userid and source vm," do
-        before(:each) do
+        before do
           @pr = FactoryGirl.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
           @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
           @vm_prov = FactoryGirl.create(:miq_provision, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -20,7 +20,7 @@ describe MiqProvisionWorkflow do
       end
 
       context "With a Valid Template," do
-        before(:each) do
+        before do
           @ems         = FactoryGirl.create(:ems_vmware, :name => "Test EMS", :zone => server.zone)
           @host        = FactoryGirl.create(:host, :name => "test_host", :hostname => "test_host", :state => 'on',
                                             :ext_management_system => @ems)

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -6,7 +6,7 @@ describe MiqRegion do
     ApplicationRecord.region_to_range(remote_region_number).first
   end
   context "after seeding" do
-    before(:each) do
+    before do
       MiqRegion.seed
     end
 

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
-  before(:each) do
+  before do
     EvmSpecHelper.local_miq_server
 
     @group = FactoryGirl.create(:miq_group)

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -2,7 +2,7 @@ describe MiqReport do
   include Spec::Support::ArelHelper
 
   context "::Search" do
-    before(:each) do
+    before do
       @miq_report = MiqReport.new(:db => "Vm")
     end
 

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -11,7 +11,7 @@ describe MiqReportResult do
       }
     end
 
-    before(:each) do
+    before do
       stub_settings(settings)
 
       @rr1 = [
@@ -72,7 +72,7 @@ describe MiqReportResult do
     end
 
     context "#purge_queue" do
-      before(:each) do
+      before do
         EvmSpecHelper.create_guid_miq_server_zone
         described_class.purge_queue(:remaining, 1)
       end

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -74,7 +74,7 @@ describe MiqReportResult do
   end
 
   context "persisting generated report results" do
-    before(:each) do
+    before do
       5.times do |i|
         vm = FactoryGirl.build(:vm_vmware)
         vm.evm_owner_id = @user1.id               if i > 2
@@ -106,7 +106,7 @@ describe MiqReportResult do
     end
 
     context "for miq_report_result is used different miq_group_id than user's current id" do
-      before(:each) do
+      before do
         MiqUserRole.seed
         role = MiqUserRole.find_by(:name => "EvmRole-operator")
         @miq_group = FactoryGirl.create(:miq_group, :miq_user_role => role, :description => "Group1")

--- a/spec/models/miq_schedule_filter_spec.rb
+++ b/spec/models/miq_schedule_filter_spec.rb
@@ -1,6 +1,6 @@
 describe "MiqSchedule Filter" do
   context "Getting schedule targets" do
-    before(:each) do
+    before do
       @server1 = EvmSpecHelper.local_miq_server
 
       # Vm Scan Schedules
@@ -40,7 +40,7 @@ describe "MiqSchedule Filter" do
     end
 
     context "for a scheduled report" do
-      before(:each) do
+      before do
         MiqReport.seed_report("Vendor and Guest OS")
         @report = MiqReport.first
         @report_schedule = FactoryGirl.create(:miq_schedule,

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -1,7 +1,7 @@
 describe MiqSchedule do
   before { EvmSpecHelper.create_guid_miq_server_zone }
   context 'with schedule infrastructure and valid run_ats' do
-    before(:each) do
+    before do
       @valid_run_ats =  [{:start_time => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}},
                          {:start_time => "2010-07-08 04:10:00 Z", :interval => {:unit => "once"}}]
     end
@@ -123,7 +123,7 @@ describe MiqSchedule do
     end
 
     context "with valid schedules" do
-      before(:each) do
+      before do
         @valid_schedules = []
 
         @valid_run_ats.each do |run_at|
@@ -168,14 +168,14 @@ describe MiqSchedule do
       end
 
       context "at 1 AM EST create start_time and tz based on Eastern Time" do
-        before(:each) do
+        before do
           @start = Time.parse("Sun March 10 01:00:00 -0500 2010")
           Timecop.travel(@start + 10.minutes)
           @east_tz = "Eastern Time (US & Canada)"
           @first.update_attribute(:run_at, :start_time => @start.dup.utc, :interval => {:unit => "daily", :value => "1"}, :tz => @east_tz)
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -188,12 +188,12 @@ describe MiqSchedule do
         end
 
         context "after jumping to 1 AM EDT" do
-          before(:each) do
+          before do
             @start = Time.parse("Sun March 15 01:00:00 -0400 2010")
             Timecop.travel(@start + 10.minutes)
           end
 
-          after(:each) do
+          after do
             Timecop.return
           end
 
@@ -208,14 +208,14 @@ describe MiqSchedule do
       end
 
       context "at 1 AM EDT create start_time and tz based on Eastern Time" do
-        before(:each) do
+        before do
           @start = Time.parse("Sun October 6 01:00:00 -0400 2010")
           @east_tz = "Eastern Time (US & Canada)"
           Timecop.travel(@start + 10.minutes)
           @first.update_attribute(:run_at, :start_time => @start.dup.utc, :interval => {:unit => "daily", :value => "1"}, :tz => @east_tz)
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -228,12 +228,12 @@ describe MiqSchedule do
         end
 
         context "after jumping to 1 AM EST" do
-          before(:each) do
+          before do
             @start = Time.parse("Sun November 7 01:00:00 -0500 2010")
             Timecop.travel(@start + 10.minutes)
           end
 
-          after(:each) do
+          after do
             Timecop.return
           end
 
@@ -248,7 +248,7 @@ describe MiqSchedule do
       end
 
       context "at 1 AM EST create start_time and tz based on UTC" do
-        before(:each) do
+        before do
           @start = Time.parse("Sun March 10 01:00:00 -0500 2010")
           @east_tz = "Eastern Time (US & Canada)"
           @utc_tz  = "UTC"
@@ -256,7 +256,7 @@ describe MiqSchedule do
           @first.update_attribute(:run_at, :start_time => @start.dup.utc, :interval => {:unit => "daily", :value => "1"})
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -277,12 +277,12 @@ describe MiqSchedule do
         end
 
         context "after jumping to 1 AM EDT" do
-          before(:each) do
+          before do
             @start = Time.parse("Sun March 15 01:00:00 -0400 2010")
             Timecop.travel(@start + 10.minutes)
           end
 
-          after(:each) do
+          after do
             Timecop.return
           end
 
@@ -305,7 +305,7 @@ describe MiqSchedule do
       end
 
       context "at 1 AM AKDT create start_time and tz based on Alaska time and interval every 3 days" do
-        before(:each) do
+        before do
           @east_tz = "Eastern Time (US & Canada)"
           @ak_tz = "Alaska"
           @utc_tz  = "UTC"
@@ -315,7 +315,7 @@ describe MiqSchedule do
           @first.update_attribute(:run_at, :start_time => @ak_time.dup.utc, :interval => {:unit => "daily", :value => "3"}, :tz => @ak_tz)
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -340,12 +340,12 @@ describe MiqSchedule do
         end
 
         context "after jumping to EST" do
-          before(:each) do
+          before do
             @start = Time.parse("Sun November 7 01:00:00 -0500 2010")
             Timecop.travel(@start + 10.minutes)
           end
 
-          after(:each) do
+          after do
             Timecop.return
           end
 
@@ -368,17 +368,17 @@ describe MiqSchedule do
       end
 
       context "with Time.now stubbed as 'Jan 1 2011' at 6 am UTC" do
-        before(:each) do
+        before do
           @now = Time.parse("2011-01-01 06:00:00 Z")
           Timecop.travel(@now)
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
         context "with no last run time" do
-          before(:each) do
+          before do
             @first.update_attribute(:last_run_on, nil)
           end
 
@@ -414,7 +414,7 @@ describe MiqSchedule do
         end
 
         context "with last run time 20 minutes ago" do
-          before(:each) do
+          before do
             time = @now - 20.minutes
             @first.update_attribute(:last_run_on, time)
           end
@@ -477,7 +477,7 @@ describe MiqSchedule do
     end
 
     context "valid db_gc unsaved schedule, run_adhoc_db_gc" do
-      before(:each) do
+      before do
         @task_id = MiqSchedule.run_adhoc_db_gc(:userid => "admin", :aggressive => true)
         @gc_message = MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "gc", :role => "database_operations").first
 
@@ -496,7 +496,7 @@ describe MiqSchedule do
       end
 
       context "deliver DatabaseBackup.gc message" do
-        before(:each) do
+        before do
           # stub out the actual backup behavior
           allow(PostgresAdmin).to receive(:gc)
 
@@ -547,7 +547,7 @@ describe MiqSchedule do
       end
 
       context "calling run adhoc_db_backup" do
-        before(:each) do
+        before do
           @task_id = @schedule.run_adhoc_db_backup
           @backup_message = MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations").first
 
@@ -572,7 +572,7 @@ describe MiqSchedule do
       end
 
       context "calling queue scheduled work via a db_backup schedule firing" do
-        before(:each) do
+        before do
           MiqSchedule.queue_scheduled_work(@schedule.id, nil, Time.now.utc.to_i, nil)
           @invoke_actions_message = MiqQueue.where(:class_name => "MiqSchedule", :instance_id => @schedule.id, :method_name => "invoke_actions").first
         end
@@ -586,7 +586,7 @@ describe MiqSchedule do
         end
 
         context "deliver invoke actions message" do
-          before(:each) do
+          before do
             status, message, result = @invoke_actions_message.deliver
             @invoke_actions_message.delivered(status, message, result)
             @backup_message = MiqQueue.where(:class_name => "DatabaseBackup", :method_name => "backup", :role => "database_operations").first
@@ -609,13 +609,13 @@ describe MiqSchedule do
           end
 
           context "_backup is stubbed" do
-            before(:each) do
+            before do
               # stub out the actual backup behavior
               allow_any_instance_of(DatabaseBackup).to receive(:_backup)
             end
 
             context "deliver DatabaseBackup.backup message" do
-              before(:each) do
+              before do
                 @status, message, result = @backup_message.deliver
                 @backup_message.delivered(@status, message, result)
               end
@@ -628,7 +628,7 @@ describe MiqSchedule do
             end
 
             context "deliver DatabaseBackup.backup message with adhoc true" do
-              before(:each) do
+              before do
                 @schedule.update_attribute(:adhoc, true)
                 @schedule_id = @schedule.id
                 @status, message, result = @backup_message.deliver
@@ -641,7 +641,7 @@ describe MiqSchedule do
             end
 
             context "deliver DatabaseBackup.backup message with adhoc false" do
-              before(:each) do
+              before do
                 @schedule.update_attribute(:adhoc, false)
                 @schedule_id = @schedule.id
                 @status, message, result = @backup_message.deliver

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -1,6 +1,6 @@
 describe MiqScheduleWorker::Runner do
   context ".new" do
-    before(:each) do
+    before do
       @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)
       @zone = @miq_server.zone
 
@@ -15,7 +15,7 @@ describe MiqScheduleWorker::Runner do
     end
 
     context "with a stuck dispatch in each zone" do
-      before(:each) do
+      before do
         @cond = {:class_name => 'JobProxyDispatcher', :method_name => 'dispatch'}
         @opts = @cond.merge(:state => 'dequeue', :updated_on => Time.now.utc)
         @stale_timeout = 2.minutes
@@ -32,7 +32,7 @@ describe MiqScheduleWorker::Runner do
         Timecop.travel 5.minutes
       end
 
-      after(:each) do
+      after do
         Timecop.return
       end
 
@@ -85,19 +85,19 @@ describe MiqScheduleWorker::Runner do
     end
 
     context "with Time before DST" do
-      before(:each) do
+      before do
         @start = Time.parse('Sun November 6 01:00:00 -0400 2010')
         @east_tz = 'Eastern Time (US & Canada)'
         Timecop.travel(@start)
         @schedule_worker.reset_dst
       end
 
-      after(:each) do
+      after do
         Timecop.return
       end
 
       context "using Rufus::Scheduler" do
-        before(:each) do
+        before do
           rufus_frequency = 0.00001  # How often rufus will check for jobs to do
           require 'rufus/scheduler'
           @schedule_worker.instance_eval do
@@ -108,7 +108,7 @@ describe MiqScheduleWorker::Runner do
           @system = @schedule_worker.instance_variable_get(:@system_scheduler)
         end
 
-        after(:each) do
+        after do
           @user.stop
           @system.stop
           @user = nil
@@ -173,7 +173,7 @@ describe MiqScheduleWorker::Runner do
         end
 
         context "calling check_roles_changed" do
-          before(:each) do
+          before do
             allow(@schedule_worker).to receive(:worker_settings).and_return(Hash.new(5.minutes))
             @schedule_worker.instance_variable_set(:@schedules, :scheduler => [])
 
@@ -221,7 +221,7 @@ describe MiqScheduleWorker::Runner do
         end
 
         context "Database operations role" do
-          before(:each) do
+          before do
             stub_server_configuration(Hash.new(5.minutes))
             allow(@schedule_worker).to receive(:heartbeat)
 
@@ -245,7 +245,7 @@ describe MiqScheduleWorker::Runner do
           end
 
           context "with database_owner in region" do
-            before(:each) do
+            before do
               allow(@region).to receive(:role_active?).with("database_owner").and_return(true)
             end
 
@@ -300,7 +300,7 @@ describe MiqScheduleWorker::Runner do
           end
 
           context "without database_owner in region" do
-            before(:each) do
+            before do
               allow(@region).to receive(:role_active?).with("database_owner").and_return(false)
             end
 
@@ -357,7 +357,7 @@ describe MiqScheduleWorker::Runner do
         end
 
         context "end-to-end schedules modified to run every 5 minutes" do
-          before(:each) do
+          before do
             allow(@schedule_worker).to receive(:worker_settings).and_return(Hash.new(5.minutes))
             stub_server_configuration(Hash.new(5.minutes))
             allow(@schedule_worker).to receive(:heartbeat)
@@ -367,7 +367,7 @@ describe MiqScheduleWorker::Runner do
           end
 
           context "#schedules_for_all_roles"  do
-            before(:each) do
+            before do
               @schedule_worker.instance_variable_set(:@active_roles, [])
               @start_time = Time.utc(2011, 1, 31, 8, 30, 0)
             end
@@ -418,7 +418,7 @@ describe MiqScheduleWorker::Runner do
         end
 
         context "#schedules_for_event_role" do
-          before(:each) do
+          before do
             allow(@schedule_worker).to receive(:heartbeat)
             @schedule_worker.instance_variable_set(:@active_roles, ["event"])
             allow(@schedule_worker).to receive(:worker_settings).and_return(:event_streams_purge_interval => 1.day,

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -1,7 +1,7 @@
 describe "Server Environment Management" do
   context ".spartan_mode" do
-    before(:each) { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
-    after(:each) { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
+    before { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
+    after { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
 
     it "when ENV['MIQ_SPARTAN'] is not set" do
       allow(ENV).to receive(:[]).with('MIQ_SPARTAN').and_return(nil)
@@ -45,8 +45,8 @@ describe "Server Environment Management" do
   end
 
   context ".minimal_env_options" do
-    before(:each) { MiqServer.class_eval { instance_variable_set :@minimal_env_options, nil } }
-    after(:each) { MiqServer.class_eval { instance_variable_set :@minimal_env_options, nil } }
+    before { MiqServer.class_eval { instance_variable_set :@minimal_env_options, nil } }
+    after { MiqServer.class_eval { instance_variable_set :@minimal_env_options, nil } }
 
     it "when spartan_mode is 'minimal'" do
       allow(MiqServer).to receive(:spartan_mode).and_return("minimal")
@@ -66,7 +66,7 @@ describe "Server Environment Management" do
 
   context ".startup_mode" do
     context "when minimal_env? is true" do
-      before(:each) { allow(MiqServer).to receive(:minimal_env?).and_return(true) }
+      before { allow(MiqServer).to receive(:minimal_env?).and_return(true) }
 
       it "when minimal_env_options is empty" do
         allow(MiqServer).to receive(:minimal_env_options).and_return([])

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -1,6 +1,6 @@
 describe "Server Role Management" do
   context "After Setup," do
-    before(:each) do
+    before do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         automate,Automation Engine,0,false,region

--- a/spec/models/miq_server/server_monitor_spec.rb
+++ b/spec/models/miq_server/server_monitor_spec.rb
@@ -1,6 +1,6 @@
 describe "Server Monitor" do
   context "After Setup," do
-    before(:each) do
+    before do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         automate,Automation Engine,0,false,region
@@ -41,7 +41,7 @@ describe "Server Monitor" do
     end
 
     context "with 1 Server" do
-      before(:each) do
+      before do
         @miq_server = EvmSpecHelper.local_miq_server
         @miq_server.monitor_servers
 
@@ -108,7 +108,7 @@ describe "Server Monitor" do
       end
 
       context "after initial monitor_servers" do
-        before(:each) do
+        before do
           @miq_server.monitor_server_roles
         end
 
@@ -229,7 +229,7 @@ describe "Server Monitor" do
     end
 
     context "with 2 Servers in 2 Zones where I am the Master" do
-      before(:each) do
+      before do
         @miq_server1 = EvmSpecHelper.local_miq_server(:is_master => true)
         @miq_server1.deactivate_all_roles
         @miq_server1.role = 'event, ems_operations, scheduler, reporting'
@@ -269,7 +269,7 @@ describe "Server Monitor" do
       end
 
       context "after monitor_servers" do
-        before(:each) do
+        before do
           @miq_server1.monitor_server_roles
           @miq_server2.reload
         end
@@ -283,7 +283,7 @@ describe "Server Monitor" do
       end
 
       context "with Non-Master having the active roles" do
-        before(:each) do
+        before do
           @miq_server2.activate_roles("event")
           @miq_server1.monitor_server_roles
         end
@@ -294,7 +294,7 @@ describe "Server Monitor" do
         end
 
         context "where Non-Master shuts down cleanly" do
-          before(:each) do
+          before do
             @miq_server2.deactivate_all_roles
             @miq_server2.stopped_on = Time.now.utc
             @miq_server2.status = "stopped"
@@ -314,7 +314,7 @@ describe "Server Monitor" do
         end
 
         context "where Non-Master is not responding" do
-          before(:each) do
+          before do
             @miq_server1.monitor_servers
             Timecop.travel 5.minutes do
               @miq_server1.monitor_servers
@@ -347,7 +347,7 @@ describe "Server Monitor" do
     end
 
     context "with 2 Servers where I am the non-Master" do
-      before(:each) do
+      before do
         @miq_server1 = EvmSpecHelper.local_miq_server
         @miq_server1.deactivate_all_roles
         @miq_server1.role = 'event, ems_operations, scheduler, reporting'
@@ -373,7 +373,7 @@ describe "Server Monitor" do
       end
 
       context "where Master shuts down cleanly" do
-        before(:each) do
+        before do
           @miq_server2.deactivate_all_roles
           @miq_server2.stopped_on = Time.now.utc
           @miq_server2.status = "stopped"
@@ -400,12 +400,12 @@ describe "Server Monitor" do
       end
 
       context "where Master is not responding" do
-        before(:each) do
+        before do
           Timecop.travel 5.minutes
           @miq_server1.monitor_servers
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -437,7 +437,7 @@ describe "Server Monitor" do
     end
 
     context "with 3 Servers where I am the Master" do
-      before(:each) do
+      before do
         @miq_server1 = EvmSpecHelper.local_miq_server(:is_master => true, :name => "Miq1")
         @miq_server1.deactivate_all_roles
         @roles1 = [['ems_operations', 2], ['event', 2], ['ems_inventory', 3], ['ems_metrics_coordinator', 2],]
@@ -545,7 +545,7 @@ describe "Server Monitor" do
       end
 
       context "when Server3 is stopped" do
-        before(:each) do
+        before do
           @miq_server3.deactivate_all_roles
           @miq_server3.stopped_on = Time.now.utc
           @miq_server3.status = "stopped"
@@ -575,7 +575,7 @@ describe "Server Monitor" do
         end
 
         context "and then restarted" do
-          before(:each) do
+          before do
             @miq_server3.status = "started"
             @miq_server3.save!
 
@@ -606,7 +606,7 @@ describe "Server Monitor" do
       end
 
       context "when Server2 is stopped" do
-        before(:each) do
+        before do
           @miq_server2.deactivate_all_roles
           @miq_server2.stopped_on = Time.now.utc
           @miq_server2.status = "stopped"
@@ -636,7 +636,7 @@ describe "Server Monitor" do
         end
 
         context "and then restarted" do
-          before(:each) do
+          before do
             @miq_server2.status = "started"
             @miq_server2.save!
 
@@ -668,7 +668,7 @@ describe "Server Monitor" do
     end
 
     context "with 3 Servers where I am the non-Master" do
-      before(:each) do
+      before do
         @miq_server1 = EvmSpecHelper.local_miq_server(:name => "Server 1")
         @miq_server1.deactivate_all_roles
         @miq_server1.role = 'event, ems_operations, ems_inventory'
@@ -704,7 +704,7 @@ describe "Server Monitor" do
       end
 
       context "where Master shuts down cleanly" do
-        before(:each) do
+        before do
           @miq_server2.deactivate_all_roles
           @miq_server2.stopped_on = Time.now.utc
           @miq_server2.status = "stopped"
@@ -746,12 +746,12 @@ describe "Server Monitor" do
       end
 
       context "where Master is not responding" do
-        before(:each) do
+        before do
           Timecop.travel 5.minutes
           @miq_server1.monitor_servers
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -786,13 +786,13 @@ describe "Server Monitor" do
     end
 
     context "In 2 Zones," do
-      before(:each) do
+      before do
         @zone1 = FactoryGirl.create(:zone)
         @zone2 = FactoryGirl.create(:zone, :name => "zone2", :description => "Zone 2")
       end
 
       context "with 2 Servers across Zones where there is no master" do
-        before(:each) do
+        before do
           @miq_server1 = EvmSpecHelper.local_miq_server(:zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
 
@@ -825,7 +825,7 @@ describe "Server Monitor" do
       end
 
       context "with 2 Servers across Zones where I am the Master" do
-        before(:each) do
+        before do
           @miq_server1 = EvmSpecHelper.local_miq_server(:is_master => true, :zone => @zone1, :name => "Server 1")
           @miq_server1.deactivate_all_roles
           @roles1 = [['ems_operations', 1], ['event', 1], ['ems_metrics_coordinator', 2], ['scheduler', 1], ['reporting', 1]]
@@ -856,7 +856,7 @@ describe "Server Monitor" do
         end
 
         context "Server2 moved into zone of Server 1" do
-          before(:each) do
+          before do
             @miq_server2.zone = @zone1
             @miq_server2.save!
           end

--- a/spec/models/miq_server/status_management_spec.rb
+++ b/spec/models/miq_server/status_management_spec.rb
@@ -1,6 +1,6 @@
 describe MiqServer do
   context "StatusManagement" do
-    before(:each) do
+    before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     end
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -1,6 +1,6 @@
 describe "MiqWorker Monitor" do
   context "After Setup," do
-    before(:each) do
+    before do
       allow(MiqWorker).to receive(:nice_increment).and_return("+10")
       allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(120)
       allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(100.megabytes)
@@ -10,7 +10,7 @@ describe "MiqWorker Monitor" do
     end
 
     context "A worker" do
-      before(:each) do
+      before do
         @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
       end
 
@@ -73,7 +73,7 @@ describe "MiqWorker Monitor" do
       end
 
       context "with 1 message" do
-        before(:each) do
+        before do
           @message = FactoryGirl.create(:miq_queue, :state => 'dequeue', :handler => @worker)
         end
 
@@ -84,7 +84,7 @@ describe "MiqWorker Monitor" do
       end
 
       context "with multiple messages" do
-        before(:each) do
+        before do
           @messages = []
           @actives  = []
 
@@ -148,7 +148,7 @@ describe "MiqWorker Monitor" do
 
     context "A WorkerMonitor" do
       context "with active messages without worker" do
-        before(:each) do
+        before do
           @actives = []
           @actives << FactoryGirl.create(:miq_queue, :state => 'dequeue', :msg_timeout => 4.minutes)
           @actives << FactoryGirl.create(:miq_queue, :state => 'dequeue', :msg_timeout => 5.minutes)
@@ -168,7 +168,7 @@ describe "MiqWorker Monitor" do
       end
 
       context "with expired active messages assigned to workers from multiple" do
-        before(:each) do
+        before do
           @miq_server2 = FactoryGirl.create(:miq_server, :zone => @miq_server.zone)
           @worker1 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id)
           @worker2 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server2.id)
@@ -203,7 +203,7 @@ describe "MiqWorker Monitor" do
       end
 
       context "with vanilla generic worker" do
-        before(:each) do
+        before do
           @worker1 = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => 42, :type => 'MiqGenericWorker')
           allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(2.minutes)
           allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(500.megabytes)
@@ -214,7 +214,7 @@ describe "MiqWorker Monitor" do
 
         context "when worker exits" do
           context "because it exited" do
-            before(:each) do
+            before do
               @worker1.update_attributes(:status => MiqWorker::STATUS_STOPPED)
             end
 
@@ -226,7 +226,7 @@ describe "MiqWorker Monitor" do
           end
 
           context "because it aborted" do
-            before(:each) do
+            before do
               @worker1.update_attributes(:status => MiqWorker::STATUS_ABORTED)
             end
 
@@ -238,7 +238,7 @@ describe "MiqWorker Monitor" do
           end
 
           context "because it was killed" do
-            before(:each) do
+            before do
               @worker1.update_attributes(:status => MiqWorker::STATUS_KILLED)
             end
 
@@ -251,7 +251,7 @@ describe "MiqWorker Monitor" do
         end
 
         context "when worker queues up message for server" do
-          before(:each) do
+          before do
             @ems_id = 7
             @worker1.send_message_to_worker_monitor('reconnect_ems', @ems_id.to_s)
           end
@@ -269,7 +269,7 @@ describe "MiqWorker Monitor" do
         end
 
         context "when server has a single non-sync message" do
-          before(:each) do
+          before do
             @miq_server.message_for_worker(@worker1.id, "foo")
           end
 
@@ -279,7 +279,7 @@ describe "MiqWorker Monitor" do
         end
 
         context "when server has a single sync_config message" do
-          before(:each) do
+          before do
             @miq_server.message_for_worker(@worker1.id, "sync_config")
           end
 
@@ -289,7 +289,7 @@ describe "MiqWorker Monitor" do
         end
 
         context "when server has a single reconnect_ems message with a parameter" do
-          before(:each) do
+          before do
             @ems_id = 7
             @miq_server.message_for_worker(@worker1.id, 'reconnect_ems', @ems_id.to_s)
           end
@@ -299,7 +299,7 @@ describe "MiqWorker Monitor" do
           end
 
           context "and an exit message" do
-            before(:each) do
+            before do
               @miq_server.message_for_worker(@worker1.id, 'exit')
             end
 
@@ -326,7 +326,7 @@ describe "MiqWorker Monitor" do
         let(:worker) { FactoryGirl.create(:miq_worker, :miq_server_id => server.id, :pid => 42) }
         let(:server) { @miq_server }
 
-        before(:each) do
+        before do
           allow(server).to receive(:get_time_threshold).and_return(2.minutes)
           allow(server).to receive(:get_memory_threshold).and_return(500.megabytes)
           allow(server).to receive(:get_restart_interval).and_return(0.hours)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -235,7 +235,7 @@ describe MiqServer do
     end
 
     context "with a worker" do
-      before(:each) do
+      before do
         @worker = FactoryGirl.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => Process.pid)
         allow(@miq_server).to receive(:validate_worker).and_return(true)
         @miq_server.setup_drb_variables
@@ -283,7 +283,7 @@ describe MiqServer do
       end
 
       context "with an active messsage and a second server" do
-        before(:each) do
+        before do
           @msg = FactoryGirl.create(:miq_queue, :state => 'dequeue')
           @miq_server2 = FactoryGirl.create(:miq_server, :is_master => true, :zone => @zone)
         end
@@ -348,7 +348,7 @@ describe MiqServer do
     end
 
     context "with server roles" do
-      before(:each) do
+      before do
         @server_roles = []
         [
           ['event',                  1],
@@ -364,7 +364,7 @@ describe MiqServer do
       end
 
       context "activating All roles" do
-        before(:each) do
+        before do
           @miq_server.activate_all_roles
         end
 
@@ -374,7 +374,7 @@ describe MiqServer do
       end
 
       context "activating Event role" do
-        before(:each) do
+        before do
           @miq_server.activate_roles("event")
         end
 

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -211,7 +211,7 @@ describe MiqTask do
     let(:miq_task2) { FactoryGirl.create(:miq_task_plain) }
     let(:miq_task3) { FactoryGirl.create(:miq_task_plain) }
     let(:zone) { 'New York' }
-    before(:each) do
+    before do
       allow(MiqServer).to receive(:my_zone).and_return(zone)
     end
 

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -40,7 +40,7 @@ describe MiqUserRole do
   end
 
   context "testing allows methods" do
-    before(:each) do
+    before do
       EvmSpecHelper.seed_specific_product_features(%w(
         dashboard_add
         dashboard_view

--- a/spec/models/miq_user_scope_spec.rb
+++ b/spec/models/miq_user_scope_spec.rb
@@ -1,6 +1,6 @@
 describe MiqUserScope do
   context "testing hash_to_scope method" do
-    before(:each) do
+    before do
     end
 
     it "should return the correct converted scope instance" do
@@ -13,7 +13,7 @@ describe MiqUserScope do
   end
 
   context "testing get_filters method" do
-    before(:each) do
+    before do
       @scope1 = MiqUserScope.new(
         :view =>           {:belongsto =>
                                           {:_all_ =>               ["/belongsto/ExtManagementSystem|VC1/EmsFolder|Datacenters/EmsFolder|DataCenter1/EmsFolder|host/EmsCluster|Cluster1",
@@ -87,7 +87,7 @@ describe MiqUserScope do
   end
 
   context "testing merging methods" do
-    before(:each) do
+    before do
       @exp1  = {">" => {"value" => "2", "count" => "Vm.hardware.disks"}}
       @exp2  = {">=" => {"value" => "4096", "field" => "Vm-mem_cpu"}}
       @scope = MiqUserScope.new(

--- a/spec/models/miq_vim_broker_worker/runner_spec.rb
+++ b/spec/models/miq_vim_broker_worker/runner_spec.rb
@@ -2,7 +2,7 @@ require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
 describe MiqVimBrokerWorker::Runner do
-  before(:each) do
+  before do
     _guid_2, _server_2, @zone_2 = EvmSpecHelper.create_guid_miq_server_zone
     _guid, server, @zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone)
@@ -33,7 +33,7 @@ describe MiqVimBrokerWorker::Runner do
   end
 
   context "with a worker created" do
-    before(:each) do
+    before do
       expect_any_instance_of(described_class).to receive(:after_initialize).once
       @vim_broker_worker = described_class.new(:guid => @worker_guid)
       allow(@vim_broker_worker).to receive(:worker_settings).and_return(
@@ -205,7 +205,7 @@ describe MiqVimBrokerWorker::Runner do
 
     context "#drain_event" do
       context "instance with update notification enabled" do
-        before(:each) do
+        before do
           @vim_broker_worker.instance_variable_set(:@vim_broker_server, double('dummy_broker_server').as_null_object)
           @vim_broker_worker.instance_variable_set(:@active_roles, ['ems_inventory'])
           @vim_broker_worker.instance_variable_set(:@queue, Queue.new)

--- a/spec/models/miq_widget/chart_content_spec.rb
+++ b/spec/models/miq_widget/chart_content_spec.rb
@@ -1,6 +1,6 @@
 describe "Widget Chart Content" do
   let(:widget) { MiqWidget.find_by(:description => "chart_vendor_and_guest_os") }
-  before(:each) do
+  before do
     _guid, _server, _zone = EvmSpecHelper.create_guid_miq_server_zone
 
     RssFeed.sync_from_yml_dir

--- a/spec/models/miq_widget/rss_content_spec.rb
+++ b/spec/models/miq_widget/rss_content_spec.rb
@@ -56,7 +56,7 @@ describe "Widget RSS Content" do
   </channel></rss>
   EOF
 
-  before(:each) do
+  before do
     RssFeed.sync_from_yml_dir
 
     EvmSpecHelper.local_miq_server

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -4,12 +4,12 @@ describe MiqWidget do
     include_examples(".seed called multiple times", 21)
   end
 
-  before(:each) do
+  before do
     EvmSpecHelper.local_miq_server
   end
 
   context "setup" do
-    before(:each) do
+    before do
       MiqReport.seed_report("Vendor and Guest OS")
 
       feature1 = MiqProductFeature.find_all_by_identifier("dashboard_admin")
@@ -55,7 +55,7 @@ describe MiqWidget do
     end
 
     context "#queue_generate_content_for_users_or_group" do
-      before(:each) do
+      before do
         @widget = @widget_report_vendor_and_guest_os
         @queue_conditions = {
           :method_name => "generate_content",
@@ -229,7 +229,7 @@ describe MiqWidget do
   end
 
   context "#queue_generate_content" do
-    before(:each) do
+    before do
       MiqReport.seed_report("Top CPU Consumers weekly")
 
       role1 = FactoryGirl.create(:miq_user_role, :name => 'EvmRole-support')

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -35,7 +35,7 @@ describe MiqWorker do
       expect(described_class.has_required_role?).to eq(expected_result)
     end
 
-    before(:each) do
+    before do
       active_roles = %w(foo bar).map { |rn| FactoryGirl.create(:server_role, :name => rn) }
       @server = EvmSpecHelper.local_miq_server(:active_roles => active_roles)
     end
@@ -108,13 +108,13 @@ describe MiqWorker do
   end
 
   context ".workers_configured_count" do
-    before(:each) do
+    before do
       @configured_count = 2
       allow(described_class).to receive(:worker_settings).and_return(:count => @configured_count)
       @maximum_workers_count = described_class.maximum_workers_count
     end
 
-    after(:each) do
+    after do
       described_class.maximum_workers_count = @maximum_workers_count
     end
 
@@ -336,7 +336,7 @@ describe MiqWorker do
   end
 
   context "instance" do
-    before(:each) do
+    before do
       allow(described_class).to receive(:nice_increment).and_return("+10")
       @worker = FactoryGirl.create(:miq_worker)
     end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -89,7 +89,7 @@ describe AuthenticationMixin do
   end
 
   context "authorization event and check for container providers" do
-    before(:each) do
+    before do
       allow(MiqServer).to receive(:my_zone).and_return("default")
     end
 
@@ -161,13 +161,13 @@ describe AuthenticationMixin do
   end
 
   context "with server and zone" do
-    before(:each) do
+    before do
       @miq_server = EvmSpecHelper.local_miq_server
       @data = {:default => {:userid => "test", :password => "blah"}}
     end
 
     context "with multiple zones, emses, and hosts" do
-      before(:each) do
+      before do
         @zone1 = @miq_server.zone
         @zone2 = FactoryGirl.create(:zone, :name => 'test1')
         @ems1  = FactoryGirl.create(:ems_vmware_with_authentication, :zone => @zone1)
@@ -296,7 +296,7 @@ describe AuthenticationMixin do
     end
 
     context "with a host and ems" do
-      before(:each) do
+      before do
         @host         = FactoryGirl.create(:host_vmware_esx_with_authentication)
         @host_no_auth = FactoryGirl.create(:host_vmware_esx)
         @ems          = FactoryGirl.create(:ems_vmware_with_authentication)
@@ -580,13 +580,13 @@ describe AuthenticationMixin do
       end
 
       context "with credentials_changed_on set to now and jump 1 minute" do
-        before(:each) do
+        before do
           @before = Time.now.utc
           @auth.update_attribute(:credentials_changed_on, @before)
           Timecop.travel 1.minute
         end
 
-        after(:each) do
+        after do
           Timecop.return
         end
 
@@ -604,7 +604,7 @@ describe AuthenticationMixin do
       end
 
       context "with saved authentications" do
-        before(:each) do
+        before do
           @ems.update_authentication(@data, :save => true)
           @conditions = {:class_name => @ems.class.base_class.name, :instance_id => @ems.id, :method_name => 'authentication_check_types', :role => @ems.authentication_check_role}
           @queued_auth_checks = MiqQueue.where(@conditions)
@@ -622,7 +622,7 @@ describe AuthenticationMixin do
       end
 
       context "creds unchanged" do
-        before(:each) do
+        before do
           @data[:default][:userid] = @orig_ems_user
           @data[:default][:password] = @orig_ems_pwd
         end
@@ -645,7 +645,7 @@ describe AuthenticationMixin do
       end
 
       context "creds incomplete userid" do
-        before(:each) do
+        before do
           @data[:default][:userid] = nil
           @data[:default][:password] = @orig_ems_pwd
         end

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -1,5 +1,5 @@
 describe PerEmsWorkerMixin do
-  before(:each) do
+  before do
     _guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryGirl.create(:ems_vmware_with_authentication, :zone => zone)
     @ems_queue_name = "ems_#{@ems.id}"
@@ -42,7 +42,7 @@ describe PerEmsWorkerMixin do
 
   context ".stop_worker_for_ems" do
     context "when worker status is started" do
-      before(:each) do
+      before do
         @worker_record.status = MiqWorker::STATUS_STARTED
         @worker_record.save
       end
@@ -70,7 +70,7 @@ describe PerEmsWorkerMixin do
     end
 
     context "when worker status is not started" do
-      before(:each) do
+      before do
         @worker_record.status = MiqWorker::STATUS_STARTING
         @worker_record.save
       end

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -58,7 +58,7 @@ describe RelationshipMixin do
     # than one associated tree node.
 
     context "#set_child on a new parent object" do
-      before(:each) { @parent = FactoryGirl.create(:vm_vmware) }
+      before { @parent = FactoryGirl.create(:vm_vmware) }
 
       it "with a second new object will link a new tree node for the parent to a new tree node for the child" do
         child = FactoryGirl.create(:vm_vmware)
@@ -102,7 +102,7 @@ describe RelationshipMixin do
     end
 
     context "#set_parent on a new child object" do
-      before(:each) { @child = FactoryGirl.create(:vm_vmware) }
+      before { @child = FactoryGirl.create(:vm_vmware) }
 
       it "with a second new object will link a new tree node for the parent to a new tree node for the child" do
         parent = FactoryGirl.create(:vm_vmware)
@@ -146,7 +146,7 @@ describe RelationshipMixin do
     end
 
     context "with a new parent object, #replace_parent" do
-      before(:each) { @parent = FactoryGirl.create(:vm_vmware) }
+      before { @parent = FactoryGirl.create(:vm_vmware) }
 
       it "on a second new object will link a new tree node for the parent to a new tree node for the child and be the only parent for the child" do
         child = FactoryGirl.create(:vm_vmware)
@@ -325,7 +325,7 @@ describe RelationshipMixin do
   end
 
   context ".alias_with_relationship_type" do
-    before(:each) do
+    before do
       @ws = FactoryGirl.create(:miq_widget_set)
       @w1 = FactoryGirl.create(:miq_widget)
       @w2 = FactoryGirl.create(:miq_widget)

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -1,5 +1,5 @@
 describe "Service Retirement Management" do
-  before(:each) do
+  before do
     @miq_server = EvmSpecHelper.local_miq_server
     @stack = FactoryGirl.create(:orchestration_stack)
   end

--- a/spec/models/partition_alignment_spec.rb
+++ b/spec/models/partition_alignment_spec.rb
@@ -1,6 +1,6 @@
 describe "PartitionAlignment" do
   context "Running test" do
-    before(:each) do
+    before do
       aligned = 64.kilobytes
       not_aligned = 1
 

--- a/spec/models/pxe_menu_ipxe_spec.rb
+++ b/spec/models/pxe_menu_ipxe_spec.rb
@@ -1,5 +1,5 @@
 describe PxeMenuIpxe do
-  before(:each) do
+  before do
     @contents = <<-PXEMENU
 #!ipxe
 menu ManageIQ iPXE Boot Menu
@@ -87,7 +87,7 @@ PXEMENU
   end
 
   context "#synchronize_images" do
-    before(:each) do
+    before do
       @pxe_server = FactoryGirl.create(:pxe_server)
       @pxe_menu   = FactoryGirl.create(:pxe_menu_ipxe, :contents => @contents, :pxe_server => @pxe_server)
     end

--- a/spec/models/pxe_menu_pxelinux_spec.rb
+++ b/spec/models/pxe_menu_pxelinux_spec.rb
@@ -1,5 +1,5 @@
 describe PxeMenuPxelinux do
-  before(:each) do
+  before do
     @contents = <<-PXEMENU
 default vesamenu.c32
 Menu Title ManageIQ TFTP Boot Menu
@@ -87,7 +87,7 @@ PXEMENU
   end
 
   context "#synchronize_images" do
-    before(:each) do
+    before do
       @pxe_server = FactoryGirl.create(:pxe_server)
       @pxe_menu = FactoryGirl.create(:pxe_menu_pxelinux, :contents => @contents, :pxe_server => @pxe_server)
     end

--- a/spec/models/pxe_menu_spec.rb
+++ b/spec/models/pxe_menu_spec.rb
@@ -1,5 +1,5 @@
 describe PxeMenu do
-  before(:each) do
+  before do
     @contents_pxelinux = <<-PXEMENU
 default vesamenu.c32
 Menu Title ManageIQ TFTP Boot Menu
@@ -130,7 +130,7 @@ PXEMENU
   end
 
   context "#synchronize" do
-    before(:each) do
+    before do
       @pxe_server = FactoryGirl.create(:pxe_server)
       allow(@pxe_server).to receive_messages(:read_file => @contents_ipxe)
     end

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -1,5 +1,5 @@
 describe PxeServer do
-  before(:each) do
+  before do
     EvmSpecHelper.local_miq_server
     @pxe_server = FactoryGirl.create(:pxe_server, :uri_prefix => "nfs", :uri => "nfs:///#{@mnt_point}")
   end
@@ -23,7 +23,7 @@ describe PxeServer do
   end
 
   context "pxelinux depot" do
-    before(:each) do
+    before do
       @pxe_server.pxe_directory = "pxelinux.cfg"
       class << @pxe_server
         def test_mount_point
@@ -67,7 +67,7 @@ describe PxeServer do
     end
 
     context "#sync_images" do
-      before(:each) do
+      before do
         @expected = [
           ["default",              "Ubuntu-10.10-Desktop-amd64-LIVE_BOOT", "ubuntu-10.10-desktop-amd64/vmlinuz"],
           ["default",              "Ubuntu-10.10-Desktop-i386-LIVE_BOOT",  "ubuntu-10.10-desktop-i386/vmlinuz"],
@@ -161,7 +161,7 @@ PXE
   end
 
   context "ipxe depot" do
-    before(:each) do
+    before do
       @pxe_server.pxe_directory = "ipxe/mac"
       class << @pxe_server
         def test_mount_point
@@ -205,7 +205,7 @@ PXE
     end
 
     context "#sync_images" do
-      before(:each) do
+      before do
         @expected = [
           ["00-50-56-91-79-d5", "00-50-56-91-79-d5", "http://192.168.252.60/ipxe/rhel6.2-desktop/vmlinuz", "ramdisk_size=10000 ks=http://192.168.252.60/pxelinux.cfg/rhel6.2-host.ks.cfg ksdevice=00:50:56:91:79:d5"]
         ]
@@ -292,7 +292,7 @@ PXE
   end
 
   context "with pxe images" do
-    before(:each) do
+    before do
       pxe_menu          = FactoryGirl.create(:pxe_menu,  :pxe_server => @pxe_server)
       @advertised_image = FactoryGirl.create(:pxe_image, :pxe_server => @pxe_server, :pxe_menu => pxe_menu)
       @discovered_image = FactoryGirl.create(:pxe_image, :pxe_server => @pxe_server)

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,6 +1,6 @@
 describe Relationship do
   describe "#filtered?" do
-    before(:each) do
+    before do
       @rel = FactoryGirl.build(:relationship_vm_vmware)
     end
 

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -1,7 +1,7 @@
 describe ResourceActionWorkflow do
   let(:admin) { FactoryGirl.create(:user_with_group) }
   context "#create" do
-    before(:each) do
+    before do
       @dialog       = FactoryGirl.create(:dialog, :label => 'dialog')
       @dialog_tab   = FactoryGirl.create(:dialog_tab, :label => 'tab')
       @dialog_group = FactoryGirl.create(:dialog_group, :label => 'group')
@@ -47,7 +47,7 @@ describe ResourceActionWorkflow do
     end
 
     context "with workflow" do
-      before(:each) do
+      before do
         @wf = ResourceActionWorkflow.new({}, admin, @resource_action)
       end
 

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -1,6 +1,6 @@
 describe ResourcePool do
   context "Testing VM count virtual columns" do
-    before(:each) do
+    before do
       @rp1 = FactoryGirl.create(:resource_pool, :name => "RP 1")
       @rp2 = FactoryGirl.create(:resource_pool, :name => "RP 2")
       @rp3 = FactoryGirl.create(:resource_pool, :name => "RP 3")

--- a/spec/models/rss_feed/rss_feed_spec.rb
+++ b/spec/models/rss_feed/rss_feed_spec.rb
@@ -1,7 +1,7 @@
 describe RssFeed do
   Y_DIR = File.expand_path(File.join(File.dirname(__FILE__), "data"))
 
-  before(:each) { Kernel.silence_warnings { RssFeed.const_set(:YML_DIR, Y_DIR) } }
+  before { Kernel.silence_warnings { RssFeed.const_set(:YML_DIR, Y_DIR) } }
 
   context "with vms" do
     before do
@@ -49,7 +49,7 @@ describe RssFeed do
   end
 
   context "with 2 hosts" do
-    before(:each) do
+    before do
       @host1 = FactoryGirl.create(:host,           :created_on => Time.utc(2013, 1, 1, 0, 0, 0))
       @host2 = FactoryGirl.create(:host_microsoft, :created_on => @host1.created_on + 1.second)
     end
@@ -88,7 +88,7 @@ EOXML
   end
 
   context ".sync_from_yml_dir" do
-    before(:each) do
+    before do
       RssFeed.seed
     end
 
@@ -116,7 +116,7 @@ EOXML
   include_examples(".seed called multiple times", 2)
 
   context ".sync_from_yml_file" do
-    before(:each) { @name = "newest_hosts" }
+    before { @name = "newest_hosts" }
 
     it "when the model does not exist" do
       described_class.sync_from_yml_file(@name)

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -1,6 +1,6 @@
 describe ServerRole do
   context "Without Seeding" do
-    before(:each) do
+    before do
       @server_roles = []
       [
         ['event',                   1],
@@ -27,7 +27,7 @@ describe ServerRole do
   end
 
   context "With Seeding" do
-    before(:each) do
+    before do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         automate,Automation Engine,0,false,region

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -1,5 +1,5 @@
 describe "Service Retirement Management" do
-  before(:each) do
+  before do
     @server = EvmSpecHelper.local_miq_server
     @service = FactoryGirl.create(:service)
   end

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -54,12 +54,12 @@ describe ServiceReconfigureTask do
   end
 
   describe "#deliver_to_automate" do
-    before(:each) do
+    before do
       allow(request).to receive(:approved?).and_return(true)
     end
 
     context "automation entry point available" do
-      before(:each) do
+      before do
         FactoryGirl.create(:resource_action, :action       => 'Reconfigure',
                                              :resource     => template,
                                              :ae_namespace => 'namespace',

--- a/spec/models/service_record_spec.rb
+++ b/spec/models/service_record_spec.rb
@@ -1,6 +1,6 @@
 describe ServiceResource do
   context "default values" do
-    before(:each) do
+    before do
       @resource = ServiceResource.new
     end
 

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -1,7 +1,7 @@
 describe ServiceTemplateProvisionRequest do
   let(:admin) { FactoryGirl.create(:user_admin) }
   context "with multiple tasks" do
-    before(:each) do
+    before do
       @request  = FactoryGirl.create(:service_template_provision_request, :description => 'Service Request', :requester => admin)
 
       @task_1   = FactoryGirl.create(:service_template_provision_task, :description => 'Task 1',     :userid => admin.userid, :miq_request_id => @request.id)

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -1,6 +1,6 @@
 describe ServiceTemplateProvisionTask do
   context "with multiple tasks" do
-    before(:each) do
+    before do
       @admin = FactoryGirl.create(:user_with_group)
 
       @request = FactoryGirl.create(:service_template_provision_request,
@@ -219,7 +219,7 @@ describe ServiceTemplateProvisionTask do
     end
 
     context "with a service" do
-      before(:each) do
+      before do
         @service = FactoryGirl.create(:service, :name => 'Test Service')
       end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -215,7 +215,7 @@ describe ServiceTemplate do
   end
 
   context "#type_display" do
-    before(:each) do
+    before do
       @st1 = FactoryGirl.create(:service_template, :name => 'Service Template 1')
     end
 
@@ -235,7 +235,7 @@ describe ServiceTemplate do
   end
 
   context "#atomic?" do
-    before(:each) do
+    before do
       @st1 = FactoryGirl.create(:service_template)
     end
 
@@ -250,7 +250,7 @@ describe ServiceTemplate do
   end
 
   context "#composite?" do
-    before(:each) do
+    before do
       @st1 = FactoryGirl.create(:service_template)
     end
 
@@ -287,7 +287,7 @@ describe ServiceTemplate do
   end
 
   context "with multiple services" do
-    before(:each) do
+    before do
       @svc_a = FactoryGirl.create(:service_template, :name => 'Svc A')
       @svc_b = FactoryGirl.create(:service_template, :name => 'Svc B')
       @svc_c = FactoryGirl.create(:service_template, :name => 'Svc C')
@@ -429,7 +429,7 @@ describe ServiceTemplate do
   end
 
   context "with a small env" do
-    before(:each) do
+    before do
       @zone1 = FactoryGirl.create(:small_environment)
       allow(MiqServer).to receive(:my_server).and_return(@zone1.miq_servers.first)
       @st1 = FactoryGirl.create(:service_template, :name => 'Service Template 1')
@@ -482,7 +482,7 @@ describe ServiceTemplate do
     end
 
     context "with a VM Provision Request Template" do
-      before(:each) do
+      before do
         admin = FactoryGirl.create(:user_admin)
 
         vm_template = Vm.first

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -65,7 +65,7 @@ describe Storage do
   end
 
   context "with multiple storages" do
-    before(:each) do
+    before do
       @server = EvmSpecHelper.local_miq_server
       @zone   = @server.zone
 
@@ -157,7 +157,7 @@ describe Storage do
     end
 
     context "on a host with authentication status ok" do
-      before(:each) do
+      before do
         allow_any_instance_of(Authentication).to receive(:after_authentication_changed)
         FactoryGirl.create(:authentication, :resource => @host1, :status => "Valid")
       end
@@ -221,7 +221,7 @@ describe Storage do
       end
 
       context "with performance capture disabled" do
-        before(:each) do
+        before do
           allow_any_instance_of(Storage).to receive_messages(:perf_capture_enabled? => false)
         end
 
@@ -242,7 +242,7 @@ describe Storage do
       end
 
       context "with performance capture enabled" do
-        before(:each) do
+        before do
           allow_any_instance_of(Storage).to receive_messages(:perf_capture_enabled? => true)
           allow(MiqEvent).to receive(:raise_evm_job_event)
         end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -77,7 +77,7 @@ describe Tag do
   end
 
   context "categorization" do
-    before(:each) do
+    before do
       FactoryGirl.create(:classification_department_with_tags)
 
       @tag            = Tag.find_by(:name => "/managed/department/finance")

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -1,5 +1,5 @@
 describe TimeProfile do
-  before(:each) do
+  before do
     @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
   end
@@ -24,7 +24,7 @@ describe TimeProfile do
   end
 
   context "will seed the database" do
-    before(:each) do
+    before do
       TimeProfile.seed
     end
 
@@ -64,7 +64,7 @@ describe TimeProfile do
   end
 
   context "with an existing time profile with rollups disabled" do
-    before(:each) do
+    before do
       @tp = FactoryGirl.create(:time_profile)
       MiqQueue.delete_all
     end
@@ -89,7 +89,7 @@ describe TimeProfile do
   end
 
   context "with an existing time profile with rollups enabled" do
-    before(:each) do
+    before do
       @tp = FactoryGirl.create(:time_profile_with_rollup)
       MiqQueue.delete_all
     end
@@ -111,7 +111,7 @@ describe TimeProfile do
   end
 
   context "profiles_for_user" do
-    before(:each) do
+    before do
       TimeProfile.seed
     end
 
@@ -136,7 +136,7 @@ describe TimeProfile do
   end
 
   context "profile_for_user_tz" do
-    before(:each) do
+    before do
       TimeProfile.seed
     end
 

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -2,7 +2,7 @@ require 'bcrypt'
 
 describe "User Password" do
   context "With admin user" do
-    before(:each) do
+    before do
       EvmSpecHelper.create_guid_miq_server_zone
 
       @old = 'smartvm'
@@ -15,7 +15,7 @@ describe "User Password" do
     end
 
     context "call change_password" do
-      before(:each) do
+      before do
         @new = 'Zug-drep5s'
         @admin.change_password(@old, @new)
       end
@@ -26,7 +26,7 @@ describe "User Password" do
     end
 
     context "call password=" do
-      before(:each) do
+      before do
         @new = 'Zug-drep5s'
         @admin.password = @new
         @admin.save!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -158,7 +158,7 @@ describe User do
   end
 
   context "#authorize_ldap" do
-    before(:each) do
+    before do
       @fq_user = "thin1@manageiq.com"
       @task = MiqTask.create(:name => "LDAP User Authorization of '#{@fq_user}'", :userid => @fq_user)
       @auth_config =
@@ -215,14 +215,14 @@ describe User do
   end
 
   context "group assignment" do
-    before(:each) do
+    before do
       @group1 = FactoryGirl.create(:miq_group, :description => "EvmGroup 1")
       @group2 = FactoryGirl.create(:miq_group, :description => "EvmGroup 2")
       @group3 = FactoryGirl.create(:miq_group, :description => "EvmGroup 3")
     end
 
     describe "#miq_groups=" do
-      before(:each) do
+      before do
         @user = FactoryGirl.create(:user, :miq_groups => [@group3])
       end
 
@@ -252,7 +252,7 @@ describe User do
     end
 
     describe "#current_group=" do
-      before(:each) do
+      before do
         @user = FactoryGirl.create(:user, :miq_groups => [@group1, @group2])
       end
 

--- a/spec/models/vim_performance_tag_spec.rb
+++ b/spec/models/vim_performance_tag_spec.rb
@@ -1,5 +1,5 @@
 describe VimPerformanceTag do
-  before(:each) do
+  before do
     @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
 
@@ -8,7 +8,7 @@ describe VimPerformanceTag do
   end
 
   context "with a small environment and tagged VMs" do
-    before(:each) do
+    before do
       @prod = "environment/prod"
       @dev  = "environment/dev"
       @test = "environment/test"
@@ -24,7 +24,7 @@ describe VimPerformanceTag do
     end
 
     context "with Vm hourly performances" do
-      before(:each) do
+      before do
         case_sets = {
           :host => {
             "2010-04-13T21:00:00Z" => 1100.0,

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -1,5 +1,5 @@
 describe 'VM::Operations' do
-  before(:each) do
+  before do
     @miq_server = EvmSpecHelper.local_miq_server
     @ems        = FactoryGirl.create(:ems_vmware, :zone => @miq_server.zone)
     @vm         = FactoryGirl.create(:vm_vmware, :ems_id => @ems.id)
@@ -25,7 +25,7 @@ describe 'VM::Operations' do
     end
 
     context 'cloud providers' do
-      before(:each) { @ipaddresses = %w(10.10.1.121 35.190.140.48) }
+      before { @ipaddresses = %w(10.10.1.121 35.190.140.48) }
       it 'returns the public ipv4 address for AWS' do
         ems = FactoryGirl.create(:ems_google, :project => 'manageiq-dev')
         az  = FactoryGirl.create(:availability_zone_google)

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -1,5 +1,5 @@
 describe "VM Retirement Management" do
-  before(:each) do
+  before do
     miq_server = EvmSpecHelper.local_miq_server
     @zone = miq_server.zone
     @ems = FactoryGirl.create(:ems_vmware, :zone => @zone)

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -84,7 +84,7 @@ describe VmOrTemplate do
 
   context ".event_by_property" do
     context "should add an EMS event" do
-      before(:each) do
+      before do
         Timecop.freeze(Time.now)
 
         @host            = FactoryGirl.create(:host,      :name  => "host")
@@ -94,7 +94,7 @@ describe VmOrTemplate do
         @event_timestamp = Time.now.utc
       end
 
-      after(:each) do
+      after do
         Timecop.return
       end
 
@@ -123,7 +123,7 @@ describe VmOrTemplate do
   end
 
   context "#add_ems_event" do
-    before(:each) do
+    before do
       @host            = FactoryGirl.create(:host, :name => "host 1")
       @vm              = FactoryGirl.create(:vm_vmware, :name => "vm 1", :location => "/local/path", :host => @host, :uid_ems => "1", :ems_id => 101)
       @event_type      = "foo"
@@ -138,7 +138,7 @@ describe VmOrTemplate do
     end
 
     context "should add an EMS Event" do
-      before(:each) do
+      before do
         @ipaddress       = "192.268.20.1"
         @hardware        = FactoryGirl.create(:hardware, :vm_or_template_id => @vm.id)
         @network         = FactoryGirl.create(:network,  :hardware_id       => @hardware.id, :ipaddress => @ipaddress)

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -1,6 +1,6 @@
 describe VmScan do
   context "A single VM Scan Job on VMware provider," do
-    before(:each) do
+    before do
       @server = EvmSpecHelper.local_miq_server(:capabilities => {:vixDisk => true})
       assign_smartproxy_role_to_server(@server)
 
@@ -57,12 +57,12 @@ describe VmScan do
     end
 
     context "without Broker Running and with valid MiqVimBrokerWorker record," do
-      before(:each) do
+      before do
         @vim_broker_worker = FactoryGirl.create(:miq_vim_broker_worker, :miq_server_id => @server.id)
       end
 
       context "in status of 'starting'," do
-        before(:each) do
+        before do
           @vim_broker_worker.update_attributes(:status => 'starting')
         end
 
@@ -75,7 +75,7 @@ describe VmScan do
       end
 
       context "in status of 'stopped'," do
-        before(:each) do
+        before do
           @vim_broker_worker.update_attributes(:status => 'stopped')
         end
 
@@ -88,7 +88,7 @@ describe VmScan do
       end
 
       context "in status of 'killed'," do
-        before(:each) do
+        before do
           @vim_broker_worker.update_attributes(:status => 'killed')
         end
 
@@ -101,7 +101,7 @@ describe VmScan do
       end
 
       context "in status of 'started'," do
-        before(:each) do
+        before do
           @vim_broker_worker.update_attributes(:status => 'started')
           JobProxyDispatcher.dispatch
           @job.reload
@@ -113,7 +113,7 @@ describe VmScan do
         end
 
         context "when signaled with 'start'" do
-          before(:each) do
+          before do
             q = MiqQueue.last
             q.delivered(*q.deliver)
             @job.reload
@@ -233,7 +233,7 @@ describe VmScan do
 
     describe "#call_snapshot_create" do
       context "for providers other than OpenStack and Microsoft" do
-        before(:each) { @job.miq_server_id = @server.id }
+        before { @job.miq_server_id = @server.id }
 
         it "does not call #create_snapshot but sends signal :snapshot_complete" do
           expect(@job).to receive(:signal).with(:snapshot_complete)
@@ -242,7 +242,7 @@ describe VmScan do
         end
 
         context "if snapshot for scan required" do
-          before(:each) do
+          before do
             allow(@vm).to receive(:require_snapshot_for_scan?).and_return(true)
             allow(MiqServer).to receive(:use_broker_for_embedded_proxy?).and_return(true)
           end
@@ -285,7 +285,7 @@ describe VmScan do
     end
 
     describe "#call_scan" do
-      before(:each) do
+      before do
         @job.miq_server_id = @server.id
         allow(VmOrTemplate).to receive(:find).with(@vm.id).and_return(@vm)
         allow(MiqServer).to receive(:find).with(@server.id).and_return(@server)
@@ -317,7 +317,7 @@ describe VmScan do
     end
 
     describe "#call_synchronize" do
-      before(:each) do
+      before do
         @job.miq_server_id = @server.id
         allow(VmOrTemplate).to receive(:find).with(@vm.id).and_return(@vm)
         allow(MiqServer).to receive(:find).with(@server.id).and_return(@server)
@@ -347,7 +347,7 @@ describe VmScan do
 
     describe "#call_snapshot_delete" do
       let(:snapshot_description) { "Snapshot description" }
-      before(:each) do
+      before do
         allow(VmOrTemplate).to receive(:find).with(@vm.id).and_return(@vm)
         @job.update_attributes(:state => 'snapshot_delete')
         @job.context[:snapshot_mor] = snapshot_description

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -14,7 +14,7 @@ describe Vm do
   end
 
   context "#template=" do
-    before(:each) { @vm = FactoryGirl.create(:vm_vmware) }
+    before { @vm = FactoryGirl.create(:vm_vmware) }
 
     it "false" do
       @vm.update_attribute(:template, false)
@@ -83,7 +83,7 @@ describe Vm do
   end
 
   context "with relationships of multiple types" do
-    before(:each) do
+    before do
       @rp        = FactoryGirl.create(:resource_pool, :name => "RP")
       @parent_vm = FactoryGirl.create(:vm_vmware, :name => "Parent VM")
       @vm        = FactoryGirl.create(:vm_vmware, :name => "VM")
@@ -97,7 +97,7 @@ describe Vm do
     end
 
     context "#destroy" do
-      before(:each) do
+      before do
         @vm.destroy
       end
 
@@ -113,7 +113,7 @@ describe Vm do
   end
 
   context "#invoke_tasks_local" do
-    before(:each) do
+    before do
       EvmSpecHelper.create_guid_miq_server_zone
       @host = FactoryGirl.create(:host)
       @vm = FactoryGirl.create(:vm_vmware, :host => @host)
@@ -281,7 +281,7 @@ describe Vm do
   end
 
   context "#cockpit_url" do
-    before(:each) do
+    before do
       @csv = <<-CSV.gsub(/^\s+/, "")
         name,description,max_concurrent,external_failover,role_scope
         cockpit_ws,Cockpit,1,false,zone

--- a/spec/models/vmdb_database/metric_capture_spec.rb
+++ b/spec/models/vmdb_database/metric_capture_spec.rb
@@ -1,7 +1,7 @@
 describe VmdbDatabase do
   context "::MetricCapture" do
     context "#capture_database_metrics" do
-      before(:each) do
+      before do
         MiqDatabase.seed
         described_class.seed_self
         @db = described_class.my_database
@@ -38,7 +38,7 @@ describe VmdbDatabase do
       end
 
       context "when database is not local" do
-        before(:each) do
+        before do
           allow(EvmDatabase).to receive(:local?).and_return(false)
         end
 

--- a/spec/models/vmdb_database/seeding_spec.rb
+++ b/spec/models/vmdb_database/seeding_spec.rb
@@ -12,7 +12,7 @@ describe VmdbDatabase do
     end
 
     context "#seed" do
-      before(:each) do
+      before do
         MiqDatabase.seed
         @db = FactoryGirl.create(:vmdb_database)
       end

--- a/spec/models/vmdb_metric_spec.rb
+++ b/spec/models/vmdb_metric_spec.rb
@@ -1,5 +1,5 @@
 describe VmdbMetric do
-  before(:each) do
+  before do
     EvmSpecHelper.create_guid_miq_server_zone
   end
 

--- a/spec/models/vmdb_table_evm_spec.rb
+++ b/spec/models/vmdb_table_evm_spec.rb
@@ -57,7 +57,7 @@ describe VmdbTableEvm do
   end
 
   context "#seed_texts" do
-    before(:each) do
+    before do
       @db = VmdbDatabase.seed_self
       @evm_table = FactoryGirl.create(:vmdb_table_evm, :vmdb_database => @db, :name => 'foo')
     end

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -1,6 +1,6 @@
 describe VmdbTable do
   context "#seed_indexes" do
-    before(:each) do
+    before do
       @db = VmdbDatabase.seed_self
       @vmdb_table = FactoryGirl.create(:vmdb_table, :vmdb_database => @db, :name => 'foo')
     end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -2,7 +2,7 @@ describe Zone do
   include_examples ".seed called multiple times"
 
   context "with two small envs" do
-    before(:each) do
+    before do
       @zone1 = FactoryGirl.create(:small_environment)
       @host1 = @zone1.ext_management_systems.first.hosts.first
       @zone1.reload
@@ -147,7 +147,7 @@ describe Zone do
 
   context "ConfigurationManagementMixin" do
     describe "#remote_cockpit_ws_miq_server" do
-      before(:each) do
+      before do
         @csv = <<-CSV.gsub(/^\s+/, "")
           name,description,max_concurrent,external_failover,role_scope
           cockpit_ws,Cockpit,1,false,zone

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ RSpec.configure do |config|
   #   EvmSpecHelper.log_ruby_object_usage
   # end
 
-  config.before do |example|
+  config.before do
     EmsRefresh.try(:debug_failures=, true)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ RSpec.configure do |config|
   #   EvmSpecHelper.log_ruby_object_usage
   # end
 
-  config.before(:each) do |example|
+  config.before do |example|
     EmsRefresh.try(:debug_failures=, true)
   end
 


### PR DESCRIPTION
`:each` is the default for rspec `before` and `after` blocks, so we don't need to specify it.

refers to https://github.com/ManageIQ/manageiq/issues/16366