### PR TITLE
No event will be shown when a compliance policy is created for a Physical Infra

### DIFF
--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -222,6 +222,7 @@ containerproject_created,Container Project Discovered,Default,container_operatio
 #
 # Physical Server Operations
 #
+physicalserver_compliance_check,Physical Server Compliance Check,Default,compliance
 physical_server_shutdown,Physical Server Shutdown,Default,physical_server_operations
 physical_server_start,Physical Server Start,Default,physical_server_operations
 physical_server_reset,Physical Server Reset,Default,physical_server_operations


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1565576.
Where there is no event shown when a compliance policy is created for a Physical Infra Provider