### PR TITLE
[EUWE] Lock fog-vcloud-director gem to 0.1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "default_value_for",              "~>3.0.2"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "fog-google",                     "=0.5.2",        :require => false
-gem "fog-vcloud-director",            "~>0.1.6",       :require => false
+gem "fog-vcloud-director",            "0.1.8",         :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.1.0"
 gem "google-api-client",              "=0.8.6",        :require => false


### PR DESCRIPTION
With this commit we prevent `euwe` branch from silently following fog-vcloud-director gem development as not all chages are compatible. So we lock the version to 0.1.8.

@miq-bot add_label dependencies,euwe/yes
@miq-bot assign @simaishi 

/cc @agrare 