### PR TITLE
Fix RefreshWorker dequeue race condition

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1175,6 +1175,7 @@
           :poll_method: :normal
           :queue_timeout: 120.minutes
           :restart_interval: 2.hours
+          :dequeue_method: :sql
         :ems_refresh_worker_ansible_tower_automation: {}
         :ems_refresh_worker_embedded_ansible_automation: {}
         :ems_refresh_worker_foreman_configuration: {}


### PR DESCRIPTION
A race condition is present on `RefreshWorker` when the worker is consolidated on related provider managers and one refresh tries to queue another refresh of all related managers.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1559442

## DRB dequeue
Default method for dequeue on any `QueueWorker` is [`:drb`](https://github.com/ManageIQ/manageiq/blob/d885f8c6d6fb33bad62d20a75d6ba82bd97a5942/app/models/miq_queue_worker_base/runner.rb#L35). This method is using a special [`Dequeue`](  https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_server/worker_management/dequeue.rb) module. This is an optimization, which does a job prefetch (in batches) for a worker - it peeks on the `MiqQueue` and finds a batch of jobs matching the worker `queue_name` and `priority`. That is done as one select query. Then, when a job from this batch is selected by the worker, the worker fetches whole record form database and proceeds to work on this job.

This means the database load is lowered, because `MiqQueue` is scanned and filtered only once for a batch of jobs.

## SQL dequeue
On the other hand the [`:sql`](https://github.com/ManageIQ/manageiq/blob/d885f8c6d6fb33bad62d20a75d6ba82bd97a5942/app/models/miq_queue_worker_base/runner.rb#L73) dequeue strategy filters the `MiqQueue` scanning for a viable job and returns the first record available. This might be slower due to the need for scanning of the queue each time.

## Race condition
In `RefreshWorker`s we're trying to achieve a chained reaction on consolidated workers (for example here on [Azure](https://github.com/ManageIQ/manageiq-providers-azure/blob/master/app/models/manageiq/providers/azure/cloud_manager/refresher.rb) and [Amazon](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager/refresher.rb)). If a user requests a full `CloudManager` refresh, we want to schedule a `NetworkManager` (or any other manager) refresh as well. This brings a new challenge and risk of job starvation when the `:drb` strategy is used:

1. Each `RefreshWorker`, when started, schedules an [initial refresh](https://github.com/ManageIQ/manageiq/blob/d885f8c6d6fb33bad62d20a75d6ba82bd97a5942/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb#L16) for all its `ExtManagementSystem`s. In other words a new job is added to `MiqQueue` for each `ems`. This job belongs to the queue of the `ems`'s `RefreshWorker` = all this jobs will be processed by this worker.
2. The `:drb` strategy prefetches some amount of jobs for the worker and for each job it remembers `:id`, `:lock_version`, `:priority` and `:role`. When the worker requests a new job to work on, it is selected from this batch.
3. The first job picked is the `CloudManager` initial refresh, because the provider addition strategy prefers cloud over network managers and naturally the record precedes by `:id` in database, so the job for cloud manager is queued as first.
4. When this job is done, it automatically tries to queue the job for other managers (as described above). This addition to queue is done via [`MiqQueue.put_or_update()` call](https://github.com/ManageIQ/manageiq/blob/d885f8c6d6fb33bad62d20a75d6ba82bd97a5942/app/models/ems_refresh.rb#L174). And the call finds the already existent initial refresh jobs for these managers so instead of putting new jobs in the queue, it rather updates the targets of the refresh.
5. `MiqQueue` supports [optimistic locking](http://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html) mechanism. The access and update done by `put_or_update` results in incrementation of the `:lock_version` counter.
6. The `RefreshWorker` tries to pick a new job. The `:drb` strategy has already prefetched the list of jobs which includes the initial refresh for the other managers as well. But these jobs have a different `:lock_version` now, so they are skipped and next job is picked.
7. If user starts scheduling new `CloudManager` refreshes in the time a different cloud refresh of the same `ems`  is being processed, it results in starvation for the jobs on other managers (which are queued by the cloud refresh), because suitable cloud refresh job is present every time.
8. The other manager can be refreshed if and only if queues processed by the worker are free of any other cloud refreshes.

## Proposed solution
The `RefreshWorker` is designed for heavy lifting on one provider and the access time to get a new job is a low priority in comparison of fast refresh resolutions. Using the `:sql` dequeue strategy eliminates the race condition, because it searches the `MiqQueue` each time - a fresh record is acquired every time and possibility of stalling is lowered.

@miq-bot add_label bug, core/workers
cc @Ladas