### PR TITLE
[WIP] remove rake task to create REGION file

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -62,12 +62,6 @@ namespace :evm do
     puts "Encryption key valid"
   end
 
-  desc "Write a remote region id to this server's REGION file"
-  task :join_region => :environment do
-    configured_region = ApplicationRecord.region_number_from_sequence.to_i
-    EvmApplication.set_region_file(Rails.root.join("REGION"), configured_region)
-  end
-
   # update_start can be called in an environment where the database configuration is
   # not set, so we need to give it a dummy config
   desc "Start updating the appliance"

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -176,15 +176,6 @@ class EvmApplication
     stop
   end
 
-  def self.set_region_file(region_file, new_region)
-    old_region = region_file.exist? ? region_file.read.to_i : nil
-
-    return if new_region == old_region
-
-    _log.info("Changing REGION file from [#{old_region}] to [#{new_region}]. Restart to use the new region.")
-    region_file.write(new_region)
-  end
-
   def self.encryption_key_valid?
     # if we're a new deployment we won't even be able to get the database row
     # and if there is no database row, allow this key to be used

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -235,48 +235,6 @@ describe EvmApplication do
     end
   end
 
-  describe ".set_region_file" do
-    let(:region_file) { Pathname.new(Tempfile.new("REGION").path) }
-
-    after do
-      FileUtils.rm_f(region_file)
-    end
-
-    context "when the region file exists" do
-      it "writes the new region if the regions differ" do
-        old_region = 1
-        new_region = 4
-
-        region_file.write(old_region)
-        described_class.set_region_file(region_file, new_region)
-        expect(region_file.read).to eq(new_region.to_s)
-      end
-
-      it "does not write the region if the regions are the same" do
-        old_region = 1
-        new_region = 1
-
-        region_file.write(old_region)
-        expect(region_file).not_to receive(:write)
-
-        described_class.set_region_file(region_file, new_region)
-      end
-    end
-
-    context "when the region file does not exist" do
-      before do
-        FileUtils.rm_f(region_file)
-      end
-
-      it "creates the file with the new region number" do
-        new_region = 4
-
-        described_class.set_region_file(region_file, new_region)
-        expect(region_file.read).to eq(new_region.to_s)
-      end
-    end
-  end
-
   describe ".deployment_status" do
     it "returns new_deployment if the database is not migrated" do
       expect(ActiveRecord::Migrator).to receive(:current_version).and_return(0)


### PR DESCRIPTION
We no longer use a `REGION` file to determine the region of an appliance.
This removes the rake task that creates it