### PR TITLE
Return with HTML table instead of PDF in the saved report async task

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -274,7 +274,7 @@ class MiqReportResult < ApplicationRecord
       new_res.report_results = user.with_my_timezone do
         case result_type.to_sym
         when :csv then rpt.to_csv
-        when :pdf then to_pdf
+        when :pdf then html_rows.join
         when :txt then rpt.to_text
         else
           raise _("Result type %{result_type} not supported") % {:result_type => result_type}


### PR DESCRIPTION
We're moving the PDF generation to the client side, so let's just send the data and not the whole PDF from the background task.

@miq-bot add_label gaprindashvili/no, reporting, enhancement
@miq-bot add_reviewer @martinpovolny

UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4201
Related issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/4113
https://bugzilla.redhat.com/show_bug.cgi?id=1588072