### PR TITLE
Validate name uniqueness for Transformation Plans

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -32,6 +32,8 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     nil
   end
 
+  validates :name, :presence => true, :uniqueness => {:scope => [:tenant_id]}
+
   # create ServiceTemplate and supporting ServiceResources and ResourceActions
   # options
   #   :name

--- a/spec/factories/service_template.rb
+++ b/spec/factories/service_template.rb
@@ -3,7 +3,9 @@ FactoryGirl.define do
   factory :service_template_orchestration, :class => 'ServiceTemplateOrchestration', :parent => :service_template
   factory :service_template_ansible_playbook, :class => 'ServiceTemplateAnsiblePlaybook', :parent => :service_template
   factory :service_template_container_template, :class => 'ServiceTemplateContainerTemplate', :parent => :service_template
-  factory :service_template_transformation_plan, :class => 'ServiceTemplateTransformationPlan', :parent => :service_template
+  factory :service_template_transformation_plan, :class => 'ServiceTemplateTransformationPlan', :parent => :service_template do
+    sequence(:name) { |n| "service_template_#{seq_padded_for_sorting(n)}" }
+  end
 
   trait :with_provision_resource_action_and_dialog do
     after(:create) do |x|

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -61,5 +61,12 @@ describe ServiceTemplateTransformationPlan do
         described_class.create_catalog_item(catalog_item_options)
       end.to raise_error(StandardError, 'Must select a list of valid vms')
     end
+
+    it 'validates unique name' do
+      described_class.create_catalog_item(catalog_item_options)
+      expect { described_class.create_catalog_item(catalog_item_options) }.to raise_error(
+        ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken'
+      )
+    end
   end
 end


### PR DESCRIPTION
Add a unique name validation, scoped to the tenant, for
ServiceTemplateTransformationPlans.

https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/451