### PR TITLE
Add physical server asset details collection

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/physical_infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/physical_infra_manager.rb
@@ -11,5 +11,16 @@ class ManagerRefresh::InventoryCollectionDefault::PhysicalInfraManager < Manager
 
       attributes.merge!(extra_attributes)
     end
+
+    def physical_server_details(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::AssetDetail,
+        :association                  => :physical_server_details,
+        :manager_ref                  => [:resource],
+        :parent_inventory_collections => [:physical_servers],
+      }
+
+      attributes.merge!(extra_attributes)
+    end
   end
 end


### PR DESCRIPTION
Most of the metadata about the physical servers is stored in associated
asset details entry, which serves as a data source for UI components.

This commit adds default collection for asset details that can be used
to store physical server metadata.

/cc @gberginc @matejart
@miq-bot assign @gtanzillo 
@miq-bot add_reviewer @Ladas 