### PR TITLE
ar_lock.rb - add a lock_with_proc method

### DIFF
--- a/lib/extensions/ar_lock.rb
+++ b/lib/extensions/ar_lock.rb
@@ -33,4 +33,40 @@ module ArLock
       end
     end
   end
+  
+  # Creates a critical section around the specified block, in the style of
+  # Mutex#synchronize, by locking on the database record in SQL.
+  #
+  # See ActiveRecord::Locking::Pessimistic#with_lock for details about
+  #   the original version of this method.
+  #
+  # mode::    :exclusive or :shared (or :EX or :SH).  Default is :exclusive.
+  #           :exclusive mode will prevent two database callers from entering
+  #             the block concurrently.
+  #           :shared mode will allow concurrent entry into the block, but will
+  #             escalate to an :exclusive lock when ActiveRecord issues an
+  #             update to the record.
+  # timeout:: The amount of time, in seconds, before the block is timed out.
+  #             This prevents the block from blocking others indefinitely.
+  #             Default is 60 seconds.
+  # proc::    The Proc to execute in the context of the lock.
+  def lock_with_proc(mode = :exclusive, timeout = 60.seconds, proc)
+    lock = case mode
+           when :shared,    :SH then ActiveRecordQueryParts.shared_row_lock
+           when :exclusive, :EX then ActiveRecordQueryParts.update_row_lock
+           else raise "unknown lock mode <#{mode.inspect}>"
+           end
+
+    transaction do
+      _log.debug "Acquiring lock on #{self.class.name}::#{id}..."
+      lock!(lock)
+      _log.debug "Acquired lock"
+
+      begin
+        Timeout.timeout(timeout) { proc.call self }
+      ensure
+        _log.debug "Releasing lock"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Need the ability to do
```
proc = Proc.new { puts "Hello World" }
service = $evm.vmdb(:service).find_by_name("Test")
service.object_send(:lock_with_proc, :exclusive, 60,  proc)
```

Can't do this with current lock method because no way to get an anonymous block passed through the `object_send` call.