### PR TITLE
Add virtual columns PersistentVolume#storage_capacity and PersistentVolumeClaim#storage_capacity 

### DIFF
--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -6,4 +6,10 @@ class PersistentVolume < ContainerVolume
   has_many :container_volumes, -> { where(:type => 'ContainerVolume') }, :through => :persistent_volume_claim
   has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'
   alias_attribute :container_groups, :parents
+
+  virtual_column :storage, :type => :integer
+
+  def storage
+    capacity[:storage] if capacity
+  end
 end

--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -10,6 +10,6 @@ class PersistentVolume < ContainerVolume
   virtual_column :storage_capacity, :type => :integer
 
   def storage_capacity
-    capacity[:storage] if capacity
+    capacity[:storage]
   end
 end

--- a/app/models/persistent_volume.rb
+++ b/app/models/persistent_volume.rb
@@ -7,9 +7,9 @@ class PersistentVolume < ContainerVolume
   has_many :parents, -> { distinct }, :through => :container_volumes, :source_type => 'ContainerGroup'
   alias_attribute :container_groups, :parents
 
-  virtual_column :storage, :type => :integer
+  virtual_column :storage_capacity, :type => :integer
 
-  def storage
+  def storage_capacity
     capacity[:storage] if capacity
   end
 end

--- a/app/models/persistent_volume_claim.rb
+++ b/app/models/persistent_volume_claim.rb
@@ -6,7 +6,13 @@ class PersistentVolumeClaim < ApplicationRecord
   serialize :requests, Hash
   serialize :limits, Hash
 
+  virtual_column :storage_capacity, :type => :integer
+
   def persistent_volume
     container_volumes.find_by_type('PersistentVolume')
+  end
+
+  def storage_capacity
+    capacity[:storage] if capacity
   end
 end

--- a/app/models/persistent_volume_claim.rb
+++ b/app/models/persistent_volume_claim.rb
@@ -13,6 +13,6 @@ class PersistentVolumeClaim < ApplicationRecord
   end
 
   def storage_capacity
-    capacity[:storage] if capacity
+    capacity[:storage]
   end
 end

--- a/spec/models/persistent_volume_claim_spec.rb
+++ b/spec/models/persistent_volume_claim_spec.rb
@@ -1,0 +1,21 @@
+describe PersistentVolumeClaim do
+  describe "#storage_capacity" do
+    let(:storage_size) { 123_456_789 }
+
+    it "returns value for :storage key in Hash column :capacity" do
+      persistent_volume = FactoryGirl.create(
+        :persistent_volume_claim,
+        :capacity => {:storage => storage_size, :foo => "something"}
+      )
+      expect(persistent_volume.storage_capacity).to eq storage_size
+    end
+
+    it "returns nil if there is no :storage key in Hash column :capacity" do
+      persistent_volume = FactoryGirl.create(
+        :persistent_volume_claim,
+        :capacity => {:foo => "something"}
+      )
+      expect(persistent_volume.storage_capacity).to be nil
+    end
+  end
+end

--- a/spec/models/persistent_volume_spec.rb
+++ b/spec/models/persistent_volume_spec.rb
@@ -40,4 +40,24 @@ describe PersistentVolume do
     expect(persistent_volume.container_groups.first.name).to eq("group")
     expect(persistent_volume.container_groups.count).to eq(1)
   end
+
+  describe "#storage" do
+    let(:storage) { 123_456_789 }
+
+    it "returns value for :storage key in Hash column :capacity" do
+      persistent_volume = FactoryGirl.create(
+        :persistent_volume,
+        :capacity => {:storage => storage, :foo => "something"}
+      )
+      expect(persistent_volume.storage).to eq storage
+    end
+
+    it "returns nil if there is no :storage key in Hash column :capacity" do
+      persistent_volume = FactoryGirl.create(
+        :persistent_volume,
+        :capacity => {:foo => "something"}
+      )
+      expect(persistent_volume.storage).to be nil
+    end
+  end
 end

--- a/spec/models/persistent_volume_spec.rb
+++ b/spec/models/persistent_volume_spec.rb
@@ -41,15 +41,15 @@ describe PersistentVolume do
     expect(persistent_volume.container_groups.count).to eq(1)
   end
 
-  describe "#storage" do
-    let(:storage) { 123_456_789 }
+  describe "#storage_capacity" do
+    let(:storage_size) { 123_456_789 }
 
     it "returns value for :storage key in Hash column :capacity" do
       persistent_volume = FactoryGirl.create(
         :persistent_volume,
-        :capacity => {:storage => storage, :foo => "something"}
+        :capacity => {:storage => storage_size, :foo => "something"}
       )
-      expect(persistent_volume.storage).to eq storage
+      expect(persistent_volume.storage_capacity).to eq storage_size
     end
 
     it "returns nil if there is no :storage key in Hash column :capacity" do
@@ -57,7 +57,7 @@ describe PersistentVolume do
         :persistent_volume,
         :capacity => {:foo => "something"}
       )
-      expect(persistent_volume.storage).to be nil
+      expect(persistent_volume.storage_capacity).to be nil
     end
   end
 end


### PR DESCRIPTION
There is `PersistentVolume.capacity` column, defined as `serialize :capacity, Hash` and one of entry in that hash could be `:storage =>...`. 

This PR: Virtual column `storage` added to `PersistentVolume` model for the purpose of showing on report 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1576922

Example of report based on `PersistentVolume` model with new column `Storage`:
<img width="804" alt="screen shot 2018-05-11 at 2 35 29 pm" src="https://user-images.githubusercontent.com/6556758/39942103-8c9465f4-552c-11e8-8daa-0c7f04c19366.png">

@miq-bot add-label reporting

\cc @gtanzillo 