### PR TITLE
[wip] notify users of killing workers when exceed memory

### DIFF
--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -40,7 +40,7 @@ class MiqEvent < EventStream
       return
     end
 
-    event_obj = build_evm_event(event, target)
+    event_obj = build_evm_event(event, target, inputs[:full_data])
     inputs.merge!('MiqEvent::miq_event' => event_obj.id, :miq_event_id => event_obj.id)
     inputs.merge!('EventStream::event_stream' => event_obj.id, :event_stream_id => event_obj.id)
 
@@ -79,10 +79,11 @@ class MiqEvent < EventStream
     results
   end
 
-  def self.build_evm_event(event, target)
+  def self.build_evm_event(event, target, full_data = nil)
     options = {
       :event_type => event,
       :target     => target,
+      :full_data  => full_data,
       :source     => 'POLICY',
       :timestamp  => Time.now.utc
     }

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -25,7 +25,16 @@ module MiqServer::WorkerManagement::Monitor::Validation
     if MiqWorker::STATUSES_CURRENT.include?(w.status) && usage_exceeds_threshold?(usage, memory_threshold)
       msg = "#{w.format_full_log_msg} process memory usage [#{usage}] exceeded limit [#{memory_threshold}], requesting worker to exit"
       _log.warn(msg)
-      MiqEvent.raise_evm_event_queue(w.miq_server, "evm_worker_memory_exceeded", :event_details => msg, :type => w.class.name)
+      helper = ApplicationController.helpers
+      full_data = {
+        :name             => w.type,
+        :memory_usage     => helper.number_to_human_size(usage),
+        :memory_threshold => helper.number_to_human_size(memory_threshold),
+      }
+      MiqEvent.raise_evm_event_queue(w.miq_server, "evm_worker_memory_exceeded",
+                                     :event_details => msg,
+                                     :type          => w.class.name,
+                                     :full_data     => full_data)
       restart_worker(w)
       return false
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -25,6 +25,7 @@ class Notification < ApplicationRecord
   def self.emit_for_event(event)
     return unless NotificationType.names.include?(event.event_type)
     type = NotificationType.find_by(:name => event.event_type)
+    return if type.none?
     Notification.create(:notification_type => type, :subject => event.target)
   end
 

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -4,6 +4,8 @@ class NotificationType < ApplicationRecord
   AUDIENCE_TENANT = 'tenant'.freeze
   AUDIENCE_GLOBAL = 'global'.freeze
   AUDIENCE_SUPERADMIN = 'superadmin'.freeze
+  # don't send out notifications, but keep the template around
+  AUDIENCE_NONE = 'none'.freeze
   has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
@@ -27,7 +29,13 @@ class NotificationType < ApplicationRecord
       end.try(:user_ids)
     when AUDIENCE_SUPERADMIN
       User.superadmins.pluck(:id)
+    when AUDIENCE_NONE
+      []
     end
+  end
+
+  def none?
+    audience == AUDIENCE_NONE
   end
 
   def self.names

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -264,3 +264,8 @@
   :expires_in: 24.hours
   :level: :error
   :audience: superadmin
+- :name: evm_worker_memory_exceeded
+  :message: 'Killing worker %{name} due to excessive memory usage. %{memory_usage} used memory exceeds limit of %{memory_threshold}.'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: none


### PR DESCRIPTION
When a worker exceeds the memory threshold, it is killed and restarted.
But it is difficult for users to detect these events and fix the underlying problem.

https://bugzilla.redhat.com/show_bug.cgi?id=1535177

This change adds a notification to bring the problem to the attention of administrators. It includes the worker name and the current memory value to make action easier.

<img width="258" alt="worker_out_of_memory_notification" src="https://user-images.githubusercontent.com/1930/41980992-e4747906-79f5-11e8-8cef-a9b36ee2dc58.png">

implementation notes:
The event stream record `after_create` callback currently creates the notification record.
This lost some necessary data, so I skipped the after create callback and manually create the notification record.

