### PR TITLE
Cash cloud volumes in ChargebackVm

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -50,11 +50,13 @@ describe MiqExpression do
 
           # case: change name
           volume_2.update_attributes!(:volume_type => 'NEW_TYPE_2')
+          ChargebackVm.current_volume_types_clear_cache
           report_fields = described_class.reporting_available_fields(model).map(&:second)
           expect(report_fields).to include(volume_1_type_field_cost)
           expect(report_fields).not_to include(volume_2_type_field_cost) # old field
 
           # check existence of new name
+          ChargebackVm.current_volume_types_clear_cache
           report_fields = described_class.reporting_available_fields(model).map(&:second)
           volume_2_type_field_cost = "#{model}-storage_allocated_#{volume_2.volume_type}_cost"
           expect(report_fields).to include(volume_1_type_field_cost)
@@ -62,6 +64,7 @@ describe MiqExpression do
 
           # case: add volume_type
           volume_3
+          ChargebackVm.current_volume_types_clear_cache
           report_fields = described_class.reporting_available_fields(model).map(&:second)
           expect(report_fields).to include(volume_1_type_field_cost)
           expect(report_fields).to include(volume_3_type_field_cost)
@@ -70,6 +73,7 @@ describe MiqExpression do
           volume_2.destroy
           volume_3.destroy
 
+          ChargebackVm.current_volume_types_clear_cache
           report_fields = described_class.reporting_available_fields(model).map(&:second)
           expect(report_fields).to include(volume_1_type_field_cost)
           expect(report_fields).not_to include(volume_2_type_field_cost)

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -202,6 +202,7 @@ describe ChargebackVm do
 
             cloud_volume_hdd.destroy
 
+            described_class.current_volume_types_clear_cache
             described_class.refresh_dynamic_metric_columns
             fields = described_class.attribute_names
             expect(fields).not_to include(cloud_volume_hdd_field)


### PR DESCRIPTION
Invoke cloud volume query only when report is run.
Previously query was invoked each time when when method `ChargebackVm.attribute_names` was called.

Based on @NickLaMuro's code and findings. Thanks!

Stats are as part of bigger issue. (Will be added lately)

@miq-bot assign @gtanzillo 

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1566452
one of 6 PRs for a fix.
