### PR TITLE
Purge old MiqTasks and associated records

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -99,6 +99,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name => "Notification", :method_name => "purge_timer", :zone => nil)
   end
 
+  def task_purge_timer
+    queue_work(:class_name => "MiqTask", :method_name => "purge_timer", :zone => nil)
+  end
+
   def policy_event_purge_timer
     queue_work(:class_name => "PolicyEvent", :method_name => "purge_timer", :zone => nil)
   end

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -208,6 +208,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       enqueue(:notification_purge_timer)
     end
 
+    every = worker_settings[:task_purge_interval]
+    scheduler.schedule_every(every, :first_in => every) do
+      enqueue(:task_purge_timer)
+    end
+
     every = worker_settings[:vim_performance_states_purge_interval]
     scheduler.schedule_every(every, :first_in => every) do
       enqueue(:vim_performance_states_purge_timer)

--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -1,4 +1,6 @@
 class MiqTask < ApplicationRecord
+  include_concern 'Purging'
+
   serialize :context_data
   STATE_INITIALIZED = 'Initialized'.freeze
   STATE_QUEUED      = 'Queued'.freeze

--- a/app/models/miq_task/purging.rb
+++ b/app/models/miq_task/purging.rb
@@ -1,0 +1,26 @@
+class MiqTask
+  module Purging
+    extend ActiveSupport::Concern
+    include PurgingMixin
+
+    module ClassMethods
+      def purge_date
+        ::Settings.task.history.keep_tasks.to_i_with_method.seconds.ago.utc
+      end
+
+      def purge_window_size
+        ::Settings.task.history.purge_window_size
+      end
+
+      def purge_scope(older_than)
+        where(arel_table[:created_on].lt(older_than))
+      end
+
+      def purge_associated_records(ids)
+        Job.where(:miq_task_id => ids).delete_all
+        LogFile.where(:miq_task_id => ids).delete_all
+        BinaryBlob.where(:resource_type => 'MiqTask', :resource_id => ids).delete_all
+      end
+    end
+  end
+end

--- a/app/models/miq_task/purging.rb
+++ b/app/models/miq_task/purging.rb
@@ -13,7 +13,7 @@ class MiqTask
       end
 
       def purge_scope(older_than)
-        where(arel_table[:created_on].lt(older_than))
+        MiqTask.finished.where(arel_table[:created_on].lt(older_than))
       end
 
       def purge_associated_records(ids)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1091,6 +1091,10 @@
   :watchdog_interval: 1.minute
 :task:
   :active_task_timeout: 6.hours
+  :history:
+    :keep_tasks: 1.week
+    :purge_window_size: 1000
+
 :ui:
   :mark_translated_strings: false
   :url:
@@ -1253,6 +1257,7 @@
       :session_timeout_interval: 30.seconds
       :storage_file_collection_interval: 1.days
       :storage_file_collection_time_utc: 21600
+      :task_purge_interval: 1.day
       :task_timeout_check_frequency: 1.hour
       :vim_performance_states_purge_interval: 1.day
       :vm_retired_interval: 10.minutes

--- a/spec/models/miq_task/purging_spec.rb
+++ b/spec/models/miq_task/purging_spec.rb
@@ -1,0 +1,42 @@
+describe MiqTask do
+  context "::Purging" do
+    describe ".purge_by_date" do
+      before do
+        Timecop.freeze(8.days.ago) do
+          @old_task = Job.create_job("VmScan", :guid => "old").miq_task
+          FactoryGirl.create(:binary_blob, :name => "old", :resource_type => 'MiqTask', :resource_id => @old_task.id)
+          FactoryGirl.create(:log_file, :name => "old", :miq_task_id => @old_task.id)
+        end
+
+        Timecop.freeze(6.days.ago) do
+          @new_task = Job.create_job("VmScan", :guid => "recent").miq_task
+          FactoryGirl.create(:binary_blob, :name => "recent", :resource_type => 'MiqTask', :resource_id => @new_task.id)
+          FactoryGirl.create(:log_file, :name => "recent", :miq_task_id => @new_task.id)
+        end
+      end
+
+      it "purges old notifications" do
+        expect(described_class.all).to match_array([@old_task, @new_task])
+
+        described_class.purge_by_date(described_class.purge_date)
+
+        expect(described_class.all).to match_array([@new_task])
+        expect(BinaryBlob.count).to eq(1)
+        expect(BinaryBlob.first.name).to eq("recent")
+        expect(LogFile.count).to eq(1)
+        expect(LogFile.first.name).to eq("recent")
+        expect(Job.count).to eq(1)
+        expect(Job.first.guid).to eq("recent")
+      end
+    end
+
+    describe ".purge_timer" do
+      it "queues the correct purge method" do
+        EvmSpecHelper.local_miq_server
+        described_class.purge_timer
+        q = MiqQueue.first
+        expect(q).to have_attributes(:class_name => described_class.name, :method_name => "purge_by_date")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**BEFORE:** 
There were no purging of old  records from`miq_task` table

**AFTER:**
* sets to remove records from `miq_task` that are finished and older than a week
* purging is run daily 
* remove associated records from ```jobs```, ```log_files```, and ```binary_blobs``` tables

This PR should go together with https://github.com/ManageIQ/manageiq-schema/pull/201

@miq-bot add-label  technical debt 

