### PR TITLE
Allow duplicate nil pxe_image_types during seed (for the current region)

### DIFF
--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -5,10 +5,14 @@ class CustomizationTemplate < ApplicationRecord
   has_many   :pxe_images, :through => :pxe_image_type
 
   validates :pxe_image_type, :presence => true, :unless => :system?
-  validates :name,           :unique_within_region => true
+  validates :name, :uniqueness => {:scope => :pxe_image_type }, :unless => :seeding?
 
   scope :with_pxe_image_type_id, ->(pxe_image_type_id) { where(:pxe_image_type_id => pxe_image_type_id) }
   scope :with_system,            ->(bool = true)       { where(:system => bool) }
+
+  def seeding?
+    system? && pxe_image_type.nil?
+  end
 
   def self.seed_file_name
     @seed_file_name ||= Rails.root.join("db", "fixtures", "#{table_name}.yml")

--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -21,7 +21,7 @@ class CustomizationTemplate < ApplicationRecord
   def self.seed
     return unless self == base_class # Prevent subclasses from seeding
 
-    current = where(:system => true).index_by(&:name)
+    current = in_my_region.where(:system => true).index_by(&:name)
 
     seed_data.each do |s|
       log_attrs = s.slice(:name, :type, :description)

--- a/spec/lib/unique_within_region_validator_spec.rb
+++ b/spec/lib/unique_within_region_validator_spec.rb
@@ -73,18 +73,41 @@ describe UniqueWithinRegionValidator do
     end
 
     context "class with STI" do
+      let(:test_base_class) do
+        Class.new(ApplicationRecord) do
+          validates :name, :unique_within_region => true
+          self.table_name = "vms"
+        end
+      end
+
+      let(:test_subclass1) do
+        Class.new(test_base_class) do
+          def self.name
+            "Subclass1"
+          end
+        end
+      end
+
+      let(:test_subclass2) do
+        Class.new(test_base_class) do
+          def self.name
+            "Subclass2"
+          end
+        end
+      end
+
       context "two subclasses" do
         it "raises error with non-unique names in same region" do
-          FactoryGirl.create(:customization_template_cloud_init, :name => "foo")
+          test_subclass1.create(:name => "foo")
 
-          expect { FactoryGirl.create(:customization_template_sysprep, :name => "foo") }
+          expect { test_subclass2.create!(:name => "foo") }
             .to raise_error(ActiveRecord::RecordInvalid, / Name is not unique within region/)
         end
 
         it "doesn't raise error with unique names" do
-          FactoryGirl.create(:customization_template_cloud_init)
+          test_subclass1.create(:name => "foo")
 
-          expect { FactoryGirl.create(:customization_template_sysprep) }.to_not raise_error
+          expect { test_subclass2.create!(:name => "bar") }.to_not raise_error
         end
       end
     end

--- a/spec/models/customization_template_spec.rb
+++ b/spec/models/customization_template_spec.rb
@@ -1,0 +1,57 @@
+describe CustomizationTemplate do
+  context "unique name validation" do
+    it "doesn't allow same name, same pxe_image_type in same region" do
+      pit = FactoryGirl.create(:pxe_image_type)
+      FactoryGirl.create(:customization_template, :name => "fred", :pxe_image_type => pit)
+      expect { FactoryGirl.create(:customization_template, :name => "fred", :pxe_image_type => pit) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "allows same name, different pxe_image_type in same region" do
+      FactoryGirl.create(:customization_template, :name => "fred", :pxe_image_type => FactoryGirl.create(:pxe_image_type))
+      FactoryGirl.create(:customization_template, :name => "fred", :pxe_image_type => FactoryGirl.create(:pxe_image_type))
+
+      first, second = described_class.all
+      expect(first.name).to eq(second.name)
+      expect(first.pxe_image_type).to_not eq(second.pxe_image_type)
+      expect(ApplicationRecord.id_to_region(first.id)).to eq(ApplicationRecord.id_to_region(second.id))
+    end
+
+    it "allows different name, same pxe_image_type in same region" do
+      pit = FactoryGirl.create(:pxe_image_type)
+      FactoryGirl.create(:customization_template, :name => "fred", :pxe_image_type => pit)
+      FactoryGirl.create(:customization_template, :name => "nick", :pxe_image_type => pit)
+      expect(described_class.count).to eq(2)
+
+      first, second = described_class.all
+      expect(first.name).to_not eq(second.name)
+      expect(first.pxe_image_type).to eq(second.pxe_image_type)
+      expect(ApplicationRecord.id_to_region(first.id)).to eq(ApplicationRecord.id_to_region(second.id))
+    end
+
+    it "allows same name, nil pxe_image_types in different regions (for system seeding)" do
+      system_template   = described_class.create!(:system => true, :name => "nick")
+      other_template_id = ApplicationRecord.id_in_region(system_template.id, ApplicationRecord.my_region_number + 1)
+      described_class.create!(:system => true, :name => "nick", :id => other_template_id)
+
+      first, second = described_class.all
+      expect(first.name).to eq(second.name)
+      expect(first.pxe_image_type).to be nil
+      expect(first.pxe_image_type).to eq(second.pxe_image_type)
+      expect(ApplicationRecord.id_to_region(first.id)).to_not eq(ApplicationRecord.id_to_region(second.id))
+    end
+
+    it "allows same name, different pxe_image_types in different regions" do
+      pit               = FactoryGirl.create(:pxe_image_type)
+      template          = FactoryGirl.create(:customization_template, :name => "nick", :pxe_image_type => pit)
+      other_template_id = ApplicationRecord.id_in_region(template.id, MiqRegion.my_region_number + 1)
+      other_pit_id      = ApplicationRecord.id_in_region(pit.id, MiqRegion.my_region_number + 1)
+      other_pit         = FactoryGirl.create(:pxe_image_type, :id => other_pit_id)
+      FactoryGirl.create(:customization_template, :name => "nick", :pxe_image_type => other_pit, :id => other_template_id)
+
+      first, second = described_class.all
+      expect(first.name).to eq(second.name)
+      expect(first.pxe_image_type).to_not eq(second.pxe_image_type)
+      expect(ApplicationRecord.id_to_region(first.id)).to_not eq(ApplicationRecord.id_to_region(second.id))
+    end
+  end
+end


### PR DESCRIPTION
@jrafanie @carbonin Please review

https://bugzilla.redhat.com/show_bug.cgi?id=1588417

We want to disallow the same name template in different regions with the
same pxe_image_type.  Normally, region id sequences prevent this from
happening but we were treating nil pxe_image_types as the same.
Therefore you could have the "same" pxe_image_type in different regions
for the same name template.

