### PR TITLE
Fix call for future retirement

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -12,7 +12,7 @@ module RetirementMixin
   module ClassMethods
     def make_retire_request(*src_ids)
       options = {:src_ids => src_ids.presence || id}
-      (name + "RetireRequest").constantize.make_request(nil, options, User.current_user, true)
+      (name.demodulize + "RetireRequest").constantize.make_request(nil, options, User.current_user, true)
     end
 
     def retire(ids, options = {})
@@ -122,7 +122,7 @@ module RetirementMixin
       end
     end
 
-    make_retire_request if retirement_due?
+    self.class.make_retire_request(self.id) if retirement_due?
   end
 
   def retire_now(requester = nil)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -7,14 +7,15 @@ describe "Service Retirement Management" do
 
   # shouldn't be running make_retire_request because it's the bimodal not from ui part
   it "#retirement_check" do
-    expect(MiqEvent).to receive(:raise_evm_event)
-    @service.update_attributes(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
-    expect(@service.retirement_last_warn).to be_nil
-    expect(@service).to receive(:make_retire_request).once
-    @service.retirement_check
-    @service.reload
-    expect(@service.retirement_last_warn).not_to be_nil
-    expect(Time.now.utc - @service.retirement_last_warn).to be < 30
+    User.with_user(user) do
+      expect(MiqEvent).to receive(:raise_evm_event)
+      @service.update_attributes(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
+      expect(@service.retirement_last_warn).to be_nil
+      @service.retirement_check
+      @service.reload
+      expect(@service.retirement_last_warn).not_to be_nil
+      expect(Time.now.utc - @service.retirement_last_warn).to be < 30
+    end
   end
 
   it "#start_retirement" do

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -10,14 +10,15 @@ describe "VM Retirement Management" do
   end
 
   it "#retirement_check" do
-    expect(MiqEvent).to receive(:raise_evm_event).once
-    @vm.update_attributes(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
-    expect(@vm.retirement_last_warn).to be_nil
-    expect(@vm).to receive(:make_retire_request).once
-    @vm.retirement_check
-    @vm.reload
-    expect(@vm.retirement_last_warn).not_to be_nil
-    expect(Time.now.utc - @vm.retirement_last_warn).to be < 30
+    User.with_user(user) do
+      expect(MiqEvent).to receive(:raise_evm_event).once
+      @vm.update_attributes(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
+      expect(@vm.retirement_last_warn).to be_nil
+      @vm.retirement_check
+      @vm.reload
+      expect(@vm.retirement_last_warn).not_to be_nil
+      expect(Time.now.utc - @vm.retirement_last_warn).to be < 30
+    end
   end
 
   it "#start_retirement" do


### PR DESCRIPTION
The make_retire_request changes necessitate this call change for future retirement. Note that the retirement as done through the UI, when set to retire on future date/time, will only work after https://bugzilla.redhat.com/show_bug.cgi?id=1574628 gets resolved, so while this PR fixes the call, future retirement through UI is still a bit kaput for the time being. 