### PR TITLE
Memoize _log.prefix calls

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -835,7 +835,8 @@ class MiqRequestWorkflow
   def find_classes_under_ci(item, klass)
     results = []
     return results if item.nil?
-    node = load_ems_node(item, _log.prefix)
+    @_find_classes_under_ci_prefix ||= _log.prefix
+    node = load_ems_node(item, @_find_classes_under_ci_prefix)
     each_ems_metadata(node.attributes[:object], klass) { |ci| results << ci } unless node.nil?
     results
   end
@@ -865,7 +866,8 @@ class MiqRequestWorkflow
     end
 
     # Process child folders
-    node = load_ems_node(folder, _log.prefix)
+    @_get_ems_folders_prefix ||= _log.prefix
+    node = load_ems_node(folder, @_get_ems_folders_prefix)
     node.children.each { |child| get_ems_folders(child.attributes[:object], dh, full_path) } unless node.nil?
 
     dh
@@ -905,7 +907,8 @@ class MiqRequestWorkflow
 
   def find_class_above_ci(item, klass, _ems_src = nil, datacenter = false)
     result = nil
-    node = load_ems_node(item, _log.prefix)
+    @_find_class_above_ci_prefix ||= _log.prefix
+    node = load_ems_node(item, @_find_class_above_ci_prefix)
     klass_name = klass.name.to_sym
     # Walk the xml document parents to find the requested class
     while node.kind_of?(XmlHash::Element)
@@ -926,7 +929,8 @@ class MiqRequestWorkflow
       ems_xml = get_ems_metadata_tree(src)
       ems_node = ems_xml.try(:root)
     else
-      ems_node = load_ems_node(ems_ci, _log.prefix)
+      @_each_ems_metadata_prefix ||= _log.prefix
+      ems_node = load_ems_node(ems_ci, @_each_ems_metadata_prefix)
     end
     klass_name = klass.name.to_sym unless klass.nil?
     unless ems_node.nil?
@@ -1030,7 +1034,8 @@ class MiqRequestWorkflow
     hosts_ids = find_all_ems_of_type(Host).collect(&:id)
     hosts_ids &= load_ar_obj(src[:storage]).hosts.collect(&:id) unless src[:storage].nil?
     if datacenter
-      dc_node = load_ems_node(datacenter, _log.prefix)
+      @_allowed_hosts_obj_prefix ||= _log.prefix
+      dc_node = load_ems_node(datacenter, @_allowed_hosts_obj_prefix)
       hosts_ids &= find_hosts_under_ci(dc_node.attributes[:object]).collect(&:id)
     end
     return [] if hosts_ids.blank?


### PR DESCRIPTION
In situations where an EMS has a large number of hosts, the tree that gets built is quite large, and so the number of times that `_log.prefix` is fired is very high.  This updates each one of those calls to memoize them to a instance variable, since the resulting prefix will not change.


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries |  rows |
|    --: |  ---: |    ---: |  ---: |
| before | 15023 |    1961 | 48395 |
|  after | 10056 |    1961 | 48395 |

```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 1034363078 bytes (19721183 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending                                    |      9665227  pending
   5561668  manageiq/app                               |      5561668  manageiq/app
   3513258  manageiq/lib  <<<<<<<<<<                   |      2512007  activerecord-5.0.7
   2512007  activerecord-5.0.7                         |       861272  activesupport-5.0.7
    861270  activesupport-5.0.7                        |       418737  ancestry-2.2.2
    418737  ancestry-2.2.2                             |       278793  activemodel-5.0.7
    278793  activemodel-5.0.7                          |       178419  ruby-2.3.3/lib
    178419  ruby-2.3.3/lib                             |       165577  arel-7.1.4
    165577  arel-7.1.4                                 |        52875  manageiq-providers-vmware-0be2f13a0dc9
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        14424  fast_gettext-1.2.0
     14424  fast_gettext-1.2.0                         |         7903  manageiq/lib  <<<<<<<<<<
       ...                                             |          ...
```

**Note**:  The benchmarks for this change do _**NOT**_ include the changes from other PRs (https://github.com/ManageIQ/manageiq/pull/17354 for example).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17354
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17360