### PR TITLE
Adding connection b/w physical servers and physical switches

### DIFF
--- a/app/models/computer_system.rb
+++ b/app/models/computer_system.rb
@@ -3,4 +3,6 @@ class ComputerSystem < ApplicationRecord
 
   has_one :operating_system, :dependent => :destroy
   has_one :hardware, :dependent => :destroy
+
+  has_many :connected_physical_switches, :through => :hardware
 end

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -16,6 +16,7 @@ class GuestDevice < ApplicationRecord
   has_many :child_devices, -> { where(:parent_device_id => ids) }, :foreign_key => "parent_device_id", :class_name => "GuestDevice", :dependent => :destroy
 
   has_many :physical_network_ports, :dependent => :destroy
+  has_many :connected_physical_switches, :through => :physical_network_ports
 
   alias_attribute :name, :device_name
 

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -22,6 +22,7 @@ class Hardware < ApplicationRecord
   has_many    :nics, -> { where("device_type = 'ethernet'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
   has_many    :ports, -> { where("device_type != 'storage'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
   has_many    :physical_ports, -> { where("device_type = 'physical_port'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+  has_many    :connected_physical_switches, :through => :guest_devices
 
   virtual_column :ipaddresses,   :type => :string_set, :uses => :networks
   virtual_column :hostnames,     :type => :string_set, :uses => :networks

--- a/app/models/physical_network_port.rb
+++ b/app/models/physical_network_port.rb
@@ -1,4 +1,7 @@
 class PhysicalNetworkPort < ApplicationRecord
   belongs_to :guest_device
-  belongs_to :physical_switch
+  belongs_to :physical_switch, :foreign_key => :switch_id, :inverse_of => :physical_network_ports
+
+  has_one :connected_port, :foreign_key => "connected_port_uid", :primary_key => "uid_ems", :class_name => "PhysicalNetworkPort", :dependent => :nullify, :inverse_of => :connected_port
+  has_one :connected_physical_switch, :through => :connected_port, :source => :physical_switch
 end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -33,6 +33,8 @@ class PhysicalServer < ApplicationRecord
   virtual_column :v_availability, :type => :string, :uses => :host
   virtual_column :v_host_os, :type => :string, :uses => :host
 
+  has_many :physical_switches, :through => :computer_system, :source => :connected_physical_switches
+
   def name_with_details
     details % {
       :name => name,


### PR DESCRIPTION
__This PR is able to:__
- Bind the connected physical network ports;
- Bind the connected physical servers and physical switches;

__It is prerequisite to:__
- https://github.com/ManageIQ/manageiq-ui-classic/pull/3799

__Depends on:__
- ~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/132~ - Merged
- ~https://github.com/ManageIQ/manageiq/pull/17268~ - Merged
- ~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/152~ - Merged
- ~https://github.com/ManageIQ/manageiq-schema/pull/208~ - Merged