### PR TITLE
Ensure sorting does not happen when sort_by is set to "none"

### DIFF
--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -19,7 +19,7 @@ class DialogFieldSortedItem < DialogField
   end
 
   def sort_by
-    options[:sort_by] || :description
+    options[:sort_by].try(:to_sym) || :description
   end
 
   def sort_by=(value)

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -350,6 +350,17 @@ describe DialogFieldSortedItem do
             it "returns the values with the first option being a nil 'None' option" do
               expect(dialog_field.values).to eq([[nil, "<None>"], %w(test test), %w(abc abc)])
             end
+
+            context "when the values are in a seemingly random order" do
+              let(:values) { [%w(3 Three), %w(1 One), %w(2 Two)] }
+              before do
+                dialog_field.options[:sort_by] = "none"
+              end
+
+              it "does not attempt to sort them" do
+                expect(dialog_field.values).to eq([[nil, "<None>"], %w(3 Three), %w(1 One), %w(2 Two)])
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
I didn't dig in too deep to track down how the code is getting through this point where the `sort_by` isn't a symbol, but basically we were ignoring the fact that `sort_by` in the options was a string instead of a symbol (when creating/updating/editing an existing dialog, the `sort_by=` code automatically forces it into a symbol so this was getting bypassed).

So, this was causing us to attempt to sort the items in the values list even if the `none` sort_by value was selected. This will need to be combined with the fix from the [ui-components repo here](https://github.com/ManageIQ/ui-components/pull/307) since the javascript code was also attempting to sort even when the `sort_by` value was `none`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593874

@miq-bot add_label gaprindashvili/yes, bug, blocker
@d-m-u Please review
@miq-bot assign @gmcculloug 

/cc @tinaafitz 
