### PR TITLE
MiqSchedule call method directly if available

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -93,6 +93,9 @@ class MiqSchedule < ApplicationRecord
 
       _log.info("Queueing start of schedule id: [#{id}] [#{sched.name}] [#{sched.towhat}] [#{method}]...complete")
       msg
+    elsif sched.resource.respond_to?(method)
+      sched.resource.send(method, *sched.sched_action[:args])
+      sched.update_attributes(:last_run_on => Time.now.utc)
     else
       _log.warn("[#{sched.name}] no such action: [#{method}], aborting schedule")
     end

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -42,6 +42,12 @@ class MiqSchedule < ApplicationRecord
   default_value_for :enabled, true
   default_value_for(:zone_id) { MiqServer.my_server.zone_id }
 
+  def resource
+    # HACK: this should be a real relation, but for now it's using a reserve_attribute for backport reasons
+    return unless resource_id
+    towhat.safe_constantize.find_by(:id => resource_id)
+  end
+
   def set_start_time_and_prod_default
     run_at # Internally this will correct :start_time to UTC
     self.prod_default = "system" if SYSTEM_SCHEDULE_CLASSES.include?(towhat.to_s)

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -1,4 +1,7 @@
 class MiqSchedule < ApplicationRecord
+  include ReservedMixin
+  reserve_attribute :resource_id, :big_integer
+
   validates :name, :uniqueness => {:scope => [:userid, :towhat]}
   validates :name, :description, :towhat, :run_at, :presence => true
   validate  :validate_run_at, :validate_file_depot


### PR DESCRIPTION
Based on: https://github.com/ManageIQ/manageiq/pull/17581

If the MiqSchedule#resource responds to the method, call it

This avoids having to create an action_ method in the MiqSchedule namespace
