### PR TITLE
[WIP] [FINE] ContainerLabelTagMapping::Mapper class, separate tag creation

### DIFF
--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -12,21 +12,6 @@ class ContainerLabelTagMapping < ApplicationRecord
   #
   # All involved tags must also have a Classification.
 
-  AUTOTAG_PREFIX = "kubernetes".freeze
-
-  MAPPABLE_ENTITIES = [
-    nil,
-    "Amazon::Vm",
-    "Amazon::Image",
-    "Kubernetes::ContainerProject",
-    "Kubernetes::ContainerRoute",
-    "Kubernetes::ContainerNode",
-    "Kubernetes::ContainerReplicator",
-    "Kubernetes::ContainerService",
-    "Kubernetes::ContainerGroup",
-    "Kubernetes::ContainerBuild"
-  ].freeze
-
   belongs_to :tag
 
   # Pass the data this returns to map_* methods.

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -64,7 +64,7 @@ class ContainerLabelTagMapping < ApplicationRecord
       category = Tag.find(tag_hash[:category_tag_id]).classification
       entry = category.find_entry_by_name(tag_hash[:entry_name])
       unless entry
-        category.lock :exclusive do
+        category.lock(:exclusive) do
           begin
             entry = category.add_entry(:name        => tag_hash[:entry_name],
                                        :description => tag_hash[:entry_description])

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -1,83 +1,38 @@
+# A mapping matches labels on `resource_type` (NULL means any), `name` (required),
+# and `value` (NULL means any).
+#
+# Note: `labeled_resource_type` doesn't really need to match the actual label's `resource_type`;
+# it's simply matched against the type argument to Mapper#map_labels,
+# and sometimes is a fake string like 'Vm' or 'Image' instead of a model name.
+#
+# Different labels might map to same tag, and one label might map to multiple tags.
+#
+# There are 2 kinds of rows:
+# - When `label_value` is specified, we map only this value to a specific `tag`.
+#   TODO: drop this.  This was never exposed in UI and is dead code to maintain.
+#
+# - When `label_value` is NULL, we map this name with any value to per-value tags.
+#   In this case, `tag` specifies the category under which to create
+#   the value-specific tag (and classification) on demand.
+#
+# All involved tags must also have a Classification.
+#
+# TODO: rename, no longer specific to containers.
 class ContainerLabelTagMapping < ApplicationRecord
-  # A mapping matches labels on `resource_type` (NULL means any), `name` (required),
-  # and `value` (NULL means any).
-  #
-  # Different labels might map to same tag, and one label might map to multiple tags.
-  #
-  # There are 2 kinds of rows:
-  # - When `label_value` is specified, we map only this value to a specific `tag`.
-  # - When `label_value` is NULL, we map this name with any value to per-value tags.
-  #   In this case, `tag` specifies the category under which to create
-  #   the value-specific tag (and classification) on demand.
-  #
-  # All involved tags must also have a Classification.
-
   belongs_to :tag
 
-  # Pass the data this returns to map_* methods.
-  def self.cache
-    # {[name, type, value] => [tag_id, ...]}
-    in_my_region.find_each
-                .group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
-                .transform_values { |mappings| mappings.collect(&:tag_id) }
+  require_nested :Mapper
+
+  # Return ContainerLabelTagMapping::Mapper instance that holds all current mappings,
+  # can compute applicable tags, and create/find Tag records.
+  def self.mapper
+    ContainerLabelTagMapping::Mapper.new(in_my_region.all)
   end
 
-  # We expect labels to be {:name, :value} hashes
-  # and return {:tag_id} or {:category_tag_id, :entry_name, :entry_description} hashes.
+  # Assigning/unassigning should be possible without Mapper instance, perhaps in another process.
 
-  def self.map_labels(cache, type, labels)
-    labels.collect_concat { |label| map_label(cache, type, label) }.uniq
-  end
-
-  def self.map_label(cache, type, label)
-    # Apply both specific-type and any-type, independently.
-    (map_name_type_value(cache, label[:name], type, label[:value]) +
-     map_name_type_value(cache, label[:name], nil,  label[:value]))
-  end
-
-  def self.map_name_type_value(cache, name, type, value)
-    specific_value = cache[[name, type, value]] || []
-    any_value      = cache[[name, type, nil]]   || []
-    if !specific_value.empty?
-      specific_value.map { |tag_id| {:tag_id => tag_id} }
-    else
-      if value.empty?
-        [] # Don't map empty value to any tag.
-      else
-        # Note: if the way we compute `entry_name` changes,
-        # consider what will happen to previously created tags.
-        any_value.map do |tag_id|
-          {:category_tag_id   => tag_id,
-           :entry_name        => Classification.sanitize_name(value),
-           :entry_description => value}
-        end
-      end
-    end
-  end
-  private_class_method :map_name_type_value
-
-  # Given a hash built by `map_*` methods, returns a Tag (creating if needed).
-  def self.find_or_create_tag(tag_hash)
-    if tag_hash[:tag_id]
-      Tag.find(tag_hash[:tag_id])
-    else
-      category = Tag.find(tag_hash[:category_tag_id]).classification
-      entry = category.find_entry_by_name(tag_hash[:entry_name])
-      unless entry
-        category.lock(:exclusive) do
-          begin
-            entry = category.add_entry(:name        => tag_hash[:entry_name],
-                                       :description => tag_hash[:entry_description])
-            entry.save!
-          rescue ActiveRecord::RecordInvalid
-            entry = category.find_entry_by_name(tag_hash[:entry_name])
-          end
-        end
-      end
-      entry.tag
-    end
-  end
-
+  # Checks whether a Tag record is under mapping control.
+  # TODO: expensive.
   def self.controls_tag?(tag)
     return false unless tag.classification.try(:read_only) # never touch user-assignable tags.
     tag_ids = [tag.id, tag.category.tag_id].uniq
@@ -85,8 +40,9 @@ class ContainerLabelTagMapping < ApplicationRecord
   end
 
   # Assign/unassign mapping-controlled tags, preserving user-assigned tags.
-  def self.retag_entity(entity, tag_hashes)
-    mapped_tags = tag_hashes.map { |tag_hash| find_or_create_tag(tag_hash) }
+  # All tag references must have been resolved first by Mapper#find_or_create_tags.
+  def self.retag_entity(entity, tag_references)
+    mapped_tags = Mapper.references_to_tags(tag_references)
     existing_tags = entity.tags
     Tagging.transaction do
       (mapped_tags - existing_tags).each do |tag|

--- a/app/models/container_label_tag_mapping/mapper.rb
+++ b/app/models/container_label_tag_mapping/mapper.rb
@@ -1,0 +1,100 @@
+# coding: utf-8
+class ContainerLabelTagMapping
+  # Performs most of the work of ContainerLabelTagMapping - holds current mappings,
+  # computes applicable tags, and creates/finds Tag records - except actually [un]assigning.
+  class Mapper
+    # @param mappings [Array<ContainerLabelTagMapping>] Mapping records to use
+    def initialize(mappings)
+      # {[name, type, value] => [tag_id, ...]}
+      @mappings = mappings.group_by { |m| [m.label_name, m.labeled_resource_type, m.label_value].freeze }
+                          .transform_values { |ms| ms.collect(&:tag_id) }
+      @tags_to_resolve = []
+    end
+
+    # Compute desired tags, in intermediate form to be resolved later.
+    #
+    # @param type [String] Matched against `labeled_resource_type` in mappings.
+    #   May be `resource_type` of an actual label, but doesn't have to; can be fake string such as 'Vm'.
+    # @param labels [Array] array of {:name, :value} hashes.
+    # @return [Array] opaque "tag references" representing desired tags.
+    #   (Currently {:tag_id} or {:category_tag_id, :entry_name, :entry_description} hashes but will change.)
+    def map_labels(type, labels)
+      labels.collect_concat { |label| map_label(type, label) }.uniq
+    end
+
+    # Resolves/creates all "tag references" built by `map_labels` method of same Mapper.
+    # The references are mutated to contain a Tag id.
+    # @return [void]
+    def find_or_create_tags
+      # TODO: O(N) queries, optimize.
+      @tags_to_resolve.each do |h|
+        find_or_create_tag(h)
+      end
+    end
+
+    # Convert "tag references" to actual Tag objects.  Must have been resolved to known id first.
+    # @param tag_references [Array]
+    # @return [Array<Tag>]
+    def self.references_to_tags(tag_references)
+      ref_without_id = tag_references.detect { |ref| ref[:tag_id].nil? }
+      raise "Unresolved tag reference #{ref_without_id}, must call find_or_create_tags first" if ref_without_id
+
+      Tag.find(tag_references.collect { |ref| ref[:tag_id] })
+    end
+
+    private
+
+    def map_label(type, label)
+      # Apply both specific-type and any-type, independently.
+      (map_name_type_value(label[:name], type, label[:value]) +
+       map_name_type_value(label[:name], nil,  label[:value]))
+    end
+
+    def map_name_type_value(name, type, value)
+      specific_value = @mappings[[name, type, value]] || []
+      any_value      = @mappings[[name, type, nil]]   || []
+      if !specific_value.empty?
+        specific_value.map { |tag_id| {:tag_id => tag_id} }
+      else
+        if value.empty?
+          [] # Don't map empty value to any tag.
+        else
+          # Note: if the way we compute `entry_name` changes,
+          # consider what will happen to previously created tags.
+          any_value.map do |tag_id|
+            emit_tag_reference(
+              :category_tag_id   => tag_id,
+              :entry_name        => Classification.sanitize_name(value),
+              :entry_description => value,
+            )
+          end
+        end
+      end
+    end
+
+    def emit_tag_reference(h)
+      @tags_to_resolve << h
+      h
+    end
+
+    # Mutate the hash to contain :tag_id.
+    def find_or_create_tag(tag_hash)
+      return if tag_hash[:tag_id]
+
+      category = Tag.find(tag_hash[:category_tag_id]).classification
+      entry = category.find_entry_by_name(tag_hash[:entry_name])
+      unless entry
+        category.lock(:exclusive) do
+          begin
+            entry = category.add_entry(:name        => tag_hash[:entry_name],
+                                       :description => tag_hash[:entry_description])
+            entry.save!
+          rescue ActiveRecord::RecordInvalid
+            entry = category.find_entry_by_name(tag_hash[:entry_name])
+          end
+        end
+      end
+      tag_hash[:tag_id] = entry.tag_id
+    end
+  end
+end

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -182,14 +182,12 @@ module EmsRefresh::SaveInventory
   end
 
   # Convert all mapped hashes into actual tags and associate them with the object.
-  # The collection or collection[:tags] object should be an array of hashes, probably
-  # created by the ContainerLabelTagMapping.map_labels method. Each hash in the array
-  # should have the following basic structure:
-  #
-  # {:category_tag_id=>139, :entry_name=>"foo", :entry_description=>"bar"}
+  # The collection or collection[:tags] object should be an array of values
+  # created by the ContainerLabelTagMapping::Mapper#map_labels method
+  # that should already have ids set by `Mapper#find_or_create_tags` method.
   #
   # The +collection+ argument can either be a Hash, in which case the argument
-  # should have a single :tags key, or a simple Array of hashes.
+  # should have a single :tags key, or a simple Array.
   #
   def save_tags_inventory(object, collection, _target = nil)
     return if collection.nil?

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -45,6 +45,8 @@ module EmsRefresh::SaveInventoryCloud
       _log.debug "#{log_header} hashes:\n#{YAML.dump(hashes)}"
     end
 
+    hashes[:tag_mapper].find_or_create_tags if hashes[:tag_mapper]
+
     child_keys = [
       :cloud_tenants,
       :flavors,

--- a/app/models/ems_refresh/save_inventory_container.rb
+++ b/app/models/ems_refresh/save_inventory_container.rb
@@ -1,5 +1,6 @@
 module EmsRefresh::SaveInventoryContainer
   def save_ems_container_inventory(ems, hashes, _target = nil)
+    hashes[:tag_mapper].find_or_create_tags
 
     child_keys = [:container_projects, :container_quotas, :container_limits, :container_nodes,
                   :container_builds, :container_build_pods, :persistent_volume_claims, :persistent_volumes,

--- a/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/kubernetes/container_manager/refresh_parser.rb
@@ -10,7 +10,8 @@ module ManageIQ::Providers::Kubernetes
     def initialize
       @data = {}
       @data_index = {}
-      @label_tag_mapping = ContainerLabelTagMapping.cache
+      @tag_mapper = ContainerLabelTagMapping.mapper
+      @data[:tag_mapper] = @tag_mapper
     end
 
     def ems_inv_to_hashes(inventory, _options = Config::Options.new)
@@ -142,7 +143,7 @@ module ManageIQ::Providers::Kubernetes
     end
 
     def map_labels(model_name, labels)
-      ContainerLabelTagMapping.map_labels(@label_tag_mapping, model_name, labels)
+      @tag_mapper.map_labels(model_name, labels)
     end
 
     def find_host_by_provider_id(provider_id)

--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -6,21 +6,4 @@ FactoryGirl.define do
       labeled_resource_type 'ContainerNode'
     end
   end
-
-  # Mapping for <All> entities, as created in UI.
-  factory :tag_mapping_with_category, :parent => :container_label_tag_mapping do
-    transient do
-      category_name { "kubernetes::" + Classification.sanitize_name(label_name.tr("/", ":")) }
-      category_description { "Mapped #{label_name}" }
-    end
-
-    tag do
-      category = FactoryGirl.create(:classification,
-                                    :name         => category_name,
-                                    :description  => category_description,
-                                    :single_value => true,
-                                    :read_only    => true)
-      category.tag
-    end
-  end
 end

--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -6,4 +6,21 @@ FactoryGirl.define do
       labeled_resource_type 'ContainerNode'
     end
   end
+
+  # Mapping for <All> entities, as created in UI.
+  factory :tag_mapping_with_category, :parent => :container_label_tag_mapping do
+    transient do
+      category_name { "kubernetes::" + Classification.sanitize_name(label_name.tr("/", ":")) }
+      category_description { "Mapped #{label_name}" }
+    end
+
+    tag do
+      category = FactoryGirl.create(:classification,
+                                    :name         => category_name,
+                                    :description  => category_description,
+                                    :single_value => true,
+                                    :read_only    => true)
+      category.tag
+    end
+  end
 end

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -6,37 +6,21 @@ context "save_tags_inventory" do
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
     @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
-    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner')
-    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff')
-    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:foo') # All
-
-    @cat1 = FactoryGirl.create(:category, :description => 'amazon_vm_owner', :tag => @tag1)
-    @cat2 = FactoryGirl.create(:category, :description => 'department', :tag => @tag2)
-    @cat3 = FactoryGirl.create(:category, :description => 'location', :tag => @tag3)
+    # These might not pass the ContainerLabelTagMapping.controls_tag? criteria, doesn't matter if only adding.
+    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner/alice')
+    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff/jabberwocky')
+    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes::foo/bar') # All
   end
 
-  # This is what ContainerLabelTagMapping.map_labels(cache, 'Type', labels) would
+  # This is what ContainerLabelTagMapping::Mapper.map_labels(cache, 'Type', labels) would
   # return in the refresh parser. Note that we don't explicitly test the mapping
   # creation here, the assumption is that these were the generated mappings.
-  #
   let(:data) do
     {
       :tags => [
-        {
-          :category_tag_id   => @cat1.tag_id,
-          :entry_name        => 'owner',
-          :entry_description => 'Daniel'
-        },
-        {
-          :category_tag_id   => @cat2.tag_id,
-          :entry_name        => 'stuff',
-          :entry_description => 'Ladas'
-        },
-        {
-          :category_tag_id   => @cat3.tag_id,
-          :entry_name        => 'foo',
-          :entry_description => 'Bronagh'
-        }
+        {:tag_id => @tag1.id},
+        {:tag_id => @tag2.id},
+        {:tag_id => @tag3.id},
       ]
     }
   end

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,12 +1,4 @@
 context "save_tags_inventory" do
-  # @return [Tag] for a category linked to a mapping.
-  def mapped_cat(category_name)
-    mapping = FactoryGirl.create(:tag_mapping_with_category,
-                                 :category_name        => category_name,
-                                 :category_description => category_name)
-    mapping.tag.classification
-  end
-
   before(:each) do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
@@ -14,82 +6,50 @@ context "save_tags_inventory" do
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
     @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
-    @cat1 = mapped_cat('amazon:vm:owner')
-    @cat2 = mapped_cat('kubernetes:container_node:stuff')
-    @cat3 = mapped_cat('kubernetes::foo') # All entities
+    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner')
+    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff')
+    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:foo') # All
+
+    @cat1 = FactoryGirl.create(:category, :description => 'amazon_vm_owner', :tag => @tag1)
+    @cat2 = FactoryGirl.create(:category, :description => 'department', :tag => @tag2)
+    @cat3 = FactoryGirl.create(:category, :description => 'location', :tag => @tag3)
   end
 
   # This is what ContainerLabelTagMapping.map_labels(cache, 'Type', labels) would
   # return in the refresh parser. Note that we don't explicitly test the mapping
   # creation here, the assumption is that these were the generated mappings.
   #
-  let(:tag1_hash) do
-    {
-      :category_tag_id   => @cat1.tag_id,
-      :entry_name        => 'owner',
-      :entry_description => 'Daniel'
-    }
-  end
-  let(:tag2_hash) do
-    {
-      :category_tag_id   => @cat2.tag_id,
-      :entry_name        => 'stuff',
-      :entry_description => 'Ladas'
-    }
-  end
-  let(:tag3_hash) do
-    {
-      :category_tag_id   => @cat3.tag_id,
-      :entry_name        => 'foo',
-      :entry_description => 'Bronagh'
-    }
-  end
-
   let(:data) do
     {
       :tags => [
-        tag1_hash,
-        tag2_hash,
-        tag3_hash
+        {
+          :category_tag_id   => @cat1.tag_id,
+          :entry_name        => 'owner',
+          :entry_description => 'Daniel'
+        },
+        {
+          :category_tag_id   => @cat2.tag_id,
+          :entry_name        => 'stuff',
+          :entry_description => 'Ladas'
+        },
+        {
+          :category_tag_id   => @cat3.tag_id,
+          :entry_name        => 'foo',
+          :entry_description => 'Bronagh'
+        }
       ]
     }
-  end
-  let(:data2) do
-    {
-      :tags => [
-        tag2_hash
-      ]
-    }
-  end
-  let(:data_empty) do
-    {
-      :tags => []
-    }
-  end
-  let(:data_empty_array) do
-    []
   end
 
   # Note that in these tests we're explicitly passing the object, so that's
   # why the object type may not match what you would expect from the tag
   # name type above.
 
-  it "creates/deletes the expected number of taggings" do
+  it "creates the expected number of taggings" do
     EmsRefresh.save_tags_inventory(@vm, data)
-    expect(Tagging.count).to eql(3)
-    expect(@vm.reload.tags.size).to eql(3)
-
-    EmsRefresh.save_tags_inventory(@vm, data_empty)
-    expect(Tagging.count).to eql(0)
-    expect(@vm.reload.tags.size).to eql(0)
-
-    EmsRefresh.save_tags_inventory(@vm, data2)
-    expect(Tagging.count).to eql(1)
-    expect(@vm.reload.tags.size).to eql(1)
-
-    EmsRefresh.save_tags_inventory(@vm, data_empty_array)
-    expect(Tagging.count).to eql(0)
-    expect(@vm.reload.tags.size).to eql(0)
+    taggings = Tagging.all
+    expect(taggings.size).to eql(3)
+    expect(@vm.tags.size).to eql(3)
   end
 
   it "creates the expected taggings for a VM" do

--- a/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory/save_tags_inventory_spec.rb
@@ -1,4 +1,14 @@
 context "save_tags_inventory" do
+  # @return [Tag] a tag in a category linked to a mapping.
+  def mapped_tag(category_name, tag_name)
+    mapping = FactoryGirl.create(:tag_mapping_with_category,
+                                 :category_name        => category_name,
+                                 :category_description => category_name)
+    category = mapping.tag.category
+    entry = category.add_entry(:name => tag_name, :description => tag_name)
+    category.tag
+  end
+
   before(:each) do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_amazon, :zone => @zone)
@@ -6,10 +16,9 @@ context "save_tags_inventory" do
     @vm   = FactoryGirl.create(:vm, :ext_management_system => @ems)
     @node = FactoryGirl.create(:container_node, :ext_management_system => @ems)
 
-    # These might not pass the ContainerLabelTagMapping.controls_tag? criteria, doesn't matter if only adding.
-    @tag1 = FactoryGirl.create(:tag, :name => '/managed/amazon:vm:owner/alice')
-    @tag2 = FactoryGirl.create(:tag, :name => '/managed/kubernetes:container_node:stuff/jabberwocky')
-    @tag3 = FactoryGirl.create(:tag, :name => '/managed/kubernetes::foo/bar') # All
+    @tag1 = mapped_tag('amazon:vm:owner', 'alice')
+    @tag2 = mapped_tag('kubernetes:container_node:stuff', 'jabberwocky')
+    @tag3 = mapped_tag('kubernetes::foo', 'bar') # All entities
   end
 
   # This is what ContainerLabelTagMapping::Mapper.map_labels(cache, 'Type', labels) would
@@ -24,16 +33,42 @@ context "save_tags_inventory" do
       ]
     }
   end
+  let(:data2) do
+    {
+      :tags => [
+        instance_double(ManagerRefresh::InventoryObject, :id => @tag2.id),
+      ]
+    }
+  end
+  let(:data_empty) do
+    {
+      :tags => []
+    }
+  end
+  let(:data_empty_array) do
+    []
+  end
 
   # Note that in these tests we're explicitly passing the object, so that's
   # why the object type may not match what you would expect from the tag
   # name type above.
 
-  it "creates the expected number of taggings" do
+  it "creates/deletes the expected number of taggings" do
     EmsRefresh.save_tags_inventory(@vm, data)
-    taggings = Tagging.all
-    expect(taggings.size).to eql(3)
-    expect(@vm.tags.size).to eql(3)
+    expect(Tagging.count).to eql(3)
+    expect(@vm.reload.tags.size).to eql(3)
+
+    EmsRefresh.save_tags_inventory(@vm, data_empty)
+    expect(Tagging.count).to eql(0)
+    expect(@vm.reload.tags.size).to eql(0)
+
+    EmsRefresh.save_tags_inventory(@vm, data2)
+    expect(Tagging.count).to eql(1)
+    expect(@vm.reload.tags.size).to eql(1)
+
+    EmsRefresh.save_tags_inventory(@vm, data_empty_array)
+    expect(Tagging.count).to eql(0)
+    expect(@vm.reload.tags.size).to eql(0)
   end
 
   it "creates the expected taggings for a VM" do


### PR DESCRIPTION
Backport to Fine branch of #16098 and associated PRs.
#16098 changed tag mapper interface used by refresh parsers; backporting it will allow backporting current refresh code, specifically for Azure and maybe Amazon.
https://bugzilla.redhat.com/show_bug.cgi?id=1493041

also backporting:
- [ ] #14849 TODO how is this related, can it be fine/yes separately?
- reverting #16511 which was modified for fine version of #16453, applying #16453 as-is now it's possible.
- one rubocop fix from #15561 needed for #16098 cherry pick to apply cleanly.
- https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/130, simultaneous with #16098, in Fine belonged in this repo.
- [ ] TODO simultaneous https://github.com/ManageIQ/manageiq-providers-amazon/pull/316

TODO tests:
- [ ] fails a core test!
- [ ] test provider repos!