### PR TITLE
Reuse dialog values so we don't have to reload dialog

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -103,7 +103,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       dialog.target_resource = @target
       if options[:display_view_only]
         dialog.init_fields_with_values_for_request(values)
-      elsif options[:refresh]
+      elsif options[:refresh] || options[:submit_workflow]
         dialog.load_values_into_fields(values)
       elsif options[:reconfigure]
         dialog.initialize_with_given_values(values)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -437,11 +437,14 @@ class ServiceTemplate < ApplicationRecord
   def provision_workflow(user, dialog_options = nil, request_options = nil)
     dialog_options ||= {}
     request_options ||= {}
-    ra_options = { :target => self, :initiator => request_options[:initiator] }
-    ResourceActionWorkflow.new({}, user,
-                               provision_action, ra_options).tap do |wf|
+    ra_options = {
+      :target          => self,
+      :initiator       => request_options[:initiator],
+      :submit_workflow => request_options[:submit_workflow]
+    }
+
+    ResourceActionWorkflow.new(dialog_options, user, provision_action, ra_options).tap do |wf|
       wf.request_options = request_options
-      dialog_options.each { |key, value| wf.set_value(key, value) }
     end
   end
 

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -149,6 +149,15 @@ describe ResourceActionWorkflow do
       end
     end
 
+    context "when the options are set to a submit workflow request" do
+      let(:options) { {:submit_workflow => true} }
+
+      it "loads the values into fields" do
+        expect(dialog).to receive(:load_values_into_fields).with(values)
+        ResourceActionWorkflow.new(values, nil, resource_action, options)
+      end
+    end
+
     context "when neither display_view_only nor refresh are true" do
       let(:options) { {} }
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -814,7 +814,7 @@ describe ServiceTemplate do
     let(:user) { FactoryGirl.create(:user, :userid => "barney") }
     let(:resource_action) { FactoryGirl.create(:resource_action, :action => "Provision") }
     let(:service_template) { FactoryGirl.create(:service_template, :resource_actions => [resource_action]) }
-    let(:resource_action_options) { {:target => service_template, :initiator => 'control'} }
+    let(:resource_action_options) { {:target => service_template, :initiator => 'control', :submit_workflow => true} }
     let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
     let!(:resource_action_workflow) { ResourceActionWorkflow.new({}, user, resource_action, resource_action_options) }
 
@@ -845,23 +845,42 @@ describe ServiceTemplate do
 
     context "#provision_request" do
       let(:arg1) { {'ordered_by' => 'fred'} }
-      let(:arg2) { {:initiator => 'control'} }
+      context "with submit_workflow" do
+        let(:arg2) { {:initiator => 'control', :submit_workflow => true} }
 
-      it "provision's a service template without errors" do
-        expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
-        expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
-        expect(resource_action_workflow).to receive(:set_value).with('ordered_by', 'fred')
-        expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+        it "provisions a service template without errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
+          expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
+          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control', :submit_workflow => true)
 
-        expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
+          expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
+        end
+
+        it "provisions a service template with errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
+          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control', :submit_workflow => true)
+
+          expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
+        end
       end
 
-      it "provision's a service template with errors" do
-        expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
-        expect(resource_action_workflow).to receive(:set_value).with('ordered_by', 'fred')
-        expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+      context "without submit_workflow" do
+        let(:arg2) { {:initiator => 'control'} }
 
-        expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
+        it "provisions a service template without errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
+          expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
+          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+
+          expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
+        end
+
+        it "provisions a service template with errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
+          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+
+          expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
+        end
       end
     end
   end


### PR DESCRIPTION
Dialogs are being run twice, once on load, once on submit, this lets us reuse the values we picked so they don't rerun on submit.

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1584355

There's a related API PR.

It's eclarizio's code.

## depends on 
https://github.com/ManageIQ/manageiq-api/pull/407
