### PR TITLE
ContainerImage deleting

### DIFF
--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -1,6 +1,6 @@
 class ContainerImageRegistry < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
-  has_many :container_images, :dependent => :destroy # What about deleted registry but containers are still running
+  has_many :container_images, :dependent => :nullify
   has_many :containers, :through => :container_images
   has_many :container_services
   has_many :container_groups, :through => :container_services

--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -17,7 +17,7 @@ module ManageIQ::Providers
     has_many :container_quotas, -> { active }, :foreign_key => :ems_id
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
-    has_many :container_images, -> { active }, :foreign_key => :ems_id
+    has_many :container_images, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
     has_many :persistent_volumes, :as => :parent, :dependent => :destroy
     has_many :persistent_volume_claims, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_builds, :foreign_key => :ems_id, :dependent => :destroy


### PR DESCRIPTION
- [ ] **dependent** https://github.com/ManageIQ/manageiq-providers-openshift/pull/101

ContainerImageRegistry association can destroy ContainerImage, but all images have to be archived due to reports and chargebacks.

Solves OpenShift pending specs