### PR TITLE
Various fixes to miqssh.

### DIFF
--- a/tools/miqssh/README.md
+++ b/tools/miqssh/README.md
@@ -4,7 +4,7 @@ These tools allow for running commands and copying files and searching log files
 
 Also, even if you do have pssh or other tools for running commands on multiple systems, the new miqgrep, miqgrep -r, miqtail, and miqtail -r are worth a look.
 
-Different transport mechanisms are now supported and can be selected by updating the .config file.  By default, Ansible is used since it can work in parallel and is included by default with ManageIQ.  Alternatively, if installed and selected, Parallel SSH can be used and is faster opening connections than Ansible.
+Different transport mechanisms are now supported and can be selected by updating the .config file.  By default, Ansible is used since it can work in parallel and is included by default with ManageIQ.  Ansible is now the recommended transport for best functionality.
 
 **Note that this program can enable you to do things faster, including mistakes, use at your own risk.**
 

--- a/tools/miqssh/miqhosts.rb
+++ b/tools/miqssh/miqhosts.rb
@@ -43,7 +43,10 @@ end
 
 # Method to list the servers belonging to the specified group.
 def list_servers(data, group)
-  puts data[group.to_sym].join(" ")
+  groups = group.split(',')
+  servers = []
+  groups.each { |g| servers.push(data[g.to_sym]) }
+  puts servers.uniq.sort.join(" ")
 end
 
 file = ARGV[0]

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -159,9 +159,9 @@ function clean_pssh_out {
 
 if [ $NAME == 'miqtail' ]
 then
-  GREP='grep -e'
+  GREP='grep'
 else
-  GREP='zgrep -e'
+  GREP='zgrep'
 fi
 
 L='L'
@@ -190,6 +190,8 @@ do
 done
 
 shift $((OPTIND-1))
+
+GREP="$GREP -e"
 
 if [[ -z "$TRANSPORT" || -z "$PARALLELISM" ]]
 then

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -193,6 +193,19 @@ shift $((OPTIND-1))
 
 GREP="$GREP -e"
 
+if [[ "$TRANSPORT" == 'ansible' && $NAME == 'miqcollect' ]]
+then
+  wildcards=( '*' '.' '?' '|' ']' '[' ) 
+  for wildcard in "${wildcards[@]}"
+  do
+    if [[ $1 == *"${wildcard}"* ]]
+    then
+      echo "*** Switching TRANSPORT to ssh due to wild card in source file name ***"
+      TRANSPORT=ssh
+    fi
+  done
+fi
+
 if [[ -z "$TRANSPORT" || -z "$PARALLELISM" ]]
 then
   echo "TRANSPORT and/or PARALLELISM not specified, see $DIR/.config."

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -458,7 +458,7 @@ then
 fi
 
 ARGS=$*
-ARGS=$(echo $ARGS | sed 's/*/\\*/g')
+#ARGS=$(echo $ARGS | sed 's/*/\\*/g')
 
 if [ $NAME != 'miqtail' ]
 then

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -276,11 +276,14 @@ then
     echo "Not enough arguments!"
     usage
   fi
-elif [[ "$2" == "list" && $# -lt 2 ]]
+elif [ "$1" == "list" ]
 then
-  echo
-  echo "Not enough arguments!"
-  usage
+  if [ $# -ne 1 ]
+  then
+    echo
+    echo "Wrong number of arguments!"
+    usage
+  fi
 elif [[ $NAME == 'miqgrep' || $NAME == "miqtail" ]]
 then
   if [[ $# -ne 1 && $# -ne 2 ]]

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -44,7 +44,7 @@ groups=$($miqhosts_cmd $miqhosts_file list_groups)
 function usage_common {
   echo "DESCRIPTION: $2"
   echo
-  echo "USAGE: $NAME [-g group] [-s] $1"
+  echo "USAGE: $NAME [-g group1[,groupN]] [-s] $1"
   echo
   shift 2
   echo "DETAILS:"
@@ -362,29 +362,19 @@ then
   exit 1
 fi
 
-group_good=false
-
-for i in $groups
-do
-  if [ "$i" == "$group" ]
-  then
-    group_good=true
-  fi
-done
-
-if [ "$group_good" != "true" ]
-then
-  echo
-  echo "Group $group not found in $miqhosts_file"
-  usage
-fi
-
 if [[ "$QUIET" != 'true' && "$TRANSPORT" != 'pssh' && "$TRANSPORT" != 'ansible' || ( $NAME == 'miqgrep' && $REQUEST == 'true' ) ]]
 then
   echo
 fi
 
 SERVERS=$($miqhosts_cmd $miqhosts_file list_servers $group)
+
+if [ -z "$SERVERS" ]
+then
+  echo
+  echo "No servers found matching group(s) $group in $miqhosts_file"
+  usage
+fi
 
 if [ "$1" == "list" ]
 then
@@ -395,7 +385,7 @@ then
   for i in $SERVERS
   do
     echo $i
-  done
+  done | sort
   exit
 fi
 

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -503,9 +503,9 @@ then
       "miqgrep")
         if [ -n "$PATTERN" ]
         then
-          ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP \"$PATTERN\" $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE
+          ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP \"$PATTERN\" $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE | perl -ne "print if /^\S+\s\|\s\S+\s\|\src=\d+\s>>\s*$|^\S+\s\|\s\S+\s=>\s\{\s*$/"
         else
-          ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE
+          ansible all -i $HOSTS -f $PARALLELISM -m shell -a "$GREP $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" | tee $TMPFILE | perl -ne "print if /\|\src=\d+\s>>/"
         fi ;;
     esac
 

--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -477,7 +477,7 @@ then
     case $NAME in
       "miqssh") pssh -t 0 -i $HOSTS $ARGS ;;
       "miqscp") pscp.pssh -t 0 $HOSTS $1 $2 ;;
-      "miqcollect") pslurp -t 0 $HOSTS -L $2 $1 . ;;
+      "miqcollect") pslurp -t 0 $HOSTS -L $2 "$1" . ;;
       "miqgrep") pssh -t 0 $HOSTS -o $PSSH_OUTDIR "$GREP \"$PATTERN\" $LOG | perl -pe 's/^\/.*?://' | sed -e \"s/^/[\$(hostname -s)] /\"" ;;
     esac
 


### PR DESCRIPTION
Fix miqgrep -i functionality.
Fix parameter checking for list mode.
Fix miqgrep with Ansible transport to no longer show output to screen from individual systems.
Fix group matching to be able to match multiple groups.
Fix miqcollect to support wildcard with pssh.
Fix miqcollect to fail back to ssh transport when wildcards are used with Ansible transport.
Fix ARGS to work better with Ansible transport.
Make Ansible transport the default and recommended transport.