### PR TITLE
[WIP] Use loaded custom_attributes in MiqReport#generate

### DIFF
--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -51,7 +51,13 @@ module CustomAttributeMixin
         where_args[:name]    = custom_attribute_without_section
         where_args[:section] = section if section
 
-        custom_attributes.find_by(where_args).try(:value)
+        if custom_attributes.loaded?
+          custom_attributes.detect do |ca|
+            ca.name == custom_attribute_without_section && (section.nil? || ca.section == section)
+          end.try(:value)
+        else
+          custom_attributes.find_by(where_args).try(:value)
+        end
       end
     end
   end


### PR DESCRIPTION
When calling the virtual_attribute methods for `custom_attributes` in reports, we are currently loading them upfront via an `includes` statement in the query.  This is expensive for memory, but avoids an large N+1 situation later when calculating the row values.  

Unfortunately, this cached set of rows was never used when generating the miq_report_result_details since the `.find_by` in the `virtual_attribute` method definition will not check if the `custom_attributes` relation has been already loaded.

This patch makes it so that relation is checked to be loaded, and will use the values from the before trying to access anything from the database again in an N+1 fashion


Benchmarks
----------

These benchmarks are currently a work in progress, and contain some incomplete data.  Most of those inconsistencies are noted in below.

Tested on a local machine with the DB running on the same machine, so next to no network based latency for queries is observed. 


**Before**

50 uniq query types executed.  212961 are just the N+1 fetching `custom_attributes`

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
| 472820 |  223205 |    80092.4 | 419419 |

Raw `Benchmark.measure` numbers:

```
281.100000  13.840000 294.940000 (322.186379)
280.330000  12.210000 292.540000 (318.992034)
278.170000  11.730000 289.900000 (316.135889)
```


**After**

48 uniq query types executed.

NOTE:  10141 of the total queries and ~3522ms of the `query (ms)` here are `INSERT` statements into `miq_report_result_details`.  Only takes ~20 seconds to insert into the DB once the rows have been calculated.

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
| 130194 |   10243 |     8157.2 | 301016 |

Raw `Benchmark.measure` numbers:

```
117.120000   3.560000 120.680000 (125.573425)
117.010000   3.930000 120.940000 (126.202923)
115.340000   3.470000 118.810000 (124.154485)
```



TODO
----

* [ ] Add tests
* [ ] Clean up commit message


Links
-----

* Was originally opened for bug 592480
  - We are going with a different fix:  https://github.com/ManageIQ/manageiq/pull/17615