### PR TITLE
[GAPRINDASHVILI] Compare decimal columns correctly in batch saver

### DIFF
--- a/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
+++ b/app/models/manager_refresh/save_collection/saver/concurrent_safe_batch.rb
@@ -101,13 +101,18 @@ module ManagerRefresh::SaveCollection
 
             next unless assert_distinct_relation(primary_key_value)
 
+            # Incoming values are in SQL string form.
             # TODO(lsmola) unify this behavior with object_index_with_keys method in InventoryCollection
             index = unique_index_keys_to_s.map do |attribute|
+              value = record_key(record, attribute)
               if attribute == "timestamp"
+                # TODO: can this be covered by @deserializable_keys?
                 type = model_class.type_for_attribute(attribute)
-                type.cast(record_key(record, attribute)).utc.iso8601.to_s
+                type.cast(value).utc.iso8601.to_s
+              elsif (type = deserializable_keys[attribute.to_sym])
+                type.deserialize(value).to_s
               else
-                record_key(record, attribute).to_s
+                value.to_s
               end
             end.join(inventory_collection.stringify_joiner)
 
@@ -258,7 +263,11 @@ module ManagerRefresh::SaveCollection
         # for every remainders(a last batch in a stream of batches)
         if !supports_remote_data_timestamp?(all_attribute_keys) || result.count == batch_size_for_persisting
           result.each do |inserted_record|
-            key                 = unique_index_columns.map { |x| inserted_record[x.to_s] }
+            key = unique_index_columns.map do |x|
+              value = inserted_record[x.to_s]
+              type = deserializable_keys[x]
+              type ? type.deserialize(value) : value
+            end
             inventory_object    = indexed_inventory_objects[key]
             inventory_object.id = inserted_record[primary_key] if inventory_object
           end

--- a/spec/models/manager_refresh/save_inventory/init_data_helper.rb
+++ b/spec/models/manager_refresh/save_inventory/init_data_helper.rb
@@ -56,6 +56,25 @@ module InitDataHelper
     init_data(network.network_ports(extra_attributes))
   end
 
+  # Following 2 are fictional, not like this in practice.
+  def container_quota_items_init_data(extra_attributes = {})
+    init_data(extra_attributes).merge(
+      :model_class => ContainerQuotaItem,
+      :arel        => ContainerQuotaItem.all,
+      :manager_ref => [:quota_desired], # a decimal column
+    )
+  end
+
+  # Quota items don't even have custom attrs; this is just to have a dependent
+  # for quota items collection to test their .id are set correctly.
+  def container_quota_items_attrs_init_data(extra_attributes = {})
+    init_data(extra_attributes).merge(
+      :model_class => CustomAttribute,
+      :arel        => CustomAttribute.where(:resource_type => 'ContainerQuotaItem'),
+      :manager_ref => [:name],
+    )
+  end
+
   def cloud
     ManagerRefresh::InventoryCollectionDefault::CloudManager
   end

--- a/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
@@ -171,6 +171,7 @@ describe ManagerRefresh::SaveInventory do
                 )
               )
             )
+
             @data[:container_quota_items] = ::ManagerRefresh::InventoryCollection.new(
               container_quota_items_init_data(inventory_collection_options(options))
             )
@@ -221,10 +222,10 @@ describe ManagerRefresh::SaveInventory do
             @container_quota_items_data_2 = container_quota_items_data(2)
 
             @container_quota_items_attrs_data_1 = container_quota_items_attrs_data(1).merge(
-              :resource => @data[:container_quota_items].lazy_find(container_quota_items_data(1)[:quota_desired])
+              :resource => @data[:container_quota_items].lazy_find(container_quota_items_data(1)[:quota_desired].to_s)
             )
             @container_quota_items_attrs_data_2 = container_quota_items_attrs_data(2).merge(
-              :resource => @data[:container_quota_items].lazy_find(container_quota_items_data(2)[:quota_desired])
+              :resource => @data[:container_quota_items].lazy_find(container_quota_items_data(2)[:quota_desired].to_s)
             )
 
             # Fill InventoryCollections with data
@@ -249,6 +250,7 @@ describe ManagerRefresh::SaveInventory do
             add_data_to_inventory_collection(@data[:container_quota_items_attrs],
                                              @container_quota_items_attrs_data_1,
                                              @container_quota_items_attrs_data_2)
+
             # Assert data before save
             expect(@network_port1.device).to eq @vm1
             expect(@network_port1.name).to eq "network_port_name_1"

--- a/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
@@ -171,6 +171,12 @@ describe ManagerRefresh::SaveInventory do
                 )
               )
             )
+            @data[:container_quota_items] = ::ManagerRefresh::InventoryCollection.new(
+              container_quota_items_init_data(inventory_collection_options(options))
+            )
+            @data[:container_quota_items_attrs] = ::ManagerRefresh::InventoryCollection.new(
+              container_quota_items_attrs_init_data(inventory_collection_options(options))
+            )
 
             # Parse data for InventoryCollections
             @network_port_data_1  = network_port_data(1).merge(
@@ -211,6 +217,16 @@ describe ManagerRefresh::SaveInventory do
             @image_data_2 = image_data(2).merge(:name => "image_changed_name_2")
             @image_data_3 = image_data(3).merge(:name => "image_changed_name_3")
 
+            @container_quota_items_data_1 = container_quota_items_data(1)
+            @container_quota_items_data_2 = container_quota_items_data(2)
+
+            @container_quota_items_attrs_data_1 = container_quota_items_attrs_data(1).merge(
+              :resource => @data[:container_quota_items].lazy_find(container_quota_items_data(1)[:quota_desired])
+            )
+            @container_quota_items_attrs_data_2 = container_quota_items_attrs_data(2).merge(
+              :resource => @data[:container_quota_items].lazy_find(container_quota_items_data(2)[:quota_desired])
+            )
+
             # Fill InventoryCollections with data
             add_data_to_inventory_collection(@data[:network_ports],
                                              @network_port_data_1,
@@ -227,6 +243,12 @@ describe ManagerRefresh::SaveInventory do
             add_data_to_inventory_collection(@data[:miq_templates],
                                              @image_data_2,
                                              @image_data_3)
+            add_data_to_inventory_collection(@data[:container_quota_items],
+                                             @container_quota_items_data_1,
+                                             @container_quota_items_data_2)
+            add_data_to_inventory_collection(@data[:container_quota_items_attrs],
+                                             @container_quota_items_attrs_data_1,
+                                             @container_quota_items_attrs_data_2)
             # Assert data before save
             expect(@network_port1.device).to eq @vm1
             expect(@network_port1.name).to eq "network_port_name_1"
@@ -252,6 +274,11 @@ describe ManagerRefresh::SaveInventory do
             @network_port12.reload
 
             @image2 = MiqTemplate.find(@image2.id)
+
+            @quota_item_1 = ContainerQuotaItem.find_by(:quota_desired => container_quota_items_data(1)[:quota_desired])
+            @quota_item_2 = ContainerQuotaItem.find_by(:quota_desired => container_quota_items_data(2)[:quota_desired])
+            @quota_attr_1 = CustomAttribute.find_by(:name => container_quota_items_attrs_data(1)[:name])
+            @quota_attr_2 = CustomAttribute.find_by(:name => container_quota_items_attrs_data(2)[:name])
 
             # Check ICs stats
             expect(@data[:vms].created_records).to match_array(record_stats([@vm3, @vm31]))
@@ -391,6 +418,19 @@ describe ManagerRefresh::SaveInventory do
             )
 
             expect(::ManageIQ::Providers::CloudManager::AuthKeyPair.all).to eq([])
+
+            assert_all_records_match_hashes(
+              [CustomAttribute.where(:resource_type => 'ContainerQuotaItem')],
+              {
+                :id          => @quota_attr_1.id,
+                :name        => @quota_attr_1.name,
+                :resource_id => @quota_item_1.id,
+              }, {
+                :id          => @quota_attr_2.id,
+                :name        => @quota_attr_2.name,
+                :resource_id => @quota_item_2.id,
+              }
+            )
           end
         end
       end

--- a/spec/models/manager_refresh/save_inventory/spec_parsed_data.rb
+++ b/spec/models/manager_refresh/save_inventory/spec_parsed_data.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module SpecParsedData
   def vm_data(i, data = {})
     {
@@ -97,6 +99,19 @@ module SpecParsedData
       :ems_ref               => "network_port_ems_ref_#{i}",
       :status                => "network_port_status#{i}",
       :mac_address           => "network_port_mac_#{i}",
+    }.merge(data)
+  end
+
+  def container_quota_items_data(i, data = {})
+    {
+      :quota_desired => BigDecimal("#{i}.#{i}"),
+    }.merge(data)
+  end
+
+  def container_quota_items_attrs_data(i, data = {})
+    {
+      :name          => "container_quota_items_attrs_#{i}",
+      :resource_type => "ContainerQuotaItem",
     }.merge(data)
   end
 end


### PR DESCRIPTION
Backport (again) #17020, the only difference being @Ladas's `.to_s` test fix #17194 (see separate commits).

I didn't remember what exactly this test was suppossed to test :-), so wasn't sure that `.to_s` fix retains the test meaning, took me a couple days to understand & experiment...

- The `.to_s` is fine, the `lazy_find` done here is not the part tested.
- Turns out the test as I wrote it only checked the [addition to `map_ids_to_inventory_objects`](https://github.com/ManageIQ/manageiq/pull/17020/files#diff-7c21a46a3d372504f628e6ce9a96b65cR270).  It still checks it  — breaks without it.
- The [addition to `update_or_destroy_records!`](https://github.com/ManageIQ/manageiq/pull/17020/files#diff-7c21a46a3d372504f628e6ce9a96b65cR112) isn't checked because test does just 1 refresh and all quota-related records are new.
  I can't simply wrap the test in `2.times do ... end`, other parts break.

  ~~=> I'll maybe try to change the test to pre-create one of quotas before refresh.  But that would be a separate PR to master first.~~

  EDIT: however, this part *is* checked by manageiq-providers-kubernetes specs, so I think it's good enough as is.

https://bugzilla.redhat.com/show_bug.cgi?id=1559544 (gaprindashvili)