### PR TITLE
Do not delete children snapshots as part of parent

### DIFF
--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -1,7 +1,7 @@
 require 'time'
 
 class Snapshot < ApplicationRecord
-  acts_as_tree
+  acts_as_tree :dependent => :nullify
 
   belongs_to :vm_or_template
 


### PR DESCRIPTION
Do not delete children snapshots as part of parent. The default
relation :children, added by acts_as_tree, has :dependent => :destroy.

So deleting parent, will delete all it's children. This is not behavior
we want in refresh. In old refresh, we were bypassing this by:
https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_refresh/save_inventory.rb#L366

So first, we deleted the tree relations, then we did create/update/delete
of the nodes, then we updated the tree connections again. All of that should
not be needed, if we will just use :dependent => :nullify

Partially fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=1571291

PR with spec is here:
https://github.com/ManageIQ/manageiq-providers-ovirt/pull/241