### PR TITLE
Add :limit to SupportsFeatureMixin for Ansible job/workflow template dialog.

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -96,6 +96,7 @@ module SupportsFeatureMixin
     :launch_mks_console                  => 'Launch WebMKS Console',
     :launch_spice_console                => 'Launch Spice Console',
     :admin_ui                            => 'Open Admin UI for a Provider',
+    :limit                               => 'Limit Option for Ansible Job Template',
     :live_migrate                        => 'Live Migration',
     :migrate                             => 'Migration',
     :capture                             => 'Capture of Capacity & Utilization Metrics',


### PR DESCRIPTION
:limit is supported by Ansbile job template but not workflow template.

Blocks https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/103.

https://bugzilla.redhat.com/show_bug.cgi?id=1590975

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement