### PR TITLE
[WIP] Add a precanned physical server policy

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -526,6 +526,16 @@ class MiqAction < ApplicationRecord
     end
   end
 
+  def action_physical_server_power_on(action, rec, inputs)
+    unless rec.kind_of?(PhysicalServer)
+      MiqPolicy.logger.error("MIQ(physical_server_power_on): Unable to perform action [#{action.description}], object [#{rec.inspect}] is not a physical server")
+      return
+    end
+
+    invoke_or_queue(inputs[:synchronous], __method__, "ems_operations", rec.my_zone, rec, 'power_on',
+                    [], "[#{action.description}] of physical server [#{rec.name}]")
+  end
+
   def action_vm_mark_as_vm(action, rec, inputs)
     unless rec.kind_of?(VmOrTemplate)
       MiqPolicy.logger.error("MIQ(action_vm_mark_as_vm): Unable to perform action [#{action.description}], object [#{rec.inspect}] is not a VM")

--- a/db/fixtures/miq_policy_sets.yml
+++ b/db/fixtures/miq_policy_sets.yml
@@ -166,3 +166,45 @@
           action_type: default
           options: {}
       Condition: []
+- MiqPolicySet:
+    name: physical infrastructure profile 
+    description: Physical Infrastructure Profile
+    set_type: MiqPolicySet
+    guid: e89997cd-e7ba-4c1f-92f6-57154fe1c875
+    read_only: true
+    set_data:
+    mode: control
+    owner_type:
+    owner_id:
+    userid:
+    group_id:
+    MiqPolicy:
+    - name: power on servers that were powered off
+      description: Power on servers that were powered off
+      expression:
+      towhat: PhysicalServer
+      guid: 6220e15b-01a4-430c-9e70-d67af4798708
+      created_by: admin
+      updated_by: admin
+      notes:
+      active: true
+      mode: control
+      read_only: true
+      MiqPolicyContent:
+      - qualifier: success
+        failure_sequence: 1
+        failure_synchronous: true
+        MiqEventDefinition:
+          name: physical_server_shutdown
+          description: Physical Server Shutdown
+          event_type: Default
+          definition:
+          default:
+          enabled:
+        MiqAction:
+          name: physical_server_power_on
+          description: Power on the Server
+          action_type: default
+          options: {}
+      Condition: []
+


### PR DESCRIPTION
This PR adds a precanned policy and profile for powering on servers that were powered off.