### PR TITLE
Check all costs fields for relevancy for the report 

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -94,7 +94,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption, options)
     result = {}
-    if (relevant_fields & [metric_key, cost_keys[0]]).present?
+    if (relevant_fields & ([metric_key] + cost_keys)).present?
       metric_value, cost = metric_and_cost_by(consumption, options)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -350,6 +350,17 @@ describe ChargebackVm do
           expect(subject.metering_used_cost).to eq(hours_in_day * count_hourly_rate)
         end
 
+        context "only memory_cost instead of all report columns" do
+          let(:options) { base_options.merge(:interval => 'daily', :report_cols => %w(memory_cost)) }
+
+          it "brings in relevant fields needed for calculation" do
+            memory_allocated_cost = memory_available * hourly_rate * hours_in_day
+            used_metric = used_average_for(:derived_memory_used, hours_in_day, @vm1)
+            memory_used_cost = used_metric * hourly_rate * hours_in_day
+            expect(subject.memory_cost).to eq(memory_allocated_cost + memory_used_cost)
+          end
+        end
+
         context "fixed rates" do
           let(:hourly_fixed_rate) { 10.0 }
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567254

If a user asks only for some of the fields (memory cost) in a chargeback report
and they didn't request specific ones (memory allocated cost), we would skip
calculating the memory cost because we thought it wasn't relevant.  We need to
check all cost fields to see if they're relevant for the requested fields in the
report.