### PR TITLE
Skip default value setting if the dialog is dynamic

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -61,6 +61,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def default_value_included?(values_list)
     if force_multi_value
       return false if default_value.blank?
+      return false if dynamic
       converted_values_list = values_list.collect { |value_pair| value_pair[0].send(value_modifier) }
       converted_default_values = JSON.parse(default_value).collect { |value| value.send(value_modifier) }
       overlap = converted_values_list & converted_default_values

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -3,16 +3,6 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     !!show_refresh_button
   end
 
-  def force_multi_value
-    return true if options[:force_multi_value].present? &&
-                   options[:force_multi_value] != "null" &&
-                   options[:force_multi_value]
-  end
-
-  def force_multi_value=(setting)
-    options[:force_multi_value] = setting
-  end
-
   def initial_values
     [[nil, "<None>"]]
   end

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -61,7 +61,6 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   def default_value_included?(values_list)
     if force_multi_value
       return false if default_value.blank?
-      return false if dynamic
       converted_values_list = values_list.collect { |value_pair| value_pair[0].send(value_modifier) }
       converted_default_values = JSON.parse(default_value).collect { |value| value.send(value_modifier) }
       overlap = converted_values_list & converted_default_values

--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -7,6 +7,10 @@ class DialogFieldRadioButton < DialogFieldSortedItem
     [[nil, "<None>"]]
   end
 
+  def force_multi_value
+    false
+  end
+
   private
 
   def raw_values

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -10,6 +10,16 @@ class DialogFieldSortedItem < DialogField
     end
   end
 
+  def force_multi_value
+    return true if options[:force_multi_value].present? &&
+                   options[:force_multi_value] != "null" &&
+                   options[:force_multi_value]
+  end
+
+  def force_multi_value=(setting)
+    options[:force_multi_value] = setting
+  end
+
   def sort_by
     options[:sort_by] || :description
   end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -96,6 +96,9 @@ class DialogFieldSortedItem < DialogField
   end
 
   def determine_selected_default_value
+    if dynamic? && force_multi_value && !default_value.kind_of?(Array)
+      self.default_value = Array.wrap(default_value)
+    end
     use_first_value_as_default unless default_value_included?(@raw_values)
     self.value ||= default_value.nil? && data_type == "integer" ? nil : default_value.send(value_modifier)
   end


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1559030

The value of the  is set to be an id of provider (ExtManagementSystem)

Steps for Testing/QA
-------------------------------

1) setup automate expression method:
  - automation -> automate -> explorer -> datastore -> configuration -> add a new domain
  - select the new domain -> configuration -> add a new instance
  - select the new instance -> configuration -> add a new class
  - select the new class -> switch to the `methods` tab -> configuration -> add a new method
    - select expression -> Expression Object set to ExtManagementSystem
    - at the bottom select field -> Provider: Total Vms >= 1 -> commit -> save
  - select the class in explorer -> switch to the `schema` tab -> configuration -> edit selected schema
    - click the green plus -> set name to `execute` -> type set to `method` -> data type set to `String` -> save
  - select the class in explorer -> switch to the `instance` tab -> configuration -> add a new instance
    - use the name of created method as the value

_the rest is from the BZ ticket:_

2) Create a service dialog containing a single drop-down list element. Make this element dynamic, and create an expression method to populate it (I used a simple expression method that lists all VMs). Leave the 'Multiselect' option as 'No'. Save the dialog.
3) Now edit the dialog, and change the 'Multiselect' option to 'Yes'. Save the dialog


Thanks for the help with setting up the expression method @pkomanek!