### PR TITLE
Add delete notification types for Network Router

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -289,6 +289,16 @@
   :expires_in: 24.hours
   :level: error
   :audience: global
+- :name: network_router_delete_success
+  :message: 'Deleting Network Router %{subject} completed successfully.'
+  :expires_in: 24.hours
+  :level: :success
+  :audience: global
+- :name: network_router_delete_error
+  :message: 'Deleting Network Router %{subject} failed: %{error_message}'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: global
 - :name: generic_task_start
   :message: '%{message}'
   :expires_in: 7.days


### PR DESCRIPTION
Added notification types `network_router_delete_success` and `network_router_delete_error`
Relevant BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1518734