### PR TITLE
Add 'breakable' optional argument to report_build_html_table method

### DIFF
--- a/lib/vmdb/global_methods.rb
+++ b/lib/vmdb/global_methods.rb
@@ -84,9 +84,9 @@ module Vmdb
     end
 
     # Wrap a report html table body with html table tags and headers for the columns
-    def report_build_html_table(report, table_body)
+    def report_build_html_table(report, table_body, breakable = true)
       html = ''
-      html << "<table class='table table-striped table-bordered'>"
+      html << "<table class=\"table table-striped table-bordered #{breakable ? '' : 'non-breakable'}\">"
       html << "<thead>"
       html << "<tr>"
 


### PR DESCRIPTION
**BZ:** https://bugzilla.redhat.com/show_bug.cgi?id=1428536
**Depends on** (PR to UI repo): https://github.com/ManageIQ/manageiq-ui-classic/pull/3681

---

Add _'breakable'_ optional argument to `report_build_html_table` method for fixing bad formatting of VM Chargeback Preview Report table (unset `word-break` css attribute). The purpose was not to break/edit any other tables if not needed.

**Before:**
![preview_before](https://user-images.githubusercontent.com/13417815/37917537-f7f16fcc-311e-11e8-94b9-ba750ff0792b.png)

**After:**
![preview_after](https://user-images.githubusercontent.com/13417815/37916477-316dbcb8-311c-11e8-9560-2c094dedc51d.png)

