### PR TITLE
Prevents N+1 SQL queries in miq_request_workflow.rb

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1750,11 +1750,19 @@ class Host < ApplicationRecord
   end
 
   def writable_storages
-    storages.where(:host_storages => {:read_only => [false, nil]})
+    if host_storages.loaded? && host_storages.all? { |hs| hs.association(:storage).loaded? }
+      host_storages.reject(&:read_only).map(&:storage)
+    else
+      storages.where(:host_storages => {:read_only => [false, nil]})
+    end
   end
 
   def read_only_storages
-    storages.where(:host_storages => {:read_only => true})
+    if host_storages.loaded? && host_storages.all? { |hs| hs.association(:storage).loaded? }
+      host_storages.select(&:read_only).map(&:storage)
+    else
+      storages.where(:host_storages => {:read_only => true})
+    end
   end
 
   def archived?

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1077,7 +1077,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
             elsif src[:host_id]
               selected_host(src)
             else
-              load_ar_obj(allowed_hosts)
+              allowed_hosts.group_by(&:evm_object_class).flat_map do |type, objs|
+                type.to_s.camelize.constantize.where(:id => objs.map(&:id)).to_a
+              end
             end
     Rbac.filtered(hosts, :class => Host, :user => @requester)
   end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1050,7 +1050,7 @@ class MiqRequestWorkflow
 
     rails_logger('allowed_storages', 0)
     st = Time.now
-    MiqPreloader.preload(hosts, :storages)
+    MiqPreloader.preload(hosts, :storages => {}, :host_storages => :storage)
 
     storages = hosts.each_with_object({}) do |host, hash|
       host.writable_storages.each { |s| hash[s.id] = s }


### PR DESCRIPTION
This has 3 different fixes for 3 different N+1's:

- Handles `.writable_storages` with `MiqPreloader` properly
- Collects all host records at once in `.get_selected_hosts`
- ~~Does a HACK to MiqPreloader to handle polymorphic relationships, and allows the `.get_ems_metadata_tree` to properly preload hosts.~~

~~The hack should be isolated to just this methods that need it, and should work just like the normal `MiqPreloader.preload` when there isn't a hash passed in, but it is admittedly pretty gross...~~ 

 Update:  The "HACK" has been rebased out and will be done in a separate branch.


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries |  rows |
|    --: |  ---: |    ---: |  ---: |
| before | 15023 |    1961 | 48395 |
|  after | 11722 |      59 | 48395 |

```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 1975603612 bytes (21900482 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending                                    |      9665227  pending
   5561668  manageiq/app  <<<<<<<<<<                   |      5557939  manageiq/app  <<<<<<<<<<
   3513258  manageiq/lib  <<<<<<<<<<                   |      3508974  manageiq/lib  <<<<<<<<<<
   2512007  activerecord-5.0.7  <<<<<<<<<<             |      1576834  activerecord-5.0.7  <<<<<<<<<<
    861270  activesupport-5.0.7  <<<<<<<<<<            |       808731  activesupport-5.0.7  <<<<<<<<<<
    418737  ancestry-2.2.2                             |       418737  ancestry-2.2.2
    278793  activemodel-5.0.7  <<<<<<<<<<              |       274449  activemodel-5.0.7  <<<<<<<<<<
    178419  ruby-2.3.3/lib  <<<<<<<<<<                 |        52875  manageiq-providers-vmware-0be2f13a0dc9
    165577  arel-7.1.4                                 |        14424  fast_gettext-1.2.0
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        13366  arel-7.1.4  <<<<<<<<<<
     14424  fast_gettext-1.2.0                         |         8453  ruby-2.3.3/lib  <<<<<<<<<<
      4115  other                                      |          309  other
        75  default_value_for-3.0.5                    |           75  default_value_for-3.0.5
        68  concurrent-ruby-1.0.5                      |           66  concurrent-ruby-1.0.5
        16  memoist-0.15.0                             |           16  memoist-0.15.0
         4  rubygems                                   |            4  rubygems
         3  manageiq-providers-lenovo-470f5d68672b     |            3  manageiq-providers-lenovo-470f5d68672b
```

**Note**: The benchmarks for this change do NOT include the changes from other PRs in the links below.  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).

Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes:  [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17360
  - https://github.com/ManageIQ/manageiq/pull/17381
  - https://github.com/ManageIQ/manageiq/pull/17402
  - https://github.com/ManageIQ/manageiq/pull/17403