### PR TITLE
Rename the v2v plugin gem name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -197,7 +197,7 @@ group :ui_dependencies do # Added to Bundler.require in config/application.rb
 end
 
 group :v2v, :ui_dependencies do
-  gem "miq_v2v_ui", :git => "https://github.com/ManageIQ/miq_v2v_ui_plugin.git", :branch => "master"
+  gem "manageiq-v2v", :git => "https://github.com/ManageIQ/miq_v2v_ui_plugin.git", :branch => "master"
 end
 
 group :web_server, :manageiq_default do


### PR DESCRIPTION
This was originally changed in https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/344