### PR TITLE
Nested lazy find with secondary ref

### DIFF
--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -47,6 +47,7 @@ module ManagerRefresh
         # @return [ManagerRefresh::InventoryObject] Passed InventoryObject
         def build_primary_index_for(inventory_object)
           # Building the object, we need to provide all keys of a primary index
+
           assert_index(inventory_object.data, primary_index_ref)
           primary_index.store_index_for(inventory_object)
         end

--- a/app/models/manager_refresh/inventory_collection/index/proxy.rb
+++ b/app/models/manager_refresh/inventory_collection/index/proxy.rb
@@ -99,7 +99,7 @@ module ManagerRefresh
           lazy_find(manager_uuid_hash, :ref => ref, :key => key, :default => default)
         end
 
-        def lazy_find(manager_uuid, ref: primary_index_ref, key: nil, default: nil)
+        def lazy_find(manager_uuid, ref: primary_index_ref, key: nil, default: nil, transform_nested_lazy_finds: false)
           # TODO(lsmola) also, it should be enough to have only 1 find method, everything can be lazy, until we try to
           # access the data
           # TODO(lsmola) lazy_find will support only hash, then we can remove the _by variant
@@ -108,7 +108,10 @@ module ManagerRefresh
 
           ::ManagerRefresh::InventoryObjectLazy.new(inventory_collection,
                                                     manager_uuid,
-                                                    :ref => ref, :key => key, :default => default)
+                                                    :ref                         => ref,
+                                                    :key                         => key,
+                                                    :default                     => default,
+                                                    :transform_nested_lazy_finds => transform_nested_lazy_finds)
         end
 
         def named_ref(ref = primary_index_ref)

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -16,14 +16,19 @@ module ManagerRefresh
         @ref            = ref
         @keys           = keys
 
+        @nested_secondary_index = keys.select { |key| full_reference[key].kind_of?(ManagerRefresh::InventoryObjectLazy) }.any? do |key|
+          !full_reference[key].primary?
+        end
+
         @stringified_reference = self.class.build_stringified_reference(full_reference, keys)
       end
 
-      # Return true if reference is to primary index, false otherwise.
+      # Return true if reference is to primary index, false otherwise. Reference is primary, only if all the nested
+      # references are primary.
       #
       # @return [Boolean] true if reference is to primary index, false otherwise
       def primary?
-        ref == :manager_ref
+        ref == :manager_ref && !nested_secondary_index
       end
 
       class << self
@@ -57,13 +62,17 @@ module ManagerRefresh
 
         # Returns joiner for string UIID
         #
-        # @return [String] Joiner for stirng UIID
+        # @return [String] Joiner for string UIID
         def stringify_joiner
           "__"
         end
       end
 
       private
+
+      # @return Returns true if reference has nested references that are not pointing to primary index, but to
+      #         secondary indexes.
+      attr_reader :nested_secondary_index
 
       # Returns original Hash, or build hash out of passed string
       #

--- a/app/models/manager_refresh/inventory_collection/reference.rb
+++ b/app/models/manager_refresh/inventory_collection/reference.rb
@@ -31,6 +31,10 @@ module ManagerRefresh
         ref == :manager_ref && !nested_secondary_index
       end
 
+      def nested_secondary_index?
+        nested_secondary_index
+      end
+
       class << self
         # Builds string uuid from passed Hash and keys
         #

--- a/app/models/manager_refresh/inventory_collection/serialization.rb
+++ b/app/models/manager_refresh/inventory_collection/serialization.rb
@@ -56,12 +56,13 @@ module ManagerRefresh
       # @return [Hash] Serialized ManagerRefresh::InventoryObjectLazy
       def lazy_relation_to_hash(value, depth = 0)
         {
-          :type                      => "ManagerRefresh::InventoryObjectLazy",
-          :inventory_collection_name => value.inventory_collection.name,
-          :reference                 => data_to_hash(value.reference.full_reference, depth + 1),
-          :ref                       => value.reference.ref,
-          :key                       => value.try(:key),
-          :default                   => value.try(:default),
+          :type                        => "ManagerRefresh::InventoryObjectLazy",
+          :inventory_collection_name   => value.inventory_collection.name,
+          :reference                   => data_to_hash(value.reference.full_reference, depth + 1),
+          :ref                         => value.reference.ref,
+          :key                         => value.try(:key),
+          :default                     => value.try(:default),
+          :transform_nested_lazy_finds => value.try(:transform_nested_lazy_finds)
         }
       end
 
@@ -78,9 +79,10 @@ module ManagerRefresh
 
         inventory_collection.lazy_find(
           hash_to_data(value['reference'], available_inventory_collections, depth + 1).symbolize_keys!,
-          :ref     => value['ref'].try(:to_sym),
-          :key     => value['key'].try(:to_sym),
-          :default => value['default']
+          :ref                         => value['ref'].try(:to_sym),
+          :key                         => value['key'].try(:to_sym),
+          :default                     => value['default'],
+          :transform_nested_lazy_finds => value['transform_nested_lazy_finds']
         )
       end
 

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -4,7 +4,7 @@ module ManagerRefresh
 
     attr_reader :reference, :inventory_collection, :key, :default
 
-    delegate :stringified_reference, :ref, :[], :to => :reference
+    delegate :primary?, :stringified_reference, :ref, :[], :to => :reference
 
     # @param inventory_collection [ManagerRefresh::InventoryCollection] InventoryCollection object owning the
     #        InventoryObject

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -73,6 +73,8 @@ module ManagerRefresh
     end
 
     def transform_nested_secondary_indexes!(depth = 0)
+      raise "Nested references are too deep!" if depth > 20
+
       keys.each do |x|
         attr = full_reference[x]
         next unless attr.kind_of?(ManagerRefresh::InventoryObjectLazy)

--- a/spec/models/manager_refresh/persister/serializing_spec.rb
+++ b/spec/models/manager_refresh/persister/serializing_spec.rb
@@ -51,13 +51,8 @@ describe ManagerRefresh::Inventory::Persister do
     expect(vm2.hardware.networks.first.ipaddress).to eq("10.10.10.2")
     expect(vm2.hardware.disks.first.device_name).to eq("disk_name_2")
 
-    # TODO(lsmola) interestingly persister.hardwares.lazy_find({:vm_or_template => lazy_find_image_sec}) will not work
-    # because we build the reference only from the passed data. To make it work, we would have to do internally
-    # persister.hardwares.lazy_find({:vm_or_template => lazy_find_image_sec.load}), which will allow the nested lazy
-    # find to reach its :manager_ref data. That would mean the stringified reference would have to be build when
-    # we try to evaluate the lazy object. We should be able to do that.
-    expect(vm.hardware.model).to eq(nil)
-    expect(vm.hardware.manufacturer).to eq(nil)
+    expect(vm.hardware.model).to eq("test1")
+    expect(vm.hardware.manufacturer).to eq("test2")
 
     expect(Vm.find_by(:ems_ref => "vm_ems_ref_20").ems_id).to be_nil
     expect(Vm.find_by(:ems_ref => "vm_ems_ref_21").ems_id).not_to be_nil


### PR DESCRIPTION
Nested lazy find with secondary ref. Allowing to pass option, that will transform all nested InventoryObjectLazy into InventoryObject, allowing us to use nested InventoryObjectLazy with secondary references