### PR TITLE
[WIP] Load decorators from the manageiq-decorators plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,6 +168,14 @@ group :rest_api, :manageiq_default do
   manageiq_plugin "manageiq-api"
 end
 
+# FIXME: uncomment this after the decorator repo has been created
+# group :decorators, :manageiq_default do
+#   manageiq_plugin "manageiq-decorators"
+# end
+
+# FIXME: delete this after the decorator repo has been created
+gem 'manageiq-decorators', :git => "https://github.com/skateman/manageiq-decorators"
+
 group :graphql_api, :manageiq_default do
   manageiq_plugin "manageiq-graphql"
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -15,7 +15,7 @@ class ApplicationRecord < ActiveRecord::Base
   extend ArTableLock
 
   # FIXME: UI code - decorator support
-  if defined?(ManageIQ::UI::Classic::Engine)
+  if defined?(ManageIQ::Decorators::Engine)
     extend MiqDecorator::Klass
     include MiqDecorator::Instance
   end


### PR DESCRIPTION
This will allow us to use decorators independently from the classic UI.

Related issue: https://github.com/ManageIQ/manageiq/issues/17675

@miq-bot add_label gaprindashvili/no
@miq-bot add_reviewer @martinpovolny 