### PR TITLE
Makes http_proxy_uri class method

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -25,7 +25,11 @@ module ManageIQ::Providers
     end
 
     def http_proxy_uri
-      VMDB::Util.http_proxy_uri(emstype.try(:to_sym)) || VMDB::Util.http_proxy_uri
+      self.class.http_proxy_uri
+    end
+
+    def self.http_proxy_uri
+      VMDB::Util.http_proxy_uri(ems_type.try(:to_sym)) || VMDB::Util.http_proxy_uri
     end
 
     def self.default_blacklisted_event_names


### PR DESCRIPTION
Instance method uses new class method.
Class method needed by UI when adding new cloud provider and validating it.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1552114
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1559019

PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/3693

Cc @agrare 
