### PR TITLE
Use OpenStruct over MiqHashStruct

### DIFF
--- a/app/models/miq_host_provision_workflow.rb
+++ b/app/models/miq_host_provision_workflow.rb
@@ -207,15 +207,15 @@ class MiqHostProvisionWorkflow < MiqRequestWorkflow
   end
 
   def self.from_ws(*args)
-    # Move optional arguments into the MiqHashStruct object
+    # Move optional arguments into the OpenStruct object
     prov_args = args[0, 6]
-    prov_options = MiqHashStruct.new(:values => args[6], :ems_custom_attributes => args[7], :miq_custom_attributes => args[8])
+    prov_options = OpenStruct.new(:values => args[6], :ems_custom_attributes => args[7], :miq_custom_attributes => args[8])
     prov_args << prov_options
     MiqHostProvisionWorkflow.from_ws_ver_1_x(*prov_args)
   end
 
   def self.from_ws_ver_1_x(version, user, template_fields, vm_fields, requester, tags, options)
-    options = MiqHashStruct.new if options.nil?
+    options = OpenStruct.new if options.nil?
     _log.warn("Web-service host provisioning starting with interface version <#{version}> by requester <#{user.userid}>")
 
     init_options = {:use_pre_dialog => false, :request_type => request_type(parse_ws_string(template_fields)[:request_type])}

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -724,8 +724,8 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     version = args.first.to_f
     return from_ws_ver_1_0(*args) if version == 1.0
 
-    # Move optional arguments into the MiqHashStruct object
-    prov_options = MiqHashStruct.new(
+    # Move optional arguments into the OpenStruct object
+    prov_options = OpenStruct.new(
       :values                => args[6],
       :ems_custom_attributes => args[7],
       :miq_custom_attributes => args[8],
@@ -938,7 +938,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def self.from_ws_ver_1_x(version, user, template_fields, vm_fields, requester, tags, options)
-    options = MiqHashStruct.new if options.nil?
+    options = OpenStruct.new if options.nil?
     _log.warn("Web-service provisioning starting with interface version <#{version}> by requester <#{user.userid}>")
 
     init_options = {:use_pre_dialog => false, :request_type => request_type(parse_ws_string(template_fields)[:request_type]), :initial_pass => true}
@@ -1045,11 +1045,11 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
                  :v_total_snapshots      => vm_or_template.v_total_snapshots,
                  :evm_object_class       => :Vm}
     data_hash[:cloud_tenant] = vm_or_template.cloud_tenant if vm_or_template.respond_to?(:cloud_tenant)
-    hash_struct = MiqHashStruct.new(data_hash)
-    hash_struct.operating_system = MiqHashStruct.new(
+    hash_struct = OpenStruct.new(data_hash)
+    hash_struct.operating_system = OpenStruct.new(
       :product_name => vm_or_template.operating_system.product_name
     ) if vm_or_template.operating_system
-    hash_struct.ext_management_system = MiqHashStruct.new(
+    hash_struct.ext_management_system = OpenStruct.new(
       :name => vm_or_template.ext_management_system.name
     ) if vm_or_template.ext_management_system
     if options[:include_datacenter] == true

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1,5 +1,5 @@
 require 'enumerator'
-require 'miq-hash_struct'
+require 'ostruct'
 
 class MiqRequestWorkflow
   include Vmdb::Logging
@@ -113,6 +113,7 @@ class MiqRequestWorkflow
             init_values[field_name] = [val, field_values[:values][val]]
           else
             field_values[:values].each do |tz|
+              next unless tz.kind_of?(Array)
               if tz[1].to_i_with_method == val.to_i_with_method
                 # Save [value, description] for timezones array
                 init_values[field_name] = [val, tz[0]]
@@ -641,7 +642,7 @@ class MiqRequestWorkflow
   end
 
   def build_ci_hash_struct(ci, props)
-    nh = MiqHashStruct.new(:id => ci.id, :evm_object_class => ci.class.base_class.name.to_sym)
+    nh = OpenStruct.new(:id => ci.id, :evm_object_class => ci.class.base_class.name.to_sym)
     props.each { |p| nh.send("#{p}=", ci.send(p)) }
     nh
   end
@@ -843,7 +844,7 @@ class MiqRequestWorkflow
 
   def load_ems_node(item, log_header)
     @ems_xml_nodes ||= {}
-    klass_name = if item.kind_of?(MiqHashStruct)
+    klass_name = if item.kind_of?(OpenStruct)
                    Object.const_get(item.evm_object_class)
                  else
                    item.class.base_class
@@ -855,7 +856,7 @@ class MiqRequestWorkflow
 
   def ems_has_clusters?
     found = each_ems_metadata(nil, EmsCluster) { |ci| break(ci) }
-    return found.evm_object_class == :EmsCluster if found.kind_of?(MiqHashStruct)
+    return found.evm_object_class == :EmsCluster if found.kind_of?(OpenStruct)
     false
   end
 
@@ -1023,7 +1024,7 @@ class MiqRequestWorkflow
 
   def load_ar_obj(ci)
     return load_ar_objs(ci) if ci.kind_of?(Array)
-    return ci unless ci.kind_of?(MiqHashStruct)
+    return ci unless ci.kind_of?(OpenStruct)
     ci.evm_object_class.to_s.camelize.constantize.find_by(:id => ci.id)
   end
 
@@ -1243,7 +1244,7 @@ class MiqRequestWorkflow
       field_values = dlg_field[:values]
       _log.info("processing key <#{dialog_name}:#{key}(#{data_type})> with values <#{field_values.inspect}>")
       if field_values.present?
-        result = if field_values.first.kind_of?(MiqHashStruct)
+        result = if field_values.first.kind_of?(OpenStruct)
                    found = field_values.detect { |v| v.id == set_value }
                    [found.id, found.name] if found
                  elsif data_type == :array_integer
@@ -1284,7 +1285,7 @@ class MiqRequestWorkflow
       field_values = dlg_field[:values]
       _log.info("processing key <#{dialog_name}:#{key}(#{data_type})> with values <#{field_values.inspect}>")
       if field_values.present?
-        result = if field_values.first.kind_of?(MiqHashStruct)
+        result = if field_values.first.kind_of?(OpenStruct)
                    found = field_values.detect { |v| v.send(obj_key).to_s.downcase == find_value }
                    [found.id, found.send(obj_key)] if found
                  else

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -25,8 +25,8 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
   context "with allowed customization templates" do
     it "#allowed_customization_templates" do
-      expect(workflow.allowed_customization_templates.first).to be_a(MiqHashStruct)
-      expect(sysprep_workflow.allowed_customization_templates.first).to be_a(MiqHashStruct)
+      expect(workflow.allowed_customization_templates.first).to be_a(OpenStruct)
+      expect(sysprep_workflow.allowed_customization_templates.first).to be_a(OpenStruct)
     end
 
     it "should retrieve cloud-init templates when cloning" do
@@ -35,7 +35,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
       result = workflow.allowed_customization_templates(options)
       customization_template = workflow.instance_variable_get(:@values)[:customization_template_script]
-      template_hash = result.first.instance_variable_get(:@hash)
+      template_hash = result.first.instance_variable_get(:@table)
 
       expect(customization_template).to eq cloud_init_template.script
       expect(template_hash).to be_a(Hash)
@@ -53,7 +53,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
       result = sysprep_workflow.allowed_customization_templates(options)
       customization_template = sysprep_workflow.instance_variable_get(:@values)[:customization_template_script]
-      template_hash = result.first.instance_variable_get(:@hash)
+      template_hash = result.first.instance_variable_get(:@table)
 
       expect(customization_template).to eq sysprep_template.script
       expect(template_hash).to be_a(Hash)

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -262,7 +262,7 @@ describe MiqProvisionVirtWorkflow do
       host1  = FactoryGirl.create(:host_vmware, :ems_id => ems.id)
       src_vm = FactoryGirl.create(:vm_vmware, :host => host1, :ems_id => ems.id)
       allow(workflow).to receive(:source_vm_rbac_filter).and_return([src_vm])
-      expect(workflow.ws_find_template_or_vm("", "VMWARE", "asdf-adsf", "asdfadfasdf")).to be_a(MiqHashStruct)
+      expect(workflow.ws_find_template_or_vm("", "VMWARE", "asdf-adsf", "asdfadfasdf")).to be_a(OpenStruct)
     end
   end
 

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -625,7 +625,7 @@ describe MiqRequestWorkflow do
     let(:storage) { FactoryGirl.create(:storage) }
 
     it 'filters out storage_clusters not in same ems' do
-      allow(workflow).to receive(:get_source_and_targets).and_return(:ems => MiqHashStruct.new(:id => ems.id))
+      allow(workflow).to receive(:get_source_and_targets).and_return(:ems => OpenStruct.new(:id => ems.id))
       storage_cluster1 = FactoryGirl.create(:storage_cluster, :name => 'test_storage_cluster1', :ems_id => ems.id)
       storage_cluster2 = FactoryGirl.create(:storage_cluster, :name => 'test_storage_cluster2', :ems_id => ems.id + 1)
       storage_cluster1.add_child(storage)


### PR DESCRIPTION
This is almost a straight 1 for 1 conversion, and performs much better than our implementation: `MiqHashStruct`.

* * *

### ~~Regarding the [WIP] portion:~~

_**Update**_:  This section is no longer relevant as I have found the solution to the issue (tests caught what was supposed to be happening).  Keeping the below for posterity, but see the last commit for updates to the rational here.

The only part that doesn't work (but also doesn't make any sense that it ever did), was the portion of this code that was commented out:

```diff
- if tz[1].to_i_with_method == val.to_i_with_method
-   # Save [value, description] for timezones array
-   init_values[field_name] = [val, tz[0]]
- end
+ # if tz[1].to_i_with_method == val.to_i_with_method
+ #   # Save [value, description] for timezones array
+ #   init_values[field_name] = [val, tz[0]]
+ # end
```

`tz` in the above always seems to be a `MiqHashStruct` (in the previous commit), and when `tz[1]` is called, it hit's `method_missing` with `:[]` as the method argument.  This of course will almost never have a match in the underlying `@hash` in the `MiqHashStruct`, but will not blow up at least.

When it is an `OpenStruct`, this fails with an error since `1` can't be converted to a symbol properly.  I am uncertain if this code is ever activated, so for now, I have just commented it out to observe the advantages to using `OpenStruct` over `MiqHashStruct`.


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries |  rows |
|    --: |  ---: |    ---: |  ---: |
| before | 15023 |    1961 | 48395 |
|  after | 14021 |    1961 | 48395 |

```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 1592827666 bytes (11222271 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending  <<<<<<<<<<                        |      3513258  manageiq/lib
   5561668  manageiq/app  <<<<<<<<<<                   |      3074174  manageiq/app  <<<<<<<<<<
   3513258  manageiq/lib                               |      2512007  activerecord-5.0.7
   2512007  activerecord-5.0.7                         |       861263  activesupport-5.0.7
    861270  activesupport-5.0.7                        |       418737  ancestry-2.2.2
    418737  ancestry-2.2.2                             |       278793  activemodel-5.0.7
    278793  activemodel-5.0.7                          |       244083  ruby-2.3.3/lib
    178419  ruby-2.3.3/lib                             |       165577  arel-7.1.4
    165577  arel-7.1.4                                 |        82799  pending  <<<<<<<<<<
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        52875  manageiq-providers-vmware-0be2f13a0dc9
     14424  fast_gettext-1.2.0                         |        14424  fast_gettext-1.2.0
       ...                                             |          ...
```

Another analysis that included other fixes in addition to this, but gives an alternative solution as well (though it becomes quite obvious why this was chosen), can be found [here](https://gist.github.com/NickLaMuro/d68a18aa3c18f344c57b5b21071d8266).

**Note**:  The benchmarks for this change do _**NOT**_ include the changes from other PRs (https://github.com/ManageIQ/manageiq/pull/17354 for example).  Benchmarks of all changes can be found  [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* More in depth benchmarks and different strategies to solve this:  [gist](https://gist.github.com/NickLaMuro/d68a18aa3c18f344c57b5b21071d8266)
* Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17354
    * Extracted PRs: https://github.com/ManageIQ/manageiq/pull/17457, https://github.com/ManageIQ/manageiq/pull/17460, https://github.com/ManageIQ/manageiq/pull/17461
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17360
  - https://github.com/ManageIQ/manageiq/pull/17381
  - https://github.com/ManageIQ/manageiq/pull/17402
  - https://github.com/ManageIQ/manageiq/pull/17403