### PR TITLE
Add tool to remove grouping from report results

### DIFF
--- a/tools/remove_grouping_from_report_results.rb
+++ b/tools/remove_grouping_from_report_results.rb
@@ -18,9 +18,11 @@ end
 # Load rails after trollop options are set.  No one wants to wait for -h.
 require File.expand_path('../config/environment', __dir__)
 
+# Wrap all changes in a transaction and roll them back if dry-run or an error occurs.
+ActiveRecord::Base.connection.begin_transaction(:joinable => false)
+
 if opts[:dry_run]
-  puts "Running in dry-run, changes will be rolled back when complete."
-  ActiveRecord::Base.connection.begin_transaction(:joinable => false)
+  puts "Running in dry-run, all changes will be rolled back when complete."
 
   at_exit do
     ActiveRecord::Base.connection.rollback_transaction
@@ -30,23 +32,32 @@ end
 start = Time.now.utc
 total = 0
 fixed = 0
-MiqReportResult.find_each(:batch_size => opts[:batch_size]).with_index do |rr, i|
-  break if opts[:count].positive? && i == opts[:count]
-  next if rr.report.nil? || rr.report.extras.nil?
 
-  if rr.report.extras.key?(:grouping)
-    rr.report.extras.except!(:grouping)
-    rr.save!
-    if rr.reload.report.extras.key?(:grouping)
-      puts "MiqReportResult: #{rr.id} could NOT be fixed"
+MiqReportResult.find_each(:batch_size => opts[:batch_size]).with_index do |rr, i|
+  begin
+    break if opts[:count].positive? && i == opts[:count]
+    next if rr.report.nil? || rr.report.extras.nil?
+
+    if rr.report.extras.key?(:grouping)
+      rr.report.extras.except!(:grouping)
+      rr.save!
+      if rr.reload.report.extras.key?(:grouping)
+        puts "MiqReportResult: #{rr.id} could NOT be fixed"
+      else
+        puts "MiqReportResult: #{rr.id} fixed"
+        fixed += 1
+      end
     else
-      puts "MiqReportResult: #{rr.id} fixed"
-      fixed += 1
+      puts "MiqReportResult: #{rr.id} doesn't need fixing"
     end
-  else
-    puts "MiqReportResult: #{rr.id} doesn't need fixing"
+
+    total += 1
+  rescue => err
+    puts "\nWarning: Rolling back all changes since an error occurred on MiqReportResult with id: #{rr.try(:id)}: #{err.message}"
+    ActiveRecord::Base.connection.rollback_transaction unless opts[:dry_run]
+    exit 1
   end
-  total += 1
 end
 
-puts "Processed #{total} rows. #{fixed} were fixed. #{Time.now.utc - start} seconds"
+ActiveRecord::Base.connection.commit_transaction unless opts[:dry_run]
+puts "\nProcessed #{total} rows. #{fixed} were fixed. #{Time.now.utc - start} seconds"

--- a/tools/remove_grouping_from_report_results.rb
+++ b/tools/remove_grouping_from_report_results.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+require 'trollop'
+
+opts = Trollop.options do
+  banner "Remove extras[:grouping] from MiqReportResult#report column.\n\nUsage: ruby #{$PROGRAM_NAME} [options]\n\nOptions:\n\t"
+  opt :dry_run,    "For testing, rollback any changes when the script exits.", :short => :none, :default => false
+  opt :batch_size, "Limit memory usage by process this number of report results at a time.",    :default => 50
+  opt :count,      "Stop checking after this number of report results.",                        :default => 0
+end
+
+puts "Using options: #{opts.inspect}\n\n"
+
+if defined?(Rails)
+  puts "Warning: Rails is already loaded!  Please do not invoke using rails runner. Exiting with help text.\n\n"
+  Trollop.educate
+end
+
+# Load rails after trollop options are set.  No one wants to wait for -h.
+require File.expand_path('../config/environment', __dir__)
+
+if opts[:dry_run]
+  puts "Running in dry-run, changes will be rolled back when complete."
+  ActiveRecord::Base.connection.begin_transaction(:joinable => false)
+
+  at_exit do
+    ActiveRecord::Base.connection.rollback_transaction
+  end
+end
+
+start = Time.now.utc
+total = 0
+fixed = 0
+MiqReportResult.find_each(:batch_size => opts[:batch_size]).with_index do |rr, i|
+  break if opts[:count].positive? && i == opts[:count]
+  next if rr.report.nil? || rr.report.extras.nil?
+
+  if rr.report.extras.key?(:grouping)
+    rr.report.extras.except!(:grouping)
+    rr.save!
+    if rr.reload.report.extras.key?(:grouping)
+      puts "MiqReportResult: #{rr.id} could NOT be fixed"
+    else
+      puts "MiqReportResult: #{rr.id} fixed"
+      fixed += 1
+    end
+  else
+    puts "MiqReportResult: #{rr.id} doesn't need fixing"
+  end
+  total += 1
+end
+
+puts "Processed #{total} rows. #{fixed} were fixed. #{Time.now.utc - start} seconds"

--- a/tools/remove_grouping_from_report_results.rb
+++ b/tools/remove_grouping_from_report_results.rb
@@ -36,6 +36,8 @@ fixed = 0
 MiqReportResult.find_each(:batch_size => opts[:batch_size]).with_index do |rr, i|
   begin
     break if opts[:count].positive? && i == opts[:count]
+    total += 1
+
     next if rr.report.nil? || rr.report.extras.nil?
 
     if rr.report.extras.key?(:grouping)
@@ -50,8 +52,6 @@ MiqReportResult.find_each(:batch_size => opts[:batch_size]).with_index do |rr, i
     else
       puts "MiqReportResult: #{rr.id} doesn't need fixing"
     end
-
-    total += 1
   rescue => err
     puts "\nWarning: Rolling back all changes since an error occurred on MiqReportResult with id: #{rr.try(:id)}: #{err.message}"
     ActiveRecord::Base.connection.rollback_transaction unless opts[:dry_run]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1590908

Some aggregation information was persisted into the miq_report_results
table in the report column's `extras[:grouping]` section.  We don't need
the grouping after we've generated the html data.  This tool removes
this from each row in the table.

The default options will process the whole table in batches of 50 at a
time and will persist all changes.

If you run it with -h, you'll receive a help banner:

```
Remove extras[:grouping] from MiqReportResult#report column.

Usage: ruby tools/remove_grouping_from_report_results.rb [options]

Options:

  --dry-run               For testing, rollback any changes when the script exits.
  -b, --batch-size=<i>    Limit memory usage by process this number of report results at a time. (Default: 50)
  -c, --count=<i>         Stop checking after this number of report results. (Default: 0)
  -h, --help              Show this message

```

Example output looks like this:

```
ruby tools/remove_grouping_from_report_results.rb -c 11
Using options: {:dry_run=>false, :batch_size=>50, :count=>11, :help=>false, :count_given=>true}
** Using session_store: ActionDispatch::Session::MemCacheStore
MiqReportResult: 22000000000001 doesn't need fixing
MiqReportResult: 22000000000002 doesn't need fixing
MiqReportResult: 22000000000003 fixed
MiqReportResult: 22000000000004 doesn't need fixing
MiqReportResult: 22000000000005 doesn't need fixing
MiqReportResult: 22000000000006 fixed
MiqReportResult: 22000000000007 doesn't need fixing
MiqReportResult: 22000000000008 doesn't need fixing
MiqReportResult: 22000000000009 doesn't need fixing
MiqReportResult: 22000000000010 doesn't need fixing
MiqReportResult: 22000000000011 fixed
Processed 11 rows. 1 were fixed. 13.170998 seconds
```