### PR TITLE
Replace remove duplicate timestamp by sql version for chargeback

### DIFF
--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -14,15 +14,18 @@ class Chargeback
 
         next unless options.include_metrics?
 
-        records = base_rollup.where(:timestamp => query_start_time...query_end_time, :capture_interval_name => 'hourly')
+        records = MetricRollup.where(:timestamp => query_start_time...query_end_time, :capture_interval_name => 'hourly')
         records = cb_class.where_clause(records, options, region)
-        records = Metric::Helper.remove_duplicate_timestamps(records)
+        records = uniq_timestamp_record_map(records, options.group_by_tenant?)
+
         next if records.empty?
         _log.info("Found #{records.length} records for time range #{[query_start_time, query_end_time].inspect}")
 
         # we are building hash with grouped calculated values
         # values are grouped by resource_id and timestamp (query_start_time...query_end_time)
-        options.group_with(records).each_value do |metric_rollup_records|
+
+        records.each_value do |rollup_record_ids|
+          metric_rollup_records = base_rollup.where(:id => rollup_record_ids).to_a
           consumption = ConsumptionWithRollups.new(metric_rollup_records, query_start_time, query_end_time)
           yield(consumption) unless consumption.consumed_hours_in_interval.zero?
         end
@@ -43,5 +46,29 @@ class Chargeback
     end
 
     private_class_method :base_rollup_scope
+
+    def self.uniq_timestamp_record_map(report_scope, group_by_tenant = false)
+      main_select = MetricRollup.select(:id, :resource_id).arel.ast.to_sql
+                                .gsub("SELECT", "DISTINCT ON (resource_type, resource_id, timestamp)")
+                                .gsub(/ FROM.*$/, '')
+
+      query = report_scope.select(main_select)
+                          .order(:resource_type, :resource_id, :timestamp)
+                          .order("created_on DESC")
+
+      rows = ActiveRecord::Base.connection.select_rows(query.to_sql)
+
+      if group_by_tenant
+        vms = Hash[Vm.where(:id => rows.map(&:second)).pluck(:id, :tenant_id)]
+      end
+
+      rows.each_with_object({}) do |(id, resource_id), result|
+        resource_id = vms[resource_id] if group_by_tenant
+        result[resource_id] ||= []
+        result[resource_id] << id
+      end
+    end
+
+    private_class_method :uniq_timestamp_record_map
   end
 end

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -121,10 +121,6 @@ class Chargeback
       consumption.resource.tenant
     end
 
-    def group_with(records)
-      group_by_tenant? ? records.group_by { |x| x.resource.tenant.id } : records.group_by(&:resource_id)
-    end
-
     def classification_for(consumption)
       tag = consumption.tag_names.find { |x| x.starts_with?(groupby_tag) } # 'department/*'
       tag = tag.split('/').second unless tag.blank? # 'department/finance' -> 'finance'


### PR DESCRIPTION
This is first part of decreasing memory in chargeback. I think that there is not too much reducing memory but this change is absolutely important for next step in other PRs in Links section.

This is adding possibility to avoid array of AR objects and we go with query. 

This code is written by @NickLaMuro (almost). Many thanks! it helped me a lot in order do further changes with signification memory reduction.
 
# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1566452

https://github.com/ManageIQ/manageiq/pull/17538 - **first part**
https://github.com/ManageIQ/manageiq/pull/17552  - second part
https://github.com/ManageIQ/manageiq/pull/17558 - third part - **Can be merged before first and second part**
https://github.com/ManageIQ/manageiq/pull/17560  - last part

cc @NickLaMuro @kbrock 

@miq-bot assign @gtanzillo 