### PR TITLE
Remove ansible_tower_client version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,10 +85,6 @@ group :amazon, :manageiq_default do
   gem "amazon_ssa_support",                          :require => false, :git => "https://github.com/ManageIQ/amazon_ssa_support.git", :branch => "master" # Temporary dependency to be moved to manageiq-providers-amazon when officially release
 end
 
-group :ansible, :manageiq_default do
-  gem "ansible_tower_client",           "~>0.13.0",      :require => false
-end
-
 group :azure, :manageiq_default do
   manageiq_plugin "manageiq-providers-azure"
 end


### PR DESCRIPTION
The `ansible_tower_client_ruby` gem dependency is in the Gemfile only for the Ansible Tower provider’s needs. The provider has now this dependency [declared](https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/84), so there is no need to keep it here as a duplicate information.

[Suggested](https://github.com/ManageIQ/manageiq/pull/17290#pullrequestreview-124931088) by @jameswnl. Still, prior to merging this, I’d like to verify this:

* Is the gem really not used in the `manageiq` repository itself and the dependency is there only because it wasn’t specified in the `manageiq-providers-ansible_tower` plugin?
* Doesn’t this prevent using overriding the `ansible_tower_client_ruby` gem with the `override_gem` directive?

@miq-bot add_reviewer @jameswnl 