### PR TITLE
automation_manager should use :manager(_id) instead of :ems_id

### DIFF
--- a/app/models/manager_refresh/inventory_collection/builder/automation_manager.rb
+++ b/app/models/manager_refresh/inventory_collection/builder/automation_manager.rb
@@ -51,6 +51,12 @@ module ManagerRefresh
         def default_manager_ref
           add_properties(:manager_ref => %i(manager_ref))
         end
+
+        def add_common_default_values
+          add_default_values(
+            :manager => ->(persister) { persister.manager }
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/17621 is breaking https://travis-ci.org/ManageIQ/manageiq-providers-ansible_tower/jobs/402774240

```
 1) ManageIQ::Providers::AnsibleTower::AutomationManager::Refresher behaves like ansible refresher will perform a full refresh
     Failure/Error: record = inventory_collection.model_class.create!(hash.except(:id))
     ActiveModel::UnknownAttributeError:
       unknown attribute 'ems_id' for ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow.
     Shared Example Group: "ansible refresher" called from ./spec/models/manageiq/providers/ansible_tower/automation_manager/refresher_spec.rb:8
```
