### PR TITLE
Shift qpid_proton version to 0.22.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,7 @@ group :nuage, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.19.0",      :require => false
+  gem "qpid_proton",                    "~>0.22.0",      :require => false
 end
 
 group :openshift, :manageiq_default do


### PR DESCRIPTION
With this commit we shift required qpid_proton version because 0.22.0 implements heartbeating, which is essential. Without the heartbeating, connection was being closed by ActiveMQ every 2 minutes.

See our bug reports on qpid_proton Jira:
- https://issues.apache.org/jira/browse/PROTON-1782
- https://issues.apache.org/jira/browse/PROTON-1791
- https://issues.apache.org/jira/browse/PROTON-1806

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1563534

@miq-bot assign @Fryguy 
@miq-bot add_label enhancement,gaprindashvili/yes

/cc @gberginc @pdellaert