### PR TITLE
Initialize MiqQueue.miq_task_id column when queuing ems-refresh task 

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -195,6 +195,7 @@ module EmsRefresh
       item.merge(
         :data        => targets,
         :task_id     => task_id,
+        :miq_task_id => task_id,
         :msg_timeout => queue_timeout
       )
     end


### PR DESCRIPTION
This PR will allow to automatically initialize `MiqTask.started_on` field when `ems_refresh` queued command delivered.

This PR is follow-up to https://github.com/ManageIQ/manageiq/pull/17015

@miq-bot add-label core, technical debt