### PR TITLE
Do not change current_group for super admin user when executing Rbac#lookup_user_group

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -573,16 +573,18 @@ module Rbac
       miq_group_id ||= miq_group.try!(:id)
       return [user, user.current_group] if user && user.current_group_id.to_s == miq_group_id.to_s
 
+      found_group = user.try(:current_group)
       if user
         if miq_group_id && (detected_group = user.miq_groups.detect { |g| g.id.to_s == miq_group_id.to_s })
           user.current_group = detected_group
+          found_group = detected_group
         elsif miq_group_id && user.super_admin_user?
-          user.current_group = miq_group || MiqGroup.find_by(:id => miq_group_id)
+          found_group = miq_group || MiqGroup.find_by(:id => miq_group_id)
         end
       else
-        miq_group ||= miq_group_id && MiqGroup.find_by(:id => miq_group_id)
+        found_group = miq_group || (miq_group_id && MiqGroup.find_by(:id => miq_group_id))
       end
-      [user, user.try(:current_group) || miq_group]
+      [user, found_group]
     end
 
     # for reports, user is currently nil, so use the group filter

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -573,18 +573,18 @@ module Rbac
       miq_group_id ||= miq_group.try!(:id)
       return [user, user.current_group] if user && user.current_group_id.to_s == miq_group_id.to_s
 
-      found_group = user.try(:current_group)
-      if user
-        if miq_group_id && (detected_group = user.miq_groups.detect { |g| g.id.to_s == miq_group_id.to_s })
-          user.current_group = detected_group
-          found_group = detected_group
-        elsif miq_group_id && user.super_admin_user?
-          found_group = miq_group || MiqGroup.find_by(:id => miq_group_id)
-        end
-      else
-        found_group = miq_group || (miq_group_id && MiqGroup.find_by(:id => miq_group_id))
-      end
-      [user, found_group]
+      group = if user
+                if miq_group_id && (detected_group = user.miq_groups.detect { |g| g.id.to_s == miq_group_id.to_s })
+                  user.current_group = detected_group
+                elsif miq_group_id && user.super_admin_user?
+                  miq_group || MiqGroup.find_by(:id => miq_group_id)
+                else
+                  user.try(:current_group)
+                end
+              else
+                miq_group || (miq_group_id && MiqGroup.find_by(:id => miq_group_id))
+              end
+      [user, group]
     end
 
     # for reports, user is currently nil, so use the group filter

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2151,6 +2151,14 @@ describe Rbac::Filterer do
         _, group = filter.send(:lookup_user_group, admin, nil, nil, random_group.id)
         expect(group).to eq(random_group)
       end
+
+      it "does not update user.current_group if user is super admin" do
+        admin = FactoryGirl.create(:user_admin)
+        admin_group = admin.current_group
+        random_group = FactoryGirl.create(:miq_group)
+        filter.send(:lookup_user_group, admin, nil, nil, random_group.id)
+        expect(admin.current_group).to eq(admin_group)
+      end
     end
 
     context "user" do


### PR DESCRIPTION
Changing `user.current_user` for superadmin  and assigning group this admin does not belong-to may trigger not expected errors,
like below error raised for super admin in attempt to generate widget's content:
```
F, [2018-04-19T16:56:28.867955 #11598] FATAL -- : Error caught: [MiqException::RbacPrivilegeException] The user is not authorized for this task or item.
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/application_controller.rb:2124:in `assert_privileges'
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/report_controller/widgets.rb:36:in `widget_refresh'
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/report_controller/widgets.rb:148:in `widget_generate_content'
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/application_controller/explorer.rb:201:in `generic_x_button'
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/report_controller.rb:62:in `x_button'
```


caused by: https://github.com/ManageIQ/manageiq/pull/10457/commits/55a6a33e6d850d2c35b20cb6e9c13ac48037c808

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1564986

@miq-bot add-label bug, core, rbac