### PR TITLE
Add missing cinder and glance store types to the Storage model

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -64,7 +64,7 @@ class Storage < ApplicationRecord
   virtual_column :total_unmanaged_vms,            :type => :integer  # uses is handled via class method that aggregates
   virtual_column :count_of_vmdk_disk_files,       :type => :integer
 
-  SUPPORTED_STORAGE_TYPES = %w( VMFS NFS NFS41 FCP ISCSI GLUSTERFS )
+  SUPPORTED_STORAGE_TYPES = %w( VMFS NFS NFS41 FCP ISCSI GLUSTERFS GLANCE CINDER )
 
   supports :smartstate_analysis do
     if ext_management_systems.blank? || !ext_management_system.class.supports_smartstate_analysis?


### PR DESCRIPTION
I might be wrong, but IMO these should be included in the list, just for consistency.

Found them via:
```ruby
Storage.pluck(:store_type).uniq
=> ["NTFS", "NFS", "GLANCE", "CINDER", "VMFS", "NFS41"]
```