### PR TITLE
Force user_type to UPN when username is a UPN

### DIFF
--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -279,10 +279,10 @@ class MiqLdap
   end
 
   def fqusername(username)
-    return username if self.dn?(username) || self.domain_username?(username)
+    return username if dn?(username) || domain_username?(username)
 
     user_type = @user_type.split("-").first
-    return username if user_type != "mail" && self.upn?(username)
+    return username if user_type != "mail" && upn?(username)
 
     user_prefix = @user_type.split("-").last
     user_prefix = "cn" if user_prefix == "dn"
@@ -295,7 +295,7 @@ class MiqLdap
 
       return "#{username}@#{@user_suffix}"
     when "mail"
-      username = "#{username}@#{@user_suffix}" unless @user_suffix.blank? || self.upn?(username)
+      username = "#{username}@#{@user_suffix}" unless @user_suffix.blank? || upn?(username)
       dbuser = User.find_by_email(username.downcase)
       dbuser ||= User.find_by_userid(username.downcase)
       return dbuser.userid if dbuser && dbuser.userid
@@ -308,8 +308,11 @@ class MiqLdap
 
   def get_user_object(username, user_type = nil)
     user_type ||= @user_type.split("-").first
-    user_type = "dn" if self.dn?(username)
-    user_type = "upn" if self.upn?(username)
+    if dn?(username)
+      user_type = "dn"
+    elsif upn?(username)
+      user_type = "upn"
+    end
 
     begin
       search_opts = {:base => @basedn, :scope => :sub, :attributes => ["*", @group_attribute]}

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -226,9 +226,17 @@ describe MiqLdap do
     end
 
     it "returns samaccountname when user_type is samaccountname" do
-      @opts[:user_type]   = 'samaccountname'
+      @opts[:user_type] = 'samaccountname'
       ldap = MiqLdap.new(@opts)
       expect(ldap.fqusername('myuserid')).to eq('my\domain\myuserid')
+    end
+
+    it "searches for username when user_type is mail even when username is UPN" do
+      @opts[:user_type] = 'mail'
+      ldap = MiqLdap.new(@opts)
+      expect(User).to receive(:find_by_email)
+      expect(User).to receive(:find_by_userid)
+      expect(ldap.fqusername('myuserid@mycompany.com')).to eq('myuserid@mycompany.com')
     end
   end
 end

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -196,9 +196,19 @@ describe MiqLdap do
     end
 
     it "returns username when username is already a dn" do
-      # ldap = MiqLdap.new(:host => ["192.0.2.2"])
       ldap = MiqLdap.new(@opts)
       expect(ldap.fqusername("cn=myuser,ou=people,ou=prod,dc=example,dc=com")).to eq("cn=myuser,ou=people,ou=prod,dc=example,dc=com")
+    end
+
+    it "returns username when username is a dn with an @ in the dn" do
+      ldap = MiqLdap.new(@opts)
+      expect(ldap.fqusername("cn=my@user,ou=people,ou=prod,dc=example,dc=com")).to eq("cn=my@user,ou=people,ou=prod,dc=example,dc=com")
+    end
+
+    it "returns a constructed dn when user type is a dn" do
+      @opts[:user_type] = 'dn'
+      ldap = MiqLdap.new(@opts)
+      expect(ldap.fqusername("myuser")).to eq("cn=myuser,mycompany.com")
     end
 
     it "returns username when username is already a upn" do


### PR DESCRIPTION

When ordering a remote service the userid passed to the remote is taken from the database's
userid field, which can be either a _UPN_ or a full _DN_. If it is a _UPN_ and the authentication 
configuration specifies _samaccountname_ for **User Type** the domain prefix is erroneously
prepended to the username causing group lookup to fail.

This PR plugs this edge case by not prepending the domain prefix to the username if the username is already in UPN format.

Testing Done
----------------

In addition to the updated spec tests included in this PR I configured a service on a remote region on a live appliance and successfully ordered it from the global region while logged in as a:
1. **AD** _samaccount_ **User Type** user
2. **AD** _UPN_ **User Type** user
3. **OpenLdap** _Distinguished Name (CN=<user>_


Links 
----------------

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594641


Steps for Testing/QA
-------------------------------

1. Integrate AD to authenticate Global and subordinate region on CFME appliance 
   with the **User Type** of _samaccountname_
2. Configure a service on the subordinate region
3. Login on Global region via AD user and order a service.