### PR TITLE
Provide base graph refresh attributes for ::Snapshot

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/cloud_manager.rb
@@ -131,6 +131,17 @@ class ManagerRefresh::InventoryCollectionDefault::CloudManager < ManagerRefresh:
       attributes.merge!(extra_attributes)
     end
 
+    def snapshots(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::Snapshot,
+        :association                  => :snapshots,
+        :manager_ref                  => [:vm_or_template, :ems_ref],
+        :parent_inventory_collections => [:vms, :miq_templates],
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
     def orchestration_stack_ancestry(extra_attributes = {})
       orchestration_stack_ancestry_save_block = lambda do |_ems, inventory_collection|
         stacks_inventory_collection = inventory_collection.dependency_attributes[:orchestration_stacks].try(:first)


### PR DESCRIPTION
With this commit we provide base function to be used when inventoring snapshots.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1571120

@miq-bot assign @Ladas 
@miq-bot add_label enhancement,gaprindashvili/yes

Related PR: https://github.com/ManageIQ/manageiq-providers-vmware/pull/217