### PR TITLE
Add TransformationMapping#validate_vms method

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -1,4 +1,8 @@
 class TransformationMapping < ApplicationRecord
+  VM_VALID = N_("OK").freeze
+  VM_NON_EXIST = N_("VM does not exist").freeze
+  VM_CONFLICT = N_("Conflict").freeze
+
   has_many :transformation_mapping_items, :dependent => :destroy
   has_many :service_resources, :as => :resource, :dependent => :nullify
   has_many :service_templates, :through => :service_resources
@@ -7,5 +11,73 @@ class TransformationMapping < ApplicationRecord
 
   def destination(source)
     transformation_mapping_items.find_by(:source => source).try(:destination)
+  end
+
+  # vm_list: collection of hashes, each descriping a VM.
+  def validate_vms(vm_list = nil)
+    vm_list.present? ? identify_vms(vm_list) : select_vms
+  end
+
+  private
+
+  def select_vms
+    # TBD
+  end
+
+  def identify_vms(vm_list)
+    valid_list = []
+    invalid_list = []
+    conflict_list = []
+
+    vm_list.each do |row|
+      vm_name = row['name']
+
+      query = Vm.where(:name => vm_name)
+      query = query.where(:uid_ems => row['uid_ems']) if row['uid_ems'].present?
+      query = query.joins(:host).where(:hosts => {:name => row['host']}) if row['host'].present?
+      query = query.joins(:ext_management_system).where(:ext_management_systems => {:name => row['provider']}) if row['provider'].present?
+
+      vms = query.to_a
+      invalid_list << describe_non_vm(vm_name) if vms.empty?
+
+      if vms.size == 1
+        reason = validate_vm(vms.first)
+        (reason == VM_VALID ? valid_list : invalid_list) << describe_vm(vms.first, reason)
+      else
+        vms.each { |vm| conflict_list << describe_vm(vm, VM_CONFLICT) }
+      end
+    end
+
+    {
+      "valid_vms"    => valid_list,
+      "invalid_vms"  => invalid_list,
+      "conflict_vms" => conflict_list
+    }
+  end
+
+  def describe_non_vm(vm_name)
+    {
+      "name"   => vm_name,
+      "reason" => VM_NON_EXIST
+    }
+  end
+
+  def describe_vm(vm, reason)
+    # formate to be finalized
+    {
+      "name"           => vm.name,
+      "cluster"        => vm.ems_cluster.name,
+      "path"           => "#{vm.ext_management_system.name}/#{vm.parent_blue_folder_path(:exclude_non_display_folders => true)}",
+      "allocated_size" => vm.allocated_disk_storage,
+      "id"             => vm.id,
+      "reason"         => reason
+    }
+  end
+
+  # return an empty string if the vm can be migrated
+  # otherwise the reason why it can't be migrated
+  def validate_vm(vm)
+    # a valid vm must find all resources in the mapping and has never been migrated
+    VM_VALID
   end
 end

--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -1,7 +1,10 @@
 class TransformationMapping < ApplicationRecord
-  VM_VALID = N_("OK").freeze
-  VM_NON_EXIST = N_("VM does not exist").freeze
-  VM_CONFLICT = N_("Conflict").freeze
+  VM_CONFLICT = "conflict".freeze
+  VM_EMPTY_NAME = "empty_name".freeze
+  VM_IN_OTHER_PLAN = "in_other_plan".freeze
+  VM_MIGRATED = "migrated".freeze
+  VM_NOT_EXIST = "not_exist".freeze
+  VM_VALID = "ok".freeze
 
   has_many :transformation_mapping_items, :dependent => :destroy
   has_many :service_resources, :as => :resource, :dependent => :nullify
@@ -21,7 +24,16 @@ class TransformationMapping < ApplicationRecord
   private
 
   def select_vms
-    # TBD
+    valid_list = []
+
+    transformation_mapping_items.where(:source_type => EmsCluster).collect(&:source).each do |cluster|
+      cluster.vms.each do |vm|
+        reason = validate_vm(vm, true)
+        valid_list << describe_vm(vm, reason) if reason == VM_VALID
+      end
+    end
+
+    {"valid_vms" => valid_list}
   end
 
   def identify_vms(vm_list)
@@ -32,16 +44,21 @@ class TransformationMapping < ApplicationRecord
     vm_list.each do |row|
       vm_name = row['name']
 
+      if vm_name.blank?
+        invalid_list << describe_non_vm(vm_name)
+        next
+      end
+
       query = Vm.where(:name => vm_name)
       query = query.where(:uid_ems => row['uid_ems']) if row['uid_ems'].present?
       query = query.joins(:host).where(:hosts => {:name => row['host']}) if row['host'].present?
       query = query.joins(:ext_management_system).where(:ext_management_systems => {:name => row['provider']}) if row['provider'].present?
 
       vms = query.to_a
-      invalid_list << describe_non_vm(vm_name) if vms.empty?
-
-      if vms.size == 1
-        reason = validate_vm(vms.first)
+      if vms.size.zero?
+        invalid_list << describe_non_vm(vm_name)
+      elsif vms.size == 1
+        reason = validate_vm(vms.first, false)
         (reason == VM_VALID ? valid_list : invalid_list) << describe_vm(vms.first, reason)
       else
         vms.each { |vm| conflict_list << describe_vm(vm, VM_CONFLICT) }
@@ -58,12 +75,11 @@ class TransformationMapping < ApplicationRecord
   def describe_non_vm(vm_name)
     {
       "name"   => vm_name,
-      "reason" => VM_NON_EXIST
+      "reason" => vm_name.blank? ? VM_EMPTY_NAME : VM_NOT_EXIST
     }
   end
 
   def describe_vm(vm, reason)
-    # formate to be finalized
     {
       "name"           => vm.name,
       "cluster"        => vm.ems_cluster.name,
@@ -74,10 +90,48 @@ class TransformationMapping < ApplicationRecord
     }
   end
 
-  # return an empty string if the vm can be migrated
-  # otherwise the reason why it can't be migrated
-  def validate_vm(vm)
+  def validate_vm(vm, quick = true)
     # a valid vm must find all resources in the mapping and has never been migrated
-    VM_VALID
+    invalid_list = []
+
+    unless valid_cluster?(vm)
+      invalid_list << "cluster: %{name}" % {:name => vm.ems_cluster.name}
+      return no_mapping_msg(invalid_list) if quick
+    end
+
+    invalid_storages = unmapped_storages(vm)
+    if invalid_storages.present?
+      invalid_list << "storages: %{list}" % {:list => invalid_storages.collect(&:name).join(", ")}
+      return no_mapping_msg(invalid_list) if quick
+    end
+
+    invalid_lans = unmapped_lans(vm)
+    if invalid_lans.present?
+      invalid_list << "lans: %{list}" % {:list => invalid_lans.collect(&:name).join(', ')}
+      return no_mapping_msg(invalid_list) if quick
+    end
+
+    return no_mapping_msg(invalid_list) if invalid_list.present?
+    vm.validate_v2v_migration
+  end
+
+  def no_mapping_msg(list)
+    "Mapping source not found - %{list}" % {:list => list.join('. ')}
+  end
+
+  def valid_cluster?(vm)
+    transformation_mapping_items.where(:source => vm.ems_cluster).exists?
+  end
+
+  # return an empty array if all storages are valid for transformation
+  # otherwise return an array of invalid datastores
+  def unmapped_storages(vm)
+    vm.datastores - transformation_mapping_items.where(:source => vm.datastores).collect(&:source)
+  end
+
+  # return an empty array if all lans are valid for transformation
+  # otherwise return an array of invalid lans
+  def unmapped_lans(vm)
+    vm.lans - transformation_mapping_items.where(:source => vm.lans).collect(&:source)
   end
 end

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,6 +1,7 @@
 describe TransformationMapping do
   let(:src) { FactoryGirl.create(:ems_cluster) }
   let(:dst) { FactoryGirl.create(:ems_cluster) }
+  let(:vm)  { FactoryGirl.create(:vm_vmware, :ems_cluster => src) }
 
   let(:mapping) do
     FactoryGirl.create(
@@ -25,6 +26,114 @@ describe TransformationMapping do
 
     it 'finds the transformation plans' do
       expect(mapping.service_templates).to match([plan])
+    end
+  end
+
+  describe '#validate_vms' do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryGirl.create(:ext_management_system)) }
+    let(:storage) { FactoryGirl.create(:storage) }
+    let(:lan) { FactoryGirl.create(:lan) }
+    let(:nic) { FactoryGirl.create(:guest_device_nic, :lan => lan) }
+
+    before do
+      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => storage, :destination => storage)
+      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => lan, :destination => lan)
+      vm.storages << storage
+      vm.hardware = FactoryGirl.create(:hardware, :guest_devices => [nic])
+    end
+
+    context 'with VM list' do
+      context 'returns invalid vms' do
+        it 'if VM does not exist' do
+          result = mapping.validate_vms(['name' => 'vm1'])
+          expect(result['invalid_vms'].first).to match(hash_including('reason' => TransformationMapping::VM_NOT_EXIST))
+        end
+
+        it "if VM's cluster is not in the mapping" do
+          FactoryGirl.create(
+            :vm_vmware,
+            :name                  => 'vm2',
+            :ems_cluster           => FactoryGirl.create(:ems_cluster, :name => 'cluster1'),
+            :ext_management_system => FactoryGirl.create(:ext_management_system)
+          )
+          result = mapping.validate_vms(['name' => 'vm2'])
+          expect(result['invalid_vms'].first['reason']).to match(/Mapping source not found - cluster: cluster1/)
+        end
+
+        it "if VM's storages are not all in the mapping" do
+          vm.storages << FactoryGirl.create(:storage, :name => 'storage2')
+          result = mapping.validate_vms(['name' => vm.name])
+          expect(result['invalid_vms'].first['reason']).to match(/Mapping source not found - storages: storage2/)
+        end
+
+        it "if VM's lans are not all in the mapping" do
+          vm.hardware.guest_devices << FactoryGirl.create(:guest_device_nic, :lan =>FactoryGirl.create(:lan, :name => 'lan2'))
+          result = mapping.validate_vms(['name' => vm.name])
+          expect(result['invalid_vms'].first['reason']).to match(/Mapping source not found - lans: lan2/)
+        end
+
+        it "if any source is invalid" do
+          vm.storages << FactoryGirl.create(:storage, :name => 'storage2')
+          vm.hardware.guest_devices << FactoryGirl.create(:guest_device_nic, :lan =>FactoryGirl.create(:lan, :name => 'lan2'))
+          result = mapping.validate_vms(['name' => vm.name])
+          expect(result['invalid_vms'].first['reason']).to match(/Mapping source not found - storages: storage2. lans: lan2/)
+        end
+
+        it 'if VM is in another migration plan' do
+          %w(Queued Approved Active).each do |status|
+            FactoryGirl.create(
+              :service_resource,
+              :resource         => vm,
+              :service_template => FactoryGirl.create(:service_template_transformation_plan),
+              :status           => status
+            )
+
+            result = mapping.validate_vms(['name' => vm.name])
+            expect(result['invalid_vms'].first['reason']).to match(/in_other_plan/)
+          end
+        end
+
+        it 'if VM has been migrated' do
+          FactoryGirl.create(
+            :service_resource,
+            :resource         => vm,
+            :service_template => FactoryGirl.create(:service_template_transformation_plan),
+            :status           => 'Completed'
+          )
+
+          result = mapping.validate_vms(['name' => vm.name])
+          expect(result['invalid_vms'].first['reason']).to match(/migrated/)
+        end
+      end
+
+      it 'returns valid vms' do
+        result = mapping.validate_vms(['name' => vm.name])
+        expect(result['valid_vms'].first).to match(hash_including('reason' => TransformationMapping::VM_VALID))
+      end
+
+      it 'returns conflict vms' do
+        FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryGirl.create(:ext_management_system))
+        result = mapping.validate_vms(['name' => vm.name])
+        expect(result['conflict_vms'].first).to match(hash_including('reason' => TransformationMapping::VM_CONFLICT))
+      end
+    end
+
+    context 'without VM list' do
+      it 'returns valid vms' do
+        result = mapping.validate_vms
+        expect(result['valid_vms'].count).to eq(1)
+      end
+
+      it 'skips invalid vms' do
+        FactoryGirl.create(
+          :vm_vmware,
+          :name                  => 'vm2',
+          :ems_cluster           => FactoryGirl.create(:ems_cluster, :name => 'cluster1'),
+          :ext_management_system => FactoryGirl.create(:ext_management_system)
+        )
+        result = mapping.validate_vms
+        expect(result['valid_vms'].count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
Add `#validate_vms` method to support API `/api/transformation_mappings/id` action `search_vms_and_validate`.

If the action provides no csv content, the method should select all VMs that are qualified for migration based on the mapping.
If csv is provided in the POST body, the method should filter all selections and group them into `valid_vms`, `invalid_vms`, and `conflict_vms`.
Selected attributes of each VM are included for displaying purpose. `id` is critical to be used by following up API call to create a transformation plan. 