### PR TITLE
Add support to show Group Level of an event in the timeline page.

### DIFF
--- a/product/timelines/miq_reports/tl_events_daily.yaml
+++ b/product/timelines/miq_reports/tl_events_daily.yaml
@@ -21,6 +21,7 @@ db: EventStream
 cols:
 - event_type
 - source
+- group_level
 - message
 - timestamp
 - ems_cluster_name
@@ -51,6 +52,7 @@ col_order:
 - timestamp
 - event_type
 - source
+- group_level
 - ext_management_system.name
 - message
 - ems_cluster_name
@@ -73,6 +75,7 @@ headers:
 - Date Time
 - Event Type
 - Event Source
+- Group Level
 - Provider
 - Message
 - Cluster

--- a/product/timelines/miq_reports/tl_events_hourly.yaml
+++ b/product/timelines/miq_reports/tl_events_hourly.yaml
@@ -21,6 +21,7 @@ db: EventStream
 cols:
 - event_type
 - source
+- group_level
 - message
 - timestamp
 - ems_cluster_name
@@ -51,6 +52,7 @@ col_order:
 - timestamp
 - event_type
 - source
+- group_level
 - ext_management_system.name
 - message
 - ems_cluster_name
@@ -73,6 +75,7 @@ headers:
 - Date Time
 - Event Type
 - Event Source
+- Group Level
 - Provider
 - Message
 - Cluster


### PR DESCRIPTION
This PR is able to:
* Add support to show the group level information in the timeline page.
![print_timeline](https://user-images.githubusercontent.com/12627705/42695584-3c04ff4a-868c-11e8-857d-fec91969514c.png)
