### PR TITLE
Add vault credential support to automat playbook method.

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -39,7 +39,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook <
       :extra_vars               => options[:extra_vars].try(:to_json)
     }
 
-    %i(credential cloud_credential network_credential).each do |credential|
+    %i(credential vault_credential cloud_credential network_credential).each do |credential|
       cred_sym = "#{credential}_id".to_sym
       params[credential] = Authentication.find(options[cred_sym]).manager_ref if options[cred_sym]
     end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -1,5 +1,7 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
   let(:manager) { FactoryGirl.create(:embedded_automation_manager_ansible) }
+  let(:auth_one) { FactoryGirl.create(:authentication, :manager_ref => 6) }
+  let(:auth_two) { FactoryGirl.create(:authentication, :manager_ref => 8) }
   subject { FactoryGirl.create(:embedded_playbook, :manager => manager) }
 
   describe '#run' do
@@ -13,12 +15,14 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
 
   describe '#raw_create_job_template' do
     it 'delegates request to job template raw creation' do
-      options = {:inventory => 'inv', :extra_vars => {'a' => 'x'} }
+      options = {:inventory => 'inv', :extra_vars => {'a' => 'x'}, :credential_id => auth_one.id, :vault_credential_id => auth_two.id }
       option_matcher = hash_including(
-        :inventory  => 'inv',
-        :extra_vars => '{"a":"x"}',
-        :playbook   => subject.name,
-        :project    => 'mref'
+        :inventory        => 'inv',
+        :extra_vars       => '{"a":"x"}',
+        :playbook         => subject.name,
+        :project          => 'mref',
+        :credential       => '6',
+        :vault_credential => '8'
       )
 
       allow(subject).to receive(:configuration_script_source).and_return(double(:manager_ref => 'mref'))


### PR DESCRIPTION
Backend support for ManageIQ/manageiq-ui-classic#3468 for automate playbook method.

@miq-bot assign @gmcculloug
@miq-bot add_label enhancement, automate, gaprindashvili/yes

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1526048 required to get to Embedded Ansible 3.2.x

cc @syncrou @bzwei 