### PR TITLE
Fix editing Ansible Credential/Repository for restricted user

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,4 +1,6 @@
 class Authentication < ApplicationRecord
+  acts_as_miq_taggable
+
   include NewWithTypeStiMixin
   def self.new(*args, &block)
     if self == Authentication

--- a/app/models/configuration_script_payload.rb
+++ b/app/models/configuration_script_payload.rb
@@ -1,4 +1,6 @@
 class ConfigurationScriptPayload < ConfigurationScriptBase
+  acts_as_miq_taggable
+
   belongs_to :configuration_script_source
 
   def self.base_model

--- a/app/models/configuration_script_source.rb
+++ b/app/models/configuration_script_source.rb
@@ -1,4 +1,6 @@
 class ConfigurationScriptSource < ApplicationRecord
+  acts_as_miq_taggable
+
   has_many    :configuration_script_payloads, :dependent => :destroy
   belongs_to  :authentication
   belongs_to  :manager, :class_name => "ExtManagementSystem"

--- a/app/models/manageiq/providers/automation_manager/authentication.rb
+++ b/app/models/manageiq/providers/automation_manager/authentication.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AutomationManager::Authentication < Authentication
-  acts_as_miq_taggable
 end

--- a/app/models/manageiq/providers/automation_manager/configuration_script_payload.rb
+++ b/app/models/manageiq/providers/automation_manager/configuration_script_payload.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AutomationManager::ConfigurationScriptPayload < ::ConfigurationScriptPayload
-  acts_as_miq_taggable
 end

--- a/app/models/manageiq/providers/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/automation_manager/configuration_script_source.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::AutomationManager::ConfigurationScriptSource < ConfigurationScriptSource
-  acts_as_miq_taggable
 end


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1560525

---

Move `acts_as_miq_taggable` to base `Authentication` class to prevent 500 Internal Server Error when
editing _Ansible Credential_ for restricted user, in _Automation > Ansible > Credentials_.
The same for _Ansible Repository_, in _Automation > Ansible > Repositories_ page. The reason is that it looks like that API does not work with classes like `ManageIQ::Providers::AutomationManager` well so it is needed to add `acts_as_miq_taggable` to base classes.

**Note:** This PR addresses new changes which should have been done by https://github.com/ManageIQ/manageiq/pull/17049 (see the comments, there is one unanswered question about the UI and `ManageIQ::Providers::AutomationManager` class)

**Before reproducing:**
 - you need to enable _Embedded Ansible_: https://github.com/himdel/guides/blob/5b4723bc5361d66e344d134e67db58561f154c56/providers/embedded_ansible.md
or you have to make `disabled?` method return `false`, in _app/helpers/application_helper/button/embedded_ansible.rb_ (not recommended, only for urgent needs!)
- as an admin, tag some credential(s)/repository(ies) from _Automation > Ansible > Credentials/Repositories_, remember those tags
-  then in _Configuration > Access Control > Groups_, create a group so that under _Assigned Filters_ in the first tab called _My Company Tags_, you choose the same tags as tags from previous step
- then set _EvmRole-administrator_ as a role of that group (not super administrator!) and save the group
- then create a user with that group from the previous step

**Steps to reproduce the bug:**
1. Login as a restricted user, created by the steps from the previous section above
2. Go to _Automation > Ansible > Credentials/Repositories_ page
3. Select some credential/repository by checking its checkbox in the left in the list
4. Under _Configuration_, choose _Edit this Credential/Repository:_
![edit_credential](https://user-images.githubusercontent.com/13417815/38242967-73bf802c-3736-11e8-8db4-8fe9fb2d5ab0.png)

**Before:** (error occurs)
![edit_credential_bad](https://user-images.githubusercontent.com/13417815/38242892-3f1d3544-3736-11e8-9fb0-6820f7a76091.png)
![edit_repo_bad](https://user-images.githubusercontent.com/13417815/38242900-4404dd50-3736-11e8-8bec-81cfd5cb1fc0.png)

**After:** (no error occurred, editing page successfully opened)
![edit_credential_ok](https://user-images.githubusercontent.com/13417815/38242926-5112c246-3736-11e8-82b2-b6c152332bf8.png)
![edit_credential_save](https://user-images.githubusercontent.com/13417815/38242947-5f9e7d3c-3736-11e8-919c-91e4db09a0bf.png)

![edit_repo_ok](https://user-images.githubusercontent.com/13417815/38242933-58772338-3736-11e8-8883-2c73e2e1ae82.png)
![edit_repo-save](https://user-images.githubusercontent.com/13417815/38242958-66d42fd4-3736-11e8-8e03-8fffd4e923d7.png)
