### PR TITLE
[Fine] Fixauth handles serialized objects

### DIFF
--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -11,10 +11,8 @@ describe FixAuth::AuthModel do
   let(:enc_v1)  { MiqPassword.new.encrypt(pass, "v1", v1_key) }
   let(:enc_v2)  { MiqPassword.new.encrypt(pass) }
   let(:bad_v2)  { "v2:{5555555555555555555555==}" }
-  let(:enc_leg) { v0_key.encrypt64(pass) }
 
   before do
-    MiqPassword.add_legacy_key(v0_key, :v0)
     MiqPassword.add_legacy_key(v1_key, :v1)
   end
 
@@ -24,7 +22,7 @@ describe FixAuth::AuthModel do
 
   context "#authentications" do
     subject { FixAuth::FixAuthentication }
-    let(:contenders) { subject.contenders.collect(&:name) }
+    let(:contenders) { subject.contenders.select(:name).collect(&:name) }
 
     # NOTE: these are not created unless you reference them
     # if you want to always create them use let!(:var) {} instead
@@ -33,7 +31,6 @@ describe FixAuth::AuthModel do
     let(:v1)     { subject.create(:name => "v1", :password => enc_v1) }
     let(:v2)     { subject.create(:name => "v2", :password => enc_v2) }
     let(:badv2)  { subject.create(:name => "badv2", :password => bad_v2) }
-    let(:leg)    { subject.create(:name => "lg", :password => enc_leg) }
     let(:nls)    { subject.create(:name => "nls") }
     let(:not_c)  { subject.create(:name => "notc", :password => "nope") }
 
@@ -51,8 +48,7 @@ describe FixAuth::AuthModel do
     end
 
     it "should build selection criteria (non selects)" do
-      expect(subject.selection_criteria).to match(/OR/)
-      expect(subject.selection_criteria).to match(/password.*<>.*''.*OR.*auth_key.*<>.*''/)
+      expect(subject.selection_criteria).to match(/password.*OR.*auth_key/)
     end
 
     it "should not find empty records" do
@@ -61,8 +57,8 @@ describe FixAuth::AuthModel do
     end
 
     it "should find records with encrypted passwords" do
-      [v1, v2, leg, nls].each(&:save!)
-      expect(contenders).to include(v1.name, leg.name, v2.name)
+      [v2, nls].each(&:save!)
+      expect(contenders).to include(v2.name)
       expect(contenders).not_to include(nls.name)
     end
 
@@ -76,14 +72,6 @@ describe FixAuth::AuthModel do
       it "should not upgrade blank column" do
         subject.fix_passwords(nls)
         expect(nls).not_to be_password_changed
-      end
-
-      it "should upgrade legacy columns" do
-        subject.fix_passwords(leg)
-        expect(leg).to be_password_changed
-        expect(leg).not_to be_auth_key_changed
-        expect(leg.password).to be_encrypted(pass)
-        expect(leg.password).to be_encrypted_version(2)
       end
 
       it "should upgrade v1 columns" do
@@ -108,13 +96,6 @@ describe FixAuth::AuthModel do
     end
 
     context "#hardcode" do
-      it "should upgrade legacy columns" do
-        subject.fix_passwords(leg, :hardcode => "newpass")
-        expect(leg.password).to be_encrypted("newpass")
-        expect(leg.password).to be_encrypted_version(2)
-        expect(leg.auth_key).to be_blank
-      end
-
       it "should upgrade v2 columns" do
         subject.fix_passwords(v2, :hardcode => "newpass")
         expect(v2.password).to be_encrypted("newpass")
@@ -154,12 +135,12 @@ describe FixAuth::AuthModel do
     subject { FixAuth::FixMiqAeValue }
 
     let(:pass_field) { FixAuth::FixMiqAeField.new(:name => "pass", :datatype => "password") }
-    let(:v1) { subject.create(:field => pass_field, :value => enc_v1) }
+    let(:v2) { subject.create(:field => pass_field, :value => enc_v2) }
 
     it "should update with complex contenders" do
-      v1 # make sure record exists
+      v2 # make sure record exists
       subject.run(:silent => true)
-      expect(v1.reload.value).to be_encrypted_version(2)
+      expect(v2.reload.value).to be_encrypted_version(2)
     end
   end
 

--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 # usage: ruby fix_auth -h
 #
@@ -15,7 +17,6 @@ require 'active_support/concern'
 # this gets around a bug if a user mistakingly
 # serializes a drb object into a configuration hash
 require 'drb'
-require 'manageiq-gems-pending'
 require_relative '../lib/vmdb/settings/walker'
 require 'fix_auth/auth_model'
 require 'fix_auth/auth_config_model'

--- a/tools/fix_auth/auth_config_model.rb
+++ b/tools/fix_auth/auth_config_model.rb
@@ -42,8 +42,10 @@ module FixAuth
         symbol_keys ? hash.deep_symbolize_keys! : hash.deep_stringify_keys!
         hash.to_yaml
       rescue ArgumentError # undefined class/module
-        puts "potentially bad yaml:"
-        puts old_value
+        unless options[:allow_failures]
+          STDERR.puts "potentially bad yaml:"
+          STDERR.puts old_value
+        end
         raise
       end
     end

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -24,6 +24,7 @@ module FixAuth
         opt :databaseyml, "Rewrite database.yml", :type => :boolean, :short => "y", :default => false
         opt :db,       "Upgrade database",  :type => :boolean, :short => 'x', :default => false
         opt :legacy_key, "Legacy Key",      :type => :string, :short => "K"
+        opt :allow_failures, "Run through all records, even with errors", :type => :boolean, :short => nil, :default => false
       end
 
       options[:databases] = args.presence || %w(vmdb_production)

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -26,7 +26,7 @@ module FixAuth
     end
 
     def run_options
-      options.slice(:verbose, :dry_run, :hardcode, :invalid)
+      options.slice(:verbose, :dry_run, :hardcode, :invalid, :allow_failures)
     end
 
     def databases
@@ -35,7 +35,7 @@ module FixAuth
 
     def models
       [FixAuthentication, FixMiqDatabase, FixMiqAeValue, FixMiqAeField,
-       FixMiqRequest, FixMiqRequestTask, FixSettingsChange]
+       FixSettingsChange, FixMiqRequest, FixMiqRequestTask]
     end
 
     def generate_password
@@ -75,6 +75,10 @@ module FixAuth
       FixDatabaseYml.run({:hardcode => options[:password]}.merge(run_options))
     end
 
+    def load_rails
+      require File.expand_path("../../../config/application.rb", __FILE__)
+    end
+
     def set_passwords
       MiqPassword.key_root = cert_dir if cert_dir
       MiqPassword.add_legacy_key("v0_key", :v0)
@@ -89,6 +93,7 @@ module FixAuth
 
       generate_password if options[:key]
       fix_database_yml if options[:databaseyml]
+      load_rails if options[:allow_failures]
       fix_database_passwords if options[:db]
     end
   end

--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -56,10 +56,6 @@ module FixAuth
     self.password_prefix = "password::"
     self.symbol_keys = true
     self.table_name = "miq_requests"
-
-    def self.contenders
-      where("options like '%password%'")
-    end
   end
 
   class FixMiqRequestTask < ActiveRecord::Base
@@ -71,10 +67,6 @@ module FixAuth
     self.password_prefix = "password::"
     self.symbol_keys = true
     self.table_name = "miq_request_tasks"
-
-    def self.contenders
-      where("options like '%password%'")
-    end
   end
 
   class FixSettingsChange < ActiveRecord::Base
@@ -111,6 +103,10 @@ module FixAuth
     def load
       @yaml = File.read(id)
       self
+    end
+
+    def changed?
+      true
     end
 
     def save!


### PR DESCRIPTION
allow rails to be loaded in fix auth

When objects are serialized into yaml blobs in tables,
we need to load our whole environment to handle the deserialization

This typically happens with miq_requests.options

- add `--allow-failures` flag
- add note where error was found
- require standard rails when allow failures
- continue despite errors when allow failures
- display status, counts, and # errors
- change order of fixes
- reduce columns brought back
- sending error output to STDERR
- only bring back request/task records that have v1/2 encoded passwords

related to #17413 

Performance implication: For one customer, it is taking a multi hour process down to 3 minutes