### PR TITLE
Adding scan action with userid to container_image

### DIFF
--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -66,8 +66,8 @@ class ContainerImage < ApplicationRecord
     container_image_registry.present? ? container_image_registry.full_name : _("Unknown image source")
   end
 
-  def scan
-    ext_management_system.scan_job_create(self)
+  def scan(userid = "system")
+    ext_management_system.scan_job_create(self, userid)
   end
 
   def perform_metadata_scan(ost)

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -209,7 +209,7 @@ class EmsCluster < ApplicationRecord
     EmsEvent.where(ewc).order("timestamp").to_a
   end
 
-  def scan
+  def scan(_userid = "system")
     MiqQueue.submit_job(
       :service     => "smartstate",
       :affinity    => ext_management_system,

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -192,7 +192,7 @@ class MiqSchedule < ApplicationRecord
 
   def action_scan(obj, _at)
     sched_action[:options] ||= {}
-    obj.scan
+    obj.scan(userid)
     _log.info("Action [#{name}] has been run for target type: [#{obj.class}] with name: [#{obj.name}]")
   end
 


### PR DESCRIPTION
## What this does?
Currently a `ContainerImage` scan that was scheduled is **not** associated with the current `userid`. This patch allows the user to schedule a `ContainerImage` scan associated with the current `userid`.

## Why?
Currently scheduled `ContainerImage` scans are failing due to lack of associated `userid` required to create the Job.

cc: @cben @agrare @oourfali 
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1559459