### PR TITLE
Restrict ansible_tower_client to =0.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :amazon, :manageiq_default do
 end
 
 group :ansible, :manageiq_default do
-  gem "ansible_tower_client",           "~>0.12.2",      :require => false
+  gem "ansible_tower_client",           "=0.12.2",   :require => false
 end
 
 group :azure, :manageiq_default do


### PR DESCRIPTION
Current master of `ansible_tower_client` requires `faraday ~> 0.13`. This is in conflict with other packages that require `faraday`:
* `prometheus-alert-buffer-client`required by
  `manageiq-providers-kubernetes`requires `faraday ~> 0.9.2`
* `xclarity_client` required by `manageiq-providers-lenovo` requires `faraday ~> 0.9.2`

Any future released version of `ansible_tower_client` would thus make `manageiq` unbundleable.

This is the `ansible_tower_client` PR that upgrades `faraday`: https://github.com/ansible/ansible_tower_client_ruby/pull/97

Here is a list of `faraday` dependencies: https://gist.github.com/Glutexo/0caa78980a09fd8fdaecb1b1c521cba0#gistcomment-2394617 The `manageiq-api-client`’s failing `faraday` dependency listed in this gist has been already fixed.