### PR TITLE
evm:export:service_dialogs -- Set the current user to admin

### DIFF
--- a/lib/task_helpers/exports/service_dialogs.rb
+++ b/lib/task_helpers/exports/service_dialogs.rb
@@ -4,6 +4,7 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
+        User.current_user = User.where(:userid => 'admin').first
         dialogs = DialogSerializer.new.serialize(Dialog.order(:id).all)
 
         dialogs.each do |dialog|


### PR DESCRIPTION
This PR sets the current user when exporting Service Dialogs. When exporting service dialogs an error is logged to evm.log about `User.current_user` being nil when the `id` of the current_user is referenced. In some cases this causes Service Dialogs to not be exported.

Links
----------------

* [evm:export:service_dialogs blows up on a nil user](https://github.com/ManageIQ/manageiq/issues/17443)

Steps for Testing/QA
-------------------------------

* Create a Service Dialog with a dynamic field
* Create a directory to store the exported dialogs `mkdir /tmp/dialogs`
* In a seperate terminal window `tail -f evm.log`
* Export Service Dialogs via the rake command `bin/rake evm:export:service_dialogs -- --directory /tmp/dialogs`
* inspect evm.log for the errors in the referenced issue. With this fix there will be no errors and a yaml file for each Service Dialog will be present in the export directory.

/cc @jrafanie @gmcculloug @eclarizio 