### PR TITLE
Use current tags for filtering resources in chargeback for VMs

### DIFF
--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -22,8 +22,7 @@ class Chargeback
 
     def tag_names
       @tag_names ||= @rollups.inject([]) do |memo, rollup|
-        tag_names = rollup.resource_current_tag_names | rollup.resource_tag_names
-        memo |= tag_names if tag_names.present?
+        memo |= rollup.all_tag_names
         memo
       end
     end

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -6,6 +6,8 @@ class Chargeback
 
     attr_accessor :start_time, :end_time
 
+    TAG_PREFIX = '/managed/'.freeze
+
     def initialize(metric_rollup_records, start_time, end_time)
       super(start_time, end_time)
       @rollups = metric_rollup_records
@@ -22,7 +24,11 @@ class Chargeback
 
     def tag_names
       @tag_names ||= @rollups.inject([]) do |memo, rollup|
-        memo |= rollup.tag_names.split('|') if rollup.tag_names.present?
+        resource = rollup.resource
+        tag_names = []
+        tag_names |= resource.tags.collect(&:name).map { |x| x.gsub(TAG_PREFIX, "") } if resource
+        tag_names |= rollup.tag_names.split('|') if rollup.tag_names.present?
+        memo |= tag_names if tag_names.present?
         memo
       end
     end

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -6,8 +6,6 @@ class Chargeback
 
     attr_accessor :start_time, :end_time
 
-    TAG_PREFIX = '/managed/'.freeze
-
     def initialize(metric_rollup_records, start_time, end_time)
       super(start_time, end_time)
       @rollups = metric_rollup_records
@@ -24,9 +22,7 @@ class Chargeback
 
     def tag_names
       @tag_names ||= @rollups.inject([]) do |memo, rollup|
-        resource = rollup.resource
-        tag_names = []
-        tag_names |= resource.tags.collect(&:name).map { |x| x.gsub(TAG_PREFIX, "") } if resource
+        tag_names = rollup.resource_current_tag_names
         tag_names |= rollup.tag_names.split('|') if rollup.tag_names.present?
         memo |= tag_names if tag_names.present?
         memo

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -22,8 +22,7 @@ class Chargeback
 
     def tag_names
       @tag_names ||= @rollups.inject([]) do |memo, rollup|
-        tag_names = rollup.resource_current_tag_names
-        tag_names |= rollup.tag_names.split('|') if rollup.tag_names.present?
+        tag_names = rollup.resource_current_tag_names | rollup.resource_tag_names
         memo |= tag_names if tag_names.present?
         memo
       end

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -83,7 +83,8 @@ class ChargebackVm < Chargeback
   def self.where_clause(records, options, region)
     scope = records.where(:resource_type => "VmOrTemplate")
     if options[:tag] && (@report_user.nil? || !@report_user.self_service?)
-      scope.for_tag_names(options[:tag].split("/")[2..-1])
+      scope_with_current_tags = scope.where(:resource => Vm.find_tagged_with(:any => @options[:tag], :ns => '*'))
+      scope.for_tag_names(options[:tag].split("/")[2..-1]).or(scope_with_current_tags)
     else
       scope.where(:resource => vms(region))
     end

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -26,7 +26,7 @@ module Metric::ChargebackHelper
       end
     end
 
-    "#{image_tag_name}#{(resource_current_tag_names | resource_tag_names).join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
+    "#{image_tag_name}#{all_tag_names.join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
   end
 
   def resource_parents
@@ -54,5 +54,9 @@ module Metric::ChargebackHelper
 
   def resource_tag_names
     tag_names ? tag_names.split("|") : []
+  end
+
+  def all_tag_names
+    resource_current_tag_names | resource_tag_names
   end
 end

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -26,7 +26,10 @@ module Metric::ChargebackHelper
       end
     end
 
-    "#{image_tag_name}#{tag_names}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
+    current_tag_names = resource ? resource.tags.collect(&:name).map { |x| x.gsub("/managed/", "") } : []
+    rollup_tag_names = tag_names ? tag_names.split("|") : []
+
+    "#{image_tag_name}#{(current_tag_names | rollup_tag_names).join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
   end
 
   def resource_parents

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -26,10 +26,9 @@ module Metric::ChargebackHelper
       end
     end
 
-    current_tag_names = resource ? resource.tags.collect(&:name).map { |x| x.gsub("/managed/", "") } : []
     rollup_tag_names = tag_names ? tag_names.split("|") : []
 
-    "#{image_tag_name}#{(current_tag_names | rollup_tag_names).join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
+    "#{image_tag_name}#{(resource_current_tag_names | rollup_tag_names).join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
   end
 
   def resource_parents
@@ -49,5 +48,9 @@ module Metric::ChargebackHelper
     when Container.name
       [parent_ems].compact
     end
+  end
+
+  def resource_current_tag_names
+    resource ? resource.tags.collect(&:name).map { |x| x.gsub("/managed/", "") } : []
   end
 end

--- a/app/models/metric/chargeback_helper.rb
+++ b/app/models/metric/chargeback_helper.rb
@@ -26,9 +26,7 @@ module Metric::ChargebackHelper
       end
     end
 
-    rollup_tag_names = tag_names ? tag_names.split("|") : []
-
-    "#{image_tag_name}#{(resource_current_tag_names | rollup_tag_names).join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
+    "#{image_tag_name}#{(resource_current_tag_names | resource_tag_names).join("|")}".split("|").reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + (labels || [])
   end
 
   def resource_parents
@@ -52,5 +50,9 @@ module Metric::ChargebackHelper
 
   def resource_current_tag_names
     resource ? resource.tags.collect(&:name).map { |x| x.gsub("/managed/", "") } : []
+  end
+
+  def resource_tag_names
+    tag_names ? tag_names.split("|") : []
   end
 end


### PR DESCRIPTION
2 issues:
- selection of rates based on tags
- filtering resources to charge them by tags

but We are using `MetricRollup#tag_names` as tag_names from resources in these two situations and if user will add tags later then related `MetricRollup` records have still old tags.

So thanks to that it could not choose rate and aslo found any  `MetricRollup` records  because in query is used non-current  `MetricRollup#tag_names`.

This fix using current tags  and also old tags(in MetricRollups) in for these two places.


Links
------------
* https://bugzilla.redhat.com/show_bug.cgi?id=1581724

