### PR TITLE
Add case insensitivity when validating uniqueness of name of new group/role

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -21,7 +21,7 @@ class MiqGroup < ApplicationRecord
 
   delegate :self_service?, :limited_self_service?, :disallowed_roles, :to => :miq_user_role, :allow_nil => true
 
-  validates :description, :presence => true, :unique_within_region => true
+  validates :description, :presence => true, :unique_within_region => { :match_case => false }
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
   before_destroy :ensure_can_be_destroyed
   after_destroy :reset_current_group_for_users

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -9,8 +9,7 @@ class MiqUserRole < ApplicationRecord
 
   virtual_column :vm_restriction,                   :type => :string
 
-  validates_presence_of   :name
-  validates_uniqueness_of :name
+  validates :name, :presence => true, :uniqueness => { :case_sensitive => false }
 
   serialize :settings
 


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=1537171

Add case insensitivity when validating uniqueness of the name of a new **group within a region.**
Add case insensitivity when validating uniqueness of the name of a new **role** + little refactoring.

---

**After:** (different capitalization but the same names => flash messages)
![group_after](https://user-images.githubusercontent.com/13417815/37856484-e750976e-2ef4-11e8-9d9f-eb5c1a69fc5a.png)
![role_after](https://user-images.githubusercontent.com/13417815/37856485-ea442436-2ef4-11e8-9fba-388106bf0dc4.png)
