### PR TITLE
Remove changes to enable workers to be started in containers

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -92,7 +92,6 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def check_not_responding(class_name = nil)
-    return [] if MiqEnvironment::Command.is_podified?
     processed_workers = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)

--- a/app/models/miq_server/worker_management/monitor/system_limits.rb
+++ b/app/models/miq_server/worker_management/monitor/system_limits.rb
@@ -9,13 +9,11 @@ module MiqServer::WorkerManagement::Monitor::SystemLimits
   }
 
   def kill_workers_due_to_resources_exhausted?
-    return false if MiqEnvironment::Command.is_podified?
     options = worker_monitor_settings[:kill_algorithm].merge(:type => :kill)
     invoke_algorithm(options)
   end
 
   def enough_resource_to_start_worker?(worker_class)
-    return true if MiqEnvironment::Command.is_podified?
     # HACK, sync_config is done in the server, while this method is called from miq_worker
     # This method should move to the worker and the server should pass the settings.
     sync_config if worker_monitor_settings.nil? || child_worker_settings.nil?

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -2,7 +2,6 @@ module MiqServer::WorkerManagement::Monitor::Validation
   extend ActiveSupport::Concern
 
   def validate_worker(w)
-    return true if MiqEnvironment::Command.is_podified?
     time_threshold   = get_time_threshold(w)
     restart_interval = get_restart_interval(w)
     memory_threshold = get_memory_threshold(w)

--- a/app/models/miq_ui_worker/runner.rb
+++ b/app/models/miq_ui_worker/runner.rb
@@ -1,8 +1,3 @@
 class MiqUiWorker::Runner < MiqWorker::Runner
   include MiqWebServerRunnerMixin
-
-  def prepare
-    super
-    MiqApache::Control.start if MiqEnvironment::Command.is_podified?
-  end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -372,6 +372,8 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.containerized_worker?
+    # un-rearch containers for Hammer
+    return false
     MiqEnvironment::Command.is_podified? && supports_container?
   end
 
@@ -527,8 +529,6 @@ class MiqWorker < ApplicationRecord
   end
 
   def status_update
-    return if MiqEnvironment::Command.is_podified?
-
     begin
       pinfo = MiqProcess.processInfo(pid)
     rescue Errno::ESRCH


### PR DESCRIPTION
This will allow us to use the G-release architecture for the
H-release container images without undoing all of the work
in #15884

https://www.pivotaltracker.com/story/show/157774394

These changes really only need to be here for the `hammer` branch.

Merging them to master will break manageiq-pods master branch, but if we want to branch `hammer` in manageiq-pods then we really need this here now.

Interested in what people think about a way to proceed with this.