### PR TITLE
Honor user provided execution_ttl option

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < ::Job
+  DEFAULT_EXECUTION_TTL = 10 # minutes
+
   # options are job table columns, including options column which is the playbook context info
   def self.create_job(options)
     super(name, options.with_indifferent_access)
@@ -7,6 +9,11 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
   def minimize_indirect
     @minimize_indirect = true if @minimize_indirect.nil?
     @minimize_indirect
+  end
+
+  def current_job_timeout(_timeout_adjustment = 1)
+    @execution_ttl ||=
+      (options[:execution_ttl].try(:to_i) || DEFAULT_EXECUTION_TTL) * 60
   end
 
   def start

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -32,6 +32,24 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
     end
   end
 
+  describe '#current_job_timeout' do
+    context 'timeout set in options' do
+      let(:options) { {:execution_ttl => 50} }
+
+      it 'uses customized timeout value' do
+        expect(subject.current_job_timeout).to eq(3000)
+      end
+    end
+
+    context 'timeout not set in options' do
+      let(:options) { {} }
+
+      it 'uses default timeout value' do
+        expect(subject.current_job_timeout).to eq(described_class::DEFAULT_EXECUTION_TTL * 60)
+      end
+    end
+  end
+
   describe '#create_inventory' do
     context 'hosts are given' do
       # Use string key to also test the indifferent accessibility


### PR DESCRIPTION
`PlaybookRunner` is a subclass of `Job`. Previously it depends on `Job` `DEFAULT_TIMEOUT` which equals 5 minutes. If the playbook does not complete before this timeout, it gets abort. 

`PlaybookRunner` already takes option `execution_ttl` in minutes from user when the automate playbook method is defined. This number is now used to override `current_job_timeout` method. If this option is not given a new default 10 minute is used instead. 

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581465
