### PR TITLE
Adding title and cve's to openscap_rule_result creation

### DIFF
--- a/app/models/openscap_result.rb
+++ b/app/models/openscap_result.rb
@@ -38,11 +38,17 @@ class OpenscapResult < ApplicationRecord
   def create_results(rule_results, benchmark_items)
     openscap_rule_results.delete_all
     rule_results.each do |openscap_id, result|
+      idents = []
+      benchmark_items[openscap_id].idents.each do |ident|
+        idents << ident.id
+      end
       openscap_rule_results << OpenscapRuleResult.new(
         :name            => ascii8bit_to_utf8(openscap_id),
         :result          => ascii8bit_to_utf8(result.result),
         :openscap_result => self,
-        :severity        => ascii8bit_to_utf8(benchmark_items[openscap_id].severity)
+        :severity        => ascii8bit_to_utf8(benchmark_items[openscap_id].severity),
+        :title           => ascii8bit_to_utf8(benchmark_items[openscap_id].title),
+        :cves            => idents.join(",")
       )
     end
   end

--- a/spec/models/openscap_result_spec.rb
+++ b/spec/models/openscap_result_spec.rb
@@ -19,19 +19,22 @@ describe OpenscapResult do
       rule_results = [
         [1, double(:result => 'result_1')],
         [2, double(:result => 'result_2')]]
-      benchmark_items = {1 => double(:severity => 'Bad'),
-                         2 => double(:severity => 'Not That Bad')}
+
+      benchmark_items = {1 => double(:severity => 'Bad', :idents => [], :title => "Bad"),
+                         2 => double(:severity => 'Not That Bad', :idents => [], :title => "Not That Bad")}
 
       openscap_result.instance_eval { create_results(rule_results, benchmark_items) }
       expect(openscap_result.openscap_rule_results[0]).to have_attributes(
         :openscap_result_id => 17,
         :name               => '1',
         :result             => "result_1",
+        :title              => "Bad",
         :severity           => "Bad")
       expect(openscap_result.openscap_rule_results[1]).to have_attributes(
         :openscap_result_id => 17,
         :name               => '2',
         :result             => "result_2",
+        :title              => "Not That Bad",
         :severity           => "Not That Bad")
     end
   end


### PR DESCRIPTION
New pull request for https://github.com/ManageIQ/manageiq/pull/17219#issuecomment-401064220 with a rebase. 

In conjunction with PR OpenSCAP/ruby-openscap#12

Gives the ability to store OpenSCAP Rule title and linked CVE's. This gives usefulness to the OpenSCAP reporting options in cloudforms. Currently only only a non human friendly id is present and there are no links to the actual CVE references.

This change also requires a schema change to the database:

class AddCVEToOpenScapRuleResults < ActiveRecord::Migration[5.0] def change add_column :openscap_rule_results, :title, :string add_column :openscap_rule_results, :cves, :string end end

@hsong-rh please review. 