### PR TITLE
Fix the issue of defined analyisis profile missed in vm scanning.

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -74,6 +74,7 @@ class VmScan < Job
         scan_profiles = []
         prof_policies.each { |p| scan_profiles += p[:result] unless p[:result].nil? }
         options[:scan_profiles] = scan_profiles unless scan_profiles.blank?
+        save
       end
     end
 


### PR DESCRIPTION
Normally job state transition is done by signal to the next state, which will save job options. But here the MiqQueue is used to change job states, the profiles information has to be saved before proceeding.

https://bugzilla.redhat.com/show_bug.cgi?id=1553808 
