### PR TITLE
Fix infra inventory collections for targeted refresh

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -22,6 +22,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::Network,
         :manager_ref                 => %i(hardware ipaddress),
         :association                 => :host_networks,
+        :parent_inventory_collections => [:hosts],
         :inventory_object_attributes => %i(
           description
           hostname
@@ -60,6 +61,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::Hardware,
         :manager_ref                 => [:host],
         :association                 => :host_hardwares,
+        :parent_inventory_collections => [:hosts],
         :inventory_object_attributes => %i(
           annotation
           cpu_cores_per_socket
@@ -122,6 +124,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::OperatingSystem,
         :manager_ref                 => [:host],
         :association                 => :host_operating_systems,
+        :parent_inventory_collections => [:hosts],
         :inventory_object_attributes => %i(
           name
           product_name
@@ -346,6 +349,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::HostStorage,
         :manager_ref                 => %i(host storage),
         :association                 => :host_storages,
+        :parent_inventory_collections => [:hosts],
         :inventory_object_attributes => %i(
           ems_ref
           read_only
@@ -362,6 +366,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::HostSwitch,
         :manager_ref                 => %i(host switch),
         :association                 => :host_switches,
+        :parent_inventory_collections => [:hosts],
         :inventory_object_attributes => %i(
           host
           switch


### PR DESCRIPTION
The host related inventory collections did not have the
parent_inventory_collections set which was causing targeted refresh to
fail.