### PR TITLE
Add Memoization to LogProxy.prefix results

### DIFF
--- a/lib/vmdb/logging.rb
+++ b/lib/vmdb/logging.rb
@@ -1,7 +1,7 @@
 require 'vmdb/loggers'
 
 module Vmdb
-  class LogProxy < Struct.new(:klass, :separator)
+  class LogProxy < Struct.new(:klass, :separator, :prefix_cache)
     LEVELS = [:debug, :info, :warn, :error]
 
     # def debug?
@@ -30,8 +30,7 @@ module Vmdb
     def prefix(location = caller_locations(1, 1))
       location = location.first if location.kind_of?(Array)
       meth = location.base_label
-      meth = meth ? "#{klass}#{separator}#{meth}" : klass
-      "MIQ(#{meth})"
+      prefix_cache[meth] ||= meth ? "MIQ(#{klass}#{separator}#{meth})" : "MIQ(#{klass})"
     end
 
     private
@@ -49,11 +48,11 @@ module Vmdb
 
   module ClassLogging
     def instance_logger
-      @instance_logger ||= LogProxy.new(name, '#')
+      @instance_logger ||= LogProxy.new(name, '#', Hash.new)
     end
 
     def _log
-      @_log ||= LogProxy.new(name, '.')
+      @_log ||= LogProxy.new(name, '.', Hash.new)
     end
   end
 


### PR DESCRIPTION
This is a more generic form of https://github.com/ManageIQ/manageiq/pull/17355 that ends up being a little more risky, and doesn't help as well in the specific use case of `miq_request_workflow.rb`.

It is worth noting, though, that I have see `LogProxy#prefix` show up a lot in memory profiled results in other situations in the past, so this is a sore spot for extraneous allocations that wouldn't hurt from being addressed platform wide (since we log a lot...).  That said, this is something that should more be considered in the future, but not necessarily immediately.


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries |  rows |
|    --: |  ---: |    ---: |  ---: |
| before | 15023 |    1961 | 48395 |
|  after | 13676 |    1961 | 48395 |

```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 1882630774 bytes (21824382 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending                                    |      9665227  pending
   5561668  manageiq/app                               |      5561668  manageiq/app
   3513258  manageiq/lib  <<<<<<<<<<                   |      2512007  activerecord-5.0.7
   2512007  activerecord-5.0.7                         |      2111094  manageiq/lib  <<<<<<<<<<
    861270  activesupport-5.0.7                        |       861280  activesupport-5.0.7
    418737  ancestry-2.2.2                             |       418737  ancestry-2.2.2
    278793  activemodel-5.0.7                          |       278793  activemodel-5.0.7
    178419  ruby-2.3.3/lib                             |       178419  ruby-2.3.3/lib
    165577  arel-7.1.4                                 |       165577  arel-7.1.4
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        52875  manageiq-providers-vmware-0be2f13a0dc9
     14424  fast_gettext-1.2.0                         |        14424  fast_gettext-1.2.0
       ...                                             |          ...
```

**Note**:  The benchmarks for this change do _**NOT**_ include the changes from other PRs (https://github.com/ManageIQ/manageiq/pull/17354 for example).  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* * Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17354
    * Extracted PRs: https://github.com/ManageIQ/manageiq/pull/17457, https://github.com/ManageIQ/manageiq/pull/17460, https://github.com/ManageIQ/manageiq/pull/17461
  - https://github.com/ManageIQ/manageiq/pull/17355