### PR TITLE
Add switch_uuid as secondary_refs to swiches

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -381,6 +381,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :model_class                 => ::Switch,
         :manager_ref                 => [:uid_ems],
         :association                 => :switches,
+        :secondary_refs              => {:by_switch_uuid => [:switch_uuid]},
         :inventory_object_attributes => %i(
           uid_ems
           name


### PR DESCRIPTION
Add switch_uuid to switches inventory collection as a secondary ref.