### PR TITLE
Moved method for testing feature support

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -8,6 +8,7 @@ class OrchestrationStack < ApplicationRecord
   include RetirementMixin
   include TenantIdentityMixin
   include CustomActionsMixin
+  include SupportsFeatureMixin
 
   acts_as_miq_taggable
 
@@ -49,6 +50,8 @@ class OrchestrationStack < ApplicationRecord
   alias_method :orchestration_stack_parameters, :parameters
   alias_method :orchestration_stack_outputs,    :outputs
   alias_method :orchestration_stack_resources,  :resources
+
+  supports :retire
 
   def orchestration_stacks
     children

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -92,6 +92,8 @@ class Service < ApplicationRecord
     unsupported_reason_add(:reconfigure, _("Reconfigure unsupported")) unless validate_reconfigure
   end
 
+  supports :retire
+
   alias parent_service parent
   alias_attribute :service, :parent
   virtual_belongs_to :service

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1692,16 +1692,6 @@ class VmOrTemplate < ApplicationRecord
 
   supports_not :snapshots
 
-  def self.batch_operation_supported?(operation, ids)
-    VmOrTemplate.where(:id => ids).all? do |vm_or_template|
-      if vm_or_template.respond_to?("supports_#{operation}?")
-        vm_or_template.public_send("supports_#{operation}?")
-      else
-        vm_or_template.public_send("validate_#{operation}")[:available]
-      end
-    end
-  end
-
   # Stop showing Reconfigure VM task unless the subclass allows
   def reconfigurable?
     false

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -564,32 +564,6 @@ describe VmOrTemplate do
     end
   end
 
-  context "#self.batch_operation_supported?" do
-    let(:ems)     { FactoryGirl.create(:ext_management_system) }
-    let(:storage) { FactoryGirl.create(:storage) }
-    let(:host) { FactoryGirl.create(:host) }
-
-    it "when the vm_or_template supports migrate,  returns false" do
-      vm1 =  FactoryGirl.create(:vm_microsoft)
-      vm2 =  FactoryGirl.create(:vm_vmware)
-      expect(VmOrTemplate.batch_operation_supported?(:migrate, [vm1.id, vm2.id])).to eq(false)
-    end
-
-    it "when the vm_or_template exists and can be migrated, returns true" do
-      vm1 =  FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
-      vm2 =  FactoryGirl.create(:vm_vmware, :storage => storage, :ext_management_system => ems)
-      expect(VmOrTemplate.batch_operation_supported?(:migrate, [vm1.id, vm2.id])).to eq(true)
-    end
-
-    it "when the vm_or_template supports terminate, returns true" do
-      ems_vmware = FactoryGirl.create(:ems_vmware)
-      ems_ms = FactoryGirl.create(:ems_microsoft)
-      vm1 =  FactoryGirl.create(:vm_microsoft, :host => host, :ext_management_system => ems_ms)
-      vm2 =  FactoryGirl.create(:vm_vmware, :host => host, :ext_management_system => ems_vmware)
-      expect(VmOrTemplate.batch_operation_supported?(:terminate, [vm1.id, vm2.id])).to eq(true)
-    end
-  end
-
   context ".set_tenant_from_group" do
     before { Tenant.seed }
     let(:tenant1) { FactoryGirl.create(:tenant) }


### PR DESCRIPTION
## This PR needs to be merged together with https://github.com/ManageIQ/manageiq-ui-classic/pull/3660

Removing unnecessary method for testing support for multiple records (last usage was removed in d41b08b212a0f9bd82e9e0e594d13e13c6d6eb0d)

Links
----------------
https://github.com/ManageIQ/manageiq-ui-classic/pull/3660

commit name: "Removing test for a VmOrTemplate's support for smartstate action"