### PR TITLE
Allow for empty strings in the execution_ttl field

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
 
   def current_job_timeout(_timeout_adjustment = 1)
     @execution_ttl ||=
-      (options[:execution_ttl].try(:to_i) || DEFAULT_EXECUTION_TTL) * 60
+      (options[:execution_ttl].present? ? options[:execution_ttl].try(:to_i) : DEFAULT_EXECUTION_TTL) * 60
   end
 
   def start

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -48,6 +48,14 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
         expect(subject.current_job_timeout).to eq(described_class::DEFAULT_EXECUTION_TTL * 60)
       end
     end
+
+    context 'timeout is blank in options' do
+      let(:options) { {:execution_ttl => ""} }
+
+      it 'uses default timeout value' do
+        expect(subject.current_job_timeout).to eq(described_class::DEFAULT_EXECUTION_TTL * 60)
+      end
+    end
   end
 
   describe '#create_inventory' do


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1601538

An empty string yields a 0 timeout value causing jobs to be
terminated right away.

Use default timeout value if the execution_ttl is nil or an empty string