### PR TITLE
Refactoring of my_role to allow passing 'action' parameter.

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -70,7 +70,7 @@ class AutomationRequest < MiqRequest
   def customize_request_task_attributes(_req_task_attrs, _idx)
   end
 
-  def my_role
+  def my_role(_action = nil)
     'automate'
   end
 

--- a/app/models/miq_host_provision_request.rb
+++ b/app/models/miq_host_provision_request.rb
@@ -53,7 +53,7 @@ class MiqHostProvisionRequest < MiqRequest
     options[:src_host_ids].collect { |id_str| Host.find_by(:id => id_str.to_i) }.compact
   end
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 

--- a/app/models/miq_provision_configured_system_request.rb
+++ b/app/models/miq_provision_configured_system_request.rb
@@ -21,7 +21,7 @@ class MiqProvisionConfiguredSystemRequest < MiqRequest
     src_configured_systems.first.my_zone
   end
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 

--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -69,7 +69,7 @@ class MiqProvisionRequest < MiqRequest
     update_attributes(:description => miq_request_tasks.reload.first.description)
   end
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -401,7 +401,7 @@ class MiqRequest < ApplicationRecord
     MiqServer.my_zone
   end
 
-  def my_role
+  def my_role(_action = nil)
     nil
   end
 
@@ -429,7 +429,7 @@ class MiqRequest < ApplicationRecord
       :instance_id    => id,
       :method_name    => "create_request_tasks",
       :zone           => options.fetch(:miq_zone, my_zone),
-      :role           => kind_of?(ServiceTemplateProvisionRequest) ? 'automate' : my_role,
+      :role           => my_role(:create_request_tasks),
       :tracking_label => tracking_label_id,
       :msg_timeout    => 3600,
       :deliver_on     => deliver_on

--- a/app/models/service_reconfigure_request.rb
+++ b/app/models/service_reconfigure_request.rb
@@ -11,7 +11,7 @@ class ServiceReconfigureRequest < MiqRequest
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
   default_value_for :source_type,  SOURCE_CLASS_NAME
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -33,8 +33,8 @@ class ServiceTemplateProvisionRequest < MiqRequest
     end
   end
 
-  def my_role
-    'ems_operations'
+  def my_role(action = nil)
+    action == :create_request_tasks ? 'automate' : 'ems_operations'
   end
 
   def my_zone

--- a/app/models/vm_cloud_reconfigure_request.rb
+++ b/app/models/vm_cloud_reconfigure_request.rb
@@ -25,7 +25,7 @@ class VmCloudReconfigureRequest < MiqRequest
     vm.nil? ? super : vm.my_zone
   end
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 end

--- a/app/models/vm_migrate_request.rb
+++ b/app/models/vm_migrate_request.rb
@@ -12,7 +12,7 @@ class VmMigrateRequest < MiqRequest
     vm.nil? ? super : vm.my_zone
   end
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 end

--- a/app/models/vm_reconfigure_request.rb
+++ b/app/models/vm_reconfigure_request.rb
@@ -93,7 +93,7 @@ class VmReconfigureRequest < MiqRequest
     vm.nil? ? super : vm.my_zone
   end
 
-  def my_role
+  def my_role(_action = nil)
     'ems_operations'
   end
 end


### PR DESCRIPTION
Some actions my require different roles during the lifecycle of a request.

Based on work from PR https://github.com/ManageIQ/manageiq/pull/17297