### PR TITLE
Providers discovery without unspecified discovery types (FIX)

### DIFF
--- a/lib/manageiq/network_discovery/discovery.rb
+++ b/lib/manageiq/network_discovery/discovery.rb
@@ -29,6 +29,7 @@ module ManageIQ
         end
 
         if ping
+          raise ArgumentError, "must pass discover_types" if ost.discover_types.blank?
           # Trigger probes
           ost.discover_types.each do |type|
             next unless PROVIDERS_BY_TYPE.include?(type)


### PR DESCRIPTION
Host discovery raises exception without discovery types options

Cc @agrare 

Links 
----------------

* PR https://github.com/ManageIQ/manageiq-providers-vmware/pull/221
Doesn't block that PR

Steps for Testing/QA [Optional]
-------------------------------
In Rails console, put 
`Host.discoverHost(Marshal.dump({:ipaddr => '10.8.196.29'}))`
