### PR TITLE
ConfigurationWorkflow to exist only in AutomationManager space

### DIFF
--- a/app/models/configuration_workflow.rb
+++ b/app/models/configuration_workflow.rb
@@ -1,5 +1,0 @@
-class ConfigurationWorkflow < ConfigurationScriptBase
-  def self.base_model
-    ConfigurationWorkflow
-  end
-end

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -11,7 +11,12 @@ class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
 
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
+  has_many :configuration_scripts,
+           :dependent   => :destroy,
+           :foreign_key => "manager_id",
+           :class_name  => "::ConfigurationScript",
+           :inverse_of  => :manager
+
   has_many :configuration_workflows,      :dependent => :destroy, :foreign_key => "manager_id", :inverse_of => :manager
   has_many :credentials,                  :class_name => "ManageIQ::Providers::AutomationManager::Authentication",
            :as => :resource, :dependent => :destroy

--- a/app/models/manageiq/providers/automation_manager.rb
+++ b/app/models/manageiq/providers/automation_manager.rb
@@ -11,13 +11,7 @@ class ManageIQ::Providers::AutomationManager < ManageIQ::Providers::BaseManager
 
   has_many :configured_systems,           :dependent => :destroy, :foreign_key => "manager_id"
   has_many :configuration_profiles,       :dependent => :destroy, :foreign_key => "manager_id"
-  has_many :configuration_scripts,
-           :dependent   => :destroy,
-           :foreign_key => "manager_id",
-           :class_name  => "::ConfigurationScript",
-           :inverse_of  => :manager
-
-  has_many :configuration_workflows,      :dependent => :destroy, :foreign_key => "manager_id", :inverse_of => :manager
+  has_many :configuration_scripts,        :dependent => :destroy, :foreign_key => "manager_id"
   has_many :credentials,                  :class_name => "ManageIQ::Providers::AutomationManager::Authentication",
            :as => :resource, :dependent => :destroy
   has_many :inventory_groups,             :dependent => :destroy, :foreign_key => "ems_id", :inverse_of => :manager

--- a/app/models/manageiq/providers/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/automation_manager/configuration_workflow.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::AutomationManager::ConfigurationWorkflow < ::ConfigurationScript
-  belongs_to :manager, :class_name => "ManageIQ::Providers::AutomationManager", :inverse_of => :configuration_workflows
-end

--- a/app/models/manageiq/providers/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/automation_manager/configuration_workflow.rb
@@ -1,3 +1,3 @@
-class ManageIQ::Providers::AutomationManager::ConfigurationWorkflow < ::ConfigurationWorkflow
+class ManageIQ::Providers::AutomationManager::ConfigurationWorkflow < ::ConfigurationScript
   belongs_to :manager, :class_name => "ManageIQ::Providers::AutomationManager", :inverse_of => :configuration_workflows
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -26,6 +26,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :Refresher
   require_nested :RefreshWorker
 
+  has_many :configuration_workflows, :dependent => :destroy, :foreign_key => "manager_id", :inverse_of => :manager
+
   def self.ems_type
     @ems_type ||= "embedded_ansible_automation".freeze
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_workflow.rb
@@ -1,3 +1,3 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationWorkflow < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationWorkflow
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationWorkflow < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::ConfigurationWorkflow
 end

--- a/app/models/manageiq/providers/embedded_automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager/configuration_workflow.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationWorkflow < ManageIQ::Providers::AutomationManager::ConfigurationWorkflow
-end

--- a/app/models/manageiq/providers/external_automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/external_automation_manager/configuration_workflow.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::ExternalAutomationManager::ConfigurationWorkflow < ManageIQ::Providers::AutomationManager::ConfigurationWorkflow
-end

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -704,6 +704,7 @@ en:
       ContainerQuota:           Container Quota
       CustomButton:             Button
       CustomButtonSet:          Button Group
+      ConfigurationScript:      Template (Ansible Tower)
       ConfigurationScriptSource: Repository
       Container:                Container
       ContainerPerformance:     Performance - Container
@@ -774,6 +775,7 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential:     Credential (VMware)
       ManageIQ::Providers::AnsibleTower::AutomationManager:                 Automation Manager (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript: Job Template (Ansible Tower)
+      ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow: Workflow Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook: Playbook (Ansible Tower)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -11,7 +11,9 @@ FactoryGirl.define do
           :parent => :configuration_script_payload
 
   factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
-  factory :configuration_workflow, :class => "ConfigurationWorkflow", :parent => :configuration_script_base
+  factory :configuration_workflow,
+          :class  => "ManageIQ::Providers::AutomationManager::ConfigurationWorkflow",
+          :parent => :configuration_script
   factory :ansible_configuration_script,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
           :parent => :configuration_script

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
 
   factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
   factory :configuration_workflow,
-          :class  => "ManageIQ::Providers::AutomationManager::ConfigurationWorkflow",
+          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow",
           :parent => :configuration_script
   factory :ansible_configuration_script,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",


### PR DESCRIPTION
As a alternative implementation in terms of relationship between `automation_manager` and `configuration_script` to https://github.com/ManageIQ/manageiq/pull/17659

The related change in external tower repo https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/112
@blomquisg @Fryguy @bzwei @gmcculloug 