### PR TITLE
Add evm:db:dump:local and evm:db:dump:remote tasks

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -106,6 +106,10 @@ class EvmDatabaseOps
     uri
   end
 
+  private_class_method def self.merged_db_opts(db_opts)
+    DEFAULT_OPTS.merge(db_opts)
+  end
+
   private_class_method def self.prepare_for_restore(filename)
     backup_type = validate_backup_file_type(filename)
 

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -199,11 +199,12 @@ namespace :evm do
       task :local do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file, "Destination file", :type => :string, :required => true
-          opt :username,   "Username",         :type => :string
-          opt :password,   "Password",         :type => :string
-          opt :hostname,   "Hostname",         :type => :string
-          opt :dbname,     "Database name",    :type => :string
+          opt :local_file,           "Destination file",       :type => :string, :required => true
+          opt :username,             "Username",               :type => :string
+          opt :password,             "Password",               :type => :string
+          opt :hostname,             "Hostname",               :type => :string
+          opt :dbname,               "Database name",          :type => :string
+          opt :"exclude-table-data", "Tables to exclude data", :type => :strings
         end
 
         opts.delete_if { |_, v| v.nil? }
@@ -216,18 +217,19 @@ namespace :evm do
       task :remote do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",       :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",  :type => :string
-          opt :uri_password,     "Destination depot password",  :type => :string
-          opt :remote_file_name, "Destination depot filename",  :type => :string
-          opt :username,         "Username",                    :type => :string
-          opt :password,         "Password",                    :type => :string
-          opt :hostname,         "Hostname",                    :type => :string
-          opt :dbname,           "Database name",               :type => :string
+          opt :uri,                  "Destination depot URI",      :type => :string, :required => true
+          opt :uri_username,         "Destination depot username", :type => :string
+          opt :uri_password,         "Destination depot password", :type => :string
+          opt :remote_file_name,     "Destination depot filename", :type => :string
+          opt :username,             "Username",                   :type => :string
+          opt :password,             "Password",                   :type => :string
+          opt :hostname,             "Hostname",                   :type => :string
+          opt :dbname,               "Database name",              :type => :string
+          opt :"exclude-table-data", "Tables to exclude data",     :type => :strings
         end
 
         db_opts = {}
-        [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
+        [:dbname, :username, :password, :hostname, :"exclude-table-data"].each { |k| db_opts[k] = opts[k] if opts[k] }
 
         connect_opts = {}
         [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -193,6 +193,53 @@ namespace :evm do
       end
     end
 
+    namespace :dump do
+      require Rails.root.join("lib", "evm_database_ops").expand_path.to_s
+      desc 'Dump the local ManageIQ EVM Database (VMDB) to a local file'
+      task :local do
+        require 'trollop'
+        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+          opt :local_file, "Destination file", :type => :string, :required => true
+          opt :username,   "Username",         :type => :string
+          opt :password,   "Password",         :type => :string
+          opt :hostname,   "Hostname",         :type => :string
+          opt :dbname,     "Database name",    :type => :string
+        end
+
+        opts.delete_if { |_, v| v.nil? }
+        EvmDatabaseOps.dump(opts)
+
+        exit # exit so that parameters to the first rake task are not run as rake tasks
+      end
+
+      desc 'Dump the local ManageIQ EVM Database (VMDB) to a remote file'
+      task :remote do
+        require 'trollop'
+        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+          opt :uri,              "Destination depot URI",       :type => :string, :required => true
+          opt :uri_username,     "Destination depot username",  :type => :string
+          opt :uri_password,     "Destination depot password",  :type => :string
+          opt :remote_file_name, "Destination depot filename",  :type => :string
+          opt :username,         "Username",                    :type => :string
+          opt :password,         "Password",                    :type => :string
+          opt :hostname,         "Hostname",                    :type => :string
+          opt :dbname,           "Database name",               :type => :string
+        end
+
+        db_opts = {}
+        [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
+
+        connect_opts = {}
+        [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
+        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
+        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+
+        EvmDatabaseOps.dump(db_opts, connect_opts)
+
+        exit # exit so that parameters to the first rake task are not run as rake tasks
+      end
+    end
+
     namespace :restore do
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a local backup file'
       task :local => :environment do

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -60,6 +60,52 @@ describe EvmDatabaseOps do
     end
   end
 
+  context "#dump" do
+    before do
+      @connect_opts = {:username => 'blah', :password => 'blahblah', :uri => "smb://myserver.com/share"}
+      @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
+      allow(MiqSmbSession).to receive(:runcmd)
+      allow_any_instance_of(MiqSmbSession).to receive(:settings_mount_point).and_return(Rails.root.join("tmp"))
+      allow(MiqUtil).to receive(:runcmd)
+      allow(PostgresAdmin).to receive(:runcmd_with_logging)
+      allow(FileUtils).to receive(:mv).and_return(true)
+      allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(200.megabytes)
+      allow(EvmDatabaseOps).to receive(:database_size).and_return(100.megabytes)
+    end
+
+    it "locally" do
+      local_dump = "/tmp/dump_1"
+      @db_opts[:local_file] = local_dump
+      expect(EvmDatabaseOps.dump(@db_opts, @connect_opts)).to eq(local_dump)
+    end
+
+    it "defaults" do
+      local_dump = "/tmp/dump_1"
+      @db_opts[:local_file] = local_dump
+      expect(EvmDatabaseOps.dump(@db_opts, {})).to eq(local_dump)
+    end
+
+    it "without enough free space" do
+      EvmSpecHelper.create_guid_miq_server_zone
+      allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(100.megabytes)
+      allow(EvmDatabaseOps).to receive(:database_size).and_return(200.megabytes)
+      expect { EvmDatabaseOps.dump(@db_opts, @connect_opts) }.to raise_error(MiqException::MiqDatabaseBackupInsufficientSpace)
+      expect(MiqQueue.where(:class_name => "MiqEvent", :method_name => "raise_evm_event").count).to eq(1)
+    end
+
+    it "remotely" do
+      @db_opts[:local_file] = nil
+      @connect_opts[:remote_file_name] = "custom_pg_dump"
+      expect(EvmDatabaseOps.dump(@db_opts, @connect_opts)).to eq("smb://myserver.com/share/db_dump/custom_pg_dump")
+    end
+
+    it "remotely without a remote file name" do
+      @db_opts[:local_file] = nil
+      @connect_opts[:remote_file_name] = nil
+      expect(EvmDatabaseOps.dump(@db_opts, @connect_opts)).to match(/smb:\/\/myserver.com\/share\/db_dump\/miq_pg_dump_.*/)
+    end
+  end
+
   context "#restore" do
     before do
       @connect_opts = {:username => 'blah', :password => 'blahblah'}


### PR DESCRIPTION
Builds off of https://github.com/ManageIQ/manageiq-gems-pending/pull/351 , which added `pg_dump` functionality back to the `PostgresAdmin` lib, and creates rake tasks for running a database dump to either a local file, of NFS/SMB share.


Notable changes
---------------

* Refactors `EvmDatabaseOps#backup` so that `EvmDatabaseOps#dump` can leverage almost all of the same code.
* Carbon copies the `evm:db:backup` tasks into `evm:db:dump` tasks.
* Adds option to `--exclude-table-data` from the dump for specific tables


Links
-----

* Part of https://bugzilla.redhat.com/show_bug.cgi?id=1535345
* Required (already merged): https://github.com/ManageIQ/manageiq-gems-pending/pull/351


Steps for Testing/QA
--------------------

Not sure the best way to test that these work, but we probably should run some tests to confirm everything is behaving as expected.  I will probably do some testing of this locally now that I have this up for review, and will report back with how I tested things for others to try as well.

**Update**:  Here is what I did to test:

* Found a db to dump on my local machine
  
* Ran in the terminal:
  
  ```console
  $ rake evm:db:dump:local -- --local-file tmp/vmdb_db_dump --dbname my_vmdb
  ```
  
* Checked the `log/evm.log` to see that the commands run made sense:
  
  ```console
  $ tail log/evm.log
  ...
  [----] I, [2018-05-25T17:17:16.749795 #46992:3ff54d03fa0c]  INFO -- : MIQ(PostgresAdmin.runcmd_with_logging) Running command... psql --no-password --dbname my_vmdb --command SELECT\ pg_database_size\(\'my_vmdb\'\)\;
  [----] I, [2018-05-25T17:17:16.769418 #46992:3ff54d03fa0c]  INFO -- : MIQ(EvmDatabaseOps.run_db_opt_for_new_uri) [my_vmdb] with database size: [100 bytes], free space at [tmp/vmdb_db_dump]: [200 bytes]
  [----] I, [2018-05-25T17:17:16.769763 #46992:3ff54d03fa0c]  INFO -- : MIQ(PostgresAdmin.runcmd_with_logging) Running command... pg_dump --no-password --format c --file tmp/vmdb_db_dump my_vmdb
  [----] I, [2018-05-25T17:18:25.311775 #46992:3ff54d03fa0c]  INFO -- : MIQ(EvmDatabaseOps.dump) [my_vmdb] database has been dumped up to file: [tmp/vmdb_db_dump]
  ```
  
* Ran in the terminal:
  
  ```console
  $ rake evm:db:dump:local --           \
      --local-file tmp/vmdb_db_dump_2   \
      --dbname my_vmdb                  \
      --exclude-table-data "metrics_*" "vim_performance_states" "event_streams"
  ```
  
* Confirmed that the dump size was smaller and commands executed made sense:
  
  ```console
  $ ls -lhtmp/vmdb_db_dump*
  -rw-r--r--  1 nicklamuro  staff   452M May 25 17:18 tmp/vmdb_db_dump
  -rw-r--r--  1 nicklamuro  staff   331M May 25 18:35 tmp/vmdb_db_dump_2
  $ tail log/evm.log
  ...
  [----] I, [2018-05-25T18:34:16.749795 #46993:3ff54d03fa0c]  INFO -- : MIQ(PostgresAdmin.runcmd_with_logging) Running command... psql --no-password --dbname my_vmdb --command SELECT\ pg_database_size\(\'my_vmdb\'\)\;
  [----] I, [2018-05-25T18:34:16.769418 #46993:3ff54d03fa0c]  INFO -- : MIQ(EvmDatabaseOps.run_db_opt_for_new_uri) [my_vmdb] with database size: [100 bytes], free space at [tmp/vmdb_db_dump]: [200 bytes]
  [----] I, [2018-05-25T18:34:16.769763 #46993:3ff54d03fa0c]  INFO -- : MIQ(PostgresAdmin.runcmd_with_logging) Running command... pg_dump --no-password --format c --file tmp/vmdb_db_dump my_vmdb --exclude-table-data metrics_\* --exclude-table-data vim_performance_states --exclude-table-data event_streams
  [----] I, [2018-05-25T18:35:25.311775 #46993:3ff54d03fa0c]  INFO -- : MIQ(EvmDatabaseOps.dump) [my_vmdb] database has been dumped up to file: [tmp/vmdb_db_dump]
  ```