### PR TITLE
Add timeout knob for monitoring server roles

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -262,8 +262,12 @@ module MiqServer::RoleManagement
     end
   end
 
+  def monitor_server_roles_timeout
+    ::Settings.server.monitor_server_roles_timeout.to_i_with_method
+  end
+
   def monitor_server_roles
-    MiqRegion.my_region.lock do |region|
+    MiqRegion.my_region.lock(:exclusive, monitor_server_roles_timeout) do |region|
       region.zones.each do |zone|
         synchronize_active_roles(zone.active_miq_servers.includes([:active_roles, :inactive_roles]), ServerRole.zone_scoped_roles)
       end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1009,6 +1009,7 @@
   :mks_classid: 338095E4-1806-4BA3-AB51-38A3179200E9
   :mks_version: 2.1.0.0
   :monitor_poll: 5.seconds
+  :monitor_server_roles_timeout: 5.minutes
   :prefetch_max_per_worker: 10
   :prefetch_max_per_worker_dequeue: 100
   :prefetch_min_per_worker_dequeue: 10


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1564567

Monitoring server roles as the master server is so important, it should
finish and not ever timeout. If it times out, servers will not be able
to gain roles. Previously, the default lock timeout of 1 minute is too
low in situations where the master server has higher than normal
latency to the database.  We need to give it more time to finish before
timing it out.

Additionally, we can specify this value in advanced settings in the server
section if 5.minutes is still not enough or just a wrong value.