### PR TITLE
[WIP] Add STI to guest devices and add controllers to disks

### DIFF
--- a/app/models/controller.rb
+++ b/app/models/controller.rb
@@ -1,0 +1,3 @@
+class Controller < GuestDevice
+  has_many :disks, :foreign_key => :controller_id, :dependent => :nullify, :inverse_of => :controller
+end

--- a/app/models/disk.rb
+++ b/app/models/disk.rb
@@ -3,6 +3,7 @@ class Disk < ApplicationRecord
   belongs_to :storage
   belongs_to :storage_profile
   belongs_to :backing, :polymorphic => true
+  belongs_to :controller
   has_many :partitions
   virtual_column :allocated_space,             :type => :integer, :uses => :partitions
   virtual_column :allocated_space_percent,     :type => :float,   :uses => :allocated_space

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -220,7 +220,7 @@ module EmsRefresh::SaveInventory
 
   def save_hardware_inventory(parent, hash)
     return if hash.nil?
-    save_inventory_single(:hardware, parent, hash, [:disks, :guest_devices, :networks, :firmwares])
+    save_inventory_single(:hardware, parent, hash, [:guest_devices, :disks, :networks, :firmwares])
     parent.save!
   end
 
@@ -272,9 +272,10 @@ module EmsRefresh::SaveInventory
       h[:storage_id]         = h.fetch_path(:storage, :id)
       h[:backing_id]         = h.fetch_path(:backing, :id)
       h[:storage_profile_id] = h.fetch_path(:storage_profile, :id)
+      h[:controller_id]      = h.fetch_path(:controller, :id)
     end
 
-    save_inventory_multi(hardware.disks, hashes, :use_association, [:controller_type, :location], nil, [:storage, :backing, :storage_profile])
+    save_inventory_multi(hardware.disks, hashes, :use_association, [:controller_type, :location], nil, [:storage, :backing, :storage_profile, :controller])
   end
 
   def save_network_inventory(guest_device, hash)

--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -1,4 +1,6 @@
 class GuestDevice < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :hardware
 
   has_one :vm_or_template, :through => :hardware
@@ -18,12 +20,4 @@ class GuestDevice < ApplicationRecord
   has_many :physical_network_ports, :dependent => :destroy
 
   alias_attribute :name, :device_name
-
-  def self.with_ethernet_type
-    where(:device_type => "ethernet")
-  end
-
-  def self.with_storage_type
-    where(:device_type => "storage")
-  end
 end

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -20,6 +20,7 @@ class Hardware < ApplicationRecord
   has_many    :guest_devices,    :dependent => :destroy
   has_many    :storage_adapters, :foreign_key => :hardware_id
   has_many    :network_adapters, :foreign_key => :hardware_id
+  has_many    :controllers,      :foreign_key => :hardware_id
   has_many    :ports, -> { where("device_type != 'storage'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
   has_many    :physical_ports, -> { where("device_type = 'physical_port'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
 

--- a/app/models/network_adapter.rb
+++ b/app/models/network_adapter.rb
@@ -1,0 +1,2 @@
+class NetworkAdapter < GuestDevice
+end

--- a/app/models/storage_adapter.rb
+++ b/app/models/storage_adapter.rb
@@ -1,0 +1,2 @@
+class StorageAdapter < GuestDevice
+end


### PR DESCRIPTION
Add properties needed for provisioning and reconfiguration without broker cache.

Currently we use device_type as a pseudo sub-class, this changes the users of device_type over to use the class and association which frees up device_type to store the more specific device type which can be used by the provider like `VirtualVmxnet3`.

The device_type is needed to edit an existing NIC and the controller information is needed for adding new disks.

Depends on: https://github.com/ManageIQ/manageiq-schema/pull/204