### PR TITLE
Refactor historical / current log collection

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -159,6 +159,7 @@ module MiqServer::LogManagement
     resource = who_am_i
 
     evm = VMDB::Util.get_evm_log_for_date("log/*.log")
+    return if evm.nil?
 
     log_start, log_end = VMDB::Util.get_log_start_end_times(evm)
 

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -29,7 +29,7 @@ module MiqServer::LogManagement
       date_string = "#{format_log_time(log_start)} #{format_log_time(log_end)}" unless log_start.nil? && log_end.nil?
       date_string ||= date
 
-      msg = "Zipping and posting #{log_type.downcase} logs for [#{resource}] dated: [#{date}] from: [#{log_start}] to [#{log_end}]"
+      msg = "Zipping and posting #{log_type.downcase} logs for [#{resource}] from: [#{log_start}] to [#{log_end}]"
       _log.info("#{log_prefix} #{msg}")
       task.update_status("Active", "Ok", msg)
 
@@ -166,7 +166,7 @@ module MiqServer::LogManagement
     log_start, log_end = VMDB::Util.get_log_start_end_times(evm)
     date_string = "#{format_log_time(log_start)} #{format_log_time(log_end)}" unless log_start.nil? && log_end.nil?
 
-    msg = "Zipping and posting #{log_type.downcase} logs and configs for #{resource}"
+    msg = "Zipping and posting #{log_type.downcase} logs for [#{resource}] from: [#{log_start}] to [#{log_end}]"
     _log.info("#{log_prefix} #{msg}")
     task.update_status("Active", "Ok", msg)
 

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -60,7 +60,7 @@ module MiqServer::LogManagement
           :logging_ended_on   => log_end,
           :name               => name,
           :description        => desc,
-          :miq_task_id        => task.id
+          :miq_task           => task
         )
 
         logfile.upload
@@ -160,7 +160,6 @@ module MiqServer::LogManagement
       desc = "Logs for Zone #{zone.name rescue nil} Server #{self.name} #{date_string}"
 
       logfile = LogFile.current_logfile
-      logfile.update_attributes(:miq_task_id => taskid)
       log_files << logfile
       save
 
@@ -177,6 +176,7 @@ module MiqServer::LogManagement
         :logging_ended_on   => log_end,
         :name               => name,
         :description        => desc,
+        :miq_task           => task
       )
 
       logfile.upload

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -43,9 +43,10 @@ module MiqServer::LogManagement
 
       log_files << logfile
       save
+
       msg = "Zipping and posting historical logs for [#{resource}] dated: [#{date}] from: [#{log_start}] to [#{log_end}]"
-      task.update_status("Active", "Ok", msg)
       _log.info(msg)
+      task.update_status("Active", "Ok", msg)
 
       begin
         local_file = VMDB::Util.zip_logs("evm_server_daily.zip", archive_log_patterns(pattern), "admin")

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -64,8 +64,8 @@ module MiqServer::LogManagement
 
         logfile.upload
       rescue StandardError, Timeout::Error => err
-        logfile.update_attributes(:state => "error")
         _log.error("#{log_prefix} Posting of historical logs failed for #{resource} due to error: [#{err.class.name}] [#{err}]")
+        logfile.update_attributes(:state => "error")
         raise
       end
 

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -148,10 +148,11 @@ module MiqServer::LogManagement
   end
 
   def post_current_logs(taskid, log_depot)
-    resource = who_am_i
-    task = MiqTask.find(taskid)
-
     delete_old_requested_logs
+
+    task = MiqTask.find(taskid)
+    resource = who_am_i
+
     logfile = LogFile.current_logfile
     logfile.update_attributes(:miq_task_id => taskid)
     begin

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -70,8 +70,8 @@ module MiqServer::LogManagement
       end
 
       msg = "Historical log files from #{resource} for #{date} are posted"
-      task.update_status("Active", "Ok", msg)
       _log.info("#{log_prefix} #{msg}")
+      task.update_status("Active", "Ok", msg)
 
       # TODO: If the gz has been posted and the gz is more than X days old, delete it
     end

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -159,10 +159,6 @@ module MiqServer::LogManagement
       save
 
       log_prefix = "Task: [#{task.id}]"
-      msg = "Posting logs for: #{resource}"
-      _log.info("#{log_prefix} #{msg}")
-      task.update_status("Active", "Ok", msg)
-
       msg = "Zipping and posting current logs and configs on #{resource}"
       _log.info("#{log_prefix} #{msg}")
       task.update_status("Active", "Ok", msg)

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -22,8 +22,8 @@ module MiqServer::LogManagement
       next if evm.nil?
 
       log_start, log_end = VMDB::Util.get_log_start_end_times(evm)
-      date = File.basename(pattern).gsub!(/\*|\.gz/, "")
 
+      date = File.basename(pattern).gsub!(/\*|\.gz/, "")
       date_string = "#{format_log_time(log_start)} #{format_log_time(log_end)}" unless log_start.nil? && log_end.nil?
       date_string ||= date
       name = "Archived #{self.name} logs #{date_string} "
@@ -33,6 +33,7 @@ module MiqServer::LogManagement
       cond[:logging_started_on] = log_start unless log_start.nil?
       cond[:logging_ended_on] = log_end unless log_end.nil?
       logfile = log_files.find_by(cond)
+
       if logfile && logfile.log_uri.nil?
         _log.info("Historical logfile already exists with id: [#{logfile.id}] for [#{resource}] dated: [#{date}] with contents from: [#{log_start}] to: [#{log_end}]")
         next

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -139,7 +139,6 @@ module MiqServer::LogManagement
     begin
       local_file = VMDB::Util.zip_logs("evm.zip", log_patterns(log_type, pattern), "system")
       self.log_files << logfile
-      save
 
       logfile.update_attributes(
         :local_file         => local_file,

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -48,11 +48,7 @@ module MiqServer::LogManagement
         task.update_status("Active", "Ok", msg)
         _log.info(msg)
 
-        patterns = [pattern]
-        cfg_pattern = ::Settings.log.collection.archive.pattern
-        patterns += cfg_pattern if cfg_pattern.kind_of?(Array)
-
-        local_file = VMDB::Util.zip_logs("evm_server_daily.zip", patterns, "admin")
+        local_file = VMDB::Util.zip_logs("evm_server_daily.zip", archive_log_patterns(pattern), "admin")
 
         logfile.update_attributes(
           :file_depot         => log_depot,
@@ -77,6 +73,13 @@ module MiqServer::LogManagement
 
       # TODO: If the gz has been posted and the gz is more than X days old, delete it
     end
+  end
+
+  def archive_log_patterns(pattern)
+    patterns = [pattern]
+    cfg_pattern = ::Settings.log.collection.archive.pattern
+    patterns += cfg_pattern if cfg_pattern.kind_of?(Array)
+    patterns
   end
 
   def _post_my_logs(options)

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -40,14 +40,10 @@ module MiqServer::LogManagement
         logfile = LogFile.historical_logfile
       end
 
-      msg = "Creating historical Logfile for [#{resource}] dated: [#{date}] from: [#{log_start}] to [#{log_end}]"
-      task.update_status("Active", "Ok", msg)
-      _log.info(msg)
-
       begin
         log_files << logfile
         save
-        msg = "Zipping and posting historical logs and configs on #{resource}"
+        msg = "Zipping and posting historical logs for [#{resource}] dated: [#{date}] from: [#{log_start}] to [#{log_end}]"
         task.update_status("Active", "Ok", msg)
         _log.info(msg)
 
@@ -160,7 +156,7 @@ module MiqServer::LogManagement
       save
 
       log_prefix = "Task: [#{task.id}]"
-      msg = "Zipping and posting current logs and configs on #{resource}"
+      msg = "Zipping and posting current logs and configs for #{resource}"
       _log.info("#{log_prefix} #{msg}")
       task.update_status("Active", "Ok", msg)
 

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -44,17 +44,10 @@ module MiqServer::LogManagement
     "#{category} #{self.name} logs #{date_string} "
   end
 
-  def archive_log_patterns(pattern)
-    patterns = [pattern]
-    cfg_pattern = ::Settings.log.collection.archive.pattern
-    patterns += cfg_pattern if cfg_pattern.kind_of?(Array)
-    patterns
-  end
-
   def log_patterns(log_type, base_pattern = nil)
     case log_type.to_s.downcase
     when "archived"
-      archive_log_patterns(base_pattern)
+      Array(::Settings.log.collection.archive.pattern).unshift(base_pattern)
     when "current"
       current_log_patterns
     end

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -136,7 +136,7 @@ module MiqServer::LogManagement
 
     begin
       local_file = VMDB::Util.zip_logs("evm.zip", glob_patterns, "system")
-      log_files << logfile
+      self.log_files << logfile
       save
 
       logfile.update_attributes(

--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -27,10 +27,8 @@ module MiqServer::LogManagement
       date = File.basename(pattern).gsub!(/\*|\.gz/, "")
       date_string = "#{format_log_time(log_start)} #{format_log_time(log_end)}" unless log_start.nil? && log_end.nil?
       date_string ||= date
-      name = "Archived #{self.name} logs #{date_string} "
-      desc = "Logs for Zone #{zone.name rescue nil} Server #{self.name} #{date_string}"
 
-      cond = {:historical => true, :name => name, :state => 'available'}
+      cond = {:historical => true, :name => logfile_name("Archived", date_string), :state => 'available'}
       cond[:logging_started_on] = log_start unless log_start.nil?
       cond[:logging_ended_on] = log_end unless log_end.nil?
       logfile = log_files.find_by(cond)
@@ -57,8 +55,8 @@ module MiqServer::LogManagement
           :local_file         => local_file,
           :logging_started_on => log_start,
           :logging_ended_on   => log_end,
-          :name               => name,
-          :description        => desc,
+          :name               => logfile_name("Archived", date_string),
+          :description        => "Logs for Zone #{zone.name rescue nil} Server #{self.name} #{date_string}",
           :miq_task           => task
         )
 
@@ -75,6 +73,10 @@ module MiqServer::LogManagement
 
       # TODO: If the gz has been posted and the gz is more than X days old, delete it
     end
+  end
+
+  def logfile_name(category, date_string)
+    "#{category} #{self.name} logs #{date_string} "
   end
 
   def archive_log_patterns(pattern)
@@ -161,8 +163,6 @@ module MiqServer::LogManagement
     log_start, log_end = VMDB::Util.get_log_start_end_times(evm)
 
     date_string = "#{format_log_time(log_start)} #{format_log_time(log_end)}" unless log_start.nil? && log_end.nil?
-    name = "Requested #{self.name} logs #{date_string} "
-    desc = "Logs for Zone #{zone.name rescue nil} Server #{self.name} #{date_string}"
 
     logfile = LogFile.current_logfile
     log_files << logfile
@@ -180,8 +180,8 @@ module MiqServer::LogManagement
         :local_file         => local_file,
         :logging_started_on => log_start,
         :logging_ended_on   => log_end,
-        :name               => name,
-        :description        => desc,
+        :name               => logfile_name("Requested", date_string),
+        :description        => "Logs for Zone #{zone.name rescue nil} Server #{self.name} #{date_string}",
         :miq_task           => task
       )
 

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -165,7 +165,11 @@ describe MiqServer do
             allow(VMDB::Util).to receive(:get_evm_log_for_date).and_return(compressed_evm_log)
             allow(VMDB::Util).to receive(:get_log_start_end_times).and_return([log_start, log_end])
             allow(VMDB::Util).to receive(:zip_logs).and_return(daily_log)
-            allow_any_instance_of(LogFile).to receive(:upload)
+            %w{historical_logfile current_logfile}.each do |kind|
+              logfile = FactoryGirl.create(:log_file, :historical => kind == "historical_logfile")
+              allow(logfile).to receive(:upload)
+              allow(LogFile).to receive(kind).and_return(logfile)
+            end
           end
 
           it "no prior historical logfile" do

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -181,7 +181,7 @@ describe MiqServer do
             )
 
             expect(task.reload).to have_attributes(
-             :message => "Historical log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} for evm.log are posted",
+             :message => "Archived log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} for evm.log are posted",
              :state   => "Active",
              :status  => "Ok",
             )

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -181,7 +181,7 @@ describe MiqServer do
             )
 
             expect(task.reload).to have_attributes(
-             :message => "Archived log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} for evm.log are posted",
+             :message => "Archived log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
              :state   => "Active",
              :status  => "Ok",
             )


### PR DESCRIPTION
This refactoring is required so we can post things other than historical and current logs such as automate dialogs, domains/models, etc.

https://bugzilla.redhat.com/show_bug.cgi?id=1535179

Note, the tests are going to be moved and refactored in a followup PR when I need to add the automate dialogs/domains posting.
