### PR TITLE
Adding PhysicalNetworkPort model

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -247,8 +247,13 @@ module EmsRefresh::SaveInventory
     end
 
     deletes = hardware.guest_devices.where(:device_type => ["ethernet", "storage"])
-    save_inventory_multi(hardware.guest_devices, hashes, deletes, [:device_type, :uid_ems], [:network, :miq_scsi_targets, :firmwares, :child_devices], [:switch, :lan])
-    store_ids_for_new_records(hardware.guest_devices, hashes, [:device_type, :uid_ems])
+
+    find_key = %i(device_type uid_ems)
+    child_keys = %i(network miq_scsi_targets firmwares physical_network_ports)
+    extra_keys = %i(switch lan)
+
+    save_inventory_multi(hardware.guest_devices, hashes, deletes, find_key, child_keys, extra_keys)
+    store_ids_for_new_records(hardware.guest_devices, hashes, find_key)
   end
 
   def save_child_devices_inventory(guest_device, hashes)

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -50,7 +50,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
 
     deletes = target == ems ? :use_association : []
 
-    save_inventory_multi(ems.physical_switches, hashes, deletes, [:uid_ems], %i(asset_detail hardware))
+    save_inventory_multi(ems.physical_switches, hashes, deletes, [:uid_ems], %i(asset_detail hardware physical_network_ports))
   end
 
   def save_physical_servers_inventory(ems, hashes, target = nil)
@@ -82,5 +82,15 @@ module EmsRefresh::SaveInventoryPhysicalInfra
   def save_asset_detail_inventory(parent, hash)
     return if hash.nil?
     save_inventory_single(:asset_detail, parent, hash)
+  end
+
+  def save_physical_network_ports_inventory(guest_device, hashes, target = nil)
+    return if hashes.nil?
+
+    deletes = target == guest_device ? :use_association : []
+
+    find_keys = %i(port_type uid_ems)
+
+    save_inventory_multi(guest_device.physical_network_ports, hashes, deletes, find_keys)
   end
 end

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -15,6 +15,8 @@ class GuestDevice < ApplicationRecord
   has_many :firmwares, :dependent => :destroy
   has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
 
+  has_many :physical_network_ports, :dependent => :destroy
+
   alias_attribute :name, :device_name
 
   def self.with_ethernet_type

--- a/app/models/physical_network_port.rb
+++ b/app/models/physical_network_port.rb
@@ -1,0 +1,4 @@
+class PhysicalNetworkPort < ApplicationRecord
+  belongs_to :guest_device
+  belongs_to :physical_switch
+end

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -1,6 +1,7 @@
 class PhysicalSwitch < Switch
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => :resource
   has_one :hardware, :dependent => :destroy, :foreign_key => :switch_id, :inverse_of => :physical_switch
+  has_many :physical_network_ports, :dependent => :destroy, :foreign_key => :switch_id
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_switches
 end


### PR DESCRIPTION
__This PR is able to:__
- Add `PhysicalNetworkPort` model to represent the ports of network devices;
- Add `PhysicalNetworkPort` relationship with `PhysicalSwitch`;
- Add `PhysicalNetworkPort` relationship with `GuestDevice`.

__Depends on:__
~https://github.com/ManageIQ/manageiq-schema/pull/185~ - Merged