### PR TITLE
Notify users of killing workers when exceed memory

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -309,6 +309,7 @@ class MiqAction < ApplicationRecord
         :header            => "Alert Triggered",
         :policy_detail     => "Alert '#{inputs[:policy].description}', triggered",
         :event_description => inputs[:event].description,
+        :event_details     => Notification.notification_text(inputs[:triggering_type], inputs[:triggering_data]),
         :entity_type       => rec.class.to_s,
         :entity_name       => rec.name
       }

--- a/app/models/miq_event.rb
+++ b/app/models/miq_event.rb
@@ -40,7 +40,7 @@ class MiqEvent < EventStream
       return
     end
 
-    event_obj = build_evm_event(event, target)
+    event_obj = build_evm_event(event, target, inputs[:full_data])
     inputs.merge!('MiqEvent::miq_event' => event_obj.id, :miq_event_id => event_obj.id)
     inputs.merge!('EventStream::event_stream' => event_obj.id, :event_stream_id => event_obj.id)
 
@@ -61,6 +61,8 @@ class MiqEvent < EventStream
     results = {}
     inputs[:type] ||= target.class.name
     inputs[:source_event] = source_event if source_event
+    inputs[:triggering_type] = event_type
+    inputs[:triggering_data] = full_data
 
     _log.info("Event Raised [#{event_type}]")
     begin
@@ -79,10 +81,11 @@ class MiqEvent < EventStream
     results
   end
 
-  def self.build_evm_event(event, target)
+  def self.build_evm_event(event, target, full_data = nil)
     options = {
       :event_type => event,
       :target     => target,
+      :full_data  => full_data,
       :source     => 'POLICY',
       :timestamp  => Time.now.utc
     }

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -25,7 +25,15 @@ module MiqServer::WorkerManagement::Monitor::Validation
     if MiqWorker::STATUSES_CURRENT.include?(w.status) && usage_exceeds_threshold?(usage, memory_threshold)
       msg = "#{w.format_full_log_msg} process memory usage [#{usage}] exceeded limit [#{memory_threshold}], requesting worker to exit"
       _log.warn(msg)
-      MiqEvent.raise_evm_event_queue(w.miq_server, "evm_worker_memory_exceeded", :event_details => msg, :type => w.class.name)
+      full_data = {
+        :name             => w.type,
+        :memory_usage     => ActiveSupport::NumberHelper.number_to_human_size(usage),
+        :memory_threshold => ActiveSupport::NumberHelper.number_to_human_size(memory_threshold),
+      }
+      MiqEvent.raise_evm_event_queue(w.miq_server, "evm_worker_memory_exceeded",
+                                     :event_details => msg,
+                                     :type          => w.class.name,
+                                     :full_data     => full_data)
       restart_worker(w)
       return false
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -25,7 +25,10 @@ class Notification < ApplicationRecord
   def self.emit_for_event(event)
     return unless NotificationType.names.include?(event.event_type)
     type = NotificationType.find_by(:name => event.event_type)
-    Notification.create(:notification_type => type, :subject => event.target)
+    return unless type.enabled?
+    Notification.create(:notification_type => type,
+                        :options           => event.full_data,
+                        :subject           => event.target)
   end
 
   def to_h
@@ -39,6 +42,12 @@ class Notification < ApplicationRecord
 
   def seen_by_all_recipients?
     notification_recipients.unseen.empty?
+  end
+
+  def self.notification_text(name, message_params)
+    return unless message_params && NotificationType.names.include?(name)
+    type = NotificationType.find_by(:name => name)
+    type.message % message_params
   end
 
   private

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -4,6 +4,8 @@ class NotificationType < ApplicationRecord
   AUDIENCE_TENANT = 'tenant'.freeze
   AUDIENCE_GLOBAL = 'global'.freeze
   AUDIENCE_SUPERADMIN = 'superadmin'.freeze
+  # don't send out notifications, but keep the template around
+  AUDIENCE_NONE = 'none'.freeze
   has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
@@ -27,7 +29,15 @@ class NotificationType < ApplicationRecord
       end.try(:user_ids)
     when AUDIENCE_SUPERADMIN
       User.superadmins.pluck(:id)
+    when AUDIENCE_NONE
+      []
     end
+  end
+
+  # this disables notifications, but allows the notification to still exist
+  # this notification template can be used for emails
+  def enabled?
+    audience != AUDIENCE_NONE
   end
 
   def self.names

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -264,3 +264,8 @@
   :expires_in: 24.hours
   :level: :error
   :audience: superadmin
+- :name: evm_worker_memory_exceeded
+  :message: 'Killing worker %{name} due to excessive memory usage. %{memory_usage} used memory exceeds limit of %{memory_threshold}.'
+  :expires_in: 24.hours
+  :level: :error
+  :audience: none

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -131,4 +131,25 @@ describe Notification, :type => :model do
       expect(notification.seen_by_all_recipients?).to be_truthy
     end
   end
+
+  describe '.notification_text' do
+    before do
+      NotificationType.instance_variable_set(:@names, nil)
+      NotificationType.seed if NotificationType.all.empty?
+    end
+
+    it 'does not lookup notificaiton type without event or full_data' do
+      NotificationType.names
+      expect do
+        Notification.notification_text(nil, nil)
+        Notification.notification_text('abc', nil)
+        Notification.notification_text(nil, {})
+      end.to match_query_limit_of(0)
+    end
+
+    it 'applies message' do
+      full_data = {:subject => 'vm1'}
+      expect(Notification.notification_text('vm_retired', full_data)).to eq("Virtual Machine vm1 has been retired.")
+    end
+  end
 end


### PR DESCRIPTION
### Overview

Notifications provide information about events to users.
The workflows for larger customers rely more upon email than logging into the console.

manageiq can send out emails for these events using alerts. These emails do not have the rich information that the notifications provide.

In our particular case, when a workers is killed, only the server information is provided, not the worker itself.

---

### Before

Alert Triggered
Alert 'aKB Worker killed', triggered

Event: | Alert condition met
-- | --
Entity: | (MiqServer) local

---

### After

Alert Triggered
Alert 'aKB Worker killed', triggered

|Event: | Alert condition met
|-- | --
|Entity: | (MiqServer) local
|Details: | Killing worker MiqPriorityWorker due to excessive memory usage. 144.6 MB used memory exceeds limit of 100 MB.

---

This PR adds a details section to the Alert emails.

- Improves information for out of memory events
- Add notification text for out of memory errors
- Introduce ability to disable notification while keeping the notification template
- Include `notification#message` in alert emails

Followup:

- [x] Put gook into Email https://github.com/ManageIQ/manageiq-ui-classic/pull/4291

https://bugzilla.redhat.com/show_bug.cgi?id=1535177

