### PR TITLE
Support moving a VM to another folder during VM Migrate.

### DIFF
--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -95,6 +95,21 @@ module VmOrTemplate::Operations::Relocation
     raw_relocate(host, pool, datastore, disk_move_type, transform, priority, disk)
   end
 
+  def raw_move_into_folder(folder)
+    raise _("VM has no EMS, unable to move VM into a new folder") unless ext_management_system
+    raise _("Folder not specified, unable to move VM into a new folder") unless folder.kind_of?(EmsFolder)
+
+    if parent_blue_folder == folder
+      raise _("The VM '%{name}' is already running on the same folder as the destination.") % {:name => name}
+    end
+
+    run_command_via_parent(:vm_move_into_folder, :folder => folder)
+  end
+
+  def move_into_folder(folder)
+    raw_move_into_folder(folder)
+  end
+
   def migrate_via_ids(host_id, pool_id = nil, priority = "defaultPriority", state = nil)
     host = Host.find_by(:id => host_id)
     raise _("Host with ID=%{host_id} was not found") % {:host_id => host_id} if host.nil?

--- a/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
+++ b/product/dialogs/miq_dialogs/vm_migrate_dialogs.yaml
@@ -198,6 +198,14 @@
           :required: false
           :display: :edit
           :data_type: :integer
+        :placement_folder_name:
+          :values_from:
+            :method: :allowed_folders
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
       :display: :show
     :schedule:
       :description: Schedule

--- a/spec/models/vm_migrate_task_spec.rb
+++ b/spec/models/vm_migrate_task_spec.rb
@@ -1,7 +1,11 @@
 describe VmMigrateTask do
   describe '.do_request' do
     let(:vm) { Vm.new }
-    before { subject.vm = vm }
+    before do
+      subject.vm = vm
+      host = FactoryGirl.create(:host, :name => "test")
+      subject.update_attributes(:options => {:placement_host_name => [host.id, host.name]})
+    end
 
     it 'migrates the vm and updates the status' do
       expect(vm).to receive(:migrate)
@@ -11,7 +15,7 @@ describe VmMigrateTask do
 
     it 'catches migrate error and update the status' do
       expect(vm).to receive(:migrate).and_raise("Bad things happened")
-      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => 'finished', :status => 'error', :message => 'Failed. Reason[Bad things happened]'))
+      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => 'finished', :status => 'Error', :message => 'Failed. Reason[Bad things happened]'))
       subject.do_request
     end
   end


### PR DESCRIPTION
RHEV v4+ supports VM Migrate. Only supported migration options for RHEV would be shown in the workflow. Folder is one of the [unsupported migration options](https://github.com/ManageIQ/manageiq-providers-ovirt/blob/78dc6000e37045f33de1dced62ea15893931812a/app/models/manageiq/providers/redhat/infra_manager.rb#L230).  
SCVMM does not support Migrate.

Includes https://github.com/ManageIQ/manageiq-providers-vmware/pull/285.
~~Includes https://github.com/ManageIQ/manageiq-schema/pull/219.~~
Includes https://github.com/ManageIQ/manageiq-ui-classic/pull/4045.

https://bugzilla.redhat.com/show_bug.cgi?id=1090957

@miq-bot assign @gmcculloug 
@miq-bot add_label gaprindashvili/no, enhancement

cc @agrare @bronaghs 