### PR TITLE
Adjusting ManageIQ core to enable PhysicalChassis API endpoint

### DIFF
--- a/app/models/physical_chassis.rb
+++ b/app/models/physical_chassis.rb
@@ -8,4 +8,23 @@ class PhysicalChassis < ApplicationRecord
   has_one :hardware, :through => :computer_system
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
   has_many :guest_devices, :through => :hardware
+
+  def my_zone
+    ems = ext_management_system
+    ems ? ems.my_zone : MiqServer.my_zone
+  end
+
+  def refresh_ems
+    unless ext_management_system
+      raise _("No Provider defined")
+    end
+    unless ext_management_system.has_credentials?
+      raise _("No Provider credentials defined")
+    end
+    unless ext_management_system.authentication_status_ok?
+      raise _("Provider failed last authentication check")
+    end
+
+    EmsRefresh.queue_refresh(ext_management_system)
+  end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5848,6 +5848,35 @@
       :feature_type: admin
       :identifier: ems_physical_infra_new
 
+# Physical Chassis
+- :name: Physical Chassis
+  :description: Everything under Physical Chassis
+  :feature_type: node
+  :identifier: physical_chassis
+  :children:
+  - :name: View
+    :description: View Physical Chassis
+    :feature_type: view
+    :identifier: physical_chassis_view
+    :children:
+    - :name: List
+      :description: Display Lists of Physical Chassis
+      :feature_type: view
+      :identifier: physical_chassis_show_list
+    - :name: Show
+      :description: Display Individual Physical Chassis
+      :feature_type: view
+      :identifier: physical_chassis_show
+  - :name: Operate
+    :description: Perform Operations on Physical Chassis
+    :feature_type: control
+    :identifier: physical_chassis_control
+    :children:
+    - :name: Refresh
+      :description: Refresh relationships and power states for all items related to Physical Chassis
+      :feature_type: control
+      :identifier: physical_chassis_refresh
+
 # Physical Servers
 - :name: Physical Servers
   :description: Everything under Physical Servers


### PR DESCRIPTION
**This PR is able to:**
- In order to enable PhysicalChassis API endpoint implementation, the chassis class name inflection had to be removed and added to the ExtManagementSystem reference to PhysicalChassis.