### PR TITLE
Load Lans effeciently in MiqProvisionVirtWorkflow

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -230,8 +230,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     hosts = get_selected_hosts(src)
     unless @vlan_options[:vlans] == false
       rails_logger('allowed_vlans', 0)
-      # TODO: Use Active Record to preload this data?
-      MiqPreloader.preload(hosts, :lans => :switches)
       load_allowed_vlans(hosts, vlans)
       rails_logger('allowed_vlans', 1)
     end
@@ -244,9 +242,11 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def load_hosts_vlans(hosts, vlans)
-    hosts.each do |h|
-      h.lans.each { |l| vlans[l.name] = l.name unless l.switch.shared? }
-    end
+    Lan.joins(:switch => :hosts)
+       .where(:hosts => {:id => hosts.map(&:id)})
+       .where(:switches => {:shared => [nil, false]})
+       .distinct.pluck(:name)
+       .each_with_object(vlans) { |v, h| h[v] = v }
   end
 
   def filter_by_tags(target, options)


### PR DESCRIPTION
Instead of preloading `Lan` records, splitting them up based on if they are shareable and instantiating entire `ActiveRecord` instances to only use the name column in a hash, use a specific query to gather and filter those values and generate a hash from that.

**IMPORTANT NOTE:**  The provider PRs linked below should be merged first:

* https://github.com/ManageIQ/manageiq-providers-vmware/pull/249
* https://github.com/ManageIQ/manageiq-providers-scvmm/pull/73

**UPDATE:**  These PRs have been merged, so this is good to be merged now.

As the performance impact from removing the `MiqPreloader.preload` in this PR will then not be an issue.


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries | query (ms) |  rows |
|    --: |  ---: |    ---: |       ---: |  ---: |
| before | 15023 |    1961 |      715.2 | 48395 |
|  after |  8395 |    1960 |      758.3 | 22105 |

```
Before                                                               After
------                                                               -----

Total allocated: 2069091751 bytes (23226536 objects)             |   Total allocated: 925043206 bytes (18683089 objects)
                                                                 |   
allocated objects by gem                                         |   allocated objects by gem
-----------------------------------                              |   -----------------------------------
   9665227  pending                                              |      9665227  pending
   5561668  manageiq/app  <<<<<<<<<<                             |      5509120  manageiq/app  <<<<<<<<<<
   3513258  manageiq/lib                                         |      1697100  activerecord-5.0.7  <<<<<<<<<<
   2512007  activerecord-5.0.7  <<<<<<<<<<                       |       834238  activesupport-5.0.7
    861270  activesupport-5.0.7                                  |       418737  ancestry-2.2.2
    418737  ancestry-2.2.2                                       |       188479  activemodel-5.0.7
    278793  activemodel-5.0.7                                    |       178212  ruby-2.3.3/lib
    178419  ruby-2.3.3/lib                                       |       166857  arel-7.1.4
    165577  arel-7.1.4                                           |        13032  fast_gettext-1.2.0
     52875  manageiq-providers-vmware-0be2f13a0dc9  <<<<<<<<<<   |         7789  manageiq/lib
     14424  fast_gettext-1.2.0                                   |         4109  other
      4115  other                                                |           75  default_value_for-3.0.5
        75  default_value_for-3.0.5                              |           60  concurrent-ruby-1.0.5
        68  concurrent-ruby-1.0.5                                |           34  manageiq-providers-vmware-0be2f13a0dc9  <<<<<<<<<<
       ...                                                       |          ...
```

**Note**:  The benchmarks for this change do _**NOT**_ include the changes from other PRs (https://github.com/ManageIQ/manageiq/pull/17354 for example).  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort: [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Provider PRs (should be merged first!)
  - https://github.com/ManageIQ/manageiq-providers-vmware/pull/249
  - https://github.com/ManageIQ/manageiq-providers-scvmm/pull/73
* Related PRs
  - https://github.com/ManageIQ/manageiq/pull/17354
    * Extracted PRs: https://github.com/ManageIQ/manageiq/pull/17457, https://github.com/ManageIQ/manageiq/pull/17460, https://github.com/ManageIQ/manageiq/pull/17461
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17360
  - https://github.com/ManageIQ/manageiq/pull/17402
  - https://github.com/ManageIQ/manageiq/pull/17403