### PR TITLE
Add configuration_script_sources.last_update_error

### DIFF
--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -28,7 +28,7 @@ module ManagerRefresh::Inventory::Core
         :manager_ref                 => [:manager_ref],
         :inventory_object_attributes => %i(
           name description scm_type scm_url scm_branch scm_clean scm_delete_on_update
-          scm_update_on_launch authentication status last_updated_on
+          scm_update_on_launch authentication status last_updated_on last_update_error
         ),
       }.merge(options))
     end


### PR DESCRIPTION
Add new `last_update_stdout` column to `configuration_script_sources` table. This allows to store last update stdout to display more information about why its refresh failed.

Fetching and presenting this information is a workaround for cloning repositories from HTTPS servers with untrusted SSL certificates. Tower API does not offer an option to disable SSL check, so with the stdout user can at least see, why the cloning actually failed.

https://bugzilla.redhat.com/show_bug.cgi?id=1513616

Prior merging this PR, folowing PRs require to be merged:

* [x] manageiq/manageiq#17515 Gemfile dependency
* [x] manageiq/manageiq-schema#187 migration
* [x] ansible/ansible_tower_client_ruby#103 version release

/cc @jameswnl for review