### PR TITLE
InventoryCollection definitions for vmware infra

### DIFF
--- a/app/models/manager_refresh/inventory_collection/builder.rb
+++ b/app/models/manager_refresh/inventory_collection/builder.rb
@@ -158,11 +158,15 @@ module ManagerRefresh
       def to_hash
         add_inventory_attributes(auto_inventory_attributes) if @options[:auto_inventory_attributes]
 
-        @properties.merge(
-          :inventory_object_attributes => @inventory_object_attributes,
-          :builder_params              => @default_values,
-          :dependency_attributes       => @dependency_attributes
-        )
+        @properties[:inventory_object_attributes] ||= @inventory_object_attributes
+
+        @properties[:builder_params] ||= {}
+        @properties[:builder_params].merge!(@default_values)
+
+        @properties[:dependency_attributes] ||= {}
+        @properties[:dependency_attributes].merge!(@dependency_attributes)
+
+        @properties
       end
 
       protected

--- a/app/models/manager_refresh/inventory_collection/builder/infra_manager.rb
+++ b/app/models/manager_refresh/inventory_collection/builder/infra_manager.rb
@@ -211,6 +211,30 @@ module ManagerRefresh
             :custom_save_block => snapshot_parent_save_block
           )
         end
+
+        def customization_specs
+          add_properties(:manager_ref => %i(name))
+
+          add_common_default_values
+        end
+
+        def miq_scsi_luns
+          add_properties(
+            :manager_ref                  => %i(miq_scsi_target uid_ems),
+            :parent_inventory_collections => %i(hosts)
+          )
+        end
+
+        def miq_scsi_targets
+          add_properties(
+            :manager_ref                  => %i(guest_device uid_ems),
+            :parent_inventory_collections => %i(hosts)
+          )
+        end
+
+        def storage_profiles
+          add_common_default_values
+        end
       end
     end
   end


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq/issues/17396

**dependent**: https://github.com/ManageIQ/manageiq-providers-vmware/pull/299

InventoryCollection Builder extension for vmware infra - new IC definitions

Also fix for merging `default values` and `dependency attributes` (previously these values defined by `add_properties` were ignored)
