### PR TITLE
Added ActAsTaggable concern to MiqRequest model

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -12,6 +12,8 @@ class MiqRequest < ApplicationRecord
   has_many   :miq_approvals,     :dependent   => :destroy
   has_many   :miq_request_tasks, :dependent   => :destroy
 
+  acts_as_miq_taggable
+
   alias_attribute :state, :request_state
 
   serialize   :options, Hash


### PR DESCRIPTION
`MiqRequest` was added to RBAC in https://github.com/ManageIQ/manageiq/pull/17208 without adding `ActAsTaggable`. It cause raising 
```
[----] F, [2018-05-08T19:34:15.481475 #7215:1428924] FATAL -- : Error caught: [NoMethodError] undefined method `find_tags_by_grouping' for #<MiqRequest::ActiveRecord_Relation:0x0000000012b154b0>
/opt/rh/cfme-gemset/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:124:in `method_missing'
/opt/rh/cfme-gemset/gems/activerecord-5.0.6/lib/active_record/relation/delegation.rb:94:in `method_missing'
/var/www/miq/vmdb/lib/rbac/filterer.rb:493:in `get_managed_filter_object_ids'
/var/www/miq/vmdb/lib/rbac/filterer.rb:426:in `calc_filtered_ids'

```
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1576129

BEFORE:
<img width="871" alt="before" src="https://user-images.githubusercontent.com/6556758/40401096-f1ab38ac-5e12-11e8-9f9a-050758944bc5.png">

AFTER:
<img width="1005" alt="after" src="https://user-images.githubusercontent.com/6556758/40401103-f7ab5d0e-5e12-11e8-9d47-f7ec425021a4.png">

@miq-bot add-label bug, core, gaprindashvili/yes, fine/yes
