### PR TITLE
Change the v2v plugin branch to master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,7 +197,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
 end
 
 group :v2v, :ui_dependencies do
-  gem "miq_v2v_ui", :git => "https://github.com/priley86/miq_v2v_ui_plugin.git", :branch => "alpha"
+  gem "miq_v2v_ui", :git => "https://github.com/priley86/miq_v2v_ui_plugin.git", :branch => "master"
 end
 
 group :web_server, :manageiq_default do


### PR DESCRIPTION
Per the discussion in https://github.com/ManageIQ/manageiq/pull/17369, the v2v plugin branch goes back to `master`

/cc @priley86