### PR TITLE
Suspend providers

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -72,7 +72,7 @@ class ExtManagementSystem < ApplicationRecord
   has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   belongs_to :zone
-  belongs_to :backup_zone, :class_name => "Zone", :inverse_of => :paused_ext_management_systems # used for maintenance mode
+  belongs_to :zone_before_pause, :class_name => "Zone", :inverse_of => :paused_ext_management_systems # used for maintenance mode
 
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
@@ -226,9 +226,9 @@ class ExtManagementSystem < ApplicationRecord
   def pause!
     _log.info("Pausing EMS [#{name}] id [#{id}].")
     update!(
-      :backup_zone => zone,
-      :zone        => Zone.maintenance_zone,
-      :enabled     => false
+      :zone_before_pause => zone,
+      :zone              => Zone.maintenance_zone,
+      :enabled           => false
     )
     _log.info("Pausing EMS [#{name}] id [#{id}] successful.")
   end
@@ -237,9 +237,9 @@ class ExtManagementSystem < ApplicationRecord
   def resume!
     _log.info("Resuming EMS [#{name}] id [#{id}].")
     update!(
-      :backup_zone => nil,
-      :zone        => backup_zone || Zone.default_zone,
-      :enabled     => true
+      :zone_before_pause => nil,
+      :zone              => zone_before_pause || Zone.default_zone,
+      :enabled           => true
     )
     _log.info("Resuming EMS [#{name}] id [#{id}] successful.")
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -236,9 +236,16 @@ class ExtManagementSystem < ApplicationRecord
   # Move ems to original zone, reschedule task/jobs/.. collected during maintenance
   def resume!
     _log.info("Resuming EMS [#{name}] id [#{id}].")
+
+    new_zone = if zone_before_pause.nil?
+                 zone.visible? ? zone : Zone.default_zone
+               else
+                 zone_before_pause
+               end
+
     update!(
       :zone_before_pause => nil,
-      :zone              => zone_before_pause || Zone.default_zone,
+      :zone              => new_zone,
       :enabled           => true
     )
     _log.info("Resuming EMS [#{name}] id [#{id}] successful.")

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -126,7 +126,7 @@ class ExtManagementSystem < ApplicationRecord
 
   # validation - Zone cannot be maintenance_zone when enabled == true
   def validate_zone_not_maintenance_when_ems_enabled?
-    if enabled? && zone == Zone.maintenance_zone
+    if enabled? && zone.present? && zone == Zone.maintenance_zone
       errors.add(:zone, N_("cannot be the maintenance zone when provider is active"))
     end
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -223,11 +223,10 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   # Move ems to maintenance zone and backup current one
-  # @param orig_zone [Zone] children original zones can be replaced in provider-specific callbacks
-  def pause!(orig_zone = nil)
+  def pause!
     _log.info("Pausing EMS [#{name}] id [#{id}].")
     update!(
-      :backup_zone => orig_zone || zone,
+      :backup_zone => zone,
       :zone        => Zone.maintenance_zone,
       :enabled     => false
     )
@@ -800,12 +799,10 @@ class ExtManagementSystem < ApplicationRecord
 
   # Child managers went to/from maintenance mode with parent
   def change_maintenance_for_child_managers
-    child_managers.each do |child_ems|
-      if enabled?
-        child_ems.resume!
-      else
-        child_ems.pause!(backup_zone)
-      end
+    if enabled?
+      child_managers.each(&:enable!)
+    else
+      child_managers.each(&:disable!)
     end
   end
 

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -128,6 +128,11 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
+    if options[:zone] == Zone::MAINTENANCE_ZONE_NAME
+      _log.debug("MiqQueue#put skipped: #{options.inspect}")
+      return
+    end
+
     create_with_options = all.values[:create_with] || {}
     options[:priority]    ||= create_with_options[:priority] || NORMAL_PRIORITY
     options[:queue_name]  ||= create_with_options[:queue_name] || "generic"

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -128,7 +128,7 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
-    if options[:zone] == Zone::MAINTENANCE_ZONE_NAME
+    if options[:zone] == Zone.maintenance_zone&.name
       _log.debug("MiqQueue#put skipped: #{options.inspect}")
       return
     end
@@ -180,7 +180,6 @@ class MiqQueue < ApplicationRecord
   def self.submit_job(options)
     service = options.delete(:service) || "generic"
     resource = options.delete(:affinity)
-
     case service
     when "automate"
       # options[:queue_name] = "generic"

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -128,7 +128,7 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
-    if options[:zone] == Zone.maintenance_zone&.name
+    if options[:zone].present? && options[:zone] == Zone.maintenance_zone&.name
       _log.debug("MiqQueue#put skipped: #{options.inspect}")
       return
     end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -175,6 +175,7 @@ class MiqQueue < ApplicationRecord
   def self.submit_job(options)
     service = options.delete(:service) || "generic"
     resource = options.delete(:affinity)
+
     case service
     when "automate"
       # options[:queue_name] = "generic"

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -1,5 +1,5 @@
 class MiqRegion < ApplicationRecord
-  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_region
+  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => false
 
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -1,4 +1,6 @@
 class MiqRegion < ApplicationRecord
+  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_regions
+
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -1,5 +1,5 @@
 class MiqRegion < ApplicationRecord
-  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_regions
+  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_region
 
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -39,7 +39,7 @@ class MiqServer < ApplicationRecord
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
   virtual_delegate :description, :to => :zone, :prefix => true
 
-  validate :validate_zone_visible?
+  validate :validate_zone_not_maintenance?
 
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze
@@ -55,8 +55,8 @@ class MiqServer < ApplicationRecord
 
   RESTART_EXIT_STATUS = 123
 
-  def validate_zone_visible?
-    errors.add(:zone, N_('has to be visible')) unless zone.visible?
+  def validate_zone_not_maintenance?
+    errors.add(:zone, N_('cannot be maintenance zone')) if zone == Zone.maintenance_zone
   end
 
   def hostname

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -39,6 +39,8 @@ class MiqServer < ApplicationRecord
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
   virtual_delegate :description, :to => :zone, :prefix => true
 
+  validate :validate_zone_visible?, :if => proc { |server| server.zone.present? }
+
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze
   STATUS_RESTARTING     = 'restarting'.freeze
@@ -52,6 +54,10 @@ class MiqServer < ApplicationRecord
   STATUSES_ALIVE   = STATUSES_ACTIVE + [STATUS_RESTARTING, STATUS_QUIESCE]
 
   RESTART_EXIT_STATUS = 123
+
+  def validate_zone_visible?
+    errors.add(:zone, N_('has to be visible')) unless zone.visible?
+  end
 
   def hostname
     h = super

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -39,7 +39,7 @@ class MiqServer < ApplicationRecord
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
   virtual_delegate :description, :to => :zone, :prefix => true
 
-  validate :validate_zone_visible?, :if => proc { |server| server.zone.present? }
+  validate :validate_zone_visible?
 
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -4,11 +4,12 @@ class Zone < ApplicationRecord
 
   serialize :settings, Hash
 
-  belongs_to      :log_file_depot, :class_name => "FileDepot"
+  belongs_to :log_file_depot, :class_name => "FileDepot"
 
   has_many :miq_servers
   has_many :ext_management_systems
-  has_many :paused_ext_management_systems, :class_name => 'ExtManagementSystem', :inverse_of => :backup_zone
+  has_many :paused_ext_management_systems, :class_name => 'ExtManagementSystem', :inverse_of => :zone_before_pause
+  has_one  :maintenance_zone_region, :class_name => 'MiqRegion', :inverse_of => :maintenance_zone
   has_many :container_managers, :class_name => "ManageIQ::Providers::ContainerManager"
   has_many :miq_schedules, :dependent => :destroy
   has_many :providers
@@ -40,7 +41,7 @@ class Zone < ApplicationRecord
   scope :visible, -> { where(:visible => true) }
   default_value_for :visible, true
 
-  MAINTENANCE_ZONE_NAME = '__maintenance__'.freeze
+  MAINTENANCE_ZONE_NAME_PREFIX = '__maintenance__'.freeze
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)
@@ -54,10 +55,38 @@ class Zone < ApplicationRecord
     active_miq_servers.detect(&:is_master?)
   end
 
-  def self.seed
-    create_with(:description => "Maintenance Zone", :visible => false).find_or_create_by!(:name => MAINTENANCE_ZONE_NAME) do |_z|
-      _log.info("Creating maintenance zone...")
+  def self.create_maintenance_zone
+    if maintenance_zone.nil?
+      # 1) Create region, if not exists
+      MiqRegion.seed
+
+      # 2) Create Maintenance zone
+      threshold = 100 # avoiding infinite loop
+      zone = nil
+      (1..threshold).each do |idx|
+        zone = create(:name        => "#{MAINTENANCE_ZONE_NAME_PREFIX}#{idx}",
+                      :description => "Maintenance Zone",
+                      :visible     => false)
+        break if zone.valid?
+      end
+
+      # 3) Assign zone to region
+      if zone&.valid?
+        region = zone.miq_region
+        region&.maintenance_zone = zone
+        unless region&.save
+          _log.error("Saving Maintenance zone to region failed with: #{region&.errors&.messages.inspect}")
+        end
+        _log.info("Creating maintenance zone...")
+      else
+        _log.error("Maintenance zone not created in #{threshold} attempts")
+      end
     end
+  end
+
+  def self.seed
+    create_maintenance_zone
+
     create_with(:description => "Default Zone").find_or_create_by!(:name => 'default') do |_z|
       _log.info("Creating default zone...")
     end
@@ -87,9 +116,9 @@ class Zone < ApplicationRecord
     in_my_region.find_by(:name => "default")
   end
 
-  # Zone for suspended providers (no servers in it), not visible by default
+  # Zone for paused providers (no servers in it), not visible by default
   def self.maintenance_zone
-    in_my_region.find_by(:name => MAINTENANCE_ZONE_NAME)
+    MiqRegion.find_by(:region => my_region_number)&.maintenance_zone
   end
 
   def remote_cockpit_ws_miq_server
@@ -223,7 +252,7 @@ class Zone < ApplicationRecord
 
   def check_zone_in_use_on_destroy
     raise _("cannot delete default zone") if name == "default"
-    raise _("cannot delete maintenance zone") if name == MAINTENANCE_ZONE_NAME
+    raise _("cannot delete maintenance zone") if self == miq_region&.maintenance_zone
     raise _("zone name '%{name}' is used by a server") % {:name => name} unless miq_servers.blank?
   end
 end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -53,7 +53,6 @@ class Zone < ApplicationRecord
   end
 
   def self.create_maintenance_zone
-    MiqRegion.seed
     return MiqRegion.my_region.maintenance_zone if MiqRegion.my_region.maintenance_zone.present?
 
     begin

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -74,6 +74,7 @@ class Zone < ApplicationRecord
   private_class_method :create_maintenance_zone
 
   def self.seed
+    MiqRegion.seed
     create_maintenance_zone
 
     create_with(:description => "Default Zone").find_or_create_by!(:name => 'default') do |_z|

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -38,6 +38,7 @@ class Zone < ApplicationRecord
   include ConfigurationManagementMixin
 
   scope :visible, -> { where(:visible => true) }
+  default_value_for :visible, true
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -1,6 +1,7 @@
 describe AutomationRequest do
   let(:admin) { FactoryBot.create(:user, :role => "admin") }
   before do
+    MiqRegion.seed
     allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
     @zone        = FactoryBot.create(:zone, :name => "fred")
     @approver    = FactoryBot.create(:user_miq_request_approver)

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -91,6 +91,7 @@ describe CustomButton do
 
       context "when invoking for a particular VM" do
         before do
+          MiqRegion.seed
           @vm    = FactoryBot.create(:vm_vmware)
           @user2 = FactoryBot.create(:user_with_group)
           EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
@@ -321,6 +322,7 @@ describe CustomButton do
     let(:custom_button)   { FactoryBot.create(:custom_button, :applies_to => vm.class, :resource_action => resource_action) }
 
     before do
+      MiqRegion.seed
       EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
     end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -452,7 +452,10 @@ describe ExtManagementSystem do
   end
 
   context "#resume" do
-    before { Zone.seed }
+    before do
+      MiqRegion.seed
+      Zone.seed
+    end
 
     it "enables an ems with child managers and move them from maintenance zone" do
       zone = FactoryGirl.create(:zone)
@@ -528,7 +531,10 @@ describe ExtManagementSystem do
   end
 
   context "changing zone" do
-    before { Zone.seed }
+    before do
+      MiqRegion.seed
+      Zone.seed
+    end
 
     it 'is allowed when enabled' do
       zone = FactoryGirl.create(:zone)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -397,7 +397,7 @@ describe ExtManagementSystem do
   end
 
   context "#pause!" do
-    it 'disables an ems with child managers and moves them to maintenance zone' do
+    it 'disables an ems with child managers and moves parent to maintenance zone' do
       zone  = FactoryGirl.create(:zone)
       ems   = FactoryGirl.create(:ext_management_system, :zone => zone)
       child = FactoryGirl.create(:ext_management_system, :zone => zone)
@@ -411,13 +411,11 @@ describe ExtManagementSystem do
 
       child.reload
       expect(child.enabled).to be_falsy
-      expect(child.zone).to eq(Zone.maintenance_zone)
-      expect(child.backup_zone).to eq(zone)
     end
   end
 
   context "#resume" do
-    it "enables an ems with child managers and move them from maintenance zone" do
+    it "enables an ems with child managers and move parent from maintenance zone" do
       zone = FactoryGirl.create(:zone)
       ems = FactoryGirl.create(:ext_management_system,
                                :backup_zone => zone,
@@ -425,9 +423,8 @@ describe ExtManagementSystem do
                                :enabled     => false)
 
       child = FactoryGirl.create(:ext_management_system,
-                                 :backup_zone => zone,
-                                 :zone        => Zone.maintenance_zone,
-                                 :enabled     => false)
+                                 :zone    => zone,
+                                 :enabled => false)
       ems.child_managers << child
 
       ems.resume!
@@ -438,8 +435,6 @@ describe ExtManagementSystem do
 
       child.reload
       expect(child.enabled).to be_truthy
-      expect(child.zone).to eq(zone)
-      expect(child.backup_zone).to be_nil
     end
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -531,18 +531,18 @@ describe ExtManagementSystem do
     before { Zone.seed }
 
     it 'is allowed when enabled' do
-      zones = FactoryGirl.create_list(:zone, 2)
-      ems   = FactoryGirl.create(:ext_management_system, :zone => zones[0])
+      zone = FactoryGirl.create(:zone)
+      ems  = FactoryGirl.create(:ext_management_system, :zone => Zone.default_zone)
 
-      ems.zone = zones[1]
+      ems.zone = zone
       expect(ems.save).to eq(true)
     end
 
     it 'is denied when disabled' do
-      zones = FactoryGirl.create_list(:zone, 2)
-      ems   = FactoryGirl.create(:ext_management_system, :zone => zones[0], :enabled => false)
+      zone = FactoryGirl.create(:zone)
+      ems  = FactoryGirl.create(:ext_management_system, :zone => Zone.default_zone, :enabled => false)
 
-      ems.zone = zones[1]
+      ems.zone = zone
       expect(ems.save).to eq(false)
       expect(ems.errors.messages[:zone]).to be_present
     end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -436,6 +436,19 @@ describe ExtManagementSystem do
       child.reload
       expect(child.enabled).to be_truthy
     end
+
+    it "doesn't change zone when current is visible" do
+      zone = FactoryGirl.create(:zone)
+      ems = FactoryGirl.create(:ext_management_system,
+                               :zone_before_pause => nil,
+                               :zone              => zone,
+                               :enabled           => false)
+
+      ems.resume!
+
+      expect(ems.enabled).to be_truthy
+      expect(ems.zone).to eq(zone)
+    end
   end
 
   context "changing zone" do

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -407,7 +407,7 @@ describe ExtManagementSystem do
 
       expect(ems.enabled).to be_falsy
       expect(ems.zone).to eq(Zone.maintenance_zone)
-      expect(ems.backup_zone).to eq(zone)
+      expect(ems.zone_before_pause).to eq(zone)
 
       child.reload
       expect(child.enabled).to be_falsy
@@ -418,9 +418,9 @@ describe ExtManagementSystem do
     it "enables an ems with child managers and move parent from maintenance zone" do
       zone = FactoryGirl.create(:zone)
       ems = FactoryGirl.create(:ext_management_system,
-                               :backup_zone => zone,
-                               :zone        => Zone.maintenance_zone,
-                               :enabled     => false)
+                               :zone_before_pause => zone,
+                               :zone              => Zone.maintenance_zone,
+                               :enabled           => false)
 
       child = FactoryGirl.create(:ext_management_system,
                                  :zone    => zone,
@@ -431,7 +431,7 @@ describe ExtManagementSystem do
 
       expect(ems.enabled).to be_truthy
       expect(ems.zone).to eq(zone)
-      expect(ems.backup_zone).to be_nil
+      expect(ems.zone_before_pause).to be_nil
 
       child.reload
       expect(child.enabled).to be_truthy

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -443,6 +443,36 @@ describe ExtManagementSystem do
     end
   end
 
+  context "changing zone" do
+    it 'is allowed when enabled' do
+      zones = (1..2).collect { FactoryGirl.create(:zone) }
+      ems   = FactoryGirl.create(:ext_management_system, :zone => zones[0])
+
+      ems.zone = zones[1]
+      expect(ems.save).to be_truthy
+    end
+
+    it 'is denied when disabled' do
+      zones = (1..2).collect { FactoryGirl.create(:zone) }
+      ems   = FactoryGirl.create(:ext_management_system, :zone => zones[0], :enabled => false)
+
+      ems.zone = zones[1]
+      expect(ems.save).to be_falsy
+      expect(ems.errors.messages[:zone]).to be_present
+    end
+
+    it 'to invisible is not possible when provider enabled' do
+      zone_visible = FactoryGirl.create(:zone)
+      zone_invisible = FactoryGirl.create(:zone, :visible => false)
+
+      ems = FactoryGirl.create(:ext_management_system, :zone => zone_visible, :enabled => true)
+
+      ems.zone = zone_invisible
+      expect(ems.save).to be_falsy
+      expect(ems.errors.messages[:zone]).to be_present
+    end
+  end
+
   context "destroy" do
     it "destroys an ems with no active workers" do
       ems = FactoryBot.create(:ext_management_system)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -354,6 +354,7 @@ describe MiqQueue do
 
   context "#put" do
     before do
+      MiqRegion.seed
       Zone.seed
       _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
     end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -368,6 +368,19 @@ describe MiqQueue do
       expect(MiqQueue.get).to eq(nil)
     end
 
+    it "should skip putting message on queue in maintenance zone" do
+      Zone.seed
+
+      msg = MiqQueue.put(
+        :class_name  => 'MyClass',
+        :method_name => 'method1',
+        :args        => [1, 2],
+        :zone        => Zone.maintenance_zone&.name
+      )
+
+      expect(MiqQueue.get).to eq(nil)
+    end
+
     it "should accept non-Array args (for now)" do
       begin
         class MiqQueueSpecNonArrayArgs

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -354,6 +354,7 @@ describe MiqQueue do
 
   context "#put" do
     before do
+      Zone.seed
       _, @miq_server, = EvmSpecHelper.create_guid_miq_server_zone
     end
 
@@ -369,16 +370,13 @@ describe MiqQueue do
     end
 
     it "should skip putting message on queue in maintenance zone" do
-      Zone.seed
-
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
         :args        => [1, 2],
-        :zone        => Zone.maintenance_zone&.name
+        :zone        => Zone.maintenance_zone.name
       )
-
-      expect(MiqQueue.get).to eq(nil)
+      expect(MiqQueue.count).to eq(0)
     end
 
     it "should accept non-Array args (for now)" do

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -1,5 +1,6 @@
 describe MiqServer do
   before do
+    MiqRegion.seed
     @server = EvmSpecHelper.local_miq_server(:zone => Zone.seed)
   end
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,6 +1,10 @@
 describe MiqServer do
   context ".seed" do
-    before { Zone.seed }
+    before do
+      MiqRegion.seed
+      Zone.seed
+    end
+
     include_examples ".seed called multiple times"
   end
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -94,6 +94,14 @@ describe MiqServer do
       expect(@miq_server.zone.name).to eq(@zone.name)
     end
 
+    it "cannot have invisible zone" do
+      zone = FactoryGirl.create(:zone, :visible => false)
+
+      @miq_server.zone = zone
+      expect(@miq_server.save).to be_falsy
+      expect(@miq_server.errors.messages[:zone]).to be_present
+    end
+
     it "shutdown will raise an event and quiesce" do
       expect(MiqEvent).to receive(:raise_evm_event)
       expect(@miq_server).to receive(:quiesce)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -94,11 +94,12 @@ describe MiqServer do
       expect(@miq_server.zone.name).to eq(@zone.name)
     end
 
-    it "cannot have invisible zone" do
-      zone = FactoryGirl.create(:zone, :visible => false)
+    it "cannot assign to maintenance zone" do
+      MiqRegion.seed
+      Zone.seed
 
-      @miq_server.zone = zone
-      expect(@miq_server.save).to be_falsy
+      @miq_server.zone = Zone.maintenance_zone
+      expect(@miq_server.save).to eq(false)
       expect(@miq_server.errors.messages[:zone]).to be_present
     end
 

--- a/spec/models/orchestration_stack_retire_task_spec.rb
+++ b/spec/models/orchestration_stack_retire_task_spec.rb
@@ -11,6 +11,7 @@ describe OrchestrationStackRetireTask do
 
   describe "deliver_to_automate" do
     before do
+      MiqRegion.seed
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
       miq_request.approve(approver, "why not??")
     end

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -53,6 +53,7 @@ describe ServiceRetireTask do
 
     context "with resource" do
       before do
+        MiqRegion.seed
         allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
         miq_request.approve(approver, reason)
       end
@@ -116,6 +117,7 @@ describe ServiceRetireTask do
 
   describe "deliver_to_automate" do
     before do
+      MiqRegion.seed
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
       miq_request.approve(approver, reason)
     end

--- a/spec/models/vm_retire_task_spec.rb
+++ b/spec/models/vm_retire_task_spec.rb
@@ -11,6 +11,7 @@ describe VmRetireTask do
 
   describe "deliver_to_automate" do
     before do
+      MiqRegion.seed
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
       miq_request.approve(approver, "why not??")
     end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -194,9 +194,9 @@ describe Zone do
 
   context "maintenance zone" do
     it "creates missing region during seed" do
-      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)).to be_nil
+      expect(MiqRegion.my_region).to be_nil
       described_class.seed
-      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)).to be_present
+      expect(MiqRegion.my_region).to be_present
     end
 
     it "is seeded with relation to region" do
@@ -205,21 +205,12 @@ describe Zone do
 
       expect(described_class.maintenance_zone).to be_present
       expect(described_class.maintenance_zone.id).to eq(zone.id)
-      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)&.maintenance_zone).to eq(zone)
+      expect(MiqRegion.my_region&.maintenance_zone).to eq(zone)
     end
 
     it "is not visible" do
       described_class.seed
       expect(described_class.maintenance_zone.visible).to be_falsey
-    end
-
-    it "is created when default name exists" do
-      (1..5).each do |idx|
-        FactoryGirl.create(:zone, :name => "#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}#{idx}")
-      end
-      described_class.seed
-
-      expect(Zone.maintenance_zone.name).to eq("#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}6")
     end
   end
 

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,5 +1,8 @@
 describe Zone do
-  include_examples ".seed called multiple times", 2
+  context ".seed" do
+    before { MiqRegion.seed }
+    include_examples ".seed called multiple times", 2
+  end
 
   context "with two small envs" do
     before do
@@ -193,11 +196,7 @@ describe Zone do
   end
 
   context "maintenance zone" do
-    it "creates missing region during seed" do
-      expect(MiqRegion.my_region).to be_nil
-      described_class.seed
-      expect(MiqRegion.my_region).to be_present
-    end
+    before { MiqRegion.seed }
 
     it "is seeded with relation to region" do
       described_class.seed
@@ -225,6 +224,7 @@ describe Zone do
   end
 
   it "removes queued items on destroy" do
+    MiqRegion.seed
     Zone.seed
     zone = FactoryBot.create(:zone)
     FactoryBot.create(:miq_queue, :zone => zone.name)

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,5 +1,5 @@
 describe Zone do
-  include_examples ".seed called multiple times"
+  include_examples ".seed called multiple times", 2
 
   context "with two small envs" do
     before do

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -137,7 +137,7 @@ describe Zone do
     it "false" do
       allow(miq_server).to receive(:active?).and_return(false)
 
-      expect(zone.active?).to be_falsey
+      expect(zone.active?).to eq(false)
     end
   end
 
@@ -201,16 +201,16 @@ describe Zone do
 
     it "is seeded with relation to region" do
       described_class.seed
-      zone = Zone.where("name LIKE ?", "#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}%").first
+      expect(Zone.maintenance_zone).to have_attributes(
+        :name => a_string_starting_with("__maintenance__")
+      )
 
-      expect(described_class.maintenance_zone).to be_present
-      expect(described_class.maintenance_zone.id).to eq(zone.id)
-      expect(MiqRegion.my_region&.maintenance_zone).to eq(zone)
+      expect(MiqRegion.my_region&.maintenance_zone).to eq(Zone.maintenance_zone)
     end
 
     it "is not visible" do
       described_class.seed
-      expect(described_class.maintenance_zone.visible).to be_falsey
+      expect(described_class.maintenance_zone.visible).to eq(false)
     end
   end
 
@@ -225,6 +225,7 @@ describe Zone do
   end
 
   it "removes queued items on destroy" do
+    Zone.seed
     zone = FactoryBot.create(:zone)
     FactoryBot.create(:miq_queue, :zone => zone.name)
     expect(MiqQueue.where(:zone => zone.name).count).to eq(1)

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -205,7 +205,7 @@ describe Zone do
         :name => a_string_starting_with("__maintenance__")
       )
 
-      expect(MiqRegion.my_region&.maintenance_zone).to eq(Zone.maintenance_zone)
+      expect(MiqRegion.my_region.maintenance_zone).to eq(Zone.maintenance_zone)
     end
 
     it "is not visible" do

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -192,6 +192,37 @@ describe Zone do
     end
   end
 
+  context "maintenance zone" do
+    it "creates missing region during seed" do
+      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)).to be_nil
+      described_class.seed
+      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)).to be_present
+    end
+
+    it "is seeded with relation to region" do
+      described_class.seed
+      zone = Zone.where("name LIKE ?", "#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}%").first
+
+      expect(described_class.maintenance_zone).to be_present
+      expect(described_class.maintenance_zone.id).to eq(zone.id)
+      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)&.maintenance_zone).to eq(zone)
+    end
+
+    it "is not visible" do
+      described_class.seed
+      expect(described_class.maintenance_zone.visible).to be_falsey
+    end
+
+    it "is created when default name exists" do
+      (1..5).each do |idx|
+        FactoryGirl.create(:zone, :name => "#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}#{idx}")
+      end
+      described_class.seed
+
+      expect(Zone.maintenance_zone.name).to eq("#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}6")
+    end
+  end
+
   context "validate multi region" do
     let!(:other_region_id)         { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
     let!(:default_in_other_region) { described_class.create(:name => "default", :description => "Default Zone", :id => other_region_id) }

--- a/spec/tools/environment_builders/openstack/helper_methods.rb
+++ b/spec/tools/environment_builders/openstack/helper_methods.rb
@@ -27,7 +27,7 @@ module Openstack
                     :ipaddress             => hostname,
                     :port                  => port,
                     :api_version           => version,
-                    :zone                  => Zone.first,
+                    :zone                  => Zone.visible.first,
                     :security_protocol     => 'no_ssl',
                     :keystone_v3_domain_id => 'default'}
 

--- a/spec/tools/environment_builders/openstack/helper_methods.rb
+++ b/spec/tools/environment_builders/openstack/helper_methods.rb
@@ -27,7 +27,7 @@ module Openstack
                     :ipaddress             => hostname,
                     :port                  => port,
                     :api_version           => version,
-                    :zone                  => Zone.visible.first,
+                    :zone                  => Zone.default_zone,
                     :security_protocol     => 'no_ssl',
                     :keystone_v3_domain_id => 'default'}
 


### PR DESCRIPTION
Adds ability to suspend provider due to maintenance

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1455145
**Issue**: https://github.com/ManageIQ/manageiq/issues/17489

- [x] **depends on**: https://github.com/ManageIQ/manageiq-schema/pull/275
- **dependent**: https://github.com/ManageIQ/manageiq-ui-classic/pull/4269
- **dependent**: https://github.com/ManageIQ/manageiq-api/pull/434

- [ ] **depends on**: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/311

It moves EMS and child managers to Maintenance zone, also sets EMS.enabled to false, which causes stopping provider-specific workers

Cc @Ladas, @agrare, @jerryk55, @romanblanco 

