### PR TITLE
Log ansible-playbook's STDOUT when AnsibleRunner fails

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -8,7 +8,12 @@ module Ansible
       private
 
       def run_via_cli(env_vars, extra_vars, playbook_path)
-        result = AwesomeSpawn.run!(ansible_command, :env => env_vars, :params => [{:extra_vars => JSON.dump(extra_vars)}, playbook_path])
+        result = AwesomeSpawn.run(ansible_command, :env => env_vars, :params => [{:extra_vars => JSON.dump(extra_vars)}, playbook_path])
+        if result.failure?
+          $log.error("ansible-playbook errored - stdout: #{result.output}")
+          $log.error("ansible-playbook errored - stderr: #{result.error}")
+          raise AwesomeSpawn::CommandResultError
+        end
         JSON.parse(result.output)
       end
 


### PR DESCRIPTION
With this commit we make sure STDOUT is logged in case when AnsibleRunner returns with exit status other than 0. Previously, only STDERR was logged but there is no information about what exactly went wrong with playbook.

Before: I forgot to pass some variable to the playbook. AnsibleRunner failed. There was nothing in log.

After: Ansible STDOUT appears in evm.log telling me exactly what variable am I missing. Unfortunately, the format is JSON, but still better than nothing :)

@miq-bot assign @Ladas
@miq-bot add_label enhancement