### PR TITLE
Excluding 'Last Analysis' field from Drift Workload section

### DIFF
--- a/product/compare/vms.yaml
+++ b/product/compare/vms.yaml
@@ -12,7 +12,6 @@ cols:
 - name
 - vendor
 - location
-- last_scan_on
 - retires_on
 - boot_time
 - tools_status
@@ -199,7 +198,6 @@ col_order:
 - name
 - vendor
 - location
-- last_scan_on
 - retires_on
 - boot_time
 - tools_status
@@ -300,7 +298,6 @@ headers:
 - Name
 - Vendor
 - Location
-- Last Analysis
 - Retires On
 - Boot Time
 - VMware Tools Status


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1561167

---

This PR excludes _Last Analysis_ field from Drift _Workload_ section. The 'Last Analysis' field will always be different between any two drift states for a VM. And we already see analysis date and time in each column.

**Before:**
![last_before](https://user-images.githubusercontent.com/13417815/40010958-a02121b2-57a6-11e8-986d-4e732bb9e1f2.png)

**After:**
![last_after](https://user-images.githubusercontent.com/13417815/40010970-a5570124-57a6-11e8-8455-10b215f8ca67.png)

---

**Note:**
The change also excludes the field when comparing two VMs. I assume that we want this, too. What do you think, @dclarizio ?
![compare_after](https://user-images.githubusercontent.com/13417815/40010691-cb1186f6-57a5-11e8-969b-1833315d6497.png)
