### PR TITLE
Add support to filter event_streams on the API.

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -28,11 +28,61 @@ class EventStream < ApplicationRecord
   belongs_to :middleware_server, :foreign_key => :middleware_server_id
   belongs_to :physical_server
 
+  virtual_column :group,       :type => :string
+  virtual_column :group_level, :type => :string
+  virtual_column :group_name,  :type => :string
+
   after_commit :emit_notifications, :on => :create
 
   def emit_notifications
     Notification.emit_for_event(self)
   rescue => err
     _log.log_backtrace(err)
+  end
+
+  def self.event_groups
+    core_event_groups = ::Settings.event_handling.event_groups.to_hash
+    Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
+      provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
+      next unless provider_event_groups
+      DeepMerge.deep_merge!(
+        provider_event_groups.to_hash, event_groups,
+        :preserve_unmergeables => false,
+        :overwrite_arrays      => false
+      )
+    end
+  end
+
+  def self.group_and_level(event_type)
+    group, v = event_groups.find { |_k, v| v[:critical].include?(event_type) || v[:detail].include?(event_type) }
+    if group.nil?
+      group, level = :other, :detail
+    else
+      level = v[:detail].include?(event_type) ? :detail : :critical
+    end
+    return group, level
+  end
+
+  def self.group_name(group)
+    return nil if group.nil?
+    group = event_groups[group.to_sym]
+    return nil if group.nil?
+    group[:name]
+  end
+
+  def group
+    return @group unless @group.nil?
+    @group, @group_level = self.class.group_and_level(event_type)
+    @group
+  end
+
+  def group_level
+    return @group_level unless @group_level.nil?
+    @group, @group_level = self.class.group_and_level(event_type)
+    @group_level
+  end
+
+  def group_name
+    @group_name ||= self.class.group_name(group)
   end
 end


### PR DESCRIPTION
This PR is able to: 
* Add support to filter event_streams by group, group_name and group_level on the MIQ-API.

example: 
```
http://localhost:3000/api/event_streams?expand=resources&filter[]= group = 'power'
```
![image](https://user-images.githubusercontent.com/12627705/41385943-12967bf0-6f55-11e8-8787-06cf08337c9a.png)

