### PR TITLE
[GAPRINDASHVILI] Add option to prov workflow to not rerun methods

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -103,7 +103,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       dialog.target_resource = @target
       if options[:display_view_only]
         dialog.init_fields_with_values_for_request(values)
-      elsif options[:refresh]
+      elsif options[:refresh] || options[:submit_workflow]
         dialog.load_values_into_fields(values)
       else
         dialog.initialize_value_context(values)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -406,11 +406,15 @@ class ServiceTemplate < ApplicationRecord
   def provision_workflow(user, dialog_options = nil, request_options = nil)
     dialog_options ||= {}
     request_options ||= {}
-    ra_options = { :target => self, :initiator => request_options[:initiator] }
-    ResourceActionWorkflow.new({}, user,
-                               provision_action, ra_options).tap do |wf|
+    ra_options = {
+      :target          => self,
+      :initiator       => request_options[:initiator],
+      :submit_workflow => request_options[:submit_workflow]
+    }
+
+    ResourceActionWorkflow.new(dialog_options, user, provision_action, ra_options).tap do |wf|
       wf.request_options = request_options
-      dialog_options.each { |key, value| wf.set_value(key, value) }
+      # dialog_options.each { |key, value| wf.set_value(key, value) }
     end
   end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -808,7 +808,7 @@ describe ServiceTemplate do
     let(:user) { FactoryGirl.create(:user, :userid => "barney") }
     let(:resource_action) { FactoryGirl.create(:resource_action, :action => "Provision") }
     let(:service_template) { FactoryGirl.create(:service_template, :resource_actions => [resource_action]) }
-    let(:hash) { {:target => service_template, :initiator => 'control'} }
+    let(:hash) { {:target => service_template, :initiator => 'control', :submit_workflow => nil} }
     let(:workflow) { instance_double(ResourceActionWorkflow) }
     let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
     let(:good_result) { { :errors => [], :request => miq_request } }
@@ -816,21 +816,19 @@ describe ServiceTemplate do
     let(:arg1) { {'ordered_by' => 'fred'} }
     let(:arg2) { {:initiator => 'control'} }
 
-    it "provision's a service template without errors" do
+    it "provisions a service template without errors" do
       expect(ResourceActionWorkflow).to(receive(:new)
-        .with({}, user, resource_action, hash).and_return(workflow))
+        .with({'ordered_by' => 'fred'}, user, resource_action, hash).and_return(workflow))
       expect(workflow).to receive(:submit_request).and_return(good_result)
-      expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
       expect(workflow).to receive(:request_options=).with(:initiator => 'control')
 
       expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
     end
 
-    it "provision's a service template with errors" do
+    it "provisions a service template with errors" do
       expect(ResourceActionWorkflow).to(receive(:new)
-        .with({}, user, resource_action, hash).and_return(workflow))
+        .with({'ordered_by' => 'fred'}, user, resource_action, hash).and_return(workflow))
       expect(workflow).to receive(:submit_request).and_return(bad_result)
-      expect(workflow).to receive(:set_value).with('ordered_by', 'fred')
       expect(workflow).to receive(:request_options=).with(:initiator => 'control')
       expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
     end


### PR DESCRIPTION
Dialogs are being run twice, once on load, once on submit, this lets us reuse the values we picked so they don't rerun on submit. 

Master PR: https://github.com/ManageIQ/manageiq/pull/17642
Fix for ~~https://bugzilla.redhat.com/show_bug.cgi?id=1591427~~
https://bugzilla.redhat.com/show_bug.cgi?id=1595776

There's a related API PR.

It's eclarizio's code. 

Also it's WIP cause it needs tests. 

## Depends on
https://github.com/ManageIQ/manageiq-api/pull/406


c'est the g release version of this fun: https://github.com/ManageIQ/manageiq/pull/17642 and https://github.com/ManageIQ/manageiq-api/pull/407