### PR TITLE
Remove :match_via_decendants for ConfiguredSystem::ConfiguredSystem

### DIFF
--- a/app/models/configuration_profile.rb
+++ b/app/models/configuration_profile.rb
@@ -70,7 +70,7 @@ class ConfigurationProfile < ApplicationRecord
   alias_method :configuration_manager, :manager
 
   def total_configured_systems
-    Rbac.filtered(configured_systems, :match_via_descendants => ConfiguredSystem).count
+    Rbac.filtered(configured_systems).count
   end
 
   def image_name

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -33,6 +33,6 @@ class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
   end
 
   def total_configured_systems
-    Rbac.filtered(configured_systems, :match_via_descendants => ConfiguredSystem).count
+    Rbac.filtered(configured_systems).count
   end
 end

--- a/app/models/manageiq/providers/configuration_manager.rb
+++ b/app/models/manageiq/providers/configuration_manager.rb
@@ -19,6 +19,6 @@ class ManageIQ::Providers::ConfigurationManager < ManageIQ::Providers::BaseManag
   end
 
   def total_configured_systems
-    Rbac.filtered(configured_systems, :match_via_descendants => ConfiguredSystem).count
+    Rbac.filtered(configured_systems).count
   end
 end


### PR DESCRIPTION
Let's clean up nonsense Rbac requests for `:match_via_descendants` since `ConfiguredSystem::ConfiguredSystem` is not a valid relation. This only causes `evm.log` warning pollution:
```
WARN -- : MIQ(Rbac::Filterer#lookup_method_for_descendant_class) could not find method name for ConfiguredSystem::ConfiguredSystem
```

For valid relations, please consult [Rbac's filterer.rb](https://github.com/ManageIQ/manageiq/blob/9d5ed08d602381d407802cde3375ef01261b7931/lib/rbac/filterer.rb#L92)

Partially fixes: [bug 1565266](https://bugzilla.redhat.com/show_bug.cgi?id=1565266)
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/3952

@miq-bot add_label rbac, bug