### PR TITLE
fix vm and template taggings doubling issue

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -63,12 +63,9 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
       attributes = {
         :model_class                  => Tagging,
         :association                  => :vm_and_template_taggings,
-        :manager_ref                  => [:taggable, :tag],
-        :parent_inventory_collections => [:vms, :miq_templates],
-        :inventory_object_attributes  => [
-          :taggable,
-          :tag,
-        ]
+        :manager_ref                  => %i(taggable tag).freeze,
+        :inventory_object_attributes  => %i(taggable tag).freeze,
+        :parent_inventory_collections => %i(vms miq_templates).freeze,
       }
 
       attributes[:targeted_arel] = lambda do |inventory_collection|
@@ -83,12 +80,13 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
         taggable_attributes = %i(taggable_id taggable_type).freeze
         manager_ref_cols = inventory_collection.manager_ref_to_cols
 
-        attributes_index.values
-          .group_by { |attributes| attributes.slice(*taggable_attributes) }
+        attributes_index
+          .values
+          .group_by { |object_attributes| object_attributes.slice(*taggable_attributes) }
           .each do |taggable_ref, attributes_array|
             next unless (taggable_attributes - taggable_ref.keys).empty?
 
-            tag_ids = attributes_array.map { |attributes| attributes[:tag_id] }.uniq.compact
+            tag_ids = attributes_array.map { |object_attributes| object_attributes[:tag_id] }.uniq.compact
             relation = inventory_collection.model_class.where(taggable_ref)
 
             relation.where.not(:tag_id => tag_ids).in_batches(&:destroy_all)
@@ -98,7 +96,7 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
               inventory_object = inventory_objects_index.delete(index)
               inventory_object.id = record.id
               attributes_index.delete(index)
-              inventory_collection.store_updated_records(record) if !inventory_collection.check_changed?
+              inventory_collection.store_updated_records(record) unless inventory_collection.check_changed?
             end
           end
       end.freeze


### PR DESCRIPTION
I've found that `Tagging` records being doubled on each EMS refresh 
_(true for Amazon and Azure providers)_

Related Amazon repo PR: https://github.com/ManageIQ/manageiq-providers-amazon/pull/430
For the Azure repo this will be taken into account by a https://github.com/ManageIQ/manageiq-providers-azure/pull/229 PR

Tests are in the Amazon repo: https://github.com/ManageIQ/manageiq-providers-amazon/pull/430/files#diff-8eb32bbfc5abbdd5da39e8d2a11419d0R42