### PR TITLE
Remove 'Storage Total' field from Chargeback Preview reports

### DIFF
--- a/product/charts/miq_reports/vm_chargeback.yaml
+++ b/product/charts/miq_reports/vm_chargeback.yaml
@@ -28,7 +28,6 @@ cols:
 - storage_allocated_cost
 - storage_used_metric
 - storage_used_cost
-- storage_metric
 - storage_cost
 - total_cost
 
@@ -58,7 +57,6 @@ col_order:
 - storage_allocated_cost
 - storage_used_metric
 - storage_used_cost
-- storage_metric
 - storage_cost
 - total_cost
 
@@ -88,7 +86,6 @@ headers:
 - Storage Allocated Cost
 - Storage Used
 - Storage Used Cost
-- Storage Total
 - Storage Total Cost
 - Total Cost
 
@@ -185,9 +182,6 @@ col_options:
     :grouping:
     - :total
   storage_cost:
-    :grouping:
-    - :total
-  storage_metric:
     :grouping:
     - :total
   storage_used_cost:


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1533671

Remove **'Storage Total'** field from Chargeback Preview reports, which were displayed after clicking on _Monitoring -> Chargeback Preview_ from summary page of a VM.

---

**Before:**
![storage_total_before](https://user-images.githubusercontent.com/13417815/37903752-4f35751a-30f9-11e8-833a-6aa647795c72.png)

**After:**
![storage_total_after](https://user-images.githubusercontent.com/13417815/37903479-635f0eee-30f8-11e8-9376-171ea62dda40.png)
