### PR TITLE
Ensure uniqueness in MiqRegion rspec factory

### DIFF
--- a/spec/factories/miq_region.rb
+++ b/spec/factories/miq_region.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
+  region_remote = MiqRegion.my_region_number
+
   factory :miq_region do
-    sequence(:region)  { |reg| reg }
+    sequence(:region) { |region| region == region_remote ? region + 1 : region }
   end
 end


### PR DESCRIPTION
fix for sporadic test failure from [CI result](https://travis-ci.org/ManageIQ/manageiq/jobs/387867414)
(this is only about rspec **./spec/models/chargeback_vm_spec.rb:1041**)


it looks like that `sequence(:region)` doesn't consider region created by `MiqRegion.seed` which is setting default region in CI specs.

## **Reproducer**:
**1. Apply patch**
```
diff --git a/spec/models/chargeback_vm_spec.rb b/spec/models/chargeback_vm_spec.rb
index e3f81f5ffe..60c8686622 100644
--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1038,28 +1038,30 @@ describe ChargebackVm do

           subject! { ChargebackVm.build_results_for_report_ChargebackVm(options_tenant).first }

-          it "report from all regions and only for tenant_1" do
-            # report only VMs from tenant 1
-            vm_ids = subject.map(&:vm_id)
-            vm_ids_from_tenant = [tenant_1, tenant_1_region_1].map { |t| t.subtree.map(&:vms).map(&:ids) }.flatten
-            expect(vm_ids).to match_array(vm_ids_from_tenant)
-
-            # default region subject
-            default_region_chargeback = find_result_by_vm_name_and_region(subject, vm_name_1, MiqRegion.my_region_number)
-            used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, vm_1_t_1)
-            expect(default_region_chargeback.cpu_used_metric).to be_within(0.01).of(used_metric)
-            expect(default_region_chargeback.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
-            expect(default_region_chargeback.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
-            expect(default_region_chargeback.cpu_allocated_metric).to eq(cpu_count)
-
-            # region 1
-            region_1_chargeback = find_result_by_vm_name_and_region(subject, vm_name_1, region_1.region)
-            used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, vm_1_region_1_t_1)
-            expect(region_1_chargeback.cpu_used_metric).to be_within(0.01).of(used_metric)
-            expect(region_1_chargeback.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
-            expect(region_1_chargeback.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
-
-            expect(region_1_chargeback.vm_id).to eq(vm_1_region_1_t_1.id)
+          20.times do
+            it "report from all regions and only for tenant_1" do
+              # report only VMs from tenant 1
+              vm_ids = subject.map(&:vm_id)
+              vm_ids_from_tenant = [tenant_1, tenant_1_region_1].map { |t| t.subtree.map(&:vms).map(&:ids) }.flatten
+              expect(vm_ids).to match_array(vm_ids_from_tenant)
+
+              # default region subject
+              default_region_chargeback = find_result_by_vm_name_and_region(subject, vm_name_1, MiqRegion.my_region_number)
+              used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, vm_1_t_1)
+              expect(default_region_chargeback.cpu_used_metric).to be_within(0.01).of(used_metric)
+              expect(default_region_chargeback.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
+              expect(default_region_chargeback.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
+              expect(default_region_chargeback.cpu_allocated_metric).to eq(cpu_count)
+
+              # region 1
+              region_1_chargeback = find_result_by_vm_name_and_region(subject, vm_name_1, region_1.region)
+              used_metric = used_average_for(:cpu_usagemhz_rate_average, hours_in_month, vm_1_region_1_t_1)
+              expect(region_1_chargeback.cpu_used_metric).to be_within(0.01).of(used_metric)
+              expect(region_1_chargeback.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
+              expect(region_1_chargeback.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
+
+              expect(region_1_chargeback.vm_id).to eq(vm_1_region_1_t_1.id)
+            end
           end
         end
```
**2. run the test**
```
rspec ./spec/models/chargeback_vm_spec.rb:1041 -fd
```

**3.Wait for failure( it was enough to have 20 repetition to get failure)**
