### PR TITLE
Deduplicate embedded ansible notifications

### DIFF
--- a/app/models/embedded_ansible_worker/runner.rb
+++ b/app/models/embedded_ansible_worker/runner.rb
@@ -97,7 +97,12 @@ class EmbeddedAnsibleWorker::Runner < MiqWorker::Runner
       :role_name   => ServerRole.find_by(:name => worker.class.required_roles.first).description,
       :server_name => MiqServer.my_server.name
     }
-    Notification.create(:type => notification_type, :options => notification_options)
+
+    # Create the notification only if there are no existing ones for embedded ansible which are unseen
+    Notification.create(:type => notification_type, :options => notification_options) if Notification.of_type(notification_type).none? do |n|
+      correct_notification = n.options == notification_options
+      correct_notification && !n.seen_by_all_recipients?
+    end
   end
 
   def embedded_ansible

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -16,6 +16,8 @@ class Notification < ApplicationRecord
   serialize :options, Hash
   default_value_for(:options) { Hash.new }
 
+  scope :of_type, ->(notification_type) { joins(:notification_type).where(:notification_types => {:name => notification_type}) }
+
   def type=(typ)
     self.notification_type = NotificationType.find_by!(:name => typ)
   end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -35,6 +35,10 @@ class Notification < ApplicationRecord
     }
   end
 
+  def seen_by_all_recipients?
+    notification_recipients.unseen.empty?
+  end
+
   private
 
   def emit_message

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -4,6 +4,23 @@ describe Notification, :type => :model do
   let(:tenant) { FactoryGirl.create(:tenant) }
   let!(:user) { FactoryGirl.create(:user_with_group, :tenant => tenant) }
 
+  describe '.of_type' do
+    it "only returns notification of the given type" do
+      types = NotificationType.all
+      type_name_one   = types[0].name
+      type_name_two   = types[1].name
+      type_name_three = types[2].name
+
+      Notification.create(:type => type_name_one, :initiator => user)
+      Notification.create(:type => type_name_one, :initiator => user)
+      Notification.create(:type => type_name_two, :initiator => user)
+
+      expect(Notification.of_type(type_name_one).count).to eq(2)
+      expect(Notification.of_type(type_name_two).count).to eq(1)
+      expect(Notification.of_type(type_name_three).count).to eq(0)
+    end
+  end
+
   describe '.emit' do
     context 'successful' do
       let(:vm) { FactoryGirl.create(:vm, :tenant => tenant) }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -96,4 +96,22 @@ describe Notification, :type => :model do
       )
     end
   end
+
+  describe "#seen_by_all_recipients?" do
+    let(:notification) { FactoryGirl.create(:notification, :initiator => user) }
+
+    it "is false if a user has not seen the notification" do
+      expect(notification.seen_by_all_recipients?).to be_falsey
+    end
+
+    it "is true when all recipients have seen the notification" do
+      notification.notification_recipients.each { |r| r.update_attributes(:seen => true) }
+      expect(notification.seen_by_all_recipients?).to be_truthy
+    end
+
+    it "is true when there are no recipients" do
+      notification.notification_recipients.destroy_all
+      expect(notification.seen_by_all_recipients?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This PR changes the Embedded Ansible role notification behavior so that a new notification is only created when either there is no existing one for that server or the existing one has been read.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1486695