### PR TITLE
Fix multiple parents error moving vm to new folder

### DIFF
--- a/app/models/ems_refresh/link_inventory.rb
+++ b/app/models/ems_refresh/link_inventory.rb
@@ -55,15 +55,6 @@ module EmsRefresh::LinkInventory
       [disconnect_proc, connect_proc]
     end
 
-    # Do the Folders to Vms relationships
-    update_relats(:folders_to_vms, prev_relats, new_relats) do |f|
-      folder = instance_with_id(EmsFolder, f)
-      break if folder.nil?
-      [do_disconnect ? proc { |v| folder.remove_vm(instance_with_id(VmOrTemplate, v)) } : nil, # Disconnect proc
-       proc { |v| folder.add_vm(instance_with_id(VmOrTemplate, v)) },                          # Connect proc
-       proc { |vs| folder.add_vm(instances_with_ids(VmOrTemplate, vs)) }]                      # Bulk connect proc
-    end
-
     # Do the Folders to Storages relationships
     update_relats(:folders_to_storages, prev_relats, new_relats) do |f|
       folder = instance_with_id(EmsFolder, f)
@@ -120,6 +111,15 @@ module EmsRefresh::LinkInventory
     #   we have enough information in the filtered data
 
     do_disconnect ||= target.kind_of?(VmOrTemplate) if disconnect
+
+    # Do the Folders to Vms relationships
+    update_relats(:folders_to_vms, prev_relats, new_relats) do |f|
+      folder = instance_with_id(EmsFolder, f)
+      break if folder.nil?
+      [do_disconnect ? proc { |v| folder.remove_vm(instance_with_id(VmOrTemplate, v)) } : nil, # Disconnect proc
+       proc { |v| folder.add_vm(instance_with_id(VmOrTemplate, v)) },                          # Connect proc
+       proc { |vs| folder.add_vm(instances_with_ids(VmOrTemplate, vs)) }]                      # Bulk connect proc
+    end
 
     # Do the ResourcePools to VMs relationships
     update_relats(:resource_pools_to_vms, prev_relats, new_relats) do |r|

--- a/spec/models/ems_refresh/link_inventory_spec.rb
+++ b/spec/models/ems_refresh/link_inventory_spec.rb
@@ -1,0 +1,60 @@
+describe EmsRefresh::LinkInventory do
+  context ".link_ems_inventory" do
+    let!(:ems) do
+      _, _, zone = EvmSpecHelper.local_guid_miq_server_zone
+      FactoryGirl.create(:ems_vmware, :zone => zone).tap do |e|
+        build_vmware_folder_structure!(e)
+        folder = e.ems_folders.find_by(:name => "blue1")
+        folder.add_child(FactoryGirl.create(:vm_vmware, :name => "vm1", :ems_id => e.id))
+        folder.add_child(FactoryGirl.create(:vm_vmware, :name => "vm2", :ems_id => e.id))
+      end
+    end
+    let(:folder1)     { ems.ems_folders.find_by(:name => "blue1") }
+    let(:folder2)     { ems.ems_folders.find_by(:name => "blue2") }
+    let(:vm1)         { ems.vms_and_templates.find_by(:name => "vm1") }
+    let(:vm2)         { ems.vms_and_templates.find_by(:name => "vm2") }
+
+    context "when a vm moves to a different folder" do
+      before do
+        prev_relats = EmsRefresh.vmdb_relats(target)
+        new_relats = prev_relats.deep_dup
+
+        new_relats[:folders_to_vms][folder1.id].delete(vm1.id)
+        new_relats[:folders_to_vms].delete(folder1.id) if new_relats[:folders_to_vms][folder1.id].empty?
+        new_relats[:folders_to_vms][folder2.id] = [vm1.id]
+
+        EmsRefresh.link_ems_inventory(ems, target, prev_relats, new_relats, true)
+      end
+
+      context "full refresh" do
+        let(:target) { ems }
+
+        it "changes the parent folder and children" do
+          expect(vm1.reload.parent_blue_folder).to eq(folder2)
+          expect(folder1.children).not_to include(vm1)
+          expect(folder2.children).to include(vm1)
+        end
+
+        it "doesn't impact other inventory" do
+          expect(vm2.reload.parent_blue_folder).to eq(folder1)
+          expect(folder1.children).to include(vm2)
+        end
+      end
+
+      context "targeted refresh" do
+        let(:target) { vm1 }
+
+        it "changes the parent folder and children" do
+          expect(vm1.reload.parent_blue_folder).to eq(folder2)
+          expect(folder1.children).not_to include(vm1)
+          expect(folder2.children).to include(vm1)
+        end
+
+        it "doesn't impact other inventory" do
+          expect(vm2.reload.parent_blue_folder).to eq(folder1)
+          expect(folder1.children).to include(vm2)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Linking inventory when doing a targeted refresh switches when to
disconnect relationships depending on what the target type is.  This is
due to the fact that the full list of items for e.g. folders/clustes is
only known when running a full refresh, otherwise it has a sparse list.

Currently the folders_to_vms relat is only disconnected when refreshing
a full ems.

When moving a vm to a new folder the Move Into event queues a full
refresh, and the VM Relocate event queues a host targeted refresh.

The issue is when moving a vm to a new host _and_ a new folder, the host
event queues a targeted refresh but the vm being moved to a new folder
is picked up in this targeted refresh also.

This leads to the do_disconnect value being false when processing the
folders_to_vms relationship leading to the multiple parents error.

To fix this we can process the folders_to_vms under the section where it
disconnects if the target type is a VmOrTemplate.

Steps for Testing
-------------------------------

1. If evmserverd is running, stop it (important to not have the event
catcher running).
2. From the rails console run a full refresh
`EmsRefresh.refresh(ExtManagementSystem.first)`
3. Go to the vmware web console and move a vm to a different folder
4. Run a targeted refresh from the rails console `vm = Vm.find_by(:name
=> "vm name"); EmsRefresh.refresh(vm)`
5. Check the parent folder of the vm `vm.reload.parent_blue_folder`