### PR TITLE
Fix issue with source type being derived from base class, being nil

### DIFF
--- a/app/models/miq_retire_request.rb
+++ b/app/models/miq_retire_request.rb
@@ -1,12 +1,9 @@
 class MiqRetireRequest < MiqRequest
-  # subclasses must set this
-  SOURCE_CLASS_NAME = nil
 
   validates :request_state, :inclusion => { :in => %w(pending finished) + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished" }
   validate :must_have_user
 
   default_value_for(:source_id)    { |r| r.get_option(:src_id) }
-  default_value_for :source_type,  SOURCE_CLASS_NAME
 
   def my_zone
   end

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -553,4 +553,16 @@ describe MiqRequest do
       expect(request.options[:abc]).to eq(1)
     end
   end
+
+  context "retire request source classes" do
+    let(:vm_retire_request)      { FactoryGirl.create(:vm_retire_request, :requester => fred) }
+    let(:service_retire_request) { FactoryGirl.create(:service_retire_request, :requester => fred) }
+    let(:orch_stack_request)     { FactoryGirl.create(:orchestration_stack_retire_request, :requester => fred) }
+
+    it "gets the right source class names" do
+      expect(vm_retire_request.class::SOURCE_CLASS_NAME).to eq('Vm')
+      expect(service_retire_request.class::SOURCE_CLASS_NAME).to eq('Service')
+      expect(orch_stack_request.class::SOURCE_CLASS_NAME).to eq('OrchestrationStack')
+    end
+  end
 end


### PR DESCRIPTION
The child classes of retire_request all set the source type so the base class doesn't need this code. This is part 1/3 of issue that's described [here](https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/73). 