### PR TITLE
[WIP] Lighter unique Host#domain lookup for in MiqProvisionVirtWorkflow

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -194,6 +194,17 @@ class Host < ApplicationRecord
     where(:failover => true)
   end
 
+  def self.all_unique_downcased_domains(includes = nil)
+    select_rows = select("lower(regexp_replace(split_part(hostname, ',', 1), '[^\.]*\.', '')) as domain")
+                    .select(:id).to_sql
+                    .sub!("SELECT", "DISTINCT ON (domain)")
+                    .sub!(/ FROM.*$/, '')
+
+    query = select(select_rows).where.not(:hostname => nil)
+    query = query.includes(includes) if includes
+    query
+  end
+
   def authentication_check_role
     'smartstate'
   end


### PR DESCRIPTION
Makes use of `Host.all_unique_downcased_domains` (new method) in the `MiqProvisionVirtWorkflow#allowed_domains` method to return only a list of the domain objects, pre-formatted and reduced to unique entries in SQL, reducing object allocations by reducing what is returned from the DB, the number of unneeded rows that needed to be type casted in ruby, and the temp objects generated to build the `domain` string in ruby.

The `includes` option of that method is also taken advantage of if the `option[:platform]` is set, though, to me it seems to not make sense since it seems like you could have multiple hosts on the same "domain", but have different platforms for each, so this might return different results when filtered on depending on the order and records in the DB (seems like a bug).


About `Host.all_unique_downcased_domains`
-----------------------------------------

This query is meant to be a query does the work of `Host#domain` in the query it self, and return it as a column, along with the `id` column as well.

The advantage of this is it is a much faster way of collecting the domains for a given host, and doesn't require nearly as many attributes to be returned from the DB, creating object allocations we just don't use (`hosts` has over 30+ columns on it).

It also handles filtering uniq domains in the DB by using `SELECT DISTINCT ON (domain) ...` in the query, but this has a disadvantage in which it `DISTINCT ON` doesn't
play nicely with `ActiveRecord#select` (hence the `gsub`ing).


Metrics
-------

Benchmarks were taken by monitoring the UI requests using the `manageiq_performance` gem.  The route monitored was selecting the `"Lifecycle" -> "Publish this VM to a Template"` menu button from a VM show page.  The metrics shown are against database with a fairly large EMS, with about 600 hosts, and are 3 subsequent requests against that route.

Note the change in `row` counts:


**Before**

|    ms | queries | query (ms) |  rows |
|  ---: |    ---: |       ---: |  ---: |
| 18613 |    2062 |     1463.7 | 70017 |
| 17695 |    2062 |     1475.5 | 70017 |
| 17774 |    2062 |     1578.4 | 70017 |


**After**

|    ms | queries | query (ms) |  rows |
|  ---: |    ---: |       ---: |  ---: |
| 19377 |    2062 |     1401.6 | 66781 |
| 17789 |    2062 |     1450.4 | 66781 |
| 17874 |    2062 |     1615.5 | 66781 |


**Note**:  The benchmarks for this change do _**NOT**_ include the changes from other PRs (https://github.com/ManageIQ/manageiq/pull/17354 for example).  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes: [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17354
    * Extracted PRs: https://github.com/ManageIQ/manageiq/pull/17457, https://github.com/ManageIQ/manageiq/pull/17460, https://github.com/ManageIQ/manageiq/pull/17461
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17381
  - https://github.com/ManageIQ/manageiq/pull/17402