### PR TITLE
Changes to be able to save config for zone and region records

### DIFF
--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -53,7 +53,7 @@ module VMDB
     end
 
     def save(resource = MiqServer.my_server)
-      resource.set_config(config)
+      resource.add_settings_for_resource(config)
     end
 
     # NOTE: Used by Configuration -> Advanced

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -49,7 +49,7 @@ describe VMDB::Config do
   end
 
   context ".save_file" do
-    it "normal" do
+    it "saves server config" do
       resource = FactoryGirl.create(:miq_server)
       MiqRegion.seed
       data = {}
@@ -59,6 +59,33 @@ describe VMDB::Config do
       expect(VMDB::Config.save_file(data, resource)).to be true
       expect(SettingsChange.count).to eq(1)
       expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
+      expect(SettingsChange.first.resource).to eq(resource)
+    end
+
+    it "saves zone config" do
+      resource = FactoryGirl.create(:zone)
+      MiqRegion.seed
+      data = {}
+      data.store_path(:api, :token_ttl, "1.day")
+      data = data.to_yaml
+
+      expect(VMDB::Config.save_file(data, resource)).to be true
+      expect(SettingsChange.count).to eq(1)
+      expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
+      expect(SettingsChange.first.resource).to eq(resource)
+    end
+
+    it "saves region config" do
+      resource = FactoryGirl.create(:miq_region)
+      MiqRegion.seed
+      data = {}
+      data.store_path(:api, :token_ttl, "1.day")
+      data = data.to_yaml
+
+      expect(VMDB::Config.save_file(data, resource)).to be true
+      expect(SettingsChange.count).to eq(1)
+      expect(SettingsChange.first).to have_attributes(:key => '/api/token_ttl', :value => "1.day")
+      expect(SettingsChange.first.resource).to eq(resource)
     end
 
     it "catches syntax errors" do


### PR DESCRIPTION
Changes to be able to save config for zone and region records

Changed save method to call 'add_settings_for_resource' to be able ot support saving of config settings for selected zone and region records

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1082155

@Fryguy we need this to get https://github.com/ManageIQ/manageiq-ui-classic/pull/3967 working. Please review