### PR TITLE
Add support for sysprep customization templates

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtWorkflow
   include_concern "DialogFieldValidation"
   include CloudInitTemplateMixin
+  include SysprepTemplateMixin
 
   def allowed_availability_zones(_options = {})
     source = load_ar_obj(get_source_vm)
@@ -63,6 +64,10 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
     true
   end
 
+  def supports_sysprep?
+    true
+  end
+
   def set_or_default_hardware_field_values(_vm)
   end
 
@@ -76,7 +81,7 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def allowed_customization_templates(options = {})
-    allowed_cloud_init_customization_templates(options)
+    allowed_cloud_init_customization_templates(options).concat(allowed_sysprep_customization_templates(options))
   end
 
   private

--- a/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision_workflow.rb
@@ -60,12 +60,16 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
     ci.description.blank? ? ci.name : "#{ci.name}: #{ci.description}"
   end
 
+  # Override in provider subclass as needed.
+  #
   def supports_cloud_init?
     true
   end
 
+  # Override in provider subclass as needed.
+  #
   def supports_sysprep?
-    true
+    false
   end
 
   def set_or_default_hardware_field_values(_vm)
@@ -81,7 +85,10 @@ class ManageIQ::Providers::CloudManager::ProvisionWorkflow < ::MiqProvisionVirtW
   end
 
   def allowed_customization_templates(options = {})
-    allowed_cloud_init_customization_templates(options).concat(allowed_sysprep_customization_templates(options))
+    allowed = []
+    allowed.concat(allowed_cloud_init_customization_templates(options)) if supports_cloud_init?
+    allowed.concat(allowed_sysprep_customization_templates(options)) if supports_sysprep?
+    allowed
   end
 
   private

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -59,8 +59,12 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
     false
   end
 
+  def supports_sysprep?
+    false
+  end
+
   def supports_customization_template?
-    supports_pxe? || supports_iso? || supports_cloud_init?
+    supports_pxe? || supports_iso? || supports_cloud_init? || supports_sysprep?
   end
 
   def continue_request(values)

--- a/app/models/mixins/sysprep_template_mixin.rb
+++ b/app/models/mixins/sysprep_template_mixin.rb
@@ -1,0 +1,19 @@
+module SysprepTemplateMixin
+  def allowed_sysprep_customization_templates(_options = {})
+    result = []
+    return result if (source = load_ar_obj(get_source_vm)).blank?
+    return result unless source.platform.casecmp('windows').zero?
+
+    customization_template_id = get_value(@values[:customization_template_id])
+    @values[:customization_template_script] = nil if customization_template_id.nil?
+
+    result = CustomizationTemplateSysprep.in_region(source.region_number).all.collect do |c|
+      @values[:customization_template_script] = c.script if c.id == customization_template_id
+      build_ci_hash_struct(c, %i(name description updated_at))
+    end
+
+    result.compact!
+    @values[:customization_template_script] = nil if result.blank?
+    result
+  end
+end

--- a/spec/factories/customization_template.rb
+++ b/spec/factories/customization_template.rb
@@ -29,7 +29,7 @@ FactoryGirl.define do
   factory :customization_template_sysprep,
           :parent => :customization_template,
           :class  => "CustomizationTemplateSysprep" do
-    sequence(:name)        { |n| "customization_template_syspre_#{seq_padded_for_sorting(n)}" }
+    sequence(:name)        { |n| "customization_template_sysprep_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "Customization Template Sysprep #{seq_padded_for_sorting(n)}" }
     after(:build) do |x|
       x.pxe_image_type ||= FactoryGirl.create(:pxe_image_type)

--- a/spec/models/customization_template_sysprep_spec.rb
+++ b/spec/models/customization_template_sysprep_spec.rb
@@ -1,0 +1,7 @@
+describe CustomizationTemplateSysprep do
+  context "#default_filename" do
+    it "should be unattend.xml" do
+      expect(described_class.new.default_filename).to eq('unattend.xml')
+    end
+  end
+end

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -47,6 +47,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
     it "should retrieve sysprep templates when cloning" do
       options = {'key' => 'value' }
       allow(sysprep_workflow).to receive(:supports_native_clone?).and_return(true)
+      allow(sysprep_workflow).to receive(:supports_sysprep?).and_return(true)
       allow(sysprep_workflow).to receive(:load_ar_obj).and_return(template)
       allow(template).to receive(:platform).and_return('windows')
 
@@ -229,7 +230,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
     context "#supports_sysprep?" do
       it "returns the expected boolean value" do
-        expect(workflow.supports_sysprep?).to eql(true)
+        expect(workflow.supports_sysprep?).to eql(false)
       end
     end
   end


### PR DESCRIPTION
This adds support for sysprep customization templates.

Attempts to address https://github.com/ManageIQ/manageiq/issues/17288

This is a WIP for now because I'm not sure if we want to support this by default, or if individual providers should have to opt-in. And also because it needs more specs and UAT.