### PR TITLE
Refactor service_type to use constants

### DIFF
--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -313,7 +313,7 @@ module MiqProvisionQuotaMixin
   def service_quota_values(request, result)
     return unless request.service_template
     request.service_template.service_resources.each do |sr|
-      if request.service_template.service_type == 'composite'
+      if request.service_template.service_type == ServiceTemplate::SERVICE_TYPE_COMPOSITE
         bundle_quota_values(sr, result)
       else
         next if request.service_template.prov_type.starts_with?("generic")

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -25,6 +25,9 @@ class ServiceTemplate < ApplicationRecord
     "vmware"                     => N_("VMware")
   }.freeze
 
+  SERVICE_TYPE_ATOMIC    = 'atomic'.freeze
+  SERVICE_TYPE_COMPOSITE = 'composite'.freeze
+
   RESOURCE_ACTION_UPDATE_ATTRS = [:dialog,
                                   :dialog_id,
                                   :fqname,
@@ -65,7 +68,7 @@ class ServiceTemplate < ApplicationRecord
   virtual_column   :archived,                     :type => :boolean
   virtual_column   :active,                       :type => :boolean
 
-  default_value_for :service_type, 'unknown'
+  default_value_for :service_type, SERVICE_TYPE_ATOMIC
   default_value_for(:generic_subtype) { |st| 'custom' if st.prov_type == 'generic' }
 
   virtual_has_one :config_info, :class_name => "Hash"
@@ -206,37 +209,19 @@ class ServiceTemplate < ApplicationRecord
     svc
   end
 
-  def set_service_type
-    svc_type = nil
-
-    if service_resources.size.zero?
-      svc_type = 'unknown'
-    else
-      service_resources.each do |sr|
-        if sr.resource_type == 'Service' || sr.resource_type == 'ServiceTemplate'
-          svc_type = 'composite'
-          break
-        end
-      end
-      svc_type = 'atomic' if svc_type.blank?
-    end
-
-    self.service_type = svc_type
-  end
-
   def composite?
-    service_type.to_s.include?('composite')
+    service_type.to_s.include?(self.class::SERVICE_TYPE_COMPOSITE)
   end
 
   def atomic?
-    service_type.to_s.include?('atomic')
+    service_type.to_s.include?(self.class::SERVICE_TYPE_ATOMIC)
   end
 
   def type_display
     case service_type
-    when "atomic"    then "Item"
-    when "composite" then "Bundle"
-    when nil         then "Unknown"
+    when self.class::SERVICE_TYPE_ATOMIC    then "Item"
+    when self.class::SERVICE_TYPE_COMPOSITE then "Bundle"
+    when nil                                then "Unknown"
     else
       service_type.to_s.capitalize
     end
@@ -452,7 +437,7 @@ class ServiceTemplate < ApplicationRecord
 
   def add_resource(rsc, options = {})
     super
-    set_service_type
+    adjust_service_type
   end
 
   def self.display_name(number = 1)
@@ -537,5 +522,17 @@ class ServiceTemplate < ApplicationRecord
 
   def generic_custom_buttons
     CustomButton.buttons_for("Service")
+  end
+
+  def adjust_service_type
+    svc_type = self.class::SERVICE_TYPE_ATOMIC
+    service_resources.try(:each) do |sr|
+      if sr.resource_type == 'Service' || sr.resource_type == 'ServiceTemplate'
+        svc_type = self.class::SERVICE_TYPE_COMPOSITE
+        break
+      end
+    end
+
+    self.service_type = svc_type
   end
 end

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -38,7 +38,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   #     :reconfigure (same as provision)
   #
   def self.create_catalog_item(options, auth_user)
-    options      = options.merge(:service_type => 'atomic', :prov_type => 'generic_ansible_playbook')
+    options      = options.merge(:service_type => SERVICE_TYPE_ATOMIC, :prov_type => 'generic_ansible_playbook')
     service_name = options[:name]
     description  = options[:description]
     config_info  = validate_config_info(options[:config_info])
@@ -115,7 +115,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   private_class_method :build_parameter_list
 
   def self.validate_config_info(info)
-    info[:provision][:fqname]   ||= default_provisioning_entry_point('atomic') if info.key?(:provision)
+    info[:provision][:fqname]   ||= default_provisioning_entry_point(SERVICE_TYPE_ATOMIC) if info.key?(:provision)
     info[:reconfigure][:fqname] ||= default_reconfiguration_entry_point if info.key?(:reconfigure)
 
     if info.key?(:retirement)

--- a/app/models/service_template_container_template.rb
+++ b/app/models/service_template_container_template.rb
@@ -18,7 +18,7 @@ class ServiceTemplateContainerTemplate < ServiceTemplateGeneric
   #       :container_template_id or :container_template
   #
   def self.create_catalog_item(options, _auth_user = nil)
-    options     = options.merge(:service_type => 'atomic', :prov_type => 'generic_container_template')
+    options     = options.merge(:service_type => SERVICE_TYPE_ATOMIC, :prov_type => 'generic_container_template')
     config_info = validate_config_info(options[:config_info])
     enhanced_config = config_info.deep_merge(
       :provision => {
@@ -34,7 +34,7 @@ class ServiceTemplateContainerTemplate < ServiceTemplateGeneric
   end
 
   def self.validate_config_info(info)
-    info[:provision][:fqname] ||= default_provisioning_entry_point('atomic') if info.key?(:provision)
+    info[:provision][:fqname] ||= default_provisioning_entry_point(SERVICE_TYPE_ATOMIC) if info.key?(:provision)
 
     # TODO: Add more validation for required fields
     info

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -49,7 +49,6 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     enhanced_config_info = validate_config_info(options)
     default_options =  {
       :display      => false,
-      :service_type => 'atomic',
       :prov_type    => 'transformation_plan'
     }
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -219,18 +219,29 @@ describe ServiceTemplate do
       @st1 = FactoryGirl.create(:service_template, :name => 'Service Template 1')
     end
 
-    it "with service_type of unknown" do
-      expect(@st1.type_display).to eq('Unknown')
+    it "with default service_type" do
+      expect(@st1.service_type).to eq("atomic")
+      expect(@st1.type_display).to eq('Item')
     end
 
     it "with service_type of atomic" do
-      @st1.update_attributes(:service_type => 'atomic')
+      @st1.update_attributes(:service_type => described_class::SERVICE_TYPE_ATOMIC)
       expect(@st1.type_display).to eq('Item')
     end
 
     it "with service_type of composite" do
-      @st1.update_attributes(:service_type => 'composite')
+      @st1.update_attributes(:service_type => described_class::SERVICE_TYPE_COMPOSITE)
       expect(@st1.type_display).to eq('Bundle')
+    end
+
+    it "with user service_type" do
+      @st1.update_attributes(:service_type => 'user')
+      expect(@st1.type_display).to eq('User')
+    end
+
+    it "with no service_type" do
+      @st1.update_attributes(:service_type => nil)
+      expect(@st1.type_display).to eq('Unknown')
     end
   end
 
@@ -240,12 +251,18 @@ describe ServiceTemplate do
     end
 
     it "with service_type of unknown" do
+      @st1.update_attributes(:service_type => 'user')
       expect(@st1.atomic?).to be_falsey
     end
 
     it "with service_type of atomic" do
-      @st1.update_attributes(:service_type => 'atomic')
+      @st1.update_attributes(:service_type => described_class::SERVICE_TYPE_ATOMIC)
       expect(@st1.atomic?).to be_truthy
+    end
+
+    it "with service_type of composite" do
+      @st1.update_attributes(:service_type => described_class::SERVICE_TYPE_COMPOSITE)
+      expect(@st1.atomic?).to be_falsey
     end
   end
 
@@ -255,11 +272,17 @@ describe ServiceTemplate do
     end
 
     it "with service_type of unknown" do
+      @st1.update_attributes(:service_type => 'user')
+      expect(@st1.composite?).to be_falsey
+    end
+
+    it "with service_type of atomic" do
+      @st1.update_attributes(:service_type => described_class::SERVICE_TYPE_ATOMIC)
       expect(@st1.composite?).to be_falsey
     end
 
     it "with service_type of composite" do
-      @st1.update_attributes(:service_type => 'composite')
+      @st1.update_attributes(:service_type => described_class::SERVICE_TYPE_COMPOSITE)
       expect(@st1.composite?).to be_truthy
     end
   end
@@ -438,6 +461,7 @@ describe ServiceTemplate do
     it "should create a valid service template" do
       expect(@st1.guid).not_to be_empty
       expect(@st1.service_resources.size).to eq(0)
+      expect(@st1.service_type).to eq(described_class::SERVICE_TYPE_ATOMIC)
     end
 
     it "should not set the owner for the service template" do
@@ -457,12 +481,6 @@ describe ServiceTemplate do
       expect(@test_service.evm_owner.name).to eq(@user.name)
       expect(@test_service.evm_owner.current_group).not_to be_nil
       expect(@test_service.evm_owner.current_group.description).to eq(@user.current_group.description)
-    end
-
-    it "should create an empty service template without a type" do
-      expect(@st1.service_type).to eq('unknown')
-      expect(@st1.composite?).to be_falsey
-      expect(@st1.atomic?).to be_falsey
     end
 
     it "should create a composite service template" do
@@ -513,12 +531,6 @@ describe ServiceTemplate do
       user         = FactoryGirl.create(:user, :name => 'Fred Flintstone', :userid => 'fred')
       @vm_template = FactoryGirl.create(:template_vmware, :ext_management_system => FactoryGirl.create(:ems_vmware_with_authentication))
       @ptr = FactoryGirl.create(:miq_provision_request_template, :requester => user, :src_vm_id => @vm_template.id)
-    end
-
-    it 'unknown' do
-      expect(@st1.service_type).to eq "unknown"
-      expect(@st1.template_valid?).to be_truthy
-      expect(@st1.template_valid_error_message).to be_nil
     end
 
     context 'atomic' do


### PR DESCRIPTION
Introduce new service type `internal`. This type of service template is intended to be used internally, not directly exposed through catalog. `TransformationPlan` is the first template to have this type.

Internal template is expected to be a single item, not bundled.

New method `ServiceTemplate.public_service_templates` excludes all internal templates. 

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1594408

cc @h-kataria 

[Edit]
It has been decided that we will make a schema change to introduce a new column to flag whether a template is internal.
This PR will remain open for refactoring purpose.