### PR TITLE
Initialize MiqQueue.miq_task_id column when queuing metric capture task

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -87,6 +87,8 @@ module Metric::CiMixin::Capture
       queue_item_options[:args] = start_and_end_time if start_and_end_time.present?
       next if item_interval != 'realtime' && messages[start_and_end_time].try(:priority) == priority
       MiqQueue.put_or_update(queue_item_options) do |msg, qi|
+        # reason for setting MiqQueue#miq_task_id is to initializes MiqTask.started_on column when message delivered.
+        qi[:miq_task_id] = task_id if task_id
         if msg.nil?
           qi[:priority] = priority
           qi.delete(:state)

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -355,6 +355,13 @@ describe Metric::CiMixin::Capture do
         verify_perf_capture_queue(last_perf_capture_on, 11)
       end
     end
+
+    it "links supplied miq_task with queued item which allow to initialize MiqTask#started_on attribute" do
+      MiqQueue.delete_all
+      task = FactoryGirl.create(:miq_task)
+      vm.perf_capture_queue("realtime", :task_id => task.id)
+      expect(MiqQueue.first.miq_task_id).to eq task.id
+    end
   end
 
   describe "#perf_capture_queue('historical')" do


### PR DESCRIPTION
This PR will allow to automatically initialize `MiqTask.started_on` field when queued command to perform metric capture delivered.

This PR is follow-up to https://github.com/ManageIQ/manageiq/pull/17015

related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1543289

@miq-bot add-label core, enhancement

