### PR TITLE
Expose get_assigned_tos as virtual attribute to allow access via the API

### DIFF
--- a/app/models/miq_alert_set.rb
+++ b/app/models/miq_alert_set.rb
@@ -5,6 +5,8 @@ class MiqAlertSet < ApplicationRecord
 
   include AssignmentMixin
 
+  virtual_has_one :get_assigned_tos
+
   def self.assigned_to_target(target, options = {})
     get_assigned_for_target(target, options)
   end

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -78,6 +78,22 @@ describe AssignmentMixin do
     end
   end
 
+  describe "#get_assigned_tos" do
+    it "returns objects and tags" do
+      cc_classification = FactoryGirl.create(:classification_cost_center)
+      classification_tag = FactoryGirl.create(:classification_tag, :parent => cc_classification)
+      vm = FactoryGirl.create(:vm)
+      alert_set = FactoryGirl.create(:miq_alert_set)
+
+      alert_set.assign_to_objects([vm])
+      alert_set.assign_to_tags([classification_tag], "vms")
+
+      assigned_tos = alert_set.get_assigned_tos
+      expect(assigned_tos[:objects]).to include(vm)
+      expect(assigned_tos[:tags]).to include([classification_tag, "vms"])
+    end
+  end
+
   describe ".all_assignments" do
     it "returns only tags representing assignments" do
       t1 = Tag.create(:name => "/chargeback_rate/assigned_to/vm/tag/managed/environment/any1")


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-api/pull/348 

This exposes `get_assigned_tos` as a virtual attribute so that the assigned objects and tags (classifications) can be returned like so:

```
{  
   "href":"http://localhost:3000/api/alert_definition_profiles/10000000000084",
   "id":"10000000000084",
   ...
   "get_assigned_tos":{  
      "objects":[  
         {  
            "href":"http://localhost:3000/api/vms/10000000000001",
            "id":"10000000000001",
            "vendor":"vmware",
            "format":null,
            "version":null,
            "name":"jmarc-nginx",
            "description":null,
            ...
         }
      ],
      "tags":[  
         [  
            {  
               "id":"10000000000198",
               "description":"api",
               "icon":null,
               "read_only":false,
              ...
            },
            "vms"
         ]
      ],
      "labels":[  

      ]
   }
}
```

Have validated (as can be seen above) that `hrefs` are returned for objects. These tags are "classification tags" (class `Classification`), which are not currently exposed via the API. Will have to follow up with a PR for `Classification` to return those `href`s

@miq-bot assign @abellotti 