### PR TITLE
Add skip_references option to Rbac/MiqReport

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -46,7 +46,7 @@ class MiqReport < ApplicationRecord
   alias_attribute :menu_name, :name
   attr_accessor_that_yamls :table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                            :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
-                           :report_run_time, :chart
+                           :report_run_time, :chart, :skip_references
 
   attr_accessor_that_yamls :reserved # For legacy imports
 

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -90,7 +90,11 @@ module MiqReport::Search
 
     order = get_order_info
 
-    search_options = options.merge(:class => db, :conditions => conditions, :include_for_find => includes)
+    search_options = options.merge(:class            => db,
+                                   :conditions       => conditions,
+                                   :include_for_find => includes,
+                                   :skip_references  => skip_references
+                                  )
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
 
     if options[:parent]

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -310,8 +310,9 @@ module Rbac
     # as done previously.
     def skip_references?(scope, options, attrs, exp_sql, exp_includes)
       return false if scope.singleton_class.included_modules.include?(ActiveRecord::NullRelation)
-      options[:extra_cols].blank? &&
-        (!attrs[:apply_limit_in_sql] && (exp_sql.nil? || exp_includes.nil?))
+      options[:skip_references] ||
+      (options[:extra_cols].blank? &&
+        (!attrs[:apply_limit_in_sql] && (exp_sql.nil? || exp_includes.nil?)))
     end
 
     def include_references(scope, klass, include_for_find, exp_includes, skip)


### PR DESCRIPTION
This allows for the manual configuration of product reports to include an option to use `skip_references` to avoid `LEFT JOIN` bombs from happening when multiple includes are being referenced in Rbac.

This partially fixes the issue reported in https://bugzilla.redhat.com/show_bug.cgi?id=1580569, but will require an update to the `manageiq-ui-classic` to be fixed fully.

Background
------------
The `/ems_infra/:id?display=hosts` route would pull up the `product/views/Host.yaml` from the `manageiq-ui-classic` report and run the following query:

```SQL
-- Many rows here in the SELECT are omitted for space
SELECT "hosts"."id" AS t0_r0,
       "hosts"."name" AS t0_r1,
       -- ...
       "hosts"."physical_server_id" AS t0_r36,
       "ext_management_systems"."id" AS t1_r0,
       "ext_management_systems"."name" AS t1_r1,
       -- ...
       "ext_management_systems"."tenant_mapping_enabled" AS t1_r23,
       "compliances"."id" AS t2_r0,
       -- ...
       "compliances"."event_type" AS t2_r6,
       "tags"."id" AS t3_r0,
       "tags"."name" AS t3_r1
FROM "hosts"
LEFT OUTER JOIN "ext_management_systems" ON "ext_management_systems"."id" = "hosts"."ems_id"
LEFT OUTER JOIN "compliances" ON "compliances"."resource_id" = "hosts"."id" AND "compliances"."resource_type" = 'Host'
LEFT OUTER JOIN "taggings" ON "taggings"."taggable_id" = "hosts"."id" AND "taggings"."taggable_type" = 'Host'
LEFT OUTER JOIN "tags" ON "tags"."id" = "taggings"."tag_id"
ORDER BY LOWER("hosts"."name") ASC
```

With only 20 hosts, but around 14k compliances, the result set returned from above was over 2 million rows with 60+ columns per row.  This caused `ActiveRecord`/`pg` gems to use Gigs of memory to process the query, and was taking over 25min for the query to be fully processed.

The change makes it so the query is done in a more SQL friendly fashion by executing the includes as individual SQL calls.  Means more SQL calls over all, but only a increase of about 4, with drastically less data sent back over the wire (most of it previously was duplicate).


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1580569
* UI PR (merge after this one):  https://github.com/ManageIQ/manageiq-ui-classic/pull/3984
* Previous required PRs for this to work:
  - https://github.com/ManageIQ/manageiq/pull/17141
  - https://github.com/ManageIQ/manageiq/pull/17429