### PR TITLE
[GAPRINDASHVILI] Changes custom_attribute virtual_attributes to support AREL/SQL

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -199,6 +199,14 @@ class MiqReport < ApplicationRecord
     rpt_options.try(:fetch_path, :pdf, :page_size) || "a4"
   end
 
+  def all_custom_attributes_are_virtual_sql_attributes?
+    ca_va_cols    = CustomAttributeMixin.select_virtual_custom_attributes(cols)
+    va_sql_cols ||= cols.select do |col|
+      db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
+    end
+    ca_va_cols.all? { |custom_attribute| va_sql_cols.include?(custom_attribute) }
+  end
+
   def load_custom_attributes
     klass = db.safe_constantize
     return unless klass < CustomAttributeMixin || Chargeback.db_is_chargeback?(db)

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -276,6 +276,13 @@ module MiqReport::Generator
       va_sql_cols = cols.select do |col|
         db_class.virtual_attribute?(col) && db_class.attribute_supported_by_sql?(col)
       end
+
+      # Remove custom_attributes as part of the `includes` if all of them exist
+      # in the select statement
+      if all_custom_attributes_are_virtual_sql_attributes?
+        remove_loading_relations_for_virtual_custom_attributes
+      end
+
       rbac_opts = options.merge(
         :targets          => targets,
         :filter           => conditions,


### PR DESCRIPTION
GAPRINDASHVILI version of https://github.com/ManageIQ/manageiq/pull/17615 .  Original commit message below

* * *

Converts the `virtual_column` definitions in `CustomAttributeMixin` to support the `arel` attribute, and allow `MiqReport#generate` to take advantage of this, and avoid needing an extra include.

Other notable changes:

* If all `custom_attributes` have arel backed `virtual_attribute` (aka `virtual_column`) methods, then the includes of `:custom_attributes => {}` will be removed from the `Rbac` query.  A helper method was added to assist with this
* The method defined for accessing the `virtual_attribute` from the instance will now check the attributes hash prior to executing the rest of the method, and return something if it has a key
* Some shared values calculated in both the `virtual_attribute` method definition and would be in the `custom_attribute_arel` method have been extracted out so it is only calculated once (minor performance benefit).


Benchmarks
----------

These benchmarks are currently a work in progress, and contain some incomplete data.  Most of those inconsistencies are noted in below.

Tested on a local machine with the DB running on the same machine, so next to no network based latency for queries is observed. 


**Before**

50 uniq query types executed.  212961 are just the N+1 fetching `custom_attributes`

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
| 472820 |  223205 |    80092.4 | 419419 |

Raw `Benchmark.measure` numbers:

```
281.100000  13.840000 294.940000 (322.186379)
280.330000  12.210000 292.540000 (318.992034)
278.170000  11.730000 289.900000 (316.135889)
```


**After**

While that patch was present during the benchmarks, most of what is done in this patch negates it's usefulness, so almost everything seeing here is from the changes in this pull request.

NOTE:  10141 of the total queries and ~3580ms of the `query (ms)` here are `INSERT` statements into `miq_report_result_details`.

|    ms | queries | query (ms) |  rows |
|  ---: |    ---: |       ---: |  ---: |
| 41189 |   10220 |     5017.1 | 38435 |

Raw `Benchmark.measure` numbers:

```
 38.170000   1.270000  39.440000 ( 43.803676)
 34.660000   0.700000  35.360000 ( 38.079291)
 35.000000   0.730000  35.730000 ( 38.463884)
```


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1594027
* Original PR:  https://github.com/ManageIQ/manageiq/pull/17615