### PR TITLE
Explicitly shortcut "everything" for privileges

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -30,7 +30,9 @@ class MiqUserRole < ApplicationRecord
   # @param identifier [String] Product feature identifier to check if this role allows access to it
   #   Returns true when requested feature is directly assigned or a descendant of a feature
   def allows?(identifier:)
-    if feature_identifiers.include?(identifier)
+    # all features are children of "everything", so checking it isn't strictly necessary
+    # but it simplifies testing
+    if feature_identifiers.include?(MiqProductFeature::SUPER_ADMIN_FEATURE) || feature_identifiers.include?(identifier)
       true
     elsif (parent_identifier = MiqProductFeature.feature_parent(identifier))
       allows?(:identifier => parent_identifier)
@@ -107,13 +109,13 @@ class MiqUserRole < ApplicationRecord
   end
 
   def report_admin_user?
-    allows_any?(:identifiers => [MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::REPORT_ADMIN_FEATURE])
+    allows?(:identifier => MiqProductFeature::REPORT_ADMIN_FEATURE)
   end
 
   alias admin_user? report_admin_user?
 
   def request_admin_user?
-    allows_any?(:identifiers => [MiqProductFeature::SUPER_ADMIN_FEATURE, MiqProductFeature::REQUEST_ADMIN_FEATURE])
+    allows?(:identifier => MiqProductFeature::REQUEST_ADMIN_FEATURE)
   end
 
   def self.default_tenant_role


### PR DESCRIPTION
The seeds in the database have `"everything"` as the root of all `miq_product_features`. Features are in a tree, so asking a role if it has a feature will work it's way up the tree. If an `miq_user_role` with the `"everything"` role returns `true` for any request.

### Before:

When writing tests, it is currently not possible to create an `miq_product_feature` hierarchy with `"everything"` at the root. We are getting around by stubbing our authorization code to `true`.
This stub methods no longer works with the new way we are checking for the admin feature. (e.g.: `request_admin_user?`)

### After

This change states that if a role has the `miq_product_feature` of `"everything"`, then it has the privilege to perform all product features. This used to be more data driven before rather than hardcoded in the ruby logic.

So it does special case `"everything"` and the code now actually knows that `everything` means everything. On the up side, this change allow us to remove the stubbed out authentication logic.


This change is part of https://github.com/ManageIQ/manageiq/pull/17444 - it currently helps get https://github.com/ManageIQ/manageiq-ui-classic/pull/3993 to pass