### PR TITLE
Normal Operating Range cpu/mem usage rate to use avg (instead of max) values 

### DIFF
--- a/app/models/metric/long_term_averages.rb
+++ b/app/models/metric/long_term_averages.rb
@@ -1,6 +1,8 @@
 module Metric::LongTermAverages
   AVG_COLS_TO_OVERHEAD_TYPE = {
     :cpu_usagemhz_rate_average      => nil,
+    :cpu_usage_rate_average         => nil,
+    :mem_usage_absolute_average     => nil,
     :derived_memory_used            => nil,
     :max_cpu_usage_rate_average     => :cpu,
     :max_mem_usage_absolute_average => :memory

--- a/app/models/vm_or_template/right_sizing.rb
+++ b/app/models/vm_or_template/right_sizing.rb
@@ -157,12 +157,14 @@ module VmOrTemplate::RightSizing
       p.abs_max_cpu_usage_rate_average_value
     end.compact.max
   end
+  alias_method :cpu_usage_rate_average_max_over_time_period, :max_cpu_usage_rate_average_max_over_time_period
 
   def max_mem_usage_absolute_average_max_over_time_period
     end_date = Time.now.utc.beginning_of_day - 1
     perfs = VimPerformanceAnalysis.find_perf_for_time_period(self, "daily", :end_date => end_date, :days => Metric::LongTermAverages::AVG_DAYS)
     perfs.collect(&:abs_max_mem_usage_absolute_average_value).compact.max
   end
+  alias_method :mem_usage_absolute_average_max_over_time_period, :max_mem_usage_absolute_average_max_over_time_period
 
   def cpu_usagemhz_rate_average_max_over_time_period
     end_date = Time.now.utc.beginning_of_day - 1

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -672,6 +672,13 @@ describe Metric do
 
           expect(@vm1.max_cpu_usage_rate_average_avg_over_time_period).to     be_within(0.001).of(13.124)
           expect(@vm1.max_mem_usage_absolute_average_avg_over_time_period).to be_within(0.001).of(33.056)
+
+          expect(@vm1.cpu_usage_rate_average_avg_over_time_period).to         be_within(0.001).of(13.124)
+          expect(@vm1.cpu_usage_rate_average_high_over_time_period).to        be_within(0.001).of(20.048)
+          expect(@vm1.cpu_usage_rate_average_low_over_time_period).to         be_within(0.001).of(6.199)
+          expect(@vm1.mem_usage_absolute_average_avg_over_time_period).to     be_within(0.001).of(33.056)
+          expect(@vm1.mem_usage_absolute_average_high_over_time_period).to    be_within(0.001).of(37.865)
+          expect(@vm1.mem_usage_absolute_average_low_over_time_period).to     be_within(0.001).of(28.248)
         end
 
         it "should calculate the correct right-size values" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1474511

Corresponding UI side change PR https://github.com/ManageIQ/manageiq-ui-classic/pull/4186