### PR TITLE
Add a memcached bind address for tower

### DIFF
--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -82,10 +82,11 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
 
   def run_setup_script(exclude_tags)
     json_extra_vars = {
-      :minimum_var_space  => 0,
-      :http_port          => HTTP_PORT,
-      :https_port         => HTTPS_PORT,
-      :tower_package_name => "ansible-tower-server"
+      :awx_install_memcached_bind => MiqMemcached.server_address,
+      :minimum_var_space          => 0,
+      :http_port                  => HTTP_PORT,
+      :https_port                 => HTTPS_PORT,
+      :tower_package_name         => "ansible-tower-server"
     }.to_json
 
     with_inventory_file do |inventory_file_path|

--- a/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
@@ -124,10 +124,11 @@ describe ApplianceEmbeddedAnsible do
     let(:miq_database) { MiqDatabase.first }
     let(:extra_vars) do
       {
-        :minimum_var_space  => 0,
-        :http_port          => described_class::HTTP_PORT,
-        :https_port         => described_class::HTTPS_PORT,
-        :tower_package_name => "ansible-tower-server"
+        :awx_install_memcached_bind => MiqMemcached.server_address,
+        :minimum_var_space          => 0,
+        :http_port                  => described_class::HTTP_PORT,
+        :https_port                 => described_class::HTTPS_PORT,
+        :tower_package_name         => "ansible-tower-server"
       }.to_json
     end
 


### PR DESCRIPTION
This prevents newer versions of the ansible tower setup playbook
from making memcached bind to a local socket rather than to tcp
localhost.

/cc @simaishi 