### PR TITLE
Fixed case of expression in OOTB report.

### DIFF
--- a/product/reports/520_Events - Policy/120_Policy Events2.yaml
+++ b/product/reports/520_Events - Policy/120_Policy Events2.yaml
@@ -6,7 +6,7 @@ reserved:
 title: Policy Events for the Last 7 Days
 conditions: !ruby/object:MiqExpression
   exp:
-    "after":
+    "AFTER":
       field: PolicyEvent.miq_policy_sets-created_on
       value: 7 Days Ago
 updated_on: 2009-04-06 20:18:30 Z


### PR DESCRIPTION
This was causing an issue when copying this report and trying to change an expression of new report.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1558087

@gtanzillo please review/verify.

was getting error prior to fix:
Error building timeline PG::UndefinedTable: ERROR: missing FROM-clause entry for table "miq_sets" LINE 1: ...s"."ems_id" AS t0_r15 FROM "policy_events" WHERE ("miq_sets"... ^ : SELECT "policy_events"."id" AS t0_r0, "policy_events"."miq_event_definition_id" AS t0_r1, "policy_events"."event_type" AS t0_r2, "policy_events"."miq_event_definition_description" AS t0_r3, "policy_events"."miq_policy_id" AS t0_r4, "policy_events"."miq_policy_description" AS t0_r5, "policy_events"."result" AS t0_r6, "policy_events"."timestamp" AS t0_r7, "policy_events"."target_id" AS t0_r8, "policy_events"."target_class" AS t0_r9, "policy_events"."target_name" AS t0_r10, "policy_events"."chain_id" AS t0_r11, "policy_events"."username" AS t0_r12, "policy_events"."host_id" AS t0_r13, "policy_events"."ems_cluster_id" AS t0_r14, "policy_events"."ems_id" AS t0_r15 FROM "policy_events" WHERE ("miq_sets"."created_on" BETWEEN '2018-03-19 00:00:00' AND '2018-03-25 23:59:59.999999') 

after fix:
![after](https://user-images.githubusercontent.com/3450808/37836986-65affb1a-2e8a-11e8-96d4-755512550688.png)
