### PR TITLE
Require dalli before using it

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -160,6 +160,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def key_store
+    require 'dalli'
     @key_store ||= Dalli::Client.new(MiqMemcached.server_address, :namespace => "server_monitor")
   end
 

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -398,6 +398,7 @@ class MiqWorker::Runner
   end
 
   def key_store
+    require 'dalli'
     @key_store ||= Dalli::Client.new(MiqMemcached.server_address, :namespace => "server_monitor")
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1564647

Note, we require dalli in the session_store.rb only if you're configured
for session_store: cache.  If you specify, 'sql', dalli doesn't get
required, and these two code paths could hit a NameError.

This was originally added in https://github.com/ManageIQ/manageiq/pull/15471