### PR TITLE
Removes last call to automate from dialog_field serializer

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -27,6 +27,7 @@ class DialogFieldSerializer < Serializer
         dialog_field.options[:force_single_value] = dialog_field.options[:force_single_value] || category.single_value
       end
     end
-    included_attributes(dialog_field.as_json(:methods => [:type, :values]), all_attributes).merge(extra_attributes)
+    json_options = dialog_field.dynamic? ? {:methods => [:type], :except => [:values]} : {:methods => %i(type values)}
+    included_attributes(dialog_field.as_json(json_options), all_attributes).merge(extra_attributes)
   end
 end

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -4,6 +4,7 @@ describe DialogFieldSerializer do
 
   describe "#serialize" do
     let(:dialog_field) { DialogFieldTextBox.new(expected_serialized_values.merge(:resource_action => resource_action, :dialog_field_responders => dialog_field_responders)) }
+    let(:dialog_field_with_values) { DialogFieldTextBox.new(expected_serialized_values.merge(:resource_action => resource_action, :dialog_field_responders => dialog_field_responders, :values => "drew")) }
     let(:type) { "DialogFieldTextBox" }
     let(:resource_action) { ResourceAction.new }
     let(:dialog_field_responders) { [] }
@@ -79,6 +80,18 @@ describe DialogFieldSerializer do
                           'values'                  => 'dynamic values'
             ))
         end
+      end
+
+      let(:all_attributes) { true }
+
+      it 'does not call values' do
+        expect(dialog_field_serializer.serialize(dialog_field_with_values, all_attributes))
+          .to include(expected_serialized_values.merge(
+                        'id'                      => dialog_field.id,
+                        'resource_action'         => 'serialized resource action',
+                        'dialog_field_responders' => [],
+                        'values'                  => nil
+          ))
       end
     end
 


### PR DESCRIPTION
The field serializer shouldn't be calling automate, so any call to values needs to be removed. I think this was the last one. We've had multiple issues with automate running more times than it needs to and this is at least partially a fix for those type of issues.

Should fix https://github.com/ManageIQ/manageiq/pull/17446

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1570298
