### PR TITLE
Extend support from memberof to other multi-value attribute for group membership

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,7 @@
   :follow_referrals: false
   :get_direct_groups: true
   :group_memberships_max_depth: 2
+  :group_attribute: memberof
   :ldaphost:
   :ldapport: '389'
   :mode: database

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -43,6 +43,7 @@ class MiqLdap
     @bind_timeout     = options.delete(:bind_timeout) || ::Settings.authentication.bind_timeout.to_i_with_method
     @search_timeout   = options.delete(:search_timeout) || ::Settings.authentication.search_timeout.to_i_with_method
     @follow_referrals = options.delete(:follow_referrals) || ::Settings.authentication.follow_referrals
+    @group_attribute  = options.delete(:group_attribute) || ::Settings.authentication.group_attribute
     options[:host] ||= ::Settings.authentication.ldaphost
     options[:port] ||= ::Settings.authentication.ldapport
     options[:host] = resolve_host(options[:host], options[:port])
@@ -304,7 +305,7 @@ class MiqLdap
     user_type ||= @user_type.split("-").first
     user_type = "dn" if self.is_dn?(username)
     begin
-      search_opts = {:base => @basedn, :scope => :sub, :attributes => ["*", "memberof"]}
+      search_opts = {:base => @basedn, :scope => :sub, :attributes => ["*", @group_attribute]}
 
       case user_type
       when "samaccountname"
@@ -368,7 +369,7 @@ class MiqLdap
     udata
   end
 
-  def get_memberships(obj, max_depth = 0, attr = :memberof, followed = [], current_depth = 0)
+  def get_memberships(obj, max_depth = 0, attr = @group_attribute.to_sym, followed = [], current_depth = 0)
     current_depth += 1
 
     _log.debug("Enter get_memberships: #{obj.inspect}")

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -157,4 +157,27 @@ describe MiqLdap do
       expect(ldap.ldap.instance_variable_get(:@encryption)).to be_nil
     end
   end
+
+  context '#get_user_object' do
+    before do
+      allow(TCPSocket).to receive(:new)
+      @opts = {:base => nil, :scope => :sub, :filter => "(userprincipalname=myuserid@mycompany.com)"}
+    end
+
+    it "searches for group memberships with the specified group attribute" do
+      ldap = MiqLdap.new(:host => ["192.0.2.2"], :group_attribute => "groupMembership")
+      @opts[:attributes] = ["*", "groupMembership"]
+      expect(ldap).to receive(:search).with(@opts)
+
+      ldap.get_user_object("myuserid@mycompany.com", "upn")
+    end
+
+    it "searches for group memberships with the default group attribute" do
+      ldap = MiqLdap.new(:host => ["192.0.2.2"])
+      @opts[:attributes] = ["*", "memberof"]
+      expect(ldap).to receive(:search).with(@opts)
+
+      ldap.get_user_object("myuserid@mycompany.com", "upn")
+    end
+  end
 end


### PR DESCRIPTION
MiqLdap currently has the group membership attribute hardcodes to _memberof_.

This PR moves this same hardcoded value into ::Settings.authentication.group_attribute. 
The result being that by default the current functionality will not change but it will now be
possible for uses who want to use a different multi-value attribute for group membership
to do so by manually setting the Advanced Configuration option _group_attribute_.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1353037

Steps for Testing/QA [Optional]
-------------------------------

- Configure your LDAP directory to have _groupMembership_ attribute to contain a user's group membership
- Configure MiQ authentication mode LDAP or LDAPS.
- Manually configure _group_attribute_ in MiQ UI under **Configuration/Advanced** 
-- `From:  :group_attribute: memberof`
--  `To:  :group_attribute: groupmembership`
- Test by adding a group for the user configured in you LDAP directory with the _groupMembership_ attribute  by looking up groups by checking: _(Look up LDAP Groups)_ and providing the needed input.


Note: ldapsearch can be used to confirm the multi-value attribute,  _groupmembership_, is correctly configured in LDAP:
-------------------------------

```bash
ldapsearch -x -LLL -H ldap://<my ldap>:389  -b "dc=example,dc=com"  -D "cn=Manager,dc=example,dc=com" -w ******** -s sub "(CN=ldaptest1)" "groupmembership"
dn: cn=ldaptest1,ou=people,ou=prod,dc=example,dc=com
groupmembership: cn=ldap-group-2,ou=groups,ou=prod,dc=example,dc=com
groupmembership: cn=ldap-group-1,ou=groups,ou=prod,dc=example,dc=com
```

