### PR TITLE
Change dialog import to only use auto_refresh if new triggers are blank

### DIFF
--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -144,16 +144,15 @@ class DialogImportService
       dialog.except!(:blueprint_id, 'blueprint_id') # blueprint_id might appear in some old dialogs, but no longer exists
       new_or_existing_dialog = Dialog.where(:label => dialog["label"]).first_or_create
       dialog['id'] = new_or_existing_dialog.id
-      associations_to_be_created = build_association_list(dialog)
+      new_associations = build_association_list(dialog)
       new_or_existing_dialog.update_attributes(
         dialog.merge(
           "dialog_tabs"      => build_dialog_tabs(dialog),
           "resource_actions" => build_resource_actions(dialog)
         )
       )
-      old_associations = build_old_association_list(new_or_existing_dialog.dialog_fields).flatten
-      association_list = (associations_to_be_created + old_associations).reject(&:blank?)
-      build_associations(new_or_existing_dialog, association_list)
+      association_list = new_associations.reject(&:blank?).present? ? new_associations : build_old_association_list(new_or_existing_dialog.dialog_fields).flatten
+      build_associations(new_or_existing_dialog, association_list.reject(&:blank?))
     end
   end
 


### PR DESCRIPTION
The old field associations still exist and are used to create the dialog associations on import. Because you can't touch the auto_refresh in the UI anymore but they still live in db and exist when we export dialogs. So if we have new associations we should use them and only them, not both the old associations and the new ones.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1572777