### PR TITLE
Ignore server IP for embedded ansible when in development env

### DIFF
--- a/lib/embedded_ansible/docker_embedded_ansible.rb
+++ b/lib/embedded_ansible/docker_embedded_ansible.rb
@@ -184,7 +184,7 @@ class DockerEmbeddedAnsible < EmbeddedAnsible
   def database_host
     db_host = database_configuration["host"]
     return db_host if db_host.presence && db_host != "localhost"
-
+    return docker_bridge_gateway unless MiqEnvironment::Command.is_appliance?
     MiqServer.my_server.ipaddress || docker_bridge_gateway
   end
 


### PR DESCRIPTION
With this commit we ignore server's IP (which is stored in VMDB) in case we're running embedded ansible in local environment, because in such circumstances this IP value is not valid.

@miq-bot assign @carbonin 
@miq-bot add_label enhancement
