### PR TITLE
Fixed error with dialog expression when virtual column involved

### DIFF
--- a/lib/miq_expression/subst_mixin.rb
+++ b/lib/miq_expression/subst_mixin.rb
@@ -71,6 +71,7 @@ module MiqExpression::SubstMixin
         end
         exp[key]["value"] = value # Replace the exp value with the proper qs value
       end
+      exp.delete(:token)
     end
   end
 

--- a/spec/lib/miq_expression/subst_mixin_spec.rb
+++ b/spec/lib/miq_expression/subst_mixin_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe MiqExpression::SubstMixin do
+  let(:test_class) { Class.new { include MiqExpression::SubstMixin } }
+  let(:test_obj) { test_class.new }
+
+  describe "#exp_replace_qs_tokens" do
+    it "removes :token key from passed expression" do
+      exp = {"=" => {"field" => "Vm-active", "value" => "true"}, :token => 1}
+      test_obj.exp_replace_qs_tokens(exp, {})
+      expect(exp).to eq("=" => {"field" => "Vm-active", "value" => "true"})
+    end
+  end
+end

--- a/spec/lib/miq_expression/subst_mixin_spec.rb
+++ b/spec/lib/miq_expression/subst_mixin_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe MiqExpression::SubstMixin do
 
   describe "#exp_replace_qs_tokens" do
     it "removes :token key from passed expression" do
-      exp = {"=" => {"field" => "Vm-active", "value" => "true"}, :token => 1}
+      exp = {"and" => [{"=" => {"field" => "Vm-active", "value" => "true"}, :token => 1}, {"=" => {"field" => "Vm-archived", "value" => "true"}, :token => 2}]}
       test_obj.exp_replace_qs_tokens(exp, {})
-      expect(exp).to eq("=" => {"field" => "Vm-active", "value" => "true"})
+      expect(exp).to eq("and" => [{"=" => {"field" => "Vm-active", "value" => "true"}}, {"=" => {"field" => "Vm-archived", "value" => "true"}}])
     end
   end
 end


### PR DESCRIPTION
**ISSUE**: 
   When virtual column involved in expression for automate method than error raised during attempt to order service. Error `operator 'token' is not supported...` raised  when `MiqExpression` trying to convert expression to sql.
The same expression works fine in other places, like report.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1558926

**Automation vs Report:**
   Automation do special pre-processing of expression (before converting to sql) and substitute value in expression with supplied tokens (if any). This pre-processing includes adding temporary entry like `:token=>1` and supposed to be removed after automation specific pre-processing finished.

There is place on UI side were those temporary tokens removed before saving record: https://github.com/ManageIQ/manageiq-ui-
classic/blob/f16e3f542c0463773ca19291ddd8884e8863aa9c/app/controllers/application_controller/filter.rb#L343 , but there is no clean-up on automation side during method invocation

**FIX**:
Remove temporary tokens from expression during token substitution. 
It would allow to skip attempt to transfer expression `to_sql` here: https://github.com/ManageIQ/manageiq/blob/9e95f2ba1a471c4bba37c2d51fe2b11c55f57606/lib/miq_expression.rb#L289



EXPRESSION:
<img width="934" alt="setting-virtual" src="https://user-images.githubusercontent.com/6556758/37998287-07dba704-31ec-11e8-998c-94ec9e70a434.png">


BEFORE:
<img width="1187" alt="before" src="https://user-images.githubusercontent.com/6556758/37998313-20467d00-31ec-11e8-88fb-f0ca5fa54b72.png">


AFTER:
<img width="1042" alt="after" src="https://user-images.githubusercontent.com/6556758/37998310-1b7c957a-31ec-11e8-97a5-93d746d09472.png">


@miq-bot add-label bug

\cc @gtanzillo @gmcculloug 
