### PR TITLE
locale:po_to_json: add support for including catalogs from javascript plugins

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -191,30 +191,60 @@ namespace :locale do
 
   desc "Convert PO files from all plugins to JS files"
   task "po_to_json" => :environment do
-    require_relative 'gettext_task_override.rb'
-    require Rails.root.join("lib/vmdb/gettext/domains")
+    begin
+      require_relative 'gettext_task_override.rb'
+      require Rails.root.join('lib/manageiq/environment')
+      require Rails.root.join("lib/vmdb/gettext/domains")
 
-    po_files = {}
-    Vmdb::Gettext::Domains.paths.each do |path|
-      files = ::Pathname.glob(::File.join(path, "**", "*.po"))
-      files.each do |file|
-        locale = file.dirname.basename.to_s
-        po_files[locale] ||= []
-        po_files[locale].push(file)
+      po_files = {}
+      Vmdb::Gettext::Domains.paths.each do |path|
+        files = ::Pathname.glob(::File.join(path, "**", "*.po"))
+        files.each do |file|
+          locale = file.dirname.basename.to_s
+          po_files[locale] ||= []
+          po_files[locale].push(file)
+        end
       end
-    end
 
-    combined_dir = File.join(Rails.root, "locale/combined")
-    Dir.mkdir(combined_dir, 0700)
-    po_files.keys.each do |locale|
-      dir = File.join(combined_dir, locale)
-      po = File.join(dir, 'manageiq.po')
-      Dir.mkdir(dir, 0700)
-      system "rmsgcat -o #{po} #{po_files[locale].join(' ')}"
-    end
+      js_plugins = {
+        'ui-components' => {
+          'en'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/en/ui-components.po',
+          'es'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/es/ui-components.po',
+          'fr'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/fr/ui-components.po',
+          'ja'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/ja/ui-components.po',
+          'pt_BR' => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/pt_BR/ui-components.po',
+          'zh_CN' => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/zh_CN/ui-components.po',
+        }
+      }
 
-    Rake::Task['gettext:po_to_json'].invoke
-    system "rm -rf #{combined_dir}"
+      plugins_dir = File.join(Rails.root, 'locale/plugins')
+      Dir.mkdir(plugins_dir, 0700)
+      js_plugins.each do |plugin, content|
+        plugin_dir = File.join(plugins_dir, plugin)
+        Dir.mkdir(plugin_dir)
+        content.each do |lang, url|
+          lang_dir = File.join(plugin_dir, lang)
+          Dir.mkdir(lang_dir)
+          lang_file = "#{lang_dir}/#{url.split('/')[-1]}"
+          ManageIQ::Environment.system! "curl -f -o #{lang_file} #{url}"
+          po_files[lang] ||= []
+          po_files[lang].push(Pathname(lang_file))
+        end
+      end
+
+      combined_dir = File.join(Rails.root, "locale/combined")
+      Dir.mkdir(combined_dir, 0700)
+      po_files.keys.each do |locale|
+        dir = File.join(combined_dir, locale)
+        po = File.join(dir, 'manageiq.po')
+        Dir.mkdir(dir, 0700)
+        system "rmsgcat -o #{po} #{po_files[locale].join(' ')}"
+      end
+
+      Rake::Task['gettext:po_to_json'].invoke
+    ensure
+      system "rm -rf #{combined_dir} #{plugins_dir}"
+    end
   end
 
   desc "Create display names for models"


### PR DESCRIPTION
When creating gettext catalogs for javascript consumption, we need to merge catalogs from all ManageIQ plugins and convert the result into a json file. So far, we were only able to do that for regular rails engines (i.e. ManageIQ ruby plugins). As things are, we need to include javascript plugins (such as ui-compoments) into the equation as well.

This change makes it possible to download the gettext catalogs from plugins and include them into the merge & conversion process.

@himdel review please?

@miq-bot add_label gaprindashvili/yes