### PR TITLE
Don't ignore errors in Vm#running_processes

### DIFF
--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -76,7 +76,7 @@ class Vm < VmOrTemplate
     check = validate_collect_running_processes
     unless check[:message].nil?
       _log.warn(check[:message].to_s)
-      return pl
+      raise check[:message].to_s
     end
 
     begin


### PR DESCRIPTION
The Vm#running_processes method currently logs all errors/exceptions
instead of raising them up.  This causes the tasks to look like they
were successful even though there are warnings in the log about
mis-configuration which should be corrected by the user.

The bottom two tasks were from before this change, they actually failed but look successful in the task list.  The top two tasks were from after this change.

![screenshot from 2018-03-28 09-30-10](https://user-images.githubusercontent.com/12851112/38032056-b038d8e4-326a-11e8-94cd-28dc55e44fb9.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1534023