### PR TITLE
Removed redundant method ServerSmartProxy#forceVmScan

### DIFF
--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -157,10 +157,6 @@ module MiqServer::ServerSmartProxy
     errArray.each { |e| $log.error("Error Trace: [#{e}]") }
   end
 
-  def forceVmScan
-    true
-  end
-
   # TODO: This should be moved - where?
   def is_vix_disk_supported?
     caps = {:vixDisk => false}

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -115,7 +115,7 @@ class VmScan < Job
           return
         end
 
-        if proxy && proxy.forceVmScan
+        if proxy
           options[:snapshot] = :smartProxy
           _log.info("Skipping snapshot creation, it will be performed by the SmartProxy")
           context[:snapshot_mor] = options[:snapshot_description] = snapshotDescription("(embedded)")


### PR DESCRIPTION
```ServerSmartProxy#forceVmScan``` returns constant (```true```) and called in a single place

@miq-bot add-label technical debt