### PR TITLE
Fix to show vm/image related info in audit log when deleting vm/image

### DIFF
--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -12,9 +12,11 @@ class AuditEvent < ApplicationRecord
     }.merge(attrs)
 
     event = AuditEvent.create(attrs)
+    ipaddress = MiqServer.my_server.ipaddress
+    hostname  = MiqServer.my_server.hostname
 
     # Cut an Audit log message
-    $audit_log.send(attrs[:status], "MIQ(#{attrs[:source]}) userid: [#{attrs[:userid]}] - #{attrs[:message]}")
+    $audit_log.send(attrs[:status], "MIQ(#{attrs[:source]}) userid: [#{attrs[:userid]}] userip: [#{ipaddress}] hostname: [#{hostname}] - #{attrs[:message]}")
     event
   end
 

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -12,11 +12,9 @@ class AuditEvent < ApplicationRecord
     }.merge(attrs)
 
     event = AuditEvent.create(attrs)
-    ipaddress = MiqServer.my_server&.ipaddress
-    hostname  = MiqServer.my_server&.hostname
 
     # Cut an Audit log message
-    $audit_log.send(attrs[:status], "MIQ(#{attrs[:source]}) userid: [#{attrs[:userid]}] userip: [#{ipaddress}] hostname: [#{hostname}] - #{attrs[:message]}")
+    $audit_log.send(attrs[:status], "MIQ(#{attrs[:source]}) userid: [#{attrs[:userid]}] - #{attrs[:message]}")
     event
   end
 

--- a/app/models/audit_event.rb
+++ b/app/models/audit_event.rb
@@ -12,8 +12,8 @@ class AuditEvent < ApplicationRecord
     }.merge(attrs)
 
     event = AuditEvent.create(attrs)
-    ipaddress = MiqServer.my_server.ipaddress
-    hostname  = MiqServer.my_server.hostname
+    ipaddress = MiqServer.my_server&.ipaddress
+    hostname  = MiqServer.my_server&.hostname
 
     # Cut an Audit log message
     $audit_log.send(attrs[:status], "MIQ(#{attrs[:source]}) userid: [#{attrs[:userid]}] userip: [#{ipaddress}] hostname: [#{hostname}] - #{attrs[:message]}")

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -54,6 +54,8 @@ module ProcessTasksMixin
         invoke_task_local(task, instance, options, args)
 
         msg = "#{instance.name}: '#{options[:task]}' initiated"
+        msg = "[Name: #{instance.name},Id: #{instance.id}, Ems_ref: #{instance.ems_ref}] Record destroyed" if options[:task] == 'destroy'
+
         task_audit_event(:success, options, :target_id => instance.id, :message => msg)
         task.update_status("Queued", "Ok", "Task has been queued") if task
       end


### PR DESCRIPTION
Added extra vm or image related information in audit log file when removing them from providers.

https://bugzilla.redhat.com/show_bug.cgi?id=1434762


