### PR TITLE
Add relationship between [physical switch and physical chassis] and event stream

### DIFF
--- a/app/models/event_stream.rb
+++ b/app/models/event_stream.rb
@@ -27,6 +27,8 @@ class EventStream < ApplicationRecord
 
   belongs_to :middleware_server, :foreign_key => :middleware_server_id
   belongs_to :physical_server
+  belongs_to :physical_chassis, :inverse_of => :event_streams
+  belongs_to :physical_switch, :inverse_of => :event_streams
 
   virtual_column :group,       :type => :string
   virtual_column :group_level, :type => :string

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -1,10 +1,14 @@
 class PhysicalSwitch < Switch
+  include SupportsFeatureMixin
+  include EventMixin
+
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :physical_switches,
     :class_name => "ManageIQ::Providers::PhysicalInfraManager"
 
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => :resource
   has_one :hardware, :dependent => :destroy, :foreign_key => :switch_id, :inverse_of => :physical_switch
   has_many :physical_network_ports, :dependent => :destroy, :foreign_key => :switch_id
+  has_many :event_streams, :inverse_of => :physical_switch, :dependent => :nullify
 
   def my_zone
     ems = ext_management_system
@@ -23,6 +27,10 @@ class PhysicalSwitch < Switch
     end
 
     EmsRefresh.queue_refresh(ext_management_system)
+  end
+
+  def event_where_clause(assoc = :ems_events)
+    ["#{events_table_name(assoc)}.physical_switch_id = ?", id]
   end
 
   def self.display_name(number = 1)


### PR DESCRIPTION
This PR is able to add a relationship between `physical_switch` - `event_stream` and `physical_chassis` - `event_stream`

Depends on: ~https://github.com/ManageIQ/manageiq-schema/pull/229~