### PR TITLE
Don't export catalog_id for Tag Control Service Dialog fields

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -26,6 +26,7 @@ class DialogFieldSerializer < Serializer
       if category
         dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
         dialog_field.options[:force_single_value] = dialog_field.options[:force_single_value] || category.single_value
+        dialog_field.options.reject! { |key| key == :category_id } unless all_attributes
       end
     end
     included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -152,7 +152,6 @@ describe DialogFieldSerializer do
                    "resource_action"         => "serialized resource action",
                    "dialog_field_responders" => dialog_field_responders,
                    "options"                 => {
-                     :category_id          => "123",
                      :category_name        => "best category ever",
                      :category_description => "best category ever",
                      :force_single_value   => true


### PR DESCRIPTION
When exporting Service Dialogs with Tag Control elements, the ID of the Tag Category is included in the export. This can cause imports to fail when importing the Service Dialog into a different region.

This PR removes the category_id from the export for Tag Control elements. This makes the exporting of IDs consistent for all types of IDs (ID attributes for the dialog, dialog tabs, and dialog groups are already not exported).

Steps for Testing/QA [Optional]
-------------------------------

1. Create a Service Dialog with a Tag Control Element with a valid tag category selected
2. Export the Service Dialog
3. Inspect the resulting YAML file. There will not be a `catalog_id` field in the `options` section

**Export Before:**
```
---
- description: Simple Dialog to test export and import
  buttons: submit,cancel
  label: Simple Dialog
  dialog_tabs:
  - description: 
    display: 
    label: New tab
    display_method: 
    display_method_options: 
    position: 0
    dialog_groups:
    - description: 
      display: 
      label: New section
      display_method: 
      display_method_options: 
      position: 0
      dialog_fields:
      - name: tag_0_import_test
        description: ''
        data_type: string
        notes: 
        notes_display: 
        display: edit
        display_method: 
        display_method_options: {}
        required: false
        required_method: 
        required_method_options: {}
        default_value: ''
        values:
        - :id: 
          :name: "<None>"
          :description: "<None>"
        - :id: 185
          :name: '1'
          :description: One
        - :id: 174
          :name: new_a
          :description: A
        - :id: 186
          :name: new_tag_cat
          :description: My New Tag Category
        values_method: 
        values_method_options: {}
        options:
          :category_id: '173'
          :force_single_value: true
          :sort_by: description
          :sort_order: ascending
          :category_description: Import Test
          :category_name: import_test
        label: Test Tag Control
        position: 0
        validator_type: 
        validator_rule: 
        reconfigurable: false
        dynamic: false
        show_refresh_button: false
        load_values_on_init: false
        read_only: false
        auto_refresh: false
        trigger_auto_refresh: false
        visible: true
        type: DialogFieldTagControl
        resource_action:
          action: 
          resource_type: DialogField
          ae_namespace: 
          ae_class: 
          ae_instance: 
          ae_message: 
          ae_attributes: {}
        dialog_field_responders: []
```

**Export After:**
```
---
- description: Simple Dialog to test export and import
  buttons: submit,cancel
  label: Simple Dialog
  dialog_tabs:
  - description: 
    display: 
    label: New tab
    display_method: 
    display_method_options: 
    position: 0
    dialog_groups:
    - description: 
      display: 
      label: New section
      display_method: 
      display_method_options: 
      position: 0
      dialog_fields:
      - name: tag_0_import_test
        description: ''
        data_type: string
        notes: 
        notes_display: 
        display: edit
        display_method: 
        display_method_options: {}
        required: false
        required_method: 
        required_method_options: {}
        default_value: ''
        values:
        - :id: 
          :name: "<None>"
          :description: "<None>"
        - :id: 185
          :name: '1'
          :description: One
        - :id: 174
          :name: new_a
          :description: A
        - :id: 186
          :name: new_tag_cat
          :description: My New Tag Category
        values_method: 
        values_method_options: {}
        options:
          :force_single_value: true
          :sort_by: description
          :sort_order: ascending
          :category_description: Import Test
          :category_name: import_test
        label: Test Tag Control
        position: 0
        validator_type: 
        validator_rule: 
        reconfigurable: false
        dynamic: false
        show_refresh_button: false
        load_values_on_init: false
        read_only: false
        auto_refresh: false
        trigger_auto_refresh: false
        visible: true
        type: DialogFieldTagControl
        resource_action:
          action: 
          resource_type: DialogField
          ae_namespace: 
          ae_class: 
          ae_instance: 
          ae_message: 
          ae_attributes: {}
        dialog_field_responders: []
```