### PR TITLE
Bug 1518304: Don't show events tab for openstack network provider edit

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -138,7 +138,8 @@ module SupportsFeatureMixin
     :block_storage                       => 'Block Storage',
     :object_storage                      => 'Object Storage',
     :vm_import                           => 'VM Import',
-    :change_password                     => 'Change Password'
+    :change_password                     => 'Change Password',
+    :configure_events                    => 'Configure Events'
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.


### PR DESCRIPTION
Adds a support item to indicate whether a provider supports events
configuration -- this is used to show or hide the events tab
on the provider edit UI.

https://github.com/ManageIQ/manageiq-ui-classic/pull/3832 depends on this.