### PR TITLE
Don't queue EmsRefresh if using streaming refresh

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -51,6 +51,9 @@ module EmsRefresh
       h[e] << t unless e.nil?
     end
 
+    # Drop targets on EMSs which are using streaming refresh
+    targets_by_ems.reject! { |ems, _| ems.supports_streaming_refresh? }
+
     # Queue the refreshes
     task_ids = targets_by_ems.collect do |ems, ts|
       ts = ts.collect { |t| [t.class.to_s, t.id] }.uniq

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -129,6 +129,7 @@ module SupportsFeatureMixin
     :snapshots                           => 'Snapshots',
     :shutdown_guest                      => 'Shutdown Guest Operation',
     :start                               => 'Start',
+    :streaming_refresh                   => 'Streaming refresh',
     :suspend                             => 'Suspending',
     :terminate                           => 'Terminate a VM',
     :timeline                            => 'Query for events',

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -43,6 +43,14 @@ describe EmsRefresh do
       target2 = FactoryGirl.create(:vm_vmware, :ext_management_system => @ems)
       queue_refresh_and_assert_queue_item(target2, [target, target2])
     end
+
+    it "with streaming refresh enabled doesn't queue a refresh" do
+      allow(@ems).to receive(:supports_streaming_refresh?).and_return(true)
+      target = @ems
+
+      described_class.queue_refresh(target)
+      expect(MiqQueue.count).to eq(0)
+    end
   end
 
   context "stopping targets unbounded growth" do


### PR DESCRIPTION
If a target's ems is using streaming refresh don't queue an EmsRefresh
because it will not be processed.

VMware associated PR: https://github.com/ManageIQ/manageiq-providers-vmware/pull/284