### PR TITLE
Seed plugin ansible playbooks

### DIFF
--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -6,6 +6,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
     ensure_credential(provider, connection)
     ensure_inventory(provider, connection)
     ensure_host(provider, connection)
+    ensure_plugin_playbooks_project_seeded(connection)
   end
 
   def remove_demo_data(connection)

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -61,6 +61,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
     copy_plugin_ansible_content
 
     commit_git_plugin_content
+    FileUtils.chown_R('awx', 'awx', CONSOLIDATED_PLUGIN_PLAYBOOKS_TEMPDIR)
 
     project = existing_plugin_playbook_project(connection)
     if project

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -85,8 +85,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
   def copy_plugin_ansible_content
     FileUtils.mkdir_p(self.class.consolidated_plugin_directory)
 
-    # TODO: make this a public api via an attr_reader
-    Vmdb::Plugins.instance.instance_variable_get(:@registered_ansible_content).each do |content|
+    Vmdb::Plugins.instance.registered_ansible_content.each do |content|
       FileUtils.cp_r(Dir.glob("#{content.path}/*"), self.class.consolidated_plugin_directory)
     end
   end

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -108,9 +108,8 @@ module EmbeddedAnsibleWorker::ObjectManagement
     end
   end
 
-  PLUGIN_PLAYBOOK_PROJECT_NAME = "#{I18n.t('product.name')} Default Project".freeze
   PLAYBOOK_PROJECT_ATTRIBUTES = {
-      :name                 => PLUGIN_PLAYBOOK_PROJECT_NAME,
+      :name                 => "#{I18n.t('product.name')} Default Project".freeze,
       :scm_type             => "git",
       :scm_url              => "file://#{CONSOLIDATED_PLUGIN_PLAYBOOKS_TEMPDIR}",
       :scm_update_on_launch => false

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -89,10 +89,19 @@ module EmbeddedAnsibleWorker::ObjectManagement
 
   def commit_git_plugin_content
     Dir.chdir(CONSOLIDATED_PLUGIN_PLAYBOOKS_TEMPDIR) do
-      # ruggedize this
-      `git init`
-      `git add -A`
-      `git commit -m "YOLO Initial Commit"`
+      require 'rugged'
+      repo = Rugged::Repository.init_at(".")
+      index = repo.index
+      index.add_all("*")
+      index.write
+
+      options              = {}
+      options[:tree]       = index.write_tree(repo)
+      options[:author]     = options[:committer] = { :email => "system@localhost", :name => "System", :time => Time.now.utc }
+      options[:message]    = "Initial Commit"
+      options[:parents]    = []
+      options[:update_ref] = 'HEAD'
+      Rugged::Commit.create(repo, options)
     end
   end
 

--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -108,7 +108,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
     end
   end
 
-  PLUGIN_PLAYBOOK_PROJECT_NAME = "Default ManageIQ Playbook Project".freeze
+  PLUGIN_PLAYBOOK_PROJECT_NAME = "#{I18n.t('product.name')} Default Project".freeze
   PLAYBOOK_PROJECT_ATTRIBUTES = {
       :name                 => PLUGIN_PLAYBOOK_PROJECT_NAME,
       :scm_type             => "git",

--- a/app/models/manageiq/providers/embedded_ansible/provider/default_ansible_objects.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider/default_ansible_objects.rb
@@ -23,6 +23,10 @@ module ManageIQ::Providers::EmbeddedAnsible::Provider::DefaultAnsibleObjects
     get_default_ansible_object("host")
   end
 
+  def default_project
+    get_default_ansible_object("project")
+  end
+
   def default_organization=(org)
     set_default_ansible_object("organization", org)
   end
@@ -37,6 +41,10 @@ module ManageIQ::Providers::EmbeddedAnsible::Provider::DefaultAnsibleObjects
 
   def default_host=(host)
     set_default_ansible_object("host", host)
+  end
+
+  def default_project=(project)
+    set_default_ansible_object("project", project)
   end
 
   def delete_ansible_object(name)

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -2,6 +2,7 @@ module Vmdb
   class Plugins
     include Singleton
 
+    attr_reader :registered_ansible_content
     attr_reader :registered_automate_domains
 
     def initialize

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -136,6 +136,49 @@ describe EmbeddedAnsibleWorker do
       end
     end
 
+    describe "#ensure_plugin_playbooks_project_seeded" do
+      let!(:tmp_dir) { Pathname.new(Dir.mktmpdir("consolidated_ansible_playbooks")) }
+      let!(:expected_attributes) do
+        {
+          :name                 => "ManageIQ Default Project",
+          :scm_type             => "git",
+          :scm_url              => "file://#{tmp_dir}",
+          :scm_update_on_launch => false,
+          :organization         => 42
+        }
+      end
+
+      before do
+        provider.default_organization = 42
+        allow(EmbeddedAnsibleWorker).to receive(:consolidated_plugin_directory).and_return(tmp_dir)
+        allow(subject).to receive(:chown_playbooks_tempdir)
+      end
+
+      after do
+        FileUtils.rm_rf(tmp_dir)
+      end
+
+      it "creates a git project as the provider's default project" do
+        expect(proj_collection).to receive(:create!)
+          .with(expected_attributes.to_json)
+          .and_return(double(:id => 1234))
+
+        subject.ensure_plugin_playbooks_project_seeded(provider, api_connection)
+        expect(Dir.exist?(tmp_dir.join(".git"))).to be_truthy
+        expect(provider.default_project).to eq(1234)
+      end
+
+      it "updates an existing project" do
+        project = double(:id => 1234)
+        expect(subject).to receive(:find_default_project).and_return(project)
+        expect(project).to receive(:update_attributes!)
+          .with(expected_attributes)
+          .and_return(double(:id => 1234))
+
+        subject.ensure_plugin_playbooks_project_seeded(provider, api_connection)
+      end
+    end
+
     describe "#start_monitor_thread" do
       let(:pool) { double("ConnectionPool") }
 

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -37,6 +37,7 @@ describe EmbeddedAnsibleWorker do
         expect(cred_collection).to receive(:create!).and_return(cred_resource)
         expect(inv_collection).to receive(:create!).and_return(inv_resource)
         expect(host_collection).to receive(:create!).and_return(host_resource)
+        expect(subject).to receive(:ensure_plugin_playbooks_project_seeded)
 
         subject.ensure_initial_objects(provider, api_connection)
       end


### PR DESCRIPTION
* Clean the temp directory before each role activation
* Consolidates all gem plugin ansible content
* Creates git repo from this content
* Creates or updates an existing ansible project for this git repo
  * Links it to the default organization
  * The project id is retained so we can find by the id to retrieve it in the future

ManageIQ/manageiq-design#40
https://bugzilla.redhat.com/show_bug.cgi?id=1539762

All of this depends on:
https://github.com/ManageIQ/manageiq/pull/17096
ManageIQ/manageiq-content#254

To test this on downstream appliances:

```
yum install git patch

vmdb
wget https://github.com/ManageIQ/ManageIQ/manageiq/pull/17096.patch
patch -p1 < 17096.patch

cd `bundle show manageiq-content`
wget https://github.com/ManageIQ/manageiq-content/pull/254.patch
patch -p1 < 254.patch
```
