### PR TITLE
remote log/.gitkeep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
 addons:
   postgresql: '9.5'
 before_install:
+- mkdir ${TRAVIS_BUILD_DIR}/log
 - source ${TRAVIS_BUILD_DIR}/tools/ci/before_install.sh
 before_script:
 - bundle exec rake test:$TEST_SUITE:setup

--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,7 @@ end
 
 Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.ensure_config_files
+  Dir.mkdir("log") unless File.exist?("log")
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler


### PR DESCRIPTION
Our appliances link log to a different direction.
This means it will always be a modified git tree.
Git stash does not work across symbolic links. so it makes patching and git
functions difficult on the appliance

Not sure the downside of not having a `log` directory by default on a developer's rails machine.
The only downside I can see.