### PR TITLE
remove most of test authentication stubbing

### DIFF
--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -5,39 +5,29 @@ module Spec
         request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
       end
 
-      def login_as(user)
+      def login_as(user, stub_controller: false)
         User.current_user = user
+        STDERR.puts "WARNING: double stubbing user - only use login_as or stub_user once" if user != User.current_user
         session[:userid]  = user.userid
         session[:group]   = user.current_group_id
+        allow(controller).to receive(:current_user).and_return(user) if stub_controller
         user
       end
 
-      # TODO: Stub specific features, document use
-      def stub_user(features:, user: FactoryGirl.build(:user_with_group))
-        allow(controller).to receive(:current_user).and_return(user)
-        allow(User).to receive(:current_user).and_return(user)
+      # Stubs the user in context for a controller
+      # @param features (:all|:none|Array<>,String,Symbol) features for a user
+      #    :all   means all features are avaiable, essentially "super_administrator"
+      #    :none  means no features are available. (feature "none" ends up being assigned - which does nothing)
+      def stub_user(features:)
         allow(User).to receive(:server_timezone).and_return("UTC")
         allow_any_instance_of(described_class).to receive(:set_user_time_zone)
 
-        stub_bool = case features
-                    when :all  then true
-                    when :none then false
-                    else
-                      raise ArgumentError, <<-EOS
-      Unknown features option. You must pass :all or :none to #stub_user.
-      If you need specific features, use #login_as with an actual User model instead.
-                      EOS
-                    end
-        allow(controller).to receive(:check_privileges).and_return(stub_bool)
-        allow(controller).to receive(:assert_rbac).and_return(stub_bool)
-        allow(Rbac).to receive(:role_allows?).and_return(stub_bool)
-
-        login_as user
-        user
+        features = "everything" if features == :all
+        login_as FactoryGirl.create(:user, :features => Array.wrap(features).map(&:to_s)), :stub_controller => true
       end
 
       def stub_admin
-        stub_user(:features => :all, :user => FactoryGirl.create(:user_admin))
+        stub_user(:features => :all)
       end
     end
 


### PR DESCRIPTION
If we have fewer stubs, then we are testing more code and we are encouraged to pay attention to roles/miq_product_features and authorization.

I can see the argument that this makes it more or less stable.
So I'm putting it out there and seeing what others thing.

I just ran master classic-ui and all tests passed locally
@himdel - thoughts?