### PR TITLE
Improve end of life of resource in metering/chargeback reports

### DIFF
--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -25,8 +25,12 @@ class Chargeback
       [@start_time, born_at].compact.max
     end
 
+    def resource_end_of_life
+      resource.try(:retires_on)
+    end
+
     def consumption_end
-      [Time.current, @end_time, resource.try(:retires_on)].compact.min
+      [Time.current, @end_time, resource_end_of_life].compact.min
     end
 
     private

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -26,7 +26,11 @@ class Chargeback
     end
 
     def resource_end_of_life
-      resource.try(:retires_on)
+      if resource.try(:retires_on)
+        resource.retires_on
+      elsif resource.try(:ems_id).nil?
+        resource.try(:updated_on)
+      end
     end
 
     def consumption_end


### PR DESCRIPTION
when we was determining end of life of vm, we didn't consider a case when VM has been disconnected.

it means the it doesn't have a provider. Vm#ems_is == nil and updated_on is updated.

so we need to use `Vm#updated_on` for this case 


@miq-bot add_label bug, chargeback
@miq-bot assign @gtanzillo 