### PR TITLE
[WIP] Add Active Record extension DisplayName

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,7 @@ class ApplicationRecord < ActiveRecord::Base
   include ArNestedCountBy
   include ArHrefSlug
   include ToModelHash
+  include DisplayName
 
   extend ArTableLock
 
@@ -18,9 +19,5 @@ class ApplicationRecord < ActiveRecord::Base
   if defined?(ManageIQ::UI::Classic::Engine)
     extend MiqDecorator::Klass
     include MiqDecorator::Instance
-  end
-
-  def self.display_name(number = 1)
-    n_(model_name.singular.titleize, model_name.plural.titleize, number)
   end
 end

--- a/lib/extensions/display_name
+++ b/lib/extensions/display_name
@@ -1,0 +1,17 @@
+module DisplayName
+  extend ActiveSupport::Concern
+
+  # define an attribute to contain display text, in order of preference
+  # description, if and when available
+  # title/name in case description is not available or does not exist
+  # default to <record id> in cases where no other attribute has been provided by user
+
+  def display_name
+    return label                      if respond_to?("label")
+    return description                if respond_to?("description") && description.present?
+    return ext_management_system.name if respond_to?("ems_id")
+    return title                      if respond_to?("title")
+    return name                       if respond_to?("name")
+    "<Record ID #{id}>"
+  end
+end


### PR DESCRIPTION
New Active Record extension to aid in proper UI pages header composition that allows for flexibility to display record description, name or ID depending on content and user preference. Most UI pages display Add/Edit/Delete action confirmation messages that match accordion leaf/node display, usually a name to conserve real estate, and then same name of the leaf/node when action is requested. In some cases users may choose to display a longer description in the messages. 

This PR will be enhanced with refactoring on the UI Classic side, controllers will either use this newly added extension in place of **get_record_display_name()**, or have their own override inline when required. 
