### PR TITLE
Add factories for the Switch and HostSwitch models

### DIFF
--- a/spec/factories/switch.rb
+++ b/spec/factories/switch.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :switch_vmware, :class => 'ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch'
+end


### PR DESCRIPTION
I am writing some tests for infrastructure networking and these factories are required.

@miq-bot add_label test
@miq-bot assign @martinpovolny 