### PR TITLE
Check for the existence of credentials.

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -41,7 +41,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook <
 
     %i(credential vault_credential cloud_credential network_credential).each do |credential|
       cred_sym = "#{credential}_id".to_sym
-      params[credential] = Authentication.find(options[cred_sym]).manager_ref if options[cred_sym]
+      params[credential] = Authentication.find(options[cred_sym]).manager_ref if options[cred_sym].present?
     end
 
     params.compact

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -31,5 +31,21 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
         .to receive(:raw_create_in_provider).with(instance_of(manager.class), option_matcher)
       subject.raw_create_job_template(options)
     end
+
+    it 'works with empty credential id' do
+      options = {:inventory => 'inv', :extra_vars => {'a' => 'x'}, :credential_id => ''}
+      option_matcher = hash_including(
+        :inventory  => 'inv',
+        :extra_vars => '{"a":"x"}',
+        :playbook   => subject.name,
+        :project    => 'mref'
+      )
+
+      allow(subject).to receive(:configuration_script_source).and_return(double(:manager_ref => 'mref'))
+      expect(SecureRandom).to receive(:uuid).and_return('random-uuid')
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript)
+        .to receive(:raw_create_in_provider).with(instance_of(manager.class), option_matcher)
+      subject.raw_create_job_template(options)
+    end
   end
 end


### PR DESCRIPTION
An error is occurred "Automation Error: Couldn't find Authentication with 'id'=" without the checking for the existence of credentials.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568384

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, gaprindashvili/yes, automate

cc @bzwei 