### PR TITLE
Refactor get_ems_folders to create less strings

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -856,19 +856,25 @@ class MiqRequestWorkflow
   end
 
   def get_ems_folders(folder, dh = {}, full_path = "")
+    path = full_path
     if folder.evm_object_class == :EmsFolder
       if folder.hidden
         return dh if folder.name != 'vm'
       else
-        full_path += full_path.blank? ? folder.name.to_s : " / #{folder.name}"
-        dh[folder.id] = full_path unless folder.type == "Datacenter"
+        path = full_path.dup
+        if path.blank?
+          path << folder.name.to_s
+        else
+          path << " / ".freeze << folder.name
+        end
+        dh[folder.id] = path unless folder.type == "Datacenter".freeze
       end
     end
 
     # Process child folders
     @_get_ems_folders_prefix ||= _log.prefix
     node = load_ems_node(folder, @_get_ems_folders_prefix)
-    node.children.each { |child| get_ems_folders(child.attributes[:object], dh, full_path) } unless node.nil?
+    node.children.each { |child| get_ems_folders(child.attributes[:object], dh, path) } unless node.nil?
 
     dh
   end


### PR DESCRIPTION
Creating some strings in this method is inevitable, since we are generating string paths based on this compiled info, but there were a lot of excessive strings being created because of it:

- Both of the constants in this method were being created every time this method was called.  For the `"Datacenter".freeze` one, it was just used as a comparison as well
- Using `<<` where possible will avoid generating new substrings, so we are only creating one new string at most.
- Deferred the `.dup` of full_path until a new string was known that it would be generated.  This did require creating a new variable to hold on to the existing variable, but that wasn't a big deal and didn't increase the number of allocations.

Split up some ternary operators as well just to make running profilers on this code easier to determine what as causing allocations (granularity in tracing object allocations in ruby is only down to a line by line basis).


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries |  rows |
|    --: |  ---: |    ---: |  ---: |
| before | 15023 |    1961 | 48395 |
|  after | 15017 |    1961 | 48395 |

```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 2055920344 bytes (22741877 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending                                    |      9665227  pending
   5561668  manageiq/app  <<<<<<<<<<                   |      5076997  manageiq/app  <<<<<<<<<<
   3513258  manageiq/lib                               |      3513258  manageiq/lib
   2512007  activerecord-5.0.7                         |      2512007  activerecord-5.0.7
    861270  activesupport-5.0.7  <<<<<<<<<<            |       861282  activesupport-5.0.7  <<<<<<<<<<
    418737  ancestry-2.2.2                             |       418737  ancestry-2.2.2
    278793  activemodel-5.0.7                          |       278793  activemodel-5.0.7
    178419  ruby-2.3.3/lib                             |       178419  ruby-2.3.3/lib
    165577  arel-7.1.4                                 |       165577  arel-7.1.4
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        52875  manageiq-providers-vmware-0be2f13a0dc9
     14424  fast_gettext-1.2.0                         |        14424  fast_gettext-1.2.0
       ...                                             |          ...
```

**Note**:  The benchmarks for this change do _**NOT**_ include the changes from other PRs (https://github.com/ManageIQ/manageiq/pull/17354 for example).  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17354
    * Extracted PRs: https://github.com/ManageIQ/manageiq/pull/17457, https://github.com/ManageIQ/manageiq/pull/17460, https://github.com/ManageIQ/manageiq/pull/17461
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17360
  - https://github.com/ManageIQ/manageiq/pull/17381
  - https://github.com/ManageIQ/manageiq/pull/17402
  - https://github.com/ManageIQ/manageiq/pull/17403