### PR TITLE
Allow MiqReport.paged_view_search to take advantage of Rbac :extra_cols

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -232,4 +232,12 @@ class MiqReport < ApplicationRecord
     column_index = col_order.index { |col| col.include?(chart_column) }
     headers[column_index]
   end
+
+  private
+
+  def va_sql_cols
+    @va_sql_cols ||= cols.select do |col|
+      db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
+    end
+  end
 end

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -285,10 +285,6 @@ module MiqReport::Generator
       # TODO: add once only_cols is fixed
       # targets = targets.select(only_cols)
       where_clause = MiqExpression.merge_where_clauses(self.where_clause, options[:where_clause])
-      ## add in virtual attributes that can be calculated from sql
-      va_sql_cols = cols.select do |col|
-        db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
-      end
       rbac_opts = options.merge(
         :targets          => targets,
         :filter           => conditions,
@@ -297,6 +293,7 @@ module MiqReport::Generator
         :skip_counts      => true,
       )
 
+      ## add in virtual attributes that can be calculated from sql
       rbac_opts[:extra_cols] = va_sql_cols unless va_sql_cols.nil? || va_sql_cols.empty?
 
       results, attrs = Rbac.search(rbac_opts)

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -92,6 +92,7 @@ module MiqReport::Search
 
     search_options = options.merge(:class => db, :conditions => conditions, :include_for_find => includes)
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
+    search_options[:extra_cols] = va_sql_cols if va_sql_cols.present?
 
     if options[:parent]
       targets = get_parent_targets(options[:parent], options[:association] || options[:parent_method])


### PR DESCRIPTION
Allows reports, specifically the ones in `product/views`, to take advantage of the :extra_cols functionality.  This allows `virtual_attributes` to be gathered via SQL in the main query, instead of via includes/references.


Links
-----

* Part of the work related to https://github.com/ManageIQ/manageiq/pull/17473