### PR TITLE
removing :each from before and after

### DIFF
--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -5,7 +5,7 @@ describe AssignedServerRole do
     end
 
     context "Server Role" do
-      before (:each) do
+      before do
         @server_role = FactoryGirl.create(
           :server_role,
           :name              => "smartproxy",

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -146,7 +146,7 @@ describe DialogFieldSortedItem do
     let(:default_value) { "test2" }
 
     context "when show_refresh_button is true" do
-      before(:each) do
+      before do
         allow(dialog_field).to receive(:force_multi_value).and_return(false)
       end
       let(:show_refresh_button) { true }
@@ -195,7 +195,7 @@ describe DialogFieldSortedItem do
 
     context "when show_refresh_button is false" do
       let(:show_refresh_button) { false }
-      before(:each) do
+      before do
         allow(dialog_field).to receive(:force_multi_value).and_return(false)
       end
 

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -69,7 +69,7 @@ describe EmsEvent do
 
   context "with availability zones" do
     let(:vm) { FactoryGirl.create(:vm_openstack, :ems_ref => "vm1") }
-    before :each do
+    before do
       @zone = FactoryGirl.create(:small_environment)
       @ems  = @zone.ext_management_systems.first
       @availability_zone = FactoryGirl.create(:availability_zone_openstack, :ems_ref => "az1")
@@ -78,7 +78,7 @@ describe EmsEvent do
     context ".process_availability_zone_in_event!" do
       let(:event_hash) { { :vm_or_template_id => vm.id } }
       context "when the event has an availability zone" do
-        before :each do
+        before do
           event_hash[:availability_zone_ems_ref] = @availability_zone.ems_ref
         end
 
@@ -90,7 +90,7 @@ describe EmsEvent do
 
       context "when the event has no availability zone" do
         context "and the VM has an availability zone" do
-          before :each do
+          before do
             vm.availability_zone_id = @availability_zone.id
             vm.save
           end
@@ -160,7 +160,7 @@ describe EmsEvent do
     end
 
     context ".add" do
-      before :each do
+      before do
         @event_hash = {
           :event_type  => "event_with_availability_zone",
           :target_type => vm.class.name,

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -295,7 +295,7 @@ describe EmsCloud do
           FactoryGirl.create(:cloud_tenant_openstack, :ext_management_system => ems_cloud, :name => ct_name_3)
         end
 
-        before(:each) do
+        before do
           vm_1.cloud_tenant.update_attributes!(:parent => ct_3, :ext_management_system => ems_cloud, :name => ct_name_1)
           vm_2.cloud_tenant.update_attributes!(:ext_management_system => ems_cloud, :name => ct_name_2)
         end

--- a/spec/models/manager_refresh/persister/finders_spec.rb
+++ b/spec/models/manager_refresh/persister/finders_spec.rb
@@ -10,7 +10,7 @@ describe ManagerRefresh::Inventory::Persister do
   # Spec scenarios for asserts giving hints to developers
   ######################################################################################################################
   #
-  before :each do
+  before do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_cloud,
                                :zone            => @zone,

--- a/spec/models/manager_refresh/persister/local_db_finders_spec.rb
+++ b/spec/models/manager_refresh/persister/local_db_finders_spec.rb
@@ -12,7 +12,7 @@ describe ManagerRefresh::Inventory::Persister do
   # Spec scenarios for making sure the local db index is able to build complex queries using references
   ######################################################################################################################
   #
-  before :each do
+  before do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_cloud,
                                :zone            => @zone,
@@ -22,7 +22,7 @@ describe ManagerRefresh::Inventory::Persister do
     allow(Settings.ems_refresh).to receive(:mock).and_return({})
   end
 
-  before :each do
+  before do
     initialize_mocked_records
   end
 

--- a/spec/models/manager_refresh/persister/serializing_spec.rb
+++ b/spec/models/manager_refresh/persister/serializing_spec.rb
@@ -10,7 +10,7 @@ describe ManagerRefresh::Inventory::Persister do
   # Spec scenarios testing Persister can serialize/deserialize, with having complex nested lazy_find links
   ######################################################################################################################
   #
-  before :each do
+  before do
     @zone = FactoryGirl.create(:zone)
     @ems  = FactoryGirl.create(:ems_cloud,
                                :zone            => @zone,

--- a/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/acyclic_graph_of_inventory_collections_spec.rb
@@ -68,7 +68,7 @@ describe ManagerRefresh::SaveInventory do
   [{:inventory_object_saving_strategy => nil},
    {:inventory_object_saving_strategy => :recursive},].each do |inventory_object_settings|
     context "with settings #{inventory_object_settings}" do
-      before :each do
+      before do
         @zone = FactoryGirl.create(:zone)
         @ems  = FactoryGirl.create(:ems_cloud, :zone => @zone)
 
@@ -77,7 +77,7 @@ describe ManagerRefresh::SaveInventory do
       end
 
       context 'with empty DB' do
-        before :each do
+        before do
           initialize_data_and_inventory_collections
         end
 
@@ -586,7 +586,7 @@ describe ManagerRefresh::SaveInventory do
       end
 
       context "lazy_find vs find" do
-        before :each do
+        before do
           # Initialize the InventoryCollections
           @data             = {}
           @data[:vms]       = ::ManagerRefresh::InventoryCollection.new(
@@ -663,7 +663,7 @@ describe ManagerRefresh::SaveInventory do
       end
 
       context "assert_referential_integrity" do
-        before :each do
+        before do
           # Initialize the InventoryCollections
           @data             = {}
           @data[:vms]       = ::ManagerRefresh::InventoryCollection.new(

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_spec.rb
@@ -279,7 +279,7 @@ describe ManagerRefresh::SaveInventory do
   [{:inventory_object_saving_strategy => nil},
    {:inventory_object_saving_strategy => :recursive},].each do |inventory_object_settings|
     context "with settings #{inventory_object_settings}" do
-      before :each do
+      before do
         @zone        = FactoryGirl.create(:zone)
         @ems         = FactoryGirl.create(:ems_cloud, :zone => @zone)
         @ems_network = FactoryGirl.create(:ems_network, :zone => @zone, :parent_manager => @ems)
@@ -289,7 +289,7 @@ describe ManagerRefresh::SaveInventory do
       end
 
       context 'with empty DB' do
-        before :each do
+        before do
           initialize_inventory_collections
         end
 
@@ -359,7 +359,7 @@ describe ManagerRefresh::SaveInventory do
       end
 
       context 'with empty DB and reversed InventoryCollections' do
-        before :each do
+        before do
           initialize_inventory_collections_reversed
         end
 

--- a/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/graph_of_inventory_collections_targeted_refresh_spec.rb
@@ -15,7 +15,7 @@ describe ManagerRefresh::SaveInventory do
   [{:inventory_object_saving_strategy => nil},
    {:inventory_object_saving_strategy => :recursive}].each do |inventory_object_settings|
     context "with settings #{inventory_object_settings}" do
-      before :each do
+      before do
         @zone = FactoryGirl.create(:zone)
         @ems  = FactoryGirl.create(:ems_cloud, :zone => @zone)
 

--- a/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/saver_strategies_spec.rb
@@ -21,7 +21,7 @@ describe ManagerRefresh::SaveInventory do
         {:saver_strategy => :batch, :use_ar_object => false},
       ].each do |options|
         context "with options #{options}" do
-          before :each do
+          before do
             @zone = FactoryGirl.create(:zone)
             @ems  = FactoryGirl.create(:ems_cloud,
                                        :zone            => @zone,
@@ -31,7 +31,7 @@ describe ManagerRefresh::SaveInventory do
             allow(Settings.ems_refresh).to receive(:mock).and_return(inventory_object_settings)
           end
 
-          before :each do
+          before do
             @image1 = FactoryGirl.create(:miq_template, image_data(1))
             @image2 = FactoryGirl.create(:miq_template, image_data(2))
             @image3 = FactoryGirl.create(:miq_template, image_data(3))

--- a/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/single_inventory_collection_spec.rb
@@ -18,7 +18,7 @@ describe ManagerRefresh::SaveInventory do
   [{:inventory_object_saving_strategy => nil},
    {:inventory_object_saving_strategy => :recursive},].each do |inventory_object_settings|
     context "with settings #{inventory_object_settings}" do
-      before :each do
+      before do
         @zone = FactoryGirl.create(:zone)
         @ems  = FactoryGirl.create(:ems_cloud, :zone => @zone)
 
@@ -99,14 +99,14 @@ describe ManagerRefresh::SaveInventory do
       end
 
       context 'with existing Vms in the DB' do
-        before :each do
+        before do
           # Fill DB with test Vms
           @vm1 = FactoryGirl.create(:vm_cloud, vm_data(1).merge(:ext_management_system => @ems))
           @vm2 = FactoryGirl.create(:vm_cloud, vm_data(2).merge(:ext_management_system => @ems))
         end
 
         context 'with VM InventoryCollection with default settings' do
-          before :each do
+          before do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
@@ -237,7 +237,7 @@ describe ManagerRefresh::SaveInventory do
         end
 
         context 'with VM InventoryCollection with :delete_method => :disconnect_inv' do
-          before :each do
+          before do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(
@@ -529,7 +529,7 @@ describe ManagerRefresh::SaveInventory do
         end
 
         context 'with VM InventoryCollection with :complete => false' do
-          before :each do
+          before do
             # Initialize the InventoryCollections
             @data       = {}
             @data[:vms] = ::ManagerRefresh::InventoryCollection.new(

--- a/spec/models/manager_refresh/save_inventory/strategies_and_references_spec.rb
+++ b/spec/models/manager_refresh/save_inventory/strategies_and_references_spec.rb
@@ -17,7 +17,7 @@ describe ManagerRefresh::SaveInventory do
     context "with settings #{inventory_object_settings}" do
       [:local_db_find_references, :local_db_cache_all].each do |db_strategy|
         context "with db strategy #{db_strategy}" do
-          before :each do
+          before do
             @zone = FactoryGirl.create(:zone)
             @ems = FactoryGirl.create(:ems_cloud,
                                       :zone            => @zone,
@@ -27,7 +27,7 @@ describe ManagerRefresh::SaveInventory do
             allow(Settings.ems_refresh).to receive(:mock).and_return(inventory_object_settings)
           end
 
-          before :each do
+          before do
             @image1 = FactoryGirl.create(:miq_template, image_data(1).merge(:ext_management_system => @ems))
             @image2 = FactoryGirl.create(:miq_template, image_data(2).merge(:ext_management_system => @ems))
             @image3 = FactoryGirl.create(:miq_template, image_data(3).merge(:ext_management_system => @ems))

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -97,7 +97,7 @@ describe Metric::CiMixin::Capture do
 
     ["miq_postgres", "miq_postgres_legacy"].each do |postgre_adapter|
       context "with adapter #{postgre_adapter}" do
-        before :each do
+        before do
           mock_adapter(postgre_adapter)
         end
 

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -6,7 +6,7 @@ describe Metric do
   end
 
   context "as vmware" do
-    before :each do
+    before do
       @ems_vmware = FactoryGirl.create(:ems_vmware, :zone => @zone)
     end
 
@@ -991,7 +991,7 @@ describe Metric do
   end
 
   context "as openstack" do
-    before :each do
+    before do
       @ems_openstack = FactoryGirl.create(:ems_openstack, :zone => @zone)
     end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -150,7 +150,7 @@ describe MiqGroup do
     let(:num_cpu) { 2 }
     let(:ems) { FactoryGirl.create(:ems_vmware, :name => "test_vcenter") }
     let(:storage) { FactoryGirl.create(:storage, :name => "test_storage_nfs", :store_type => "NFS") }
-    before :each do
+    before do
       @hw1 = FactoryGirl.create(:hardware, :cpu_total_cores => num_cpu, :memory_mb => ram_size)
       @hw2 = FactoryGirl.create(:hardware, :cpu_total_cores => num_cpu, :memory_mb => ram_size)
       @hw3 = FactoryGirl.create(:hardware, :cpu_total_cores => num_cpu, :memory_mb => ram_size)

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -18,7 +18,7 @@ describe MiqRegion do
     end
 
     context "with cloud and infra EMSes" do
-      before :each do
+      before do
         _, _, zone = EvmSpecHelper.create_guid_miq_server_zone
         ems_vmware = FactoryGirl.create(:ems_vmware, :zone => zone)
         ems_openstack = FactoryGirl.create(:ems_openstack, :zone => zone)

--- a/spec/models/miq_report/generator_spec.rb
+++ b/spec/models/miq_report/generator_spec.rb
@@ -8,7 +8,7 @@ describe MiqReport::Generator do
 
   describe "#generate" do
     context "Memory Utilization Trends report (daily)" do
-      before :each do
+      before do
         @miq_report_profile_all = FactoryGirl.create(
           :miq_report,
           :db              => "VimPerformanceTrend",

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReportResult do
-  before :each do
+  before do
     EvmSpecHelper.local_miq_server
 
     @user1 = FactoryGirl.create(:user_with_group)
@@ -28,7 +28,7 @@ describe MiqReportResult do
   end
 
   context "report result created by User 1 with current group 1" do
-    before :each do
+    before do
       @report_1 = FactoryGirl.create(:miq_report)
       group_1 = FactoryGirl.create(:miq_group)
       group_2 = FactoryGirl.create(:miq_group)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -173,7 +173,7 @@ describe Tag do
     let(:filters)         { [["/managed/prov_max_memory/test"], ["/managed/my_name/test"]] }
     let(:tag)             { FactoryGirl.create(:tag, :name => "/managed/my_name/test") }
 
-    before :each do
+    before do
       miq_group.entitlement.set_managed_filters(filters)
       other_miq_group.entitlement.set_managed_filters(filters)
       [miq_group, other_miq_group].each(&:save)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -277,7 +277,7 @@ describe User do
   end
 
   context "Testing active VM aggregation" do
-    before :each do
+    before do
       @ram_size = 1024
       @disk_size = 1_000_000
       @num_cpu = 2

--- a/spec/models/vmdb_database_connection_spec.rb
+++ b/spec/models/vmdb_database_connection_spec.rb
@@ -1,7 +1,7 @@
 require "concurrent/atomic/event"
 
 describe VmdbDatabaseConnection do
-  before :each do
+  before do
     @db = FactoryGirl.create(:vmdb_database)
   end
 

--- a/spec/models/vmdb_database_setting_spec.rb
+++ b/spec/models/vmdb_database_setting_spec.rb
@@ -1,5 +1,5 @@
 describe VmdbDatabaseSetting do
-  before :each do
+  before do
     @db = FactoryGirl.create(:vmdb_database)
   end
 

--- a/spec/models/vmdb_database_spec.rb
+++ b/spec/models/vmdb_database_spec.rb
@@ -1,5 +1,5 @@
 describe VmdbDatabase do
-  before :each do
+  before do
     @db    = FactoryGirl.create(:vmdb_database)
     @table = FactoryGirl.create(:vmdb_table_evm,  :vmdb_database => @db, :name => 'accounts')
     @text  = FactoryGirl.create(:vmdb_table_text, :vmdb_database => @db, :name => 'accounts', :parent_id => @table.id)
@@ -85,7 +85,7 @@ describe VmdbDatabase do
   end
 
   context "#top_tables_by" do
-    before :each do
+    before do
       @table_1 = FactoryGirl.create(:vmdb_table_evm,  :vmdb_database => @db, :name => 'accounts1')
       @table_2 = FactoryGirl.create(:vmdb_table_evm,  :vmdb_database => @db, :name => 'accounts2')
       @table_3 = FactoryGirl.create(:vmdb_table_evm,  :vmdb_database => @db, :name => 'accounts3')

--- a/spec/models/vmdb_index_spec.rb
+++ b/spec/models/vmdb_index_spec.rb
@@ -32,7 +32,7 @@ describe VmdbIndex do
   end
 
   context "#rollup_metrics" do
-    before :each do
+    before do
       db = VmdbDatabase.seed_self
       @evm_table  = FactoryGirl.create(:vmdb_table_evm, :vmdb_database => db,         :name => 'accounts')
       @evm_index  = FactoryGirl.create(:vmdb_index,     :vmdb_table    => @evm_table, :name => "accounts_pkey")

--- a/spec/models/vmdb_table_evm_spec.rb
+++ b/spec/models/vmdb_table_evm_spec.rb
@@ -129,7 +129,7 @@ describe VmdbTableEvm do
   end
 
   context "#rollup_metrics" do
-    before :each do
+    before do
       db = VmdbDatabase.seed_self
       @evm_table = FactoryGirl.create(:vmdb_table_evm, :vmdb_database => db, :name => 'accounts')
 

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -37,7 +37,7 @@ describe Zone do
   end
 
   context "when dealing with clouds" do
-    before :each do
+    before do
       _, _, @zone = EvmSpecHelper.create_guid_miq_server_zone
     end
 

--- a/spec/tools/environment_builders/openstack/tests/interaction_methods_spec.rb
+++ b/spec/tools/environment_builders/openstack/tests/interaction_methods_spec.rb
@@ -62,7 +62,7 @@ describe Openstack::InteractionMethods do
   context "#Openstack::InteractionMethods" do
     let(:subject) { (Class.new { include Openstack::InteractionMethods }).new }
 
-    before :each do
+    before do
       allow($stdout).to receive(:puts)
     end
 

--- a/tools/radar/rollup_radar_mixin_spec.rb
+++ b/tools/radar/rollup_radar_mixin_spec.rb
@@ -123,7 +123,7 @@ describe RollupRadarMixin do
       sett
     end
 
-    before(:each) do
+    before do
       add_metrics([container_a, container_b])
     end
 
@@ -177,7 +177,7 @@ describe RollupRadarMixin do
       sett
     end
 
-    before(:each) do
+    before do
       add_metrics([container_a, container_b])
     end
 
@@ -276,7 +276,7 @@ describe RollupRadarMixin do
                          :section => 'docker_labels')
     end
 
-    before(:each) do
+    before do
       add_metrics([container_a, container_b])
     end
 
@@ -298,7 +298,7 @@ describe RollupRadarMixin do
     end
   end
 
-  after(:each) do
+  after do
     Timecop.return
   end
 end


### PR DESCRIPTION
`:each` is the default for rspec `before` and `after` blocks, so we don't need to specify it.

refers to #16366