### PR TITLE
Add a setting for ansible job data retention

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :amazon, :manageiq_default do
 end
 
 group :ansible, :manageiq_default do
-  gem "ansible_tower_client",           "~>0.12.2",      :require => false
+  gem "ansible_tower_client",           "~>0.13.0",      :require => false
 end
 
 group :azure, :manageiq_default do

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -24,6 +24,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def do_work
     embedded_ansible.start if !embedded_ansible.alive? && !embedded_ansible.running?
     provider.authentication_check if embedded_ansible.alive? && !provider.authentication_status_ok?
+    update_job_data_retention
   end
 
   def before_exit(*_)
@@ -34,7 +35,6 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     _log.info("Starting embedded ansible service ...")
     embedded_ansible.start
     _log.info("Finished starting embedded ansible service.")
-    embedded_ansible.set_job_data_retention
   end
 
   def update_embedded_ansible_provider
@@ -65,6 +65,13 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
   def message_sync_config(*_args); end
 
   private
+
+  def update_job_data_retention
+    return if @job_data_retention == ::Settings.embedded_ansible.job_data_retention_days
+
+    embedded_ansible.set_job_data_retention
+    @job_data_retention = ::Settings.embedded_ansible.job_data_retention_days
+  end
 
   def provider
     @provider ||= ManageIQ::Providers::EmbeddedAnsible::Provider.first_or_initialize

--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -34,6 +34,7 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
     _log.info("Starting embedded ansible service ...")
     embedded_ansible.start
     _log.info("Finished starting embedded ansible service.")
+    embedded_ansible.set_job_data_retention
   end
 
   def update_embedded_ansible_provider

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -128,6 +128,7 @@
     :keep_drift_states: 6.months
     :purge_window_size: 10000
 :embedded_ansible:
+  :job_data_retention_days: 120
   :docker:
     :task_image_name: ansible/awx_task
     :task_image_tag: latest

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -39,7 +39,21 @@ class EmbeddedAnsible
     true
   end
 
+  def set_job_data_retention
+    sched = job_cleanup_template.schedules.first
+    sched.extra_data.days = ::Settings.embedded_ansible.job_data_retention_days
+    sched.save!
+  end
+
+  def run_job_data_retention(days = ::Settings.embedded_ansible.job_data_retention_days)
+    job_cleanup_template.launch("days" => days)
+  end
+
   private
+
+  def job_cleanup_template
+    api_connection.api.system_job_templates.all.find { |t| t.job_type == "cleanup_jobs" }
+  end
 
   def api_connection_raw(host, port)
     admin_auth = miq_database.ansible_admin_authentication

--- a/lib/vmdb/config/activator.rb
+++ b/lib/vmdb/config/activator.rb
@@ -40,13 +40,6 @@ module VMDB
       def server(data)
         MiqServer.my_server.config_activated(data) unless MiqServer.my_server.nil? rescue nil
       end
-
-      def embedded_ansible(_data)
-        ea = EmbeddedAnsible.new
-        return unless ea.alive?
-
-        ea.set_job_data_retention
-      end
     end
   end
 end

--- a/lib/vmdb/config/activator.rb
+++ b/lib/vmdb/config/activator.rb
@@ -40,6 +40,13 @@ module VMDB
       def server(data)
         MiqServer.my_server.config_activated(data) unless MiqServer.my_server.nil? rescue nil
       end
+
+      def embedded_ansible(_data)
+        ea = EmbeddedAnsible.new
+        return unless ea.alive?
+
+        ea.set_job_data_retention
+      end
     end
   end
 end

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -105,6 +105,16 @@ describe EmbeddedAnsible do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
+    shared_context "api connection" do
+      let(:api_conn) { double("AnsibleAPIConnection") }
+      let(:api) { double("AnsibleAPIResource") }
+
+      before do
+        expect(subject).to receive(:api_connection).and_return(api_conn)
+        expect(api_conn).to receive(:api).and_return(api)
+      end
+    end
+
     describe "#alive?" do
       it "returns false if the service is not configured" do
         expect(subject).to receive(:configured?).and_return false
@@ -118,14 +128,11 @@ describe EmbeddedAnsible do
       end
 
       context "when a connection is attempted" do
-        let(:api_conn) { double("AnsibleAPIConnection") }
-        let(:api) { double("AnsibleAPIResource") }
+        include_context "api connection"
 
         before do
           expect(subject).to receive(:configured?).and_return true
           expect(subject).to receive(:running?).and_return true
-          expect(subject).to receive(:api_connection).and_return(api_conn)
-          expect(api_conn).to receive(:api).and_return(api)
 
           miq_database.set_ansible_admin_authentication(:password => "adminpassword")
         end

--- a/spec/models/embedded_ansible_worker/runner_spec.rb
+++ b/spec/models/embedded_ansible_worker/runner_spec.rb
@@ -124,6 +124,10 @@ describe EmbeddedAnsibleWorker::Runner do
     end
 
     context "#do_work" do
+      before do
+        runner.instance_variable_set(:@job_data_retention, ::Settings.embedded_ansible.job_data_retention_days)
+      end
+
       it "starts embedded ansible if it is not alive and not running" do
         allow(embedded_ansible_instance).to receive(:alive?).and_return(false)
         allow(embedded_ansible_instance).to receive(:running?).and_return(false)
@@ -153,6 +157,15 @@ describe EmbeddedAnsibleWorker::Runner do
           allow(runner).to receive(:provider).and_return(provider)
           expect(provider).not_to receive(:authentication_check)
 
+          runner.do_work
+        end
+
+        it "sets the embedded ansible job data retention value when the setting changes" do
+          allow(embedded_ansible_instance).to receive(:alive?).and_return(true)
+          allow(runner).to receive(:provider).and_return(provider)
+          stub_settings(:embedded_ansible => {:job_data_retention_days => 30})
+
+          expect(embedded_ansible_instance).to receive(:set_job_data_retention)
           runner.do_work
         end
       end


### PR DESCRIPTION
This setting will control how many days of job data should be kept.

When the setting is changed we call out to ansible tower to alter the setting for their weekly system job. If the user wants to run the job on-demand they can use the `EmbeddedAnsible#run_job_data_retention` method.

Requires https://github.com/ansible/ansible_tower_client_ruby/pull/99 and https://github.com/ansible/ansible_tower_client_ruby/pull/100 to be merged and released.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1560478