### PR TITLE
Add ArchivedMixin to ServiceTemplate

### DIFF
--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -16,6 +16,14 @@ module ArchivedMixin
     deleted_on.nil?
   end
 
+  def archive!
+    update_attributes!(:deleted_on => Time.now.utc)
+  end
+
+  def unarchive!
+    update_attributes!(:deleted_on => nil)
+  end
+
   # Needed for metrics
   def my_zone
     if ext_management_system.present?

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -37,6 +37,7 @@ class ServiceTemplate < ApplicationRecord
   include OwnershipMixin
   include NewWithTypeStiMixin
   include TenancyMixin
+  include ArchivedMixin
   include_concern 'Filter'
 
   belongs_to :tenant

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -57,6 +57,7 @@ class ServiceTemplate < ApplicationRecord
   has_many   :dialogs, -> { distinct }, :through => :resource_actions
 
   has_many   :miq_requests, :as => :source, :dependent => :nullify
+  has_many   :active_requests, -> { where(:request_state => MiqRequest::ACTIVE_STATES) }, :as => :source, :class_name => "MiqRequest"
 
   virtual_column   :type_display,                 :type => :string
   virtual_column   :template_valid,               :type => :boolean

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -153,6 +153,11 @@ class ServiceTemplate < ApplicationRecord
     super
   end
 
+  def archive
+    raise _("Cannot archive while in use") unless active_requests.empty?
+    archive!
+  end
+
   def request_class
     ServiceTemplateProvisionRequest
   end


### PR DESCRIPTION
This adds the archived mixin to service templates to allow for v2v
migration plans to be archived by the user.

https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/314

Gap backport: https://github.com/ManageIQ/manageiq/pull/17481

Depends on: https://github.com/ManageIQ/manageiq-schema/pull/207