### PR TITLE
[FINE] [BACKPORT] Fix logging oVirt event in debug level

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/event_parsing/parser.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/event_parsing/parser.rb
@@ -28,9 +28,9 @@ module ManageIQ::Providers::Redhat::InfraManager::EventParsing
     def self.event_to_hash(event_obj, ems_id = nil)
       log_header = "ems_id: [#{ems_id}] " unless ems_id.nil?
 
-      _log.debug { "#{log_header}event: [#{event.inspect}]" }
-
       event = event_obj.to_hash
+
+      _log.debug { "#{log_header}event: [#{event.inspect}]" }
 
       # Connect back to RHEV to get the actual user_name
       ems       = ManageIQ::Providers::Redhat::InfraManager.find_by(:id => ems_id)


### PR DESCRIPTION
The log would fail on new events when set to debug level.
As a result refresh would not run and provider not updated.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1580521