### PR TITLE
Add reporting session threshold options in settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1047,6 +1047,8 @@
   :memcache_server_opts: "-l 127.0.0.1 -I 1M"
   :show_login_info: true
   :timeout: 3600
+  :log_threshold: 100.kilobytes
+  :element_threshold: 10.kilobytes
 :smartproxy_deploy:
   :queue_timeout: 30.minutes
 :smtp:


### PR DESCRIPTION
Adds reporting session thresholds to be used in a PR against
manageiq-ui-classic.

This PR is required for an incoming PR that replaces hard-coded settings in the reporting session with configurable options.  Link will be provided once that PR is available.