### PR TITLE
Add filtering of key_pairs

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -6,6 +6,16 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::AuthPrivateKey
 
   include_concern 'Operations'
 
+  # TODO(aveselov): remove this method and add filtering of keypairs with rbac
+  # This validation considers that default user in CF has no openstack_user_id assigned to it
+  def self.filter_key_pairs
+    if User.current_user.settings[:openstack_user_id].nil?
+      self.all
+    else
+      where(:userid => User.current_user.settings[:openstack_user_id])
+    end
+  end
+
   def self.class_by_ems(ext_management_system)
     ext_management_system.class::AuthKeyPair
   end


### PR DESCRIPTION
This filters key_pairs by comparing `openstack_user_id` of current user and keypairs' `userid` 

The assigning of user_ids to keypairs is coming from https://github.com/ManageIQ/manageiq/pull/17693 and https://github.com/fog/fog-openstack/pull/406

Suggested as a minimal fix for 
https://bugzilla.redhat.com/show_bug.cgi?id=1589766