### PR TITLE
Join object and block storage under ems_storage in the features tree

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5687,105 +5687,105 @@
       :feature_type: admin
       :identifier: ems_storage_new
 
-# EmsBlockStorage
-- :name: Block Storage Managers
-  :description: Everything under Block Storage Managers
-  :feature_type: node
-  :identifier: ems_block_storage
-  :children:
-  - :name: View
-    :description: View Block Storage Managers
-    :feature_type: view
-    :identifier: ems_block_storage_view
+  # EmsBlockStorage
+  - :name: Block Storage Managers
+    :description: Everything under Block Storage Managers
+    :feature_type: node
+    :identifier: ems_block_storage
     :children:
-    - :name: List
-      :description: Display Lists of Block Storage Managers
+    - :name: View
+      :description: View Block Storage Managers
       :feature_type: view
-      :identifier: ems_block_storage_show_list
-    - :name: Show
-      :description: Display Individual Block Storage Managers
-      :feature_type: view
-      :identifier: ems_block_storage_show
-    - :name: Timeline
-      :description: Display Timelines for Block Storage Managers
-      :feature_type: view
-      :identifier: ems_block_storage_timeline
-  - :name: Operate
-    :description: Perform Operations on Block Storage Managers
-    :feature_type: control
-    :identifier: ems_block_storage_control
-    :children:
-    - :name: Edit Tags
-      :description: Edit Tags of Block Storage Managers
+      :identifier: ems_block_storage_view
+      :children:
+      - :name: List
+        :description: Display Lists of Block Storage Managers
+        :feature_type: view
+        :identifier: ems_block_storage_show_list
+      - :name: Show
+        :description: Display Individual Block Storage Managers
+        :feature_type: view
+        :identifier: ems_block_storage_show
+      - :name: Timeline
+        :description: Display Timelines for Block Storage Managers
+        :feature_type: view
+        :identifier: ems_block_storage_timeline
+    - :name: Operate
+      :description: Perform Operations on Block Storage Managers
       :feature_type: control
-      :identifier: ems_block_storage_tag
-    - :name: Manage Policies
-      :description: Manage Policies of Block Storage Managers
-      :feature_type: control
-      :identifier: ems_block_storage_protect
-    - :name: Refresh
-      :description: Refresh Block Storage Managers
-      :feature_type: control
-      :identifier: ems_block_storage_refresh
-  - :name: Modify
-    :description: Modify Block Storage Managers
-    :feature_type: admin
-    :identifier: ems_block_storage_admin
-    :children:
-    - :name: Remove
-      :description: Remove Block Storage Manager
+      :identifier: ems_block_storage_control
+      :children:
+      - :name: Edit Tags
+        :description: Edit Tags of Block Storage Managers
+        :feature_type: control
+        :identifier: ems_block_storage_tag
+      - :name: Manage Policies
+        :description: Manage Policies of Block Storage Managers
+        :feature_type: control
+        :identifier: ems_block_storage_protect
+      - :name: Refresh
+        :description: Refresh Block Storage Managers
+        :feature_type: control
+        :identifier: ems_block_storage_refresh
+    - :name: Modify
+      :description: Modify Block Storage Managers
       :feature_type: admin
-      :identifier: ems_block_storage_delete
+      :identifier: ems_block_storage_admin
+      :children:
+      - :name: Remove
+        :description: Remove Block Storage Manager
+        :feature_type: admin
+        :identifier: ems_block_storage_delete
 
-# EmsObjectStorage
-- :name: Object Storage Managers
-  :description: Everything under Object Storage Managers
-  :feature_type: node
-  :identifier: ems_object_storage
-  :children:
-  - :name: View
-    :description: View Object Storage Managers
-    :feature_type: view
-    :identifier: ems_object_storage_view
+  # EmsObjectStorage
+  - :name: Object Storage Managers
+    :description: Everything under Object Storage Managers
+    :feature_type: node
+    :identifier: ems_object_storage
     :children:
-    - :name: List
-      :description: Display Lists of Object Storage Managers
+    - :name: View
+      :description: View Object Storage Managers
       :feature_type: view
-      :identifier: ems_object_storage_show_list
-    - :name: Show
-      :description: Display Individual Object Storage Managers
-      :feature_type: view
-      :identifier: ems_object_storage_show
-    - :name: Timeline
-      :description: Display Timelines for Object Storage Managers
-      :feature_type: view
-      :identifier: ems_object_storage_timeline
-  - :name: Operate
-    :description: Perform Operations on Object Storage Managers
-    :feature_type: control
-    :identifier: ems_object_storage_control
-    :children:
-    - :name: Edit Tags
-      :description: Edit Tags of Object Storage Managers
+      :identifier: ems_object_storage_view
+      :children:
+      - :name: List
+        :description: Display Lists of Object Storage Managers
+        :feature_type: view
+        :identifier: ems_object_storage_show_list
+      - :name: Show
+        :description: Display Individual Object Storage Managers
+        :feature_type: view
+        :identifier: ems_object_storage_show
+      - :name: Timeline
+        :description: Display Timelines for Object Storage Managers
+        :feature_type: view
+        :identifier: ems_object_storage_timeline
+    - :name: Operate
+      :description: Perform Operations on Object Storage Managers
       :feature_type: control
-      :identifier: ems_object_storage_tag
-    - :name: Manage Policies
-      :description: Manage Policies of Object Storage Managers
-      :feature_type: control
-      :identifier: ems_object_storage_protect
-    - :name: Refresh
-      :description: Refresh Object Storage Managers
-      :feature_type: control
-      :identifier: ems_object_storage_refresh
-  - :name: Modify
-    :description: Modify Object Storage Managers
-    :feature_type: admin
-    :identifier: ems_object_storage_admin
-    :children:
-    - :name: Remove
-      :description: Remove Object Storage Manager
+      :identifier: ems_object_storage_control
+      :children:
+      - :name: Edit Tags
+        :description: Edit Tags of Object Storage Managers
+        :feature_type: control
+        :identifier: ems_object_storage_tag
+      - :name: Manage Policies
+        :description: Manage Policies of Object Storage Managers
+        :feature_type: control
+        :identifier: ems_object_storage_protect
+      - :name: Refresh
+        :description: Refresh Object Storage Managers
+        :feature_type: control
+        :identifier: ems_object_storage_refresh
+    - :name: Modify
+      :description: Modify Object Storage Managers
       :feature_type: admin
-      :identifier: ems_object_storage_delete
+      :identifier: ems_object_storage_admin
+      :children:
+      - :name: Remove
+        :description: Remove Object Storage Manager
+        :feature_type: admin
+        :identifier: ems_object_storage_delete
 
 # EmsPhysicalInfra
 - :name: Physical Infrastructure Providers


### PR DESCRIPTION
I'm trying to [refactor something](https://github.com/ManageIQ/manageiq-ui-classic/issues/4027) in the UI. For that I would like to have a way to determine if a feature related to a given model is available for a user. However, there are some inconsistencies between the features and models of storage providers.

There are three feature subtrees for storage providers:
- `ems_storage`
- `ems_object_storage`
- `ems_block_storage`

When displaying a list of storage manager, the system is using the `ems_{block,object}_storage` route and I'm assuming also the feature with the same name from the RBAC tree. However, when opening a provider's summary screen, the route changes to `ems_storage`. This, together with the lack of separate object/block storage provider model classes is causing a lot of [struggle](https://github.com/ManageIQ/manageiq-ui-classic/issues/4027#issuecomment-394277259) with decorators/quadicons.

To solve this problem, we had this idea with @PanSpagetka to join the two specific features under the generic one. This would solve us the problem of sub-features when deciding if we want to expose the quadicon settings to a given user for the storage providers.

I was clicking in the UI a little and it seems working, also tested our case by creating a user with access only to `ems_object_storage_view`:
```ruby
Rbac.role_allows?(:user => u, :feature => :ems_storage, :any => true) # => true
Rbac.role_allows?(:user => u, :feature => :ems_block_storage, :any => true) # => true
Rbac.role_allows?(:user => u, :feature => :ems_block_storage_view, :any => true) # => true
Rbac.role_allows?(:user => u, :feature => :ems_object_storage, :any => true) # => false
Rbac.role_allows?(:user => u, :feature => :ems_object_storage_view, :any => true) # => false
```

However, I think this is too good to be true and I am afraid I don't see the whole picture and/or I'm breaking something :confused: 