### PR TITLE
Add array support to configure_server_settings.rb

### DIFF
--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -2,7 +2,7 @@
 require 'bundler/setup'
 require 'trollop'
 
-TYPES = %w(string integer boolean symbol float).freeze
+TYPES = %w(string integer boolean symbol float array).freeze
 
 opts = Trollop.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \
@@ -11,6 +11,7 @@ opts = Trollop.options(ARGV) do
          "Example (Boolean): #{__FILE__} -s 1 -p ui/mark_translated_strings -v true -t boolean\n" \
          "Example (Symbol):  #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/poll_method -v escalate -t symbol\n" \
          "Example (Float):   #{__FILE__} -s 1 -p capacity/profile/1/vcpu_commitment_ratio -v 1.5 -t float"
+         "Example (Array):   #{__FILE__} -s 1 -p ntp/server -v 0.pool.ntp.org,1.pool.ntp.org -t array"
 
   opt :dry_run,  "Dry Run",                                  :short => "d"
   opt :serverid, "Server Id",                                :short => "s", :type => :integer, :required => true
@@ -44,6 +45,8 @@ newval =
     opts[:value].to_sym
   when "float"
     opts[:value].to_f
+  when "array"
+    opts[:value]=opts[:value].split(/,/)
   end
 
 # load rails after checking CLI args so we can report args errors as fast as possible

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -10,7 +10,7 @@ opts = Trollop.options(ARGV) do
          "Example (Integer): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
          "Example (Boolean): #{__FILE__} -s 1 -p ui/mark_translated_strings -v true -t boolean\n" \
          "Example (Symbol):  #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/poll_method -v escalate -t symbol\n" \
-         "Example (Float):   #{__FILE__} -s 1 -p capacity/profile/1/vcpu_commitment_ratio -v 1.5 -t float"
+         "Example (Float):   #{__FILE__} -s 1 -p capacity/profile/1/vcpu_commitment_ratio -v 1.5 -t float" \
          "Example (Array):   #{__FILE__} -s 1 -p ntp/server -v 0.pool.ntp.org,1.pool.ntp.org -t array"
 
   opt :dry_run,  "Dry Run",                                  :short => "d"
@@ -46,7 +46,7 @@ newval =
   when "float"
     opts[:value].to_f
   when "array"
-    opts[:value]=opts[:value].split(/,/)
+    opts[:value] = opts[:value].split(",")
   end
 
 # load rails after checking CLI args so we can report args errors as fast as possible

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -46,7 +46,7 @@ newval =
   when "float"
     opts[:value].to_f
   when "array"
-    opts[:value] = opts[:value].split(",")
+    opts[:value].split(",")
   end
 
 # load rails after checking CLI args so we can report args errors as fast as possible
@@ -73,7 +73,7 @@ elsif path[key] && path[key].class != newval.class
   exit 1
 end
 
-puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{opts[:value]}]"
+puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{newval}]"
 path[key] = newval
 
 valid, errors = VMDB::Config::Validator.new(settings).validate


### PR DESCRIPTION
The static whitelist in configure_server_settings script, does not allow to configure settings of type array. 

In our use case, we need to set the NTP servers of the appliance. Since the appliance will reconfigure chrony every time the application starts, we cannot use external tools to configure NTP (like ansible). 

### Thoughts on the Implemtation:
- I don't do any additional processing of the elements of the array. Therefore the value passed to `MiqServer.set_config()`, will always be Array of Strings. This is ok for all the current values, but a Array of Integers will still be rejected by `VMDB::Config::Validator`.
- The seperator is set to comma ",".
