### PR TITLE
Do not show archived and orphaned VMs on report 'Online VMs (Powered On)'

### DIFF
--- a/product/reports/400_Operations- Virtual Machines/020_Online VMs.yaml
+++ b/product/reports/400_Operations- Virtual Machines/020_Online VMs.yaml
@@ -4,9 +4,13 @@ created_on: 2008-08-14 01:54:13.891449 Z
 title: "Online VMs (Powered On)"
 conditions: !ruby/object:MiqExpression
   exp:
-    "=":
-      field: Vm-power_state
-      value: "on"
+    and:
+    - "=":
+        field: Vm-power_state
+        value: "on"
+    - "=":
+        field: Vm-active
+        value: "true"
 updated_on: 2008-08-14 01:54:13.891449 Z
 order: Ascending
 graph:


### PR DESCRIPTION
Do not show archived and orphaned VMs on report 'Online VMs (Powered On)'

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1504010

@miq-bot add-label bug, reporting

on test DB there were 2 archived report with power state=on
BEFORE:
<img width="1226" alt="before" src="https://user-images.githubusercontent.com/6556758/37680214-9d787712-2c59-11e8-8aa2-53202e966ede.png">

AFTER:
<img width="1217" alt="screen shot 2018-03-20 at 3 59 08 pm" src="https://user-images.githubusercontent.com/6556758/37680225-a5f82298-2c59-11e8-9eae-bd3e6ee26f6a.png">

\cc @gtanzillo 