### PR TITLE
Ability to reset settings to default value and delete newly added keys

### DIFF
--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -214,24 +214,23 @@ module Vmdb
         _log.info("removing custom settings #{delta[:key]} on #{resource.class} id:#{resource.id}")
         resource.settings_changes.where("key LIKE ?", "#{delta[:key]}%").destroy_all
       when DELETE_ALL_COMMAND
-        _log.info("resetting #{delta[:key]} to defaul for all resorces")
+        _log.info("resetting #{delta[:key]} to default for all resorces")
         SettingsChange.where("key LIKE ?", "#{delta[:key]}%").destroy_all
       end
       true
     end
     private_class_method :process_magic_value
 
-    def self.walk_hash(hash, path = [], &block)
+    def self.walk_hash(hash, &block)
       hash.each do |key, value|
-        key_path = path.dup << key
-        yield key, value, key_path, hash
-        walk_hash(value, key_path, &block) if value&.class == hash.class
+        yield key, value, hash
+        walk_hash(value, &block) if value&.class == Hash
       end
     end
     private_class_method :walk_hash
 
     def self.remove_magic_values(hash)
-      walk_hash(hash) { |key, value, _path, owner| owner.delete(key) if MAGIC_VALUES.include?(value) }
+      walk_hash(hash) { |key, value, owner| owner.delete(key) if MAGIC_VALUES.include?(value) }
       hash
     end
     private_class_method :remove_magic_values

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -24,8 +24,8 @@ module Vmdb
 
     # RESET_COMMAND remove record for selected key and specific resource
     # RESET_ALL_COMMAND remove all records for selected key and all resources
-    MAGIC_VALUES = [DELETE_COMMAND      = "<<reset>>".freeze,
-                    DELETE_ALL_COMMAND  = "<<reset_all>>".freeze].freeze
+    MAGIC_VALUES = [RESET_COMMAND      = "<<reset>>".freeze,
+                    RESET_ALL_COMMAND  = "<<reset_all>>".freeze].freeze
 
     cattr_accessor :last_loaded
 
@@ -210,10 +210,10 @@ module Vmdb
     def self.process_magic_value(resource, delta)
       return false unless MAGIC_VALUES.include?(delta[:value])
       case delta[:value]
-      when DELETE_COMMAND
-        _log.info("removing custom settings #{delta[:key]} on #{resource.class} id:#{resource.id}")
+      when RESET_COMMAND
+        _log.info("resetting #{delta[:key]} on #{resource.class} id:#{resource.id}")
         resource.settings_changes.where("key LIKE ?", "#{delta[:key]}%").destroy_all
-      when DELETE_ALL_COMMAND
+      when RESET_ALL_COMMAND
         _log.info("resetting #{delta[:key]} to default for all resorces")
         SettingsChange.where("key LIKE ?", "#{delta[:key]}%").destroy_all
       end

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -270,8 +270,8 @@ describe Vmdb::Settings do
       let(:server_value) { 1 }
       let(:zone_value)   { 2 }
 
-      let(:reset)     { ::Vmdb::Settings::DELETE_COMMAND }
-      let(:reset_all) { ::Vmdb::Settings::DELETE_ALL_COMMAND }
+      let(:reset)     { ::Vmdb::Settings::RESET_COMMAND }
+      let(:reset_all) { ::Vmdb::Settings::RESET_ALL_COMMAND }
 
       let(:second_server) { FactoryGirl.create(:miq_server, :zone => miq_server.zone) }
 

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -265,6 +265,69 @@ describe Vmdb::Settings do
       miq_server.zone.reload
       expect(miq_server.zone.settings_changes.count).to eq 0
     end
+
+    context "deleting entries" do
+      let(:server_value) { 1 }
+      let(:zone_value)   { 2 }
+
+      let(:reset)     { ::Vmdb::Settings::DELETE_COMMAND }
+      let(:reset_all) { ::Vmdb::Settings::DELETE_ALL_COMMAND }
+
+      let(:second_server) { FactoryGirl.create(:miq_server, :zone => miq_server.zone) }
+
+      before do
+        MiqRegion.seed
+
+        described_class.save!(miq_server, :api => {:token_ttl => server_value}, :session => {:timeout => server_value})
+        described_class.save!(miq_server, :api => {:new_key => "new value"})
+        described_class.save!(second_server, :api => {:token_ttl => server_value}, :session => {:timeout => server_value})
+
+        described_class.save!(miq_server.zone, :api => {:token_ttl => zone_value}, :session => {:timeout => zone_value})
+        expect(SettingsChange.count).to eq 8
+      end
+
+      context "magic value <<reset>>" do
+        it "deletes key-value for specific key for the resource if specified on leaf level" do
+          described_class.save!(miq_server, :api => {:token_ttl => reset})
+
+          expect(SettingsChange.count).to eq 7
+          expect(miq_server.settings_changes.find_by(:key => "/api/token_ttl")).to be nil
+          expect(Vmdb::Settings.for_resource(miq_server).api.new_key).to eq "new value"
+          expect(Vmdb::Settings.for_resource(second_server).api.token_ttl).to eq server_value
+        end
+
+        it "deletes current node and all sub-nodes for the resource if specified on node level" do
+          described_class.save!(miq_server, :api => reset)
+
+          expect(SettingsChange.count).to eq 6
+          expect(miq_server.settings_changes.where("key LIKE ?", "/api%").count).to eq 0
+          expect(Vmdb::Settings.for_resource(miq_server).api.new_key).to eq nil
+          expect(Vmdb::Settings.for_resource(second_server).api.token_ttl).to eq server_value
+        end
+
+        it "deletes new key-value settings not present in defaul yaml" do
+          described_class.save!(miq_server, :api => {:new_key => reset})
+          expect(Vmdb::Settings.for_resource(miq_server).api.new_key).to eq nil
+        end
+      end
+
+      context "magic value <<reset_all>>" do
+        it "deletes all key-value for specific key for all resource if specified on leaf levelher" do
+          described_class.save!(miq_server, :api => {:token_ttl => reset_all})
+
+          expect(SettingsChange.where("key LIKE ?", "/api/token_ttl").count).to eq 0
+          expect(SettingsChange.where("key LIKE ?", "/api%").count).to eq 1
+          expect(SettingsChange.where("key LIKE ?", "/session%").count).to eq 4
+        end
+
+        it "deletes specific node and all sub-nodes for all resources if specified on node level" do
+          described_class.save!(miq_server, :api => reset_all)
+
+          expect(SettingsChange.where("key LIKE ?", "/api%").count).to eq 0
+          expect(SettingsChange.where("key LIKE ?", "/session%").count).to eq 4
+        end
+      end
+    end
   end
 
   describe "save_yaml!" do


### PR DESCRIPTION
Current implementation of `Settings` does not allow to reset value to default or delete new entries.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1576984


This PR introduced "magic" words:
```<<reset>>```  -  if this word set as value than key/value deleted from ```settings_changes``` table, which effectively set that value to default (default value loaded from ```settings.yaml```.
To reset all subtrees down from some node:  delete all subtree in UI editor and make that node a leaf with value ```<<reset>>>```
```<<reset_all>>>``` - works the same as ```<<reset>>``` but on ALL resources 



@miq-bot add-label  bug
