### PR TITLE
cockpit-auth-miq: Use "private-key" auth scheme

### DIFF
--- a/tools/cockpit/cockpit-auth-miq
+++ b/tools/cockpit/cockpit-auth-miq
@@ -177,7 +177,7 @@ def launch_ssh_with_authorize_cmd(ssh_command, host, user, password, key)
   host = "#{user}@#{host}"
 
   auth_data = 'Basic ' + Base64.encode64("#{user}:#{password}").chomp unless password.nil?
-  auth_data = "host-key #{key}" unless key.nil?
+  auth_data = "private-key #{key}" unless key.nil?
   send_auth_command(nil, auth_data, nil)
   exec(env, ssh_command, host, 0 => $stdin, 1 => $stdout, 2 => $stderr)
 end


### PR DESCRIPTION
"host-key" might have been the old name for this, but it was never
officially supported.  I think.

@petervo knows the history, I am sure. He also said that private keys are no longer supported at all by ManageIQ, so maybe it is best to remove this code altogether if it is untestable.
