### PR TITLE
[GAPRINDASHVILI] Update cop namespace

### DIFF
--- a/app/models/manager_refresh/inventory/middleware_manager.rb
+++ b/app/models/manager_refresh/inventory/middleware_manager.rb
@@ -5,7 +5,7 @@ module ManagerRefresh::Inventory::MiddlewareManager
   COMMON_ATTRIBUTES = %i(name ems_ref nativeid properties feed).freeze
 
   class_methods do
-    # rubocop:disable Style/PredicateName
+    # rubocop:disable Naming/PredicateName
     def has_middleware_manager_domains(options = {})
       has_inventory({
         :model_class                 => provider_module::MiddlewareManager::MiddlewareDomain,
@@ -59,6 +59,6 @@ module ManagerRefresh::Inventory::MiddlewareManager
         :builder_params              => { :ext_management_system => ->(persister) { persister.manager } }
       }.merge(options))
     end
-    # rubocop:enable Style/PredicateName
+    # rubocop:enable Naming/PredicateName
   end
 end


### PR DESCRIPTION
Rubocop currently gets `app/models/manager_refresh/inventory/middleware_manager.rb: Style/PredicateName has the wrong namespace - should be Naming`