### PR TITLE
Don't format PersistentVolume-capacity as bytes

### DIFF
--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -19,10 +19,10 @@ class MiqReport::Formats
     end
   end
 
-  def self.default_format_for_path(path, dt)
-    col = path.split('-').last.to_sym
-    sfx = col.to_s.split('__').last.try(:to_sym)
-    default_format_for(col, sfx, dt)
+  def self.default_format_for_path(path, datatype)
+    column = path.split('-').last.to_sym
+    suffix = column.to_s.split('__').last.try(:to_sym)
+    default_format_for(column, suffix, datatype)
   end
 
   def self.default_format_for(column, suffix, datatype)

--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -22,10 +22,6 @@ class MiqReport::Formats
   def self.default_format_for_path(path, datatype)
     column = path.split('-').last.to_sym
     suffix = column.to_s.split('__').last.try(:to_sym)
-    default_format_for(column, suffix, datatype)
-  end
-
-  def self.default_format_for(column, suffix, datatype)
     DEFAULTS_AND_OVERRIDES[:formats_by_suffix][suffix] ||
       DEFAULTS_AND_OVERRIDES[:formats_by_column][column] ||
       DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][sub_type(column)] ||

--- a/app/models/miq_report/formats.rb
+++ b/app/models/miq_report/formats.rb
@@ -22,10 +22,14 @@ class MiqReport::Formats
   def self.default_format_for_path(path, datatype)
     column = path.split('-').last.to_sym
     suffix = column.to_s.split('__').last.try(:to_sym)
-    DEFAULTS_AND_OVERRIDES[:formats_by_suffix][suffix] ||
-      DEFAULTS_AND_OVERRIDES[:formats_by_column][column] ||
-      DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][sub_type(column)] ||
-      DEFAULTS_AND_OVERRIDES[:formats_by_data_type][datatype]
+    # HACK: formats for columns are unqualified, so we need a
+    # temporary way to avoid collisions
+    DEFAULTS_AND_OVERRIDES[:formats_by_path].fetch(path.to_sym) do
+      DEFAULTS_AND_OVERRIDES[:formats_by_suffix][suffix] ||
+        DEFAULTS_AND_OVERRIDES[:formats_by_column][column] ||
+        DEFAULTS_AND_OVERRIDES[:formats_by_sub_type][sub_type(column)] ||
+        DEFAULTS_AND_OVERRIDES[:formats_by_data_type][datatype]
+    end
   end
 
   def self.default_format_details_for(path, column, datatype)

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -1,7 +1,10 @@
 ---
 :defaults_and_overrides:
   :formats_by_path:
+    :ContainerVolume-capacity: null
+    :ContainerVolumeKubernetes-capacity: null
     :PersistentVolume-capacity: null
+    :PersistentVolumeClaim-capacity: null
 
   :formats_by_data_type:
     :integer: :general_number_precision_0

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -1,5 +1,8 @@
 ---
 :defaults_and_overrides:
+  :formats_by_path:
+    :PersistentVolume-capacity: null
+
   :formats_by_data_type:
     :integer: :general_number_precision_0
     :decimal: :general_number_precision_0

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -43,5 +43,10 @@ describe MiqReport::Formats do
         end
       end
     end
+
+    it "can find overrides for specific paths" do
+      actual = described_class.default_format_for_path("PersistentVolume-capacity", :text)
+      expect(actual).to be_nil
+    end
   end
 end

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -45,6 +45,10 @@ describe MiqReport::Formats do
     end
 
     it "can find overrides for specific paths" do
+      # The default case:
+      expect(described_class.default_format_for_path("MiqScsiLuns-capacity", :bigint)).to eq(:bytes_human)
+
+      # The overrides:
       expect(described_class.default_format_for_path("ContainerVolume-capacity", :text)).to be_nil
       expect(described_class.default_format_for_path("ContainerVolumeKubernetes-capacity", :text)).to be_nil
       expect(described_class.default_format_for_path("PersistentVolume-capacity", :text)).to be_nil

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -45,8 +45,10 @@ describe MiqReport::Formats do
     end
 
     it "can find overrides for specific paths" do
-      actual = described_class.default_format_for_path("PersistentVolume-capacity", :text)
-      expect(actual).to be_nil
+      expect(described_class.default_format_for_path("ContainerVolume-capacity", :text)).to be_nil
+      expect(described_class.default_format_for_path("ContainerVolumeKubernetes-capacity", :text)).to be_nil
+      expect(described_class.default_format_for_path("PersistentVolume-capacity", :text)).to be_nil
+      expect(described_class.default_format_for_path("PersistentVolumeClaim-capacity", :text)).to be_nil
     end
   end
 end

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -17,7 +17,7 @@ describe MiqReport::Formats do
     end
   end
 
-  describe '.default_format_for' do
+  describe '.default_format_for_path' do
     context 'for chargebacks' do
       let!(:cloud_volume) { FactoryGirl.create(:cloud_volume_openstack) }
 
@@ -29,7 +29,7 @@ describe MiqReport::Formats do
       it 'works' do
         columns.each do |name, datatype|
           name = ChargebackVm.default_column_for_format(name)
-          subj = described_class.default_format_for(name.to_sym, name.to_sym, datatype.first)
+          subj = described_class.default_format_for_path("ChargebackVm-#{name}", datatype.first)
           if name.ends_with?('_cost')
             expect(subj).to eq(:currency_precision_2)
           elsif name.ends_with?('_metric')


### PR DESCRIPTION
There are other tables that have `capacity` columns that are formatted
as bytes. This newer column is serialized and will blow when trying to
apply this formatting to it. Since the existing way of mapping columns
to formats does not take table name into account, we need a temporary
way to override this for colliding column names. This can later be
reworked so all mapped formats will be qualified in some way.

Screens:

![manageiq_reports_-_2018-04-10_12 07 22](https://user-images.githubusercontent.com/1710874/38578324-7d938bfc-3cb8-11e8-8ed6-0540871e1737.png)


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1563861

NOTE: I did some refactoring to make this easier - probably best viewed as separate commits
