### PR TITLE
Adjust how default_value is calculated for multi-select drop downs

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -58,6 +58,20 @@ class DialogFieldDropDownList < DialogFieldSortedItem
 
   private
 
+  def determine_selected_value
+    coerce_default_value_into_proper_format if dynamic? && force_multi_value
+
+    super
+  end
+
+  def use_first_value_as_default
+    self.default_value = if force_multi_value
+                           [].to_json
+                         else
+                           sort_data(@raw_values).first.try(:first)
+                         end
+  end
+
   def default_value_included?(values_list)
     if force_multi_value
       return false if default_value.blank?
@@ -68,5 +82,13 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     else
       super(values_list)
     end
+  end
+
+  def coerce_default_value_into_proper_format
+    unless JSON.parse(default_value).kind_of?(Array)
+      self.default_value = Array.wrap(default_value).to_json
+    end
+  rescue JSON::ParserError
+    self.default_value = Array.wrap(default_value).to_json
   end
 end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -113,9 +113,6 @@ class DialogFieldSortedItem < DialogField
   end
 
   def determine_selected_value
-    if dynamic? && force_multi_value && !default_value.kind_of?(Array)
-      self.default_value = Array.wrap(default_value)
-    end
     use_first_value_as_default unless default_value_included?(@raw_values)
     self.value ||= default_value.nil? && data_type == "integer" ? nil : default_value.send(value_modifier)
   end

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -296,11 +296,63 @@ describe DialogFieldDropDownList do
 
           context "when the values returned contain a nil" do
             before do
-              allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return([[nil, "Choose something!"]])
+              allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(
+                [[nil, "Choose something!"], %w(1 one), %w(2 two), %w(abc def)]
+              )
+            end
+
+            context "when it is a multiselect" do
+              before do
+                dialog_field.force_multi_value = true
+              end
+
+              context "when the default value is included" do
+                before do
+                  dialog_field.default_value = "[\"1\"]"
+                end
+
+                it "keeps the default" do
+                  dialog_field.values
+                  expect(dialog_field.default_value).to eq("[\"1\"]")
+                end
+              end
+
+              context "when the default value is included but is not an array" do
+                before do
+                  dialog_field.default_value = "1"
+                end
+
+                it "keeps the default" do
+                  dialog_field.values
+                  expect(dialog_field.default_value).to eq("[\"1\"]")
+                end
+              end
+
+              context "when the default value is included but is not valid json" do
+                before do
+                  dialog_field.default_value = "abc"
+                end
+
+                it "keeps the default" do
+                  dialog_field.values
+                  expect(dialog_field.default_value).to eq("[\"abc\"]")
+                end
+              end
+
+              context "when the default value is not included" do
+                before do
+                  dialog_field.default_value = "[\"3\"]"
+                end
+
+                it "selects nothing" do
+                  dialog_field.values
+                  expect(dialog_field.default_value).to eq("[]")
+                end
+              end
             end
 
             it "returns the values from automate" do
-              expect(dialog_field.values).to eq([[nil, "Choose something!"]])
+              expect(dialog_field.values).to eq([[nil, "Choose something!"], %w(1 one), %w(2 two), %w(abc def)])
             end
           end
         end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -299,29 +299,6 @@ describe DialogFieldSortedItem do
         end
       end
 
-      context "when the force_multi_value is set to true" do
-        let(:default_value) { "abc" }
-        before do
-          allow(dialog_field).to receive(:force_multi_value).and_return(true)
-          # FIXME (rblanco): this is a workaround for the tested class being
-          # DialogFieldSortedItem and not DialogFieldDropDownList as it is
-          # in real usecase
-          #
-          # The test should be moved to dialog_field_drop_down_list_spec.rb, as
-          # https://github.com/ManageIQ/manageiq/pull/17272#discussion_r180468970
-          # says.
-          allow(dialog_field).to receive(:default_value_included?).and_return(true)
-        end
-
-        it "sets the default_value" do
-          dialog_field.values
-          # while reproducing the BZ, the method
-          # `determine_selected_default_value` is called twice,
-          # not just once - could be a difference here
-          expect(dialog_field.default_value).to eq("[\"abc\"]")
-        end
-      end
-
       context "when the default_value is included in the list of returned values" do
         before do
           allow(dialog_field).to receive(:force_multi_value).and_return(false)


### PR DESCRIPTION
Somewhat related to [this PR](https://github.com/ManageIQ/manageiq/pull/17272), but will clean up some of the specs and attempt to force the `default_value` for multiselect drop downs to behave consistently.

https://bugzilla.redhat.com/show_bug.cgi?id=1576288

Basically, with this change, multiselects driven by automate domains should behave slightly differently. Before, you could select a "nil" value, but that doesn't really make too much sense when you're dealing with a multiselect, because you will have to unselect the nil value after you pick another value. So instead of a nil value being selected, nothing will be selected.

Also, with this fix, within automate, the user can set their default values in a few ways:
```ruby
dialog_field = $evm.object
dialog_field['values'] = [["foo", "Foo"], ["bar", "Bar"], ["baz", "Baz"]]

dialog_field['default_value'] = "foo" # This method for selecting a single item only
dialog_field['default_value'] = ["foo", "bar"] # The preferred way to select two items
dialog_field['default_value'] = '["foo", "bar"]' # Another way to select two items (though admittedly a bit strange)

dialog_field['default_value'] = "foo, bar" # This DOES NOT work, and the field will end up with "Nothing selected"
```

@himdel I know this was kinda messy before, hopefully this cleans it up a bit. Think you can review quickly so this can get in for the build?

@d-m-u Can you review please?

@miq-bot add_label gaprindashvili/yes, bug, blocker

@miq-bot assign @gmcculloug 