### PR TITLE
Remove generic object from all related services before destroy

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -18,6 +18,7 @@ class GenericObject < ApplicationRecord
 
   delegate :name, :to => :generic_object_definition, :prefix => true, :allow_nil => false
   virtual_column :generic_object_definition_name, :type => :string
+  before_destroy :remove_go_from_all_related_services
 
   def initialize(attributes = {})
     # generic_object_definition will be set first since hash iteration is based on the order of key insertion
@@ -199,5 +200,11 @@ class GenericObject < ApplicationRecord
 
     ws = MiqAeEngine.deliver(options)
     ws.root['method_result']
+  end
+
+  def remove_go_from_all_related_services
+    ServiceResource.where(:resource => self).each do |resource|
+      remove_from_service(resource.service) if resource.service
+    end
   end
 end

--- a/spec/models/generic_object_spec.rb
+++ b/spec/models/generic_object_spec.rb
@@ -352,6 +352,14 @@ describe GenericObject do
       go.remove_from_service(service)
       expect(service.generic_objects).to be_blank
     end
+
+    it 'removes the generic object from all related services before destroy' do
+      go.add_to_service(service)
+      expect(service.generic_objects).to include(go)
+
+      go.destroy
+      expect(service.generic_objects).to be_blank
+    end
   end
 
   context "custom buttons" do


### PR DESCRIPTION
Calling the `generic_objects` method from the `service` model returns array of GenericObjects and nils(for allready destroyed objects), which makes some UI crashes. So we decided to remove a GO from all related services in the `#before_destroy` callback. This PR is based on the BZ bellow.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1595149
