### PR TITLE
Move get_file and save_file to ConfigurationManagementMixin

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -13,11 +13,28 @@ module MiqServer::ConfigurationManagement
   def set_config(config)
     config = config.config if config.respond_to?(:config)
     add_settings_for_resource(config)
-    ntp_reload_queue
   end
 
   def reload_settings
-    Vmdb::Settings.reload! if is_local?
+    return if is_remote?
+
+    Vmdb::Settings.reload!
+    activate_settings_for_appliance
+  end
+
+  # The purpose of this method is to do special activation of things
+  #   that can only happen once per server.  Normally, the
+  #   VMDB::Config::Activator would be used, however the activations
+  #   will end up occurring once per worker on the entire server, which
+  #   can be detrimental.
+  #
+  #   As an example, ntp_reload works by telling systemctl to restart
+  #   chronyd.  However, if this occurs on every worker, you end up with
+  #   dozens of calls to `systemctl restart chronyd` simultaneously.
+  #   Instead, this method will allow it to only happen once on
+  #   the reload of settings in evmserverd.
+  private def activate_settings_for_appliance
+    ntp_reload_queue
   end
 
   def servers_for_settings_reload

--- a/app/models/mixins/configuration_management_mixin.rb
+++ b/app/models/mixins/configuration_management_mixin.rb
@@ -9,8 +9,17 @@ module ConfigurationManagementMixin
     Vmdb::Settings.for_resource(self)
   end
 
+  def settings_for_resource_yaml
+    Vmdb::Settings.for_resource_yaml(self)
+  end
+
   def add_settings_for_resource(settings)
     Vmdb::Settings.save!(self, settings)
+    immediately_reload_settings
+  end
+
+  def add_settings_for_resource_yaml(contents)
+    Vmdb::Settings.save_yaml!(self, contents)
     immediately_reload_settings
   end
 

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -58,22 +58,15 @@ module VMDB
 
     # NOTE: Used by Configuration -> Advanced
     def self.get_file(resource = MiqServer.my_server)
-      Vmdb::Settings.encrypt_passwords!(resource.settings_for_resource.to_hash).to_yaml
+      resource.settings_for_resource_yaml
     end
 
     # NOTE: Used by Configuration -> Advanced
     def self.save_file(contents, resource = MiqServer.my_server)
-      config = new("vmdb")
-
-      begin
-        config.config = Vmdb::Settings.decrypt_passwords!(YAML.load(contents))
-        config.validate
-      rescue StandardError, Psych::SyntaxError => err
-        config.errors = [[:contents, "File contents are malformed, '#{err.message}'"]]
-      end
-
-      return config.errors unless config.errors.blank?
-      config.save(resource)
+      resource.add_settings_for_resource_yaml(contents)
+    rescue Vmdb::Settings::ConfigurationInvalid => err
+      err.errors
+    else
       true
     end
 

--- a/spec/lib/vmdb/config_spec.rb
+++ b/spec/lib/vmdb/config_spec.rb
@@ -49,8 +49,9 @@ describe VMDB::Config do
   end
 
   context ".save_file" do
+    let!(:resource) { FactoryGirl.create(:miq_server) }
+
     it "normal" do
-      resource = FactoryGirl.create(:miq_server)
       MiqRegion.seed
       data = {}
       data.store_path(:api, :token_ttl, "1.day")
@@ -62,7 +63,7 @@ describe VMDB::Config do
     end
 
     it "catches syntax errors" do
-      errors = VMDB::Config.save_file("xxx")
+      errors = VMDB::Config.save_file("xxx", resource)
       expect(errors.length).to eq(1)
       expect(errors.first[0]).to eq(:contents)
       expect(errors.first[1]).to start_with("File contents are malformed")


### PR DESCRIPTION
In moving, the methods become settings_for_resource_yaml and
add_settings_for_resource_yaml, respectively.  The old interfaces are
still left intact temporarily until the UI is changed to use the new
methods.

Also preserved is the special activation that is currently done for
ntp_reload, as introduced in ManageIQ/manageiq@939524fa, which avoids
repeated activation for every worker, instead preferring to do it once
at the server level.

Replaces https://github.com/ManageIQ/manageiq/pull/17458
@carbonin Please review
cc @h-kataria 