### PR TITLE
Removing confirm_password field from change_password routine

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -345,13 +345,12 @@ module AuthenticationMixin
   #
   # @param [current_password] password currently used for connected userId in provider client
   # @param [new_password]     password that will replace the current one
-  # @param [confirm_password] must confirm the value of the `new_password`
   #
   # @return [Boolean] true if the routine is executed successfully
   #
-  def change_password(current_password, new_password, confirm_password, auth_type = :default)
+  def change_password(current_password, new_password, auth_type = :default)
     raise MiqException::Error, _("Change Password is not supported for #{self.class.description} provider") unless supports?(:change_password)
-    if change_password_params_valid?(current_password, new_password, confirm_password)
+    if change_password_params_valid?(current_password, new_password)
       raw_change_password(current_password, new_password)
       update_authentication(auth_type => {:userid => authentication_userid, :password => new_password})
     end
@@ -445,16 +444,12 @@ module AuthenticationMixin
   # Verifies if the change password params are valid
   #
   # @raise [MiqException::Error] if some required data is missing
-  #                              if new_password and confirm_password are differents
   #
   # @return [Boolean] true if the params are fine
   #
-  def change_password_params_valid?(current_password, new_password, confirm_password)
-    if current_password.blank? || new_password.blank? || confirm_password.blank?
-      raise MiqException::Error, _("Please, fill the current_password, new_password and confirm_password fields.")
-    end
-    raise MiqException::Error, _("Confirm password did not match.") unless new_password.eql?(confirm_password)
+  def change_password_params_valid?(current_password, new_password)
+    return true unless current_password.blank? || new_password.blank?
 
-    true
+    raise MiqException::Error, _("Please, fill the current_password and new_password fields.")
   end
 end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -703,15 +703,7 @@ describe AuthenticationMixin do
           allow(@ems).to receive(:supports?).with(:change_password) { true }
 
           expect { @ems.change_password(current_password, new_password, confirm_password) }
-            .to raise_error(MiqException::Error, "Please, fill the current_password, new_password and confirm_password fields.")
-        end
-
-        it "should fail if the confirm password is not equal to new password" do
-          confirm_password = "different_pass"
-          allow(@ems).to receive(:supports?).with(:change_password) { true }
-
-          expect { @ems.change_password(current_password, new_password, confirm_password) }
-            .to raise_error(MiqException::Error, "Confirm password did not match.")
+            .to raise_error(MiqException::Error, "Please, fill the current_password and new_password fields.")
         end
 
         it "should fail if the provider doesn't support this operation" do


### PR DESCRIPTION
__This PR is able to:__
- Remove `confirm_password` from `change_password` routine.

__Motivation:__
This PR was motivated by the discussion in this another one https://github.com/ManageIQ/manageiq-api/pull/309