### PR TITLE
Fix ServiceTemplateTransformationPlanTask factory

### DIFF
--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -43,5 +43,7 @@ FactoryGirl.define do
     state        'pending'
   end
 
-  factory :service_template_transformation_plan_task, :parent => :service_template_provision_task, :class => 'ServiceTemplateTransformationPlanTask'
+  factory :service_template_transformation_plan_task, :parent => :service_template_provision_task, :class => 'ServiceTemplateTransformationPlanTask' do
+    request_type 'transformation_plan'
+  end
 end


### PR DESCRIPTION
Before:
     Failure/Error: let(:request_task_1) { FactoryGirl.create(factory, :miq_request => request) }

     ActiveRecord::RecordInvalid:
       Validation failed: Request type should be transformation_plan