### PR TITLE
Add permission to groups of users access the event_streams_view

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -32,6 +32,7 @@
   - ems_infra
   - ems_infra_admin_ui
   - ems_physical_infra
+  - event_streams
   - container_dashboard
   - ems_container
   - ems_container_deployment
@@ -204,6 +205,7 @@
   - ems_physical_infra_console
   - ems_physical_infra_tag
   - ems_physical_infra_view
+  - event_streams_view
   - host_show
   - host_show_list
   - host_perf
@@ -292,6 +294,7 @@
   - automation_manager
   - dashboard
   - ems_physical_infra
+  - event_streams
   - miq_request_admin
   - miq_request_view
   - miq_template_clone
@@ -390,6 +393,7 @@
   - ems_physical_infra_refresh
   - ems_physical_infra_tag
   - ems_physical_infra_view
+  - event_streams_view
   - physical_rack_control
   - physical_rack_view
   - physical_chassis_view
@@ -498,6 +502,7 @@
   - ems_infra_timeline
   - ems_physical_infra_tag
   - ems_physical_infra_view
+  - event_streams_view
   - physical_server_timeline
   - host_show
   - host_show_list
@@ -582,6 +587,7 @@
   - ems_physical_infra_console
   - ems_physical_infra_tag
   - ems_physical_infra_view
+  - event_streams_view
   - host_show
   - host_show_list
   - host_perf
@@ -671,6 +677,7 @@
   - ems_physical_infra_show_list
   - ems_physical_infra_tag
   - ems_physical_infra_timeline
+  - event_streams_view
   - host_show
   - host_show_list
   - host_perf
@@ -1179,6 +1186,7 @@
   - ems_physical_infra_view
   - ems_network_view
   - ems_object_storage_view
+  - event_streams_view
   - flavor_view
   - floating_ip_view
   - host_aggregate_view


### PR DESCRIPTION
This PR is able to:
 - Add permission to access the event_streams_view in the follow groups:
   -  administrator
   -  desktop
   -  operator
   -  security
   -  support
   -  user
   -  reader