### PR TITLE
Fixes for create action in Template model

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -27,7 +27,7 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     }
 
     queue_opts = {
-      :class_name  => self.class.name,
+      :class_name  => self.name,
       :method_name => 'create_image',
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -20,6 +20,10 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
                             ManageIQ::Providers::Openstack::CloudManager::VolumeSnapshotTemplate))
   end
 
+  def self.class_by_ems(ext_management_system)
+    ext_management_system.class::Template
+  end
+
   def self.create_image_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "Creating Cloud Template for user #{userid}",


### PR DESCRIPTION
Fixed class name in `create_image_queue` and added `class_by_ems` in order to find correct EMS, when creating a new Template