### PR TITLE
Create a virtual column for `archived` for using in the API

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -62,6 +62,7 @@ class ServiceTemplate < ApplicationRecord
   virtual_column   :type_display,                 :type => :string
   virtual_column   :template_valid,               :type => :boolean
   virtual_column   :template_valid_error_message, :type => :string
+  virtual_column   :archived?,                    :type => :boolean
 
   default_value_for :service_type, 'unknown'
   default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }


### PR DESCRIPTION
Adding a virtual column for `archived?` enables us to query it in the API as shown below -

```
/api/service_templates/<id>?attributes=archived?
```

/cc @agrare 