### PR TITLE
Catch load errors during inventory class constantization

### DIFF
--- a/app/models/manager_refresh/inventory.rb
+++ b/app/models/manager_refresh/inventory.rb
@@ -13,7 +13,7 @@ module ManagerRefresh
     def self.parser_class_for(klass)
       provider_module = ManageIQ::Providers::Inflector.provider_module(klass)
       "#{provider_module}::Inventory::Parser::#{klass.name.demodulize}".safe_constantize
-    rescue ManageIQ::Providers::Inflector::ObjectNotNamespacedError => _err
+    rescue LoadError, ManageIQ::Providers::Inflector::ObjectNotNamespacedError => _err
       nil
     end
 
@@ -24,7 +24,7 @@ module ManagerRefresh
     def self.persister_class_for(klass)
       provider_module = ManageIQ::Providers::Inflector.provider_module(klass)
       "#{provider_module}::Inventory::Persister::#{klass.name.demodulize}".safe_constantize
-    rescue ManageIQ::Providers::Inflector::ObjectNotNamespacedError => _err
+    rescue LoadError, ManageIQ::Providers::Inflector::ObjectNotNamespacedError => _err
       nil
     end
 


### PR DESCRIPTION
There seems to be an issue with safe_constantize in activesupport 5.0.6 that causes a load error instead of returning nil if it can't find a file containing the constant. It's fixed in 5.0.7 as far as I can tell. This PR works around that issue by adding LoadError to the existing rescue block in `parser_class_for` and `persister_class_for`.

Part of the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1570965