### PR TITLE
introduce evm:queue

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -56,6 +56,11 @@ namespace :evm do
     puts inventory.tableize if inventory.present?
   end
 
+  desc "Report overview of queue"
+  task :queue => :environment do
+    EvmApplication.queue_overview
+  end
+
   desc "Determine if the configured encryption key is valid"
   task :validate_encryption_key => :environment do
     raise "Invalid encryption key" unless EvmApplication.encryption_key_valid?


### PR DESCRIPTION
Let us welcome `rake evm:queue`

This lets us look into the queue and understand the health of the queue part of the system.
It lets you know how many of each message exists, and an idea of how long the wait is for the entries to get processed.

```
 Zone             | Queue              | Role           | method                                         | oldest     | count
------------------+--------------------+----------------+------------------------------------------------+------------+-------
 FLD NONPROD WKR1 | generic            | ems_operations | ExtManagementSystem.authentication_check_types | 2016-10-10 |     1
 ODC PROD WKR1    | ems_40000000000001 | ems_inventory  | EmsRefresh.refresh                             | 2016-08-22 |     1
 TDC PROD WKR1    | ems_70000000000001 | ems_inventory  | EmsRefresh.refresh                             | 2016-08-22 |     1
 default          | generic            |                | Session.check_session_timeout                  | 2016-05-23 |     1
 default          | miq_server         |                | MiqServer.restart                              | 2016-05-24 |     1
 default          | miq_server         |                | MiqServer.shutdown_and_exit                    | 2016-05-18 |    28
```

Followup to PRs like #17087 and #16980

/cc @dmetzger57 