### PR TITLE
[FINE] Support Unregister VM

### DIFF
--- a/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/ovirt_services/strategies/v4.rb
@@ -317,6 +317,10 @@ module ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies
       def destroy
         remove
       end
+
+      def unregister
+        remove(:detach_only => true)
+      end
     end
 
     class TemplateProxyDecorator < SimpleDelegator

--- a/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
+++ b/app/models/manageiq/providers/redhat/infra_manager/vm/operations.rb
@@ -8,4 +8,8 @@ module ManageIQ::Providers::Redhat::InfraManager::Vm::Operations
   def raw_destroy
     with_provider_object(&:destroy)
   end
+
+  def raw_unregister
+    with_provider_object(:version => 4, &:unregister)
+  end
 end

--- a/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/redhat/infra_manager/vm_spec.rb
@@ -150,4 +150,24 @@ describe ManageIQ::Providers::Redhat::InfraManager::Vm do
       end
     end
   end
+
+  describe "#unregister" do
+    before do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      @ems  = FactoryGirl.create(:ems_redhat_with_authentication, :zone => zone)
+      @vm   = FactoryGirl.create(:vm_redhat, :ext_management_system => @ems)
+      @vm_proxy = double("OvirtSDK4::Vm.new")
+      @vm_service = double("OvirtSDK4::Vm")
+    end
+
+    context "v4" do
+      it "unregisters a vm via v4 api" do
+        allow(@ems).to receive(:highest_supported_api_version).and_return(4)
+        allow(@vm).to receive(:with_provider_object).and_yield(@vm_service)
+        allow(@vm_service).to receive(:unregister).and_return(nil)
+
+        @vm.raw_unregister
+      end
+    end
+  end
 end


### PR DESCRIPTION
Unregister VM allows the user to remove the VM without deleting its disks.
For that purpose, the request to remove VM to ovirt-engine includes the 'detach_only=true' parameter.

This action will succeed if the VM isn't originated from a template or if the VM has no snapshots.
Also, it is only supported for using ovirt-engine APIv4 (enabled by :use_ovirt_engine_sdk: true in settings.yml)

Cherry-picked and slightly modified from https://github.com/ManageIQ/manageiq-providers-ovirt/commit/a8de7023ccd8388b17cf8edb87dae295565dbe2d
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536628
