### PR TITLE
Resolve string handling for "https://" or "http://" in update_rhsm_conf

### DIFF
--- a/app/models/registration_system.rb
+++ b/app/models/registration_system.rb
@@ -83,8 +83,9 @@ module RegistrationSystem
 
     return unless option_values[:proxy_address]
 
-    write_rhsm_config(:proxy_hostname => option_values[:proxy_address].split(':')[0],
-                      :proxy_port     => option_values[:proxy_address].split(':')[1],
+    proxy_uri = option_values[:proxy_address].gsub(/http(|s):\/\//, "")
+    write_rhsm_config(:proxy_hostname => proxy_uri.split(':')[0],
+                      :proxy_port     => proxy_uri.split(':')[1],
                       :proxy_user     => option_values[:proxy_username],
                       :proxy_password => option_values[:proxy_password])
   end

--- a/app/models/registration_system.rb
+++ b/app/models/registration_system.rb
@@ -83,9 +83,9 @@ module RegistrationSystem
 
     return unless option_values[:proxy_address]
 
-    proxy_uri = option_values[:proxy_address].gsub(/http(|s):\/\//, "")
-    write_rhsm_config(:proxy_hostname => proxy_uri.split(':')[0],
-                      :proxy_port     => proxy_uri.split(':')[1],
+    proxy_uri = URI.parse(option_values[:proxy_address].include?("://") ? option_values[:proxy_address] : "http://#{option_values[:proxy_address]}")
+    write_rhsm_config(:proxy_hostname => proxy_uri.host,
+                      :proxy_port     => proxy_uri.port,
                       :proxy_user     => option_values[:proxy_username],
                       :proxy_password => option_values[:proxy_password])
   end

--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -181,7 +181,7 @@ describe RegistrationSystem do
         ssl_verify_depth = 3
 
         # an http proxy server to use
-        proxy_hostname = 192.0.2.0
+        proxy_hostname = ProxyHostnameValue
 
         # port for http proxy server
         proxy_port = myport
@@ -210,16 +210,18 @@ describe RegistrationSystem do
 
     context "will save then update the original config file" do
       ["", "http://", "https://"].each do |prefix|
-        params = {
-          :registration_http_proxy_server   => "#{prefix}192.0.2.0:myport",
-          :registration_http_proxy_username => "my_dummy_username",
-          :registration_http_proxy_password => "my_dummy_password"
-        }
+        ["proxy.example.com", "192.0.2.0", "[2001:db8::]"].each do |address|
+          params = {
+            :registration_http_proxy_server   => "#{prefix}#{address}:myport",
+            :registration_http_proxy_username => "my_dummy_username",
+            :registration_http_proxy_password => "my_dummy_password"
+          }
 
-        it "with #{params[:registration_http_proxy_server]}" do
-          RegistrationSystem.update_rhsm_conf(params)
-          expect(File.read("#{rhsm_conf.path}.miq_orig")).to eq(original_rhsm_conf)
-          expect(File.read(rhsm_conf)).to eq(updated_rhsm_conf)
+          it "with #{params[:registration_http_proxy_server]}" do
+            RegistrationSystem.update_rhsm_conf(params)
+            expect(File.read("#{rhsm_conf.path}.miq_orig")).to eq(original_rhsm_conf)
+            expect(File.read(rhsm_conf)).to eq(updated_rhsm_conf.sub(/ProxyHostnameValue/, address))
+          end
         end
       end
     end

--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -209,24 +209,18 @@ describe RegistrationSystem do
     end
 
     context "will save then update the original config file" do
-      let(:params) { {:registration_http_proxy_username => "my_dummy_username", :registration_http_proxy_password => "my_dummy_password"} }
+      ["", "http://", "https://"].each do |prefix|
+        params = {
+          :registration_http_proxy_server   => "#{prefix}192.0.2.0:myport",
+          :registration_http_proxy_username => "my_dummy_username",
+          :registration_http_proxy_password => "my_dummy_password"
+        }
 
-      it "with server:port" do
-        RegistrationSystem.update_rhsm_conf(params.merge(:registration_http_proxy_server => "192.0.2.0:myport"))
-        expect(File.read("#{rhsm_conf.path}.miq_orig")).to eq(original_rhsm_conf)
-        expect(File.read(rhsm_conf)).to eq(updated_rhsm_conf)
-      end
-
-      it "with http://server:port" do
-        RegistrationSystem.update_rhsm_conf(params.merge(:registration_http_proxy_server => "http://192.0.2.0:myport"))
-        expect(File.read("#{rhsm_conf.path}.miq_orig")).to eq(original_rhsm_conf)
-        expect(File.read(rhsm_conf)).to eq(updated_rhsm_conf)
-      end
-
-      it "with https://server:port" do
-        RegistrationSystem.update_rhsm_conf(params.merge(:registration_http_proxy_server => "https://192.0.2.0:myport"))
-        expect(File.read("#{rhsm_conf.path}.miq_orig")).to eq(original_rhsm_conf)
-        expect(File.read(rhsm_conf)).to eq(updated_rhsm_conf)
+        it "with #{params[:registration_http_proxy_server]}" do
+          RegistrationSystem.update_rhsm_conf(params)
+          expect(File.read("#{rhsm_conf.path}.miq_orig")).to eq(original_rhsm_conf)
+          expect(File.read(rhsm_conf)).to eq(updated_rhsm_conf)
+        end
       end
     end
 

--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -184,7 +184,7 @@ describe RegistrationSystem do
         proxy_hostname = ProxyHostnameValue
 
         # port for http proxy server
-        proxy_port = myport
+        proxy_port = 0
 
         # user name for authenticating to an http proxy, if needed
         proxy_user = my_dummy_username
@@ -212,7 +212,7 @@ describe RegistrationSystem do
       ["", "http://", "https://"].each do |prefix|
         ["proxy.example.com", "192.0.2.0", "[2001:db8::]"].each do |address|
           params = {
-            :registration_http_proxy_server   => "#{prefix}#{address}:myport",
+            :registration_http_proxy_server   => "#{prefix}#{address}:0",
             :registration_http_proxy_username => "my_dummy_username",
             :registration_http_proxy_password => "my_dummy_password"
           }
@@ -234,10 +234,10 @@ describe RegistrationSystem do
     it "with no options will use database valuses" do
       MiqDatabase.seed
       MiqDatabase.first.update_attributes(
-        :registration_http_proxy_server => "192.0.2.0:myport"
+        :registration_http_proxy_server => "192.0.2.0:0"
       )
       RegistrationSystem.update_rhsm_conf
-      expect(File.read(rhsm_conf)).to include("proxy_hostname = 192.0.2.0", "proxy_port = myport")
+      expect(File.read(rhsm_conf)).to include("proxy_hostname = 192.0.2.0", "proxy_port = 0")
     end
   end
 end


### PR DESCRIPTION
Previously, if a proxy URI was entered into the registration page leading with
"https://" or "http://", it would be incorrectly entered into the rhsm.conf.
This patch prevents this by ensuring it is a valid URI, and correctly parsing
the string regardless if it has only a host in the URI or if it leads with the
protocol.