### PR TITLE
[FINE] Use Settings directly for getting the memcached server address

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -94,7 +94,7 @@ class EmbeddedAnsible
 
   def self.run_setup_script(exclude_tags)
     json_extra_vars = {
-      :awx_install_memcached_bind => MiqMemcached.server_address,
+      :awx_install_memcached_bind => ::Settings.session.memcache_server,
       :minimum_var_space          => 0,
       :http_port                  => HTTP_PORT,
       :https_port                 => HTTPS_PORT,

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -128,7 +128,7 @@ describe EmbeddedAnsible do
     let(:miq_database) { MiqDatabase.first }
     let(:extra_vars) do
       {
-        :awx_install_memcached_bind => MiqMemcached.server_address,
+        :awx_install_memcached_bind => ::Settings.session.memcache_server,
         :minimum_var_space          => 0,
         :http_port                  => described_class::HTTP_PORT,
         :https_port                 => described_class::HTTPS_PORT,


### PR DESCRIPTION
MiqMemcached.server_address was introduced in #15326 which is not in fine