### PR TITLE
Add Ownership and Tenancy Mixins to Authentication

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -34,6 +34,11 @@ class Authentication < ApplicationRecord
 
   serialize :options
 
+  include OwnershipMixin
+  include TenancyMixin
+
+  belongs_to :tenant
+
   # TODO: DELETE ME!!!!
   ERRORS = {
     :incomplete => "Incomplete credentials",

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -14,6 +14,7 @@ class MiqGroup < ApplicationRecord
   has_many   :miq_widget_contents, :dependent => :destroy
   has_many   :miq_widget_sets, :as => :owner, :dependent => :destroy
   has_many   :miq_product_features, :through => :miq_user_role
+  has_many   :authentications, :dependent => :nullify
 
   virtual_delegate :miq_user_role_name, :to => :entitlement, :allow_nil => true
   virtual_column :read_only,          :type => :boolean

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -34,6 +34,7 @@ class Tenant < ApplicationRecord
   has_many :miq_request_tasks, :dependent => :destroy
   has_many :services, :dependent => :destroy
   has_many :shares
+  has_many :authentications, :dependent => :nullify
 
   belongs_to :default_miq_group, :class_name => "MiqGroup", :dependent => :destroy
   belongs_to :source, :polymorphic => true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
   has_many   :notifications, :through => :notification_recipients
   has_many   :unseen_notification_recipients, -> { unseen }, :class_name => 'NotificationRecipient'
   has_many   :unseen_notifications, :through => :unseen_notification_recipients, :source => :notification
+  has_many   :authentications, :foreign_key => :evm_owner_id, :dependent => :nullify, :inverse_of => :evm_owner
   belongs_to :current_group, :class_name => "MiqGroup"
   has_and_belongs_to_many :miq_groups
   scope      :superadmins, lambda {


### PR DESCRIPTION
This adds ownership and tenancy to authentications allowing for key
pairs added by EmsRefresh to be associated with users in manageiq.

Depends: https://github.com/ManageIQ/manageiq-schema/pull/237

https://bugzilla.redhat.com/show_bug.cgi?id=1589766