### PR TITLE
[EUWE] Adds show to ems_network routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1434,6 +1434,7 @@ Vmdb::Application.routes.draw do
         provider_type_field_changed
         quick_search
         sections_field_changed
+        show
         show_list
         tag_edit_form_field_changed
         tagging_edit

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -39,7 +39,7 @@ shared_examples :shared_examples_for_ems_network_controller do |providers|
           expect(assigns(:breadcrumbs)).to eq([{:name => "Network Providers",
                                                 :url  => "/ems_network/show_list?page=&refresh=y"},
                                                {:name => "Cloud Manager Network Manager (Summary)",
-                                                :url  => "/ems_network/#{@ems.id}"}])
+                                                :url  => "/ems_network/show/#{@ems.id}"}])
 
           is_expected.to render_template(:partial => "layouts/listnav/_ems_network")
         end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -37,7 +37,7 @@ module Spec
       def assert_nested_list(parent, children, relation, label, child_path: nil, gtl_types: nil)
         gtl_types    ||= [:list, :tile, :grid]
         child_path   ||= relation.singularize
-        parent_route = controller.restful? ? controller.class.table_name : "#{controller.class.table_name}/show"
+        parent_route = "#{controller.class.table_name}/show"
         child_route  = "#{child_path}/show"
 
         controller.instance_variable_set(:@breadcrumbs, [])

--- a/spec/views/layouts/listnav/_ems_network.html.haml_spec.rb
+++ b/spec/views/layouts/listnav/_ems_network.html.haml_spec.rb
@@ -33,8 +33,8 @@ describe "layouts/listnav/_ems_network.html.haml" do
       it "relationships links uses restful path in #{t.camelize}" do
         @record = @provider.network_manager
         render
-        expect(response).to include("href=\"/ems_network/#{@record.id}?display=main\">Summary")
-        expect(response).to include("href=\"/ems_network/#{@record.id}?display=security_groups\">Security Groups (1)")
+        expect(response).to include("href=\"/ems_network/show/#{@record.id}?display=main\">Summary")
+        expect(response).to include("href=\"/ems_network/show/#{@record.id}?display=security_groups\">Security Groups (1)")
       end
     end
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1524443

Networks -> Providers -> click any provider -> click any subgroup (like Security Groups, Floating IPs,...) -> change Items per Page

Before:
<img width="1434" alt="screen shot 2018-06-08 at 3 21 03 pm" src="https://user-images.githubusercontent.com/9210860/41160328-9a1153a4-6b2f-11e8-9528-2ac495dfc41e.png">
Console:
```
[----] I, [2018-06-08T15:20:58.688011 #39190:3fe3918c8250]  INFO -- : Started POST "/ems_network/10000000000044?display=network_ports&ppsetting=10" for ::1 at 2018-06-08 15:20:58 +0200
[----] F, [2018-06-08T15:20:58.719422 #39190:3fe3918c8250] FATAL -- :   
[----] F, [2018-06-08T15:20:58.719568 #39190:3fe3918c8250] FATAL -- : ActionController::RoutingError (No route matches [POST] "/ems_network/10000000000044"):
[----] F, [2018-06-08T15:20:58.719620 #39190:3fe3918c8250] FATAL -- :   
[----] F, [2018-06-08T15:20:58.719672 #39190:3fe3918c8250] FATAL -- : actionpack (5.0.7) lib/action_dispatch/middleware/debug_exceptions.rb:53:in `call'
actionpack (5.0.7) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
```
After:
It works and calls `POST "/ems_network/show/10000000000044?display=network_ports&ppsetting=10"` like other `ems` controllers

@miq-bot add_label bug, ui, blocker
