### PR TITLE
remove User#admin? methods to avoid reuse

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,7 +171,7 @@ class User < ApplicationRecord
   end
 
   def self.authorize_user(userid)
-    return if userid.blank? || admin?(userid)
+    return if userid.blank? || userid == "admin".freeze
     authenticator(userid).authorize_user(userid)
   end
 
@@ -211,14 +211,6 @@ class User < ApplicationRecord
     raise _("The user's current group cannot be changed because the user does not belong to any other group") if user_groups.empty?
     self.current_group = MiqGroup.find_by(:id => user_groups.first)
     save!
-  end
-
-  def admin?
-    self.class.admin?(userid)
-  end
-
-  def self.admin?(userid)
-    userid == "admin"
   end
 
   def subscribed_widget_sets

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -572,16 +572,6 @@ describe User do
     end
   end
 
-  context ".admin?" do
-    it "admin? succeeds with admin account" do
-      expect(User.admin?("admin")).to be_truthy
-    end
-
-    it "admin? fails with non-admin account" do
-      expect(User.admin?("regular_user")).to be_falsey
-    end
-  end
-
   context ".authorize_user" do
     it "returns nil with blank userid" do
       expect(User.authorize_user("")).to be_nil


### PR DESCRIPTION
We currently have a few `admin?` checks that use string compares.
We are getting away from this.

This removes the method to discourage developers from using the check.

One string compare does remain.
This uses the local database for the admin user (first user - think root) so the local database is used instead of the external authentication source.

@abellotti Just close this PR if you want to keep the method