### PR TITLE
Restrict Vm Operating System detection for XP

### DIFF
--- a/app/models/operating_system.rb
+++ b/app/models/operating_system.rb
@@ -12,7 +12,7 @@ class OperatingSystem < ApplicationRecord
 
   @@os_map = [
     ["windows_generic", %w(winnetenterprise w2k3 win2k3 server2003 winnetstandard servernt)],
-    ["windows_generic", %w(winxppro winxp xp)],
+    ["windows_generic", %w(winxppro winxp)],
     ["windows_generic", %w(vista longhorn)],
     ["windows_generic", %w(win2k win2000)],
     ["windows_generic", %w(microsoft windows winnt)],


### PR DESCRIPTION
A code for setting Operating System on a Vm uses name parsing
as a fallback. There was too much generic pattern "xp" which
could mark linux Vm with name including "xp" as Windows machine,
which was incorrect and confusing for users.

Removing "xp" from Operating System patterns.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1576076
