### PR TITLE
Add faster MiqReportResult helper methods for viewing saved report results

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -53,6 +53,13 @@ class MiqReportResult < ApplicationRecord
     miq_task.nil? ? _("The task associated with this report is no longer available") : miq_task.message
   end
 
+  # Use this method over `report_results` if you don't plan on using the
+  # `binary_blob` associated with the MiqReportResult (chances are you don't
+  # need it).
+  def valid_report_column?
+    report.kind_of?(MiqReport)
+  end
+
   def report_results
     if binary_blob
       data = binary_blob.data

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -60,6 +60,13 @@ class MiqReportResult < ApplicationRecord
     report.kind_of?(MiqReport)
   end
 
+  # Use this over `report_results.contains_records?` if you don't need to
+  # access the binary_blob associated with the MiqReportResult (chances are you
+  # don't need it)
+  def contains_records?
+    (report && (report.extras || {})[:total_html_rows].to_i.positive?) || html_details.exists?
+  end
+
   def report_results
     if binary_blob
       data = binary_blob.data


### PR DESCRIPTION
Adds two methods:

* `MiqReportResult#has_report?`
* `MiqReportResult#contains_records?`

This is specifically used to avoid having to fetch and deserialize the `binary_blob` associated with the `MiqReportResult`, which has the entire `Ruport::Data::Table` object saved in it, and eventually is never used in some of the controllers that make use of them.


`MiqReportResult#has_report?`
-----------------------------
A quicker check than having to use `MiqReportResult#report_results`, since binary_blob doesn't need to be loaded into memory.  On top of that, generally the `binary_blob.data` isn't even used in the controller at the end of the day, and this version of the `MiqReport` record ends up being what is used when generating the page for viewing.


`MiqReportResult#contains_records?`
-----------------------------------
Like `MiqReportResult#has_report?`, this is a faster version of checking if the report_result has rows.

Like `MiqReport#contains_records?`, this will check against the `extras` attribute on the deserialized version of the `report` column, but instead of using the `table` value (which is not saved into the `report` column), just do a light SQL existence check on the `html_details` to confirm there are generated rows for this report.

The SQL query most likely won't be needed, and it is super light weight, only returning a single digit, or an empty result set if there are no records.



Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1590908
* Associated UI PR to use these methods: https://github.com/ManageIQ/manageiq-ui-classic/pull/4143

Will put benchmarks in the associated UI PR.