### PR TITLE
Add lock to retire_now start

### DIFF
--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -27,6 +27,31 @@ describe "Service Retirement Management" do
     expect(@service.retirement_state).to be_nil
     expect(MiqEvent).to receive(:raise_evm_event).once
     @service.retire_now
+    expect(@service.retirement_state).to eq('initializing')
+    @service.reload
+  end
+
+  it "#retire_now when called more than once" do
+    expect(@service.retirement_state).to be_nil
+    expect(MiqEvent).to receive(:raise_evm_event).once
+    @service.retire_now
+    @service.retire_now
+    @service.retire_now
+    expect(@service.retirement_state).to eq('initializing')
+    @service.reload
+  end
+
+  it "#retire_now not called when already retiring" do
+    @service.update_attributes(:retirement_state => 'retiring')
+    expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
+    @service.retire_now
+    @service.reload
+  end
+
+  it "#retire_now not called when already retired" do
+    @service.update_attributes(:retirement_state => 'retired')
+    expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
+    @service.retire_now
     @service.reload
   end
 

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -28,31 +28,25 @@ describe "Service Retirement Management" do
     expect(MiqEvent).to receive(:raise_evm_event).once
     @service.retire_now
     expect(@service.retirement_state).to eq('initializing')
-    @service.reload
   end
 
   it "#retire_now when called more than once" do
     expect(@service.retirement_state).to be_nil
     expect(MiqEvent).to receive(:raise_evm_event).once
-    @service.retire_now
-    @service.retire_now
-    @service.retire_now
+    3.times { @service.retire_now }
     expect(@service.retirement_state).to eq('initializing')
-    @service.reload
   end
 
   it "#retire_now not called when already retiring" do
     @service.update_attributes(:retirement_state => 'retiring')
     expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
     @service.retire_now
-    @service.reload
   end
 
   it "#retire_now not called when already retired" do
     @service.update_attributes(:retirement_state => 'retired')
     expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
     @service.retire_now
-    @service.reload
   end
 
   it "#retire_now with userid" do
@@ -64,7 +58,6 @@ describe "Service Retirement Management" do
     expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {}).once
 
     @service.retire_now('freddy')
-    @service.reload
   end
 
   it "#retire_now without userid" do
@@ -76,7 +69,6 @@ describe "Service Retirement Management" do
     expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {}).once
 
     @service.retire_now
-    @service.reload
   end
 
   it "#retire warn" do

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -34,10 +34,7 @@ describe "VM Retirement Management" do
 
   it "#retire_now when called more than once" do
     expect(MiqEvent).to receive(:raise_evm_event).once
-
-    @vm.retire_now
-    @vm.retire_now
-    @vm.retire_now
+    3.times { @vm.retire_now }
     expect(@vm.retirement_state).to eq('initializing')
   end
 
@@ -45,14 +42,12 @@ describe "VM Retirement Management" do
     @vm.update_attributes(:retirement_state => 'retiring')
     expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
     @vm.retire_now
-    @vm.reload
   end
 
   it "#retire_now not called when already retired" do
     @vm.update_attributes(:retirement_state => 'retired')
     expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
     @vm.retire_now
-    @vm.reload
   end
 
   it "#retire_now with userid" do

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -29,6 +29,30 @@ describe "VM Retirement Management" do
     expect(MiqEvent).to receive(:raise_evm_event).once
 
     @vm.retire_now
+    expect(@vm.retirement_state).to eq('initializing')
+  end
+
+  it "#retire_now when called more than once" do
+    expect(MiqEvent).to receive(:raise_evm_event).once
+
+    @vm.retire_now
+    @vm.retire_now
+    @vm.retire_now
+    expect(@vm.retirement_state).to eq('initializing')
+  end
+
+  it "#retire_now not called when already retiring" do
+    @vm.update_attributes(:retirement_state => 'retiring')
+    expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
+    @vm.retire_now
+    @vm.reload
+  end
+
+  it "#retire_now not called when already retired" do
+    @vm.update_attributes(:retirement_state => 'retired')
+    expect(MiqEvent).to receive(:raise_evm_event).exactly(0).times
+    @vm.retire_now
+    @vm.reload
   end
 
   it "#retire_now with userid" do


### PR DESCRIPTION
This is a solution for the fact that in a multi-appliance setup we can have multiple workers start retirement for the same service or vm.

related to:
https://github.com/ManageIQ/manageiq-content/pull/281
