### PR TITLE
Do not include memory in provisioned storage

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -133,7 +133,7 @@ class Hardware < ApplicationRecord
     if has_attribute?("provisioned_storage")
       self["provisioned_storage"]
     else
-      allocated_disk_storage.to_i + ram_size_in_bytes
+      allocated_disk_storage.to_i
     end
   end
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1499,11 +1499,11 @@ class VmOrTemplate < ApplicationRecord
   virtual_delegate :provisioned_storage, :to => :hardware, :allow_nil => true, :default => 0
 
   def used_storage
-    used_disk_storage.to_i + ram_size_in_bytes
+    used_disk_storage.to_i
   end
 
   def used_storage_by_state
-    used_disk_storage.to_i + ram_size_in_bytes_by_state
+    used_disk_storage.to_i
   end
 
   def uncommitted_storage

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -149,9 +149,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :v_owning_blue_folder_path,            :type => :string,     :uses => :all_relationships
   virtual_column :v_datastore_path,                     :type => :string,     :uses => :storage
   virtual_column :thin_provisioned,                     :type => :boolean,    :uses => {:hardware => :disks}
-  virtual_column :used_storage,                         :type => :integer,    :uses => [:used_disk_storage, :mem_cpu]
-  virtual_column :used_storage_by_state,                :type => :integer,    :uses => :used_storage
-  virtual_column :uncommitted_storage,                  :type => :integer,    :uses => [:provisioned_storage, :used_storage_by_state]
+  virtual_column :uncommitted_storage,                  :type => :integer,    :uses => [:provisioned_storage, :used_disk_storage]
   virtual_delegate :ram_size_in_bytes,                  :to => :hardware, :allow_nil => true, :default => 0
   virtual_delegate :mem_cpu,                            :to => "hardware.memory_mb", :allow_nil => true, :default => 0
   virtual_delegate :ram_size,                           :to => "hardware.memory_mb", :allow_nil => true, :default => 0
@@ -1497,17 +1495,13 @@ class VmOrTemplate < ApplicationRecord
                    :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}
 
   virtual_delegate :provisioned_storage, :to => :hardware, :allow_nil => true, :default => 0
-
-  def used_storage
-    used_disk_storage.to_i
-  end
-
-  def used_storage_by_state
-    used_disk_storage.to_i
-  end
+  virtual_delegate :used_storage,
+                   :to => "hardware.used_disk_storage", :allow_nil => true, :default => 0, :uses => {:hardware => :disks}
+  virtual_delegate :used_storage_by_state,
+                   :to => "hardware.used_disk_storage", :allow_nil => true, :default => 0, :uses => {:hardware => :disks}
 
   def uncommitted_storage
-    provisioned_storage.to_i - used_storage_by_state.to_i
+    provisioned_storage.to_i - used_disk_storage.to_i
   end
 
   def thin_provisioned

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -215,7 +215,7 @@ describe Hardware do
 
       it "calculates in the database" do
         hardware
-        expect(virtual_column_sql_value(Hardware, "provisioned_storage")).to eq(0)
+        expect(virtual_column_sql_value(Hardware, "provisioned_storage")).to be_nil
       end
     end
 

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -205,12 +205,10 @@ describe Hardware do
     end
   end
 
-  # this is disks + ram_size_in_bytes
-  # so we end up with 4 different senarios
   describe "#provisioned_storage" do
     let(:hardware) { FactoryGirl.create(:hardware) }
 
-    context "with no disks AND no memory" do
+    context "with no disks" do
       it "calculates in ruby" do
         expect(hardware.provisioned_storage).to eq(0) # TODO
       end
@@ -221,7 +219,7 @@ describe Hardware do
       end
     end
 
-    context "with disks AND no memory" do
+    context "with disks" do
       before do
         FactoryGirl.create(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
         FactoryGirl.create(:disk, :size => 1024, :hardware => hardware)
@@ -235,37 +233,6 @@ describe Hardware do
       it "calculates in the database" do
         hardware
         expect(virtual_column_sql_value(Hardware, "provisioned_storage")).to eq(11_264)
-      end
-    end
-
-    context "with no disks and memory" do
-      let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 5) }
-
-      it "works in ruby" do
-        expect(hardware.provisioned_storage).to eq(5.megabytes)
-      end
-
-      it "works in sql" do
-        hardware
-        expect(virtual_column_sql_value(Hardware, "provisioned_storage")).to eq(5.megabytes)
-      end
-    end
-
-    context "with disks and memory" do
-      let(:hardware) { FactoryGirl.create(:hardware, :memory_mb => 5) }
-      before do
-        FactoryGirl.create(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
-        FactoryGirl.create(:disk, :size => 1024, :hardware => hardware)
-        FactoryGirl.create(:disk, :hardware => hardware)
-      end
-
-      it "works in ruby" do
-        expect(hardware.provisioned_storage).to eq(5.megabytes + 11_264)
-      end
-
-      it "works in sql" do
-        hardware
-        expect(virtual_column_sql_value(Hardware, "provisioned_storage")).to eq(5.megabytes + 11_264)
       end
     end
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -199,7 +199,7 @@ describe MiqGroup do
     end
 
     it "#provisioned_storage" do
-      expect(miq_group.provisioned_storage).to eq(ram_size.megabyte + disk_size)
+      expect(miq_group.provisioned_storage).to eq(disk_size)
     end
 
     %w(allocated_memory allocated_vcpu allocated_storage provisioned_storage).each do |vcol|

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -198,7 +198,7 @@ describe MiqProvisionRequest do
             let(:request) { create_request(@vmware_user1, @vmware_template, {}) }
             let(:quota_method) { :active_provisions }
             let(:counts_hash) do
-              {:count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 44.gigabytes}
+              {:count => 12, :memory => 8_589_938_688, :cpu => 32, :storage => 40.gigabytes}
             end
             it_behaves_like "check_quota"
 
@@ -212,7 +212,7 @@ describe MiqProvisionRequest do
           context "infra," do
             let(:request) { create_request(@vmware_user1, @vmware_template, {}) }
             let(:counts_hash) do
-              {:count => 8, :memory => 8.gigabytes, :cpu => 16, :storage => 4.gigabytes}
+              {:count => 8, :memory => 8.gigabytes, :cpu => 16, :storage => 0.gigabytes}
             end
 
             context "active_provisions_by_tenant," do
@@ -228,7 +228,7 @@ describe MiqProvisionRequest do
             context "active_provisions_by_owner," do
               let(:quota_method) { :active_provisions_by_owner }
               let(:counts_hash) do
-                {:count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 2.gigabytes}
+                {:count => 4, :memory => 4.gigabytes, :cpu => 8, :storage => 0.gigabytes}
               end
               it_behaves_like "check_quota"
 

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -67,7 +67,7 @@ describe ServiceTemplateProvisionRequest do
         let(:load_requests) { vmware_requests }
         let(:request) { create_test_request(@vmware_user1, @vmware_template) }
         let(:counts_hash) do
-          {:count => 6, :memory => 6.gigabytes, :cpu => 16, :storage => 3.gigabytes}
+          {:count => 6, :memory => 6.gigabytes, :cpu => 16, :storage => 0.gigabytes}
         end
 
         context "active_provisions_by_tenant," do
@@ -89,7 +89,7 @@ describe ServiceTemplateProvisionRequest do
         context "active_provisions_by_owner," do
           let(:quota_method) { :active_provisions_by_owner }
           let(:counts_hash) do
-            {:count => 3, :memory => 3.gigabytes, :cpu => 8, :storage => 1_610_612_736}
+            {:count => 3, :memory => 3.gigabytes, :cpu => 8, :storage => 0.gigabytes}
           end
           it_behaves_like "check_quota"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -335,7 +335,7 @@ describe User do
     end
 
     it "#provisioned_storage" do
-      expect(@user.provisioned_storage).to eq(@ram_size.megabyte + @disk_size)
+      expect(@user.provisioned_storage).to eq(@disk_size)
     end
 
     %w(allocated_memory allocated_vcpu allocated_storage provisioned_storage).each do |vcol|


### PR DESCRIPTION
This is a continuation of #17310

- The `provisioned_storage` would still display the incorrect value in some cases
- The other columns will now directly hit the db (and be cached), be sortable, ...

Would be nice to deprecate those columns since they are simple delegates.
I tried `alias_attribute` but it was throwing errors for me.

@jrafanie need the `hardware.rb` column change - the others are more of an optimization
you can cherry-pick the commit over to your side or go with this one - your choice

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1499553