### PR TITLE
Fix Rubocop TrailingCommaInLiteral issue at UI build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -219,7 +219,7 @@ unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
     gem "haml_lint",        "~>0.20.0", :require => false
-    gem "rubocop",          "~>0.52.1", :require => false
+    gem "rubocop",          "~>0.53.0", :require => false
     # ruby_parser is required for i18n string extraction
     gem "ruby_parser",                  :require => false
     gem "scss_lint",        "~>0.48.0", :require => false


### PR DESCRIPTION
At [version`0.53.0`](https://github.com/bbatsov/rubocop/blob/3c3e315b84df45845440a25cbd71a5b99214b21d/CHANGELOG.md#0530-2018-03-05), the `TrailingCommaInLiteral` rule at Rubocop has been split into`TrailingCommaInHashLiteral` and `TrailingCommaInArrayLiteral` and no longer exists. The current version definition for Rubocop allow us to use the version `0.52.1` or superior, but it is not possible to have both versions by having that options in your `rubocop.yml` file.

In order to use the new updated rules, this PR updates the current rubocop version to `0.53.0`.