### PR TITLE
Add association of service_templates to TransformationMapping.

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -1,5 +1,7 @@
 class TransformationMapping < ApplicationRecord
   has_many :transformation_mapping_items, :dependent => :destroy
+  has_many :service_resources, :as => :resource, :dependent => :nullify
+  has_many :service_templates, :through => :service_resources
 
   validates :name, :presence => true, :uniqueness => true
 

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,21 +1,30 @@
 describe TransformationMapping do
+  let(:src) { FactoryGirl.create(:ems_cluster) }
+  let(:dst) { FactoryGirl.create(:ems_cluster) }
+
+  let(:mapping) do
+    FactoryGirl.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+    )
+  end
+
   describe '#destination' do
-    let(:src) { FactoryGirl.create(:ems_cluster) }
-    let(:dst) { FactoryGirl.create(:ems_cluster) }
-
-    let(:mapping) do
-      FactoryGirl.create(
-        :transformation_mapping,
-        :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
-      )
-    end
-
     it "finds the destination" do
       expect(mapping.destination(src)).to eq(dst)
     end
 
     it "returns nil for unmapped source" do
       expect(mapping.destination(FactoryGirl.create(:ems_cluster))).to be_nil
+    end
+  end
+
+  describe '#service_templates' do
+    let(:plan) { FactoryGirl.create(:service_template_transformation_plan) }
+    before { FactoryGirl.create(:service_resource, :resource => mapping, :service_template => plan) }
+
+    it 'finds the transformation plans' do
+      expect(mapping.service_templates).to match([plan])
     end
   end
 end


### PR DESCRIPTION
A transformation mapping may be used by many service_template_transformation_plans.

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement, transformation

cc @bzwei 