### PR TITLE
Handle non-existant tag category id when importing a service dialog

### DIFF
--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -36,11 +36,15 @@ class DialogFieldImporter
 
   def adjust_category(opts)
     return nil if opts[:category_description].nil?
-    category = if opts[:category_id]
-                 Category.find(opts[:category_id])
-               elsif opts[:category_name]
-                 Category.find_by_name(opts[:category_name])
-               end
+    category = find_category(opts)
     category.try(:description) == opts[:category_description] ? category.try(:id).to_s : nil
+  end
+
+  def find_category(opts)
+    if opts[:category_id]
+      cat = Category.find_by(:id => opts[:category_id])
+      return cat if cat.try(:name) == opts[:category_name]
+    end
+    Category.find_by_name(opts[:category_name])
   end
 end

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -78,7 +78,7 @@ describe DialogFieldImporter do
     context "when the type of the dialog field is a tag control" do
       let(:type) { "DialogFieldTagControl" }
 
-      context "when the import file contains a category name with no category_id" do
+      context "when the import file contains a category_name, but no category_id" do
         let(:options) do
           {
             :category_name        => "best_category",
@@ -122,38 +122,136 @@ describe DialogFieldImporter do
         end
       end
 
-      context "when the import file contains a category id a category name and a description" do
+      context "when the import file contains a category_id" do
         before do
+          @first_category    = Category.create!(:name => "first_category", :description => "first_category")
           @existing_category = Category.create!(:name => "best_category", :description => "best_category")
         end
+
         let(:options) do
           {
-            :category_id          => @existing_category.id,
-            :category_name        => @existing_category.name,
-            :category_description => @existing_category.description
+            :category_id          => category_id,
+            :category_name        => category_name,
+            :category_description => category_description
           }
         end
 
-        it "uses the category id provided" do
-          dialog_field_importer.import_field(dialog_field)
-          expect(DialogFieldTagControl.first.category).to eq(@existing_category.id.to_s)
-        end
-      end
+        context "when the category_id matches an existing category" do
+          let(:category_id) { @existing_category.id }
 
-      context "when the import file contains a category id with a different description" do
-        before do
-          @existing_category = Category.create!(:name => "best_category", :description => "best_category")
-        end
-        let(:options) do
-          {
-            :category_id          => @existing_category.id,
-            :category_description => "bad description"
-          }
+          context "when the category_name matches the existing category" do
+            let(:category_name) { @existing_category.name }
+
+            context "when the category_description matches the existing category" do
+              let(:category_description) { @existing_category.description }
+
+              it "sets the field to the existing category" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(@existing_category.id.to_s)
+              end
+            end
+
+            context "when the category_description does not match the existing category" do
+              let(:category_description) { "worst_description" }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+          end
+
+          context "when the category_name matches a different category" do
+            let(:category_name) { @first_category.name }
+
+            context "when the category_description matches the different category" do
+              let(:category_description) { @first_category.description }
+
+              it "sets the field to the different category" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(@first_category.id.to_s)
+              end
+            end
+
+            context "when the category_description does not match the existing category" do
+              let(:category_description) { "worst_description" }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+          end
+
+          context "when the category_name does not match the existing category" do
+            let(:category_name) { "worst_category" }
+
+            context "when the category_description matches the existing category" do
+              let(:category_description) { @existing_category.description }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+
+            context "when the category_description does not match the existing category" do
+              let(:category_description) { "worst_description" }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+          end
         end
 
-        it "returns nil" do
-          dialog_field_importer.import_field(dialog_field)
-          expect(DialogFieldTagControl.first.category).to eq(nil)
+        context "when the category_id does not match an existing category" do
+          let(:category_id) { @existing_category.id + 1 }
+
+          context "when the category_name matches an existing category" do
+            let(:category_name) { @existing_category.name }
+
+            context "when the category_description matches the existing category" do
+              let(:category_description) { @existing_category.description }
+
+              it "sets the field to the existing category" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(@existing_category.id.to_s)
+              end
+            end
+
+            context "when the category_description does not match the existing category" do
+              let(:category_description) { "worst_description" }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+          end
+
+          context "when the category_name does not match the existing category" do
+            let(:category_name) { "worst_category" }
+
+            context "when the category_description matches the existing category" do
+              let(:category_description) { @existing_category.description }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+
+            context "when the category_description does not match the existing category" do
+              let(:category_description) { "worst_description" }
+
+              it "returns nil" do
+                dialog_field_importer.import_field(dialog_field)
+                expect(DialogFieldTagControl.first.category).to eq(nil)
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Importing a Service Dialog with a Tag Control element will fail if the Tag Category ID has changed (e.g. when importing into a different region or when the tag category has been deleted and recreated).

There is no indication of failure in the UI, but a backtrace is generated in the logs

```
[----] F, [2018-03-27T15:01:04.983489 #2798:2af9b7ad40f4] FATAL -- : Error caught: [ActiveRecord::RecordNotFound] Couldn't find Category with 'id'=173 [WHERE "classifications"."parent_id" = $1]
/home/bevans/.gem/ruby/2.3.5/gems/activerecord-5.0.6/lib/active_record/relation/finder_methods.rb:353:in `raise_record_not_found_exception!'
/home/bevans/.gem/ruby/2.3.5/gems/activerecord-5.0.6/lib/active_record/relation/finder_methods.rb:479:in `find_one'
/home/bevans/.gem/ruby/2.3.5/gems/activerecord-5.0.6/lib/active_record/relation/finder_methods.rb:458:in `find_with_ids'
/home/bevans/.gem/ruby/2.3.5/gems/activerecord-5.0.6/lib/active_record/relation/finder_methods.rb:66:in `find'
/home/bevans/.gem/ruby/2.3.5/gems/activerecord-5.0.6/lib/active_record/querying.rb:3:in `find'
/home/bevans/.gem/ruby/2.3.5/gems/activerecord-5.0.6/lib/active_record/core.rb:151:in `find'
/home/bevans/my-repos/manageiq/app/models/dialog_field_importer.rb:40:in `adjust_category'
/home/bevans/my-repos/manageiq/app/models/dialog_field_importer.rb:34:in `set_category_for_tag_control'
/home/bevans/my-repos/manageiq/app/models/dialog_field_importer.rb:17:in `import_field'
/home/bevans/my-repos/manageiq/lib/services/dialog_import_service.rb:84:in `block in build_dialog_fields'
```

This PR captures the error condition and looks for the tag category using the name instead of the ID.


Steps for Testing/QA
-------------------------------

1. Create a Tag Category and add a couple of values
2. Create a Service Dialog with a Tag Control Element using the previously created category
3. Export the Service Dialog
4. Delete the Service Dialog created in step 3
5. Delete the Tag Category created in step 1
6. Recreate the Tag Category, ensuring that the name and description are exactly the same as in step 1
7. Import the Service Dialog
7a. Without this PR the import fails with no error for the user
7b. With this PR the import succeeds and the Service Dialog Tag Control Element has the category assigned


Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1566266