### PR TITLE
Convert backslashes to forward slashes for Azure factory

### DIFF
--- a/spec/factories/vm_azure.rb
+++ b/spec/factories/vm_azure.rb
@@ -2,8 +2,8 @@ FactoryGirl.define do
   factory :vm_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Vm", :parent => :vm_cloud do
     location "westus"
     vendor   "azure"
-    uid_ems  "01234567890\\test_resource_group\\microsoft.resources\\vm_1"
-    ems_ref  "01234567890\\test_resource_group\\microsoft.resources\\vm_1"
+    uid_ems  "01234567890/test_resource_group/microsoft.resources/vm_1"
+    ems_ref  "01234567890/test_resource_group/microsoft.resources/vm_1"
     raw_power_state "VM running"
     name "vm_1"
 


### PR DESCRIPTION
Part of the effort to get rid of the silly backslashes in the Azure provider.

See also https://github.com/ManageIQ/manageiq-providers-azure/pull/245