### PR TITLE
Save Canister Model

### DIFF
--- a/app/models/canister.rb
+++ b/app/models/canister.rb
@@ -1,0 +1,11 @@
+class Canister < ApplicationRecord
+  belongs_to :physical_storage, :foreign_key => :physical_storage_id, :inverse_of => :canisters
+
+  has_one :computer_system, :as => :managed_entity, :dependent => :destroy, :inverse_of => false
+  has_one :hardware, :through => :computer_system
+
+  has_many :guest_devices, :through => :hardware
+  has_many :physical_network_ports, :through => :guest_devices
+
+  acts_as_miq_taggable
+end

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -101,7 +101,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
       h[:physical_chassis_id] = h.delete(:physical_chassis).try(:[], :id)
     end
 
-    child_keys = %i(computer_system asset_detail physical_disk)
+    child_keys = %i(computer_system asset_detail physical_disk canister)
     save_inventory_multi(ems.physical_storages, hashes, deletes, [:ems_ref], child_keys)
     store_ids_for_new_records(ems.physical_storages, hashes, :ems_ref)
   end
@@ -120,6 +120,14 @@ module EmsRefresh::SaveInventoryPhysicalInfra
   def save_physical_disk_inventory(parent, hash)
     return if hash.nil?
     save_inventory_single(:physical_disk, parent, hash)
+  end
+
+  #
+  # Saves the canister information of a storage
+  #
+  def save_canister_inventory(physical_storage, hash)
+    return if hash.nil?
+    save_inventory_single(:canister, physical_storage, hash)
   end
 
   def save_physical_network_ports_inventory(guest_device, hashes, target = nil)

--- a/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
@@ -35,6 +35,14 @@ module ManageIQ::Providers
         def physical_chassis
           add_common_default_values
         end
+
+        def physical_storages
+          add_common_default_values
+        end
+
+        def canisters
+          add_common_default_values
+        end
       end
     end
   end

--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -4,10 +4,12 @@ class PhysicalStorage < ApplicationRecord
   belongs_to :physical_rack, :foreign_key => :physical_rack_id, :inverse_of => :physical_storages
   belongs_to :physical_chassis, :inverse_of => :physical_storages
 
-  has_one :computer_system, :as => :managed_entity, :dependent => :destroy, :inverse_of => false
-  has_one :hardware, :through => :computer_system
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
-  has_many :guest_devices, :through => :hardware
+
+  has_many :canisters, :dependent => :destroy, :inverse_of => false
+  has_many :computer_system, :through => :canisters
+  has_many :hardware, :through => :computer_system
+  has_many :guest_devices, :through => :canisters
 
   has_many :physical_disks, :dependent => :destroy, :inverse_of => :physical_storage
 


### PR DESCRIPTION
This PR is able to:
- Add Canister model
- Create relationship between Canisters and PhysicalStorages
- Save Canister inventory

Depends on:
- [~ManageIQ/manageiq-schema#233 - Merged~](https://github.com/ManageIQ/manageiq-schema/pull/233)
- [~ManageIQ/manageiq#17700 - Merged~](https://github.com/ManageIQ/manageiq/pull/17700)