### PR TITLE
Add Flavor model to :tag_classes: section in miq_expression.yml.

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -241,6 +241,7 @@
   ContainerService: container_service
   ContainerTemplate: container_template
   PersistentVolume: persistent_volume
+  Flavor: flavor
 :exclude_from_relats:
   ManageIQ::Providers::CloudManager:
   - hosts


### PR DESCRIPTION
 It would allow to select `Flavor.My Company Tags... ` when building expressions.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581501

**BEFORE:**
![screen shot 2018-06-06 at 10 30 52 am](https://user-images.githubusercontent.com/6556758/41044683-c7725170-6974-11e8-9440-7e39f4b3ed3b.png)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/41044424-42a4bd52-6974-11e8-8b1d-5fc4ff0a24ce.png)


@miq-bot add-label bug