### PR TITLE
Remove Request taggable and prevent tag filtering

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -12,8 +12,6 @@ class MiqRequest < ApplicationRecord
   has_many   :miq_approvals,     :dependent   => :destroy
   has_many   :miq_request_tasks, :dependent   => :destroy
 
-  acts_as_miq_taggable
-
   alias_attribute :state, :request_state
 
   serialize   :options, Hash

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -54,7 +54,7 @@ module Rbac
       VmOrTemplate
     )
 
-    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder) + %w(MiqGroup User Tenant)
+    TAGGABLE_FILTER_CLASSES = CLASSES_THAT_PARTICIPATE_IN_RBAC - %w(EmsFolder MiqRequest) + %w(MiqGroup User Tenant)
 
     NETWORK_MODELS_FOR_BELONGSTO_FILTER = %w(
       CloudNetwork


### PR DESCRIPTION
MiqRequest was changed to allow ownership for self service and limited
self-service users in ManageIQ #17208, BZ #1545395

This caused a problem if you had tag filters assign to a user's group:
`undefined method `find_tags_by_grouping'`

This was fixed in ManageIQ #17466, BZ #1576129, and shipped with:

Fine: BZ #1583711
Gaprindindashvili: BZ #1583710

Unfortunately, this second fix to add taggable caused a new bug: users in
groups having tag filters could not see their own requests.

This commit changes MiqRequest to no longer be taggable, since it's not
even taggable in the UI and instead, we add MiqRequest to a list of
models that are RBAC'able but not taggable so we don't try to filter
MiqRequest based on a user's group tag filters.

Credit goes to github user LorkScorguar who reported this issue and
provided lots of diagnostics to help us fix this properly.

To test this, simply assign managed filters to a user's group, such as
/managed/environments/production, create a request for that user and
try to see that user's request.  They couldn't see it if they received
the intermediate fix, #17466, or if they didn't receive that fix, they'd
receive the `find_tags_by_grouping` error shown above.

For gaprindashvili and fine:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596738

For hammer:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1576129