### PR TITLE
Add has_many :miq_requests in ServiceTemplate

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -55,6 +55,8 @@ class ServiceTemplate < ApplicationRecord
 
   has_many   :dialogs, -> { distinct }, :through => :resource_actions
 
+  has_many   :miq_requests, :as => :source, :dependent => :nullify
+
   virtual_column   :type_display,                 :type => :string
   virtual_column   :template_valid,               :type => :boolean
   virtual_column   :template_valid_error_message, :type => :string


### PR DESCRIPTION
Add `has_many :miq_requests` association in `ServiceTemplate`.
It helps to find out all the `miq_requests` made from the `service_template`