### PR TITLE
Return custom buttons for service having nil service template

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -58,6 +58,7 @@ class Service < ApplicationRecord
   delegate :provision_dialog, :to => :miq_request, :allow_nil => true
   delegate :user, :to => :miq_request, :allow_nil => true
 
+  include CustomActionsMixin
   include ServiceMixin
   include OwnershipMixin
   include CustomAttributeMixin
@@ -104,12 +105,14 @@ class Service < ApplicationRecord
     vms.map(&:power_state)
   end
 
+  # renaming method from custom_actions_mixin
+  alias_method :custom_service_actions, :custom_actions
   def custom_actions
-    service_template&.custom_actions(self)
+    service_template ? service_template.custom_actions(self) : custom_service_actions(self)
   end
 
   def custom_action_buttons
-    service_template&.custom_action_buttons(self)
+    service_template ? service_template.custom_action_buttons(self) : generic_custom_buttons
   end
 
   def power_state

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -826,17 +826,36 @@ describe Service do
     let(:service_template) { FactoryGirl.create(:service_template) }
     let(:service) { FactoryGirl.create(:service, :service_template => service_template) }
 
-    describe "#custom_actions" do
-      it "get list of custom actions from linked service template" do
-        expect(service_template).to receive(:custom_actions)
-        service.custom_actions
+    context "with template" do
+      describe "#custom_actions" do
+        it "get list of custom actions from linked service template" do
+          expect(service_template).to receive(:custom_actions)
+          service.custom_actions
+        end
+      end
+
+      describe "#custom_action_buttons" do
+        it "get list of custom action buttons from linked service template" do
+          expect(service_template).to receive(:custom_action_buttons)
+          service.custom_action_buttons
+        end
       end
     end
 
-    describe "#custom_action_buttons" do
-      it "get list of custom action buttons from linked service template" do
-        expect(service_template).to receive(:custom_action_buttons)
-        service.custom_action_buttons
+    context "without template" do
+      let!(:custom_button) { FactoryGirl.create(:custom_button, :applies_to_class => "Service") }
+      let(:service) { FactoryGirl.create(:service, :service_template_id => -1) }
+
+      describe "#custom_action_buttons" do
+        it "get list of custom action buttons on services" do
+          expect(service.custom_action_buttons).to include(custom_button)
+        end
+      end
+
+      describe "#custom_actions" do
+        it "get list of custom actions on services" do
+          expect(service.custom_actions).to include(:buttons => [a_hash_including("id" => custom_button.id)], :button_groups => [])
+        end
       end
     end
   end


### PR DESCRIPTION
For bz https://bugzilla.redhat.com/show_bug.cgi?id=1595051.

Services with nonexistent service templates should return all buttons applicable to services, I spose.

GM's ideas were to use a prepend or alias_method for this. The custom_action method exists in both Service and the CustomActionsMixin and in the event of a dearth of service template on the service, we want to run the mixin method. The mixin is used basically everywhere which complicates this somewhat. If anyone (ie @bdunne) has a better idea about how to handle this, I'm all 👂s. 

@eclarizio can you :eyes: for me please? 
@tinaafitz 
