### PR TITLE
[GAPRINDASHVILI] Set Settings.product.transformation to true

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -969,7 +969,7 @@
 :product:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
-  :transformation: false
+  :transformation: true
 :prototype:
   :queue_type: miq_queue
   :artemis:


### PR DESCRIPTION
..because v2v is now enabled by default.

This is a gaprindashvili version of https://github.com/ManageIQ/manageiq/pull/17711, see discussion there :).
