### PR TITLE
Fix provider proxy settings fallback

### DIFF
--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -3,7 +3,8 @@ module VMDB
     def self.http_proxy_uri(proxy_config = :default)
       # TODO: (julian) This looks really messy. Need to make it look nicer.
 
-      proxy = (::Settings.http_proxy[proxy_config] || ::Settings.http_proxy).to_h
+      proxy = ::Settings.http_proxy[proxy_config].to_hash
+      proxy = ::Settings.http_proxy.to_hash unless proxy[:host]
       return nil unless proxy[:host]
 
       user     = proxy.delete(:user)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -6,42 +6,42 @@ describe VMDB::Util do
     end
 
     it "returns proxy for old settings" do
-      stub_settings(:http_proxy => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil})
+      stub_settings_merge(:http_proxy => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4"))
     end
 
     it "without a host" do
-      stub_settings(:http_proxy => {:default => {}})
+      stub_settings_merge(:http_proxy => {:default => {}})
       expect(described_class.http_proxy_uri).to be_nil
     end
 
     it "with host" do
-      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil}})
+      stub_settings_merge(:http_proxy => {:default => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4"))
     end
 
     it "with host, port" do
-      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => nil}})
+      stub_settings_merge(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321, :user => nil, :password => nil}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
                                                                       :port   => 4321))
     end
 
     it "with host, port, user" do
-      stub_settings(:http_proxy => {:default => {:host     => "1.2.3.4", :port => 4321, :user => "testuser",
+      stub_settings_merge(:http_proxy => {:default => {:host     => "1.2.3.4", :port => 4321, :user => "testuser",
                                                  :password => nil}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
                                                                       :port   => 4321, :userinfo => "testuser"))
     end
 
     it "with host, port, user, password" do
-      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
+      stub_settings_merge(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
                                                  :user => "testuser", :password => "secret"}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
                                                                       :port => 4321, :userinfo => "testuser:secret"))
     end
 
     it "with user missing" do
-      stub_settings(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
+      stub_settings_merge(:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
                                                  :user => nil, :password => "secret"}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4",
                                                                       :port => 4321))
@@ -51,14 +51,14 @@ describe VMDB::Util do
       password = "secret#"
       config = {:http_proxy => {:default => {:host => "1.2.3.4", :port => 4321,
                                              :user => "testuser", :password => password}}}
-      stub_settings(config)
+      stub_settings_merge(config)
       userinfo = "testuser:secret%23"
       uri_parts = {:scheme => "http", :host => "1.2.3.4", :port => 4321, :userinfo => userinfo}
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(uri_parts))
     end
 
     it "with scheme overridden" do
-      stub_settings(:http_proxy => {:default => {:scheme => "https", :host => "1.2.3.4", :port => 4321,
+      stub_settings_merge(:http_proxy => {:default => {:scheme => "https", :host => "1.2.3.4", :port => 4321,
                                                  :user => "testuser", :password => "secret"}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "https", :host => "1.2.3.4",
                                                                       :port   => 4321, :userinfo => "testuser:secret"))


### PR DESCRIPTION
The VMDB::Utils.http_proxy_uri uses per-provider proxy settings first,
then falls back to the base Settings.http_proxy.  It was doing this with
`::Settings.http_proxy[proxy_config] || ::Settings.http_proxy` but
`::Settings.http_proxy[proxy_config]` wasn't returning nil so it was
never falling back to the base proxy settings.

cc @Fryguy @blomquisg 