### PR TITLE
Add method retire_now to container OrchestrationStack.

### DIFF
--- a/app/models/manageiq/providers/container_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/container_manager/orchestration_stack.rb
@@ -22,6 +22,11 @@ class ManageIQ::Providers::ContainerManager::OrchestrationStack < ::Orchestratio
     "#{name}::Status".constantize
   end
 
+  def retire_now(requester = nil)
+    update_attributes(:retirement_requester => requester)
+    finish_retirement
+  end
+
   def raw_status
     failed = resources.any? { |obj| obj.resource_status == 'failed' }
     if failed

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -74,4 +74,6 @@ FactoryGirl.define do
   factory :embedded_ansible_job, :class => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job"
 
   factory :orchestration_stack_vmware_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::Vmware::CloudManager::OrchestrationStack"
+
+  factory :orchestration_stack_container, :parent => :orchestration_stack, :class => "ManageIQ::Providers::ContainerManager::OrchestrationStack"
 end

--- a/spec/models/manageiq/providers/container_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/container_manager/orchestration_stack_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::ContainerManager::OrchestrationStack do
+  let(:stack) { FactoryGirl.create(:orchestration_stack_container) }
+
+  describe '#retire_now' do
+    it 'retires the orchestration stack' do
+      expect(stack).to receive(:finish_retirement).once
+      stack.retire_now
+    end
+  end
+end


### PR DESCRIPTION
So the container service may be retired.

https://bugzilla.redhat.com/show_bug.cgi?id=1564154

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, gaprindashvili/yes

cc @bzwei 