### PR TITLE
Use ansible-runner instead of ansible-playbook

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -24,25 +24,21 @@ module Ansible
       private
 
       def run_via_cli(env_vars, extra_vars, playbook_path)
-        prepare_tmp_structure
+        Dir.mktmpdir("ansible-runner") do |base_dir|
+          mkdir(base_dir + '/project') # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
 
-        result = AwesomeSpawn.run!(ansible_command, :env => env_vars, :params => [{:cmdline => "--extra-vars '#{JSON.dump(extra_vars)}'", :playbook => playbook_path}])
-        JSON.parse(result.output)
-      end
-
-      def prepare_tmp_structure
-        base_dir = "/tmp/ansible-runner/"
-        mkdir(base_dir)
-        mkdir(base_dir + 'project') # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
+          result = AwesomeSpawn.run!(ansible_command(base_dir), :env => env_vars, :params => [{:cmdline => "--extra-vars '#{JSON.dump(extra_vars)}'", :playbook => playbook_path}])
+          JSON.parse(result.output)
+        end
       end
 
       def mkdir(base_dir)
         Dir.mkdir(base_dir) unless Dir.exist?(base_dir)
       end
 
-      def ansible_command
+      def ansible_command(base_dir)
         # TODO add possibility to use custom path, e.g. from virtualenv
-        "ansible-runner run /tmp/ansible-runner --json"
+        "ansible-runner run #{base_dir} --json"
       end
     end
   end

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -25,7 +25,7 @@ module Ansible
 
       def run_via_cli(env_vars, extra_vars, playbook_path)
         Dir.mktmpdir("ansible-runner") do |base_dir|
-          mkdir(base_dir + '/project') # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
+          Dir.mkdir(File.join(base_dir, 'project')) # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
 
           result = AwesomeSpawn.run!(ansible_command(base_dir), :env => env_vars, :params => [{:cmdline => "--extra-vars '#{JSON.dump(extra_vars)}'", :playbook => playbook_path}])
 
@@ -35,10 +35,6 @@ module Ansible
 
       def return_code(base_dir)
         File.read(File.join(base_dir, "artifacts/result/rc"))
-      end
-
-      def mkdir(base_dir)
-        Dir.mkdir(base_dir) unless Dir.exist?(base_dir)
       end
 
       def ansible_command(base_dir)

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -27,9 +27,14 @@ module Ansible
         Dir.mktmpdir("ansible-runner") do |base_dir|
           Dir.mkdir(File.join(base_dir, 'project')) # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
 
-          result = AwesomeSpawn.run!(ansible_command(base_dir), :env => env_vars, :params => [{:cmdline => "--extra-vars '#{JSON.dump(extra_vars)}'", :playbook => playbook_path}])
+          result = AwesomeSpawn.run!(ansible_command(base_dir),
+                                     :env    => env_vars,
+                                     :params => [{:cmdline  => "--extra-vars '#{JSON.dump(extra_vars)}'",
+                                                  :playbook => playbook_path}])
 
-          return Ansible::Runner::Response.new(:return_code => return_code(base_dir), :stdout => result.output, :stderr => result.error)
+          Ansible::Runner::Response.new(:return_code => return_code(base_dir),
+                                        :stdout      => result.output,
+                                        :stderr      => result.error)
         end
       end
 

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -24,13 +24,25 @@ module Ansible
       private
 
       def run_via_cli(env_vars, extra_vars, playbook_path)
-        result = AwesomeSpawn.run!(ansible_command, :env => env_vars, :params => [{:extra_vars => JSON.dump(extra_vars)}, playbook_path])
+        prepare_tmp_structure
+
+        result = AwesomeSpawn.run!(ansible_command, :env => env_vars, :params => [{:cmdline => "--extra-vars '#{JSON.dump(extra_vars)}'", :playbook => playbook_path}])
         JSON.parse(result.output)
+      end
+
+      def prepare_tmp_structure
+        base_dir = "/tmp/ansible-runner/"
+        mkdir(base_dir)
+        mkdir(base_dir + 'project') # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
+      end
+
+      def mkdir(base_dir)
+        Dir.mkdir(base_dir) unless Dir.exist?(base_dir)
       end
 
       def ansible_command
         # TODO add possibility to use custom path, e.g. from virtualenv
-        "ansible-playbook"
+        "ansible-runner run /tmp/ansible-runner --json"
       end
     end
   end

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -34,7 +34,10 @@ module Ansible
       end
 
       def return_code(base_dir)
-        File.read(File.join(base_dir, "artifacts/result/rc"))
+        File.read(File.join(base_dir, "artifacts/result/rc")).to_i
+      rescue
+        _log.warn("Couldn't find ansible-runner return code")
+        1
       end
 
       def ansible_command(base_dir)

--- a/lib/ansible/runner/response.rb
+++ b/lib/ansible/runner/response.rb
@@ -1,0 +1,36 @@
+module Ansible
+  class Runner
+    class Response
+      include Vmdb::Logging
+
+      attr_reader :return_code, :stdout, :stderr, :parsed_stdout
+
+      def initialize(return_code:, stdout:, stderr:)
+        @return_code   = return_code
+        @stdout        = stdout
+        @parsed_stdout = parse_stdout(stdout)
+        @stderr        = stderr
+      end
+
+      private
+
+      def parse_stdout(stdout)
+        parsed_stdout = []
+
+        # output is JSON per new line
+        stdout.each_line do |line|
+          # TODO(lsmola) we can remove exception handling when this is fixed
+          # https://github.com/ansible/ansible-runner/issues/89#issuecomment-404236832 , so it fails early if there is
+          # a non json line
+          begin
+            parsed_stdout << JSON.parse(line)
+          rescue => e
+            _log.warn("Couldn't parse JSON from: #{e}")
+          end
+        end
+
+        parsed_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use ansible-runner instead of ansible-playbook

Depends on:
- [x] https://github.com/ManageIQ/manageiq/issues/17583 (the stdout is not JSON now, so the parse fails) - this is not a blocker anymore I did a workaround
- [ ] we need ansible-runner rpm, with version 1.0.4 at least 

Implements:
https://bugzilla.redhat.com/show_bug.cgi?id=1599798