### PR TITLE
Adding the profile description option to the provision error message

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -419,6 +419,7 @@
               :vlans: true
             :method: :allowed_vlans
           :description: Network
+          :required_description: Virtual NIC Profile ID or Profile Name (Network Name)
           :required: true
           :display: :edit
           :default: <Template>

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -439,7 +439,8 @@
               :dvs: true
               :vlans: true
             :method: :allowed_vlans
-          :description: Virtual NIC Profile ID
+          :description: Network
+          :required_description: Virtual NIC Profile ID or Profile Name (Network Name)
           :required: true
           :display: :edit
           :default: <Template>


### PR DESCRIPTION
If the requested vlan/network is wrong, the error message will be-
'Virtual NIC Profile ID or Profile Name (Network Name)'

Fixes https://bugzilla.redhat.com/1578393
Fixes https://bugzilla.redhat.com/1574351