### PR TITLE
Removed XClarity Client gem requirement for tests

### DIFF
--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -1,5 +1,3 @@
-require 'xclarity_client'
-
 describe ManageIQ::Providers::PhysicalInfraManager do
   before :all do
     @auth = { :user => 'admin', :pass => 'smartvm', :host => 'localhost', :port => '3000' }


### PR DESCRIPTION
The rationale for this is Physical Infra specs seem to be the only ones with a gem requirement, but it doesn't appear that this is needed for the tests, but if it is, the tests should be refactored.