### PR TITLE
Support cancellation for miq_request and miq_request_task

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -590,6 +590,14 @@ class MiqRequest < ApplicationRecord
     n_('Request', 'Requests', number)
   end
 
+  def cancel
+    raise _("Cancel operation is not supported for #{self.class.name}")
+  end
+
+  def canceling?
+    false
+  end
+
   private
 
   def clean_up_keys_for_request_task

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -206,6 +206,14 @@ class MiqRequestTask < ApplicationRecord
     n_('Request Task', 'Request Tasks', number)
   end
 
+  def cancel
+    raise _("Cancel operation is not supported for #{self.class.name}")
+  end
+
+  def canceling?
+    false
+  end
+
   private
 
   def validate_request_type

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -23,4 +23,14 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   def approve_vm(vm_id)
     vm_resources.find_by(:resource_id => vm_id).update_attributes!(:status => ServiceResource::STATUS_APPROVED)
   end
+
+  def cancel
+    options['cancel_requested'] = true
+    save!
+    miq_request_tasks.each(&:cancel)
+  end
+
+  def canceling?
+    options['cancel_requested']
+  end
 end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -102,6 +102,15 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     MiqTask.generic_action_with_callback(options, queue_options)
   end
 
+  def cancel
+    options['cancel_requested'] = true
+    save!
+  end
+
+  def canceling?
+    options['cancel_requested']
+  end
+
   private
 
   def vm_resource


### PR DESCRIPTION
There is immediate need from v2v for cancellation at both request and task levels. It is also a long demanded feature.

This PR adds `MiqRequest#cancel_request` and `MiqRequestTask#cancel_task` methods for the API controller to call in order to receive a user action to cancel a request or task.

Methods `MiqRequest#canceling` and `MiqRequestTask#canceling` are for automate to check whether user has requested to cancel. Then automate can attempt to stop its work.

These methods are initially not implemented for all types except transformation plan. The implementation for transformation plan is simply to store flag `cancel_requested` in `options`. This is a temporary solution. Ultimately we want to add `canceling` and `canceled` to allowed states for both request and task.

In this temporary solution we do not define how to report the state change or progress of the cancellation. @fdupont-redhat and @vconzola's team can agree on the keys and messages reading from options. 

Related Links: https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/370

https://bugzilla.redhat.com/show_bug.cgi?id=1564257

cc @bdunne @fdupont-redhat @vconzola @priley86 