### PR TITLE
convert Vm#miq_provision_template to has_one

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -172,7 +172,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_has_many   :lans,                                                  :uses => {:hardware => {:nics => :lan}}
   virtual_has_many   :child_resources,        :class_name => "VmOrTemplate"
 
-  virtual_belongs_to :miq_provision_template, :class_name => "Vm",           :uses => {:miq_provision => :vm_template}
+  has_one            :miq_provision_template, :through => "miq_provision", :source => "source", :source_type => "VmOrTemplate"
   virtual_belongs_to :parent_resource_pool,   :class_name => "ResourcePool", :uses => :all_relationships
 
   virtual_has_one   :direct_service,       :class_name => 'Service'
@@ -1430,10 +1430,6 @@ class VmOrTemplate < ApplicationRecord
   def v_datastore_path
     datastorepath = location || ""
     storage ? "#{storage.name}/#{datastorepath}" : datastorepath
-  end
-
-  def miq_provision_template
-    miq_provision.try(:vm_template)
   end
 
   def event_threshold?(options = {:time_threshold => 30.minutes, :event_types => ["MigrateVM_Task_Complete"], :freq_threshold => 2})

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1310,10 +1310,10 @@ class MiqExpression
   def to_arel(exp, tz)
     operator = exp.keys.first
     field = Field.parse(exp[operator]["field"]) if exp[operator].kind_of?(Hash) && exp[operator]["field"]
-    arel_attribute = field && field.target.arel_attribute(field.column)
+    arel_attribute = field&.arel_attribute
     if exp[operator].kind_of?(Hash) && exp[operator]["value"] && Field.is_field?(exp[operator]["value"])
       field_value = Field.parse(exp[operator]["value"])
-      parsed_value = field_value.target.arel_attribute(field_value.column)
+      parsed_value = field_value.arel_attribute
     elsif exp[operator].kind_of?(Hash)
       parsed_value = exp[operator]["value"]
     end
@@ -1395,7 +1395,7 @@ class MiqExpression
         arel = arel_attribute.eq(parsed_value)
         arel = arel.and(Arel::Nodes::SqlLiteral.new(extract_where_values(reflection.klass, reflection.scope))) if reflection.scope
         field.model.arel_attribute(:id).in(
-          field.target.arel_table.where(arel).project(field.target.arel_table[reflection.foreign_key]).distinct
+          field.arel_table.where(arel).project(field.arel_table[reflection.foreign_key]).distinct
         )
       end
     when "is"

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -67,6 +67,29 @@ class MiqExpression::Field < MiqExpression::Target
     (associations + [column]).join('.')
   end
 
+  # this should only be accessed in MiqExpression
+  # please avoid using it
+  def arel_table
+    if associations.none?
+      model.arel_table
+    else
+      # if we are pointing to a table that already in the query, need to alias it
+      # seems we should be able to ask AR to do this for us...
+      ref = reflections.last
+      if ref.klass.table_name == model.table_name
+        ref.klass.arel_table.alias(ref.alias_candidate(model.table_name))
+      else
+        ref.klass.arel_table
+      end
+    end
+  end
+
+  # this should only be accessed in MiqExpression
+  # please avoid using it
+  def arel_attribute
+    target.arel_attribute(column, arel_table) if target
+  end
+
   private
 
   def custom_attribute_column_name

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -201,6 +201,43 @@ RSpec.describe MiqExpression::Field do
     end
   end
 
+  describe "#arel_table" do
+    it "returns the main table when there are no associations" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.arel_table).to eq(Vm.arel_table)
+    end
+
+    it "returns the table of the target association without an alias" do
+      field = described_class.new(Vm, ["guest_applications"], "name")
+      expect(field.arel_table).to eq(GuestApplication.arel_table)
+      expect(field.arel_table.name).to eq(GuestApplication.arel_table.name)
+    end
+
+    it "returns the table of the target association with an alias if needed" do
+      field = described_class.new(Vm, ["miq_provision_template"], "name")
+      expect(field.arel_table.table_name).to eq(Vm.arel_table.table_name)
+      expect(field.arel_table.name).not_to eq(Vm.arel_table.name)
+    end
+  end
+
+  describe "#arel_attribute" do
+    it "returns the main table when there are no associations" do
+      field = described_class.new(Vm, [], "name")
+      expect(field.arel_attribute).to eq(Vm.arel_attribute("name"))
+    end
+
+    it "returns the table of the target association without an alias" do
+      field = described_class.new(Vm, ["guest_applications"], "name")
+      expect(field.arel_attribute).to eq(GuestApplication.arel_attribute("name"))
+    end
+
+    it "returns the table of the target association with an alias if needed" do
+      field = described_class.new(Vm, ["miq_provision_template"], "name")
+      expect(field.arel_attribute.name).to eq("name")
+      expect(field.arel_attribute.relation.name).to include("miq_provision_template")
+    end
+  end
+
   describe "#plural?" do
     it "returns false if the column is on a 'belongs_to' association" do
       field = described_class.new(Vm, ["storage"], "region_description")

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -28,7 +28,7 @@ describe MiqReport do
       end
 
       it "detects a virtual association (and that it can't be sorted)" do
-        @miq_report.sortby = ["miq_provision_template.name"]
+        @miq_report.sortby = ["parent_resource_pool.name"]
         order = @miq_report.get_order_info
         expect(order).to be_falsy
       end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -655,6 +655,32 @@ describe VmOrTemplate do
     expect(template.miq_provision_vms.collect(&:id)).to eq([vm.id])
   end
 
+  describe "#miq_provision_template" do
+    it "links vm to template" do
+      ems       = FactoryGirl.create(:ems_vmware_with_authentication)
+      template  = FactoryGirl.create(:template_vmware, :ext_management_system => ems)
+      vm        = FactoryGirl.create(:vm_vmware, :ext_management_system => ems)
+
+      options = {
+        :vm_name        => vm.name,
+        :vm_target_name => vm.name,
+        :src_vm_id      => [template.id, template.name]
+      }
+
+      FactoryGirl.create(
+        :miq_provision_vmware,
+        :destination  => vm,
+        :source       => template,
+        :request_type => 'clone_to_vm',
+        :state        => 'finished',
+        :status       => 'Ok',
+        :options      => options
+      )
+
+      expect(vm.miq_provision_template).to eq(template)
+    end
+  end
+
   describe ".v_pct_free_disk_space (delegated to hardware)" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :hardware => hardware) }
     let(:hardware) { FactoryGirl.create(:hardware, :disk_free_space => 20, :disk_capacity => 100) }


### PR DESCRIPTION
**Goal:** Speed up Provision Activity Report

The Provision Activity report uses `Vm#miq_provision_template` to filter
the report. Converting this virtual association over to a real association allows the query to filter in the database.

Unfortunately, `MiqExpression` was not generating the proper sql for models that refer to them self - as seen with `parent` type associations. OR in our case, the template and vm happen to be in the same table (i.e.: `vms`)

Not thrilled with the exact solution here. It is close, but feels like we're a little too deep in AR internals here.


https://bugzilla.redhat.com/show_bug.cgi?id=1560113

For MBU:

|        ms |       bytes |    objects |query |   qry ms |     rows |comments
|       ---:|         ---:|        ---:|  ---:|      ---:|      ---:| ---
|     876.3 |  29,778,104* |    302,451 |   29 |    525.4 |      898 |before-3
|     201.1 |  4,287,887  |     50,560 |   23 |     44.2 |       57 |after-3
| 77.1%     | n/a           | 83% | 21% | 91.6% | 94% | diff

\* Memory usage does not reflect 1,290 freed objects.
Disclaimer: The before forces a GC every time - hard to report the actual value. Depending upon when the GC is run, the before can show 2mb or 29mb allocated.

---

```ruby
rpt = MiqReport.find_by(:name => 'Provisioning Activity - by VM')
rpt._generate_table
rpt.instance_variable_get(:@table).count # => 6
```