### PR TITLE
Add proxy URI schema

### DIFF
--- a/config/initializers/proxy_uri.rb
+++ b/config/initializers/proxy_uri.rb
@@ -1,0 +1,47 @@
+#
+# The Ruby URI parser doesn't decode the percent encoded characters in the URI, in particular it
+# doesn't decode the password which is frequently used when specifying proxy addresses and
+# authentication. For example, the following code:
+#
+#   require 'uri'
+#   proxy = URI.parse('http://myuser:%24%3fxxxx@192.168.100.10:3128')
+#   puts proxy.password
+#
+# Produces the following output:
+#
+#   %24%3fxxxx
+#
+# But some gems, in particular `rest-client` and `kubeclient`, expect it to decode those characters,
+# as they use the value returned by the `password` method directly, and thus they fail to
+# authenticate against the proxy server when the password contains percent encoded characters.
+#
+# To address this issue this file adds a new `proxy` URI schema that almost identical to the `http`
+# schema, but that decodes the password before returning it. Users can use this schema instead of
+# `http` when they need to use percent encoded characters in the password. For example, the user
+# can type in the UI the following proxy URL:
+#
+#   proxy://myuser:%24%3fxxxx@192.168.100.10:3128
+#
+# And the new schema will automatically translate `%24%3fxxxx` into `$?xxxx`.
+#
+
+require 'cgi'
+require 'uri'
+
+module URI
+  class PROXY < HTTP
+    def password
+      value = super
+      value = CGI.unescape(value) if value
+      value
+    end
+
+    def user
+      value = super
+      value = CGI.unescape(value) if value
+      value
+    end
+  end
+
+  @@schemes['PROXY'] = PROXY
+end

--- a/spec/initializers/proxy_uri_spec.rb
+++ b/spec/initializers/proxy_uri_spec.rb
@@ -1,0 +1,38 @@
+describe "proxy uri" do
+  it "decodes the password" do
+    uri = URI('proxy://myuser:%24%3fxxxx@192.168.122.40:3128')
+    expect(uri.password).to eq('$?xxxx')
+  end
+
+  it "extracts the user" do
+    uri = URI('proxy://myuser:%24%3fxxxx@192.168.122.40:3128')
+    expect(uri.user).to eq('myuser')
+  end
+
+  it "extracts the host" do
+    uri = URI('proxy://myuser:%24%3fxxxx@192.168.122.40:3128')
+    expect(uri.host).to eq('192.168.122.40')
+  end
+
+  it "extracts the port" do
+    uri = URI('proxy://myuser:%24%3fxxxx@192.168.122.40:3128')
+    expect(uri.port).to eq(3128)
+  end
+
+  it "returns nil user and password if there is no userinfo" do
+    uri = URI('proxy://192.168.122.40:3128')
+    expect(uri.user).to be_nil
+    expect(uri.password).to be_nil
+  end
+
+  it "returns nil password if there user but no password" do
+    uri = URI('proxy://myuser@192.168.122.40:3128')
+    expect(uri.user).to eq('myuser')
+    expect(uri.password).to be_nil
+  end
+
+  it "decodes users that are e-mail addresses" do
+    uri = URI('proxy://myuser%40example.com@192.168.122.40:3128')
+    expect(uri.user).to eq('myuser@example.com')
+  end
+end


### PR DESCRIPTION
The Ruby URI parser doesn't decode the percent encoded characters in the URI, in particular it doesn't decode the password which is frequently used when specifying proxy addresses and authentication. For example, the following code:

```ruby
require 'uri'
proxy = URI.parse('http://myuser:%24%3fxxxx@192.168.100.10:3128')
puts proxy.password
```

Produces the following output:

```
%24%3fxxxx
```

But some gems, in particular `rest-client` and `kubeclient`, expect it to decode those characters, as they use the value returned by the `password` method directly, and thus they fail to authenticate against the proxy server when the password contains percent encoded characters.

To address this issue this patch adds a new `proxy` URI schema that almost identical to the `http` schema, but that decodes the password before returning it. Users can use this schema instead of `http` when
they need to use percent encoded characters in the password. For example, the user can type in the UI the following proxy URL:

```
proxy://myuser:%24%3fxxxx@192.168.100.10:3128
```

And the new schema will automatically translate `%24%3fxxxx` into
`$?xxxx`.

Fixes https://bugzilla.redhat.com/1566615.