### PR TITLE
Miq server zone description

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -19,6 +19,8 @@ class MiqServer < ApplicationRecord
   acts_as_miq_taggable
   include RelationshipMixin
 
+  alias_attribute :description, :name
+
   belongs_to              :vm, :inverse_of => :miq_server
   belongs_to              :zone
   has_many                :messages,  :as => :handler, :class_name => 'MiqQueue'

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -29,14 +29,12 @@ class MiqServer < ApplicationRecord
   before_destroy          :validate_is_deleteable
   after_destroy           :destroy_linked_events_queue
 
-  virtual_column :zone_description, :type => :string
-
   default_value_for(:name, "EVM")
   default_value_for(:zone) { Zone.default_zone }
 
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
-  delegate :description, :to => :zone, :prefix => true
+  virtual_delegate :description, :to => :zone, :prefix => true
 
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -456,4 +456,11 @@ describe MiqServer do
       expect(miq_server.zone_description).to eq(zone.description)
     end
   end
+
+  describe "#description" do
+    it "doesnt blowup" do
+      s = described_class.new(:name => "name")
+      expect(s.description).to eq(s.name)
+    end
+  end
 end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -449,4 +449,11 @@ describe MiqServer do
       expect(described_class.new(:status => "stopped").active?).to be_falsey
     end
   end
+
+  describe "#zone_description" do
+    it "delegates to zone" do
+      _, miq_server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      expect(miq_server.zone_description).to eq(zone.description)
+    end
+  end
 end


### PR DESCRIPTION
1. most ui objects have a description. MiqServer does not. The ui server list (used by alert profiles view) blows up when fetching a server without a name.

2. MiqServer#zone_description is a typical virtual delegate. a virtual column that is delegated to another model

This is not a BZ bug, but it makes the screen blow up. so I've marked it as a bug