### PR TITLE
[GAPRINDASHVILI] Use AREL for custom_attributes virtual_attributes in MiqReport ONLY

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -206,6 +206,13 @@ class MiqReport < ApplicationRecord
     klass.load_custom_attributes_for(cols.uniq)
   end
 
+  def select_custom_attributes_for(cols)
+    klass = db.safe_constantize
+    return unless klass < CustomAttributeMixin
+
+    klass.select_custom_attributes_for(cols)
+  end
+
   # this method adds :custom_attributes => {} to MiqReport#include
   # when report with virtual custom attributes is stored
   # we need preload custom_attributes table to main query for building report for elimination of superfluous queries

--- a/app/models/mixins/custom_attribute_mixin.rb
+++ b/app/models/mixins/custom_attribute_mixin.rb
@@ -38,21 +38,51 @@ module CustomAttributeMixin
       custom_attributes.each { |custom_attribute| add_custom_attribute(custom_attribute) }
     end
 
+    def self.select_custom_attributes_for(cols)
+      custom_attributes = CustomAttributeMixin.select_virtual_custom_attributes(cols)
+      custom_attributes.map do |custom_attribute|
+        without_prefix         = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
+        name_val, section      = without_prefix.split(SECTION_SEPARATOR)
+        sanatized_column_alias = custom_attribute.tr('.', 'DOT').tr('/', 'BS').tr(':', 'CLN')
+
+        custom_attribute_arel(name_val, section, sanatized_column_alias)
+      end
+    end
+
     def self.add_custom_attribute(custom_attribute)
       return if respond_to?(custom_attribute)
 
-      virtual_column(custom_attribute.to_sym, :type => :string, :uses => :custom_attributes)
+      ca_sym                 = custom_attribute.to_sym
+      without_prefix         = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
+      name_val, section      = without_prefix.split(SECTION_SEPARATOR)
+      sanatized_column_alias = custom_attribute.tr('.', 'DOT').tr('/', 'BS').tr(':', 'CLN')
 
-      define_method(custom_attribute.to_sym) do
-        custom_attribute_without_prefix           = custom_attribute.sub(CUSTOM_ATTRIBUTES_PREFIX, "")
-        custom_attribute_without_section, section = custom_attribute_without_prefix.split(SECTION_SEPARATOR)
+      virtual_column(ca_sym, :type => :string, :uses => :custom_attributes)
 
-        where_args = {}
-        where_args[:name]    = custom_attribute_without_section
+      define_method(ca_sym) do
+        return self[sanatized_column_alias] if has_attribute?(sanatized_column_alias)
+
+        where_args           = {}
+        where_args[:name]    = name_val
         where_args[:section] = section if section
 
         custom_attributes.find_by(where_args).try(:value)
       end
+    end
+
+    def self.custom_attribute_arel(name_val, section, column_alias)
+      ca_field    = CustomAttribute.arel_table
+
+      field_where = ca_field[:resource_id].eq(arel_table[:id])
+      field_where = field_where.and(ca_field[:resource_type].eq(base_class.name))
+      field_where = field_where.and(ca_field[:name].eq(name_val))
+      field_where = field_where.and(ca_field[:section].eq(section)) if section
+
+      # Because there is a `find_by` in the `define_method` above, we are
+      # using a `take(1)` here as well, since a limit is assumed in each.
+      # Without it, there can be some invalid queries if more than one result
+      # is returned.
+      ca_field.project(:value).where(field_where).take(1).as(column_alias)
     end
   end
 


### PR DESCRIPTION
Backport rework of https://github.com/ManageIQ/manageiq/pull/17615 for gapindashvili

https://bugzilla.redhat.com/show_bug.cgi?id=1594027
https://bugzilla.redhat.com/show_bug.cgi?id=1594027

This is a reworking of all of the commits in:

    https://github.com/ManageIQ/manageiq/pull/17615

Previous commits include:

  0ad75c2117faa8ce3678932fc8d383429d55b4e5
  e7fd484acc9813462744046dd8b464a08b443527
  065405d49975c80b3b852ddb21d413719bec976e

Allows MiqReport generation to use Arel columns for the custom_attribute cols, but not use virtual_attributes as the mechanism for it, since they are not supported in other places (like `MiqExpression`) in this version of the application.

This is a single commit for the changes, since they are not really the mechanism we want going forward, and allow for an easier backport for fine.


Original commit message below


* * *


Converts the `virtual_column` definitions in `CustomAttributeMixin` to support the `arel` attribute, and allow `MiqReport#generate` to take advantage of this, and avoid needing an extra include.

Other notable changes:

* If all `custom_attributes` have arel backed `virtual_attribute` (aka `virtual_column`) methods, then the includes of `:custom_attributes => {}` will be removed from the `Rbac` query.  A helper method was added to assist with this
* The method defined for accessing the `virtual_attribute` from the instance will now check the attributes hash prior to executing the rest of the method, and return something if it has a key
* Some shared values calculated in both the `virtual_attribute` method definition and would be in the `custom_attribute_arel` method have been extracted out so it is only calculated once (minor performance benefit).


Benchmarks
----------

These benchmarks are currently a work in progress, and contain some incomplete data.  Most of those inconsistencies are noted in below.

Tested on a local machine with the DB running on the same machine, so next to no network based latency for queries is observed. 


**Before**

50 uniq query types executed.  212961 are just the N+1 fetching `custom_attributes`

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
| 472820 |  223205 |    80092.4 | 419419 |

Raw `Benchmark.measure` numbers:

```
281.100000  13.840000 294.940000 (322.186379)
280.330000  12.210000 292.540000 (318.992034)
278.170000  11.730000 289.900000 (316.135889)
```


**After**

While that patch was present during the benchmarks, most of what is done in this patch negates it's usefulness, so almost everything seeing here is from the changes in this pull request.

NOTE:  10141 of the total queries and ~3580ms of the `query (ms)` here are `INSERT` statements into `miq_report_result_details`.

|    ms | queries | query (ms) |  rows |
|  ---: |    ---: |       ---: |  ---: |
| 41189 |   10220 |     5017.1 | 38435 |

Raw `Benchmark.measure` numbers:

```
 38.170000   1.270000  39.440000 ( 43.803676)
 34.660000   0.700000  35.360000 ( 38.079291)
 35.000000   0.730000  35.730000 ( 38.463884)
```


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1594027
* Original PR:  https://github.com/ManageIQ/manageiq/pull/17615