### PR TITLE
Fix 200+ SQL CACHE statements when hitting /api in logs

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -27,7 +27,7 @@ class MiqUserRole < ApplicationRecord
   }
 
   def feature_identifiers
-    miq_product_features.pluck(:identifier)
+    @feature_identifiers ||= miq_product_features.pluck(:identifier)
   end
 
   # @param identifier [String] Product feature identifier to check if this role allows access to it


### PR DESCRIPTION
This prevents a large amount (over 200) of `CACHE` statements from showing up in the rails DEBUG logs for the `/api` endpoint.   More detailed explanation of this issue below.


Long Version (#noOneReadsMe #foreverAlone)
------------------------------------------

Added in https://github.com/ManageIQ/manageiq/pull/17007 and https://github.com/ManageIQ/manageiq-api/pull/311

This feature calls the newly created `MiqGroup.sui_product_features`, which is a `virtual_has_one`, and makes use of `MiqUserRole.allow?` for every feature being analyzed.  First, once, to fetch all of the feature children for "sui", and they once for every one of those "sui" child features.  The code where that happens:

```ruby
return [] unless miq_user_role.allows?(:identifier => 'sui')
MiqProductFeature.feature_all_children('sui').each_with_object([]) do |sui_feature, sui_features|
  sui_features << sui_feature if miq_user_role.allows?(:identifier => sui_feature)
end
```

The code for `MiqUserRole#allows?` calls `feature_identifiers`, which is just a call to `miq_product_features.pluck(:identifier)`.  The problem with this is that since `.pluck` is called, there is no model caching that would normally be done with the `miq_product_features` relation on `MiqUserRole`.

In a Rails request, this will always be cached, so this isn't too big of a deal, though under the hood, there is a decent amount of object `.dup` calls that end up happening.  But outside of it's use in a request, this might not be cached, so it actually performs the `.pluck` queries every time.  Prior to the change in this commit, this can be simulated by doing the following:

```ruby
User.where(:userid => "admin").first
    .miq_groups.first
    .sui_product_features
```

Adding caching basically prevents performing that operation from happening more than once.

The only concern with this is if we had code paths in `manageiq` that relied on fresh permissions of the `MiqUserRole` instance every time we checked, but that was also recently changed at the time of this commit:

https://github.com/ManageIQ/manageiq/pull/17008

And the `TODO` had been there for 2 years, so I think we are good ;)

Of note about the previous version of `MiqUserRole#feature_identifiers`:

```ruby
def feature_identifiers
  miq_product_features.collect(&:identifier)
end
```

While the `pluck` version avoids the `.collect` call every time this is called, the `miq_product_features` are cached, so it is just doing a loop over them every time and would have avoided the `CACHE` statements that this commit fixes.  That said, this version should be the best of both worlds since it will be less CPU cycles (since there isn't a `.collect` for each call of this method) and memory allocations overall (since we aren't doing a `.dup` under the hood in `ActiveRecord::QueryCache`).


Links
-----

* [Conversation that noticed the issue](https://gitter.im/ManageIQ/v2v?at=5ab2ba84fa066c5325581d82)
* [My Response](https://gitter.im/ManageIQ/v2v?at=5ab2bb3135dd17022e86e8a6)
* API change:  https://github.com/ManageIQ/manageiq-api/pull/311
* Supporting core PRS: 
    - https://github.com/ManageIQ/manageiq/pull/17007 
    - https://github.com/ManageIQ/manageiq/pull/17008


Steps for Testing/QA
--------------------

Take your pick:

1.  Run `bin/rails s` and log in.  The UI will eventually hit `/api` and that call shouldn't be loaded with any more than 6ish queries in the log.
2.  Run `bin/rails c` and run `User.where(:userid => "admin").first.miq_groups.first.sui_product_features`.  There should only be a handful of queries run to do that.

In both of the above, running on master should lead to a lot of `CACHE` statements in the log (assuming you have the rails log set to `DEBUG`)