### PR TITLE
Use MiqPreloader/Relationship improvements in MiqRequestWorkflow

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -942,7 +942,15 @@ class MiqRequestWorkflow
     @ems_metadata_tree ||= begin
       return if src[:ems].nil?
       st = Time.zone.now
-      result = load_ar_obj(src[:ems]).fulltree_arranged(:except_type => "VmOrTemplate")
+      hosts_scope   = Host.select(Host.arel_table[Arel.star], :v_total_vms)
+      fulltree_opts = {
+        :except_type               => "VmOrTemplate",
+        :class_specific_preloaders => {
+          EmsCluster => [:hosts, hosts_scope],
+          Host       => hosts_scope
+        }
+      }
+      result = load_ar_obj(src[:ems]).fulltree_arranged(fulltree_opts)
       ems_metadata_tree_add_hosts_under_clusters!(result)
       @ems_xml_nodes = {}
       xml = MiqXml.newDoc(:xmlhash)

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -515,7 +515,8 @@ module RelationshipMixin
 
   # Returns the records in the tree from the root arranged in a tree
   def fulltree_arranged(*args)
-    Relationship.arranged_rels_to_resources(fulltree_rels_arranged(*args))
+    class_specific_preloaders = args.last.delete(:class_specific_preloaders) if args.last.kind_of?(Hash)
+    Relationship.arranged_rels_to_resources(fulltree_rels_arranged(*args), true, class_specific_preloaders)
   end
 
   # Returns a list of all unique child types

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -82,8 +82,11 @@ class Relationship < ApplicationRecord
     end
   end
 
-  def self.arranged_rels_to_resources(relationships, initial = true)
-    MiqPreloader.preload(flatten_arranged_rels(relationships), :resource) if initial
+  def self.arranged_rels_to_resources(relationships, initial = true, class_specific_preloaders = nil)
+    if initial
+      record_set = flatten_arranged_rels(relationships)
+      MiqPreloader.polymorphic_preload_for_child_classes(record_set, :resource, class_specific_preloaders)
+    end
 
     relationships.each_with_object({}) do |(rel, children), h|
       h[rel.resource] = arranged_rels_to_resources(children, false)

--- a/lib/miq_preloader.rb
+++ b/lib/miq_preloader.rb
@@ -31,4 +31,88 @@ module MiqPreloader
       target_klass.where(join_key.key.to_sym => records.select(join_key.foreign_key.to_sym))
     end
   end
+
+  # Allows having a polymorphic preloader, but then having class specific
+  # preloaders fire for the loaded polymorphic classes.
+  #
+  # @param records [ActiveRecord::Relation] collection of activerecord objects to preload into
+  # @param associations [Symbol|String|Array|Hash] association(s) to load (see .includes for examples)
+  # @param class_preloaders [Hash] keys are Classes, and values are associations for that polymorphic type
+  #
+  # Values for class_preloaders can either be an Array of two (args for sub
+  # preloader relationships), or an arel statement, which is the arel scope to
+  # execute for that specific class only (no sub relationships preloaded.
+  #
+  # Example:
+  #
+  #   irb> tree = ExtManagementSystem.last.fulltree_rels_arranged(:except_type => "VmOrTemplate")
+  #   irb> records = Relationship.flatten_arranged_rels(tree)
+  #   irb> hosts_scope = Host.select(Host.arel_table[Arel.star], :v_total_vms)
+  #   irb> preloaders_per_class = { EmsCluster => [:hosts, hosts_scope], Host => hosts_scope }
+  #   irb> MiqPreloader.polymorphic_preload_for_child_classes(records, nil, preloaders_per_class)
+  #
+  # Note:  Class's .base_class are favored over their specific class
+  #
+  def self.polymorphic_preload_for_child_classes(records, associations, class_preloaders = {})
+    preloader = ActiveRecord::Associations::Preloader.new
+    preloader.extend(Module.new {
+      attr_accessor :class_specific_preloaders
+
+      # DIRTY HACK... but hey... at least I am just isolating it to this method
+      # right...
+      #
+      # Everyone else: "No Nick... just no..."
+
+      # Updated form from ar_virtual.rb, and merged with the code originally in
+      # ActiveRecord.  If the code in ar_virtual.rb is changed, this should
+      # probably also be updated.
+      def preloaders_for_one(association, records, scope)
+        klass_map = records.compact.group_by(&:class)
+
+        loaders = klass_map.keys.group_by { |klass| klass.virtual_includes(association) }.flat_map do |virtuals, klasses|
+          subset = klasses.flat_map { |klass| klass_map[klass] }
+          preload(subset, virtuals)
+        end
+
+        records_with_association = klass_map.select { |k, rs| k.reflect_on_association(association) }.flat_map { |k, rs| rs }
+        if records_with_association.any?
+          # This injects the original code from preloaders_for_one from
+          # ActiveRecord so we can add our own `if` in the middle of it.  The
+          # positive part of the `if` is the only portion of this that has
+          # changed, and the code copied is within the `loaders.concat`.
+          loaders.concat(grouped_records(association, records_with_association).flat_map do |reflection, klasses|
+            klasses.map do |rhs_klass, rs|
+              base_klass = rhs_klass.base_class if rhs_klass.respond_to?(:base_class)
+
+              # Start of new code (1)
+              class_preloader = (class_specific_preloaders[base_klass] || class_specific_preloaders[rhs_klass])
+              loader_klass    = preloader_for(reflection, rs, rhs_klass)
+
+              loader = if class_preloader.kind_of?(ActiveRecord::Relation)
+                         loader_klass.new(rhs_klass, rs, reflection, class_preloader)
+                       else
+                         loader_klass.new(rhs_klass, rs, reflection, scope)
+                       end
+              # End of new code (1)
+
+              loader.run self
+
+              # Start of new code (2)
+              if class_preloader.kind_of?(Array) && class_preloader.count == 2
+                [loader, MiqPreloader.preload(loader.preloaded_records, class_preloader[0], class_preloader[1])]
+              else
+                loader
+              end
+              # End of new code (2)
+            end
+          end)
+        end
+
+        loaders
+      end
+    })
+    preloader.class_specific_preloaders = class_preloaders || {}
+
+    preloader.preload(records, associations, nil)
+  end
 end

--- a/spec/support/examples_group/shared_context_for_ems_metadata_tree.rb
+++ b/spec/support/examples_group/shared_context_for_ems_metadata_tree.rb
@@ -1,0 +1,68 @@
+shared_context "simple ems_metadata tree" do
+  #####################
+  # Context Variables #
+  #####################
+
+  # These can be updated to increase the amount of data in the tree
+
+  let(:cluster_count)     { 2 }
+  let(:hosts_per_cluster) { 2 }
+  let(:vms_per_host)      { 2 }
+
+  ###############
+  # Base models #
+  ###############
+
+  let(:ems)      { FactoryGirl.create(:ems_infra) }
+  let(:clusters) { FactoryGirl.create_list(:ems_cluster, cluster_count, :ext_management_system => ems) }
+
+  let(:hosts) do
+    hosts = []
+    clusters.each do |cluster|
+      hosts += FactoryGirl.create_list(:host, hosts_per_cluster,
+                                       :ext_management_system => ems,
+                                       :ems_cluster           => cluster)
+    end
+    hosts
+  end
+
+  let(:vms) do
+    vms = []
+    hosts.each do |host|
+      vms += FactoryGirl.create_list(:vm, vms_per_host,
+                                     :ext_management_system => ems,
+                                     :host                  => host)
+    end
+    vms
+  end
+
+  #################
+  # Relationships #
+  #################
+
+  let(:ems_rel)      { ems.init_relationship }
+  let(:cluster_rels) { clusters.map { |cluster| cluster.init_relationship(ems_rel) } }
+
+  # The next to use a integer division trick to map the proper parent_rel to
+  # the record being created (the `[index / child_per_parent]` part)
+
+  let(:host_rels) do
+    hosts.map.with_index do |host, index|
+      host.init_relationship(cluster_rels[index / hosts_per_cluster])
+    end
+  end
+
+  let(:vm_rels) do
+    vms.map.with_index do |vm, index|
+      vm.init_relationship(host_rels[index / vms_per_host])
+    end
+  end
+
+  ###########
+  # Helpers #
+  ###########
+
+  # Convenience statement for initializing the tree (there is no included
+  # `before` to do this automatically
+  let(:init_full_tree) { vm_rels }
+end


### PR DESCRIPTION
Extracted from https://github.com/ManageIQ/manageiq/pull/17354

Built off of and depends on https://github.com/ManageIQ/manageiq/pull/17457 and https://github.com/ManageIQ/manageiq/pull/17460

This takes the `MiqPreloader.polymorphic_preload_for_child_classes` changes, and makes use of them through the `fulltree_arranged` method to drastically reduce the number of N+1 queries in `MiqRequestWorkflow#ems_metadata_tree`.



Benchmarks
----------

_**tl; dr**_  Same as in the other PRs, just different code

Note:  There is actually a slight improvement in number of queries called when combining both the changes from this branch, and the previous ones in #17354.  This is due to the addition of `Host => hosts_scope` option which addresses a slightly smaller N+1 for hosts that happen to show up directly in the `ems_metadata_tree` versus are accessed through the `EmsCluster` records.  In my dataset, this was only 4 hosts in total this affected, but in different scendarios, this might have a bigger affect.

Also, these benchmarks don't integrate the merged changes from https://github.com/ManageIQ/manageiq/pull/17354 as I have been benchmarking all of these changes from an individual perspective off of a specific commit from master, and wanted to keep the before and after benchmark results consistent with the rest of the related PRs.

The benchmark script used here basically runs the following:

```ruby
ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow.new.init_from_dialog
```

And is targeting a fairly large EMS, with about 600 hosts.

|        |    ms | queries | query (ms) |  rows |
|    --: |  ---: |    ---: |       ---: |  ---: |
| before | 15023 |    1961 |      873.4 | 48395 |
|  after | 12772 |    1308 |      451.2 | 48395 |

```
Before                                                     After
------                                                     -----

Total allocated: 2069091751 bytes (23226536 objects)   |   Total allocated: 2023972840 bytes (22605560 objects)
                                                       |   
allocated objects by gem                               |   allocated objects by gem
-----------------------------------                    |   -----------------------------------
   9665227  pending                                    |      9665227  pending
   5561668  manageiq/app  <<<<<<<<<<                   |      5559167  manageiq/app  <<<<<<<<<<
   3513258  manageiq/lib  <<<<<<<<<<                   |      3508927  manageiq/lib  <<<<<<<<<<
   2512007  activerecord-5.0.7  <<<<<<<<<<             |      2131310  activerecord-5.0.7  <<<<<<<<<<
    861270  activesupport-5.0.7 <<<<<<<<<<             |       839043  activesupport-5.0.7  <<<<<<<<<<
    418737  ancestry-2.2.2                             |       418737  ancestry-2.2.2
    278793  activemodel-5.0.7  <<<<<<<<<<              |       276326  activemodel-5.0.7  <<<<<<<<<<
    178419  ruby-2.3.3/lib  <<<<<<<<<<                 |        77456  ruby-2.3.3/lib  <<<<<<<<<<
    165577  arel-7.1.4  <<<<<<<<<<                     |        59093  arel-7.1.4  <<<<<<<<<<
     52875  manageiq-providers-vmware-0be2f13a0dc9     |        52875  manageiq-providers-vmware-0be2f13a0dc9
     14424  fast_gettext-1.2.0                         |        14424  fast_gettext-1.2.0
      4115  other  <<<<<<<<<<                          |         2809  other  <<<<<<<<<<
        75  default_value_for-3.0.5                    |           75  default_value_for-3.0.5
        68  concurrent-ruby-1.0.5                      |           68  concurrent-ruby-1.0.5
        16  memoist-0.15.0                             |           16  memoist-0.15.0
         4  rubygems                                   |            4  rubygems
```

**Note**: The benchmarks for this change do NOT include the changes from other PRs in the links below.  Benchmarks of all changes can be found [here](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27).


Links
-----

* Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1569626
* Extracted from https://github.com/ManageIQ/manageiq/pull/17354
* Built off of and depends on:
  - https://github.com/ManageIQ/manageiq/pull/17457
  - https://github.com/ManageIQ/manageiq/pull/17460
* Full collection of proposed changes:  [git compare](https://github.com/ManageIQ/manageiq/compare/master...NickLaMuro:multiple_miq_provision_workflow_query_optimizations)
* Document keeping track of overall improvements for this effort:  [gist](https://gist.github.com/NickLaMuro/36f9f394a5b3cecc4aaf33d3e84dfb27)
* Other Related PRs:
  - https://github.com/ManageIQ/manageiq/pull/17355
  - https://github.com/ManageIQ/manageiq/pull/17357
  - https://github.com/ManageIQ/manageiq/pull/17358
  - https://github.com/ManageIQ/manageiq/pull/17359
  - https://github.com/ManageIQ/manageiq/pull/17360
  - https://github.com/ManageIQ/manageiq/pull/17381
  - https://github.com/ManageIQ/manageiq/pull/17402
  - https://github.com/ManageIQ/manageiq/pull/17403
  - https://github.com/ManageIQ/manageiq/pull/17457