### PR TITLE
GuestDevice model updates for support of storage devices

### DIFF
--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -20,4 +20,8 @@ class GuestDevice < ApplicationRecord
   def self.with_ethernet_type
     where(:device_type => "ethernet")
   end
+
+  def self.with_storage_type
+    where(:device_type => "storage")
+  end
 end

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -735,7 +735,6 @@ en:
       GenericObject:            Generic Object
       GenericObjectDefinition:  Generic Object Class
       GuestApplication:         Guest Application
-      GuestDevice:              Network Device
       Host:                     Host / Node
       HostPerformance:          Performance - Host
       IsoDatastore:             ISO Datastore


### PR DESCRIPTION
This PR updates the GuestDevice model to support storage devices. In addition, the alias for renaming guest device to network device has been removed because it's no longer needed. In the UI, a breadcrumb_title is now passed to the nested_list method instead.