### PR TITLE
Add customization template specs for cloud-init

### DIFF
--- a/spec/factories/customization_template.rb
+++ b/spec/factories/customization_template.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :customization_template do
     sequence(:name)        { |n| "customization_template_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "Customization Template #{seq_padded_for_sorting(n)}" }
+    sequence(:script)      { |n| "script_name_#{seq_padded_for_sorting(n)}" }
     after(:build) do |x|
       x.pxe_image_type ||= FactoryGirl.create(:pxe_image_type)
     end


### PR DESCRIPTION
Add specs around the cloud-init template methods.

1. Validate we pull the correct customization template in
2. The script name is pulled correctly and assigned to the workflow.