### PR TITLE
Service AnsibleTower and EmbeddedAnsible UI parity

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -17,13 +17,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
       ).id
     end
 
-    options = {:userid => userid || 'system', :action => 'ansible_stdout'}
-    queue_options = {:class_name  => self.class,
-                     :method_name => 'raw_stdout',
-                     :instance_id => id,
-                     :args        => [format],
-                     :priority    => MiqQueue::HIGH_PRIORITY,
-                     :role        => 'embedded_ansible'}
-    MiqTask.generic_action_with_callback(options, queue_options)
+    super(userid, format, 'embedded_ansible')
   end
 end

--- a/app/models/service_ansible_tower.rb
+++ b/app/models/service_ansible_tower.rb
@@ -16,8 +16,9 @@ class ServiceAnsibleTower < Service
     save_launch_options
   end
 
-  def job
-    @job ||= service_resources.find { |sr| sr.resource.kind_of?(OrchestrationStack) }.try(:resource)
+  def job(_action = nil)
+    # parameter _action unifies the interface with ServiceAnsiblePlaybook
+    @job ||= service_resources.find_by(:resource_type => "OrchestrationStack").try(:resource)
   end
 
   def build_stack_options_from_dialog(dialog_options)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -1,49 +1,20 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
   let(:job) { FactoryGirl.create(:embedded_ansible_job) }
 
-  it_behaves_like 'ansible job'
+  before do
+    region = MiqRegion.seed
+    allow(region).to receive(:role_active?).with("embedded_ansible").and_return(role_enabled)
+    allow(MiqRegion).to receive(:my_region).and_return(region)
+  end
 
-  describe '#raw_stdout_via_worker' do
-    before do
-      EvmSpecHelper.create_guid_miq_server_zone
-      region = MiqRegion.seed
-      allow(region).to receive(:role_active?).with("embedded_ansible").and_return(role_enabled)
-      allow(MiqRegion).to receive(:my_region).and_return(region)
-    end
+  context 'when embedded_ansible role is enabled' do
+    let(:role_enabled) { true }
 
-    context 'when embedded_ansible role is enabled' do
-      let(:role_enabled) { true }
+    it_behaves_like 'ansible job'
+  end
 
-      before do
-        allow(described_class).to receive(:find).and_return(job)
-
-        allow(MiqTask).to receive(:wait_for_taskid) do
-          request = MiqQueue.find_by(:class_name => described_class.name)
-          request.update_attributes(:state => MiqQueue::STATE_DEQUEUE)
-          request.delivered(*request.deliver)
-        end
-      end
-
-      it 'gets stdout from the job' do
-        expect(job).to receive(:raw_stdout).and_return('A stdout from the job')
-        taskid = job.raw_stdout_via_worker('user')
-        MiqTask.wait_for_taskid(taskid)
-        expect(MiqTask.find(taskid)).to have_attributes(
-          :task_results => 'A stdout from the job',
-          :status       => 'Ok'
-        )
-      end
-
-      it 'returns the error message' do
-        expect(job).to receive(:raw_stdout).and_throw('Failed to get stdout from the job')
-        taskid = job.raw_stdout_via_worker('user')
-        MiqTask.wait_for_taskid(taskid)
-        expect(MiqTask.find(taskid).message).to include('Failed to get stdout from the job')
-        expect(MiqTask.find(taskid).status).to eq('Error')
-      end
-    end
-
-    context 'when embedded_ansible role is disabled' do
+  context 'when embedded_ansible role is disabled' do
+    describe '#raw_stdout_via_worker' do
       let(:role_enabled) { false }
 
       it 'returns an error message' do


### PR DESCRIPTION
Make the service layout same for AnsibleTower as it is for EmbeddedAnsible - Core part

- Extract `:raw_stdout_via_worker` to shared Ansible codebase
- Make the `:job` signature the same in [service_ansible_tower.rb](https://github.com/ManageIQ/manageiq/blob/f07d9545f7c5db5b33481b639b63db9417850f16/app/models/service_ansible_tower.rb#L19) and [service_ansible_playbook.rb](https://github.com/ManageIQ/manageiq/blob/f07d9545f7c5db5b33481b639b63db9417850f16/app/models/service_ansible_playbook.rb#L45)

Depends on: https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/108
Other related PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4299
Fixes: [BUG 1590840](https://bugzilla.redhat.com/show_bug.cgi?id=1590840) [BUG 1590844](https://bugzilla.redhat.com/show_bug.cgi?id=1590844)