### PR TITLE
Sorting the guest devices child devices by name

### DIFF
--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -13,7 +13,7 @@ class GuestDevice < ApplicationRecord
   has_many :miq_scsi_targets, :dependent => :destroy
 
   has_many :firmwares, :dependent => :destroy
-  has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
+  has_many :child_devices, -> { where(:parent_device_id => ids).order(:device_name) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
 
   alias_attribute :name, :device_name
 


### PR DESCRIPTION
Improvement
=========
This PR adds the order statement to `GuestDevice` relationship  with `:child_devices`. The main goal is to provide a better readability for the user. For example in the network devices page:

__Actual result:__
![image](https://user-images.githubusercontent.com/8550928/38334441-b96c58ce-3831-11e8-81b3-3b9ac4dcbe5d.png)

__Expected result:__
![image](https://user-images.githubusercontent.com/8550928/38334411-a80d90e8-3831-11e8-9a78-15912756821f.png)
