### PR TITLE
Add Automate Generic Objects shortcut menu

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -394,6 +394,11 @@
   :url: /miq_ae_customization/explorer
   :rbac_feature_name: miq_ae_customization_explorer
   :startup: true
+- :name: generic_object_definition
+  :description: Automation / Automate / Generic Objects
+  :url: /generic_object_definition
+  :rbac_feature_name: generic_object_definition_show_list
+  :startup: true
 - :name: miq_ae_class_import_export
   :description: Automation / Automate / Import / Export
   :url: /miq_ae_tools/import_export


### PR DESCRIPTION
Fix shortcut menu definitions to contain missing Automate => Generic Objects 

NOTE: This fix requires MiqShortcut.seed to refresh startup settings and db table

https://bugzilla.redhat.com/show_bug.cgi?id=1331399

This PR is related to https://github.com/ManageIQ/manageiq-ui-classic/pull/4207

Screen shot of shortcut menu dropdown list prior to code fix:
![automate generic objects dropdown entry missing prior to code fix](https://user-images.githubusercontent.com/552686/41802789-6d2b7554-7638-11e8-8599-322266580ffb.png)

With newly added definition dropdown list post code fix:
![automate generic objects dropdown entry slisted post code fix](https://user-images.githubusercontent.com/552686/41802801-8669f43c-7638-11e8-841d-396b1d516565.png)




