### PR TITLE
Adjusting ManageIQ core to enable PhysicalStorage API endpoint

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -8,4 +8,23 @@ class PhysicalStorage < ApplicationRecord
   has_one :hardware, :through => :computer_system
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
   has_many :guest_devices, :through => :hardware
+
+  def my_zone
+    ems = ext_management_system
+    ems ? ems.my_zone : MiqServer.my_zone
+  end
+
+  def refresh_ems
+    unless ext_management_system
+      raise _("No Provider defined")
+    end
+    unless ext_management_system.has_credentials?
+      raise _("No Provider credentials defined")
+    end
+    unless ext_management_system.authentication_status_ok?
+      raise _("Provider failed last authentication check")
+    end
+
+    EmsRefresh.queue_refresh(ext_management_system)
+  end
 end

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5949,6 +5949,35 @@
       :feature_type: control
       :identifier: physical_switch_restart
 
+# Physical Storages
+- :name: Physical Storages
+  :description: Everything under Physical Storages
+  :feature_type: node
+  :identifier: physical_storage
+  :children:
+  - :name: View
+    :description: View Physical Storage
+    :feature_type: view
+    :identifier: physical_storage_view
+    :children:
+    - :name: List
+      :description: Display Lists of Physical Storages
+      :feature_type: view
+      :identifier: physical_storage_show_list
+    - :name: Show
+      :description: Display Individual Physical Storage
+      :feature_type: view
+      :identifier: physical_storage_show
+  - :name: Operate
+    :description: Perform Operations on Physical Storages
+    :feature_type: control
+    :identifier: physical_storage_control
+    :children:
+    - :name: Refresh
+      :description: Refresh relationships and power states for all items related to Physical Storages
+      :feature_type: control
+      :identifier: physical_storage_refresh
+
 # Physical Servers
 - :name: Physical Servers
   :description: Everything under Physical Servers

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -72,6 +72,7 @@
   - physical_chassis
   - physical_switch
   - physical_server
+  - physical_storage
   - physical_infra_topology
   - planning
   - policy_import_export
@@ -142,6 +143,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - policy_log
   - policy_simulation
   - pxe_image_type_view
@@ -239,6 +241,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - planning
   - policy_log
   - policy_profile
@@ -316,6 +319,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - provider_foreman_explorer
   - vm_clone
   - vm_compare
@@ -395,6 +399,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - physical_infra_topology_view
   - host_new
   - host_compare
@@ -610,6 +615,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - policy_log
   - policy_simulation
   - resource_pool_show
@@ -700,6 +706,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - resource_pool_show
   - resource_pool_show_list
   - resource_pool_tag
@@ -1209,6 +1216,7 @@
   - physical_chassis_view
   - physical_switch_view
   - physical_server_view
+  - physical_storage_view
   - planning
   - policy_log
   - provider_foreman_view


### PR DESCRIPTION
**This PR is able to:**
- Adds features in `miq_product_features.yml` and ems queue refresh to enable PhysicalStorage endpoint on ManageIQ API.