### PR TITLE
[FINE] Use renamed methods

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -406,7 +406,7 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       # The required memory cannot exceed the max configured memory of the VM. Therefore, we'll increase the max
       # memory up to 1TB or to the required limit, to allow a successful update for the VM.
       # Once 'max' memory attribute will be introduced, this code should be replaced with the specified max memory.
-      supports_max = ext_management_system.version_at_least?('4.1')
+      supports_max = ext_management_system.version_higher_than?('4.1')
       max = calculate_max_memory(vm, memory) if supports_max
 
       # If the virtual machine is running we need to update first the configuration that will be used during the

--- a/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4_spec.rb
@@ -195,7 +195,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
 
       context "api version supports max" do
         before do
-          allow(@ems).to receive(:version_at_least?).with('4.1').and_return(true)
+          allow(@ems).to receive(:version_higher_than?).with('4.1').and_return(true)
           @memory_spec = { :memory => memory, :memory_policy => { :guaranteed => 2.gigabyte, :max => max } }
         end
 
@@ -232,7 +232,7 @@ describe ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V
 
       context "api version doesn't support max" do
         it "doesn't pass the max in the request" do
-          allow(@ems).to receive(:version_at_least?).with('4.1').and_return(false)
+          allow(@ems).to receive(:version_higher_than?).with('4.1').and_return(false)
 
           mod_memory_policy = { :guaranteed => 2.gigabyte }
           expect(@vm_service).to receive(:update).with(OvirtSDK4::Vm.new(:memory => 8.gigabytes, :memory_policy => mod_memory_policy))


### PR DESCRIPTION
Methods on master branch were renamed, therefore the backport failed.
This PR uses the methods names before the change on master branch.

The issue occurred by backporting https://github.com/ManageIQ/manageiq-providers-ovirt/pull/224