### PR TITLE
Don't assume mixin host has ext_management_system relation

### DIFF
--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -26,6 +26,7 @@ module ArchivedMixin
 
   # Needed for metrics
   def my_zone
+    return 'default' unless self.respond_to?(:ext_management_system)
     if ext_management_system.present?
       ext_management_system.my_zone
     elsif old_ext_management_system.present?


### PR DESCRIPTION
With this commit we prevent crash in case ArchivedMixin is included on a model that has no relation to ems hence invoking

```
model.ext_management_system
```

results in hard runtime crash.

NOTE: Is more like a dirty fix. I have no idea why embedded ansible service dialog provisioning is suddenly failing because of this.

Fixes: https://github.com/ManageIQ/manageiq/issues/17535

@miq-bot add_label bug
@miq-bot assign @jameswnl
