### PR TITLE
Allow models to include methods for MiqExpression sql evaluation

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -31,7 +31,11 @@ class Hardware < ApplicationRecord
   virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
 
   def ipaddresses
-    @ipaddresses ||= networks.collect(&:ipaddress).compact.uniq + networks.collect(&:ipv6address).compact.uniq
+    @ipaddresses ||= if networks.loaded?
+                       networks.collect(&:ipaddress).compact.uniq + networks.collect(&:ipv6address).compact.uniq
+                     else
+                       networks.pluck(:ipaddress, :ipv6address).flatten.tap(&:compact!).tap(&:uniq!)
+                     end
   end
 
   def hostnames

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1618,6 +1618,39 @@ class VmOrTemplate < ApplicationRecord
     end
   end
 
+  # This creates the following SQL conditional:
+  #
+  #   1 = (SELECT 1
+  #        FROM hardwares
+  #        JOIN networks ON networks.hardware_id = hardwares.id
+  #        WHERE hardwares.vm_or_template_id = vms.id
+  #          AND (networks.ipaddress LIKE "%IPADDRESS%"
+  #               OR networks.ipv6address LIKE "%IPADDRESS%")
+  #        LIMIT 1
+  #       )
+  #
+  # This is simply an existance check, so when one record is found matching the
+  # following conditions:
+  #
+  #   - It is a hardware record that is associated with the vm
+  #   - It has an ipaddress or ipv6address that matches the search
+  #
+  # It will return the VM record.
+  def self.miq_expression_includes_any_ipaddresses_arel(ipaddress)
+    vms       = arel_table
+    networks  = Network.arel_table
+    hardwares = Hardware.arel_table
+
+    match_grouping = networks[:ipaddress].matches("%#{ipaddress}%")
+                       .or(networks[:ipv6address].matches("%#{ipaddress}%"))
+
+    query = hardwares.project(1)
+                     .join(networks).on(networks[:hardware_id].eq(hardwares[:id]))
+                     .where(hardwares[:vm_or_template_id].eq(vms[:id]).and(match_grouping))
+                     .take(1)
+    Arel::Nodes::SqlLiteral.new("1").eq(query)
+  end
+
   def self.scan_by_property(property, value, _options = {})
     _log.info("scan_vm_by_property called with property:[#{property}] value:[#{value}]")
     case property

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -344,6 +344,15 @@ class MiqExpression
         # TODO: Support includes operator for sub-sub-tables
         return false
       end
+    when "includes any", "includes all", "includes only"
+      # Support this only from the main model (for now)
+      if exp[operator].keys.include?("field") && exp[operator]["field"].split(".").length == 1
+        model, field = exp[operator]["field"].split("-")
+        method = "miq_expression_#{operator.downcase.tr(' ', '_')}_#{field}_arel"
+        return model.constantize.respond_to?(method)
+      else
+        return false
+      end
     when "find", "regular expression matches", "regular expression does not match", "key exists", "value exists"
       return false
     else
@@ -1343,6 +1352,11 @@ class MiqExpression
       escape = nil
       case_sensitive = true
       arel_attribute.matches("%#{parsed_value}%", escape, case_sensitive)
+    when "includes all", "includes any", "includes only"
+      method = "miq_expression_"
+      method << "#{operator.downcase.tr(' ', '_')}_"
+      method << "#{field.column}_arel"
+      field.model.send(method, parsed_value)
     when "starts with"
       escape = nil
       case_sensitive = true


### PR DESCRIPTION
This is currently a first pass at making it so models can define methods for SQL fragments for specific expression types.  Specifically, this allows the "INCLUDE ANY" to work in SQL for following expression:

```
Virtual Machine : IP Addresses INCLUDES ANY ['10.XXX.X']
```

Also of note:  The ruby implementation of `INCLUDES ANY` doesn't seem work as expected, so not sure if this is a bug with `MiqExpression` or I have implemented this expression in SQL incorrectly.


Benchmarks
----------
So there is some additional slowness issues that I noticed on master that don't seem to be present on the `gaprindashvili` branch, but they seem to be mitigated by this branch.  That said, seems like they are `LEFT JOIN` based issues, and could be an issue when requesting more that 20 Vms per-page, so it might be worth looking into at a later date.

For now, as show in the benchmarks, the times are WAY faster (and this isn't including another 200k ms request that also was slow on master, but now isn't an issue), so I think this fix is fine on it's own.

**BEFORE**

```
/vm_infra/report_data
|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
| 235682 |   22810 |    27690.0 | 278708 |
| 247473 |   22810 |    32461.1 | 278708 |
| 252947 |   22810 |    41896.3 | 278708 |

:rows_by_class:
  User: 2
  MiqGroup: 2
  Tenant: 2
  MiqUserRole: 2
  Entitlement: 1
  ManageIQ::Providers::InfraManager::Vm: 241115
  Network: 37584
:total_queries: 22810
:total_rows: 278708
```


**AFTER**

```
/vm_infra/report_data
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
|  857 |       9 |      417.5 |  209 |
|  525 |       9 |      328.1 |  209 |
|  510 |       9 |      316.6 |  209 |
|  515 |       9 |      308.7 |  209 |
|  460 |       9 |      289.8 |  209 |

:rows_by_class:
  User: 2
  MiqGroup: 2
  Tenant: 2
  MiqUserRole: 2
  Entitlement: 1
  ManageIQ::Providers::InfraManager::Vm: 200
:total_queries: 9
:total_rows: 209
```


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1588082


Steps for Testing/QA
--------------------

1. Go to `Compute` > `Infrastructure` > `VirtualMachines` 
  
2. Select "All VMs" from the tree on the left
  
3. Click the down arrow to the right of the search box
  
4. Create the following query (replace "XXX.XXX.XXX" with something that makes sense for your environment)
  
  ```
  Virtual Machine : IP Addresses INCLUDES ALL ['XXX.XXX.XXX']
  ```

On master, this should be quite slow on a environment with a reasonable number of VMs (10k+), but very quick with this patch.