### PR TITLE
Add explicit Endpoint#to_s method to return url

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -12,6 +12,8 @@ class Endpoint < ApplicationRecord
   after_create  :endpoint_created
   after_destroy :endpoint_destroyed
 
+  delegate :to_s, :to => :url, :allow_nil => true
+
   def endpoint_created
     resource.endpoint_created(role) if resource.respond_to?(:endpoint_created)
   end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -127,4 +127,15 @@ describe Endpoint do
       expect(endpoint.ssl_cert_store).to be_a(OpenSSL::X509::Store)
     end
   end
+
+  context "to_s" do
+    it "returns the url if set" do
+      allow(endpoint).to receive(:url).and_return('https://www.foo.bar')
+      expect(endpoint.to_s).to eql('https://www.foo.bar')
+    end
+
+    it "returns a blank string if the url is not set" do
+      expect(endpoint.to_s).to eql('')
+    end
+  end
 end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -130,7 +130,7 @@ describe Endpoint do
 
   context "to_s" do
     it "returns the url if set" do
-      allow(endpoint).to receive(:url).and_return('https://www.foo.bar')
+      endpoint.url = 'https://www.foo.bar'
       expect(endpoint.to_s).to eql('https://www.foo.bar')
     end
 


### PR DESCRIPTION
Just a handy method to return the url of the endpoint when `Endpoint#to_s` is called.

This will be useful for endpoint support for Azure and Amazon, where internally I can call `.to_s` and it won't matter if it's a URI object or and Endpoint object, it will return what I expect - the url. Currently it just returns the object ID, which is not useful, and forces `kind_of` checks and whatnot.