### PR TITLE
NOR covers 30 days

### DIFF
--- a/app/models/metric/long_term_averages.rb
+++ b/app/models/metric/long_term_averages.rb
@@ -40,7 +40,8 @@ module Metric::LongTermAverages
     avg_cols = options[:avg_cols] || AVG_COLS
 
     ext_options = ext_options.merge(:only_cols => avg_cols)
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(obj, "daily", :end_date => Time.now.utc, :days => avg_days, :ext_options => ext_options)
+    end_date = Time.now.utc.beginning_of_day - 1
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(obj, "daily", :end_date => end_date, :days => avg_days, :ext_options => ext_options)
     perfs.each do |p|
       if ext_options[:time_profile] && !ext_options[:time_profile].ts_day_in_profile?(p.timestamp.in_time_zone(tz))
         next

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -149,7 +149,8 @@ module VmOrTemplate::RightSizing
   alias_method :overallocated_mem_pct,   :aggressive_mem_recommended_change_pct
 
   def max_cpu_usage_rate_average_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
+    end_date = Time.now.utc.beginning_of_day - 1
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => end_date, :days => Metric::LongTermAverages::AVG_DAYS)
     perfs.collect do |p|
       # Ignore any CPU bursts to 100% 15 minutes after VM booted
       next if (p.abs_max_cpu_usage_rate_average_value == 100.0) && boot_time && (p.abs_max_cpu_usage_rate_average_timestamp <= (boot_time + 15.minutes))
@@ -158,17 +159,20 @@ module VmOrTemplate::RightSizing
   end
 
   def max_mem_usage_absolute_average_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
+    end_date = Time.now.utc.beginning_of_day - 1
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => end_date, :days => Metric::LongTermAverages::AVG_DAYS)
     perfs.collect(&:abs_max_mem_usage_absolute_average_value).compact.max
   end
 
   def cpu_usagemhz_rate_average_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
+    end_date = Time.now.utc.beginning_of_day - 1
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => end_date, :days => Metric::LongTermAverages::AVG_DAYS)
     perfs.collect(&:abs_max_cpu_usagemhz_rate_average_value).compact.max
   end
 
   def derived_memory_used_max_over_time_period
-    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => Time.now.utc, :days => Metric::LongTermAverages::AVG_DAYS)
+    end_date = Time.now.utc.beginning_of_day - 1
+    perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => end_date, :days => Metric::LongTermAverages::AVG_DAYS)
     perfs.collect(&:abs_max_derived_memory_used_value).compact.max
   end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -638,6 +638,7 @@ describe Metric do
         before do
           Timecop.travel(Time.parse("2010-05-01T00:00:00Z"))
           cases = [
+            "2010-04-01T00:00:00Z",  9.14, 32.85,
             "2010-04-13T21:00:00Z",  9.14, 32.85,
             "2010-04-14T18:00:00Z", 10.23, 28.76,
             "2010-04-14T19:00:00Z", 18.92, 39.11,
@@ -669,8 +670,8 @@ describe Metric do
         it "should calculate the correct normal operating range values" do
           @vm1.generate_vim_performance_operating_range(@time_profile)
 
-          expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.692)
-          expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.085)
+          expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.124)
+          expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.056)
         end
 
         it "should calculate the correct right-size values" do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -751,6 +751,7 @@ describe VmOrTemplate do
       tp_id = TimeProfile.seed.id
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
+                         :timestamp       => 1.day.ago,
                          :time_profile_id => tp_id,
                          :resource_id     => vm.id,
                          :min_max         => {
@@ -760,6 +761,7 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :cpu_usagemhz_rate_average => 10.0,
+                         :timestamp                 => 1.day.ago,
                          :time_profile_id           => tp_id,
                          :resource_id               => vm.id,
                          :min_max                   => {
@@ -768,6 +770,7 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :cpu_usagemhz_rate_average => 100.0,
+                         :timestamp                 => 1.day.ago,
                          :time_profile_id           => tp_id,
                          :resource_id               => vm.id,
                          :min_max                   => {
@@ -798,6 +801,7 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :time_profile_id => tp_id,
+                         :timestamp       => 1.day.ago,
                          :resource_id     => vm.id,
                          :min_max         => {
                            :abs_max_derived_memory_used_value => 100.00
@@ -805,6 +809,7 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :derived_memory_used => 10.0,
+                         :timestamp           => 1.day.ago,
                          :time_profile_id     => tp_id,
                          :resource_id         => vm.id,
                          :min_max             => {
@@ -813,6 +818,7 @@ describe VmOrTemplate do
       FactoryGirl.create :metric_rollup_vm_daily,
                          :with_data,
                          :derived_memory_used => 1000.0,
+                         :timestamp           => 1.day.ago,
                          :time_profile_id     => tp_id,
                          :resource_id         => vm.id,
                          :min_max             => {


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1501996

Currently Normal Operating Range effectively only cover 29 (instead of claimed 30) days of data.  It is using the range of  [`30 days before Time.now` .. `Time.now`]  to query the `daily` rollups. However, the `daily` rollup record is only created at the end of current day and the record will have timestamp set to the beginning of current day.
