### PR TITLE
[WIP] Change multiselect default to be literally nothing 

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -166,7 +166,7 @@ class DialogField < ApplicationRecord
   end
 
   def required_value_error?
-    value.blank?
+    value.blank? || value == '[nil, "<Choose>"]' || value == 'null'
   end
 
   def value_from_dialog_fields(dialog_values)

--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -14,7 +14,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   end
 
   def initial_values
-    [[nil, "<None>"]]
+    []
   end
 
   def refresh_json_value(checked_value)

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -131,7 +131,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def use_first_value_as_default
-    self.default_value = sort_data(@raw_values).first.try(:first)
+    self.default_value = self['options'][:force_multi_value] ? nil_option : sort_data(@raw_values).first.try(:first)
   end
 
   def default_value_included?(values_list)

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -413,12 +413,13 @@ describe DialogFieldSortedItem do
   describe "#get_default_value" do
     let(:dialog_field) { described_class.new(:default_value => default_value, :values => values) }
     let(:values) { [%w(value1 text1), %w(value2 text2)] }
+    context "single value" do
+      context "when the default value is set to nil" do
+        let(:default_value) { nil }
 
-    context "when the default value is set to nil" do
-      let(:default_value) { nil }
-
-      it "returns nil as the default value" do
-        expect(dialog_field.get_default_value).to eq(nil)
+        it "returns nil as the default value" do
+          expect(dialog_field.get_default_value).to eq(nil)
+        end
       end
     end
 
@@ -435,6 +436,17 @@ describe DialogFieldSortedItem do
         let(:default_value) { "value3" }
 
         it "returns nil" do
+          expect(dialog_field.get_default_value).to eq(nil)
+        end
+      end
+    end
+
+    context "multi value" do
+      context "when the default value isn't set" do
+        let(:dialog_field) { described_class.new(:values => values, :options => {:force_multi_value => true}) }
+        let(:values) { [%w(value1 text1), %w(value2 text2)] }
+
+        it "returns nil as the default value" do
           expect(dialog_field.get_default_value).to eq(nil)
         end
       end

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -60,6 +60,20 @@ describe DialogField do
                 .to eq("tab/group/dialog_field is required")
             end
           end
+          context "with value of literally nothing" do
+            let(:value) { '[nil, "<Choose>"]' }
+            it "returns error message" do
+              expect(visible_dialog_field.validate_field_data(dialog_tab, dialog_group))
+                .to eq("tab/group/dialog_field is required")
+            end
+          end
+          context "with value of null" do
+            let(:value) { 'null' }
+            it "returns error message" do
+              expect(visible_dialog_field.validate_field_data(dialog_tab, dialog_group))
+                .to eq("tab/group/dialog_field is required")
+            end
+          end
           context "with a non-blank value" do
             let(:value) { "test value" }
             it_behaves_like "DialogField#validate that returns nil"


### PR DESCRIPTION
front-porting https://github.com/ManageIQ/manageiq/pull/17543 and https://github.com/ManageIQ/manageiq/pull/17424 from FINE

We're setting dropdown defaults if they're multiselect and dynamic to be the first value in the array. Prior to multiselect, this made sense but the use case for wanting a multiselect that loaded without an option hadn't been considered.

The problem with the workaround of creating an option that is nothing and have it say "Nothing selected" or something is that that option still gets picked. If the multiselect flag is set it might make more sense to set the default to have nothing selected which this does. This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593458

with this change:
on load: 
![screen shot 2018-05-15 at 9 20 39 am](https://user-images.githubusercontent.com/16326669/40059153-4f176d6e-5821-11e8-98da-bed3e6e6598f.png)
on change: 
![screen shot 2018-05-15 at 9 18 42 am](https://user-images.githubusercontent.com/16326669/40059071-11eaa460-5821-11e8-93fd-47bd6fd348a8.png)
when dropdown is active:
![screen shot 2018-05-15 at 9 23 38 am](https://user-images.githubusercontent.com/16326669/40059275-b3d808f8-5821-11e8-8fa4-b0a6cd57226c.png)
before: (has default of first in list)
![screen shot 2018-05-15 at 9 22 37 am](https://user-images.githubusercontent.com/16326669/40059219-8bb54f02-5821-11e8-9581-b5c5467f10b7.png)
