### PR TITLE
[wip] Fix tag control names not being the same as their classification values

### DIFF
--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -42,8 +42,8 @@ class DialogFieldImporter
 
   def find_category(opts)
     if opts[:category_id]
-      cat = Category.find_by(:id => opts[:category_id])
-      return cat if cat.try(:name) == opts[:category_name]
+      category = Category.find_by(:id => opts[:category_id])
+      return category if category.try(:name) == opts[:category_name] || category.try(:description) == opts[:category_description]
     end
     Category.find_by_name(opts[:category_name])
   end

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -189,9 +189,9 @@ describe DialogFieldImporter do
             context "when the category_description matches the existing category" do
               let(:category_description) { @existing_category.description }
 
-              it "returns nil" do
+              it "returns matching category" do
                 dialog_field_importer.import_field(dialog_field)
-                expect(DialogFieldTagControl.first.category).to eq(nil)
+                expect(DialogFieldTagControl.first.category).to eq(@existing_category.id.to_s)
               end
             end
 


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1570613

I think we should be checking the description too here so if the id matches and the description matches, we assume it's the correct tag.