### PR TITLE
Remove useless EmsRefresherMixin

### DIFF
--- a/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
+++ b/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb
@@ -1,6 +1,0 @@
-module EmsRefresh
-  module Refreshers
-    module EmsRefresherMixin
-    end
-  end
-end

--- a/app/models/manageiq/providers/base_manager/manager_refresher.rb
+++ b/app/models/manageiq/providers/base_manager/manager_refresher.rb
@@ -1,8 +1,6 @@
 module ManageIQ
   module Providers
     class BaseManager::ManagerRefresher < ManageIQ::Providers::BaseManager::Refresher
-      include ::EmsRefresh::Refreshers::EmsRefresherMixin
-
       # Gives a Builder class for Inventory
       # @param klass [Class] Class of used ManageIQ::Providers::BaseManager object
       # @return [ManageIQ::Providers::<provider_name>::Builder] Builder class for Inventory

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/refresher.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/refresher.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-  include ::EmsRefresh::Refreshers::EmsRefresherMixin
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Refresher
 
   def self.display_name(number = 1)

--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresher.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresher.rb
@@ -1,8 +1,6 @@
 #
 module ManageIQ::Providers
   class StorageManager::CinderManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-    include ::EmsRefresh::Refreshers::EmsRefresherMixin
-
     def parse_legacy_inventory(ems)
       ManageIQ::Providers::StorageManager::CinderManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end

--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresher.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresher.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class StorageManager::SwiftManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-    include ::EmsRefresh::Refreshers::EmsRefresherMixin
-
     def parse_legacy_inventory(ems)
       ManageIQ::Providers::StorageManager::SwiftManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end

--- a/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresher.rb
+++ b/lib/generators/provider/templates/app/models/manageiq/providers/%provider_name%/cloud_manager/refresher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::<%= class_name %>::CloudManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-  include ::EmsRefresh::Refreshers::EmsRefresherMixin
 end


### PR DESCRIPTION
The EmsRefresherMixin was moved to the BaseManager::Refresher in https://github.com/ManageIQ/manageiq/pull/17472

Depends:

- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/98

- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/78

- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/100

- [x] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/200

- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/21

- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/266

- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/98

- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/261

- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/304

- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/99

- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/261

- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/62

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/287