### PR TITLE
Bug 1546535: include shared external networks in list on router create

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -50,6 +50,10 @@ class CloudNetwork < ApplicationRecord
     ext_management_system && ext_management_system.class::CloudNetwork
   end
 
+  def self.tenant_id_clause_format(tenant_ids)
+    ["((tenants.id IN (?) OR cloud_networks.shared IS TRUE) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE OR ext_management_systems.tenant_mapping_enabled IS NULL", tenant_ids]
+  end
+
   private
 
   def extra_attributes_save(key, value)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1546535

When generating the list of networks for router external gateway
network, include shared networks owned by other tenants.
