### PR TITLE
[WIP] Create new virtual column AR extension for UI display text

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,7 @@ class ApplicationRecord < ActiveRecord::Base
   include ArNestedCountBy
   include ArHrefSlug
   include ToModelHash
+  include VirtualDisplayName
 
   extend ArTableLock
 

--- a/lib/extensions/virtual_display_name.rb
+++ b/lib/extensions/virtual_display_name.rb
@@ -1,0 +1,15 @@
+module VirtualDisplayName
+
+  # define an attribute to contain display text, in order of preference:
+  # description, if and when available
+  # title/name in case description is not available or does not exist
+  # default to <record id> in cases where no other attribute has been provided by user
+  def virtual_display_name
+    return label                      if respond_to?("label")
+    return description                if respond_to?("description") && description.present?
+    return ext_management_system.name if respond_to?("ems_id")
+    return title                      if respond_to?("title")
+    return name                       if respond_to?("name")
+    "<Record ID #{record.id}>"
+  end
+end


### PR DESCRIPTION
New Active Record extension to be available to any and all classes. Created mostly for UI display to make text more consistent for all actions: add/edit/delete. In most cases, currently, we call common methods to process all records to be deleted, and in many cases we then display .description (when exists and available), rather than title/name. Title/name are used to populate tree nodes' text and application then displays same title/name text in confirmation messages for add/edit actions. This creates a dichotomy with add/edit actions using one set of text for messages and delete/destroy a different set (description) in some cases. Code now can selectively use new virtual column to set same common text for messages, and particular classes can choose to override that and use chosen one, name for example, on a per case basis.  

Screen shot added to show very long Widget description in the flash message using new virtual column. 
![new virtual column test display with long description](https://user-images.githubusercontent.com/552686/41372802-2e641d12-6f03-11e8-88a3-5151e9115917.png)

