### PR TITLE
Filter relevant fields also according to chargeback class in Chargeback

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -70,6 +70,13 @@ class ChargeableField < ApplicationRecord
     "#{rate_name}_#{sub_metric ? sub_metric + '_' : ''}metric" # metric value (e.g. Storage [Used|Allocated|Fixed])
   end
 
+  # Fixed metric has _1 or _2 in name but column
+  # fixed_compute_metric is used in report and calculations
+  # TODO: remove and unify with metric_key
+  def metric_column_key
+    fixed? ? metric_key.gsub(/\_1|\_2/, '') : metric_key
+  end
+
   def cost_keys(sub_metric = nil)
     keys = ["#{rate_name}_#{sub_metric ? sub_metric + '_' : ''}cost", # cost associated with metric (e.g. Storage [Used|Allocated|Fixed] Cost)
             'total_cost']

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -116,7 +116,7 @@ class Chargeback < ActsAsArModel
                                                              :resource    => MiqEnterprise.first)
 
       data = {}
-      rate.rate_details_relevant_to(relevant_fields).each do |r|
+      rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
         r.populate_showback_rate(plan, r, showback_category)
         measure = r.chargeable_field.showback_measure
         dimension, _, _ = r.chargeable_field.showback_dimension
@@ -152,7 +152,7 @@ class Chargeback < ActsAsArModel
     self.class.try(:refresh_dynamic_metric_columns)
 
     rates.each do |rate|
-      rate.rate_details_relevant_to(relevant_fields).each do |r|
+      rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
         r.charge(relevant_fields, consumption, @options).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = self[field].kind_of?(Numeric) ? (self[field] || 0) + value : value

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -35,9 +35,13 @@ class ChargebackRate < ApplicationRecord
     super(klass)
   end
 
-  def rate_details_relevant_to(report_cols)
-    # we can memoize, as we get the same report_cols thrrough the life of the object
-    @relevant ||= chargeback_rate_details.select { |r| r.affects_report_fields(report_cols) }
+  def rate_details_relevant_to(report_cols, allowed_cols)
+    # we can memoize, as we get the same report_cols through the life of the object
+    @relevant ||= begin
+      chargeback_rate_details.select do |r|
+        r.affects_report_fields(report_cols) && allowed_cols.include?(r.metric_column_key)
+      end
+    end
   end
 
   def self.validate_rate_type(type)

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -12,7 +12,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   delegate :rate_type, :to => :chargeback_rate, :allow_nil => true
 
-  delegate :metric_key, :cost_keys, :rate_key, :to => :chargeable_field
+  delegate :metric_column_key, :metric_key, :cost_keys, :rate_key, :to => :chargeable_field
 
   FORM_ATTRIBUTES = %i(description per_time per_unit metric group source metric chargeable_field_id sub_metric).freeze
   PER_TIME_TYPES = {

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -1,4 +1,16 @@
 describe ChargebackRate do
+  describe "#rate_details_relevant_to" do
+    let(:count_hourly_variable_tier_rate) { {:variable_rate => '10'} }
+
+    let!(:chargeback_rate) do
+      FactoryGirl.create(:chargeback_rate, :detail_params => {:chargeback_rate_detail_cpu_cores_allocated => {:tiers => [count_hourly_variable_tier_rate]}})
+    end
+
+    it "skips cpu_cores_allocated column" do
+      expect(chargeback_rate.rate_details_relevant_to(['total_cost'].to_set, ChargebackVm.attribute_names)).to be_empty
+    end
+  end
+
   context ".validate_rate_type" do
     it "handles valid types" do
       [:compute, :storage, 'compute', 'storage', 'Compute', 'Storage'].each do |type|

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -627,6 +627,16 @@ describe ChargebackVm do
 
         subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first.first }
 
+        context "chargeback rate contains rate unrelated to chargeback vm" do
+          let!(:chargeback_rate) do
+            FactoryGirl.create(:chargeback_rate, :detail_params => detail_params.merge(:chargeback_rate_detail_cpu_cores_allocated => {:tiers => [count_hourly_variable_tier_rate]}))
+          end
+
+          it "skips unrelated columns and calculate related columns" do
+            expect(subject.cpu_allocated_metric).to eq(cpu_count)
+          end
+        end
+
         it "cpu" do
           expect(subject.cpu_allocated_metric).to eq(cpu_count)
           used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, @vm1)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1580543

This bug has been discovered after this [fix](https://github.com/ManageIQ/manageiq/pull/17387) and unfortunately chargeback report is broken with mentioned PR.

**Error msg** (during generation report for VMs)
```
Generating report... Costs2
/Users/liborpichler/manageiq/manageiq/.bundle/ruby/2.4.0/gems/activemodel-5.0.7/lib/active_model/attribute_methods.rb:433:in `method_missing': undefined method `derived_vm_numvcpu_cores' for #<MetricRollup:0x00007fbc0ef7d588> (NoMethodError)
Did you mean?  derived_vm_numvcpus
               derived_vm_numvcpus=
               derived_vm_numvcpus?
               derived_vm_numvcpus_change
               derived_vm_numvcpus_was
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_with_rollups.rb:91:in `collect'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_with_rollups.rb:91:in `values'
	from /Users/liborpichler/manageiq/manageiq/app/models/chargeback/consumption_with_rollups.rb:66:in `none?'
```

Note: `derived_vm_numvcpu_cores ` is related only to chargeback for chargeback for containers.

**Why?**

Chargeback rates contain chargeback rate details (`ChargebackRateDetail`) for all types of chargeback (VMs, ContainerProjects, ContainerImages).

In calculation we are cycling thru all rate details independently on chargeback type and then irrelevant fields should be skipped for certain chargeback type. It was basically accidentally skipped before this recent [fix](https://github.com/ManageIQ/manageiq/pull/17387) and now after the  [fix](https://github.com/ManageIQ/manageiq/pull/17387), relevant field is ( for example`cpu core allocated` ) **not skipped** for certain chargeback type(example: for Chargeback for VM - even field is related only for chargeback for containers) because of eventual participation on calculation of `total_cost`column done in [fix](https://github.com/ManageIQ/manageiq/pull/17387).



**Fix**
Now column represented by chargeback detail rate has to be present as attribute in related chargeback class. 


cc @gtanzillo 

@miq-bot assign @jrafanie 

@miq-bot add_label gaprindashvili/yes
