### PR TITLE
Setting PhysicalSwitch as its base model

### DIFF
--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -6,6 +6,10 @@ class PhysicalSwitch < Switch
   has_one :hardware, :dependent => :destroy, :foreign_key => :switch_id, :inverse_of => :physical_switch
   has_many :physical_network_ports, :dependent => :destroy, :foreign_key => :switch_id
 
+  def self.base_model
+    PhysicalSwitch
+  end
+
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone


### PR DESCRIPTION
This PR is able to:
 - Set PhysicalSwitch as its base model to avoid problems when Physical Infra Provider calls it

The problems:

When trying to list the Physical Switches from a Physical Infra Provider (/ems_physical_infra/:id?display=physical_switches)
![physical_swiches_listing_02](https://user-images.githubusercontent.com/7563089/40307284-349b372a-5cd8-11e8-8c23-efe0184eab0d.png)

An error is returned
![physical_switches_listing_03](https://user-images.githubusercontent.com/7563089/40307310-4fab7c46-5cd8-11e8-9280-c90bedb922ea.png)

This happens because the application controller from the UI calls paged_view_search, which is a method from Search class inside ManageIQ core that, internally, uses the base model for the class passed. The result is that, instead of "PhysicalSwitch", its parent "Switch" is called, and the Physical Infra Provider deals with PhysicalSwitch, not Switch.

And while accessing a Physical Switch in its summary page (/physical_switch/:id), the QuadIcon doesn't show all quadrants, instead, it is a single icon
![physical_switches_listing_04](https://user-images.githubusercontent.com/7563089/40307367-80da4a86-5cd8-11e8-9ea7-ace0ff79ba2c.png)

This also happens because, in quadicon helper, a call is made for the class's base model. Currently this is solved using "demodulize" in the class, but this could affect other classes, and could induce an error to happen.