### PR TITLE
Add a method to queue an Ansible::Runner.run

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -5,6 +5,22 @@ module Ansible
         run_via_cli(env_vars, extra_vars, playbook_path)
       end
 
+      def run_queue(env_vars, extra_vars, playbook_path, user_id, queue_opts)
+        queue_opts = {
+          :args        => [env_vars, extra_vars, playbook_path],
+          :queue_name  => "generic",
+          :class_name  => name,
+          :method_name => "run",
+        }.merge(queue_opts)
+
+        task_opts = {
+          :action => "Run Ansible Playbook",
+          :userid => user_id,
+        }
+
+        MiqTask.generic_action_with_callback(task_opts, queue_opts)
+      end
+
       private
 
       def run_via_cli(env_vars, extra_vars, playbook_path)


### PR DESCRIPTION
This adds a way to queue an Ansible::Runner.run and wraps it in a task
so that it can be invoked asynchronously from automate.