### PR TITLE
Add physical infra related default collections

### DIFF
--- a/app/models/manager_refresh/inventory_collection_default/physical_infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection_default/physical_infra_manager.rb
@@ -22,5 +22,51 @@ class ManagerRefresh::InventoryCollectionDefault::PhysicalInfraManager < Manager
 
       attributes.merge!(extra_attributes)
     end
+
+    def computer_systems(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::ComputerSystem,
+        :association                  => :computer_systems,
+        :manager_ref                  => [:managed_entity],
+        :parent_inventory_collections => [:physical_servers],
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def hardwares(extra_attributes = {})
+      attributes = {
+        :model_class                  => ::Hardware,
+        :association                  => :hardwares,
+        :manager_ref                  => [:computer_system],
+        :parent_inventory_collections => [:physical_servers],
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def physical_racks(extra_attributes = {})
+      attributes = {
+        :model_class    => ::PhysicalRack,
+        :association    => :physical_racks,
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.id }
+        }
+      }
+
+      attributes.merge!(extra_attributes)
+    end
+
+    def physical_chassis(extra_attributes = {})
+      attributes = {
+        :model_class    => ::PhysicalChassis,
+        :association    => :physical_chassis,
+        :builder_params => {
+          :ems_id => ->(persister) { persister.manager.id }
+        }
+      }
+
+      attributes.merge!(extra_attributes)
+    end
   end
 end


### PR DESCRIPTION
Newly added collections are used by physical infra providers when
performing inventory refresh.

@miq-bot assign @gtanzillo 
/cc @gberginc @matejart