### PR TITLE
Add custom Azure logger

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -113,7 +113,7 @@ module Vmdb
       $api_log           = create_multicast_logger(path_dir.join("api.log"))
       $miq_ae_logger     = create_multicast_logger(path_dir.join("automation.log"))
       $aws_log           = create_multicast_logger(path_dir.join("aws.log"))
-      $azure_log         = create_multicast_logger(path_dir.join("azure.log"))
+      $azure_log         = create_multicast_logger(path_dir.join("azure.log"), AzureLogger)
       $cn_monitoring_log = create_multicast_logger(path_dir.join("container_monitoring.log"))
       $datawarehouse_log = create_multicast_logger(path_dir.join("datawarehouse.log"))
       $fog_log           = create_multicast_logger(path_dir.join("fog.log"), FogLogger)

--- a/lib/vmdb/loggers/azure_logger.rb
+++ b/lib/vmdb/loggers/azure_logger.rb
@@ -1,0 +1,26 @@
+module Vmdb::Loggers
+  class AzureLogger < VMDBLogger
+    def initialize(*loggers)
+      super
+
+      # pulled from Ruby's `Logger::Formatter`, which is what it defaults to when it is `nil`
+      @datetime_format = "%Y-%m-%dT%H:%M:%S.%6N "
+      @formatter       = Vmdb::Loggers::AzureLogger::Formatter.new
+    end
+
+    def <<(msg)
+      msg = msg.strip
+      log(level, msg)
+      msg.size
+    end
+
+    class Formatter < VMDBLogger::Formatter
+      def call(severity, datetime, progname, msg)
+        msg = msg.sub(/Bearer(.*?)\"/, 'Bearer [FILTERED] "')
+        msg = msg.sub(/SharedKey(.*?)\"/, 'SharedKey [FILTERED] "')
+        msg = msg.sub(/client_secret=(.*?)&/, "client_secret=[FILTERED]&")
+        super(severity, datetime, progname, msg)
+      end
+    end
+  end
+end

--- a/spec/lib/vmdb/loggers/azure_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/azure_logger_spec.rb
@@ -1,0 +1,26 @@
+describe Vmdb::Loggers::AzureLogger do
+  before do
+    @log_stream = StringIO.new
+    @log = described_class.new(@log_stream)
+  end
+
+  context "azure" do
+    it "filters out bearer tokens" do
+      @log.log(@log.level, 'Bearer abcd1234 "stuff"')
+      @log_stream.rewind
+      expect(@log_stream.read).to match(Regexp.quote('Bearer [FILTERED] "stuff"'))
+    end
+
+    it "filters out sharedkey tokens" do
+      @log.log(@log.level, 'SharedKey xxx123 "stuff"')
+      @log_stream.rewind
+      expect(@log_stream.read).to match(Regexp.quote('SharedKey [FILTERED] "stuff"'))
+    end
+
+    it "filters out client secret tokens" do
+      @log.log(@log.level, 'client_secret=abc123&management=yadayada')
+      @log_stream.rewind
+      expect(@log_stream.read).to match(Regexp.quote('client_secret=[FILTERED]&management=yadayada'))
+    end
+  end
+end


### PR DESCRIPTION
Because of quirks of the rest-client library (see https://github.com/rest-client/rest-client/issues/34), the `$azure_log` does not include timestamp information (see https://github.com/ManageIQ/manageiq-providers-azure/issues/177). In addition, the current log includes potentially sensitive information that should be filtered, such as bearer token information. This information also happens to be large, resulting in a rather large log file after a relatively short amount of time.

Applying a custom filter to the logger requires a special subclass, as the formatter is not directly accessible from the $azure_log once created. This subclass sets the formatter so that not only adds the timestamp information, it also filters out Bearer token strings (which are passed along with most Azure REST API requests), SharedKey token strings (used to access Azure's unmanaged storage accounts) and client_id strings (used when initially generating the Bearer token).

Each Bearer token is over 1300 bytes, so this would not only filter potentially sensitive information, it reduces the size of each logged request by over 1k per request.

To test: Add or refresh an Azure cloud provider, and watch the azure.log file.

~~WIP for now until I can figure out why it always seems to set the severity to WARN, and can add some real specs.~~

Added some specs. The WARN is because that's the default setting for the Azure provider.