### PR TITLE
Update dependencies to match new fog-google

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.3.0",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
 gem "memoist",                        "~>0.15.0",      :require => false
-gem "mime-types",                     "~>2.6.1",       :path => File.expand_path("mime-types-redirector", __dir__)
+gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
 gem "more_core_extensions",           "~>3.5"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.16.1",      :require => false

--- a/mime-types-redirector/mime-types.gemspec
+++ b/mime-types-redirector/mime-types.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "mime-types"
-  s.version = "2.6.1"
+  s.version = "3.0.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to?(:required_rubygems_version=)
   s.require_paths = ["lib"]


### PR DESCRIPTION
In order to upgrade `fog-google` in google provider, it is required to upgrade the `mime_types` in our core as well.

Dependency chain:
- [`"fog-google", "~> 1.3.3"`](https://github.com/ManageIQ/manageiq-providers-google/pull/54)
- [`"google-api-client", "~> 0.19.1"`](https://github.com/fog/fog-google/blob/ee58e2a4d9502f2a4dc102ca6a4b664656551e3f/fog-google.gemspec#L28)
- [`"mime-types", "~> 3.0"`](https://github.com/google/google-api-ruby-client/blob/38e271cfb4532d61b857f624478108592288da06/google-api-client.gemspec#L26)

Related: https://github.com/ManageIQ/manageiq-providers-google/pull/54