### PR TITLE
Support for updating scheduled time of service template order

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -444,6 +444,24 @@ class ServiceTemplate < ApplicationRecord
     end
   end
 
+  def update_schedule(schedule_time)
+    if schedule_time
+      require 'time'
+      time = schedule_time.kind_of?(String) ? Time.parse(schedule_time).utc : schedule_time
+
+      schedule = miq_schedule
+      raise _('service_template is not currently scheduled') unless schedule
+      schedule.run_at = {
+        :interval   => {:unit => "once"},
+        :start_time => time,
+        :tz         => "UTC",
+      }
+      schedule.save!
+    else
+      miq_schedule&.destroy
+    end
+  end
+
   def provision_workflow(user, dialog_options = nil, request_options = nil)
     dialog_options ||= {}
     request_options ||= {}

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -64,6 +64,7 @@ class ServiceTemplate < ApplicationRecord
   virtual_column   :template_valid_error_message, :type => :string
   virtual_column   :archived,                     :type => :boolean
   virtual_column   :active,                       :type => :boolean
+  virtual_column   :schedule_time,                :type => :time
 
   default_value_for :service_type, 'unknown'
   default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }
@@ -74,6 +75,10 @@ class ServiceTemplate < ApplicationRecord
   scope :without_service_template_catalog_id,       ->         { where(:service_template_catalog_id => nil) }
   scope :with_existent_service_template_catalog_id, ->         { where.not(:service_template_catalog_id => nil) }
   scope :displayed,                                 ->         { where(:display => true) }
+
+  def schedule_time
+    miq_schedule.try(:run_at).try(:[], :start_time)
+  end
 
   def self.catalog_item_types
     ci_types = Set.new(Rbac.filtered(ExtManagementSystem.all).flat_map(&:supported_catalog_types))

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -457,9 +457,11 @@ class ServiceTemplate < ApplicationRecord
         :tz         => "UTC",
       }
       schedule.save!
-    else
-      miq_schedule&.destroy
     end
+  end
+
+  def delete_schedule
+    miq_schedule&.destroy
   end
 
   def provision_workflow(user, dialog_options = nil, request_options = nil)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -70,6 +70,7 @@ class ServiceTemplate < ApplicationRecord
   default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }
 
   virtual_has_one :config_info, :class_name => "Hash"
+  virtual_has_one :miq_schedule,:class_name => "MiqSchedule"
 
   scope :with_service_template_catalog_id,          ->(cat_id) { where(:service_template_catalog_id => cat_id) }
   scope :without_service_template_catalog_id,       ->         { where(:service_template_catalog_id => nil) }
@@ -78,6 +79,10 @@ class ServiceTemplate < ApplicationRecord
 
   def schedule_time
     miq_schedule.try(:run_at).try(:[], :start_time)
+  end
+
+  def miq_schedule
+    MiqSchedule.where(:towhat => "ServiceTemplate").find { |s| s.resource_id == id }
   end
 
   def self.catalog_item_types

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -866,6 +866,38 @@ describe ServiceTemplate do
     end
   end
 
+  context "with a schedule" do
+    let(:st)   { FactoryGirl.create(:service_template, :name => "st") }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      user = FactoryGirl.create(:user, :userid => "barney")
+      st.order(user, {}, {}, Time.now.utc.to_s)
+    end
+
+    context "update_schedule" do
+      it "updates the scheduled time" do
+        new_time = 1.day.from_now.utc
+
+        st.update_schedule(new_time)
+
+        st.reload
+        expect(st.schedule_time.to_s).to eq(new_time.to_s)
+      end
+    end
+
+    context "delete_schedule" do
+      it "deletes the schedule" do
+        st.delete_schedule
+
+        st.reload
+
+        expect(st.schedule_time).to be_nil
+        expect(st.miq_schedule).to be_nil
+      end
+    end
+  end
+
   context "catalog_item_types" do
     it "only returns generic with no providers" do
       expect(ServiceTemplate.catalog_item_types).to match(


### PR DESCRIPTION
This PR adds schedule update support to `ServiceTemplate`

The schedule time for an existing order can be updates. The schedule can also be deleted if the scheduled time is passed as nil.

Thanks @abellotti for pairing on this

Prereq for https://github.com/ManageIQ/manageiq-api/pull/408