### PR TITLE
[WIP] Fix switch modeling and deletions

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -3,12 +3,15 @@
 # - ems
 #   - storages
 #   - storage_profiles
+#   - distributed_switches
+#     - lans
 #   - ems_clusters
 #   - hosts
 #     - storages (link)
 #     - operating_system
 #     - switches
 #       - lans
+#     - host_switches
 #     - hardware
 #       - guest_devices
 #         - network
@@ -55,6 +58,7 @@ module EmsRefresh::SaveInventoryInfra
     child_keys = [
       :storages,
       :storage_profiles,
+      :distributed_switches,
       :clusters,
       :hosts,
       :vms,
@@ -78,7 +82,6 @@ module EmsRefresh::SaveInventoryInfra
 
     new_relats = hashes_relats(hashes)
     link_ems_inventory(ems, target, prev_relats, new_relats, disconnect)
-    remove_obsolete_switches
 
     ems
   end
@@ -112,6 +115,14 @@ module EmsRefresh::SaveInventoryInfra
     end
   end
 
+  def save_distributed_switches_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil?
+
+    deletes = determine_deletes_using_association(ems, target, disconnect)
+    save_inventory_multi(ems.distributed_virtual_switches, hashes, deletes, [:uid_ems], [:lans])
+    store_ids_for_new_records(ems.distributed_virtual_switches, hashes, :uid_ems)
+  end
+
   def save_hosts_inventory(ems, hashes, target = nil, disconnect = true)
     target = ems if target.nil? && disconnect
     log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
@@ -124,7 +135,7 @@ module EmsRefresh::SaveInventoryInfra
                     []
                   end
 
-    child_keys = [:operating_system, :switches, :hardware, :system_services, :host_storages]
+    child_keys = [:operating_system, :switches, :hardware, :system_services, :host_storages, :host_switches]
     extra_keys = [:ems_cluster, :storages, :vms, :power_state, :ems_children]
     remove_keys = child_keys + extra_keys
 
@@ -305,36 +316,13 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_switches_inventory(host, hashes)
-    already_saved, not_yet_saved = hashes.partition { |h| h[:id] }
-    save_inventory_multi(host.switches, not_yet_saved, [], [:uid_ems], :lans)
-    host_switches_hash = already_saved.collect { |switch| {:host_id => host.id, :switch_id => switch[:id]} }
-    save_inventory_multi(host.host_switches, host_switches_hash, [], [:host_id, :switch_id])
-    host.switches(true)
-
-    host.save!
-
-    # Collect the ids of switches and lans after saving
-    hashes.each do |sh|
-      switch = host.switches.detect { |s| s.uid_ems == sh[:uid_ems] }
-      sh[:id] = switch.id
-
-      next if sh[:lans].nil?
-      sh[:lans].each do |lh|
-        lan = switch.lans.detect { |l| l.uid_ems == lh[:uid_ems] }
-        lh[:id] = lan.id
-      end
-    end
-
-    # handle deletes here instead of inside #save_inventory_multi
-    switch_ids = Set.new(hashes.collect { |s| s[:id] })
-    deletes = host.switches.select { |s| !switch_ids.include?(s.id) }
-    host.switches.delete(deletes)
+    save_inventory_multi(host.host_virtual_switches, hashes, :use_association, [:uid_ems], [:lans])
+    store_ids_for_new_records(host.host_virtual_switches, hashes, :uid_ems)
   end
 
-  def remove_obsolete_switches
-    # delete from switches as s where s.shared is NULL and s.id not in (select switch_id from host_switches)
-    # delete from switches as s where s.shared = 't' and s.id not in (select switch_id from host_switches)
-    Switch.where.not(:id => HostSwitch.all.collect(&:switch).uniq).destroy_all
+  def save_host_switches_inventory(host, switches)
+    hashes = switches.collect { |switch| {:host_id => host.id, :switch_id => switch[:id]} }
+    save_inventory_multi(host.host_switches, hashes, [], [:host_id, :switch_id])
   end
 
   def save_lans_inventory(switch, hashes)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -47,6 +47,9 @@ class Host < ApplicationRecord
   has_many                  :miq_templates, :inverse_of => :host
   has_many                  :host_storages, :dependent => :destroy
   has_many                  :storages, :through => :host_storages
+  has_many                  :host_virtual_switches, :dependent  => :destroy,
+                                                    :inverse_of => :host,
+                                                    :class_name => "ManageIQ::Providers::InfraManager::HostVirtualSwitch"
   has_many                  :host_switches, :dependent => :destroy
   has_many                  :switches, :through => :host_switches
   has_many                  :lans,     :through => :switches

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -7,6 +7,10 @@ module ManageIQ::Providers
 
     include AvailabilityMixin
 
+    has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id,
+             :inverse_of => :ext_management_system
+    has_many :host_virtual_switches, -> { distinct }, :through => :hosts
+
     has_many :host_hardwares,             :through => :hosts, :source => :hardware
     has_many :host_operating_systems,     :through => :hosts, :source => :operating_system
     has_many :host_storages,              :through => :hosts

--- a/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::InfraManager::DistributedVirtualSwitch < ::Switch
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+end

--- a/app/models/manageiq/providers/infra_manager/host_virtual_switch.rb
+++ b/app/models/manageiq/providers/infra_manager/host_virtual_switch.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::InfraManager::HostVirtualSwitch < ::Switch
+  belongs_to :host
+end

--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -382,6 +382,7 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
         :manager_ref                 => %i(host uid_ems),
         :association                 => :host_virtual_switches,
         :inventory_object_attributes => %i(
+          host
           uid_ems
           name
           lans

--- a/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/infra_manager.rb
@@ -376,16 +376,35 @@ class ManagerRefresh::InventoryCollectionDefault::InfraManager < ManagerRefresh:
       attributes.merge!(extra_attributes)
     end
 
-    def switches(extra_attributes = {})
+    def host_virtual_switches(extra_attributes = {})
       attributes = {
-        :model_class                 => ::Switch,
-        :manager_ref                 => [:uid_ems],
-        :association                 => :switches,
+        :model_class                 => ManageIQ::Providers::InfraManager::HostVirtualSwitch,
+        :manager_ref                 => %i(host uid_ems),
+        :association                 => :host_virtual_switches,
         :inventory_object_attributes => %i(
           uid_ems
           name
           lans
         ),
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def distributed_virtual_switches(extra_attributes = {})
+      attributes = {
+        :model_class                 => ManageIQ::Providers::InfraManager::DistributedVirtualSwitch,
+        :manager_ref                 => [:uid_ems],
+        :association                 => :distributed_virtual_switches,
+        :inventory_object_attributes => %i(
+          shared
+          uid_ems
+          name
+          lans
+        ),
+        :builder_params              => {
+          :ems_id => ->(persister) { persister.manager.id },
+        },
       }
 
       attributes.merge!(extra_attributes)


### PR DESCRIPTION
Fix the modeling of distributed and host-local switches.  Currently switches are only referenced through host_switches which means we cannot do association based deletions.

This changes distributed_virtual_switches to be owned by the EMS, and host_virtual_switches to be owned by their host.  This also means that the uid_ems is correctly unique under its parent, and deletions can be handled by the association and by cascade deletes.

Fixes https://github.com/ManageIQ/manageiq/issues/17383

Depends on: https://github.com/ManageIQ/manageiq-schema/pull/200

TODO
- [ ] Update VMware refresh_parser and graph_refresh - https://github.com/ManageIQ/manageiq-providers-vmware/pull/260
- [ ] Update Ovirt refresh_parser and graph refresh - https://github.com/ManageIQ/manageiq-providers-ovirt/pull/239