### PR TITLE
Add Cloud Volume Type model

### DIFF
--- a/app/models/cloud_volume_type.rb
+++ b/app/models/cloud_volume_type.rb
@@ -1,4 +1,7 @@
 class CloudVolumeType < ApplicationRecord
+  # CloudVolumeTypes represent various "flavors" of
+  # volume that are available to create within a given
+  # Storage service.
   include NewWithTypeStiMixin
   include ProviderObjectMixin
 

--- a/app/models/cloud_volume_type.rb
+++ b/app/models/cloud_volume_type.rb
@@ -1,0 +1,12 @@
+class CloudVolumeType < ApplicationRecord
+  include NewWithTypeStiMixin
+  include ProviderObjectMixin
+
+  acts_as_miq_taggable
+
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ExtManagementSystem"
+
+  def self.class_by_ems(ext_management_system)
+    ext_management_system && ext_management_system.class::CloudVolumeType
+  end
+end

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -20,6 +20,7 @@ module ManageIQ::Providers
     has_many :cloud_tenants,                 :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_resource_quotas,         :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volumes,                 :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_volume_types,            :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volume_backups,          :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volume_snapshots,        :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_object_store_containers, :foreign_key => :ems_id, :dependent => :destroy

--- a/app/models/manageiq/providers/storage_manager/block_mixin.rb
+++ b/app/models/manageiq/providers/storage_manager/block_mixin.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::StorageManager::BlockMixin
     has_many :cloud_volumes,          :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volume_snapshots, :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_volume_backups,   :foreign_key => :ems_id, :dependent => :destroy
+    has_many :cloud_volume_types,     :foreign_key => :ems_id, :dependent => :destroy
 
     supports :block_storage
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1592900

Adds a basic model for Cloud Volume Types, which are needed for mapping new Cinder volumes to specific backends. This is especially important for Openstack V2V infrastructure mapping. Depends on the schema migration in https://github.com/ManageIQ/manageiq-schema/pull/223