### PR TITLE
Stub the connection count to fix sporadic parallel test failures

### DIFF
--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -56,6 +56,8 @@ describe EvmDatabaseOps do
       allow(PostgresAdmin).to receive(:runcmd_with_logging)
       allow(PostgresAdmin).to receive(:pg_dump_file?).and_return(true)
       allow(PostgresAdmin).to receive(:base_backup_file?).and_return(false)
+
+      allow(VmdbDatabaseConnection).to receive(:count).and_return(1)
     end
 
     it "from local backup" do


### PR DESCRIPTION
With parallel tests, we will have multiple connections to the database
so this will sometimes fail on the number of connections

This probably should have been stubbed earlier either way.

ref: https://travis-ci.org/ManageIQ/manageiq/jobs/380246988#L901-L917