### PR TITLE
Define model_name with route keys for the StorageManager model

### DIFF
--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -15,5 +15,10 @@ module ManageIQ::Providers
                :foreign_key => :parent_ems_id,
                :class_name  => "ManageIQ::Providers::BaseManager",
                :autosave    => true
+
+    class << model_name
+      define_method(:route_key) { "ems_storages" }
+      define_method(:singular_route_key) { "ems_storage" }
+    end
   end
 end


### PR DESCRIPTION
I am not sure if this is something we want, but it would make the UI happier and it looks consistent. Read more about this [here](https://github.com/ManageIQ/manageiq-ui-classic/issues/4027) and [here](https://github.com/ManageIQ/manageiq-ui-classic/pull/4034). Also tightly related to https://github.com/ManageIQ/manageiq/pull/17512.
