### PR TITLE
Save Physical Storage Model

### DIFF
--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -3,6 +3,7 @@
 # - ems
 #   - physical_racks
 #   - physical_chassis
+#   - physical_storages
 #   - physical_servers
 #   - physical_switches
 #
@@ -24,7 +25,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
       _log.debug("#{log_header} hashes:\n#{YAML.dump(hashes)}")
     end
 
-    child_keys = %i(physical_racks physical_chassis physical_servers physical_switches customization_scripts)
+    child_keys = %i(physical_racks physical_chassis physical_storages physical_servers physical_switches customization_scripts)
 
     # Save and link other subsections
     save_child_inventory(ems, hashes, child_keys, target)
@@ -89,6 +90,19 @@ module EmsRefresh::SaveInventoryPhysicalInfra
     child_keys = %i(computer_system asset_detail)
     save_inventory_multi(ems.physical_chassis, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_chassis, hashes, :ems_ref)
+  end
+
+  def save_physical_storages_inventory(ems, hashes, target = nil)
+    target = ems if target.nil?
+    deletes = target == ems ? :use_association : []
+
+    hashes.each do |h|
+      h[:physical_rack_id] = h.delete(:physical_rack).try(:[], :id)
+    end
+
+    child_keys = %i(computer_system asset_detail)
+    save_inventory_multi(ems.physical_storages, hashes, deletes, [:ems_ref], child_keys)
+    store_ids_for_new_records(ems.physical_storages, hashes, :ems_ref)
   end
 
   #

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -6,11 +6,13 @@ module ManageIQ::Providers
     has_many :physical_racks,    :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
     has_many :physical_servers,  :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
     has_many :physical_switches, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
+    has_many :physical_storages, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
     virtual_total :total_physical_chassis,  :physical_chassis
     virtual_total :total_physical_racks,    :physical_racks
     virtual_total :total_physical_servers,  :physical_servers
     virtual_total :total_physical_switches, :physical_switches
+    virtual_total :total_physical_storages, :physical_storages
 
     virtual_column :total_hosts, :type => :integer
     virtual_column :total_vms,   :type => :integer

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -1,0 +1,11 @@
+class PhysicalStorage < ApplicationRecord
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_storages,
+   :class_name => "ManageIQ::Providers::PhysicalInfraManager"
+
+  belongs_to :physical_rack, :foreign_key => :physical_rack_id, :inverse_of => :physical_storages
+
+  has_one :computer_system, :as => :managed_entity, :dependent => :destroy, :inverse_of => false
+  has_one :hardware, :through => :computer_system
+  has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
+  has_many :guest_devices, :through => :hardware
+end


### PR DESCRIPTION
This PR is able to save physical storage model into ManageIQ. Likewise Switches, Servers, Racks and Chassis, the Storage is a physical component, which is why I labeled it **PhysicalStorage** in model.

Depends on:
- [ManageIQ/manageiq-schema#196](https://github.com/ManageIQ/manageiq-schema/pull/196)