### PR TITLE
Consolidate logfile naming and destination filename

### DIFF
--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -180,10 +180,17 @@ class LogFile < ApplicationRecord
     File.join("#{resource.zone.name}_#{resource.zone.id}", "#{resource.name}_#{resource.id}")
   end
 
+  def self.logfile_name(resource, category = "Current", date_string = nil)
+    region = MiqRegion.my_region.try(:region) || "unknown"
+    [category, "region", region, resource.zone.name, resource.zone.id, resource.name, resource.id, date_string].compact.join(" ")
+  end
+
   def destination_file_name
-    date_string = "#{format_log_time(logging_started_on)}_#{format_log_time(logging_ended_on)}"
-    destname    = historical ? "Archive_" : "Current_"
-    destname << "region_#{MiqRegion.my_region.try(:region) || "unknown"}_#{resource.zone.name}_#{resource.zone.id}_#{resource.name}_#{resource.id}_#{date_string}#{File.extname(local_file)}"
+    name.gsub(/\s+/, "_").concat(File.extname(local_file))
+  end
+
+  def name
+    super || self.class.logfile_name(resource)
   end
 
   def post_upload_tasks

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -38,7 +38,7 @@ describe FileDepotFtp do
       expect(vsftpd.content).to eq('uploads' =>
                                    {"#{@zone.name}_#{@zone.id}" =>
                                    {"#{@miq_server.name}_#{@miq_server.id}" =>
-                                   {"Current_region_unknown_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}_unknown_unknown.txt" =>
+                                   {"Current_region_unknown_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}.txt".gsub(/\s+/, "_") =>
                                    log_file.local_file}}})
     end
 
@@ -49,7 +49,7 @@ describe FileDepotFtp do
       expect(vsftpd.content).to eq('uploads' =>
                                    {"#{@zone.name}_#{@zone.id}" =>
                                    {"#{@miq_server.name}_#{@miq_server.id}" =>
-                                   {"Current_region_unknown_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}_unknown_unknown.txt" =>
+                                   {"Current_region_unknown_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}.txt".gsub(/\s+/, "_") =>
                                    log_file.local_file}}})
     end
 

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -177,21 +177,23 @@ describe MiqServer do
           it "no prior historical logfile" do
             @miq_server.post_historical_logs(task.id, log_depot)
             logfile = @miq_server.reload.log_files.first
+            expected_name = ["Archive", "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, "20180511_113312 20180511_153416"].join(" ")
             expect(logfile).to have_attributes(
               :file_depot         => log_depot,
               :local_file         => daily_log,
               :logging_started_on => log_start,
               :logging_ended_on   => log_end,
-              :name               => "Archived #{@miq_server.name} logs 20180511_113312 20180511_153416 ",
+              :name               => expected_name,
               :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
               :miq_task_id        => task.id
             )
 
             expected_filename = "Archive_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
+            expected_filename.gsub!(/\s+/, "_")
             expect(logfile.destination_file_name).to eq(expected_filename)
 
             expect(task.reload).to have_attributes(
-             :message => "Archived log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
+             :message => "Archive log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
              :state   => "Active",
              :status  => "Ok",
             )
@@ -202,17 +204,19 @@ describe MiqServer do
             allow(@miq_server).to receive(:current_log_patterns).and_return(current_log_patterns)
             @miq_server.post_current_logs(task.id, log_depot)
             logfile = @miq_server.reload.log_files.first
+            expected_name = ["Current", "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, "20180511_113312 20180511_153416"].join(" ")
             expect(logfile).to have_attributes(
               :file_depot         => log_depot,
               :local_file         => daily_log,
               :logging_started_on => log_start,
               :logging_ended_on   => log_end,
-              :name               => "Requested #{@miq_server.name} logs 20180511_113312 20180511_153416 ",
+              :name               => expected_name,
               :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
               :miq_task_id        => task.id
             )
 
             expected_filename = "Current_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
+            expected_filename.gsub!(/\s+/, "_")
             expect(logfile.destination_file_name).to eq(expected_filename)
 
             expect(task.reload).to have_attributes(

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -159,6 +159,8 @@ describe MiqServer do
           let(:log_end)                   { Time.parse("2018-05-11 15:34:16 UTC") }
           let(:daily_log)                 { Rails.root.join("data", "user", "system", "evm_server_daily.zip").to_s}
           let(:log_depot)                 { FactoryGirl.create(:file_depot) }
+          let!(:region)                   { MiqRegion.seed }
+          let(:zone)                      { @miq_server.zone }
           before do
             require 'vmdb/util'
             allow(VMDB::Util).to receive(:compressed_log_patterns).and_return(compressed_log_patterns)
@@ -174,7 +176,8 @@ describe MiqServer do
 
           it "no prior historical logfile" do
             @miq_server.post_historical_logs(task.id, log_depot)
-            expect(@miq_server.reload.log_files.first).to have_attributes(
+            logfile = @miq_server.reload.log_files.first
+            expect(logfile).to have_attributes(
               :file_depot         => log_depot,
               :local_file         => daily_log,
               :logging_started_on => log_start,
@@ -184,17 +187,22 @@ describe MiqServer do
               :miq_task_id        => task.id
             )
 
+            expected_filename = "Archive_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
+            expect(logfile.destination_file_name).to eq(expected_filename)
+
             expect(task.reload).to have_attributes(
              :message => "Archived log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
              :state   => "Active",
              :status  => "Ok",
             )
+
           end
 
           it "no prior current logfile" do
             allow(@miq_server).to receive(:current_log_patterns).and_return(current_log_patterns)
             @miq_server.post_current_logs(task.id, log_depot)
-            expect(@miq_server.reload.log_files.first).to have_attributes(
+            logfile = @miq_server.reload.log_files.first
+            expect(logfile).to have_attributes(
               :file_depot         => log_depot,
               :local_file         => daily_log,
               :logging_started_on => log_start,
@@ -203,6 +211,9 @@ describe MiqServer do
               :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
               :miq_task_id        => task.id
             )
+
+            expected_filename = "Current_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
+            expect(logfile.destination_file_name).to eq(expected_filename)
 
             expect(task.reload).to have_attributes(
              :message => "Current log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1535179

Depends on prior PRs:
- [x] [Current/historical log collection refactoring](#17437) [MERGED]

LogFile#name was generating a name that was similar but yet different
than the destination_file_name.  This name is not displayed or used in
the UI, so we can push the logic of building the destination_file_name
into the name of the LogFile, which is exactly the place we need it to
differentiate current/historical/automate models/automate dialogs.