### PR TITLE
[WIP] Lets block be optional

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -40,7 +40,9 @@ module MiqRequestMixin
   def tags
     tag_ids.to_miq_a.each do |tag_id|
       tag = Classification.find(tag_id)
-      yield(tag.name, tag.parent.name)  unless tag.nil?    # yield the tag's name and category
+      if tag.present?
+        yield(tag.name, tag.parent.name) if block_given? # yield the tag's name and category
+      end
     end
   end
 


### PR DESCRIPTION
We're getting an internal server error when running whatever/api/provision_requests/1?attributes=tags. I mean I know that we can't get the tags off prov requests like that anyway... but my bug reporter says we shouldn't get internal server errors no matter what. 

Fixes the error part of https://bugzilla.redhat.com/show_bug.cgi?id=1592326 
