### PR TITLE
[WIP] Method for unavailable fields for chargeback

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -73,8 +73,8 @@ class ChargeableField < ApplicationRecord
   # Fixed metric has _1 or _2 in name but column
   # fixed_compute_metric is used in report and calculations
   # TODO: remove and unify with metric_key
-  def metric_column_key
-    fixed? ? metric_key.gsub(/\_1|\_2/, '') : metric_key
+  def metric_column_key(sub_metric)
+    fixed? ? metric_key(sub_metric).gsub(/\_1|\_2/, '') : metric_key
   end
 
   def cost_keys(sub_metric = nil)

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -39,7 +39,7 @@ class ChargebackRate < ApplicationRecord
     # we can memoize, as we get the same report_cols through the life of the object
     @relevant ||= begin
       chargeback_rate_details.select do |r|
-        r.affects_report_fields(report_cols) && allowed_cols.include?(r.metric_column_key)
+        r.affects_report_fields(report_cols) && allowed_cols.include?(r.metric_column_key(r.sub_metric))
       end
     end
   end


### PR DESCRIPTION
Usage:

```
 MiqExpression.unavailable_fields_for("ChargebackVm") =>
   [0] "Cpu Cores Allocated Metric",
    [1] "Cpu Cores Used Metric",
    [2] "Fixed Storage Metric"


MiqExpression.unavailable_fields_for("ChargebackContainerImage") =>
   [0] "Cpu Allocated Metric",
    [1] "Cpu Used Metric",
    [2] "Disk Io Used Metric",
    [3] "Fixed Storage Metric",
    [4] "Storage Allocated Metric",
    [5] "Storage Used Metric"

MiqExpression.unavailable_fields_for("NonChargebackReport") =>
[]
```

cc @hstastna 


