### PR TITLE
Add Vmdb::Plugins#asset_paths and #load_inflections

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -21,7 +21,7 @@ class Dialog < ApplicationRecord
   def self.seed
     dialog_import_service = DialogImportService.new
 
-    Vmdb::Plugins.instance.vmdb_plugins.each do |plugin|
+    Vmdb::Plugins.each do |plugin|
       Dir.glob(plugin.root.join(DIALOG_DIR_PLUGIN, YAML_FILES_PATTERN)).each do |file|
         dialog_import_service.import_all_service_dialogs_from_yaml_file(file)
       end

--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -24,7 +24,7 @@ class MiqDialog < ApplicationRecord
   end
 
   def self.sync_from_plugins
-    Vmdb::Plugins.instance.vmdb_plugins.each do |plugin|
+    Vmdb::Plugins.each do |plugin|
       sync_from_dir(plugin.root.join('content', 'miq_dialogs'))
     end
   end

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -4,9 +4,9 @@ module MiqReport::ImportExport
   module ClassMethods
     def view_paths
       @view_paths ||= (
-        Vmdb::Plugins.instance.vmdb_plugins.map do |engine|
-          directory = File.join(engine.root, 'product/views')
-          directory if File.directory?(directory)
+        Vmdb::Plugins.map do |engine|
+          path = engine.root.join('product/views')
+          path if path.directory?
         end.compact
       )
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -133,16 +133,15 @@ module Vmdb
       require 'vmdb_helper'
     end
 
-    initializer :load_inflections, :before => :load_vmdb_settings do
-      Vmdb::Inflections.load_inflections
-    end
-
     # Note: If an initializer doesn't have an after, Rails will add one based
     # on the top to bottom order of initializer calls in the file.
     # Because this is easy to mess up, keep your initializers in order.
-    # register plugins even before loading settings, as plugins can bring their own settings
-    initializer :register_vmdb_plugins, :before => :load_vmdb_settings do
-      Vmdb::Plugins.instance.register_vmdb_plugins
+    initializer :load_inflections, :before => :init_vmdb_plugins do
+      Vmdb::Inflections.load_inflections
+    end
+
+    initializer :init_vmdb_plugins, :before => :load_vmdb_settings do
+      Vmdb::Plugins.init
     end
 
     initializer :load_vmdb_settings, :before => :load_config_initializers do

--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -33,7 +33,7 @@ class EmbeddedAnsible
     FileUtils.rm_rf(dir)
     FileUtils.mkdir_p(dir)
 
-    Vmdb::Plugins.instance.registered_ansible_content.each do |content|
+    Vmdb::Plugins.ansible_content.each do |content|
       FileUtils.cp_r(Dir.glob("#{content.path}/*"), dir)
     end
   end

--- a/lib/vmdb/inflections.rb
+++ b/lib/vmdb/inflections.rb
@@ -1,6 +1,14 @@
 module Vmdb
   module Inflections
     def self.load_inflections
+      @loaded ||= begin
+        load_core_inflections
+        load_plugin_inflections
+        true
+      end
+    end
+
+    def self.load_core_inflections
       # Add new inflection rules using the following format
       # (all these examples are active by default):
       # ActiveSupport::Inflector.inflections do |inflect|
@@ -40,6 +48,11 @@ module Vmdb
 
         inflect.acronym('ManageIQ')
       end
+    end
+
+    def self.load_plugin_inflections
+      require_relative 'plugins'
+      Vmdb::Plugins.load_inflections
     end
   end
 end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -3,6 +3,8 @@ require 'singleton'
 module Vmdb
   class Plugins
     include Singleton
+    private_class_method :instance
+
     include Enumerable
 
     def self.method_missing(m, *args, &block)

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -25,6 +25,7 @@ module Vmdb
     end
 
     def init
+      load_inflections
       register_models
     end
 
@@ -52,6 +53,20 @@ module Vmdb
 
     def provider_plugins
       @provider_plugins ||= select { |engine| engine.name.start_with?("ManageIQ::Providers::") }
+    end
+
+    def asset_paths
+      @asset_paths ||= begin
+        require_relative 'plugins/asset_path'
+        map { |engine| AssetPath.new(engine) if AssetPath.asset_path?(engine) }.compact
+      end
+    end
+
+    def load_inflections
+      each do |engine|
+        file = engine.root.join("config", "initializers", "inflections.rb")
+        load file if file.exist?
+      end
     end
 
     def register_models

--- a/lib/vmdb/plugins/ansible_content.rb
+++ b/lib/vmdb/plugins/ansible_content.rb
@@ -1,14 +1,12 @@
 module Vmdb
   class Plugins
     class AnsibleContent
-      attr_reader :datastores_path
-      attr_reader :name
       attr_reader :path
 
       def initialize(path)
         raise "#{path} does not exist" unless File.directory?(path)
-        @roles_path = Pathname.new(path)
-        @path = @roles_path.split.first
+        roles_path = Pathname.new(path)
+        @path = roles_path.split.first
       end
     end
   end

--- a/lib/vmdb/plugins/asset_path.rb
+++ b/lib/vmdb/plugins/asset_path.rb
@@ -1,0 +1,29 @@
+require_relative '../inflections'
+Vmdb::Inflections.load_inflections
+
+module Vmdb
+  class Plugins
+    class AssetPath
+      attr_reader :name
+      attr_reader :path
+      attr_reader :namespace
+
+      def self.asset_path(engine)
+        engine.root.join('app', 'javascript')
+      end
+
+      def self.asset_path?(engine)
+        asset_path(engine).directory?
+      end
+
+      def initialize(engine)
+        asset_path = self.class.asset_path(engine)
+        raise "#{asset_path} does not exist" unless asset_path.directory?
+
+        @name      = engine.name
+        @path      = engine.root
+        @namespace = name.chomp("::Engine").underscore.tr("/", "-")
+      end
+    end
+  end
+end

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -153,7 +153,7 @@ module Vmdb
     private_class_method :build_without_local
 
     def self.template_roots
-      Vmdb::Plugins.instance.vmdb_plugins.collect { |p| p.root.join('config') } << Rails.root.join('config')
+      Vmdb::Plugins.collect { |p| p.root.join('config') } << Rails.root.join('config')
     end
     private_class_method :template_roots
 

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -1,0 +1,19 @@
+describe Vmdb::Plugins do
+  describe ".asset_paths" do
+    it "with normal engines" do
+      asset_paths = described_class.asset_paths
+
+      asset_path = asset_paths.detect { |ap| ap.name == "ManageIQ::UI::Classic::Engine" }
+      expect(asset_path.path).to eq ManageIQ::UI::Classic::Engine.root
+      expect(asset_path.namespace).to eq "manageiq-ui-classic"
+    end
+
+    it "with engines with inflections" do
+      asset_paths = described_class.asset_paths
+
+      asset_path = asset_paths.detect { |ap| ap.name == "ManageIQ::V2V::Engine" }
+      expect(asset_path.path).to eq ManageIQ::V2V::Engine.root
+      expect(asset_path.namespace).to eq "manageiq-v2v"
+    end
+  end
+end

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -1,4 +1,46 @@
 describe Vmdb::Plugins do
+  it ".all" do
+    all = described_class.all
+
+    expect(all).to include(
+      ManageIQ::Providers::Vmware::Engine,
+      ManageIQ::UI::Classic::Engine
+    )
+    expect(all).to_not include(
+      ActionCable::Engine
+    )
+  end
+
+  it ".ansible_content" do
+    ansible_content = described_class.ansible_content
+
+    content = ansible_content.detect { |ac| ac.path.to_s.include?("manageiq-content") }
+    expect(content.path).to eq ManageIQ::Content::Engine.root.join("content/ansible")
+
+    content = ansible_content.detect { |ac| ac.path.to_s.include?("manageiq-ui-classic") }
+    expect(content).to_not be
+  end
+
+  it ".automate_domains" do
+    automate_domains = described_class.automate_domains
+
+    domain = automate_domains.detect { |ac| ac.name == "ManageIQ" }
+    expect(domain.path).to eq ManageIQ::Content::Engine.root.join("content/automate/ManageIQ")
+
+    domain = automate_domains.detect { |ac| ac.path.to_s.include?("manageiq-ui-classic") }
+    expect(domain).to_not be
+  end
+
+  it ".system_automate_domains" do
+    automate_domains = described_class.system_automate_domains
+
+    domain = automate_domains.detect { |ac| ac.name == "ManageIQ" }
+    expect(domain.system?).to be_truthy
+
+    domain = automate_domains.detect { |ac| ac.path.to_s.include?("manageiq-ui-classic") }
+    expect(domain).to_not be
+  end
+
   describe ".asset_paths" do
     it "with normal engines" do
       asset_paths = described_class.asset_paths
@@ -15,5 +57,18 @@ describe Vmdb::Plugins do
       expect(asset_path.path).to eq ManageIQ::V2V::Engine.root
       expect(asset_path.namespace).to eq "manageiq-v2v"
     end
+  end
+
+  it ".provider_plugins" do
+    provider_plugins = described_class.provider_plugins
+
+    expect(provider_plugins).to include(
+      ManageIQ::Providers::Vmware::Engine,
+      ManageIQ::Providers::Amazon::Engine
+    )
+    expect(provider_plugins).to_not include(
+      ManageIQ::Api::Engine,
+      ManageIQ::UI::Classic::Engine
+    )
   end
 end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -10,7 +10,7 @@ describe Dialog do
 
     it "seed files from plugins" do
       mock_engine = double(:root => Rails.root)
-      expect(Vmdb::Plugins.instance).to receive(:vmdb_plugins).and_return([mock_engine])
+      expect(Vmdb::Plugins).to receive(:each).and_yield(mock_engine)
 
       stub_const('Dialog::DIALOG_DIR_PLUGIN', test_file_path)
       stub_const('Dialog::DIALOG_DIR_CORE', 'non-existent-dir')

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -292,7 +292,6 @@ describe EmsEvent do
           }
         }
       )
-      allow(Vmdb::Plugins.instance).to receive(:registered_provider_plugin_names).and_return([:some_provider])
 
       expect(described_class.event_groups[:addition][:critical]).to include('CloneTaskEvent')
       expect(described_class.event_groups[:addition][:critical]).to include(provider_event)

--- a/spec/models/miq_dialog_spec.rb
+++ b/spec/models/miq_dialog_spec.rb
@@ -17,7 +17,7 @@ describe MiqDialog do
       mock_engine = double(:root => Pathname.new('/some/root'))
       allow(described_class).to receive(:sync_from_dir)
 
-      expect(Vmdb::Plugins.instance).to receive(:vmdb_plugins).and_return([mock_engine])
+      expect(Vmdb::Plugins).to receive(:each).and_yield(mock_engine)
       expect(described_class).to receive(:sync_from_dir).once.with(
         mock_engine.root.join('content', 'miq_dialogs')
       )


### PR DESCRIPTION
Vmdb::Plugins#asset_paths returns objects that can be used to find all plugins that provide asset content.  This is important in the manageiq-ui-classic repo for use with webpack.

```ruby
[4] pry(main)> Vmdb::Plugins.instance.asset_paths
=> [#<Vmdb::Plugins::AssetPath:0x00007febcb71bb78
  @name="ManageIQ::GraphQL::Engine",
  @path=#<Pathname:/Users/jfrey/.gem/ruby/2.4.2/bundler/gems/manageiq-graphql-5f68621f2791>,
  @webpack_name="manageiq-graphql">,
 #<Vmdb::Plugins::AssetPath:0x00007febcb7384d0
  @name="ManageIQ::UI::Classic::Engine",
  @path=#<Pathname:/Users/jfrey/dev/manageiq-ui-classic>,
  @webpack_name="manageiq-ui-classic">,
 #<Vmdb::Plugins::AssetPath:0x00007febcb741d28
  @name="ManageIQ::V2V::Engine",
  @path=#<Pathname:/Users/jfrey/.gem/ruby/2.4.2/bundler/gems/miq_v2v_ui_plugin-cb559e7071d9>,
  @webpack_name="manageiq-v2v">]
[
```

This PR also refactors Vmdb::Plugins to ensure that these new methods can be executed outside of the Rails environment.

@jrafanie @carbonin @NickLaMuro Please review.  There is a follow-up PR in manageiq-ui-classic to remove all of the asset_engines code and use this from core.

Must be merged with https://github.com/ManageIQ/manageiq-automation_engine/pull/194