### PR TITLE
Add `nil` check for report.extras on save hooks

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -46,8 +46,8 @@ class MiqReportResult < ApplicationRecord
   # the remainder of the object's instantiation.  The `after_commit` hook
   # specifically is probably overkill, but allows us to not break existing code
   # that expects the temporary chargeback data in the instantiated object.
-  before_save  { @_extra_groupings = report.extras.delete(:grouping) if report.kind_of?(MiqReport) }
-  after_commit { report.extras[:grouping] = @_extra_groupings if report.kind_of?(MiqReport) }
+  before_save  { @_extra_groupings = report.extras.delete(:grouping) if report.kind_of?(MiqReport) && report.extras }
+  after_commit { report.extras[:grouping] = @_extra_groupings if report.kind_of?(MiqReport) && report.extras }
 
   delegate :table, :to => :report_results, :allow_nil => true
 


### PR DESCRIPTION
Follow up fixes from https://github.com/ManageIQ/manageiq/pull/17598

Fixes spec failures in `manageiq-ui-classic`:  https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/393871906#L2906


Links
-----

* Original PR: https://github.com/ManageIQ/manageiq/pull/17598
* https://bugzilla.redhat.com/show_bug.cgi?id=1590908
* Example Failures:  https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/393871906#L2906