### PR TITLE
Adding flavor as a has one on VM

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -65,6 +65,7 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :disks, :through => :hardware
   belongs_to                :host
   belongs_to                :ems_cluster
+  belongs_to                :flavor
 
   belongs_to                :storage
   has_and_belongs_to_many   :storages, :join_table => 'storages_vms_and_templates'


### PR DESCRIPTION
I basically want to search Vms like
`vms = Flavor.joins(:vms).where(:flavors => {:name => 't2.micro'})`

so that in the api we can filter by flavor name

`http://localhost:3000/api/vms?filter[]=flavor.name='t2.micro'`

Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1596069