### PR TITLE
Change the role for Service provisioning create_request_tasks MiqQueue.put.

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -429,7 +429,7 @@ class MiqRequest < ApplicationRecord
       :instance_id    => id,
       :method_name    => "create_request_tasks",
       :zone           => options.fetch(:miq_zone, my_zone),
-      :role           => my_role,
+      :role           => kind_of?(ServiceTemplateProvisionRequest) ? 'automate' : my_role,
       :tracking_label => tracking_label_id,
       :msg_timeout    => 3600,
       :deliver_on     => deliver_on


### PR DESCRIPTION
Most provision request types have a ```my_role``` value of ```ems_operations``` which makes sense because the provisions have to interact with a provider.  Note - the automation request value for ```my_role``` is ```automate```. 
The creation of the request tasks for Service provisioning shouldn't be tied to the ```ems_operations``` role. 

 Changed the MiqQueue.put role for the Service Template Provision Request ```create_request_tasks``` from ```ems_operations``` to ```automate```.  I changed the MiqQueue.put call instead of changing the ServiceTemplateProvisionRequest ```my_role``` method because I want to limit the role change to just the ```create_request_tasks``` method. 


fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1534068

