### PR TITLE
Use feature for admin

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -247,9 +247,9 @@ class MiqGroup < ApplicationRecord
     in_my_region.non_tenant_groups
   end
 
-  def self.with_current_user_groups(user = nil)
-    current_user = user || User.current_user
-    current_user.admin_user? ? all : where(:id => current_user.miq_group_ids)
+  # parallel to User.with_groups - only show these groups
+  def self.with_groups(miq_group_ids)
+    where(:id => miq_group_ids)
   end
 
   def single_group_users?

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -60,8 +60,10 @@ class MiqGroup < ApplicationRecord
     super(indifferent_settings)
   end
 
-  def self.with_roles_excluding(disallowed_roles)
-    includes(:miq_user_role).where.not(:miq_user_roles => {:name => disallowed_roles})
+  def self.with_roles_excluding(identifier)
+    where.not(:id => MiqGroup.joins(:miq_product_features)
+                             .where(:miq_product_features => {:identifier => identifier})
+                             .select(:id))
   end
 
   def self.next_sequence

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -15,11 +15,11 @@ class MiqGroup < ApplicationRecord
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
   has_many   :miq_product_features, :through => :miq_user_role
 
-  virtual_column :miq_user_role_name, :type => :string,  :uses => :miq_user_role
+  virtual_delegate :name, :to => :miq_user_role, :allow_nil => true, :prefix => true
   virtual_column :read_only,          :type => :boolean
   virtual_has_one :sui_product_features, :class_name => "Array"
 
-  delegate :self_service?, :limited_self_service?, :disallowed_roles, :to => :miq_user_role, :allow_nil => true
+  delegate :self_service?, :limited_self_service?, :to => :miq_user_role, :allow_nil => true
 
   validates :description, :presence => true, :unique_within_region => { :match_case => false }
   validate :validate_default_tenant, :on => :update, :if => :tenant_id_changed?
@@ -60,8 +60,8 @@ class MiqGroup < ApplicationRecord
     super(indifferent_settings)
   end
 
-  def self.with_allowed_roles_for(user_or_group)
-    includes(:miq_user_role).where.not({:miq_user_roles => {:name => user_or_group.disallowed_roles}})
+  def self.with_roles_excluding(disallowed_roles)
+    includes(:miq_user_role).where.not(:miq_user_roles => {:name => disallowed_roles})
   end
 
   def self.next_sequence
@@ -181,10 +181,6 @@ class MiqGroup < ApplicationRecord
 
   def get_belongsto_filters
     entitlement.try(:get_belongsto_filters) || []
-  end
-
-  def miq_user_role_name
-    miq_user_role.try(:name)
   end
 
   def system_group?

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -1,4 +1,6 @@
 class MiqProductFeature < ApplicationRecord
+  SUPER_ADMIN_FEATURE = "everything".freeze
+  ADMIN_FEATURE       = "miq_report_superadmin".freeze
   acts_as_tree
 
   has_and_belongs_to_many :miq_user_roles, :join_table => :miq_roles_features
@@ -107,7 +109,7 @@ class MiqProductFeature < ApplicationRecord
     features = all.to_a.index_by(&:identifier)
     seen     = seed_from_hash(YAML.load_file(fixture_yaml), seen, nil, features)
 
-    root_feature = MiqProductFeature.find_by(:identifier => 'everything')
+    root_feature = MiqProductFeature.find_by(:identifier => SUPER_ADMIN_FEATURE)
     Dir.glob(path.join("*.yml")).each do |fixture|
       seed_from_hash(YAML.load_file(fixture), seen, root_feature)
     end

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -1,6 +1,8 @@
 class MiqProductFeature < ApplicationRecord
   SUPER_ADMIN_FEATURE = "everything".freeze
-  ADMIN_FEATURE       = "miq_report_superadmin".freeze
+  REPORT_ADMIN_FEATURE  = "miq_report_superadmin".freeze
+  REQUEST_ADMIN_FEATURE = "miq_request_superadmin".freeze
+  ADMIN_FEATURE = REPORT_ADMIN_FEATURE
   acts_as_tree
 
   has_and_belongs_to_many :miq_user_roles, :join_table => :miq_roles_features

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -55,7 +55,7 @@ class MiqReport < ApplicationRecord
   IMPORT_CLASS_NAMES = %w(MiqReport).freeze
 
   scope :for_user, lambda { |user|
-    if user.admin_user?
+    if user.report_admin_user?
       all
     else
       where(

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -44,7 +44,7 @@ module MiqReport::ImportExport
         # if report exists
         if options[:overwrite]
           # if report exists delete and create new
-          if user.admin_user? || user.current_group_id == rep.miq_group_id
+          if user.report_admin_user? || user.current_group_id == rep.miq_group_id
             msg = "Overwriting Report: [#{report["name"]}]"
             rep.attributes = report
             result = {:message => "Replaced Report: [#{report["name"]}]", :level => :info, :status => :update}

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -24,7 +24,7 @@ class MiqReportResult < ApplicationRecord
     end
   }
   scope :for_user, lambda { |user|
-    for_groups(user.admin_user? ? nil : user.miq_group_ids)
+    for_groups(user.report_admin_user? ? nil : user.miq_group_ids)
   }
 
   before_save do
@@ -329,7 +329,7 @@ class MiqReportResult < ApplicationRecord
 
   def self.with_current_user_groups
     current_user = User.current_user
-    current_user.admin_user? ? all : where(:miq_group_id => current_user.miq_group_ids)
+    current_user.report_admin_user? ? all : where(:miq_group_id => current_user.miq_group_ids)
   end
 
   def self.with_chargeback

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -106,8 +106,14 @@ class MiqUserRole < ApplicationRecord
     allows?(:identifier => MiqProductFeature::SUPER_ADMIN_FEATURE)
   end
 
-  def admin_user?
-    allows_any?(:identifiers => [MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::ADMIN_FEATURE])
+  def report_admin_user?
+    allows_any?(:identifiers => [MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::REPORT_ADMIN_FEATURE])
+  end
+
+  alias admin_user? report_admin_user?
+
+  def request_admin_user?
+    allows_any?(:identifiers => [MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::REQUEST_ADMIN_FEATURE])
   end
 
   def self.default_tenant_role

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -64,12 +64,8 @@ class MiqUserRole < ApplicationRecord
     (settings || {}).fetch_path(:restrictions, :vms) == :user
   end
 
-  def disallowed_roles
-    !super_admin_user? && Rbac::Filterer::DISALLOWED_ROLES_FOR_USER_ROLE[name]
-  end
-
-  def self.with_allowed_roles_for(user_or_group)
-    where.not(:name => user_or_group.disallowed_roles)
+  def self.with_roles_excluding(disallowed_roles)
+    where.not(:name => disallowed_roles)
   end
 
   def self.seed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -285,9 +285,9 @@ class User < ApplicationRecord
     Thread.current[:user] ||= find_by_userid(current_userid)
   end
 
-  def self.with_current_user_groups(user = nil)
-    user ||= current_user
-    user.admin_user? ? all : includes(:miq_groups).where(:miq_groups => {:id => user.miq_group_ids})
+  # parallel to MiqGroup.with_groups - only show users with these groups
+  def self.with_groups(miq_group_ids)
+    includes(:miq_groups).where(:miq_groups => {:id => miq_group_ids})
   end
 
   def self.missing_user_features(db_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,8 @@ class User < ApplicationRecord
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
   scope      :superadmins, lambda {
-    joins(:miq_groups => :miq_user_role).where(:miq_user_roles => {:name => MiqUserRole::SUPER_ADMIN_ROLE_NAME })
+    joins(:miq_groups => {:miq_user_role => :miq_product_features})
+      .where(:miq_product_features => {:identifier => MiqProductFeature::SUPER_ADMIN_FEATURE })
   }
 
   virtual_has_many :active_vms, :class_name => "VmOrTemplate"
@@ -50,8 +51,10 @@ class User < ApplicationRecord
 
   scope :with_same_userid, ->(id) { where(:userid => User.find(id).userid) }
 
-  def self.with_roles_excluding(disallowed_roles)
-    includes(:miq_groups => :miq_user_role).where.not(:miq_user_roles => {:name => disallowed_roles})
+  def self.with_roles_excluding(identifier)
+    where.not(:id => User.joins(:miq_groups => :miq_product_features)
+                             .where(:miq_product_features => {:identifier => identifier})
+                             .select(:id))
   end
 
   def self.scope_by_tenant?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
 
   delegate   :miq_user_role, :current_tenant, :get_filters, :has_filters?, :get_managed_filters, :get_belongsto_filters,
              :to => :current_group, :allow_nil => true
-  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?,
+  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?, :report_admin_user?,
              :to => :miq_user_role, :allow_nil => true
 
   validates_presence_of   :name, :userid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
 
   delegate   :miq_user_role, :current_tenant, :get_filters, :has_filters?, :get_managed_filters, :get_belongsto_filters,
              :to => :current_group, :allow_nil => true
-  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?, :disallowed_roles,
+  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?,
              :to => :miq_user_role, :allow_nil => true
 
   validates_presence_of   :name, :userid
@@ -50,8 +50,8 @@ class User < ApplicationRecord
 
   scope :with_same_userid, ->(id) { where(:userid => User.find(id).userid) }
 
-  def self.with_allowed_roles_for(user_or_group)
-    includes(:miq_groups => :miq_user_role).where.not(:miq_user_roles => {:name => user_or_group.disallowed_roles})
+  def self.with_roles_excluding(disallowed_roles)
+    includes(:miq_groups => :miq_user_role).where.not(:miq_user_roles => {:name => disallowed_roles})
   end
 
   def self.scope_by_tenant?

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -180,6 +180,10 @@
       :description: Edit a Request
       :feature_type: admin
       :identifier: miq_request_edit
+  - :name: Request Admin
+    :description: Edit other user's requests
+    :feature_type: admin
+    :identifier: miq_request_superadmin
 
 # Catalog Items
 - :name: Catalogs Explorer
@@ -1599,8 +1603,8 @@
     :feature_type: node
     :identifier: miq_report_menu_editor
 # Special Admin Functionality
-  - :name: Admin
-    :description: Special Admin Functionality
+  - :name: Report Admin
+    :description: See other user's reports
     :feature_type: admin
     :identifier: miq_report_superadmin
   - :name: Import / Export

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1598,6 +1598,11 @@
     :description: Edit Report Menus Accordion
     :feature_type: node
     :identifier: miq_report_menu_editor
+# Special Admin Functionality
+  - :name: Admin
+    :description: Special Admin Functionality
+    :feature_type: admin
+    :identifier: miq_report_superadmin
   - :name: Import / Export
     :description: Import / Export Accordion
     :feature_type: node

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -63,6 +63,7 @@
   - policy_simulation
   - policy_log
   - miq_report
+  - miq_report_superadmin
   - miq_request
   - miq_template
   - orchestration_stack

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -65,6 +65,7 @@
   - miq_report
   - miq_report_superadmin
   - miq_request
+  - miq_request_superadmin
   - miq_template
   - orchestration_stack
   - physical_rack

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -514,8 +514,9 @@ module Rbac
       if user_or_group.try!(:self_service?) && MiqUserRole != klass
         scope.where(:id => klass == User ? user.id : miq_group.id)
       else
-        if user_or_group.miq_user_role_name == 'EvmRole-tenant_administrator'
-          scope = scope.with_roles_excluding(%w(EvmRole-super_administrator EvmRole-administrator))
+        # hide creating admin group / roles from tenant administrators
+        unless user_or_group.miq_user_role&.admin_user?
+          scope = scope.with_roles_excluding([MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::ADMIN_FEATURE])
         end
 
         if MiqUserRole != klass

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -76,13 +76,6 @@ module Rbac
       VmOrTemplate
     ) + NETWORK_MODELS_FOR_BELONGSTO_FILTER
 
-    # key: MiqUserRole#name - user's role
-    # value:
-    #   array - disallowed roles for the user's role
-    DISALLOWED_ROLES_FOR_USER_ROLE = {
-      'EvmRole-tenant_administrator' => %w(EvmRole-super_administrator EvmRole-administrator)
-    }.freeze
-
     # key: descendant::klass
     # value:
     #   if it is a symbol/method_name:
@@ -164,7 +157,7 @@ module Rbac
     # @option options :where_clause  []
     # @option options :sub_filter
     # @option options :include_for_find [Array<Symbol>]
-    # @option options :filter
+    # @option options :filter       [MiqExpression] (optional)
 
     # @option options :user         [User]     (default: current_user)
     # @option options :userid       [String]   User#userid (not user_id)
@@ -521,8 +514,8 @@ module Rbac
       if user_or_group.try!(:self_service?) && MiqUserRole != klass
         scope.where(:id => klass == User ? user.id : miq_group.id)
       else
-        if user_or_group.disallowed_roles
-          scope = scope.with_allowed_roles_for(user_or_group)
+        if user_or_group.miq_user_role_name == 'EvmRole-tenant_administrator'
+          scope = scope.with_roles_excluding(%w(EvmRole-super_administrator EvmRole-administrator))
         end
 
         if MiqUserRole != klass

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -520,7 +520,8 @@ module Rbac
 
         if MiqUserRole != klass
           filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, managed_filters))
-          scope = scope.with_current_user_groups(user)
+          # Non admins can only see their own groups
+          scope = scope.with_groups(user.miq_group_ids) unless user_or_group.miq_user_role&.admin_user?
         end
 
         scope_by_ids(scope, filtered_ids)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -514,15 +514,15 @@ module Rbac
       if user_or_group.try!(:self_service?) && MiqUserRole != klass
         scope.where(:id => klass == User ? user.id : miq_group.id)
       else
-        # hide creating admin group / roles from tenant administrators
-        unless user_or_group.miq_user_role&.admin_user?
-          scope = scope.with_roles_excluding([MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::ADMIN_FEATURE])
+        # hide creating admin group / roles from non-super administrators
+        unless user_or_group.miq_user_role&.super_admin_user?
+          scope = scope.with_roles_excluding(MiqProductFeature::SUPER_ADMIN_FEATURE)
         end
 
         if MiqUserRole != klass
           filtered_ids = pluck_ids(get_managed_filter_object_ids(scope, managed_filters))
           # Non admins can only see their own groups
-          scope = scope.with_groups(user.miq_group_ids) unless user_or_group.miq_user_role&.admin_user?
+          scope = scope.with_groups(user.miq_group_ids) unless user_or_group.miq_user_role&.super_admin_user?
         end
 
         scope_by_ids(scope, filtered_ids)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -882,11 +882,11 @@ describe Rbac::Filterer do
         end
 
         let!(:super_administrator_user_role) do
-          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::SUPER_ADMIN_ROLE_NAME)
+          FactoryGirl.create(:miq_user_role, :role => "super_administrator")
         end
 
         let!(:administrator_user_role) do
-          FactoryGirl.create(:miq_user_role, :name => MiqUserRole::ADMIN_ROLE_NAME)
+          FactoryGirl.create(:miq_user_role, :role => "administrator")
         end
 
         let(:group) do

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -897,7 +897,7 @@ describe Rbac::Filterer do
 
         it 'can see all roles expect to EvmRole-super_administrator' do
           expect(MiqUserRole.count).to eq(3)
-          get_rbac_results_for_and_expect_objects(MiqUserRole, [tenant_administrator_user_role])
+          get_rbac_results_for_and_expect_objects(MiqUserRole, [tenant_administrator_user_role, administrator_user_role])
         end
 
         it 'can see all groups expect to group with role EvmRole-super_administrator' do

--- a/spec/lib/task_helpers/exports/roles_spec.rb
+++ b/spec/lib/task_helpers/exports/roles_spec.rb
@@ -10,7 +10,7 @@ describe TaskHelpers::Exports::Roles do
     [{"name"                => "EvmRole-super_administrator",
       "read_only"           => true,
       "settings"            => nil,
-      "feature_identifiers" => []}]
+      "feature_identifiers" => ["everything"]}]
   end
 
   let(:export_dir) do

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -64,7 +64,7 @@ describe MiqReportResult do
       end
 
       it "returns report all results, admin user logged" do
-        admin_role = FactoryGirl.create(:miq_user_role, :name => "EvmRole-administrator", :read_only => false)
+        admin_role = FactoryGirl.create(:miq_user_role, :role => "administrator", :read_only => false)
         User.current_user.current_group.miq_user_role = admin_role
         report_result = MiqReportResult.with_current_user_groups
         expected_reports = [@report_result1, @report_result2, @report_result3, @report_result_nil_report_id]

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -174,29 +174,29 @@ describe MiqUserRole do
 
   describe "#super_admin_user?" do
     it "detects super admin" do
-      expect(FactoryGirl.build(:miq_user_role, :role => "super_administrator")).to be_super_admin_user
+      expect(FactoryGirl.create(:miq_user_role, :role => "super_administrator")).to be_super_admin_user
     end
 
     it "detects admin" do
-      expect(FactoryGirl.build(:miq_user_role, :role => "administrator")).not_to be_super_admin_user
+      expect(FactoryGirl.create(:miq_user_role, :role => "administrator")).not_to be_super_admin_user
     end
 
     it "detects non-admin" do
-      expect(FactoryGirl.build(:miq_user_role)).not_to be_super_admin_user
+      expect(FactoryGirl.create(:miq_user_role)).not_to be_super_admin_user
     end
   end
 
   describe "#admin_user?" do
     it "detects super admin" do
-      expect(FactoryGirl.build(:miq_user_role, :role => "super_administrator")).to be_admin_user
+      expect(FactoryGirl.create(:miq_user_role, :role => "super_administrator")).to be_admin_user
     end
 
     it "detects admin" do
-      expect(FactoryGirl.build(:miq_user_role, :role => "administrator")).to be_admin_user
+      expect(FactoryGirl.create(:miq_user_role, :role => "administrator")).to be_admin_user
     end
 
     it "detects non-admin" do
-      expect(FactoryGirl.build(:miq_user_role)).not_to be_admin_user
+      expect(FactoryGirl.create(:miq_user_role)).not_to be_admin_user
     end
   end
 

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -172,31 +172,39 @@ describe MiqUserRole do
     expect(MiqUserRole.count).to eq(1)
   end
 
+  let(:super_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::SUPER_ADMIN_FEATURE) }
+  let(:report_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::REPORT_ADMIN_FEATURE) }
+  let(:request_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::REQUEST_ADMIN_FEATURE) }
+  let(:regular_role) { FactoryGirl.create(:miq_user_role) }
+
   describe "#super_admin_user?" do
     it "detects super admin" do
-      expect(FactoryGirl.create(:miq_user_role, :role => "super_administrator")).to be_super_admin_user
+      expect(super_admin_role).to be_super_admin_user
     end
 
     it "detects admin" do
-      expect(FactoryGirl.create(:miq_user_role, :role => "administrator")).not_to be_super_admin_user
+      expect(report_admin_role).not_to be_super_admin_user
     end
 
     it "detects non-admin" do
-      expect(FactoryGirl.create(:miq_user_role)).not_to be_super_admin_user
+      expect(regular_role).not_to be_super_admin_user
     end
   end
 
-  describe "#admin_user?" do
+  describe "#admin_user?", "#report_admin_user?" do
     it "detects super admin" do
-      expect(FactoryGirl.create(:miq_user_role, :role => "super_administrator")).to be_admin_user
+      expect(super_admin_role).to be_admin_user
+      expect(super_admin_role).to be_report_admin_user
     end
 
     it "detects admin" do
-      expect(FactoryGirl.create(:miq_user_role, :role => "administrator")).to be_admin_user
+      expect(report_admin_role).to be_admin_user
+      expect(report_admin_role).to be_report_admin_user
     end
 
     it "detects non-admin" do
-      expect(FactoryGirl.create(:miq_user_role)).not_to be_admin_user
+      expect(regular_role).not_to be_admin_user
+      expect(regular_role).not_to be_report_admin_user
     end
   end
 

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -105,7 +105,7 @@ describe Authenticator::Ldap do
     FactoryGirl.create(
       :miq_group,
       :description   => "EvmGroup-super_administrator",
-      :miq_user_role => FactoryGirl.create(:miq_user_role, :name => "EvmRole-super_administrator")
+      :miq_user_role => FactoryGirl.create(:miq_user_role, :role => "super_administrator")
     )
   end
 


### PR DESCRIPTION
### Problem:

Users can not create a custom group with admin privileges.
Our best practices say to create a custom group and not use the included `Evm` ones.
The reason for this request most often is focused on reporting, but also focuses on `miq_request` privileges.

- https://bugzilla.redhat.com/show_bug.cgi?id=1090627
- https://bugzilla.redhat.com/show_bug.cgi?id=1545401
- https://github.com/ManageIQ/manageiq-ui-classic/pull/3993
- https://github.com/ManageIQ/manageiq-api/pull/385
- Extra reference, but not addressed: https://bugzilla.redhat.com/show_bug.cgi?id=1508490
- scroll down for ui changes.

### Before:

- We use the admin's name (admin, tenant admin, and super admin) to grant extra privileges. This is determined using `MiqUserRole#admin_user?`.
- Tenant admin checks are in place to prevent the user from creating an administrator or super administrator (and essentially escalating privileges).
- NOTE: special privileges of the `administrator` role has been whittled down to elevated report and `miq_request` privileges.

### After:

- super-administrator role (i.e.: user `admin`) now uses the the existing `everything` `miq_product_feature` to grant the special privilege.
- Report functionality previously protected by `admin_user?` now uses the `miq_product_feature` `miq_report_superadmin` to grant special privileges. (This is needed for chargeback and other reports). Introduced `report_admin_user?` for transition.
- MiqRequest functionality previously protected by `admin_user?` now uses `miq_product feature` `miq_request_superadmin` 
- The `administrator` role checks `admin_user?` is deprecated and no longer used. Essentially, this role has been removed.
- The `tenant-administrator` checks have been simplified. Now, a super admin is the only one able to create a super admin.

### Future work:

- The code currently prevents users from viewing other groups. This needs to be fixed in admin.
- A bunch of these checks could be moved further into Rbac.
- There are quite a few report / report result checks that are tangled and non trivial to move to rbac.
- There are 2 types of checks for report results - tread carefully.