### PR TITLE
AuthHelper - add stub_admin, allow stub_user to receive custom user

### DIFF
--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -13,8 +13,7 @@ module Spec
       end
 
       # TODO: Stub specific features, document use
-      def stub_user(features:)
-        user = FactoryGirl.build(:user_with_group)
+      def stub_user(features:, user: FactoryGirl.build(:user_with_group))
         allow(controller).to receive(:current_user).and_return(user)
         allow(User).to receive(:current_user).and_return(user)
         allow(User).to receive(:server_timezone).and_return("UTC")
@@ -35,6 +34,10 @@ module Spec
 
         login_as user
         user
+      end
+
+      def stub_admin
+        stub_user(:features => :all, :user => FactoryGirl.create(:user_admin))
       end
     end
 


### PR DESCRIPTION
If I just run `stub_user(:features => :all)` I get an user who can't really see anything because of RBAC.
If I do `login_as FactoryGirl(:user_admin)`, I don't get all the goodies that `stub_user` provides.

Thus, we need to be able to provide a custom user instance to `stub_user`.

And since we're doing that, logging in as an admin user happens too often not to get it's own shortcut :).

Cc @chrisarcand does this make sense? 