### PR TITLE
Add save hooks on MiqReportResult to remove groupings

### DIFF
--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -105,6 +105,23 @@ describe MiqReportResult do
       expect(report_result.report_results.table.data).not_to be_nil
     end
 
+    it "should not include `extras[:grouping]` in the report column" do
+      MiqReport.seed_report(name = "Vendor and Guest OS")
+      rpt = MiqReport.where(:name => name).last
+      rpt.generate_table(:userid => "test")
+      report_result = rpt.build_create_results(:userid => "test")
+
+      report_result.report
+      report_result.report.extras[:grouping] = { "extra data" => "not saved" }
+      report_result.save
+
+      result_reload = MiqReportResult.last
+
+      expect(report_result.report.kind_of?(MiqReport)).to be_truthy
+      expect(result_reload.report.extras[:grouping]).to be_nil
+      expect(report_result.report.extras[:grouping]).to eq("extra data" => "not saved")
+    end
+
     context "for miq_report_result is used different miq_group_id than user's current id" do
       before do
         MiqUserRole.seed


### PR DESCRIPTION
The `report.extras[:groupings]` on MiqReportResult were being serialized to the `report` column, and on certain chargeback reports, can get quite large.  This data is not needed, so we remove it prior to saving.

The after_commit exists in case there is a use for the saved data after it has been saved and still used within the original instance of the MiqReportResult for building the result.  Most likely this is overkill, but for now it is in place as a safety measure.


Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1590908