### PR TITLE
Read ui url from settings file for dev environment

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -220,6 +220,10 @@ class MiqRegion < ApplicationRecord
   end
 
   def remote_ui_url(contact_with = :hostname)
+    svr = remote_ui_miq_server
+    remote_ui_url_override = svr.settings_for_resource.ui.url if svr
+    return remote_ui_url_override if remote_ui_url_override
+
     hostname = send("remote_ui_#{contact_with}")
     hostname && "https://#{hostname}"
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1089,6 +1089,7 @@
   :active_task_timeout: 6.hours
 :ui:
   :mark_translated_strings: false
+  :url:
 :vim_performance_states:
   :history:
     :purge_window_size: 1000

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -209,4 +209,24 @@ describe MiqRegion do
       expect(region.remote_ws_url).to eq(url)
     end
   end
+
+  describe "#remote_ui_url" do
+    let(:ip) { "1.1.1.94" }
+    let(:hostname) { "www.manageiq.org" }
+    let(:url) { "http://localhost:3000" }
+    let!(:ui_server) do
+      FactoryGirl.create(:miq_server, :has_active_userinterface => true,
+                                      :hostname                 => hostname,
+                                      :ipaddress                => ip)
+    end
+
+    it "fetches the url from server" do
+      expect(region.remote_ui_url).to eq("https://#{hostname}")
+    end
+
+    it "fetches the url from the setting" do
+      Vmdb::Settings.save!(ui_server, :ui => {:url => url})
+      expect(region.remote_ui_url).to eq(url)
+    end
+  end
 end


### PR DESCRIPTION
In dev environments we need the ability to set the UI URL
from config/settings.yml. This is used when constructing the
remote_ui_url

This is similar to PR https://github.com/ManageIQ/manageiq/pull/16185 which implemented the REST URL for dev environments.