### PR TITLE
[WIP] Add file splitting to evm:db tasks

### DIFF
--- a/app/models/file_depot_ftp.rb
+++ b/app/models/file_depot_ftp.rb
@@ -1,6 +1,8 @@
 require 'net/ftp'
 
 class FileDepotFtp < FileDepot
+  include ManageIQ::Util::FtpLib
+
   attr_accessor :ftp
 
   def self.uri_prefix
@@ -62,51 +64,11 @@ class FileDepotFtp < FileDepot
     end
   end
 
-  def connect(cred_hash = nil)
-    host = URI(uri).hostname
-
-    begin
-      _log.info("Connecting to #{self.class.name}: #{name} host: #{host}...")
-      @ftp         = Net::FTP.new(host)
-      @ftp.passive = true  # Use passive mode to avoid firewall issues see http://slacksite.com/other/ftp.html#passive
-      # @ftp.debug_mode = true if settings[:debug]  # TODO: add debug option
-      creds = cred_hash ? [cred_hash[:username], cred_hash[:password]] : login_credentials
-      @ftp.login(*creds)
-      _log.info("Connected to #{self.class.name}: #{name} host: #{host}")
-    rescue SocketError => err
-      _log.error("Failed to connect.  #{err.message}")
-      raise
-    rescue Net::FTPPermError => err
-      _log.error("Failed to login.  #{err.message}")
-      raise
-    else
-      @ftp
-    end
-  end
-
-  def file_exists?(file_or_directory)
-    !ftp.nlst(file_or_directory.to_s).empty?
-  rescue Net::FTPPermError
-    false
-  end
-
   def self.display_name(number = 1)
     n_('FTP', 'FTPs', number)
   end
 
   private
-
-  def create_directory_structure(directory_path)
-    pwd = ftp.pwd
-    directory_path.to_s.split('/').each do |directory|
-      unless ftp.nlst.include?(directory)
-        _log.info("creating #{directory}")
-        ftp.mkdir(directory)
-      end
-      ftp.chdir(directory)
-    end
-    ftp.chdir(pwd)
-  end
 
   def upload(source, destination)
     create_directory_structure(destination_path)

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -70,7 +70,7 @@ class EvmDatabaseOps
       # won't hurt to do as a generic way to get a rough idea if we have enough
       # disk space or the appliance for the task.
       validate_free_space(database_opts)
-      PostgresAdmin.backup(database_opts)
+      PostgresAdmin.backup_pg_dump(database_opts)
     end
     _log.info("[#{merged_db_opts(db_opts)[:dbname]}] database has been dumped up to file: [#{uri}]")
     uri

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -53,11 +53,9 @@ class EvmDatabaseOps
     #   :password => 'Zug-drep5s',
     #   :remote_file_name => "backup_1",     - Provide a base file name for the uploaded file
 
-    uri = with_mount_session(:backup, db_opts, connect_opts) do |database_opts, session, remote_file_uri|
+    uri = with_mount_session(:backup, db_opts, connect_opts) do |database_opts|
       validate_free_space(database_opts)
-      backup_result = PostgresAdmin.backup(database_opts)
-      session&.add(database_opts[:local_file], remote_file_uri)
-      backup_result
+      PostgresAdmin.backup(database_opts)
     end
     _log.info("[#{merged_db_opts(db_opts)[:dbname]}] database has been backed up to file: [#{uri}]")
     uri
@@ -66,7 +64,7 @@ class EvmDatabaseOps
   def self.dump(db_opts, connect_opts = {})
     # db_opts and connect_opts similar to .backup
 
-    uri = with_mount_session(:dump, db_opts, connect_opts) do |database_opts, _session, _remote_file_uri|
+    uri = with_mount_session(:dump, db_opts, connect_opts) do |database_opts|
       # For database dumps, this isn't going to be as accurate (since the dump
       # size will probably be larger than the calculated BD size), but it still
       # won't hurt to do as a generic way to get a rough idea if we have enough
@@ -89,10 +87,7 @@ class EvmDatabaseOps
     #   :username => 'samba_one',
     #   :password => 'Zug-drep5s',
 
-    uri = with_mount_session(:restore, db_opts, connect_opts) do |database_opts, session, remote_file_uri|
-      if session && !File.exist?(database_opts[:local_file])
-        database_opts[:local_file] = session.download(database_opts[:local_file], remote_file_uri)
-      end
+    uri = with_mount_session(:restore, db_opts, connect_opts) do |database_opts|
       prepare_for_restore(database_opts[:local_file])
 
       # remove all the connections before we restore; AR will reconnect on the next query
@@ -124,10 +119,25 @@ class EvmDatabaseOps
       db_opts[:local_file] = session.uri_to_local_path(uri)
     end
 
-    block_result = yield(db_opts, session, uri) if block_given?
+    download_from_mount_if_needed(action, session, uri, database_opts)
+    block_result = yield(db_opts) if block_given?
+    upload_to_mount_if_needed(action, session, uri, database_opts)
     uri || block_result
   ensure
     session.disconnect if session
+  end
+
+  private_class_method def self.download_from_mount_if_needed(action, session, uri, db_opts)
+    if action == :restore && session.kind_of?(MiqS3Session) && !File.exist?(db_opts[:local_file])
+      db_opts[:local_file] = session.download(db_opts[:local_file], uri)
+    end
+  end
+
+  private_class_method def self.upload_to_mount_if_needed(action, session, uri, db_opts)
+    if action == :backup && session.kind_of?(MiqS3Session)
+      session.add(database_opts[:local_file], uri)
+      FileUtils.rm_rf database_opts[:local_file] if false # TODO: consider doing this
+    end
   end
 
   private_class_method def self.prepare_for_restore(filename)

--- a/lib/manageiq/util/file_splitter.rb
+++ b/lib/manageiq/util/file_splitter.rb
@@ -13,11 +13,14 @@
 # platform, without having to be concerned with differences in `split`
 # functionality.
 
+require_relative 'ftp_lib'
 require 'optparse'
 
 module ManageIQ
   module Util
     class FileSplitter
+      include ManageIQ::Util::FtpLib
+
       KILOBYTE = 1024
       MEGABYTE = KILOBYTE * 1024
       GIGABYTE = MEGABYTE * 1024
@@ -30,6 +33,15 @@ module ManageIQ
 
       attr_accessor :input_file, :byte_count
 
+      class << self
+        attr_writer :instance_logger
+
+        # Don't log by default, but allow this to work with FtpLib logging.
+        def instance_logger
+          @instance_logger ||= Logger.new(File::NULL)
+        end
+      end
+
       def self.run(options = nil)
         options ||= parse_argv
         new(options).split
@@ -40,6 +52,15 @@ module ManageIQ
         OptionParser.new do |opt|
           opt.on("-b", "--byte-count=BYTES", "Number of bytes for each split") do |bytes|
             options[:byte_count] = parse_byte_value(bytes)
+          end
+          opt.on("--ftp-host=HOST", "Host of the FTP server") do |host|
+            options[:ftp_host] = host
+          end
+          opt.on("--ftp-dir=DIR", "Dir on the FTP server to save files") do |dir|
+            options[:ftp_dir] = dir
+          end
+          opt.on("-v", "--verbose", "Turn on logging") do
+            options[:verbose] = logging
           end
         end.parse!
 
@@ -56,20 +77,85 @@ module ManageIQ
         @input_filename = options[:input_filename]
         @byte_count     = options[:byte_count] || (10 * MEGABYTE)
         @position       = 0
+
+        setup_logging(options)
+        setup_ftp(options)
       end
 
       def split
         until input_file.eof?
-          File.open(next_split_filename, "w") do |split_file|
-            split_file << input_file.read(byte_count)
-            @position += byte_count
+          if ftp
+            split_ftp
+          else
+            split_local
           end
+          @position += byte_count
         end
       ensure
         input_file.close
+        ftp.close if ftp
       end
 
       private
+
+      def setup_logging(options)
+        self.class.instance_logger = Logger.new(STDOUT) if options[:verbose]
+      end
+
+      def setup_ftp(options)
+        if options[:ftp_host]
+          @uri      = options[:ftp_host]
+          @ftp_user = options[:ftp_user] || ENV["FTP_USERNAME"] || "anonymous"
+          @ftp_pass = options[:ftp_pass] || ENV["FTP_PASSWORD"]
+          @ftp      = connect
+
+          @input_filename = File.join(options[:ftp_dir] || "", File.basename(input_filename))
+        end
+      end
+
+      def login_credentials
+        [@ftp_user, @ftp_pass]
+      end
+
+      def split_local
+        File.open(next_split_filename, "w") do |split_file|
+          split_file << input_file.read(byte_count)
+        end
+      end
+
+      # Specific version of Net::FTP#storbinary that doesn't use an existing local
+      # file, and only uploads a specific size from the input_file
+      FTP_CHUNKSIZE = ::Net::FTP::DEFAULT_BLOCKSIZE
+      def split_ftp
+        ftp_mkdir_p
+        ftp.synchronize do
+          ftp.send(:with_binary, true) do
+            conn         = ftp.send(:transfercmd, "STOR #{next_split_filename}")
+            buf_left     = byte_count
+            while buf_left.positive?
+              cur_readsize = buf_left - FTP_CHUNKSIZE >= 0 ? FTP_CHUNKSIZE : buf_left
+              buf = input_file.read(cur_readsize)
+              break if buf == nil # rubocop:disable Style/NilComparison (from original)
+              conn.write(buf)
+              buf_left -= FTP_CHUNKSIZE
+            end
+            conn.close
+            ftp.send(:voidresp)
+          end
+        end
+      rescue Errno::EPIPE
+        # EPIPE, in this case, means that the data connection was unexpectedly
+        # terminated.  Rather than just raising EPIPE to the caller, check the
+        # response on the control connection.  If getresp doesn't raise a more
+        # appropriate exception, re-raise the original exception.
+        getresp
+        raise
+      end
+
+      def ftp_mkdir_p
+        dir_path = File.dirname(input_filename)[1..-1].split('/') - ftp.pwd[1..-1].split("/")
+        create_directory_structure(dir_path.join('/'))
+      end
 
       def input_filename
         @input_filename ||= File.expand_path(input_file.path)

--- a/lib/manageiq/util/file_splitter.rb
+++ b/lib/manageiq/util/file_splitter.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+#
+# Yes, you guessed it... this is basically the `split` command...
+#
+# The intent of this is to allow for greater flexibility and utility than is
+# provided by the BSD/GNU variants however, specifically allowing to pipe from
+# a pg_dump directly to a upload target (whether it be a mounted volume or
+# something like a FTP endpoint, though the former is basically already
+# supported with vanilla `split`).
+#
+# FTP, specifically, will be supported natively since ruby has Net::FTP support
+# built in (feature WIP).  This also allows for this to work correctly cross
+# platform, without having to be concerned with differences in `split`
+# functionality.
+
+require 'optparse'
+
+module ManageIQ
+  module Util
+    class FileSplitter
+      KILOBYTE = 1024
+      MEGABYTE = KILOBYTE * 1024
+      GIGABYTE = MEGABYTE * 1024
+
+      BYTE_HASH = {
+        "k" => KILOBYTE,
+        "m" => MEGABYTE,
+        "g" => GIGABYTE
+      }.freeze
+
+      attr_accessor :input_file, :byte_count
+
+      def self.run(options = nil)
+        options ||= parse_argv
+        new(options).split
+      end
+
+      def self.parse_argv
+        options = {}
+        OptionParser.new do |opt|
+          opt.on("-b", "--byte-count=BYTES", "Number of bytes for each split") do |bytes|
+            options[:byte_count] = parse_byte_value(bytes)
+          end
+        end.parse!
+
+        input_file, file_pattern = determine_input_file_and_file_pattern
+
+        options[:input_file]     = input_file
+        options[:input_filename] = file_pattern
+
+        options
+      end
+
+      def initialize(options = {})
+        @input_file     = options[:input_file] || ARGF
+        @input_filename = options[:input_filename]
+        @byte_count     = options[:byte_count] || (10 * MEGABYTE)
+        @position       = 0
+      end
+
+      def split
+        until input_file.eof?
+          File.open(next_split_filename, "w") do |split_file|
+            split_file << input_file.read(byte_count)
+            @position += byte_count
+          end
+        end
+      ensure
+        input_file.close
+      end
+
+      private
+
+      def input_filename
+        @input_filename ||= File.expand_path(input_file.path)
+      end
+
+      def next_split_filename
+        "#{input_filename}.#{'%05d' % (@position / byte_count + 1)}"
+      end
+
+      def self.parse_byte_value(bytes)
+        match = bytes.match(/^(?<BYTE_NUM>\d+)(?<BYTE_QUALIFIER>K|M|G)?$/i)
+        raise ArgumentError, "Invalid byte-count", [] if match.nil?
+
+        bytes = match[:BYTE_NUM].to_i
+        if match[:BYTE_QUALIFIER]
+          bytes *= BYTE_HASH[match[:BYTE_QUALIFIER].downcase]
+        end
+        bytes
+      end
+      private_class_method :parse_byte_value
+
+      def self.determine_input_file_and_file_pattern
+        input_file   = ARGV.shift
+        file_pattern = nil
+
+        case input_file
+        when "-"
+          input_file = nil
+        else
+          if input_file && File.exist?(input_file)
+            input_file = File.open(input_file)
+          else
+            file_pattern, input_file = input_file, nil
+          end
+        end
+        file_pattern ||= ARGV.shift
+        raise ArgumentError, "must pass a file pattern if piping from STDIN" if file_pattern.nil? && input_file.nil?
+
+        [input_file, file_pattern]
+      end
+      private_class_method :determine_input_file_and_file_pattern
+    end
+  end
+end
+
+ManageIQ::Util::FileSplitter.run if $PROGRAM_NAME == __FILE__

--- a/lib/manageiq/util/ftp_lib.rb
+++ b/lib/manageiq/util/ftp_lib.rb
@@ -1,0 +1,72 @@
+require 'net/ftp'
+require 'logger'
+
+# Helper methods for net/ftp based classes and files.
+#
+# Will setup a `@ftp` attr_accessor to be used as the return value for
+# `.connect`, the main method being provided in this class.  Will also setup
+# logging if not already done for the particular class (that follows the
+# VmdbLogger conventions, and setup a `uri` attr_accessor if that doesn't
+# already exist.
+module ManageIQ
+  module Util
+    module FtpLib
+      def self.included(klass)
+        klass.send(:attr_accessor, :ftp)
+
+        klass.send(:attr_accessor, :uri)  unless klass.instance_methods.include?(:uri=)
+
+        unless klass.instance_methods.include?(:_log)
+          klass.send(:define_method, :_log) do
+            self.class.instance_logger
+          end
+        end
+      end
+
+      def connect(cred_hash = nil)
+        host = URI(uri).hostname
+
+        begin
+          host_url = host
+          host_url << " (#{name})" if respond_to?(:name)
+          _log.info("Connecting to FTP host #{host_url}...")
+          @ftp         = Net::FTP.new(host)
+          # Use passive mode to avoid firewall issues see http://slacksite.com/other/ftp.html#passive
+          @ftp.passive = true
+          # @ftp.debug_mode = true if settings[:debug]  # TODO: add debug option
+          creds = cred_hash ? [cred_hash[:username], cred_hash[:password]] : login_credentials
+          @ftp.login(*creds)
+          _log.info("Successfully connected FTP host #{host_url}...")
+        rescue SocketError => err
+          _log.error("Failed to connect.  #{err.message}")
+          raise
+        rescue Net::FTPPermError => err
+          _log.error("Failed to login.  #{err.message}")
+          raise
+        else
+          @ftp
+        end
+      end
+
+      def file_exists?(file_or_directory)
+        !ftp.nlst(file_or_directory.to_s).empty?
+      rescue Net::FTPPermError
+        false
+      end
+
+      private
+
+      def create_directory_structure(directory_path)
+        pwd = ftp.pwd
+        directory_path.to_s.split('/').each do |directory|
+          unless ftp.nlst.include?(directory)
+            _log.info("creating #{directory}")
+            ftp.mkdir(directory)
+          end
+          ftp.chdir(directory)
+        end
+        ftp.chdir(pwd)
+      end
+    end
+  end
+end

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -34,6 +34,8 @@ module EvmDba
           opt :local_file,       "Destination file",           :type => :string, :required => true
         when :remote_file
           opt :remote_file_name, "Destination depot filename", :type => :string
+        when :splitable
+          opt :byte_count,       "Size to split files by",     :type => :string
         when :remote_uri
           opt :uri,              "Destination depot URI",      :type => :string, :required => true
           opt :uri_username,     "Destination depot username", :type => :string
@@ -58,6 +60,12 @@ module EvmDba
     connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
     connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
     connect_opts
+  end
+
+  def self.collect_additional_opts(opts)
+    additional_opts = {}
+    [:byte_count].each { |k| additional_opts[k] = opts[k] if opts[k] }
+    additional_opts
   end
 end
 
@@ -185,21 +193,24 @@ namespace :evm do
       require File.expand_path(File.join(Rails.root, "lib", "evm_database_ops"))
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
-        opts = EvmDba.with_options(:local_file, :db_credentials)
+        opts = EvmDba.with_options(:local_file, :splitable, :db_credentials)
 
-        EvmDatabaseOps.backup(opts)
+        additional_opts = EvmDba.collect_additional_opts(opts)
+
+        EvmDatabaseOps.backup(opts, {}, additional_opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
       end
 
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
-        opts = EvmDba.with_options(:remote_uri, :remote_file, :db_credentials)
+        opts = EvmDba.with_options(:remote_uri, :remote_file, :splitable, :db_credentials)
 
-        db_opts      = EvmDba.collect_db_opts(opts)
-        connect_opts = EvmDba.collect_connect_opts(opts)
+        db_opts         = EvmDba.collect_db_opts(opts)
+        connect_opts    = EvmDba.collect_connect_opts(opts)
+        additional_opts = EvmDba.collect_additional_opts(opts)
 
-        EvmDatabaseOps.backup(db_opts, connect_opts)
+        EvmDatabaseOps.backup(db_opts, connect_opts, additional_opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
       end
@@ -209,21 +220,23 @@ namespace :evm do
       require Rails.root.join("lib", "evm_database_ops").expand_path.to_s
       desc 'Dump the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
-        opts = EvmDba.with_options(:local_file, :db_credentials, :exclude_table_data)
+        opts = EvmDba.with_options(:local_file, :splitable, :db_credentials, :exclude_table_data)
 
-        EvmDatabaseOps.dump(opts)
+        additional_opts = EvmDba.collect_additional_opts(opts)
+        EvmDatabaseOps.dump(opts, {}, additional_opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
       end
 
       desc 'Dump the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
-        opts = EvmDba.with_options(:remote_uri, :remote_file, :db_credentials, :exclude_table_data)
+        opts = EvmDba.with_options(:remote_uri, :remote_file, :splitable, :db_credentials, :exclude_table_data)
 
-        db_opts      = EvmDba.collect_db_opts(opts)
-        connect_opts = EvmDba.collect_connect_opts(opts)
+        db_opts         = EvmDba.collect_db_opts(opts)
+        connect_opts    = EvmDba.collect_connect_opts(opts)
+        additional_opts = EvmDba.collect_additional_opts(opts)
 
-        EvmDatabaseOps.dump(db_opts, connect_opts)
+        EvmDatabaseOps.dump(db_opts, connect_opts, additional_opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
       end

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -18,6 +18,47 @@ module EvmDba
     return false unless config['adapter'] == 'postgresql'
     return %w( 127.0.0.1 localhost ).include?(config['host']) || config['host'].blank?
   end
+
+  def self.with_options(*option_types, &block)
+    require 'trollop'
+
+    Trollop.options(EvmRakeHelper.extract_command_options) do
+      option_types.each do |type|
+        case type
+        when :db_credentials
+          opt :username,         "Username",                   :type => :string
+          opt :password,         "Password",                   :type => :string
+          opt :hostname,         "Hostname",                   :type => :string
+          opt :dbname,           "Database name",              :type => :string
+        when :local_file
+          opt :local_file,       "Destination file",           :type => :string, :required => true
+        when :remote_file
+          opt :remote_file_name, "Destination depot filename", :type => :string
+        when :remote_uri
+          opt :uri,              "Destination depot URI",      :type => :string, :required => true
+          opt :uri_username,     "Destination depot username", :type => :string
+          opt :uri_password,     "Destination depot password", :type => :string
+        when :exclude_table_data
+          opt :"exclude-table-data", "Tables to exclude data", :type => :strings
+        end
+      end
+      instance_exec(&block) if block_given?
+    end.delete_nils
+  end
+
+  def self.collect_db_opts(opts)
+    db_opts = {}
+    [:dbname, :username, :password, :hostname, :"exclude-table-data"].each { |k| db_opts[k] = opts[k] if opts[k] }
+    db_opts
+  end
+
+  def self.collect_connect_opts(opts)
+    connect_opts = {}
+    [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
+    connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
+    connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+    connect_opts
+  end
 end
 
 namespace :evm do
@@ -57,12 +98,7 @@ namespace :evm do
 
     desc "clean up database"
     task :gc do
-      require 'trollop'
-      opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-        opt :username,   "Username",         :type => :string
-        opt :password,   "Password",         :type => :string
-        opt :hostname,   "Hostname",         :type => :string
-        opt :dbname,     "Database name",    :type => :string
+      opts = EvmDba.with_options(:db_credentials) do
         opt :aggressive, "Aggressive gc: vaccume with all options and reindexing"
         opt :vacuum,     "Vacuum database"
         opt :reindex,    "Reindex database (or table if --table specified)"
@@ -73,7 +109,7 @@ namespace :evm do
         opt :table,      "Tablename to reindex (if only perorm on one)", :type => :string
       end
 
-      opts = opts.delete_if { |_k, v| v.nil? || v == false }
+      opts = opts.delete_if { |_, v| v == false }
       EvmDatabaseOps.gc(opts)
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
@@ -106,8 +142,7 @@ namespace :evm do
 
     desc 'Set the region of the current ManageIQ EVM Database (VMDB)'
     task :region do
-      require 'trollop'
-      opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+      opts = EvmDba.with_options do
         opt :region, "Region number", :type => :integer, :required => ENV["REGION"].blank?
       end
 
@@ -150,16 +185,8 @@ namespace :evm do
       require File.expand_path(File.join(Rails.root, "lib", "evm_database_ops"))
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file, "Destination file", :type => :string, :required => true
-          opt :username,   "Username",         :type => :string
-          opt :password,   "Password",         :type => :string
-          opt :hostname,   "Hostname",         :type => :string
-          opt :dbname,     "Database name",    :type => :string
-        end
+        opts = EvmDba.with_options(:local_file, :db_credentials)
 
-        opts.delete_if { |k,v| v.nil? }
         EvmDatabaseOps.backup(opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
@@ -167,25 +194,10 @@ namespace :evm do
 
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",       :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",  :type => :string
-          opt :uri_password,     "Destination depot password",  :type => :string
-          opt :remote_file_name, "Destination depot filename",  :type => :string
-          opt :username,         "Username",                    :type => :string
-          opt :password,         "Password",                    :type => :string
-          opt :hostname,         "Hostname",                    :type => :string
-          opt :dbname,           "Database name",               :type => :string
-        end
+        opts = EvmDba.with_options(:remote_uri, :remote_file, :db_credentials)
 
-        db_opts = {}
-        [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
-
-        connect_opts = {}
-        [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
-        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+        db_opts      = EvmDba.collect_db_opts(opts)
+        connect_opts = EvmDba.collect_connect_opts(opts)
 
         EvmDatabaseOps.backup(db_opts, connect_opts)
 
@@ -197,17 +209,8 @@ namespace :evm do
       require Rails.root.join("lib", "evm_database_ops").expand_path.to_s
       desc 'Dump the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file,           "Destination file",       :type => :string, :required => true
-          opt :username,             "Username",               :type => :string
-          opt :password,             "Password",               :type => :string
-          opt :hostname,             "Hostname",               :type => :string
-          opt :dbname,               "Database name",          :type => :string
-          opt :"exclude-table-data", "Tables to exclude data", :type => :strings
-        end
+        opts = EvmDba.with_options(:local_file, :db_credentials, :exclude_table_data)
 
-        opts.delete_if { |_, v| v.nil? }
         EvmDatabaseOps.dump(opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
@@ -215,26 +218,10 @@ namespace :evm do
 
       desc 'Dump the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,                  "Destination depot URI",      :type => :string, :required => true
-          opt :uri_username,         "Destination depot username", :type => :string
-          opt :uri_password,         "Destination depot password", :type => :string
-          opt :remote_file_name,     "Destination depot filename", :type => :string
-          opt :username,             "Username",                   :type => :string
-          opt :password,             "Password",                   :type => :string
-          opt :hostname,             "Hostname",                   :type => :string
-          opt :dbname,               "Database name",              :type => :string
-          opt :"exclude-table-data", "Tables to exclude data",     :type => :strings
-        end
+        opts = EvmDba.with_options(:remote_uri, :remote_file, :db_credentials, :exclude_table_data)
 
-        db_opts = {}
-        [:dbname, :username, :password, :hostname, :"exclude-table-data"].each { |k| db_opts[k] = opts[k] if opts[k] }
-
-        connect_opts = {}
-        [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
-        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+        db_opts      = EvmDba.collect_db_opts(opts)
+        connect_opts = EvmDba.collect_connect_opts(opts)
 
         EvmDatabaseOps.dump(db_opts, connect_opts)
 
@@ -245,16 +232,7 @@ namespace :evm do
     namespace :restore do
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a local backup file'
       task :local => :environment do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file, "Destination file", :type => :string, :required => true
-          opt :username,   "Username",         :type => :string
-          opt :password,   "Password",         :type => :string
-          opt :hostname,   "Hostname",         :type => :string
-          opt :dbname,     "Database name",    :type => :string
-        end
-
-        opts.delete_if { |k,v| v.nil? }
+        opts = EvmDba.with_options(:local_file, :db_credentials)
 
         # If running through runner, disconnect any local connections
         ActiveRecord::Base.clear_all_connections! if ActiveRecord && ActiveRecord::Base
@@ -266,24 +244,10 @@ namespace :evm do
 
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a remote backup file'
       task :remote => :environment do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",       :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",  :type => :string
-          opt :uri_password,     "Destination depot password",  :type => :string
-          opt :username,         "Username",                    :type => :string
-          opt :password,         "Password",                    :type => :string
-          opt :hostname,         "Hostname",                    :type => :string
-          opt :dbname,           "Database name",               :type => :string
-        end
+        opts = EvmDba.with_options(:remote_uri, :db_credentials)
 
-        db_opts = {}
-        [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
-
-        connect_opts = {}
-        [:uri, :uri_username, :uri_password].each { |k| connect_opts[k] = opts[k] if opts[k] }
-        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+        db_opts      = EvmDba.collect_db_opts(opts)
+        connect_opts = EvmDba.collect_connect_opts(opts)
 
         # If running through runner, disconnect any local connections
         ActiveRecord::Base.clear_all_connections! if ActiveRecord && ActiveRecord::Base

--- a/spec/lib/manageiq/util/file_splitter_spec.rb
+++ b/spec/lib/manageiq/util/file_splitter_spec.rb
@@ -1,0 +1,180 @@
+require 'tempfile'
+require 'pathname'
+require 'manageiq/util/file_splitter'
+
+module ManageIQ::Util
+  describe FileSplitter do
+    shared_context "generated tmp files" do
+      let!(:tmpfile_size) { 10.megabytes }
+      let!(:source_path)  { Pathname.new(source_file.path) }
+      let!(:source_file) do
+        Tempfile.new("source_file").tap do |file|
+          file.write("0" * tmpfile_size)
+          file.close
+        end
+      end
+
+      after do
+        source_file.unlink
+        Dir["#{source_path.expand_path}.*"].each do |file|
+          File.delete(file)
+        end
+      end
+    end
+
+    describe ".run" do
+      include_context "generated tmp files"
+
+      it "splits a file by 10MB by default" do
+        FileSplitter.run(:input_file => File.open(source_path))
+        expected_splitfiles = [source_path.dirname.join("#{source_path.basename}.00001")]
+
+        expected_splitfiles.each do |filename|
+          expect(File.exist?(filename.to_s)).to be true
+          expect(Pathname.new(filename).lstat.size).to eq(10.megabyte)
+        end
+      end
+
+      it "splits a file by 1MB when specified" do
+        FileSplitter.run(:byte_count => 1.megabyte, :input_file => File.open(source_path))
+        expected_splitfiles = (1..10).map do |suffix|
+          source_path.dirname.join("#{source_path.basename}.000#{'%02d' % suffix}")
+        end
+
+        expected_splitfiles.each do |filename|
+          expect(File.exist?(filename.to_s)).to be true
+          expect(Pathname.new(filename).lstat.size).to eq(1.megabyte)
+        end
+      end
+
+      it "can take args from ARGV" do
+        stub_const("ARGV", ["--b", 1.megabyte.to_s, source_path])
+        FileSplitter.run
+        expected_splitfiles = (1..10).map do |suffix|
+          source_path.dirname.join("#{source_path.basename}.000#{'%02d' % suffix}")
+        end
+
+        expected_splitfiles.each do |filename|
+          expect(File.exist?(filename.to_s)).to be true
+          expect(Pathname.new(filename).lstat.size).to eq(1.megabyte)
+        end
+      end
+    end
+
+    describe ".parse_argv" do
+      context "with no args" do
+        before { stub_const("ARGV", []) }
+
+        it "raises an error" do
+          expect { FileSplitter.parse_argv }.to raise_error(ArgumentError)
+        end
+      end
+
+      context "with a source filename" do
+        include_context "generated tmp files"
+        before { stub_const("ARGV", [source_path.to_s]) }
+
+        it "sets :input_file to a file object from the filename" do
+          expected = FileSplitter.parse_argv[:input_file]
+          actual   = File.new(source_path.expand_path)
+          expect(FileUtils.compare_stream(expected, actual)).to be true
+        end
+
+        it "does not set byte_count" do
+          expect(FileSplitter.parse_argv[:byte_count]).to be nil
+        end
+      end
+
+      context "with the source file equaling -" do
+        before { stub_const("ARGV", ["-", "my_pattern"]) }
+
+        it "sets :input_file to nil" do
+          expect(FileSplitter.parse_argv[:input_file]).to eq(nil)
+        end
+
+        it "sets :input_filename to 'my_pattern'" do
+          expect(FileSplitter.parse_argv[:input_filename]).to eq('my_pattern')
+        end
+
+        it "does not set byte_count" do
+          expect(FileSplitter.parse_argv[:byte_count]).to be nil
+        end
+      end
+
+      context "with --byte-count passed in as '1048576' (1 megabyte)" do
+        before { stub_const("ARGV", ["--byte-count", 1.megabyte.to_s, 'my_pattern']) }
+
+        it "sets :input_file to nil" do
+          expect(FileSplitter.parse_argv[:input_file]).to eq(nil)
+        end
+
+        it "sets :input_filename to 'my_pattern'" do
+          expect(FileSplitter.parse_argv[:input_filename]).to eq('my_pattern')
+        end
+
+        it "set byte_count to 1,048,576" do
+          expect(FileSplitter.parse_argv[:byte_count]).to eq(1_048_576)
+        end
+      end
+
+      context "with -b passed in as '1M' (1 megabyte)" do
+        before { stub_const("ARGV", ["-b", "1M", 'my_pattern']) }
+
+        it "sets :input_file to nil" do
+          expect(FileSplitter.parse_argv[:input_file]).to eq(nil)
+        end
+
+        it "sets :input_filename to 'my_pattern'" do
+          expect(FileSplitter.parse_argv[:input_filename]).to eq('my_pattern')
+        end
+
+        it "set byte_count to 1,048,576" do
+          expect(FileSplitter.parse_argv[:byte_count]).to eq(1_048_576)
+        end
+      end
+
+      context "with -b passed in as '1k' (1 kilobyte)" do
+        before { stub_const("ARGV", ["-b", "1k", "my_pattern"]) }
+
+        it "sets :input_file to nil" do
+          expect(FileSplitter.parse_argv[:input_file]).to eq(nil)
+        end
+
+        it "set byte_count to 1048576" do
+          expect(FileSplitter.parse_argv[:byte_count]).to eq(1024)
+        end
+      end
+    end
+
+    describe "running as a command" do
+      include_context "generated tmp files"
+
+      let(:script_file) { Rails.root.join("lib", "manageiq", "util", "file_splitter.rb") }
+
+      it "can pipe output from another command" do
+        `cat #{source_path.expand_path} | #{script_file} -b 2M - #{source_path.expand_path}`
+        expected_splitfiles = (1..5).map do |suffix|
+          source_path.dirname.join("#{source_path.basename}.0000#{suffix}")
+        end
+
+        expected_splitfiles.each do |filename|
+          expect(File.exist?(filename.to_s)).to be true
+          expect(Pathname.new(filename).lstat.size).to eq(2.megabyte)
+        end
+      end
+
+      it "auto determines using a pipe if input file doesn't exist" do
+        # NOTE: ommited the '-' in the cmd
+        `cat #{source_path.expand_path} | #{script_file} -b 2M #{source_path.dirname.join('pattern')}`
+        expected_splitfiles = (1..5).map do |suffix|
+          source_path.dirname.join("pattern.0000#{suffix}")
+        end
+
+        expected_splitfiles.each do |filename|
+          expect(File.exist?(filename.to_s)).to be true
+          expect(Pathname.new(filename).lstat.size).to eq(2.megabyte)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Built off of https://github.com/ManageIQ/manageiq/pull/17549
Update:  Now also built off of https://github.com/ManageIQ/manageiq/pull/17798

Provides support for `evm:db:dump:*` tasks (will support `evm:db:backup` as well) to have the files split into chunks automatically by passing in the `--byte-count` flag to those tasks.

TODO
----

* [x] Vagrantfile and test script for testings these live (in progress)
* [x] Setup `:remote` tasks to use splitting with NFS and SMB end points
  - (want to have test vagrant env in place for this, see above)
  - This will be easy to implement, however, and it will just be adding the `additional_opts` code for the `:remote` tasks as well (see last commit)

Links
-----

* Prerequisites:
  - `pipe` support in `AwesomeSpawn`: https://github.com/ManageIQ/awesome_spawn/pull/41
  - PR to PostgresAdmin providing `:pipe` support to dump and backup:  https://github.com/ManageIQ/manageiq-gems-pending/pull/356
  - File splitter ruby script:  https://github.com/ManageIQ/manageiq/pull/17549

Steps for Testing/QA
--------------------

~~I currently am using the above prerequisites locally to test (probably a gist with a `Vagrantfile` plus test script).  Will provide detailed instructions soon.~~

**UPDATE:**  Vagrant environment for testing this code, with a README on how to use it, can be found here:

https://gist.github.com/NickLaMuro/8438015363d90a2d2456be650a2b9bc6