### PR TITLE
Make user_timezone method for MiqReportResult public

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -349,8 +349,6 @@ class MiqReportResult < ApplicationRecord
     n_('Report Result', 'Report Results', number)
   end
 
-  private
-
   def user_timezone
     user = userid.include?("|") ? nil : User.find_by_userid(userid)
     user ? user.get_timezone : MiqServer.my_server.server_timezone


### PR DESCRIPTION
We need this method in the UI for the new printing/PDF exports.

https://bugzilla.redhat.com/show_bug.cgi?id=1588072
Related issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4113

@miq-bot add_label gaprindashvili/no, reporting
@miq-bot add_reviewer @lpichler 