### PR TITLE
Remove Settings.product.transformation - v2v no longer conditional on product feature

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -976,7 +976,6 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
-  :transformation: true
 :prototype:
   :queue_type: miq_queue
   :artemis:


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/490 (and https://github.com/ManageIQ/miq_v2v_ui_plugin/pull/417). (Both merged now.)

Second part of the fix for https://github.com/ManageIQ/miq_v2v_ui_plugin/issues/432

Cc @Fryguy 
