### PR TITLE
[WIP] Update SNMP OID to represent Red Hat Software private enterprise number

### DIFF
--- a/app/models/miq_snmp.rb
+++ b/app/models/miq_snmp.rb
@@ -87,9 +87,9 @@ class MiqSnmp
     end
   end
 
-  # IANA assigned Private Enterprise Number 33482 to ManageIQ
+  # IANA assigned Private Enterprise Number 2312 to Red Hat Software
   def self.enterprise_oid_string
-    @@enterprise_oid_string ||= "1.3.6.1.4.1.33482"
+    @@enterprise_oid_string ||= "1.3.6.1.4.1.2312"
   end
 
   def self.enterprise_oid


### PR DESCRIPTION
This replaces the old, ManageIQ number (33482) which no longer exists

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1551519

For additional detail see: 
http://www.alvestrand.no/objectid/1.3.6.1.4.1.2312.html
https://bugzilla.redhat.com/show_bug.cgi?id=1136818
