### PR TITLE
Allow rails to be loaded in fix auth

### DIFF
--- a/tools/fix_auth/auth_config_model.rb
+++ b/tools/fix_auth/auth_config_model.rb
@@ -42,8 +42,10 @@ module FixAuth
         symbol_keys ? hash.deep_symbolize_keys! : hash.deep_stringify_keys!
         hash.to_yaml
       rescue ArgumentError # undefined class/module
-        puts "potentially bad yaml:"
-        puts old_value
+        unless options[:allow_failures]
+          STDERR.puts "potentially bad yaml:"
+          STDERR.puts old_value
+        end
         raise
       end
     end

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -25,6 +25,7 @@ module FixAuth
         opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false
         opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
         opt :legacy_key, "Legacy Key",      :type => :string, :short => "K"
+        opt :allow_failures, "Run through all records, even with errors", :type => :boolean, :short => nil, :default => false
       end
 
       options[:database] = args.first || "vmdb_production"

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -26,7 +26,7 @@ module FixAuth
     end
 
     def run_options
-      options.slice(:verbose, :dry_run, :hardcode, :invalid)
+      options.slice(:verbose, :dry_run, :hardcode, :invalid, :allow_failures)
     end
 
     def database
@@ -35,7 +35,7 @@ module FixAuth
 
     def models
       [FixAuthentication, FixMiqDatabase, FixMiqAeValue, FixMiqAeField,
-       FixMiqRequest, FixMiqRequestTask, FixSettingsChange]
+       FixSettingsChange, FixMiqRequest, FixMiqRequestTask]
     end
 
     def generate_password
@@ -69,6 +69,10 @@ module FixAuth
       FixDatabaseYml.run({:hardcode => options[:password]}.merge(run_options))
     end
 
+    def load_rails
+      require File.expand_path("../../../config/application.rb", __FILE__)
+    end
+
     def set_passwords
       MiqPassword.key_root = cert_dir if cert_dir
       MiqPassword.add_legacy_key("v0_key", :v0)
@@ -83,6 +87,7 @@ module FixAuth
 
       generate_password if options[:key]
       fix_database_yml if options[:databaseyml]
+      load_rails if options[:allow_failures]
       fix_database_passwords if options[:db]
     end
   end

--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -56,10 +56,6 @@ module FixAuth
     self.password_prefix = "password::"
     self.symbol_keys = true
     self.table_name = "miq_requests"
-
-    def self.contenders
-      where("options like '%password%'")
-    end
   end
 
   class FixMiqRequestTask < ActiveRecord::Base
@@ -71,10 +67,6 @@ module FixAuth
     self.password_prefix = "password::"
     self.symbol_keys = true
     self.table_name = "miq_request_tasks"
-
-    def self.contenders
-      where("options like '%password%'")
-    end
   end
 
   class FixSettingsChange < ActiveRecord::Base
@@ -111,6 +103,10 @@ module FixAuth
     def load
       @yaml = File.read(id)
       self
+    end
+
+    def changed?
+      true
     end
 
     def save!


### PR DESCRIPTION
When objects are serialized into yaml blobs in tables,
we need to load our whole environment to handle the deserialization

This typically happens with `miq_requests.options`

Even though we don't support storing non hash/list/string value in the database, it happens. A number of customers have recently run into this issue.

This provides a `--resilient` option to load our environment and allow those hashes to be deserialized.

see also `Fine` version #17428 