### PR TITLE
Add ownership for MiqRequest in RBAC

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -130,6 +130,26 @@ class MiqRequest < ApplicationRecord
     joins(:miq_approvals).where("miq_approvals.reason LIKE (?)", "#{reason[:start] ? '%' : ''}#{sanitize_sql_like(reason[:content])}#{reason[:end] ? '%' : ''}")
   end
 
+  def self.user_or_group_owned(user, miq_group)
+    if user && miq_group
+      user_owned(user).or(group_owned(miq_group))
+    elsif user
+      user_owned(user)
+    elsif miq_group
+      group_owned(miq_group)
+    else
+      none
+    end
+  end
+
+  def self.user_owned(user)
+    where(:requester_id => user.id)
+  end
+
+  def self.group_owned(miq_group)
+    where(:requester_id => miq_group.user_ids)
+  end
+
   # Supports old-style requests where specific request was a seperate table connected as a resource
   def resource
     self

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -125,6 +125,11 @@ module Rbac
       'Vm'                     => :descendant_ids
     }
 
+    # Classes inherited from these classes or mixins are allowing ownership feature on the target model
+    OWNERSHIP_CLASSES = %w(
+      OwnershipMixin
+    ).freeze
+
     include Vmdb::Logging
 
     def self.search(*args)
@@ -353,7 +358,8 @@ module Rbac
     end
 
     def self_service_ownership_scope?(miq_group, klass)
-      miq_group.present? && miq_group.self_service? && klass < OwnershipMixin
+      is_ownership_class = OWNERSHIP_CLASSES.any? { |allowed_ownership_klass| klass < allowed_ownership_klass.safe_constantize }
+      miq_group.present? && miq_group.self_service? && is_ownership_class
     end
 
     def self_service_ownership_scope(user, miq_group, klass)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -352,8 +352,12 @@ module Rbac
       targets.pluck(:id) if targets
     end
 
+    def self_service_ownership_scope?(miq_group, klass)
+      miq_group.present? && miq_group.self_service? && klass < OwnershipMixin
+    end
+
     def self_service_ownership_scope(user, miq_group, klass)
-      return nil if miq_group.nil? || !miq_group.self_service? || !(klass < OwnershipMixin)
+      return nil unless self_service_ownership_scope?(miq_group, klass)
 
       # for limited_self_service, use user's resources, not user.current_group's resources
       # for reports (user = nil), still use miq_group

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -129,6 +129,7 @@ module Rbac
     # scope user_or_group_owned is required on target model
     OWNERSHIP_CLASSES = %w(
       OwnershipMixin
+      MiqRequest
     ).freeze
 
     include Vmdb::Logging

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -125,7 +125,8 @@ module Rbac
       'Vm'                     => :descendant_ids
     }
 
-    # Classes inherited from these classes or mixins are allowing ownership feature on the target model
+    # Classes inherited from these classes or mixins are allowing ownership feature on the target model,
+    # scope user_or_group_owned is required on target model
     OWNERSHIP_CLASSES = %w(
       OwnershipMixin
     ).freeze
@@ -359,7 +360,7 @@ module Rbac
 
     def self_service_ownership_scope?(miq_group, klass)
       is_ownership_class = OWNERSHIP_CLASSES.any? { |allowed_ownership_klass| klass < allowed_ownership_klass.safe_constantize }
-      miq_group.present? && miq_group.self_service? && is_ownership_class
+      miq_group.present? && miq_group.self_service? && is_ownership_class && klass.respond_to?(:user_or_group_owned)
     end
 
     def self_service_ownership_scope(user, miq_group, klass)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -41,6 +41,7 @@ module Rbac
       MiddlewareMessaging
       MiddlewareServer
       MiddlewareServerGroup
+      MiqRequest
       NetworkPort
       NetworkRouter
       OrchestrationStack
@@ -351,7 +352,7 @@ module Rbac
       targets.pluck(:id) if targets
     end
 
-    def get_self_service_objects(user, miq_group, klass)
+    def self_service_ownership_scope(user, miq_group, klass)
       return nil if miq_group.nil? || !miq_group.self_service? || !(klass < OwnershipMixin)
 
       # for limited_self_service, use user's resources, not user.current_group's resources
@@ -366,7 +367,7 @@ module Rbac
       klass = scope.respond_to?(:klass) ? scope.klass : scope
       expression = miq_group.try(:entitlement).try(:filter_expression)
       expression.set_tagged_target(klass) if expression
-      u_filtered_ids = pluck_ids(get_self_service_objects(user, miq_group, klass))
+      u_filtered_ids = pluck_ids(self_service_ownership_scope(user, miq_group, klass))
       b_filtered_ids = get_belongsto_filter_object_ids(klass, user_filters['belongsto'])
       m_filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, expression || user_filters['managed']))
       d_filtered_ids = pluck_ids(matches_via_descendants(rbac_class(klass), user_filters['match_via_descendants'],

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -360,7 +360,7 @@ module Rbac
     end
 
     def self_service_ownership_scope?(miq_group, klass)
-      is_ownership_class = OWNERSHIP_CLASSES.any? { |allowed_ownership_klass| klass < allowed_ownership_klass.safe_constantize }
+      is_ownership_class = OWNERSHIP_CLASSES.any? { |allowed_ownership_klass| klass <= allowed_ownership_klass.safe_constantize }
       miq_group.present? && miq_group.self_service? && is_ownership_class && klass.respond_to?(:user_or_group_owned)
     end
 


### PR DESCRIPTION
Self service and limited self service users will see only his or his group's users miq_requests after this fix.

For ownership of MiqRequests to users we are using `requester_id`.

# Links 
https://bugzilla.redhat.com/show_bug.cgi?id=1545395

@miq-bot assign @gtanzillo 
