### PR TITLE
Add a generic relationships custom save block

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default.rb
+++ b/app/models/manager_refresh/inventory_collection_default.rb
@@ -187,5 +187,66 @@ class ManagerRefresh::InventoryCollectionDefault
 
       attributes.merge!(extra_attributes)
     end
+
+    def relationships(relationship_key, relationship_type, parent_type, association, extra_attributes = {})
+      relationship_save_block = lambda do |_ems, inventory_collection|
+        parents  = Hash.new { |h, k| h[k] = {} }
+        children = Hash.new { |h, k| h[k] = {} }
+
+        inventory_collection.dependency_attributes.each_value do |dependency_collections|
+          next if dependency_collections.blank?
+
+          dependency_collections.each do |collection|
+            next if collection.blank?
+
+            collection.data.each do |obj|
+              parent = obj.data[relationship_key].try(&:load)
+              next if parent.nil?
+
+              parent_klass = parent.inventory_collection.model_class
+
+              # Save the model_class and id of the parent for each child
+              children[collection.model_class][obj.id] = [parent_klass, parent.id]
+
+              # This will be populated later when looking up all the parent ids
+              parents[parent_klass][parent.id] = nil
+            end
+          end
+        end
+
+        ActiveRecord::Base.transaction do
+          # Lookup all of the parent records
+          parents.each do |model_class, ids|
+            model_class.find(ids.keys).each { |record| ids[record.id] = record }
+          end
+
+          # Loop through all children and assign parents
+          children.each do |model_class, ids|
+            child_records = model_class.find(ids.keys).index_by(&:id)
+
+            ids.each do |id, parent_info|
+              child = child_records[id]
+
+              parent_klass, parent_id = parent_info
+              parent = parents[parent_klass][parent_id]
+
+              child.with_relationship_type(relationship_type) do
+                prev_parent = child.parent(:of_type => parent_type)
+                unless prev_parent == parent
+                  prev_parent&.remove_child(child)
+                  parent.add_child(child)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      attributes = {
+        :association       => association,
+        :custom_save_block => relationship_save_block,
+      }
+      attributes.merge!(extra_attributes)
+    end
   end
 end

--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -158,7 +158,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::EmsFolder,
         :association                 => :ems_folders,
         :manager_ref                 => [:uid_ems],
-        :attributes_blacklist        => [:ems_children],
+        :attributes_blacklist        => %i(ems_children parent),
         :inventory_object_attributes => %i(
           ems_ref
           name
@@ -178,6 +178,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
       attributes = {
         :model_class                 => ::Datacenter,
         :association                 => :datacenters,
+        :attributes_blaklist         => %i(parent),
         :inventory_object_attributes => %i(
           name
           type
@@ -199,7 +200,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::ResourcePool,
         :association                 => :resource_pools,
         :manager_ref                 => [:uid_ems],
-        :attributes_blacklist        => [:ems_children],
+        :attributes_blacklist        => %i(ems_children parent),
         :inventory_object_attributes => %i(
           ems_ref
           name
@@ -218,7 +219,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
       attributes = {
         :model_class                 => ::EmsCluster,
         :association                 => :ems_clusters,
-        :attributes_blacklist        => %i(ems_children datacenter_id),
+        :attributes_blacklist        => %i(ems_children datacenter_id parent),
         :inventory_object_attributes => %i(
           ems_ref
           ems_ref_obj
@@ -241,6 +242,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :association                 => :storages,
         :complete                    => false,
         :arel                        => Storage,
+        :attributes_blacklist        => %i(parent),
         :inventory_object_attributes => %i(
           ems_ref
           ems_ref_obj
@@ -263,6 +265,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
       attributes = {
         :model_class                 => ::Host,
         :association                 => :hosts,
+        :attributes_blacklist        => %i(parent),
         :inventory_object_attributes => %i(
           type
           ems_ref
@@ -381,6 +384,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::Switch,
         :manager_ref                 => [:uid_ems],
         :association                 => :switches,
+        :attributes_blacklist        => %i(parent),
         :inventory_object_attributes => %i(
           uid_ems
           name


### PR DESCRIPTION
Start to replace the specific relationships savers with a generic one.

This allows for parents to be from other inventory collections without any special handling like is done for the current `vm_and_miq_template_ancestry` collection.