### PR TITLE
move #my_zone from ArchivedMixin to OldEmsMixin

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -2,6 +2,7 @@ class Container < ApplicationRecord
   include SupportsFeatureMixin
   include NewWithTypeStiMixin
   include ArchivedMixin
+  include OldEmsMixin
   include_concern 'Purging'
 
   belongs_to :container_group

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -6,6 +6,7 @@ class ContainerGroup < ApplicationRecord
   include NewWithTypeStiMixin
   include TenantIdentityMixin
   include ArchivedMixin
+  include OldEmsMixin
   include CustomActionsMixin
   include CockpitSupportMixin
   include_concern 'Purging'

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -5,6 +5,7 @@ class ContainerImage < ApplicationRecord
   include TenantIdentityMixin
   include CustomAttributeMixin
   include ArchivedMixin
+  include OldEmsMixin
   include NewWithTypeStiMixin
   include CustomActionsMixin
   include_concern 'Purging'

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -6,6 +6,7 @@ class ContainerNode < ApplicationRecord
   include TenantIdentityMixin
   include SupportsFeatureMixin
   include ArchivedMixin
+  include OldEmsMixin
   include CockpitMixin
   include CustomActionsMixin
   include_concern 'Purging'

--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -2,6 +2,7 @@ class ContainerProject < ApplicationRecord
   include SupportsFeatureMixin
   include CustomAttributeMixin
   include ArchivedMixin
+  include OldEmsMixin
   include MiqPolicyMixin
   include TenantIdentityMixin
   include CustomActionsMixin

--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -4,8 +4,6 @@ module ArchivedMixin
   included do
     scope :archived, -> { where.not(:deleted_on => nil) }
     scope :active, -> { where(:deleted_on => nil) }
-
-    belongs_to :old_ext_management_system, :foreign_key => :old_ems_id, :class_name => 'ExtManagementSystem'
   end
 
   def archived?
@@ -22,16 +20,5 @@ module ArchivedMixin
 
   def unarchive!
     update_attributes!(:deleted_on => nil)
-  end
-
-  # Needed for metrics
-  def my_zone
-    if ext_management_system.present?
-      ext_management_system.my_zone
-    elsif old_ext_management_system.present?
-      # Archived container entities need to retain their zone for metric collection
-      # This makes the association more complex and might need a performance fix
-      old_ext_management_system.my_zone
-    end
   end
 end

--- a/app/models/mixins/old_ems_mixin.rb
+++ b/app/models/mixins/old_ems_mixin.rb
@@ -1,0 +1,18 @@
+module OldEmsMixin
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :old_ext_management_system, :foreign_key => :old_ems_id, :class_name => 'ExtManagementSystem'
+  end
+
+  # Needed for metrics
+  def my_zone
+    if ext_management_system.present?
+      ext_management_system.my_zone
+    elsif old_ext_management_system.present?
+      # Archived container entities need to retain their zone for metric collection
+      # This makes the association more complex and might need a performance fix
+      old_ext_management_system.my_zone
+    end
+  end
+end


### PR DESCRIPTION
Not every model that needs `ArchivedMixin` has `ext_management_system` or `#old_ext_management_sytem`. For those do need to use `#old_ext_management_system` now they should include `OldEmsMixin`.

This is a followup PR of #17480 
Fixes issue #17535 

Gap backport: #17540