### PR TITLE
fix MiqGroup#miq_user_role_name

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -7,6 +7,8 @@ class Entitlement < ApplicationRecord
 
   validate :one_kind_of_managed_filter
 
+  virtual_delegate :name, :to => :miq_user_role, :allow_nil => true, :prefix => true
+
   def self.valid_filters?(filters_hash)
     return true  unless filters_hash                  # nil ok
     return false unless filters_hash.kind_of?(Hash)   # must be Hash

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -15,7 +15,7 @@ class MiqGroup < ApplicationRecord
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
   has_many   :miq_product_features, :through => :miq_user_role
 
-  virtual_delegate :name, :to => :miq_user_role, :allow_nil => true, :prefix => true
+  virtual_delegate :miq_user_role_name, :to => :entitlement, :allow_nil => true
   virtual_column :read_only,          :type => :boolean
   virtual_has_one :sui_product_features, :class_name => "Array"
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -1,4 +1,6 @@
 describe MiqGroup do
+  include Spec::Support::ArelHelper
+
   describe "#settings" do
     subject { FactoryGirl.create(:miq_group) }
 
@@ -566,6 +568,19 @@ describe MiqGroup do
       allow(role).to receive(:allows?).with(:identifier => 'sui_role_b').and_return(false)
 
       expect(subject.sui_product_features).to eq(%w(sui_role_a sui_role_c))
+    end
+  end
+
+  describe "#miq_user_role_name" do
+    let(:group) { FactoryGirl.build(:miq_group, :role => "the_role") }
+
+    it "calculates in ruby" do
+      expect(group.miq_user_role_name).to eq("EvmRole-the_role")
+    end
+
+    it "calculates in the database" do
+      group.save
+      expect(virtual_column_sql_value(MiqGroup.where(:id => group.id), "miq_user_role_name")).to eq("EvmRole-the_role")
     end
   end
 end


### PR DESCRIPTION
virtual_delegate doesn't work too well with :through
manually unroll the delegate code

introduced in 83ad831146316b65df09eb

https://bugzilla.redhat.com/show_bug.cgi?id=1593171
