### PR TITLE
Fixed the virtual columns to be able to use in the API with `filter[]`

### DIFF
--- a/app/models/mixins/archived_mixin.rb
+++ b/app/models/mixins/archived_mixin.rb
@@ -11,10 +11,12 @@ module ArchivedMixin
   def archived?
     !active?
   end
+  alias_method :archived, :archived?
 
   def active?
     deleted_on.nil?
   end
+  alias_method :active, :active?
 
   def archive!
     update_attributes!(:deleted_on => Time.now.utc)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -62,7 +62,8 @@ class ServiceTemplate < ApplicationRecord
   virtual_column   :type_display,                 :type => :string
   virtual_column   :template_valid,               :type => :boolean
   virtual_column   :template_valid_error_message, :type => :string
-  virtual_column   :archived?,                    :type => :boolean
+  virtual_column   :archived,                     :type => :boolean
+  virtual_column   :active,                       :type => :boolean
 
   default_value_for :service_type, 'unknown'
   default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }


### PR DESCRIPTION
Primary use case is to be able to use `filter[]=archived=true` in the API, which was not possible before due to the `?` in the virtual column name.

Also added the `active` attribute/virtual column
