### PR TITLE
Add support for new physical server alert

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -49,7 +49,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :hardwares,         :through => :vms_and_templates
   has_many :networks,          :through => :hardwares
   has_many :disks,             :through => :hardwares
-  has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system
+  has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
   has_many :storages,       -> { distinct },          :through => :hosts
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -49,6 +49,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :hardwares,         :through => :vms_and_templates
   has_many :networks,          :through => :hardwares
   has_many :disks,             :through => :hardwares
+  has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system
 
   has_many :storages,       -> { distinct },          :through => :hosts
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -36,7 +36,7 @@ class MiqAlert < ApplicationRecord
 
   acts_as_miq_set_member
 
-  ASSIGNMENT_PARENT_ASSOCIATIONS = [:host, :ems_cluster, :ext_management_system, :my_enterprise, :physical_server]
+  ASSIGNMENT_PARENT_ASSOCIATIONS = %i(host ems_cluster ext_management_system my_enterprise physical_server).freeze
 
   HOURLY_TIMER_EVENT   = "_hourly_timer_"
 

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -27,6 +27,7 @@ class MiqAlert < ApplicationRecord
     MiqServer
     ContainerNode
     ContainerProject
+    PhysicalServer
   )
 
   def self.base_tables
@@ -35,7 +36,7 @@ class MiqAlert < ApplicationRecord
 
   acts_as_miq_set_member
 
-  ASSIGNMENT_PARENT_ASSOCIATIONS = [:host, :ems_cluster, :ext_management_system, :my_enterprise]
+  ASSIGNMENT_PARENT_ASSOCIATIONS = [:host, :ems_cluster, :ext_management_system, :my_enterprise, :physical_server]
 
   HOURLY_TIMER_EVENT   = "_hourly_timer_"
 

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -16,7 +16,7 @@ module AssignmentMixin
   included do  #:nodoc:
     acts_as_miq_taggable
 
-    const_set("ASSIGNMENT_PARENT_ASSOCIATIONS", [:parent_blue_folders, :parent_resource_pool, :host, :ems_cluster, :ext_management_system, :my_enterprise]) unless const_defined?("ASSIGNMENT_PARENT_ASSOCIATIONS")
+    const_set("ASSIGNMENT_PARENT_ASSOCIATIONS", [:parent_blue_folders, :parent_resource_pool, :host, :ems_cluster, :ext_management_system, :my_enterprise, :physical_server]) unless const_defined?("ASSIGNMENT_PARENT_ASSOCIATIONS")
 
     cache_with_timeout(:assignments_cached, 1.minute) { assignments }
   end

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -16,7 +16,7 @@ module AssignmentMixin
   included do  #:nodoc:
     acts_as_miq_taggable
 
-    const_set("ASSIGNMENT_PARENT_ASSOCIATIONS", [:parent_blue_folders, :parent_resource_pool, :host, :ems_cluster, :ext_management_system, :my_enterprise, :physical_server]) unless const_defined?("ASSIGNMENT_PARENT_ASSOCIATIONS")
+    const_set("ASSIGNMENT_PARENT_ASSOCIATIONS", %i(parent_blue_folders parent_resource_pool host ems_cluster ext_management_system my_enterprise physical_server)) unless const_defined?("ASSIGNMENT_PARENT_ASSOCIATIONS")
 
     cache_with_timeout(:assignments_cached, 1.minute) { assignments }
   end

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -27,6 +27,7 @@ class PhysicalServer < ApplicationRecord
   has_one :host, :inverse_of => :physical_server
   has_one :asset_detail, :as => :resource, :dependent => :destroy
   has_many :guest_devices, :through => :hardware
+  has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
 
   scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
 

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -27,7 +27,7 @@ class PhysicalServer < ApplicationRecord
   has_one :host, :inverse_of => :physical_server
   has_one :asset_detail, :as => :resource, :dependent => :destroy
   has_many :guest_devices, :through => :hardware
-  has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy
+  has_many :miq_alert_statuses, :as => :resource, :dependent => :destroy, :inverse_of => :physical_server
 
   scope :with_hosts, -> { where("physical_servers.id in (select hosts.physical_server_id from hosts)") }
 

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -20,6 +20,7 @@ class Zone < ApplicationRecord
   has_many :vms,                   :through => :ext_management_systems
   has_many :miq_templates,         :through => :ext_management_systems
   has_many :ems_clusters,          :through => :ext_management_systems
+  has_many :physical_servers,      :through => :ext_management_systems
   has_many :container_nodes,       :through => :container_managers
   has_many :container_groups,      :through => :container_managers
   has_many :container_replicators, :through => :container_managers

--- a/db/fixtures/miq_alerts.yml
+++ b/db/fixtures/miq_alerts.yml
@@ -321,3 +321,18 @@
             value: prod
   :db: Vm
   :guid: 89db0be8-c240-11de-a3be-000c290de4f9
+- description: Physical server has critical health state
+  options:
+    :notifications:
+        :delay_next_evaluation: 3600
+        :email:
+            :from: ''
+            :to: []
+  miq_expression: !ruby/object:MiqExpression
+    :exp:
+      =:
+        field: PhysicalServer-health_state
+        value: "Critical"
+  db: PhysicalServer
+  guid: 15feb65a-1f36-44db-84ee-0e71d9f497c8
+  responds_to_events: _hourly_timer_

--- a/db/fixtures/miq_alerts.yml
+++ b/db/fixtures/miq_alerts.yml
@@ -324,10 +324,10 @@
 - description: Physical server has critical health state
   options:
     :notifications:
-        :delay_next_evaluation: 3600
+      :delay_next_evaluation: 3600
         :email:
-            :from: ''
-            :to: []
+          :from: ''
+          :to: []
   miq_expression: !ruby/object:MiqExpression
     :exp:
       =:

--- a/db/fixtures/miq_alerts.yml
+++ b/db/fixtures/miq_alerts.yml
@@ -321,18 +321,18 @@
             value: prod
   :db: Vm
   :guid: 89db0be8-c240-11de-a3be-000c290de4f9
-- description: Physical server has critical health state
-  options:
+- :description: Physical server has critical health state
+  :options:
     :notifications:
       :delay_next_evaluation: 3600
-        :email:
-          :from: ''
-          :to: []
-  miq_expression: !ruby/object:MiqExpression
-    :exp:
+      :email:
+        :from: ''
+        :to: []
+  :miq_expression: !ruby/object:MiqExpression
+    exp:
       =:
         field: PhysicalServer-health_state
         value: "Critical"
-  db: PhysicalServer
-  guid: 15feb65a-1f36-44db-84ee-0e71d9f497c8
-  responds_to_events: _hourly_timer_
+  :db: PhysicalServer
+  :guid: 15feb65a-1f36-44db-84ee-0e71d9f497c8
+  :responds_to_events: _hourly_timer_


### PR DESCRIPTION
This PR adds support for a new physical server alert that alerts the user about servers in "Critical" health states.