### PR TITLE
Add cloud volumes for selecting assigned tagged resources

### DIFF
--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -29,8 +29,8 @@ class Chargeback
     end
 
     def parents_determining_rate
-      [resource.host, resource.ems_cluster, resource.storage, parent_ems, resource.tenant,
-       MiqEnterprise.my_enterprise].compact
+      [resource.host, resource.ems_cluster, resource.storage, resource.try(:cloud_volumes), parent_ems, resource.tenant,
+       MiqEnterprise.my_enterprise].flatten.compact
     end
 
     def none?(metric)


### PR DESCRIPTION
Assigning `rate` for storages by tags on cloud volumes (by option `Tagged datastores`) did not work for chargeback without including metrics. 

it can be set here:

![screen shot 2018-04-10 at 10 46 30](https://user-images.githubusercontent.com/14937244/38546271-7a612cca-3cac-11e8-9329-a3d8f820f7ba.png)

# Fix
Fix was about to include also `resource's cloud_volumes` for selecting rates in `ConsumptionWithoutRollups#parents_determining_rate` for calling method to select rate:
https://github.com/ManageIQ/manageiq/blob/master/app/models/chargeback/rates_cache.rb#L24



# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1559807


@miq-bot assign @gtanzillo 
@miq-bot add_label bug, chargeback 


