### PR TITLE
Fixes undefined method `name` error during CSV validation required for v2v migration

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -82,8 +82,8 @@ class TransformationMapping < ApplicationRecord
   def describe_vm(vm, reason)
     {
       "name"           => vm.name,
-      "cluster"        => vm.ems_cluster.name,
-      "path"           => "#{vm.ext_management_system.name}/#{vm.parent_blue_folder_path(:exclude_non_display_folders => true)}",
+      "cluster"        => vm.ems_cluster.try(:name) || '',
+      "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.parent_blue_folder_path(:exclude_non_display_folders => true)}" : '',
       "allocated_size" => vm.allocated_disk_storage,
       "id"             => vm.id,
       "reason"         => reason

--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -92,10 +92,11 @@ class TransformationMapping < ApplicationRecord
   end
 
   def validate_vm(vm, quick = true)
+    validate_result = vm.validate_v2v_migration
+    return validate_result unless validate_result == VM_VALID
+
     # a valid vm must find all resources in the mapping and has never been migrated
     invalid_list = []
-
-    return VM_INACTIVE unless vm.active?
 
     unless valid_cluster?(vm)
       invalid_list << "cluster: %{name}" % {:name => vm.ems_cluster.name}
@@ -114,8 +115,7 @@ class TransformationMapping < ApplicationRecord
       return no_mapping_msg(invalid_list) if quick
     end
 
-    return no_mapping_msg(invalid_list) if invalid_list.present?
-    vm.validate_v2v_migration
+    invalid_list.present? ? no_mapping_msg(invalid_list) : VM_VALID
   end
 
   def no_mapping_msg(list)

--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -5,6 +5,7 @@ class TransformationMapping < ApplicationRecord
   VM_MIGRATED = "migrated".freeze
   VM_NOT_EXIST = "not_exist".freeze
   VM_VALID = "ok".freeze
+  VM_INACTIVE = "inactive".freeze
 
   has_many :transformation_mapping_items, :dependent => :destroy
   has_many :service_resources, :as => :resource, :dependent => :nullify
@@ -93,6 +94,8 @@ class TransformationMapping < ApplicationRecord
   def validate_vm(vm, quick = true)
     # a valid vm must find all resources in the mapping and has never been migrated
     invalid_list = []
+
+    return VM_INACTIVE unless vm.active?
 
     unless valid_cluster?(vm)
       invalid_list << "cluster: %{name}" % {:name => vm.ems_cluster.name}

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -122,6 +122,8 @@ class Vm < VmOrTemplate
   end
 
   def validate_v2v_migration
+    return TransformationMapping::VM_INACTIVE unless active?
+
     vm_as_resources = ServiceResource.where(:resource => self).includes(:service_template).where(:service_templates => {:type => "ServiceTemplateTransformationPlan"})
 
     # VM has not been migrated before

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -31,6 +31,7 @@ describe TransformationMapping do
 
   describe '#validate_vms' do
     let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryGirl.create(:ext_management_system)) }
+    let(:inactive_vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src, :ext_management_system => nil) }
     let(:storage) { FactoryGirl.create(:storage) }
     let(:lan) { FactoryGirl.create(:lan) }
     let(:nic) { FactoryGirl.create(:guest_device_nic, :lan => lan) }
@@ -47,6 +48,12 @@ describe TransformationMapping do
         it 'if VM does not exist' do
           result = mapping.validate_vms(['name' => 'vm1'])
           expect(result['invalid_vms'].first).to match(hash_including('reason' => TransformationMapping::VM_NOT_EXIST))
+        end
+
+        it 'if VM is inactive' do
+          inactive_vm.storages << FactoryGirl.create(:storage, :name => 'storage_for_inactive_vm')
+          result = mapping.validate_vms(['name' => 'test_vm_inactive'])
+          expect(result['invalid_vms'].first).to match(hash_including('reason' => TransformationMapping::VM_INACTIVE))
         end
 
         it "if VM's cluster is not in the mapping" do


### PR DESCRIPTION
Account for a case when there is no `cluster` or `ext_management_system` info available from the csv file.

https://bugzilla.redhat.com/show_bug.cgi?id=1596318