### PR TITLE
[FINE] Shouldn't be able to submit required field without a value

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -126,7 +126,7 @@ class DialogField < ApplicationRecord
   end
 
   def required_value_error?
-    value.blank?
+    value.blank? || value == '[nil, "<Choose>"]' || value == 'null'
   end
 
   def value_from_dialog_fields(dialog_values)

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -114,7 +114,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def use_first_value_as_default
-    self.default_value = self['options'][:force_multi_value] ? [nil_option] : sort_data(@raw_values).first.try(:first)
+    self.default_value = self['options'][:force_multi_value] ? nil_option : sort_data(@raw_values).first.try(:first)
   end
 
   def default_value_included?(values_list)

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -62,6 +62,20 @@ describe DialogField do
                 .to eq("tab/group/dialog_field is required")
             end
           end
+          context "with value of literally nothing" do
+            let(:value) { '[nil, "<Choose>"]' }
+            it "returns error message" do
+              expect(visible_dialog_field.validate_field_data(dialog_tab, dialog_group))
+                .to eq("tab/group/dialog_field is required")
+            end
+          end
+          context "with value of null" do
+            let(:value) { 'null' }
+            it "returns error message" do
+              expect(visible_dialog_field.validate_field_data(dialog_tab, dialog_group))
+                .to eq("tab/group/dialog_field is required")
+            end
+          end
           context "with a non-blank value" do
             let(:value) { "test value" }
             it_behaves_like "DialogField#validate that returns nil"


### PR DESCRIPTION
Fix required flag to not accept nil option introduced in https://github.com/ManageIQ/manageiq/pull/17424 as valid value. And the nil option didn't need to be an array to start with since it is already.

Fixes ~~https://bugzilla.redhat.com/show_bug.cgi?id=1555487~~ https://bugzilla.redhat.com/show_bug.cgi?id=1590949


