### PR TITLE
Removing guard conditions in Chargebaback

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -158,7 +158,6 @@ class Chargeback < ActsAsArModel
     rates.each do |rate|
       rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
         r.charge(consumption, @options).each do |field, value|
-          next unless self.class.attribute_names.include?(field)
           self[field] = self[field].kind_of?(Numeric) ? (self[field] || 0) + value : value
         end
       end

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -157,7 +157,7 @@ class Chargeback < ActsAsArModel
 
     rates.each do |rate|
       rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
-        r.charge(relevant_fields, consumption, @options).each do |field, value|
+        r.charge(consumption, @options).each do |field, value|
           next unless self.class.attribute_names.include?(field)
           self[field] = self[field].kind_of?(Numeric) ? (self[field] || 0) + value : value
         end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -94,7 +94,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption, options)
     result = {}
-    if (relevant_fields & ([metric_key] + cost_keys)).present?
+    if ((relevant_fields & [metric_key]) + (relevant_fields & cost_keys)).present?
       metric_value, cost = metric_and_cost_by(consumption, options)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -94,16 +94,16 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption, options)
     result = {}
-    if affects_report_fields(relevant_fields)
-      metric_value, cost = metric_and_cost_by(consumption, options)
-      if !consumption.chargeback_fields_present && chargeable_field.fixed?
-        cost = 0
-      end
 
-      result[rate_key(sub_metric)] = rate_values(consumption, options)
-      result[metric_key(sub_metric)] = metric_value
-      cost_keys(sub_metric).each { |field| result[field] = cost }
+    metric_value, cost = metric_and_cost_by(consumption, options)
+    if !consumption.chargeback_fields_present && chargeable_field.fixed?
+      cost = 0
     end
+
+    result[rate_key(sub_metric)] = rate_values(consumption, options)
+    result[metric_key(sub_metric)] = metric_value
+    cost_keys(sub_metric).each { |field| result[field] = cost }
+
     result
   end
 

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -94,7 +94,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption, options)
     result = {}
-    if (relevant_fields & [metric_key]).present? || (relevant_fields & cost_keys).present?
+    if (relevant_fields & [metric_key]).present? || ((cost_keys.to_set & report_cols).present? && !gratis?)
       metric_value, cost = metric_and_cost_by(consumption, options)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -94,7 +94,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption, options)
     result = {}
-    if ((relevant_fields & [metric_key]) + (relevant_fields & cost_keys)).present?
+    if (relevant_fields & [metric_key]).present? || (relevant_fields & cost_keys).present?
       metric_value, cost = metric_and_cost_by(consumption, options)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -94,7 +94,7 @@ class ChargebackRateDetail < ApplicationRecord
 
   def charge(relevant_fields, consumption, options)
     result = {}
-    if (relevant_fields & [metric_key]).present? || ((cost_keys.to_set & report_cols).present? && !gratis?)
+    if affects_report_fields(relevant_fields)
       metric_value, cost = metric_and_cost_by(consumption, options)
       if !consumption.chargeback_fields_present && chargeable_field.fixed?
         cost = 0

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -92,7 +92,7 @@ class ChargebackRateDetail < ApplicationRecord
     "#{hourly_fixed_rate}/#{hourly_variable_rate}"
   end
 
-  def charge(relevant_fields, consumption, options)
+  def charge(consumption, options)
     result = {}
 
     metric_value, cost = metric_and_cost_by(consumption, options)


### PR DESCRIPTION
We have same(on first look apparently) condition on two places. 

This is commit based story how to remove condition from one place in `ChargebackRateDetail#charge` method.
Thanks to it method `ChargebackRateDetail#charge` is more clean. 

follow up after:
https://github.com/ManageIQ/manageiq/pull/17387
https://github.com/ManageIQ/manageiq/pull/17414

cc @gtanzillo 

@miq-bot assign @jrafanie 