### PR TITLE
Add uniq on datacenters in #host_to_folder

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1195,7 +1195,7 @@ class MiqRequestWorkflow
       result = find_datacenter_for_ci(h)
       rails_logger("host_to_folder for host #{h.name}", 1)
       result
-    end.compact
+    end.compact.uniq
     datacenters.each_with_object({}) do |dc, folders|
       rails_logger("host_to_folder for dc #{dc.name}", 0)
       folders.merge!(get_ems_folders(dc))


### PR DESCRIPTION
The more stripped down version of this method, prior to the change, is as follows:

```ruby
def host_to_folder(src)
  sources = src[:host].nil? ? allowed_hosts_obj : [src[:host]]
  datacenters = sources.collect { |h|
    find_datacenter_for_ci(h)
  end.compact
  datacenters.each_with_object({}) do |dc, folders|
    folders.merge!(get_ems_folders(dc))
  end
end
```

When setting the `datacenters` local variable in that method, the `find_datacenter_for_ci` method basically looks up the datacenter for the matching `Host` object in the xml tree that has most likely already been generated.  In most/all cases, though, their will be more than one host per datacenter, and that wasn't taken into account for this method since the next block blindly takes the datacenters it found previously and merges the folder structure it gets from `get_ems_folders` for each datacenter.

By adding a `.uniq` prior to the assignment of datacenters, this saves a significant number of unnecessary CPU cycles and object allocations to fetch the same data and apply it to the `folders` variable, without changing the end result.

Note:  Ideally we would want a better algorithm for finding the datacenters for a collection of hosts, one that allowed for ejecting early from find_datacenter_for_ci when we knew an existing datacenter for a given host had already been found.  But the time taken to get the datacenters from the hosts is far less in CPU time than the time taken to call `#get_ems_folders` per datacenter object and merge the hash with the existing results.


Benchmarks
----------

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries |  rows |
|    --: |  ---: |    ---: |  ---: |
| before | 15023 |    1961 | 48395 |
|  after |  6068 |    1961 | 48395 |


```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 376117422 bytes (4221185 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending                                    |      2512007  activerecord-5.0.7
   5561668  manageiq/app  <<<<<<<<<<                   |       418737  ancestry-2.2.2
   3513258  manageiq/lib  <<<<<<<<<<                   |       278793  activemodel-5.0.7
   2512007  activerecord-5.0.7  <<<<<<<<<<             |       207491  manageiq/app
    861270  activesupport-5.0.7  <<<<<<<<<<            |       190717  pending
    418737  ancestry-2.2.2                             |       178419  ruby-2.3.3/lib
    278793  activemodel-5.0.7  <<<<<<<<<<              |       165577  arel-7.1.4
    178419  ruby-2.3.3/lib  <<<<<<<<<<                 |       165168  activesupport-5.0.7
    165577  arel-7.1.4                                 |        52875  manageiq-providers-vmware-e2e2b8029538
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        32696  manageiq/lib
     14424  fast_gettext-1.2.0                         |        14424  fast_gettext-1.2.0
       ...                                             |          ...
```


**Note**: The benchmarks for this change do NOT include the changes from other PRs in the links below.  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Full collection of proposed changes:  [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17354
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17360
  - https://github.com/ManageIQ/manageiq/pull/17381
  - https://github.com/ManageIQ/manageiq/pull/17402
  - https://github.com/ManageIQ/manageiq/pull/17403