### PR TITLE
Network Subnet total_vms work correctly

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -16,7 +16,7 @@ class CloudSubnet < ApplicationRecord
 
   has_many :cloud_subnet_network_ports, :dependent => :destroy
   has_many :network_ports, :through => :cloud_subnet_network_ports, :dependent => :destroy
-  has_many :vms, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
+  has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
   has_many :cloud_subnets, :foreign_key => :parent_cloud_subnet_id
 
   has_one :public_network, :through => :network_router, :source => :cloud_network


### PR DESCRIPTION

before:

`CloudSubnet#total_vms` does not use `distinct` for the count
`CloudNetwork#total_vms` does

after:

both use `distinct` (since it is going `:through` a `has_many`)

https://bugzilla.redhat.com/show_bug.cgi?id=1595583
