### PR TITLE
Fixes to Rbac::Filterer#skip_references

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -248,7 +248,7 @@ module Rbac
 
       exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.try(:instances_are_derived?)
       attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?
-      skip_references            = skip_references?(scope, options, attrs)
+      skip_references            = skip_references?(scope, options, attrs, exp_sql, exp_includes)
 
       # for belongs_to filters, scope_targets uses scope to make queries. want to remove limits for those.
       # if you note, the limits are put back into scope a few lines down from here
@@ -308,9 +308,10 @@ module Rbac
     # If still invalid, there is an EXPLAIN check in #include_references that
     # will make sure the query is valid and if not, will include the references
     # as done previously.
-    def skip_references?(scope, options, attrs)
+    def skip_references?(scope, options, attrs, exp_sql, exp_includes)
       return false if scope.singleton_class.included_modules.include?(ActiveRecord::NullRelation)
-      options[:extra_cols].blank? && !attrs[:apply_limit_in_sql]
+      options[:extra_cols].blank? &&
+        (!attrs[:apply_limit_in_sql] && (exp_sql.nil? || exp_includes.nil?))
     end
 
     def include_references(scope, klass, include_for_find, exp_includes, skip)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -248,7 +248,7 @@ module Rbac
 
       exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.try(:instances_are_derived?)
       attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?
-      skip_references            = skip_references?(options, attrs)
+      skip_references            = skip_references?(scope, options, attrs)
 
       # for belongs_to filters, scope_targets uses scope to make queries. want to remove limits for those.
       # if you note, the limits are put back into scope a few lines down from here
@@ -299,10 +299,17 @@ module Rbac
     # or if the MiqExpression can't apply the limit in SQL.  If both of those
     # are true, then we don't add `.references` to the scope.
     #
+    # Also, if for whatever reason we are passed a
+    # `ActiveRecord::NullRelation`, make sure that we don't skip references.
+    # This will cause the EXPLAIN to blow up since `.to_sql` gets changed to
+    # always return `""`... even though at the end of the day, we will always
+    # get back zero records from the query.
+    #
     # If still invalid, there is an EXPLAIN check in #include_references that
     # will make sure the query is valid and if not, will include the references
     # as done previously.
-    def skip_references?(options, attrs)
+    def skip_references?(scope, options, attrs)
+      return false if scope.singleton_class.included_modules.include?(ActiveRecord::NullRelation)
       options[:extra_cols].blank? && !attrs[:apply_limit_in_sql]
     end
 

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -332,7 +332,9 @@ describe Rbac::Filterer do
     context "with non-sql filter" do
       subject { described_class.new }
 
-      let(:expression)        { MiqExpression.new("=" => {"field" => "Vm-vendor_display", "value" => "VMware"}) }
+      let(:nonsql_expression) { {"=" => {"field" => "Vm-vendor_display", "value" => "VMware"}} }
+      let(:raw_expression)    { nonsql_expression }
+      let(:expression)        { MiqExpression.new(raw_expression) }
       let(:search_attributes) { { :class => "Vm", :filter => expression } }
       let(:results)           { subject.search(search_attributes).first }
 
@@ -346,6 +348,23 @@ describe Rbac::Filterer do
       it "does not add references without includes" do
         expect(subject).to receive(:include_references).with(anything, Vm, nil, nil, true).and_call_original
         results
+      end
+
+      context "with a partial non-sql filter" do
+        let(:sql_expression) { { "IS EMPTY" => { "field" => "Vm.host-name" } } }
+        let(:raw_expression) { { "AND" => [nonsql_expression, sql_expression] } }
+
+        it "finds the Vms" do
+          expect(results.to_a).to match_array [owned_vm, other_vm]
+          expect(results.count).to eq 2
+        end
+
+        it "includes references" do
+          expect(subject).to receive(:include_references).with(anything, ::Vm, nil, {:host => {}}, false)
+                                                         .and_call_original
+          expect(subject).to receive(:warn).never
+          results
+        end
       end
 
       context "with :include_for_find" do

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -371,6 +371,18 @@ describe Rbac::Filterer do
             expect(subject).to receive(:warn).exactly(4).times
             results
           end
+
+          context "and targets is a NullRelation scope" do
+            let(:targets)     { Vm.none }
+            let(:null_search) { search_with_where.merge(:targets => targets) }
+            let(:results)     { subject.search(null_search).first }
+
+            it "will not try to skip references" do
+              expect(subject).to receive(:include_references).with(anything, Vm, {:evm_owner => {}}, nil, false).and_call_original
+              expect(subject).to receive(:warn).never
+              results
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
This is a followup to https://github.com/ManageIQ/manageiq/pull/17141 which handles a few more edge cases that were found in the specs in `manageiq-ui-classic`, in the `spec/product/reports_spec.rb`.

This addresses two edge cases:

**`ActiveRecord::NullRelation` scopes**

When a `.none` is applied to the targets, which under the hood changes the `ActiveRecord::Relation` to a `ActiveRecord::NullRelation`.  This causes `.to_sql` method to change so that it always returns a empty string, which will break the `EXPLAIN` in `Rbac::Filterer#include_references`.

The fix here was to just update `#skip_references` to do some slight introspection into the scope to determine if the `.none` had been applied, and to always return false on the `#skip_references` call in the case.


**Partially SQL supported `MiqExpression`**

Turns out that `MiqExpression` objects have partial support for `:supported_by_sql`, even though the boolean makes it seem like it is yes or no.  This means that if you use an "AND" filters with a SQL supported operator like "=" and a none SQL supported operator like "FIND", the `exp_sql` and `exp_includes` returned from `MiqExpression#to_sql` can be non-nil even if options returned is `{:supported_by_sql => false}`.

This change does a simple check against the `exp_sql` and `exp_includes` if `{:supported_by_sql => false}` to confirm at least the `exp_sql` is false, and if it isn't, that at least their isn't any includes being added by the `MiqExpression`.  This is a bit of a shortcut, but we probably can safely assume that the `MiqExpression` would add it's own includes if the `exp_sql` needed to reference another table, and doing this avoids having to analyze the `exp_sql` against the main scope to determine that ourselves.


Links
-----

* Original PR:  https://github.com/ManageIQ/manageiq/pull/17141