### PR TITLE
put S3 refresh in a separate worker

### DIFF
--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -6,6 +6,7 @@ MIQ_WORKER_TYPES = {
   "ManageIQ::Providers::Amazon::CloudManager::EventCatcher"                     => %i(manageiq_default),
   "ManageIQ::Providers::Amazon::CloudManager::MetricsCollectorWorker"           => %i(manageiq_default),
   "ManageIQ::Providers::Amazon::CloudManager::RefreshWorker"                    => %i(manageiq_default),
+  "ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker"              => %i(manageiq_default),
   "ManageIQ::Providers::AnsibleTower::AutomationManager::EventCatcher"          => %i(manageiq_default),
   "ManageIQ::Providers::AnsibleTower::AutomationManager::RefreshWorker"         => %i(manageiq_default),
   "ManageIQ::Providers::Azure::CloudManager::EventCatcher"                      => %i(manageiq_default),


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1541435

Put S3 refresh in a separate worker, as it can contain too many objects, which blocks other data refresh.

Coupled PR: https://github.com/ManageIQ/manageiq-providers-amazon/pull/461