### PR TITLE
Expose plugin ansible content consolidation as a rake task

### DIFF
--- a/app/models/embedded_ansible_worker/object_management.rb
+++ b/app/models/embedded_ansible_worker/object_management.rb
@@ -6,7 +6,7 @@ module EmbeddedAnsibleWorker::ObjectManagement
     ensure_credential(provider, connection)
     ensure_inventory(provider, connection)
     ensure_host(provider, connection)
-    ensure_plugin_playbooks_project_seeded(provider, connection) unless MiqEnvironment::Command.is_container?
+    ensure_plugin_playbooks_project_seeded(provider, connection)
   end
 
   def remove_demo_data(connection)
@@ -56,7 +56,10 @@ module EmbeddedAnsibleWorker::ObjectManagement
   end
 
   def ensure_plugin_playbooks_project_seeded(provider, connection)
-    EmbeddedAnsible.new.create_local_playbook_repo
+    ea = EmbeddedAnsible.new
+    return unless ea.respond_to?(:create_local_playbook_repo)
+
+    ea.create_local_playbook_repo
 
     project = find_default_project(connection, provider.default_project)
     if project

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -29,6 +29,15 @@ class EmbeddedAnsible
     other_embedded_ansible.priority <=> priority
   end
 
+  def self.consolidate_plugin_playbooks(dir)
+    FileUtils.rm_rf(dir)
+    FileUtils.mkdir_p(dir)
+
+    Vmdb::Plugins.instance.registered_ansible_content.each do |content|
+      FileUtils.cp_r(Dir.glob("#{content.path}/*"), dir)
+    end
+  end
+
   def alive?
     return false unless configured? && running?
     begin

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -72,12 +72,7 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   end
 
   def create_local_playbook_repo
-    FileUtils.rm_rf(playbook_repo_path)
-    FileUtils.mkdir_p(playbook_repo_path)
-
-    Vmdb::Plugins.instance.registered_ansible_content.each do |content|
-      FileUtils.cp_r(Dir.glob("#{content.path}/*"), playbook_repo_path)
-    end
+    self.class.consolidate_plugin_playbooks(playbook_repo_path)
 
     Dir.chdir(playbook_repo_path) do
       require 'rugged'

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -3,13 +3,14 @@ require "fileutils"
 require "securerandom"
 
 class ApplianceEmbeddedAnsible < EmbeddedAnsible
-  TOWER_VERSION_FILE     = "/var/lib/awx/.tower_version".freeze
-  SETUP_SCRIPT           = "ansible-tower-setup".freeze
-  SECRET_KEY_FILE        = "/etc/tower/SECRET_KEY".freeze
-  SETTINGS_FILE          = "/etc/tower/settings.py".freeze
-  EXCLUDE_TAGS           = "packages,migrations,firewall".freeze
-  HTTP_PORT              = 54_321
-  HTTPS_PORT             = 54_322
+  TOWER_VERSION_FILE                    = "/var/lib/awx/.tower_version".freeze
+  SETUP_SCRIPT                          = "ansible-tower-setup".freeze
+  SECRET_KEY_FILE                       = "/etc/tower/SECRET_KEY".freeze
+  SETTINGS_FILE                         = "/etc/tower/settings.py".freeze
+  EXCLUDE_TAGS                          = "packages,migrations,firewall".freeze
+  HTTP_PORT                             = 54_321
+  HTTPS_PORT                            = 54_322
+  CONSOLIDATED_PLUGIN_PLAYBOOKS_TEMPDIR = Pathname.new("/var/lib/awx_consolidated_source").freeze
 
   def self.available?
     require "linux_admin"
@@ -68,6 +69,37 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
 
   def api_connection
     api_connection_raw("localhost", HTTP_PORT)
+  end
+
+  def create_local_playbook_repo
+    FileUtils.rm_rf(playbook_repo_path)
+    FileUtils.mkdir_p(playbook_repo_path)
+
+    Vmdb::Plugins.instance.registered_ansible_content.each do |content|
+      FileUtils.cp_r(Dir.glob("#{content.path}/*"), playbook_repo_path)
+    end
+
+    Dir.chdir(playbook_repo_path) do
+      require 'rugged'
+      repo = Rugged::Repository.init_at(".")
+      index = repo.index
+      index.add_all("*")
+      index.write
+
+      options              = {}
+      options[:tree]       = index.write_tree(repo)
+      options[:author]     = options[:committer] = { :email => "system@localhost", :name => "System", :time => Time.now.utc }
+      options[:message]    = "Initial Commit"
+      options[:parents]    = []
+      options[:update_ref] = 'HEAD'
+      Rugged::Commit.create(repo, options)
+    end
+
+    FileUtils.chown_R('awx', 'awx', playbook_repo_path)
+  end
+
+  def playbook_repo_path
+    CONSOLIDATED_PLUGIN_PLAYBOOKS_TEMPDIR
   end
 
   private

--- a/lib/embedded_ansible/null_embedded_ansible.rb
+++ b/lib/embedded_ansible/null_embedded_ansible.rb
@@ -27,6 +27,14 @@ class NullEmbeddedAnsible < EmbeddedAnsible
     raise NotImplementedError, message
   end
 
+  def create_local_playbook_repo
+    raise NotImplementedError, message
+  end
+
+  def playbook_repo_path
+    raise NotImplementedError, message
+  end
+
   private
 
   def message

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -130,4 +130,10 @@ namespace :evm do
     end
     EvmDatabase.raise_server_event(opts[:event])
   end
+
+  desc "Write all plugin ansible content to a directory"
+  task :write_plugin_ansible_content => :environment do
+    dest_dir = ENV["ANSIBLE_CONTENT_DIR"] || Rails.root.join("tmp", "ansible_content")
+    EmbeddedAnsible.consolidate_plugin_playbooks(dest_dir)
+  end
 end

--- a/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
@@ -304,6 +304,20 @@ describe ApplianceEmbeddedAnsible do
     end
   end
 
+  describe "#create_local_playbook_repo" do
+    let!(:tmp_dir) { Pathname.new(Dir.mktmpdir("consolidated_ansible_playbooks")) }
+
+    before do
+      allow(subject).to receive(:playbook_repo_path).and_return(tmp_dir)
+    end
+
+    it "creates a git project containing the plugin playbooks" do
+      expect(FileUtils).to receive(:chown_R).with("awx", "awx", tmp_dir)
+      subject.create_local_playbook_repo
+      expect(Dir.exist?(tmp_dir.join(".git"))).to be_truthy
+    end
+  end
+
   describe "#update_proxy_settings (private)" do
     let(:file_content) do
       <<-EOF

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -148,7 +148,7 @@ describe EmbeddedAnsibleWorker do
     end
 
     describe "#ensure_plugin_playbooks_project_seeded" do
-      let!(:tmp_dir) { Pathname.new(Dir.mktmpdir("consolidated_ansible_playbooks")) }
+      let(:tmp_dir) { "some/temp/directory" }
       let!(:expected_attributes) do
         {
           :name                 => "ManageIQ Default Project",
@@ -161,12 +161,8 @@ describe EmbeddedAnsibleWorker do
 
       before do
         provider.default_organization = 42
-        allow(EmbeddedAnsibleWorker).to receive(:consolidated_plugin_directory).and_return(tmp_dir)
-        allow(subject).to receive(:chown_playbooks_tempdir)
-      end
-
-      after do
-        FileUtils.rm_rf(tmp_dir)
+        ea = double("EmbeddedAnsible", :create_local_playbook_repo => "", :playbook_repo_path => tmp_dir)
+        allow(EmbeddedAnsible).to receive(:new).and_return(ea)
       end
 
       it "creates a git project as the provider's default project" do
@@ -175,7 +171,6 @@ describe EmbeddedAnsibleWorker do
           .and_return(double(:id => 1234))
 
         subject.ensure_plugin_playbooks_project_seeded(provider, api_connection)
-        expect(Dir.exist?(tmp_dir.join(".git"))).to be_truthy
         expect(provider.default_project).to eq(1234)
       end
 

--- a/spec/models/embedded_ansible_worker_spec.rb
+++ b/spec/models/embedded_ansible_worker_spec.rb
@@ -41,17 +41,6 @@ describe EmbeddedAnsibleWorker do
 
         subject.ensure_initial_objects(provider, api_connection)
       end
-
-      it "skips playbook seeding for containers" do
-        allow(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
-        expect(org_collection).to receive(:create!).and_return(org_resource)
-        expect(cred_collection).to receive(:create!).and_return(cred_resource)
-        expect(inv_collection).to receive(:create!).and_return(inv_resource)
-        expect(host_collection).to receive(:create!).and_return(host_resource)
-        expect(subject).to receive(:ensure_plugin_playbooks_project_seeded).never
-
-        subject.ensure_initial_objects(provider, api_connection)
-      end
     end
 
     describe "#remove_demo_data" do


### PR DESCRIPTION
This will allow us to pull the set of ansible content provided by our plugins together at build time to provide the data to build an rpm.

This rpm can then be used in the embedded ansible container image to provide plugin ansible content when embedded ansible does not share a file system with the manageiq application at runtime.