### PR TITLE
Upload automate models dialogs during log collection

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -94,7 +94,14 @@ class Zone < ApplicationRecord
   end
 
   def synchronize_logs(*args)
-    active_miq_servers.each { |s| s.synchronize_logs(*args) }
+    options = args.extract_options!
+    enabled = Settings.log.collection.include_automate_models_and_dialogs
+
+    active_miq_servers.each_with_index do |s, index|
+      # If enabled, export the automate domains and dialogs on the first active server
+      include_models_and_dialogs = enabled ? index.zero? : false
+      s.synchronize_logs(*args, options.merge(:include_automate_models_and_dialogs => include_models_and_dialogs))
+    end
   end
 
   def last_log_sync_on

--- a/spec/models/log_file_spec.rb
+++ b/spec/models/log_file_spec.rb
@@ -99,25 +99,28 @@ describe LogFile do
 
         context "with post_logs message" do
           it "#post_logs will only post current logs if flag enabled" do
-            message.deliver
             message.args.first[:only_current] = true
             expect_any_instance_of(MiqServer).to receive(:post_historical_logs).never
             expect_any_instance_of(MiqServer).to receive(:post_current_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_automate_dialogs).once
+            expect_any_instance_of(MiqServer).to receive(:post_automate_models).once
             message.delivered(*message.deliver)
           end
 
           it "#post_logs will post both historical and current logs if flag nil" do
-            message.deliver
             expect_any_instance_of(MiqServer).to receive(:post_historical_logs).once
             expect_any_instance_of(MiqServer).to receive(:post_current_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_automate_dialogs).once
+            expect_any_instance_of(MiqServer).to receive(:post_automate_models).once
             message.delivered(*message.deliver)
           end
 
           it "#post_logs will post both historical and current logs if flag false" do
-            message.deliver
             message.args.first[:only_current] = false
             expect_any_instance_of(MiqServer).to receive(:post_historical_logs).once
             expect_any_instance_of(MiqServer).to receive(:post_current_logs).once
+            expect_any_instance_of(MiqServer).to receive(:post_automate_dialogs).once
+            expect_any_instance_of(MiqServer).to receive(:post_automate_models).once
             message.delivered(*message.deliver)
           end
         end

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -113,6 +113,66 @@ describe MiqServer do
       expect(@miq_server.current_log_patterns).to match_array %w(/var/log/syslog* /var/lib/pgsql/data/*.conf)
     end
 
+    context "post current/historical/models/dialogs" do
+      let(:task)                      { FactoryGirl.create(:miq_task) }
+      let(:compressed_log_patterns)   { [Rails.root.join("log", "evm*.log.gz").to_s] }
+      let(:current_log_patterns)      { [Rails.root.join("log", "evm.log").to_s] }
+      let(:compressed_evm_log)        { Rails.root.join("evm.log-20180319.gz").to_s }
+      let(:log_start)                 { Time.zone.parse("2018-05-11 11:33:12 UTC") }
+      let(:log_end)                   { Time.zone.parse("2018-05-11 15:34:16 UTC") }
+      let(:daily_log)                 { Rails.root.join("data", "user", "system", "evm_server_daily.zip").to_s }
+      let(:log_depot)                 { FactoryGirl.create(:file_depot) }
+      let!(:region)                   { MiqRegion.seed }
+      let(:zone)                      { @miq_server.zone }
+      before do
+        require 'vmdb/util'
+        allow(VMDB::Util).to receive(:compressed_log_patterns).and_return(compressed_log_patterns)
+        allow(VMDB::Util).to receive(:get_evm_log_for_date).and_return(compressed_evm_log)
+        allow(VMDB::Util).to receive(:get_log_start_end_times).and_return([log_start, log_end])
+        allow(VMDB::Util).to receive(:zip_logs).and_return(daily_log)
+        allow(@miq_server).to receive(:current_log_patterns).and_return(current_log_patterns)
+        allow(@miq_server).to receive(:backup_automate_dialogs)
+        allow(@miq_server).to receive(:backup_automate_models)
+        %w(historical_logfile current_logfile).each do |kind|
+          logfile = FactoryGirl.create(:log_file, :historical => kind == "historical_logfile")
+          allow(logfile).to receive(:upload)
+          allow(LogFile).to receive(kind).and_return(logfile)
+        end
+      end
+
+      %w(
+        Archive post_historical_logs
+        Current post_current_logs
+        Models post_automate_models
+        Dialogs post_automate_dialogs
+      ).each_slice(2) do |name, method|
+        it "##{method}" do
+          @miq_server.send(method, task.id, log_depot)
+          logfile = @miq_server.reload.log_files.first
+          expected_name = [name, "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, "20180511_113312 20180511_153416"].join(" ")
+          expect(logfile).to have_attributes(
+            :file_depot         => log_depot,
+            :local_file         => daily_log,
+            :logging_started_on => log_start,
+            :logging_ended_on   => log_end,
+            :name               => expected_name,
+            :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
+            :miq_task_id        => task.id
+          )
+
+          expected_filename = "#{name}_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
+          expected_filename.gsub!(/\s+/, "_")
+          expect(logfile.destination_file_name).to eq(expected_filename)
+
+          expect(task.reload).to have_attributes(
+            :message => "#{name} log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
+            :state   => "Active",
+            :status  => "Ok",
+          )
+        end
+      end
+    end
+
     context "#synchronize_logs" do
       it "passes along server override" do
         @miq_server.synchronize_logs("system", @miq_server2)
@@ -149,66 +209,6 @@ describe MiqServer do
     describe "#post_historical_logs" do
       context "Server" do
         include_examples "post_[type_of_log]_logs", "MiqServer", :historical
-
-        context "new tests" do
-          let(:task)                      { FactoryGirl.create(:miq_task) }
-          let(:compressed_log_patterns)   { [Rails.root.join("log", "evm*.log.gz").to_s] }
-          let(:current_log_patterns)      { [Rails.root.join("log", "evm.log").to_s] }
-          let(:compressed_evm_log)        { Rails.root.join("evm.log-20180319.gz").to_s }
-          let(:log_start)                 { Time.zone.parse("2018-05-11 11:33:12 UTC") }
-          let(:log_end)                   { Time.zone.parse("2018-05-11 15:34:16 UTC") }
-          let(:daily_log)                 { Rails.root.join("data", "user", "system", "evm_server_daily.zip").to_s }
-          let(:log_depot)                 { FactoryGirl.create(:file_depot) }
-          let!(:region)                   { MiqRegion.seed }
-          let(:zone)                      { @miq_server.zone }
-          before do
-            require 'vmdb/util'
-            allow(VMDB::Util).to receive(:compressed_log_patterns).and_return(compressed_log_patterns)
-            allow(VMDB::Util).to receive(:get_evm_log_for_date).and_return(compressed_evm_log)
-            allow(VMDB::Util).to receive(:get_log_start_end_times).and_return([log_start, log_end])
-            allow(VMDB::Util).to receive(:zip_logs).and_return(daily_log)
-            allow(@miq_server).to receive(:current_log_patterns).and_return(current_log_patterns)
-            allow(@miq_server).to receive(:backup_automate_dialogs)
-            allow(@miq_server).to receive(:backup_automate_models)
-            %w(historical_logfile current_logfile).each do |kind|
-              logfile = FactoryGirl.create(:log_file, :historical => kind == "historical_logfile")
-              allow(logfile).to receive(:upload)
-              allow(LogFile).to receive(kind).and_return(logfile)
-            end
-          end
-
-          %w(
-            Archive post_historical_logs
-            Current post_current_logs
-            Models post_automate_models
-            Dialogs post_automate_dialogs
-          ).each_slice(2) do |name, method|
-            it "##{method}" do
-              @miq_server.send(method, task.id, log_depot)
-              logfile = @miq_server.reload.log_files.first
-              expected_name = [name, "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, "20180511_113312 20180511_153416"].join(" ")
-              expect(logfile).to have_attributes(
-                :file_depot         => log_depot,
-                :local_file         => daily_log,
-                :logging_started_on => log_start,
-                :logging_ended_on   => log_end,
-                :name               => expected_name,
-                :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
-                :miq_task_id        => task.id
-              )
-
-              expected_filename = "#{name}_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
-              expected_filename.gsub!(/\s+/, "_")
-              expect(logfile.destination_file_name).to eq(expected_filename)
-
-              expect(task.reload).to have_attributes(
-                :message => "#{name} log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
-                :state   => "Active",
-                :status  => "Ok",
-              )
-            end
-          end
-        end
       end
 
       context "Zone" do

--- a/spec/support/examples_group/shared_examples_for_log_collection.rb
+++ b/spec/support/examples_group/shared_examples_for_log_collection.rb
@@ -2,19 +2,19 @@ shared_examples_for "Log Collection #synchronize_logs" do |type|
   let(:instance) { instance_variable_get("@#{type}") }
 
   it "#{type.camelize} no args" do
-    expect(LogFile).to receive(:logs_from_server).with(MiqServer.my_server, {})
+    expect(LogFile).to receive(:logs_from_server).with(MiqServer.my_server, hash_excluding(:only_current))
 
     instance.synchronize_logs
   end
 
   it "#{type.camelize} with options" do
-    expect(LogFile).to receive(:logs_from_server).with(MiqServer.my_server, :only_current => true)
+    expect(LogFile).to receive(:logs_from_server).with(MiqServer.my_server, hash_including(:only_current => true))
 
     instance.synchronize_logs(:only_current => true)
   end
 
   it "#{type.camelize} user with options" do
-    expect(LogFile).to receive(:logs_from_server).with("test", MiqServer.my_server, :only_current => false)
+    expect(LogFile).to receive(:logs_from_server).with("test", MiqServer.my_server, hash_including(:only_current => false))
 
     instance.synchronize_logs("test", :only_current => false)
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1535179

Depends on prior PRs:
- [x] [Current/historical log collection refactoring](https://github.com/ManageIQ/manageiq/pull/17437) (MERGED)
- [x] [LogFile#name/destination_file_name consolidation](https://github.com/ManageIQ/manageiq/pull/17438) (MERGED)
- [x] [Setting for disabling this feature (include_automate_models_and_dialogs)](https://github.com/ManageIQ/manageiq/pull/17467) (MERGED)

`Settings.log.collection.include_automate_models_and_dialogs` if enabled, we'll include the automate dialogs and models with log collection.

If done on a Zone, the automate models and dialogs will be uploaded by one of the active appliances and will be named based on the appliance that uploaded it.

```
[root@localhost vmdb]# ls -l /home/test/ftp/files/default_1/EVM_1/
total 6740
-rw-r--r--. 1 test test 3911379 May 18 16:56 Archive_region_0_default_1_EVM_1_20171114_132136_20180516_195707.zip
-rw-r--r--. 1 test test  889927 May 18 16:56 Archive_region_0_default_1_EVM_1_20180516_195713_20180517_032559.zip
-rw-r--r--. 1 test test  284611 May 18 16:56 Archive_region_0_default_1_EVM_1_20180517_032602_20180518_134950.zip
-rw-r--r--. 1 test test 1297150 May 18 16:56 Current_region_0_default_1_EVM_1_20180518_152247_20180518_165608.zip
-rw-r--r--. 1 test test    2719 May 18 16:56 Dialogs_region_0_default_1_EVM_1.zip
-rw-r--r--. 1 test test  506811 May 18 16:56 Models_region_0_default_1_EVM_1.zip
```