### PR TITLE
Add display name for PhysicalSwitch model

### DIFF
--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -24,4 +24,8 @@ class PhysicalSwitch < Switch
 
     EmsRefresh.queue_refresh(ext_management_system)
   end
+
+  def self.display_name(number = 1)
+    n_('Physical Switch', 'Physical Switches', number)
+  end
 end

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -908,6 +908,7 @@ en:
       ManageIQ::Providers::Vmware::CloudManager::OrchestrationTemplate:    vApp Template
       PersistentVolume:         Persistent Volume
       PhysicalServer:           Physical Server
+      PhysicalSwitch:           Physical Switch
       PolicyEvent:              Policy Event
       ProductUpdate:            Product Update
       PxeCustomizationTemplate: Customization Template


### PR DESCRIPTION
Added both into `locale/en.yml` and the model itself.