### PR TITLE
Set DRb conn pool to [] after closing connections

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -350,6 +350,7 @@ class MiqWorker < ApplicationRecord
     # Once that is added this should be replaced.
     DRb::DRbConn.instance_variable_get(:@mutex).synchronize do
       DRb::DRbConn.instance_variable_get(:@pool).each(&:close)
+      DRb::DRbConn.instance_variable_set(:@pool, [])
     end
   end
 


### PR DESCRIPTION
After forking and closing open DRb pooled connections set the pool to []
to prevent other calls calling `conn.close` on already closed
connection.  This prevents the following:

```
[NoMethodError]: undefined method `close' for nil:NilClass
Did you mean?  clone
/opt/rh/rh-ruby23/root/usr/share/ruby/drb/drb.rb:1258:in `close'
/opt/rh/rh-ruby23/root/usr/share/ruby/drb/drb.rb:1237:in `block in open'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:234:in `block in sync_synchronize'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:231:in `handle_interrupt'
/opt/rh/rh-ruby23/root/usr/share/ruby/sync.rb:231:in `sync_synchronize'
/opt/rh/rh-ruby23/root/usr/share/ruby/drb/drb.rb:1235:in `open'
/opt/rh/rh-ruby23/root/usr/share/ruby/drb/drb.rb:1141:in `block in method_missing'
/opt/rh/rh-ruby23/root/usr/share/ruby/drb/drb.rb:1160:in `with_friend'
/opt/rh/rh-ruby23/root/usr/share/ruby/drb/drb.rb:1140:in `method_missing'
lib/gems/pending/VMwareWebService/MiqVimBroker.rb:419:in `getMiqVim'
```

After a successful call DRbConn.open pops a connection off the pool and closes it, https://github.com/ruby/ruby/blob/v2_3_7/lib/drb/drb.rb#L1237
And `#close` doesn't check if `@protocol` is nil before calling `@protocol.close`, https://github.com/ruby/ruby/blob/v2_3_7/lib/drb/drb.rb#L1258

https://bugzilla.redhat.com/show_bug.cgi?id=1562401