### PR TITLE
Maintenance must run VACUUM to avoid long held locks

### DIFF
--- a/lib/extensions/ar_base.rb
+++ b/lib/extensions/ar_base.rb
@@ -23,7 +23,7 @@ module ActiveRecord
 
     def self.vacuum
       _log.info("Vacuuming table #{table_name}")
-      result = connection.vacuum_full_analyze_table(table_name)
+      result = connection.vacuum_analyze_table(table_name)
       _log.info("Completed Vacuuming of table #{table_name} with result #{result.result_status}")
     end
   end

--- a/spec/lib/extensions/ar_base_spec.rb
+++ b/spec/lib/extensions/ar_base_spec.rb
@@ -1,0 +1,14 @@
+describe "ar_base extension" do
+  context "with a test class" do
+    let(:test_class) do
+      Class.new(ActiveRecord::Base) do
+        def self.name; "TestClass"; end
+      end
+    end
+
+    it ".vacuum" do
+      expect(test_class.connection).to receive(:vacuum_analyze_table).and_return(double(:result_status => 1))
+      test_class.vacuum
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1601264

It's hard to say which tables may or may not grow too large that we
cannot easily run VACUUM FULL on them as part of maintenance. Therefore
we should do the safest thing possible and run VACUUM for routine
maintenance and leave VACUUM FULL when table bloat becomes a problem.

Some tables, such as vim_performance_states can grow so large that a
VACUUM FULL could lock up the table for many minutes and could fail
to complete during the normal 10 minute queue timeout.