### PR TITLE
Connecting physical switch to computer systems

### DIFF
--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -1,10 +1,11 @@
 class GuestDevice < ApplicationRecord
   belongs_to :hardware
 
-  has_one :vm_or_template, :through => :hardware
-  has_one :vm,             :through => :hardware
-  has_one :miq_template,   :through => :hardware
-  has_one :host,           :through => :hardware
+  has_one :vm_or_template,  :through => :hardware
+  has_one :vm,              :through => :hardware
+  has_one :miq_template,    :through => :hardware
+  has_one :host,            :through => :hardware
+  has_one :computer_system, :through => :hardware
 
   belongs_to :switch    # pNICs link to one switch
   belongs_to :lan       # vNICs link to one lan

--- a/app/models/physical_network_port.rb
+++ b/app/models/physical_network_port.rb
@@ -4,6 +4,8 @@ class PhysicalNetworkPort < ApplicationRecord
 
   has_one :connected_port, :foreign_key => "connected_port_uid", :primary_key => "uid_ems", :class_name => "PhysicalNetworkPort", :dependent => :nullify, :inverse_of => :connected_port
   has_one :connected_physical_switch, :through => :connected_port, :source => :physical_switch
+  has_one :computer_system, :through => :guest_device
+  has_one :connected_computer_system, :through => :connected_port, :source => :computer_system
 
   alias_attribute :name, :port_name
 end

--- a/app/models/physical_switch.rb
+++ b/app/models/physical_switch.rb
@@ -10,6 +10,15 @@ class PhysicalSwitch < Switch
   has_many :physical_network_ports, :dependent => :destroy, :foreign_key => :switch_id
   has_many :event_streams, :inverse_of => :physical_switch, :dependent => :nullify
 
+  has_many :connected_components, :through => :physical_network_ports, :source => :connected_computer_system
+
+  has_many :connected_physical_servers,
+           :source_type => "PhysicalServer",
+           :through     => :connected_components,
+           :source      => :managed_entity
+
+  alias_attribute :physical_servers, :connected_physical_servers
+
   def my_zone
     ems = ext_management_system
     ems ? ems.my_zone : MiqServer.my_zone


### PR DESCRIPTION
__This PR is able to__
- Add a route to get the connected component from `physical_switch`.

__More details__
The connected component could be any `managed_entity` of `ComputerSystem` entity that has `PhysicalNetworkPort` parsed