### PR TITLE
Add vault credential to factory and provision_job_options.

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -105,8 +105,11 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     job_options.deep_merge!(parse_dialog_options) unless action == ResourceAction::RETIREMENT
     job_options.deep_merge!(overrides)
 
-    credential_id = job_options.delete(:credential_id)
-    job_options[:credential] = Authentication.find(credential_id).manager_ref unless credential_id.blank?
+    %i(credential vault_credential).each do |cred|
+      cred_sym = "#{cred}_id".to_sym
+      credential_id = job_options.delete(cred_sym)
+      job_options[cred] = Authentication.find(credential_id).manager_ref if credential_id.present?
+    end
 
     hosts = job_options[:hosts]
     job_options[:inventory] = create_inventory_with_hosts(action, hosts).id unless use_default_inventory?(hosts)

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -106,6 +106,10 @@ FactoryGirl.define do
           :parent => :automation_manager_authentication,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential"
 
+  factory :ansible_vault_credential,
+          :parent => :automation_manager_authentication,
+          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::VaultCredential"
+
   factory :ansible_network_credential,
           :parent => :automation_manager_authentication,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential"

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -7,6 +7,7 @@ describe(ServiceAnsiblePlaybook) do
   let(:credential_0)   { FactoryGirl.create(:authentication, :manager_ref => '1') }
   let(:credential_1)   { FactoryGirl.create(:authentication, :manager_ref => 'a') }
   let(:credential_2)   { FactoryGirl.create(:authentication, :manager_ref => 'b') }
+  let(:credential_3)   { FactoryGirl.create(:authentication, :manager_ref => '2') }
   let(:decrpyted_val)  { 'my secret' }
   let(:encrypted_val)  { MiqPassword.encrypt(decrpyted_val) }
   let(:encrypted_val2) { MiqPassword.encrypt(decrpyted_val + "new") }
@@ -43,10 +44,11 @@ describe(ServiceAnsiblePlaybook) do
     {
       :config_info => {
         :provision => {
-          :hosts         => "default_host1,default_host2",
-          :credential_id => credential_0.id,
-          :playbook_id   => 10,
-          :extra_vars    => {
+          :hosts               => "default_host1,default_host2",
+          :credential_id       => credential_0.id,
+          :vault_credential_id => credential_3.id,
+          :playbook_id         => 10,
+          :extra_vars          => {
             "var1" => {:default => "default_val1"},
             :var2  => {:default => "default_val2"},
             "var3" => {:default => "default_val3"}
@@ -68,6 +70,7 @@ describe(ServiceAnsiblePlaybook) do
     {
       :provision_job_options => {
         :credential => 1,
+        :vault_credential => 2,
         :inventory  => 2,
         :hosts      => "default_host1,default_host2",
         :extra_vars => {'var1' => 'value1', 'var2' => 'value2', 'pswd' => encrypted_val}


### PR DESCRIPTION
- [ ] Add  ansible_vault_credential into factory.
- [ ] Add vault credential to service's provision_job_options.

Blocks https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/70.

@miq-bot assign @gmcculloug
@miq-bot add_label enhancement, gaprindashvili/yes, services

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1526048 required to get to Embedded Ansible 3.2.x