### PR TITLE
Missing embedded ansible persisters dependencies

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/inventory/persister/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/inventory/persister/automation_manager.rb
@@ -1,3 +1,2 @@
-class ManageIQ::Providers::EmbeddedAnsible::Inventory::Persister::AutomationManager < ManagerRefresh::Inventory::Persister
-  include ManageIQ::Providers::AnsibleTower::Shared::Inventory::Persister::AutomationManager
+class ManageIQ::Providers::EmbeddedAnsible::Inventory::Persister::AutomationManager < ManageIQ::Providers::AnsibleTower::Inventory::Persister::AutomationManager
 end

--- a/app/models/manageiq/providers/embedded_ansible/inventory/persister/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/inventory/persister/configuration_script_source.rb
@@ -1,3 +1,2 @@
-class ManageIQ::Providers::EmbeddedAnsible::Inventory::Persister::ConfigurationScriptSource < ManagerRefresh::Inventory::Persister
-  include ManageIQ::Providers::AnsibleTower::Shared::Inventory::Persister::ConfigurationScriptSource
+class ManageIQ::Providers::EmbeddedAnsible::Inventory::Persister::ConfigurationScriptSource < ManageIQ::Providers::AnsibleTower::Inventory::Persister::ConfigurationScriptSource
 end

--- a/app/models/manager_refresh/inventory_collection/builder.rb
+++ b/app/models/manager_refresh/inventory_collection/builder.rb
@@ -207,10 +207,16 @@ module ManagerRefresh
         model_class = begin
           # a) Provider specific class
           provider_module = ManageIQ::Providers::Inflector.provider_module(@persister_class).name
-          manager_module = auto_model_class_manager_module
+          manager_module = self.class.name.split('::').last
 
           class_name = "#{provider_module}::#{manager_module}::#{@name.to_s.classify}"
-          class_name.safe_constantize
+
+          inferred_class = class_name.safe_constantize
+
+          # safe_constantize can return different similar class ( some Rails auto-magic :/ )
+          if inferred_class.to_s == class_name
+            inferred_class
+          end
         rescue ::ManageIQ::Providers::Inflector::ObjectNotNamespacedError
           nil
         end
@@ -221,10 +227,6 @@ module ManagerRefresh
           # b) general class
           "::#{@name.to_s.classify}".safe_constantize
         end
-      end
-
-      def auto_model_class_manager_module
-        self.class.name.split('::').last
       end
 
       # Enables/disables auto_model_class and exception check

--- a/app/models/manager_refresh/inventory_collection/builder.rb
+++ b/app/models/manager_refresh/inventory_collection/builder.rb
@@ -207,7 +207,7 @@ module ManagerRefresh
         model_class = begin
           # a) Provider specific class
           provider_module = ManageIQ::Providers::Inflector.provider_module(@persister_class).name
-          manager_module = self.class.name.split('::').last
+          manager_module = auto_model_class_manager_module
 
           class_name = "#{provider_module}::#{manager_module}::#{@name.to_s.classify}"
           class_name.safe_constantize
@@ -221,6 +221,10 @@ module ManagerRefresh
           # b) general class
           "::#{@name.to_s.classify}".safe_constantize
         end
+      end
+
+      def auto_model_class_manager_module
+        self.class.name.split('::').last
       end
 
       # Enables/disables auto_model_class and exception check

--- a/app/models/manager_refresh/inventory_collection/builder/automation_manager.rb
+++ b/app/models/manager_refresh/inventory_collection/builder/automation_manager.rb
@@ -48,10 +48,6 @@ module ManagerRefresh
 
         protected
 
-        def auto_model_class_manager_module
-          'AutomationManager'
-        end
-        
         def default_manager_ref
           add_properties(:manager_ref => %i(manager_ref))
         end

--- a/app/models/manager_refresh/inventory_collection/builder/automation_manager.rb
+++ b/app/models/manager_refresh/inventory_collection/builder/automation_manager.rb
@@ -48,6 +48,10 @@ module ManagerRefresh
 
         protected
 
+        def auto_model_class_manager_module
+          'AutomationManager'
+        end
+        
         def default_manager_ref
           add_properties(:manager_ref => %i(manager_ref))
         end


### PR DESCRIPTION
From old to new interface

Fixes problem https://travis-ci.org/ManageIQ/manageiq/jobs/391452668

ManageIQ::Providers::EmbeddedAnsible::Inventory::Persister::AutomationManager / ConfigurationScriptSource includes removed mixins (https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/81)

Reverting fix: https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/97 (this is intended to replace them)

- [ ] **depends on** https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/104