### PR TITLE
Add add_default_auth_status method

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -126,6 +126,10 @@ module AuthenticationMixin
     authentication_best_fit(type).try(:status) == "Valid"
   end
 
+  def default_auth_status_ok?
+    authentication_status_ok?
+  end
+
   def auth_user_pwd(type = nil)
     cred = authentication_best_fit(type)
     return nil if cred.nil? || cred.userid.blank?


### PR DESCRIPTION
The purpose of this method is to let the UI detect the status of the
default auth_status of the provider.

In a specific case there is a need to override it with 'true' instead
of relying on the value of default_auth_status_ok? :
Kubevirt provider can be managed both as an infrastructure provider and
as a sub-provider of the container manager. When it is being managed as
an infra provider, its auth_type is 'kubevirt' and the default_auth_status
refers to the parent provider.
There can be a case in which the parent provider is invalid, while the
kubevirt provider is valid.

Therefore, in that case, the default_auth_status should be 'true', to
allow editing the kubevirt infra provider.

The method will be used by https://github.com/ManageIQ/manageiq-ui-classic/pull/4137/files#diff-f402e411cd6dc158c724b14d72ead612R861

Fixes https://github.com/ManageIQ/manageiq-providers-kubevirt/issues/71

