### PR TITLE
Load config/coverage_hook.rb at process creation

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -321,6 +321,7 @@ class MiqWorker < ApplicationRecord
     DRb.stop_service
     close_drb_pool_connections
     renice(Process.pid)
+    CodeCoverage.run_hook
   end
 
   # When we fork, the children inherits the parent's file descriptors

--- a/config/preinitializer.rb
+++ b/config/preinitializer.rb
@@ -3,3 +3,6 @@ if ENV["REQUIRE_LOG"]
   $req_log_path = File.join(File.dirname(__FILE__), %w(.. log))
   require 'require_with_logging'
 end
+
+require File.join(__dir__, "..", "lib", "code_coverage")
+CodeCoverage.run_hook

--- a/lib/code_coverage.rb
+++ b/lib/code_coverage.rb
@@ -1,0 +1,12 @@
+require 'pathname'
+module CodeCoverage
+  # The HOOK_FILE is responsible for starting or restarting code coverage.
+  # Child worker forks inherit the code coverage environment when the server
+  # invoked the 'run_hook' so they must reset the environment for the new process.
+  HOOK_FILE = Pathname.new(__dir__).join("..", "config", "coverage_hook.rb").freeze
+  def self.run_hook
+    # Note: We use 'load' here because require would only load the hook once,
+    # in the server but not when the child fork starts.  Shared memory is hard.
+    load HOOK_FILE if File.exist?(HOOK_FILE)
+  end
+end


### PR DESCRIPTION
If this file exists, we'll load it before the server starts and after we fork new workers.

Note, I didn't choose to use an ENV variable to enable this.  Instead, we'll load this if `config/coverage_hook.rb` exists.  I'm not opinionated on this, I just chose the easiest thing possible.

cc @jamesooden @Fryguy 