### PR TITLE
Fix the Cockpit Worker Authenticator Spec

### DIFF
--- a/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
+++ b/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
@@ -2,8 +2,8 @@ describe MiqCockpitWsWorker::Authenticator do
   describe '#authenticate_for_host' do
     before do
       @auth = MiqCockpitWsWorker::Authenticator
-      @user = FactoryGirl.create(:user, :userid => 1)
-      @token = Api::Environment.user_token_service.generate_token(1, "api")
+      @user = FactoryGirl.create(:user, :userid => "admin")
+      @token = Api::UserTokenService.new.generate_token(@user.userid, 'api')
     end
 
     context "when using bad token" do


### PR DESCRIPTION
The spec/models/miq_cockpit_ws_worker/authenticator_spec.rb was passing
`1` as the User.userid when this is intended to be a string.

https://github.com/ManageIQ/manageiq-api/pull/371 is now calling
downcase on userid causing spec failures.