### PR TITLE
Refactor ensure_nondefault method for chargeback rate

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -132,6 +132,10 @@ class ChargebackRate < ApplicationRecord
     get_assigned_tos[:tags].present?
   end
 
+  def default?
+    super || description == 'Default Container Image Rate'
+  end
+
   ###########################################################
 
   private
@@ -150,7 +154,7 @@ class ChargebackRate < ApplicationRecord
   end
 
   def ensure_nondefault
-    if default? || description == 'Default Container Image Rate'
+    if default?
       errors.add(:rate, "default rate cannot be deleted")
       throw :abort
     end


### PR DESCRIPTION
**Fixing:** https://bugzilla.redhat.com/show_bug.cgi?id=1552260
**Needs to merge with the UI PR:** https://github.com/ManageIQ/manageiq-ui-classic/pull/3673

Refactor `ensure_nondefault` method so that a new `default?` method is created and improved: `super` is used instead of `default?`. The method is not private because we need it in chargeback controller, too.
