### PR TITLE
[FINE] Add check for tag control category fix

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -23,7 +23,7 @@ class DialogFieldSerializer < Serializer
 
     if dialog_field.type == "DialogFieldTagControl"
       category = Category.find_by(:id => dialog_field.category)
-      dialog_field.options.merge!(:category_name => category.name, :category_description => category.description)
+      dialog_field.options.merge!(:category_name => category.name, :category_description => category.description) if category
     end
 
     included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -116,21 +116,40 @@ describe DialogFieldSerializer do
       let(:dynamic) { false }
       let(:category) { double("Category", :name => "best category ever", :description => "best category ever") }
 
-      before do
-        allow(Category).to receive(:find_by).with(:id => "123").and_return(category)
-        allow(dialog_field).to receive(:values).and_return("values")
+      context "with category" do
+        before do
+          allow(Category).to receive(:find_by).with(:id => "123").and_return(category)
+          allow(dialog_field).to receive(:values).and_return("values")
+        end
+
+        it "serializes the category name and description" do
+          expect(dialog_field_serializer.serialize(dialog_field))
+            .to eq(expected_serialized_values.merge(
+                     "resource_action" => "serialized resource action",
+                     "options"         => {
+                       :category_id          => "123",
+                       :category_name        => "best category ever",
+                       :category_description => "best category ever"
+                     }
+            ))
+        end
       end
 
-      it "serializes the category name and description" do
-        expect(dialog_field_serializer.serialize(dialog_field))
-          .to eq(expected_serialized_values.merge(
-                   "resource_action" => "serialized resource action",
-                   "options"         => {
-                     :category_id          => "123",
-                     :category_name        => "best category ever",
-                     :category_description => "best category ever"
-                   }
-          ))
+      context "without category" do
+        before do
+          allow(Category).to receive(:find_by).with(:id => "123").and_return(nil)
+          allow(dialog_field).to receive(:values).and_return("values")
+        end
+
+        it "serializes the category name" do
+          expect(dialog_field_serializer.serialize(dialog_field))
+            .to eq(expected_serialized_values.merge(
+                     "resource_action" => "serialized resource action",
+                     "options"         => {
+                       :category_id => "123",
+                     }
+            ))
+        end
       end
     end
   end


### PR DESCRIPTION
The PR that fixed this issue on master is here: https://github.com/ManageIQ/manageiq/pull/16955. We need this fix on Fine for https://bugzilla.redhat.com/show_bug.cgi?id=1567755. It was blowing up because the serializer needs the check for the existence of the tag control but we've had so many changes between Fine and now (dialog runner using API now, new editor, trigger/responder changes, all the things...) that it made more sense between Tina and I to just fix it this way. 

