### PR TITLE
ConfigurationWorkflow to exist only in AutomationManager space

### DIFF
--- a/app/models/configuration_script.rb
+++ b/app/models/configuration_script.rb
@@ -2,5 +2,4 @@ class ConfigurationScript < ConfigurationScriptBase
   def self.base_model
     ConfigurationScript
   end
-  belongs_to :manager, :class_name => "ExtManagementSystem", :inverse_of => :configuration_scripts
 end

--- a/app/models/configuration_script.rb
+++ b/app/models/configuration_script.rb
@@ -2,4 +2,5 @@ class ConfigurationScript < ConfigurationScriptBase
   def self.base_model
     ConfigurationScript
   end
+  belongs_to :manager, :class_name => "ExtManagementSystem", :inverse_of => :configuration_scripts_and_workflows
 end

--- a/app/models/configuration_script.rb
+++ b/app/models/configuration_script.rb
@@ -2,5 +2,5 @@ class ConfigurationScript < ConfigurationScriptBase
   def self.base_model
     ConfigurationScript
   end
-  belongs_to :manager, :class_name => "ExtManagementSystem", :inverse_of => :configuration_scripts_and_workflows
+  belongs_to :manager, :class_name => "ExtManagementSystem", :inverse_of => :configuration_scripts
 end

--- a/app/models/configuration_workflow.rb
+++ b/app/models/configuration_workflow.rb
@@ -1,5 +1,0 @@
-class ConfigurationWorkflow < ConfigurationScriptBase
-  def self.base_model
-    ConfigurationWorkflow
-  end
-end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -76,6 +76,12 @@ class ExtManagementSystem < ApplicationRecord
   has_many :miq_events,             :as => :target, :dependent => :destroy
   has_many :cloud_subnets, :foreign_key => :ems_id, :dependent => :destroy
 
+  has_many :configuration_scripts_and_workflows,
+           :class_name  => 'ConfigurationScript',
+           :dependent   => :destroy,
+           :foreign_key => "manager_id",
+           :inverse_of  => :manager
+
   validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
   validates :hostname, :presence => true, :if => :hostname_required?
   validate :hostname_uniqueness_valid?, :hostname_format_valid?, :if => :hostname_required?

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -76,8 +76,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :miq_events,             :as => :target, :dependent => :destroy
   has_many :cloud_subnets, :foreign_key => :ems_id, :dependent => :destroy
 
-  has_many :configuration_scripts_and_workflows,
-           :class_name  => 'ConfigurationScript',
+  has_many :configuration_scripts,
            :dependent   => :destroy,
            :foreign_key => "manager_id",
            :inverse_of  => :manager

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -11,7 +11,6 @@ class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
 
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_workflows,      :dependent => :destroy, :foreign_key => "manager_id", :inverse_of => :manager
   has_many :credentials,                  :class_name => "ManageIQ::Providers::AutomationManager::Authentication",
            :as => :resource, :dependent => :destroy

--- a/app/models/manageiq/providers/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/automation_manager/configuration_workflow.rb
@@ -1,3 +1,3 @@
-class ManageIQ::Providers::AutomationManager::ConfigurationWorkflow < ::ConfigurationWorkflow
+class ManageIQ::Providers::AutomationManager::ConfigurationWorkflow < ::ConfigurationScript
   belongs_to :manager, :class_name => "ManageIQ::Providers::AutomationManager", :inverse_of => :configuration_workflows
 end

--- a/app/models/manager_refresh/inventory/core.rb
+++ b/app/models/manager_refresh/inventory/core.rb
@@ -43,7 +43,7 @@ module ManagerRefresh::Inventory::Core
 
     def has_configuration_workflows(options = {})
       has_inventory({
-        :model_class                 => ::ConfigurationWorkflow,
+        :model_class                 => ManageIQ::Providers::AutomationManager::ConfigurationWorkflow,
         :manager_ref                 => [:manager_ref],
         :inventory_object_attributes => %i(name description survey_spec variables),
       }.merge(options))

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -704,6 +704,7 @@ en:
       ContainerQuota:           Container Quota
       CustomButton:             Button
       CustomButtonSet:          Button Group
+      ConfigurationScript:      Template (Ansible Tower)
       ConfigurationScriptSource: Repository
       Container:                Container
       ContainerPerformance:     Performance - Container
@@ -774,6 +775,7 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential:     Credential (VMware)
       ManageIQ::Providers::AnsibleTower::AutomationManager:                 Automation Manager (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript: Job Template (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow: Workflow Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook: Playbook (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -11,7 +11,9 @@ FactoryGirl.define do
           :parent => :configuration_script_payload
 
   factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
-  factory :configuration_workflow, :class => "ConfigurationWorkflow", :parent => :configuration_script_base
+  factory :configuration_workflow,
+          :class  => "ManageIQ::Providers::AutomationManager::ConfigurationWorkflow",
+          :parent => :configuration_script
   factory :ansible_configuration_script,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
           :parent => :configuration_script


### PR DESCRIPTION
This is to support UI's need to get back both `configuration_script`(JobTemplate) and `configuration_workflow`(Workflow Template) with single query.

(To implement the discussed approach in https://github.com/ManageIQ/manageiq/pull/17580)

## Current Class Hierachy
![current workflow class hierachy 2](https://user-images.githubusercontent.com/2421248/43101360-35a0eeea-8e96-11e8-9c98-bc8494bd954c.png)

## New Class Hierachy

![untitled drawing](https://user-images.githubusercontent.com/2421248/42534613-17bbd6fa-845b-11e8-94c8-7cfe47dff78c.png)
