### PR TITLE
Changes to support UI changes to show Configuration Workflows in UI

### DIFF
--- a/app/models/configuration_script_base.rb
+++ b/app/models/configuration_script_base.rb
@@ -22,4 +22,18 @@ class ConfigurationScriptBase < ApplicationRecord
   scope :with_manager, ->(manager_id) { where(:manager_id => manager_id) }
 
   include ProviderObjectMixin
+
+  EXCLUDED_WORKFLOW_TYPES = ["ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook",
+                             "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook",
+                             "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript",
+                             "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptPayload",
+                             "ManageIQ::Providers::AutomationManager::ConfigurationScriptPayload"]
+
+  def self.without_playbooks
+    where.not(:type => EXCLUDED_WORKFLOW_TYPES)
+  end
+
+  def self.without_playbooks_for_manager(manager_id)
+    where(:manager_id => manager_id).where.not(:type => EXCLUDED_WORKFLOW_TYPES)
+  end
 end

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -773,6 +773,7 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential:        Credential (SCM)
       ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential:     Credential (VMware)
       ManageIQ::Providers::AnsibleTower::AutomationManager:                 Automation Manager (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow: Workflow Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript: Job Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook: Playbook (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)


### PR DESCRIPTION
Need these changes to be able to show list of Job Templates and Configuration Workflows in existing UI under Automation/Ansible Tower/Explorer in Templates Accordion. With these changes UI is expecting to get back list of both Job Templates and Configuration Workflows mixed together to show in list view and in the tree under a selected Provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1590441

UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4138