### PR TITLE
Add `:transformation` under product and set it to `true` by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -972,6 +972,7 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
+  :transformation: true
 :prototype:
   :queue_type: miq_queue
   :artemis:


### PR DESCRIPTION
Add the `:transformation` flag under the `product` section and set it to `true` by default.

This flag enables/disables v2v UI.

Related UI PR - https://github.com/priley86/miq_v2v_ui_plugin/pull/190