### PR TITLE
Add a tool to process logs looking for frequency of method calls

### DIFF
--- a/tools/log_processing/method_call_processor.rb
+++ b/tools/log_processing/method_call_processor.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+RAILS_ROOT = File.expand_path(File.join(__dir__, %w(.. ..)))
+require 'manageiq-gems-pending'
+require 'miq_logger_processor'
+
+logfile = ARGV.shift if ARGV[0] && File.file?(ARGV[0])
+logfile ||= File.join(RAILS_ROOT, "log/evm.log")
+logfile = File.expand_path(logfile)
+
+puts "Gathering method calls..."
+
+method_call_hash = MiqLoggerProcessor.new(logfile).each_with_object({}) do |line, hash|
+  next unless line.fq_method
+  hash[line.fq_method] ||= 0
+  hash[line.fq_method] += 1
+end
+
+require 'pp'
+
+puts method_call_hash.sort_by { |_key, value| value }.reverse.to_h.pretty_inspect


### PR DESCRIPTION
Enhance developer insight into what is used
Depends on https://github.com/ManageIQ/manageiq-gems-pending/pull/346

Example output:
```
Gathering method calls...
{"MiqAeYamlImportFs#add_instance"=>151953,
 "ops_controller-settings_form_field_changed"=>54376,
 "MiqAeYamlImportFs#add_method"=>54347,
 "MiqProductFeature.seed_feature"=>38162,
 "VmdbIndex.seed_for_table"=>32864,
 "MiqAeYamlImportFs#add_class_components"=>31857,
 "Vmdb::Loggers.apply_config"=>31166,
 "ops_controller-settings_update"=>29053,
 "ops_controller-explorer"=>25571,
 "MiqQueue.put"=>25161,
 "miq_request_controller-prov_field_changed"=>24062,
 "Tenant.seed"=>22630,
 "ManageIQ::Showback::InputMeasure.seed"=>20160,
 "MiqReport.sync_from_file"=>20036,
 "MiqAeYamlImportFs#process_namespace"=>19893,
 "ManageIQ::Consumption::ShowbackUsageType.seed"=>19824,
 "AuthUseridPassword#after_authentication_changed"=>17112,
 "ServerRole.seed"=>16603,
 "MiqAeYamlImportConsolidated#add_instance"=>12957,
 "VmdbTableEvm.seed_for_database"=>12681,
 "VmdbTableText.seed_for_table"=>11452,
 "MiqAeDatastore.reset"=>11215,
 "MiqEvent.raise_evm_event"=>10870,
 "MiqAeYamlExportZipfs#write_data"=>10201,
 "MiqRegion.destroy_region"=>9678,
 "MiqAlert.seed"=>8125,
 "MiqAeYamlImportFs#start_import"=>6674,
 "EvmDatabase.seed"=>6363,
 "MiqAeYamlImportConsolidated#process_namespace"=>6061,
 "MiqAeYamlImportConsolidated#start_import"=>5862,
 "MiqQueue#deliver"=>5600,
...
```