### PR TITLE
Remove N+1 obj creation in flatten_arranged_rels

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -76,10 +76,15 @@ class Relationship < ApplicationRecord
   #
 
   def self.flatten_arranged_rels(relationships)
-    relationships.each_with_object([]) do |(rel, children), a|
-      a << rel
-      a.concat(flatten_arranged_rels(children))
+    result             = relationships.keys
+    remaining_children = relationships.values
+    until remaining_children.empty?
+      remaining_children.pop.each do |rel, kids|
+        result << rel
+        remaining_children << kids
+      end
     end
+    result
   end
 
   def self.arranged_rels_to_resources(relationships, initial = true)


### PR DESCRIPTION
The recursive nature of the original code, this meant that a new array was created for every call of the method.

This new form now only creates 2 arrays, and speeds up the process to flatten the rels by 2x.


Benchmarks
----------

With 2.7k records


```
BEFORE
======

Warming up --------------------------------------
flatten_arranged_rels
run 1                    2.239k i/100ms
run 2                    2.208k i/100ms

Calculating -------------------------------------
flatten_arranged_rels
run 1                    23.328k (±17.4%) i/s -    114.189k in   5.050293s
run 2                    23.520k (±17.6%) i/s -    114.816k in   5.043277s


AFTER
=====

Warming up --------------------------------------
flatten_arranged_rels
run 1                    4.787k i/100ms
run 2                    4.771k i/100ms
Calculating -------------------------------------
flatten_arranged_rels
run 1                    48.839k (± 7.8%) i/s -    244.137k in   5.033849s
run 2                    49.114k (± 9.3%) i/s -    248.092k in   5.101038s
```


With 8.3k records

```
BEFORE
======

Warming up --------------------------------------
flatten_arranged_rels
run 1                     370.000  i/100ms
run 2                     353.000  i/100ms
Calculating -------------------------------------
flatten_arranged_rels
run 1                     3.902k (±16.6%) i/s -     19.240k in   5.078666s
run 2                     3.589k (±17.7%) i/s -     17.650k in   5.089621s


AFTER
=====

Warming up --------------------------------------
flatten_arranged_rels
run 1                     859.000  i/100ms
run 2                     859.000  i/100ms
Calculating -------------------------------------
flatten_arranged_rels
run 1                     8.521k (±12.7%) i/s -     41.232k in   5.018254s
run 2                     8.525k (± 8.5%) i/s -     42.950k in   5.077203s
```