### PR TITLE
Use constant to store ServiceResource status.

### DIFF
--- a/app/models/service_resource.rb
+++ b/app/models/service_resource.rb
@@ -1,4 +1,10 @@
 class ServiceResource < ApplicationRecord
+  STATUS_ACTIVE    = 'Active'.freeze
+  STATUS_APPROVED  = 'Approved'.freeze
+  STATUS_COMPLETED = 'Completed'.freeze
+  STATUS_FAILED    = 'Failed'.freeze
+  STATUS_QUEUED    = 'Queued'.freeze
+
   belongs_to :service_template
   belongs_to :service
   belongs_to :resource, :polymorphic => true

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -51,7 +51,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     transaction do
       create_from_options(options.merge(default_options)).tap do |service_template|
         service_template.add_resource(enhanced_config_info[:transformation_mapping])
-        enhanced_config_info[:vms].each { |vm| service_template.add_resource(vm, :status => 'Queued') }
+        enhanced_config_info[:vms].each { |vm| service_template.add_resource(vm, :status => ServiceResource::STATUS_QUEUED) }
         service_template.create_resource_actions(enhanced_config_info)
       end
     end

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -4,7 +4,7 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   delegate :transformation_mapping, :vm_resources, :to => :source
 
   def requested_task_idx
-    vm_resources.where(:status => 'Approved')
+    vm_resources.where(:status => ServiceResource::STATUS_APPROVED)
   end
 
   def customize_request_task_attributes(req_task_attrs, vm_resource)
@@ -12,7 +12,7 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   end
 
   def source_vms
-    vm_resources.where(:status => %w(Queued Failed)).pluck(:resource_id)
+    vm_resources.where(:status => [ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_FAILED]).pluck(:resource_id)
   end
 
   def validate_vm(_vm_id)
@@ -21,6 +21,6 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   end
 
   def approve_vm(vm_id)
-    vm_resources.find_by(:resource_id => vm_id).update_attributes!(:status => 'Approved')
+    vm_resources.find_by(:resource_id => vm_id).update_attributes!(:status => ServiceResource::STATUS_APPROVED)
   end
 end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -27,11 +27,11 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def task_finished
     # update the status of vm transformation status in the plan
-    vm_resource.update_attributes(:status => status == 'Ok' ? 'Completed' : 'Failed')
+    vm_resource.update_attributes(:status => status == 'Ok' ? ServiceResource::STATUS_COMPLETED : ServiceResource::STATUS_FAILED)
   end
 
   def task_active
-    vm_resource.update_attributes(:status => 'Active')
+    vm_resource.update_attributes(:status => ServiceResource::STATUS_ACTIVE)
   end
 
   private

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -1,7 +1,7 @@
 describe ServiceTemplateTransformationPlanRequest do
   let(:vms) { Array.new(3) { FactoryGirl.create(:vm_or_template) } }
   let(:vm_requests) do
-    %w(Queued Failed Approved).zip(vms).collect do |status, vm|
+    [ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_FAILED, ServiceResource::STATUS_APPROVED].zip(vms).collect do |status, vm|
       ServiceResource.new(:resource => vm, :status => status)
     end
   end
@@ -10,7 +10,7 @@ describe ServiceTemplateTransformationPlanRequest do
 
   describe '#requested_task_idx' do
     it 'selects approved vm requests' do
-      expect(request.requested_task_idx.first).to have_attributes(:resource => vms[2], :status => 'Approved')
+      expect(request.requested_task_idx.first).to have_attributes(:resource => vms[2], :status => ServiceResource::STATUS_APPROVED)
     end
   end
 
@@ -35,7 +35,7 @@ describe ServiceTemplateTransformationPlanRequest do
   describe '#approve_vm' do
     it 'turns the status to Approved' do
       request.approve_vm(vms[0].id)
-      expect(ServiceResource.find_by(:resource => vms[0]).status).to eq('Approved')
+      expect(ServiceResource.find_by(:resource => vms[0]).status).to eq(ServiceResource::STATUS_APPROVED)
     end
   end
 end

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -38,7 +38,7 @@ describe ServiceTemplateTransformationPlan do
       expect(service_template.name).to eq('Transformation Plan')
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
-      expect(service_template.vm_resources.collect(&:status)).to eq(%w(Queued Queued))
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -62,14 +62,14 @@ describe ServiceTemplateTransformationPlanTask do
     describe 'task_active' do
       it 'sets vm_request status to Started' do
         task.task_active
-        expect(plan.vm_resources.first.status).to eq('Active')
+        expect(plan.vm_resources.first.status).to eq(ServiceResource::STATUS_ACTIVE)
       end
     end
 
     describe 'task_finished' do
       it 'sets vm_request status to Completed' do
         task.task_finished
-        expect(plan.vm_resources.first.status).to eq('Completed')
+        expect(plan.vm_resources.first.status).to eq(ServiceResource::STATUS_COMPLETED)
       end
     end
 


### PR DESCRIPTION
These constants would be accessed from other classes.

Required by https://github.com/ManageIQ/manageiq/pull/17251.

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement, transformation

cc @bzwei 