### PR TITLE
Save Physical Disks Model

### DIFF
--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -101,7 +101,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
       h[:physical_chassis_id] = h.delete(:physical_chassis).try(:[], :id)
     end
 
-    child_keys = %i(computer_system asset_detail)
+    child_keys = %i(computer_system asset_detail physical_disk)
     save_inventory_multi(ems.physical_storages, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_storages, hashes, :ems_ref)
   end
@@ -112,6 +112,14 @@ module EmsRefresh::SaveInventoryPhysicalInfra
   def save_asset_detail_inventory(parent, hash)
     return if hash.nil?
     save_inventory_single(:asset_detail, parent, hash)
+  end
+
+  #
+  # Saves the drive information of a storage
+  #
+  def save_physical_disk_inventory(parent, hash)
+    return if hash.nil?
+    save_inventory_single(:physical_disk, parent, hash)
   end
 
   def save_physical_network_ports_inventory(guest_device, hashes, target = nil)

--- a/app/models/physical_disk.rb
+++ b/app/models/physical_disk.rb
@@ -1,0 +1,5 @@
+class PhysicalDisk < ApplicationRecord
+  belongs_to :physical_storage, :foreign_key => :physical_storage_id, :inverse_of => :physical_disks
+
+  acts_as_miq_taggable
+end

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -9,6 +9,8 @@ class PhysicalStorage < ApplicationRecord
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
   has_many :guest_devices, :through => :hardware
 
+  has_many :physical_disks, :dependent => :destroy, :inverse_of => :physical_storages
+
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone


### PR DESCRIPTION
This PR is able to:
- Add PhysicalDisks model
- Create a relationship between PhysicalDisks and PhysicalStorages

Depends on:
- [ManageIQ/manageiq-schema#233](https://github.com/ManageIQ/manageiq-schema/pull/233)