### PR TITLE
Add remote console feature for physical servers

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5945,7 +5945,10 @@
       :description: Provision Physical Server
       :feature_type: control
       :identifier: physical_server_provision
-
+    - :name: Physical Server Remote Console
+      :description: Access Physical Server Remote Console
+      :feature_type: control
+      :identifier: physical_server_remote_console
 # Firmwares
 - :name: Firmwares
   :description: Everything under Firmware


### PR DESCRIPTION
This feature is going to present on the physical server summary page (physical infrastructure providers). There will be a button that can be used to access the remote console for the currently viewed physical server (very similarly to what we already have on the vm summary page).
