### PR TITLE
Cache MiqExpression.get_col_type in MiqReport::Formatting

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -58,11 +58,7 @@ module MiqReport::Formatting
 
     # Use default format for column stil nil
     if format.nil? || format == :_default_
-      expression_col = col_to_expression_col(col)
-      dt = MiqExpression.get_col_type(expression_col)
-      dt = value.class.to_s.downcase.to_sym if dt.nil?
-      dt = dt.to_sym unless dt.nil?
-      format = MiqReport::Formats.default_format_details_for(expression_col, col, dt)
+      format = format_from_miq_expression(col, value)
     else
       format = format.deep_clone # Make sure we don't taint the original
     end
@@ -246,5 +242,20 @@ module MiqReport::Formatting
 
   def format_model_name(val, _options = {})
     ui_lookup(:model => val)
+  end
+
+  private
+
+  def format_from_miq_expression(col, value)
+    @miq_exp_dt_map ||= {}
+    expression_col = col_to_expression_col(col)
+
+    unless @miq_exp_dt_map.key?(col)
+      @miq_exp_dt_map[col] = MiqExpression.get_col_type(expression_col)
+    end
+    dt = @miq_exp_dt_map[col]
+    dt = value.class.to_s.downcase if dt.nil?
+    dt = dt.to_sym unless dt.nil?
+    MiqReport::Formats.default_format_details_for(expression_col, col, dt)
   end
 end


### PR DESCRIPTION
I noticed while running a report that there were a lot of `0 row` queries being executed against the DB when running a report.  Turns out that when a report is building the `html` data, the `MiqReport::Formatting` code is checking for every column in every row what the format should be, even though it shouldn't change on a row by row basis.

Specifically, this becomes a problem when it uses `MiqExpression.get_col_type` to determine the format as it will fetch from the DB what the column type is to help determine the format.  This query does not get cached, so it is duplicated for every column in each row of the report dataset.  

The query in my tests (from the report described in  https://github.com/ManageIQ/manageiq/pull/17141 ) that was being repeated in the logs was as follows:

```SQL
SELECT  "custom_attributes".*
FROM "custom_attributes"
WHERE "custom_attributes"."name" = 'build-date:SECTION:docker_labels'
  AND "custom_attributes"."resource_type" = 'ContainerImage'
ORDER BY "custom_attributes"."id" ASC
LIMIT 1
```


Benchmarks
----------

Using the same dataset and report from https://github.com/ManageIQ/manageiq/pull/17141 , the difference before and after this change is as follows:

|        |     ms | queries | query (ms) |  rows |
|   ---: |   ---: |    ---: |       ---: |  ---: |
| before | 910076 |  219950 |   444531.4 | 80492 |
|  after | 250861 |  121752 |    43773.2 | 80491 |

Of note:  The changes from https://github.com/ManageIQ/manageiq/pull/17141 were in place in both runs of the above.


Links
-----

* Related to https://github.com/ManageIQ/manageiq/pull/17141
* https://bugzilla.redhat.com/show_bug.cgi?id=1552049