### PR TITLE
Convert ComplianceMixin to use has_one/virtual_delegate

### DIFF
--- a/spec/models/mixins/compliance_mixin_spec.rb
+++ b/spec/models/mixins/compliance_mixin_spec.rb
@@ -1,0 +1,50 @@
+describe ComplianceMixin do
+  include Spec::Support::ArelHelper
+
+  let(:host)           { FactoryGirl.create(:host) }
+  let(:new_timestamp)  { 2.months.ago.change(:usec => 0) }
+  let(:old_timestamp)  { 4.months.ago.change(:usec => 0) }
+  let(:new_compliance) { FactoryGirl.create(:compliance, :resource => host, :timestamp => new_timestamp, :compliant => false) }
+  let(:old_compliance) { FactoryGirl.create(:compliance, :resource => host, :timestamp => old_timestamp) }
+  let(:compliances)    { [old_compliance, new_compliance] }
+
+  describe "#last_compliance" do
+    it "uses the most recent value" do
+      compliances
+      expect(host.last_compliance.timestamp).to eq(new_timestamp)
+    end
+  end
+
+  describe "#last_compliance_status" do
+    context "with no compliances" do
+      it "is nil with sql" do
+        host
+        expect(virtual_column_sql_value(Host, "last_compliance_status")).to be_nil
+      end
+
+      it "is nil with ruby" do
+        expect(host.last_compliance_status).to be_nil
+      end
+    end
+
+    context "with compliances" do
+      before { compliances }
+
+      it "has the most recent timestamp with sql" do
+        h = Host.select(:id, :last_compliance_status).first
+
+        expect do
+          expect(h.last_compliance_status).to eq(false)
+        end.to match_query_limit_of(0)
+        expect(h.association(:last_compliance)).not_to be_loaded
+      end
+
+      it "has the most recent timestamp with ruby" do
+        h = Host.first # clean host record
+
+        expect(h.last_compliance_status).to eq(false)
+        expect(h.association(:last_compliance)).to be_loaded
+      end
+    end
+  end
+end


### PR DESCRIPTION
~~Built off of:  https://github.com/ManageIQ/manageiq/pull/17473~~ Now Merged

This converts the functionality defined in the `virtual_has_one`, `virtual_columns`, and associated methods to a `has_one` and a pair of `virtual_delegates`.

This allows these columns to also be used in SQL, and removes some of the boilerplate code necessary for the methods that are defined.

This allows the changes in https://github.com/ManageIQ/manageiq/pull/17474 to then be used on the `Compute -> Infrastructure -> Host` page, among others, and circumvents needing all of the compliance records to be downloaded to get the `last_compliance_status` for those reports.


Metrics
-------
An example set of runs I had with a 50 `Host` provider:

**Before**

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  835 |     163 |      252.5 | 3810 |
|  782 |     163 |      164.7 | 3810 |
|  464 |     163 |      165.9 | 3810 |


**After**

|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 3061 |     113 |      172.5 | 3810 |
|  742 |     113 |      166.1 | 3810 |
|  815 |     114 |      155.0 | 3811 |


Links
-----

* For https://bugzilla.redhat.com/show_bug.cgi?id=1580569
* Built off of https://github.com/ManageIQ/manageiq/pull/17473 (merged)
* Related https://github.com/ManageIQ/manageiq/pull/17474
* Alternative to https://github.com/ManageIQ/manageiq/pull/17469 and https://github.com/ManageIQ/manageiq-ui-classic/pull/3984


Steps for Testing/QA
--------------------

~~Need to build up some seed data, but a before and after with all of these changes in place makes it so that when a large number of compliance reports exists for a small number of hosts (even when it is something like 20...), there isn't a `LEFT JOIN` bomb to build the report data (due to the `.includes`/`.references` calls in `Rbac`).~~

Here is some test data that I was using:

https://gist.github.com/NickLaMuro/225833358423723ed17ff294415fa6b4

For testing, I did the following:

* Seed with the above script: `bin/rails r bz_1580569_db_replication_script.rb`
* Spin up a server:  `bin/rails s`
* Do the following in a browser:
  - Login
  - Navigate to `Compute -> Infrastructure -> Providers` in the side menu
  - Up the `per_page` to 1k (just to load all of the records in a single page
  - Select a provider (one with the most `Host` records, ideally)
  - Select the `Hosts` button

Between `master`, and this change, you should see the number of queries per request for the last portion in the above drop by the number of `Host` records for that provider.  The `Metrics` section above used this process.