### PR TITLE
Add include_automate_models_and_dialogs to ::Settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -888,6 +888,7 @@
     :scheme:
 :log:
   :collection:
+    :include_automate_models_and_dialogs: true
     :archive:
       :pattern:
     :current:


### PR DESCRIPTION
Based on discussion in https://github.com/ManageIQ/manageiq-ui-classic/pull/3969 adding `include_automate_models_and_dialogs` to `::Settings` set to `true` by default. 

Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/3969

Part of fix for https://bugzilla.redhat.com/show_bug.cgi?id=1535179

@miq-bot add_label enhancement

@jrafanie please have a look, thanks :)

