### PR TITLE
[WIP] Add hypervisor cores report

### DIFF
--- a/product/reports/100_Configuration Management - Virtual Machines/090_Hypervisor Cores.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/090_Hypervisor Cores.yaml
@@ -1,0 +1,49 @@
+---
+where_clause:
+generate_cols:
+dims:
+reserved:
+title: "Hypervisor Cores"
+conditions:
+col_options:
+  derived_vm_used_disk_storage:
+    :grouping:
+    - :max
+    - :min
+order: Ascending
+graph:
+generate_rows:
+menu_name: "Hypervisor Cores"
+rpt_group: Custom
+priority:
+col_order:
+  - host.hostname
+  - hardware.cpu_total_cores
+  - cpu_total_cores
+timeline:
+file_mtime:
+categories:
+time_profile_id:
+rpt_type: Custom
+filename:
+col_formats:
+include:
+  host:
+    columns:
+    - hostname
+  hardware:
+    columns:
+    - cpu_total_cores
+
+db: Vm
+cols:
+  - cpu_total_cores
+template_type: report
+group: c
+sortby:
+- hostname
+headers:
+    - Host / Node Hostname
+    - Hardware Number of CPU Cores
+    - Number of CPU Cores
+display_filter:

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,5 +1,5 @@
 describe MiqReport do
   context "Seeding" do
-    include_examples(".seed called multiple times", 143)
+    include_examples(".seed called multiple times", 144)
   end
 end


### PR DESCRIPTION
Add OOTB report for number of physical/hypervisor cores.
USPTO Tags: USPTO - License column seems to not be available.

Screenshot
----------------
![screenshot from 2018-05-30 13-05-44](https://user-images.githubusercontent.com/9535558/40716721-32f61942-640a-11e8-92d2-9fa00af4da06.png)


Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1437589

Steps for Testing/QA [Optional]
-------------------------------

Cloud Intel ->  Reports -> Configuration Management -> Virtual Machines -> Hypervisor Cores -> Queue
