### PR TITLE
[EUWE] Change VMware console api detection from vCenter to ESXi Host

### DIFF
--- a/app/helpers/application_helper/toolbar_builder.rb
+++ b/app/helpers/application_helper/toolbar_builder.rb
@@ -1132,7 +1132,7 @@ class ApplicationHelper::ToolbarBuilder
           return N_("The web-based VNC console is not available because the VM is not powered on")
         end
         type = get_vmdb_config.fetch_path(:server, :remote_console_type)
-        if @record.vendor == 'vmware' && type == 'VNC' && @record.console_supported?(type) && @record.ext_management_system.api_version.to_f > 6
+        if @record.vendor == 'vmware' && type == 'VNC' && @record.console_supported?(type) && !@record.host.nil? && @record.host.vmm_version.to_f > 6
           return N_("The web-based VNC console is not available on VMware versions 6.5 and above.")
         end
       when "instance_retire_now"

--- a/spec/helpers/application_helper/toolbar_builder_spec.rb
+++ b/spec/helpers/application_helper/toolbar_builder_spec.rb
@@ -1691,10 +1691,10 @@ describe ApplicationHelper do
           }
           stub_server_configuration(vmdb_config)
 
-          ems = FactoryGirl.create(:ems_vmware)
-          @record = FactoryGirl.create(:vm_vmware, :ext_management_system => ems, :vendor => 'vmware')
+          host = FactoryGirl.create(:host)
+          @record = FactoryGirl.create(:vm_vmware, :host => host, :vendor => 'vmware')
 
-          allow(ems).to receive_messages(:api_version => '6.5')
+          allow(host).to receive_messages(:vmm_version => '6.5')
           expect(subject).to eq("The web-based VNC console is not available on VMware versions 6.5 and above.")
         end
 


### PR DESCRIPTION
This resolves an issue where a VM on a 5.5 Host was not reachable by a VNC console when the Host was in a cluster in vCenter 6.5.

Euwe backport of https://github.com/ManageIQ/manageiq-ui-classic/pull/3256

@miq-bot add_labels bug, blocker, compute/infrastructure

https://bugzilla.redhat.com/show_bug.cgi?id=1565776