### PR TITLE
Add child retirement task methods

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -14,5 +14,47 @@ class ServiceRetireTask < MiqRetireTask
   end
 
   def task_finished
+    update_attributes(:status => status == 'Ok' ? 'Completed' : 'Failed')
+  end
+
+  def task_active
+    update_attributes(:status => 'Active')
+  end
+
+  def after_request_task_create
+    update_attributes(:description => get_description)
+    parent_svc = Service.find_by(:id => options[:src_ids])
+    _log.info("- creating service tasks for service <#{self.class.name}:#{id}>")
+
+    create_retire_subtasks(parent_svc)
+  end
+
+  def create_retire_subtasks(parent_service)
+    parent_service.service_resources.collect do |svc_rsc|
+      next unless svc_rsc.resource.present? && svc_rsc.resource.respond_to?(:retire_now)
+      next if svc_rsc.resource_type == "ServiceTemplate" &&
+              !self.class.include_service_template?(self,
+                                                    svc_rsc.resource.id,
+                                                    parent_service)
+      nh = attributes.except("id", "created_on", "updated_on", "type", "state", "status", "message")
+      nh['options'] = options.except(:child_tasks)
+      # Initial Options[:dialog] to an empty hash so we do not pass down dialog values to child services tasks
+      nh['options'][:dialog] = {}
+
+      new_task = (svc_rsc.resource.type.demodulize + "RetireTask").constantize.new(nh)
+      new_task.options.merge!(
+        :src_id              => svc_rsc.resource.id,
+        :service_resource_id => svc_rsc.id,
+        :parent_service_id   => parent_service.id,
+        :parent_task_id      => id,
+      )
+      new_task.source = svc_rsc.resource
+      new_task.request_type = svc_rsc.resource.type.demodulize.downcase + "_retire"
+      new_task.save!
+      new_task.after_request_task_create
+      miq_request.miq_request_tasks << new_task
+      new_task.deliver_to_automate
+      new_task
+    end.compact!
   end
 end

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     status "Ok"
   end
 
+  factory :miq_retire_task,    :parent => :miq_request_task,   :class => "MiqRetireTask"
   factory :miq_provision_task, :parent => :miq_request_task,   :class => "MiqProvisionTask"
   factory :miq_provision,      :parent => :miq_provision_task, :class => "MiqProvision"
 
@@ -39,6 +40,10 @@ FactoryGirl.define do
   factory :service_template_provision_task, :parent => :miq_request_task, :class => "ServiceTemplateProvisionTask" do
     state        'pending'
     request_type 'clone_to_service'
+  end
+  factory :service_retire_task,             :parent => :miq_retire_task,  :class => "ServiceRetireTask" do
+    request_type 'service_retire'
+    state        'pending'
   end
 
   factory :service_template_transformation_plan_task, :parent => :service_template_provision_task, :class => 'ServiceTemplateTransformationPlanTask'

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -1,0 +1,78 @@
+describe ServiceRetireTask do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:vm) { FactoryGirl.create(:vm) }
+  let(:service) { FactoryGirl.create(:service) }
+  let(:miq_request) { FactoryGirl.create(:service_retire_request, :requester => user) }
+  let(:miq_request_task) { FactoryGirl.create(:miq_request_task, :miq_request_id => miq_request.id) }
+  let(:service_retire_task) { FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => miq_request_task.id, :miq_request_id => miq_request.id, :options => {:src_ids => [service.id] }) }
+  let(:reason) { "Why Not?" }
+  let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
+  let(:zone) { FactoryGirl.create(:zone, :name => "fred") }
+
+  it "should initialize properly" do
+    expect(service_retire_task.state).to eq('pending')
+    expect(service_retire_task.status).to eq('Ok')
+  end
+
+  describe "respond to update_and_notify_parent" do
+    context "state queued" do
+      it "should not call task_finished" do
+        service_retire_task.update_and_notify_parent(:state => "queued", :status => "Ok", :message => "yabadabadoo")
+
+        expect(service_retire_task.message).to eq("yabadabadoo")
+      end
+    end
+
+    context "state finished" do
+      it "should call task_finished" do
+        service_retire_task.update_and_notify_parent(:state => "finished", :status => "Ok", :message => "yabadabadoo")
+
+        expect(service_retire_task.status).to eq("Completed")
+      end
+    end
+  end
+
+  describe "#after_request_task_create" do
+    context "sans resource" do
+      it "doesn't create subtask" do
+        service_retire_task.after_request_task_create
+
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(VmRetireTask.count).to eq(0)
+      end
+    end
+
+    context "with resource" do
+      before do
+        allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
+        miq_request.approve(approver, reason)
+      end
+
+      it "creates subtask" do
+        resource = FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service.id, :resource_id => vm.id)
+        service.service_resources << resource
+        service_retire_task.after_request_task_create
+
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(VmRetireTask.count).to eq(1)
+      end
+    end
+  end
+
+  describe "deliver_to_automate" do
+    before do
+      allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
+      miq_request.approve(approver, reason)
+    end
+
+    it "updates the task state to pending" do
+      allow(MiqQueue).to receive(:put)
+      expect(service_retire_task).to receive(:update_and_notify_parent).with(
+        :state   => 'pending',
+        :status  => 'Ok',
+        :message => 'Automation Starting'
+      )
+      service_retire_task.deliver_to_automate
+    end
+  end
+end


### PR DESCRIPTION
The service retirement needs tasks and requests for each child item and this is the creation of those.


Depends on https://github.com/ManageIQ/manageiq/pull/17255