### PR TITLE
Reject empty button groups from the result of #custom_actions

### DIFF
--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -15,7 +15,7 @@ module CustomActionsMixin
         button_set.serializable_hash.merge(
           :buttons => serialize_buttons_if_visible(button_set.children, applies_to)
         )
-      end
+      end.reject { |button_group| button_group[:buttons].empty? }
     }
   end
 

--- a/spec/models/mixins/custom_actions_mixin_spec.rb
+++ b/spec/models/mixins/custom_actions_mixin_spec.rb
@@ -1,0 +1,31 @@
+describe CustomActionsMixin do
+  let(:test_class) do
+    Class.new(ActiveRecord::Base) do
+      def self.name; "TestClass"; end
+      self.table_name = "vms"
+      include CustomActionsMixin
+    end
+  end
+
+  describe '#custom_actions' do
+    let(:definition) { FactoryGirl.create(:generic_object_definition) }
+    let(:button) { FactoryGirl.create(:custom_button, :name => "generic_button", :applies_to_class => "GenericObject") }
+    let(:group) { FactoryGirl.create(:custom_button_set, :name => "generic_button_group") }
+
+    before { group.add_member(button) }
+
+    context 'button group has only a hidden button' do
+      before do
+        allow(definition).to receive(:serialize_buttons_if_visible).and_return([])
+      end
+
+      it 'does not return with the button group' do
+        expect(definition.custom_actions[:button_groups]).to be_empty
+      end
+    end
+
+    it 'returns with the button group' do
+      expect(definition.custom_actions[:button_groups]).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
When a button group has only buttons that are hidden by an expression, the empty button group still gets returned by the API and displayed in the SUI. My added `reject` call drops all button groups from the result of `#custom_actions` that have been evaluated as hidden.

@miq-bot assign @gtanzillo 

https://bugzilla.redhat.com/show_bug.cgi?id=1590764