### PR TITLE
Forcing default_value to an array, if the dynamic dropdown is multiselect

### DIFF
--- a/app/models/dialog_field_radio_button.rb
+++ b/app/models/dialog_field_radio_button.rb
@@ -7,6 +7,10 @@ class DialogFieldRadioButton < DialogFieldSortedItem
     [[nil, "<None>"]]
   end
 
+  def force_multi_value
+    false
+  end
+
   private
 
   def raw_values

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -96,6 +96,9 @@ class DialogFieldSortedItem < DialogField
   end
 
   def determine_selected_default_value
+    if dynamic? && force_multi_value && !default_value.kind_of?(Array)
+      self.default_value = Array.wrap(default_value)
+    end
     use_first_value_as_default unless default_value_included?(@raw_values)
     self.value ||= default_value.nil? && data_type == "integer" ? nil : default_value.send(value_modifier)
   end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -13,6 +13,9 @@ describe DialogFieldSortedItem do
     let(:default_value) { "test2" }
 
     context "when show_refresh_button is true" do
+      before(:each) do
+        allow(dialog_field).to receive(:force_multi_value).and_return(false)
+      end
       let(:show_refresh_button) { true }
 
       context "when load_values_on_init is true" do
@@ -59,6 +62,9 @@ describe DialogFieldSortedItem do
 
     context "when show_refresh_button is false" do
       let(:show_refresh_button) { false }
+      before(:each) do
+        allow(dialog_field).to receive(:force_multi_value).and_return(false)
+      end
 
       context "when load_values_on_init is true" do
         let(:load_values_on_init) { true }
@@ -148,13 +154,47 @@ describe DialogFieldSortedItem do
         allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(values)
       end
 
-      context "when the default_value is included in the list of returned values" do
+      context "when the force_multi_value is set to false" do
         let(:default_value) { "abc" }
+        before do
+          allow(dialog_field).to receive(:force_multi_value).and_return(false)
+        end
 
-        it "sets the default value" do
+        it "sets the default_value" do
           dialog_field.values
           expect(dialog_field.default_value).to eq("abc")
         end
+      end
+
+      context "when the force_multi_value is set to true" do
+        let(:default_value) { "abc" }
+        before do
+          allow(dialog_field).to receive(:force_multi_value).and_return(true)
+          # FIXME (rblanco): this is a workaround for the tested class being
+          # DialogFieldSortedItem and not DialogFieldDropDownList as it is
+          # in real usecase
+          #
+          # The test should be moved to dialog_field_drop_down_list_spec.rb, as
+          # https://github.com/ManageIQ/manageiq/pull/17272#discussion_r180468970
+          # says.
+          allow(dialog_field).to receive(:default_value_included?).and_return(true)
+        end
+
+        it "sets the default_value" do
+          dialog_field.values
+          # while reproducing the BZ, the method
+          # `determine_selected_default_value` is called twice,
+          # not just once - could be a difference here
+          expect(dialog_field.default_value).to eq("[\"abc\"]")
+        end
+      end
+
+      context "when the default_value is included in the list of returned values" do
+        before do
+          allow(dialog_field).to receive(:force_multi_value).and_return(false)
+        end
+
+        let(:default_value) { "abc" }
 
         it "sets the value to the default value" do
           dialog_field.values
@@ -163,6 +203,10 @@ describe DialogFieldSortedItem do
       end
 
       context "when the default_value is not included in the list of returned values" do
+        before do
+          allow(dialog_field).to receive(:force_multi_value).and_return(false)
+        end
+
         let(:default_value) { "123" }
 
         it "sets the default value to the first value" do


### PR DESCRIPTION
Opening this PR instead of https://github.com/ManageIQ/manageiq/pull/17259

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1559030

The value of the  is set to be an id of provider (ExtManagementSystem)

Steps for Testing/QA
-------------------------------

1) setup automate expression method:
  - automation -> automate -> explorer -> datastore -> configuration -> add a new domain
  - select the new domain -> configuration -> add a new instance
  - select the new instance -> configuration -> add a new class
  - select the new class -> switch to the `methods` tab -> configuration -> add a new method
    - select expression -> Expression Object set to ExtManagementSystem
    - at the bottom select field -> Provider: Total Vms >= 1 -> commit -> save
  - select the class in explorer -> switch to the `schema` tab -> configuration -> edit selected schema
    - click the green plus -> set name to `execute` -> type set to `method` -> data type set to `String` -> save
  - select the class in explorer -> switch to the `instance` tab -> configuration -> add a new instance
    - use the name of created method as the value

_the rest is from the BZ ticket:_

2) Create a service dialog containing a single drop-down list element. Make this element dynamic, and create an expression method to populate it (I used a simple expression method that lists all VMs). Leave the 'Multiselect' option as 'No'. Save the dialog.
3) Now edit the dialog, and change the 'Multiselect' option to 'Yes'. Save the dialog


Thanks for the help with setting up the expression method @pkomanek!