### PR TITLE
Filter out archived and orphaned VMs in 'Running VMs' filter

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -67,9 +67,13 @@
     description: Status / Running
     filter: !ruby/object:MiqExpression
       exp:
-        "=":
-          field: Vm-power_state
-          value: "on"
+        and:
+        - "=":
+            field: Vm-power_state
+            value: "on"
+        - "=":
+            field: Vm-active
+            value: "true"
     search_type: default
     db: Vm
 - attributes:
@@ -673,9 +677,13 @@
     description: Status / Running
     filter: !ruby/object:MiqExpression
       exp:
-        "=":
-          field: TemplateInfra-power_state
-          value: "on"
+        and:
+        - "=":
+            field: TemplateInfra-power_state
+            value: "on"
+        - "=":
+            field: VTemplateInfra-active
+            value: "true"
     search_type: default
     db: ManageIQ::Providers::InfraManager::Template
 - attributes:
@@ -1125,9 +1133,13 @@
     description: Status / Running
     filter: !ruby/object:MiqExpression
       exp:
-        "=":
-          field: VmInfra-power_state
-          value: "on"
+        and:
+        - "=":
+            field: VmInfra-power_state
+            value: "on"
+        - "=":
+            field: VmInfra-active
+            value: "true"
     search_type: default
     db: ManageIQ::Providers::InfraManager::Vm
 - attributes:


### PR DESCRIPTION
Filter out archived and orphaned VMs in 'Running VMs' filter

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1504006

@miq-bot add-label bug, reporting,  fine/yes,  gaprindashvili/yes  

on test DB there were 2 archived report with power state=on
**BEFORE:**
<img width="1234" alt="before" src="https://user-images.githubusercontent.com/6556758/37711904-b038261a-2ce8-11e8-9125-29dcd758a7e8.png">

**AFTER:**
<img width="1146" alt="after" src="https://user-images.githubusercontent.com/6556758/37711913-b5a556fe-2ce8-11e8-9cb7-891284ab6f7d.png">

\cc @gtanzillo

