### PR TITLE
Adds support for Physical Chassis in the UI

### DIFF
--- a/app/models/physical_chassis.rb
+++ b/app/models/physical_chassis.rb
@@ -1,4 +1,6 @@
 class PhysicalChassis < ApplicationRecord
+  acts_as_miq_taggable
+
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_chassis,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"
   belongs_to :physical_rack, :foreign_key => :physical_rack_id, :inverse_of => :physical_chassis

--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -50,6 +50,7 @@
 - OrchestrationStack
 - OrchestrationTemplate
 - PhysicalRack
+- PhysicalChassis
 - PhysicalSwitch
 - PhysicalServer
 - PolicyEvent

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -69,6 +69,7 @@
   - miq_template
   - orchestration_stack
   - physical_rack
+  - physical_chassis
   - physical_switch
   - physical_server
   - physical_infra_topology
@@ -138,6 +139,7 @@
   - miq_template_timeline
   - physical_infra_topology_view
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - policy_log
@@ -234,6 +236,7 @@
   - miq_template_tag
   - physical_infra_topology_view
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - planning
@@ -305,10 +308,12 @@
   - my_settings_time_profiles
   - my_settings_visuals
   - physical_rack
+  - physical_chassis
   - physical_switch
   - physical_server
   - physical_infra_topology
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - provider_foreman_explorer
@@ -387,6 +392,7 @@
   - ems_physical_infra_view
   - physical_rack_control
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - physical_infra_topology_view
@@ -601,6 +607,7 @@
   - miq_template_timeline
   - physical_infra_topology_view
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - policy_log
@@ -690,6 +697,7 @@
   - miq_template_timeline
   - physical_infra_topology_view
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - resource_pool_show
@@ -1198,6 +1206,7 @@
   - persistent_volume_view
   - physical_infra_topology_view
   - physical_rack_view
+  - physical_chassis_view
   - physical_switch_view
   - physical_server_view
   - planning

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -861,6 +861,7 @@ en:
       ManageIQ::Providers::Vmware::InfraManager::Host:                      Host (Vmware)
       ManageIQ::Providers::Vmware::InfraManager::HostEsx:                   Host (Vmware)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalRack:      Physical Rack (Lenovo)
+      ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis:   Physical Chassis (Lenovo)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer:    Physical Server (Lenovo)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch:    Physical Switch (Lenovo)
       MeteringContainerImage:   Metering for Image


### PR DESCRIPTION
**What this PR does:**
- Adds miq_user_roles for UI Views of Physical Chassis;
- Adds miq_expression of PhysicalChassis;
- Adds the internationalization to Lenovo PhysicalChassis class type.

**Reason:**

- In order to add Physical Chassis List & Details page in the UI we have to add these configs.