### PR TITLE
Ancestry Patch updates/fixes

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -184,7 +184,7 @@ class Tenant < ApplicationRecord
   end
 
   def visible_domains
-    MiqAeDomain.where(:tenant_id => ancestor_ids.append(id)).joins(:tenant).order('tenants.ancestry DESC NULLS LAST, priority DESC')
+    MiqAeDomain.where(:tenant_id => path_ids).joins(:tenant).order('tenants.ancestry DESC NULLS LAST, priority DESC')
   end
 
   def enabled_domains

--- a/lib/patches/ancestry_patch.rb
+++ b/lib/patches/ancestry_patch.rb
@@ -8,6 +8,16 @@ module AncestryInstanceMethodsPatch
       end
     end
   end
+
+  def parent=(parent)
+    super
+    clear_memoized_instance_variables
+  end
+
+  def parent_id=(parent)
+    super
+    clear_memoized_instance_variables
+  end
 end
 
 module Ancestry

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -365,6 +365,14 @@ describe Tenant do
                            :tenant_id => t2_2.id)
       end
 
+      # This spec is here to confirm that we don't mutate the memoized
+      # ancestor_ids value when calling `Tenant#visible_domains`.
+      it "does not affect the memoized ancestor_ids variable" do
+        expected_ancestor_ids = t1_1.ancestor_ids.dup  # dup required, don't remove
+        t1_1.visible_domains
+        expect(t1_1.ancestor_ids).to eq(expected_ancestor_ids)
+      end
+
       it "#visibile_domains sub_tenant" do
         t1_1
         expect(t1_1.visible_domains.collect(&:name)).to eq(%w(DOM5 DOM3 DOM1 DOM15 DOM10))

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -814,4 +814,20 @@ describe Tenant do
       expect(tenantA1.build_tenant_tree).to be_empty
     end
   end
+
+  describe "setting a parent for a new record" do
+    it "passes back the parent assigned" do
+      tenant.save!
+      sub_tenant = FactoryGirl.build(:tenant, :parent => Tenant.root_tenant)
+
+      expect(sub_tenant.parent = tenant).to eq(tenant)
+    end
+
+    it "passes back the parent_id assigned" do
+      tenant.save!
+      sub_tenant = FactoryGirl.build(:tenant, :parent => Tenant.root_tenant)
+
+      expect(sub_tenant.parent_id = tenant.id).to eq(tenant.id)
+    end
+  end
 end


### PR DESCRIPTION
Fixes the two issues reported in the [original PR](https://github.com/ManageIQ/manageiq/pull/17360) for the `ancestry` patches and the memoization of certain methods around it:

* Issues with `parent`/`parent_id` in `manageiq-ui-classic`:  https://github.com/ManageIQ/manageiq/pull/17360#issuecomment-393500061
* Issues with `ancestor_ids` in `manageiq-automation_engine`:  https://github.com/ManageIQ/manageiq/pull/17360#issuecomment-394097163

Both issues should be addressed by this PR.


Links
-----

* Original PR:  https://github.com/ManageIQ/manageiq/pull/17360
* Issue 1:  https://github.com/ManageIQ/manageiq/pull/17360#issuecomment-393500061
* Issue 2:  https://github.com/ManageIQ/manageiq/pull/17360#issuecomment-394097163

Steps for Testing/QA
--------------------

Run the specs for both `manageiq-ui-classic` and `manageiq-automation_engine` with this branch checked out and make sure there are not any spec failures.