### PR TITLE
Adding PhysicalComponent model

### DIFF
--- a/app/models/physical_chassis.rb
+++ b/app/models/physical_chassis.rb
@@ -9,6 +9,7 @@ class PhysicalChassis < ApplicationRecord
   has_one :hardware, :through => :computer_system
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
   has_many :guest_devices, :through => :hardware
+  has_one :physical_component, :as => :component, :dependent => :destroy
 
   def my_zone
     ems = ext_management_system

--- a/app/models/physical_component.rb
+++ b/app/models/physical_component.rb
@@ -1,0 +1,13 @@
+#
+# A hub to centralize the Physical Components relationships.
+#   and a common way to access the Physical Components.
+#
+# Physical Components:
+#   - Physical Chassis;
+#   - Physical Rack.
+#   - Physical Server;
+#   - Physical Switch;
+#
+class PhysicalComponent < ApplicationRecord
+  belongs_to :component, :polymorphic => true
+end

--- a/app/models/physical_rack.rb
+++ b/app/models/physical_rack.rb
@@ -6,6 +6,7 @@ class PhysicalRack < ApplicationRecord
 
   has_many :physical_chassis, :dependent => :nullify, :inverse_of => :physical_rack
   has_many :physical_servers, :dependent => :nullify, :inverse_of => :physical_rack
+  has_one :physical_component, :as => :component, :dependent => :destroy
 
   def my_zone
     ems = ext_management_system

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -27,6 +27,7 @@ class PhysicalServer < ApplicationRecord
   has_one :host, :inverse_of => :physical_server
   has_one :asset_detail, :as => :resource, :dependent => :destroy
   has_many :guest_devices, :through => :hardware
+  has_one :physical_component, :as => :component, :dependent => :destroy
 
   scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
 

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -5,6 +5,7 @@ class PhysicalSwitch < Switch
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => :resource
   has_one :hardware, :dependent => :destroy, :foreign_key => :switch_id, :inverse_of => :physical_switch
   has_many :physical_network_ports, :dependent => :destroy, :foreign_key => :switch_id
+  has_one :physical_component, :as => :component, :dependent => :destroy
 
   def my_zone
     ems = ext_management_system


### PR DESCRIPTION
__This PR is able to__
- Add `PhysicalComponent` model where the common relationships of physical components (Switches, Servers, Racks and Chassis) will live;
- Add the relationship with:
  - `PhysicalSwitch`;
  - `PhysicalServer`;
  - `PhysicalChassis`;
  - `PhysicalRack`.

__Depends on__
https://github.com/ManageIQ/manageiq-schema/pull/206