### PR TITLE
 Keep track of the server ids where the automate task has been processed.

### DIFF
--- a/app/models/miq_provision/state_machine.rb
+++ b/app/models/miq_provision/state_machine.rb
@@ -121,6 +121,7 @@ module MiqProvision::StateMachine
   end
 
   def finish
+    mark_execution_servers
     if status != 'Error'
       number_of_vms = get_option(:number_of_vms).to_i
       pass = get_option(:pass)

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -69,6 +69,7 @@ module MiqRequestTask::StateMachine
   end
 
   def requeue_phase
+    mark_execution_servers
     save # Save current phase_context
     MiqQueue.put(
       :class_name     => self.class.name,

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -169,4 +169,10 @@ module MiqRequestMixin
     dialog = ResourceActionWorkflow.new(values, get_user, ra, {}).dialog
     DialogSerializer.new.serialize(Array[dialog]).first
   end
+
+  def mark_execution_servers
+    options[:executed_on_servers] ||= []
+    options[:executed_on_servers] << MiqServer.my_server.id
+    update_attributes(:options => options)
+  end
 end

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -233,5 +233,23 @@ describe ServiceTemplateProvisionTask do
         @task_1_2.update_and_notify_parent(:state => "finished", :status => "Ok", :message => "Test Message")
       end
     end
+
+    describe "#mark_execution_servers" do
+      let(:server) { FactoryGirl.create(:miq_server) }
+      before { allow(MiqServer).to receive(:my_server).and_return(server) }
+
+      it "with new server id" do
+        @task_0.mark_execution_servers
+        expect(@task_0.options[:executed_on_servers]).to eq([server.id])
+      end
+
+      it "with existing server id" do
+        @task_0.options[:executed_on_servers] = [server.id]
+        @task_0.save!
+
+        @task_0.mark_execution_servers
+        expect(@task_0.options[:executed_on_servers]).to eq([server.id, server.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
Support has been asking us for helping them with diagnosing customer issues. Since we have multiple appliances and a task can bounce around from one appliance to the next, they would like to know on which appliance a task ran so that they can hone in on specific logs.

This PR tries to store the different server ids where a task was executed in the "options" hash. Which can then be used for debugging.
  
Automate tasks can get put back on the queue and picked back up several times during an automate task. 
Includes https://github.com/ManageIQ/manageiq-automation_engine/pull/183.

https://bugzilla.redhat.com/show_bug.cgi?id=1535237

@miq-bot assign @gmcculloug 
@miq-bot add_label automate