### PR TITLE
Add support for exporting and importing provision dialogs

### DIFF
--- a/lib/task_helpers/exports/provision_dialogs.rb
+++ b/lib/task_helpers/exports/provision_dialogs.rb
@@ -4,9 +4,9 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        dialogs = options[:all] ? MiqDialog.order(:id).all : MiqDialog.order(:id).where(:default => [false, nil])
+        dialogs = options[:all] ? MiqDialog.all : MiqDialog.where(:default => [false, nil])
 
-        dialogs = dialogs.collect do |dialog|
+        dialogs.order(:id).to_a.collect! do |dialog|
           Exports.exclude_attributes(dialog.to_model_hash, %i(file_mtime created_at updated_at id class))
         end
 

--- a/lib/task_helpers/exports/provision_dialogs.rb
+++ b/lib/task_helpers/exports/provision_dialogs.rb
@@ -1,0 +1,22 @@
+module TaskHelpers
+  class Exports
+    class ProvisionDialogs
+      def export(options = {})
+        export_dir = options[:directory]
+
+        dialogs = options[:all] ? MiqDialog.order(:id).all : MiqDialog.order(:id).where(:default => [false, nil])
+
+        dialogs = dialogs.collect do |dialog|
+          Exports.exclude_attributes(dialog.to_model_hash, %i(file_mtime created_at updated_at id class))
+        end
+
+        dialogs.each do |dialog|
+          $log.info("Exporting Provision Dialog: #{dialog[:name]} (#{dialog[:description]})")
+
+          fname = Exports.safe_filename("#{dialog[:dialog_type]}-#{dialog[:name]}", options[:keep_spaces])
+          File.write("#{export_dir}/#{fname}.yaml", dialog.to_yaml)
+        end
+      end
+    end
+  end
+end

--- a/lib/task_helpers/imports/provision_dialogs.rb
+++ b/lib/task_helpers/imports/provision_dialogs.rb
@@ -1,0 +1,20 @@
+module TaskHelpers
+  class Imports
+    class ProvisionDialogs
+      def import(options = {})
+        return unless options[:source]
+
+        glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
+        Dir.glob(glob) do |fname|
+          $log.info("Importing Provision Dialog from: #{fname}")
+
+          dialog = YAML.load_file(fname)
+
+          miq_dialog = MiqDialog.find_by(:name => dialog[:name], :dialog_type => dialog[:dialog_type])
+
+          miq_dialog.nil? ? MiqDialog.create(dialog) : miq_dialog.update(dialog)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/evm_export_import.rake
+++ b/lib/tasks/evm_export_import.rake
@@ -4,6 +4,7 @@
 #   * Roles
 #   * Tags
 #   * Service Dialogs
+#   * Provision Dialogs
 
 namespace :evm do
   namespace :export do
@@ -76,6 +77,14 @@ namespace :evm do
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end
+
+    desc 'Exports all provision dialogs to individual YAML files'
+    task :provision_dialogs => :environment do
+      options = TaskHelpers::Exports.parse_options
+      TaskHelpers::Exports::ProvisionDialogs.new.export(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
   end
 
   namespace :import do
@@ -137,6 +146,14 @@ namespace :evm do
     task :service_dialogs => :environment do
       options = TaskHelpers::Imports.parse_options
       TaskHelpers::Imports::ServiceDialogs.new.import(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
+
+    desc 'Imports all provision dialogs from individual YAML files'
+    task :provision_dialogs => :environment do
+      options = TaskHelpers::Imports.parse_options
+      TaskHelpers::Imports::ProvisionDialogs.new.import(options)
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end

--- a/spec/lib/task_helpers/exports/provision_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/provision_dialogs_spec.rb
@@ -1,0 +1,118 @@
+describe TaskHelpers::Exports::ProvisionDialogs do
+  let(:dialog_name1) { "default_dialog" }
+  let(:dialog_name2) { "custom_dialog" }
+  let(:dialog_desc1) { "Default Provisioning Dialog" }
+  let(:dialog_desc2) { "Custom Provisioning Dialog" }
+  let(:dialog_type1) { "MiqProvisionWorkflow" }
+  let(:dialog_type2) { "MiqProvisionWorkflow" }
+  let(:dialog_type3) { "VmMigrateWorkflow" }
+
+  let(:content) do
+    {
+      :dialogs => {
+        :hardware => {
+          :description => "Hardware",
+          :fields      => {
+            :disk_format => {
+              :description => "Disk Format",
+              :required    => false,
+              :display     => :edit,
+              :default     => "unchanged",
+              :data_type   => :string,
+              :values      => {
+                :thick => "Thick",
+                :thin  => "Thin"
+              }
+            },
+            :cpu_limit   => {
+              :description   => "CPU (MHz)",
+              :required      => false,
+              :notes         => "(-1 = Unlimited)",
+              :display       => :edit,
+              :data_type     => :integer,
+              :notes_display => :show
+            }
+          }
+        }
+      }
+    }
+  end
+
+  let(:content2) do
+    {
+      :dialogs => {
+        :buttons => %i(submit cancel)
+      }
+    }
+  end
+
+  let(:export_dir) do
+    Dir.mktmpdir('miq_exp_dir')
+  end
+
+  before do
+    FactoryGirl.create(:miq_dialog,
+                       :dialog_type => dialog_type1,
+                       :name        => dialog_name1,
+                       :description => dialog_desc1,
+                       :content     => content,
+                       :default     => true)
+
+    FactoryGirl.create(:miq_dialog,
+                       :dialog_type => dialog_type2,
+                       :name        => dialog_name2,
+                       :description => dialog_desc2,
+                       :content     => content,
+                       :default     => false)
+  end
+
+  after do
+    FileUtils.remove_entry export_dir
+  end
+
+  describe "when --all is not specified" do
+    let(:dialog_filename1) { "#{export_dir}/#{dialog_type1}-custom_dialog.yaml" }
+    let(:dialog_filename2) { "#{export_dir}/#{dialog_type3}-custom_dialog.yaml" }
+
+    it 'exports user provision dialogs to a given directory' do
+      TaskHelpers::Exports::ProvisionDialogs.new.export(:directory => export_dir)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
+      dialog = YAML.load_file(dialog_filename1)
+      expect(dialog[:content]).to eq(content)
+      expect(dialog[:description]).to eq(dialog_desc2)
+    end
+
+    it 'exports dialogs with the same name to different files' do
+      FactoryGirl.create(:miq_dialog,
+                         :dialog_type => dialog_type3,
+                         :name        => dialog_name2,
+                         :description => dialog_desc2,
+                         :content     => content2,
+                         :default     => false)
+      TaskHelpers::Exports::ProvisionDialogs.new.export(:directory => export_dir)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
+      dialog = YAML.load_file(dialog_filename1)
+      expect(dialog[:content]).to eq(content)
+      expect(dialog[:description]).to eq(dialog_desc2)
+      dialog2 = YAML.load_file(dialog_filename2)
+      expect(dialog2[:content]).to eq(content2)
+      expect(dialog2[:description]).to eq(dialog_desc2)
+    end
+  end
+
+  describe "when --all is specified" do
+    let(:dialog_filename1) { "#{export_dir}/#{dialog_type1}-default_dialog.yaml" }
+    let(:dialog_filename2) { "#{export_dir}/#{dialog_type1}-custom_dialog.yaml" }
+
+    it 'exports all provision dialogs to a given directory' do
+      TaskHelpers::Exports::ProvisionDialogs.new.export(:directory => export_dir, :all => true)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
+      dialog1 = YAML.load_file(dialog_filename1)
+      dialog2 = YAML.load_file(dialog_filename2)
+      expect(dialog1[:content]).to eq(content)
+      expect(dialog1[:description]).to eq(dialog_desc1)
+      expect(dialog2[:content]).to eq(content)
+      expect(dialog2[:description]).to eq(dialog_desc2)
+    end
+  end
+end

--- a/spec/lib/task_helpers/exports/provision_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/provision_dialogs_spec.rb
@@ -81,23 +81,6 @@ describe TaskHelpers::Exports::ProvisionDialogs do
       expect(dialog[:content]).to eq(content)
       expect(dialog[:description]).to eq(dialog_desc2)
     end
-
-    it 'exports dialogs with the same name to different files' do
-      FactoryGirl.create(:miq_dialog,
-                         :dialog_type => dialog_type3,
-                         :name        => dialog_name2,
-                         :description => dialog_desc2,
-                         :content     => content2,
-                         :default     => false)
-      TaskHelpers::Exports::ProvisionDialogs.new.export(:directory => export_dir)
-      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
-      dialog = YAML.load_file(dialog_filename1)
-      expect(dialog[:content]).to eq(content)
-      expect(dialog[:description]).to eq(dialog_desc2)
-      dialog2 = YAML.load_file(dialog_filename2)
-      expect(dialog2[:content]).to eq(content2)
-      expect(dialog2[:description]).to eq(dialog_desc2)
-    end
   end
 
   describe "when --all is specified" do
@@ -112,6 +95,31 @@ describe TaskHelpers::Exports::ProvisionDialogs do
       expect(dialog1[:content]).to eq(content)
       expect(dialog1[:description]).to eq(dialog_desc1)
       expect(dialog2[:content]).to eq(content)
+      expect(dialog2[:description]).to eq(dialog_desc2)
+    end
+  end
+
+  describe "when multiple dialogs of different types have the same name" do
+    let(:dialog_filename1) { "#{export_dir}/#{dialog_type1}-custom_dialog.yaml" }
+    let(:dialog_filename2) { "#{export_dir}/#{dialog_type3}-custom_dialog.yaml" }
+
+    before do
+      FactoryGirl.create(:miq_dialog,
+                         :dialog_type => dialog_type3,
+                         :name        => dialog_name2,
+                         :description => dialog_desc2,
+                         :content     => content2,
+                         :default     => false)
+    end
+
+    it 'exports the dialogs to different files' do
+      TaskHelpers::Exports::ProvisionDialogs.new.export(:directory => export_dir)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
+      dialog = YAML.load_file(dialog_filename1)
+      expect(dialog[:content]).to eq(content)
+      expect(dialog[:description]).to eq(dialog_desc2)
+      dialog2 = YAML.load_file(dialog_filename2)
+      expect(dialog2[:content]).to eq(content2)
       expect(dialog2[:description]).to eq(dialog_desc2)
     end
   end

--- a/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test2_miq_provision_dialogs_template.yaml
+++ b/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test2_miq_provision_dialogs_template.yaml
@@ -1,0 +1,770 @@
+---
+:name: test2_miq_provision_dialogs_template
+:description: Test2 Sample VM Provisioning Dialog (Template)
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags:
+          - environment
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_organization:
+          :description: Organization
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :sysprep_password:
+          :description: New Administrator Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_custom_spec:
+          :values_from:
+            :method: :allowed_customization_specs
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_server_license_mode:
+          :values:
+            perServer: Per server
+            perSeat: Per seat
+          :description: Identification
+          :required: false
+          :display: :edit
+          :default: perServer
+          :data_type: :string
+        :ldap_ous:
+          :values_from:
+            :method: :allowed_ous_tree
+          :auto_select_single: false
+          :description: LDAP Group
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_timezone:
+          :values_from:
+            :method: :get_timezones
+          :description: Timezone
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix List
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_product_id:
+          :description: ProductID
+          :required_method: :validate_sysprep_field
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_identification:
+          :values:
+            domain: Domain
+            workgroup: Workgroup
+          :description: Identification
+          :required: false
+          :display: :edit
+          :default: domain
+          :data_type: :string
+        :sysprep_per_server_max_connections:
+          :description: Maximum Connections
+          :required: false
+          :display: :edit
+          :default: '5'
+          :data_type: :string
+        :sysprep_computer_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_workgroup_name:
+          :description: Workgroup Name
+          :required: false
+          :display: :edit
+          :default: WORKGROUP
+          :data_type: :string
+        :sysprep_spec_override:
+          :values:
+            false: 0
+            true: 1
+          :description: Override Specification Values
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: dhcp
+          :data_type: :string
+        :linux_host_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_domain_admin:
+          :description: Domain Admin
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_change_sid:
+          :values:
+            false: 0
+            true: 1
+          :description: Change SID
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :sysprep_domain_name:
+          :values_from:
+            :options:
+              :active_proxy:
+              :platform:
+            :method: :allowed_domains
+          :auto_select_single: false
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_upload_file:
+          :description: Upload
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :ip_addr:
+          :description: IP Address
+          :required: false
+          :notes: "(Enter starting IP address)"
+          :display: :edit
+          :data_type: :string
+          :notes_display: :hide
+        :linux_domain_name:
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_domain_password:
+          :description: Domain Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_auto_logon:
+          :values:
+            false: 0
+            true: 1
+          :description: Auto Logon
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :sysprep_enabled:
+          :values_from:
+            :method: :allowed_customization
+          :description: Customize
+          :required: false
+          :display: :edit
+          :default: disabled
+          :data_type: :string
+        :sysprep_delete_accounts:
+          :display_override: :hide
+          :values:
+            false: 0
+            true: 1
+          :description: Delete Accounts
+          :required: false
+          :display: :hide
+          :default: false
+          :data_type: :boolean
+        :sysprep_upload_text:
+          :description: Sysprep Text
+          :required_method: :validate_sysprep_upload
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :wins_servers:
+          :description: WINS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_full_name:
+          :description: Full Name
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :sysprep_auto_logon_count:
+          :values:
+            1: '1'
+            2: '2'
+            3: '3'
+          :description: Auto Logon Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_cluster_name:
+          :values_from:
+            :method: :allowed_clusters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :cluster_filter:
+          :values_from:
+            :options:
+              :category: :EmsCluster
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :host_filter:
+          :values_from:
+            :options:
+              :category: :Host
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :ds_filter:
+          :values_from:
+            :options:
+              :category: :Storage
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_storage_profile:
+          :values_from:
+            :method: :allowed_storage_profiles
+          :auto_select_single: false
+          :description: Storage Profile
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_host_name:
+          :values_from:
+            :method: :allowed_hosts
+          :auto_select_single: false
+          :description: Name
+          :validation_method: :validate_placement_host_name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Host Name
+        :placement_ds_name:
+          :values_from:
+            :method: :allowed_storages
+          :auto_select_single: false
+          :description: Name
+          :required_method: :validate_placement
+          :required: true
+          :display: :edit
+          :data_type: :integer
+          :required_description: Datastore Name
+        :rp_filter:
+          :values_from:
+            :options:
+              :category: :ResourcePool
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :placement_folder_name:
+          :values_from:
+            :method: :allowed_folders
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_rp_name:
+          :values_from:
+            :method: :allowed_respools
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_dc_name:
+          :values_from:
+            :method: :allowed_datacenters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: VM Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: VM Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: VM Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+        :pxe_image_id:
+          :values_from:
+            :method: :allowed_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :required_method: :validate_pxe_image_id
+          :display: :edit
+          :data_type: :string
+        :pxe_server_id:
+          :values_from:
+            :method: :allowed_pxe_servers
+          :auto_select_single: false
+          :description: Server
+          :required: true
+          :required_method: :validate_pxe_server_id
+          :display: :edit
+          :data_type: :integer
+        :host_name:
+          :description: Host Name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :provision_type:
+          :values_from:
+            :method: :allowed_provision_types
+          :description: Provision Type
+          :required: true
+          :display: :edit
+          :default: vmware
+          :data_type: :string
+        :linked_clone:
+          :values:
+            false: 0
+            true: 1
+          :description: Linked Clone
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+          :notes: VM requires a snapshot
+          :notes_display: :show
+        :snapshot:
+          :values_from:
+            :method: :allowed_snapshots
+          :description: Snapshot
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :auto_select_single: false
+        :vm_filter:
+          :values_from:
+            :options:
+              :category: :Vm
+            :method: :allowed_filters
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :network:
+      :description: Network
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
+              :dvs: true
+              :vlans: true
+            :method: :allowed_vlans
+          :description: Virtual Network
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :mac_address:
+          :description: MAC Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+      :display: :show
+    :hardware:
+      :description: Hardware
+      :fields:
+        :disk_format:
+          :values:
+            thick: Thick
+            thin: Thin
+            unchanged: Default
+          :description: Disk Format
+          :required: false
+          :display: :edit
+          :default: unchanged
+          :data_type: :string
+        :cpu_limit:
+          :description: CPU (MHz)
+          :required: false
+          :notes: "(-1 = Unlimited)"
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :memory_limit:
+          :description: Memory (MB)
+          :required: false
+          :notes: "(-1 = Unlimited)"
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :number_of_sockets:
+          :values:
+            1: '1'
+            2: '2'
+            4: '4'
+            8: '8'
+          :description: Number of Sockets
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cores_per_socket:
+          :values:
+            1: '1'
+            2: '2'
+            4: '4'
+            8: '8'
+          :description: Cores per Socket
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cpu_reserve:
+          :description: CPU (MHz)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :vm_memory:
+          :values:
+            '1024': '1024'
+            '2048': '2048'
+            '4096': '4096'
+            '8192': '8192'
+            '12288': '12288'
+            '16384': '16384'
+            '32768': '32768'
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :default: '1024'
+          :data_type: :string
+        :memory_reserve:
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :validation_method: :validate_memory_reservation
+        :network_adapters:
+          :values:
+            1: '1'
+            2: '2'
+            3: '3'
+            4: '4'
+          :description: Network Adapters
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :network
+  - :customize
+  - :schedule
+:default: false

--- a/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template.yaml
+++ b/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template.yaml
@@ -1,0 +1,769 @@
+---
+:name: test_miq_provision_dialogs_template
+:description: Test Sample VM Provisioning Dialog (Template)
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags: []
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_organization:
+          :description: Organization
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :sysprep_password:
+          :description: New Administrator Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_custom_spec:
+          :values_from:
+            :method: :allowed_customization_specs
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_server_license_mode:
+          :values:
+            perServer: Per server
+            perSeat: Per seat
+          :description: Identification
+          :required: false
+          :display: :edit
+          :default: perServer
+          :data_type: :string
+        :ldap_ous:
+          :values_from:
+            :method: :allowed_ous_tree
+          :auto_select_single: false
+          :description: LDAP Group
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_timezone:
+          :values_from:
+            :method: :get_timezones
+          :description: Timezone
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix List
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_product_id:
+          :description: ProductID
+          :required_method: :validate_sysprep_field
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_identification:
+          :values:
+            domain: Domain
+            workgroup: Workgroup
+          :description: Identification
+          :required: false
+          :display: :edit
+          :default: domain
+          :data_type: :string
+        :sysprep_per_server_max_connections:
+          :description: Maximum Connections
+          :required: false
+          :display: :edit
+          :default: '5'
+          :data_type: :string
+        :sysprep_computer_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_workgroup_name:
+          :description: Workgroup Name
+          :required: false
+          :display: :edit
+          :default: WORKGROUP
+          :data_type: :string
+        :sysprep_spec_override:
+          :values:
+            false: 0
+            true: 1
+          :description: Override Specification Values
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: dhcp
+          :data_type: :string
+        :linux_host_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_domain_admin:
+          :description: Domain Admin
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_change_sid:
+          :values:
+            false: 0
+            true: 1
+          :description: Change SID
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :sysprep_domain_name:
+          :values_from:
+            :options:
+              :active_proxy:
+              :platform:
+            :method: :allowed_domains
+          :auto_select_single: false
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_upload_file:
+          :description: Upload
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :ip_addr:
+          :description: IP Address
+          :required: false
+          :notes: "(Enter starting IP address)"
+          :display: :edit
+          :data_type: :string
+          :notes_display: :hide
+        :linux_domain_name:
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_domain_password:
+          :description: Domain Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_auto_logon:
+          :values:
+            false: 0
+            true: 1
+          :description: Auto Logon
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :sysprep_enabled:
+          :values_from:
+            :method: :allowed_customization
+          :description: Customize
+          :required: false
+          :display: :edit
+          :default: disabled
+          :data_type: :string
+        :sysprep_delete_accounts:
+          :display_override: :hide
+          :values:
+            false: 0
+            true: 1
+          :description: Delete Accounts
+          :required: false
+          :display: :hide
+          :default: false
+          :data_type: :boolean
+        :sysprep_upload_text:
+          :description: Sysprep Text
+          :required_method: :validate_sysprep_upload
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :wins_servers:
+          :description: WINS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_full_name:
+          :description: Full Name
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :sysprep_auto_logon_count:
+          :values:
+            1: '1'
+            2: '2'
+            3: '3'
+          :description: Auto Logon Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_cluster_name:
+          :values_from:
+            :method: :allowed_clusters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :cluster_filter:
+          :values_from:
+            :options:
+              :category: :EmsCluster
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :host_filter:
+          :values_from:
+            :options:
+              :category: :Host
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :ds_filter:
+          :values_from:
+            :options:
+              :category: :Storage
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_storage_profile:
+          :values_from:
+            :method: :allowed_storage_profiles
+          :auto_select_single: false
+          :description: Storage Profile
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_host_name:
+          :values_from:
+            :method: :allowed_hosts
+          :auto_select_single: false
+          :description: Name
+          :validation_method: :validate_placement_host_name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Host Name
+        :placement_ds_name:
+          :values_from:
+            :method: :allowed_storages
+          :auto_select_single: false
+          :description: Name
+          :required_method: :validate_placement
+          :required: true
+          :display: :edit
+          :data_type: :integer
+          :required_description: Datastore Name
+        :rp_filter:
+          :values_from:
+            :options:
+              :category: :ResourcePool
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :placement_folder_name:
+          :values_from:
+            :method: :allowed_folders
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_rp_name:
+          :values_from:
+            :method: :allowed_respools
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_dc_name:
+          :values_from:
+            :method: :allowed_datacenters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: VM Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: VM Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: VM Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+        :pxe_image_id:
+          :values_from:
+            :method: :allowed_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :required_method: :validate_pxe_image_id
+          :display: :edit
+          :data_type: :string
+        :pxe_server_id:
+          :values_from:
+            :method: :allowed_pxe_servers
+          :auto_select_single: false
+          :description: Server
+          :required: true
+          :required_method: :validate_pxe_server_id
+          :display: :edit
+          :data_type: :integer
+        :host_name:
+          :description: Host Name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :provision_type:
+          :values_from:
+            :method: :allowed_provision_types
+          :description: Provision Type
+          :required: true
+          :display: :edit
+          :default: vmware
+          :data_type: :string
+        :linked_clone:
+          :values:
+            false: 0
+            true: 1
+          :description: Linked Clone
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+          :notes: VM requires a snapshot
+          :notes_display: :show
+        :snapshot:
+          :values_from:
+            :method: :allowed_snapshots
+          :description: Snapshot
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :auto_select_single: false
+        :vm_filter:
+          :values_from:
+            :options:
+              :category: :Vm
+            :method: :allowed_filters
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :network:
+      :description: Network
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
+              :dvs: true
+              :vlans: true
+            :method: :allowed_vlans
+          :description: Virtual Network
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :mac_address:
+          :description: MAC Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+      :display: :show
+    :hardware:
+      :description: Hardware
+      :fields:
+        :disk_format:
+          :values:
+            thick: Thick
+            thin: Thin
+            unchanged: Default
+          :description: Disk Format
+          :required: false
+          :display: :edit
+          :default: unchanged
+          :data_type: :string
+        :cpu_limit:
+          :description: CPU (MHz)
+          :required: false
+          :notes: "(-1 = Unlimited)"
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :memory_limit:
+          :description: Memory (MB)
+          :required: false
+          :notes: "(-1 = Unlimited)"
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :number_of_sockets:
+          :values:
+            1: '1'
+            2: '2'
+            4: '4'
+            8: '8'
+          :description: Number of Sockets
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cores_per_socket:
+          :values:
+            1: '1'
+            2: '2'
+            4: '4'
+            8: '8'
+          :description: Cores per Socket
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cpu_reserve:
+          :description: CPU (MHz)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :vm_memory:
+          :values:
+            '1024': '1024'
+            '2048': '2048'
+            '4096': '4096'
+            '8192': '8192'
+            '12288': '12288'
+            '16384': '16384'
+            '32768': '32768'
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :default: '1024'
+          :data_type: :string
+        :memory_reserve:
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :validation_method: :validate_memory_reservation
+        :network_adapters:
+          :values:
+            1: '1'
+            2: '2'
+            3: '3'
+            4: '4'
+          :description: Network Adapters
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :network
+  - :customize
+  - :schedule
+:default: false

--- a/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template_modified.yml
+++ b/spec/lib/task_helpers/imports/data/provision_dialogs/MiqProvisionWorkflow-test_miq_provision_dialogs_template_modified.yml
@@ -1,0 +1,769 @@
+---
+:name: test_miq_provision_dialogs_template
+:description: Test Sample VM Provisioning Dialog (Template)
+:dialog_type: MiqProvisionWorkflow
+:content:
+  :buttons:
+  - :submit
+  - :cancel
+  :dialogs:
+    :requester:
+      :description: Request
+      :fields:
+        :owner_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_country:
+          :description: Country/Region
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_phone_mobile:
+          :description: Mobile
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_title:
+          :description: Title
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_first_name:
+          :description: First Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager:
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_address:
+          :description: Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_company:
+          :description: Company
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_last_name:
+          :description: Last Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :owner_manager_mail:
+          :description: E-Mail
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_city:
+          :description: City
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_department:
+          :description: Department
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_load_ldap:
+          :pressed:
+            :method: :retrieve_ldap
+          :description: Look Up LDAP Email
+          :required: false
+          :display: :show
+          :data_type: :button
+        :owner_manager_phone:
+          :description: Phone
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_state:
+          :description: State
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_office:
+          :description: Office
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_zip:
+          :description: Zip code
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :owner_email:
+          :description: E-Mail
+          :required_method: :validate_regex
+          :required_regex: !ruby/regexp /\A[\w!#$\%&'*+\/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+\/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z/i
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :request_notes:
+          :description: Notes
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+      :field_order:
+    :purpose:
+      :description: Purpose
+      :fields:
+        :vm_tags:
+          :required_method: :validate_tags
+          :description: Tags
+          :required: false
+          :options:
+            :include: []
+            :order: []
+            :single_select: []
+            :exclude: []
+          :display: :edit
+          :required_tags: []
+          :data_type: :integer
+      :display: :show
+      :field_order:
+    :customize:
+      :description: Customize
+      :fields:
+        :dns_servers:
+          :description: DNS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_organization:
+          :description: Organization
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :sysprep_password:
+          :description: New Administrator Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_custom_spec:
+          :values_from:
+            :method: :allowed_customization_specs
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_server_license_mode:
+          :values:
+            perServer: Per server
+            perSeat: Per seat
+          :description: Identification
+          :required: false
+          :display: :edit
+          :default: perServer
+          :data_type: :string
+        :ldap_ous:
+          :values_from:
+            :method: :allowed_ous_tree
+          :auto_select_single: false
+          :description: LDAP Group
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_timezone:
+          :values_from:
+            :method: :get_timezones
+          :description: Timezone
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :dns_suffixes:
+          :description: DNS Suffix List
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_product_id:
+          :description: ProductID
+          :required_method: :validate_sysprep_field
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_identification:
+          :values:
+            domain: Domain
+            workgroup: Workgroup
+          :description: Identification
+          :required: false
+          :display: :edit
+          :default: domain
+          :data_type: :string
+        :sysprep_per_server_max_connections:
+          :description: Maximum Connections
+          :required: false
+          :display: :edit
+          :default: '5'
+          :data_type: :string
+        :sysprep_computer_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_workgroup_name:
+          :description: Workgroup Name
+          :required: false
+          :display: :edit
+          :default: WORKGROUP
+          :data_type: :string
+        :sysprep_spec_override:
+          :values:
+            false: 0
+            true: 1
+          :description: Override Specification Values
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :addr_mode:
+          :values:
+            static: Static
+            dhcp: DHCP
+          :description: Address Mode
+          :required: false
+          :display: :edit
+          :default: dhcp
+          :data_type: :string
+        :linux_host_name:
+          :description: Computer Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_domain_admin:
+          :description: Domain Admin
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_change_sid:
+          :values:
+            false: 0
+            true: 1
+          :description: Change SID
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :sysprep_domain_name:
+          :values_from:
+            :options:
+              :active_proxy:
+              :platform:
+            :method: :allowed_domains
+          :auto_select_single: false
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_upload_file:
+          :description: Upload
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :gateway:
+          :description: Gateway
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :ip_addr:
+          :description: IP Address
+          :required: false
+          :notes: "(Enter starting IP address)"
+          :display: :edit
+          :data_type: :string
+          :notes_display: :hide
+        :linux_domain_name:
+          :description: Domain Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_domain_password:
+          :description: Domain Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_auto_logon:
+          :values:
+            false: 0
+            true: 1
+          :description: Auto Logon
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :sysprep_enabled:
+          :values_from:
+            :method: :allowed_customization
+          :description: Customize
+          :required: false
+          :display: :edit
+          :default: disabled
+          :data_type: :string
+        :sysprep_delete_accounts:
+          :display_override: :hide
+          :values:
+            false: 0
+            true: 1
+          :description: Delete Accounts
+          :required: false
+          :display: :hide
+          :default: false
+          :data_type: :boolean
+        :sysprep_upload_text:
+          :description: Sysprep Text
+          :required_method: :validate_sysprep_upload
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :wins_servers:
+          :description: WINS Server list
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :subnet_mask:
+          :description: Subnet Mask
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :sysprep_full_name:
+          :description: Full Name
+          :required_method: :validate_sysprep_field
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :sysprep_auto_logon_count:
+          :values:
+            1: '1'
+            2: '2'
+            3: '3'
+          :description: Auto Logon Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :customization_template_id:
+          :values_from:
+            :method: :allowed_customization_templates
+          :auto_select_single: false
+          :description: Script Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :root_password:
+          :description: Root Password
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :hostname:
+          :description: Host Name
+          :required: false
+          :display: :edit
+          :data_type: :string
+        :customization_template_script:
+          :description: Script Text
+          :required: false
+          :display: :edit
+          :data_type: :string
+      :display: :show
+    :environment:
+      :description: Environment
+      :fields:
+        :placement_cluster_name:
+          :values_from:
+            :method: :allowed_clusters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :cluster_filter:
+          :values_from:
+            :options:
+              :category: :EmsCluster
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :host_filter:
+          :values_from:
+            :options:
+              :category: :Host
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :ds_filter:
+          :values_from:
+            :options:
+              :category: :Storage
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_storage_profile:
+          :values_from:
+            :method: :allowed_storage_profiles
+          :auto_select_single: false
+          :description: Storage Profile
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_host_name:
+          :values_from:
+            :method: :allowed_hosts
+          :auto_select_single: false
+          :description: Name
+          :validation_method: :validate_placement_host_name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :required_description: Host Name
+        :placement_ds_name:
+          :values_from:
+            :method: :allowed_storages
+          :auto_select_single: false
+          :description: Name
+          :required_method: :validate_placement
+          :required: true
+          :display: :edit
+          :data_type: :integer
+          :required_description: Datastore Name
+        :rp_filter:
+          :values_from:
+            :options:
+              :category: :ResourcePool
+            :method: :allowed_filters
+          :auto_select_single: false
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_auto:
+          :values:
+            false: 0
+            true: 1
+          :description: Choose Automatically
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+        :placement_folder_name:
+          :values_from:
+            :method: :allowed_folders
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_rp_name:
+          :values_from:
+            :method: :allowed_respools
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :placement_dc_name:
+          :values_from:
+            :method: :allowed_datacenters
+          :auto_select_single: false
+          :description: Name
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :service:
+      :description: Catalog
+      :fields:
+        :number_of_vms:
+          :values_from:
+            :options:
+              :max: 50
+            :method: :allowed_number_of_vms
+          :description: Count
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :vm_description:
+          :description: VM Description
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :min_length:
+          :max_length: 100
+        :vm_prefix:
+          :description: VM Name Prefix/Suffix
+          :required_method: :validate_vm_name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :src_vm_id:
+          :values_from:
+            :options:
+              :tag_filters: []
+            :method: :allowed_templates
+          :description: Name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :vm_name:
+          :description: VM Name
+          :required_method: :validate_vm_name
+          :required: true
+          :notes:
+          :display: :edit
+          :data_type: :string
+          :notes_display: :show
+          :min_length:
+          :max_length:
+        :pxe_image_id:
+          :values_from:
+            :method: :allowed_images
+          :auto_select_single: false
+          :description: Image
+          :required: true
+          :required_method: :validate_pxe_image_id
+          :display: :edit
+          :data_type: :string
+        :pxe_server_id:
+          :values_from:
+            :method: :allowed_pxe_servers
+          :auto_select_single: false
+          :description: Server
+          :required: true
+          :required_method: :validate_pxe_server_id
+          :display: :edit
+          :data_type: :integer
+        :host_name:
+          :description: Host Name
+          :required: false
+          :display: :hide
+          :data_type: :string
+        :provision_type:
+          :values_from:
+            :method: :allowed_provision_types
+          :description: Provision Type
+          :required: true
+          :display: :edit
+          :default: vmware
+          :data_type: :string
+        :linked_clone:
+          :values:
+            false: 0
+            true: 1
+          :description: Linked Clone
+          :required: false
+          :display: :edit
+          :default: false
+          :data_type: :boolean
+          :notes: VM requires a snapshot
+          :notes_display: :show
+        :snapshot:
+          :values_from:
+            :method: :allowed_snapshots
+          :description: Snapshot
+          :required: false
+          :display: :edit
+          :data_type: :string
+          :auto_select_single: false
+        :vm_filter:
+          :values_from:
+            :options:
+              :category: :Vm
+            :method: :allowed_filters
+          :description: Filter
+          :required: false
+          :display: :edit
+          :data_type: :integer
+      :display: :show
+    :schedule:
+      :description: Schedule
+      :fields:
+        :schedule_type:
+          :values:
+            schedule: Schedule
+            immediately: Immediately on Approval
+          :description: When to Provision
+          :required: false
+          :display: :edit
+          :default: immediately
+          :data_type: :string
+        :vm_auto_start:
+          :values:
+            false: 0
+            true: 1
+          :description: Power on virtual machines after creation
+          :required: false
+          :display: :edit
+          :default: true
+          :data_type: :boolean
+        :schedule_time:
+          :values_from:
+            :options:
+              :offset: 1.day
+            :method: :default_schedule_time
+          :description: Provision on
+          :required: false
+          :display: :edit
+          :data_type: :time
+        :retirement:
+          :values:
+            0: Indefinite
+            1.month: 1 Month
+            3.months: 3 Months
+            6.months: 6 Months
+          :description: Time until Retirement
+          :required: false
+          :display: :edit
+          :default: 0
+          :data_type: :integer
+        :retirement_warn:
+          :values_from:
+            :options:
+              :values:
+                1.week: 1 Week
+                2.weeks: 2 Weeks
+                30.days: 30 Days
+              :include_equals: false
+              :field: :retirement
+            :method: :values_less_then
+          :description: Retirement Warning
+          :required: true
+          :display: :edit
+          :default: 1.week
+          :data_type: :integer
+      :display: :show
+    :network:
+      :description: Network
+      :fields:
+        :vlan:
+          :values_from:
+            :options:
+              :dvs: true
+              :vlans: true
+            :method: :allowed_vlans
+          :description: Virtual Network
+          :required: true
+          :display: :edit
+          :data_type: :string
+        :mac_address:
+          :description: MAC Address
+          :required: false
+          :display: :hide
+          :data_type: :string
+      :display: :show
+    :hardware:
+      :description: Hardware
+      :fields:
+        :disk_format:
+          :values:
+            thick: Thick
+            thin: Thin
+            unchanged: Default
+          :description: Disk Format
+          :required: false
+          :display: :edit
+          :default: unchanged
+          :data_type: :string
+        :cpu_limit:
+          :description: CPU (MHz)
+          :required: false
+          :notes: "(-1 = Unlimited)"
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :memory_limit:
+          :description: Memory (MB)
+          :required: false
+          :notes: "(-1 = Unlimited)"
+          :display: :edit
+          :data_type: :integer
+          :notes_display: :show
+        :number_of_sockets:
+          :values:
+            1: '1'
+            2: '2'
+            4: '4'
+            8: '8'
+            16: '16'
+          :description: Number of Sockets
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cores_per_socket:
+          :values:
+            1: '1'
+            2: '2'
+            4: '4'
+            8: '8'
+          :description: Cores per Socket
+          :required: false
+          :display: :edit
+          :default: 1
+          :data_type: :integer
+        :cpu_reserve:
+          :description: CPU (MHz)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+        :vm_memory:
+          :values:
+            '2048': '2048'
+            '4096': '4096'
+            '8192': '8192'
+            '12288': '12288'
+            '16384': '16384'
+            '32768': '32768'
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :default: '1024'
+          :data_type: :string
+        :memory_reserve:
+          :description: Memory (MB)
+          :required: false
+          :display: :edit
+          :data_type: :integer
+          :validation_method: :validate_memory_reservation
+        :network_adapters:
+          :values:
+            1: '1'
+            2: '2'
+            3: '3'
+            4: '4'
+          :description: Network Adapters
+          :required: false
+          :display: :hide
+          :default: 1
+          :data_type: :integer
+      :display: :show
+  :dialog_order:
+  - :requester
+  - :purpose
+  - :service
+  - :environment
+  - :hardware
+  - :network
+  - :customize
+  - :schedule
+:default: false

--- a/spec/lib/task_helpers/imports/provision_dialogs_spec.rb
+++ b/spec/lib/task_helpers/imports/provision_dialogs_spec.rb
@@ -1,0 +1,78 @@
+describe TaskHelpers::Imports::ProvisionDialogs do
+  let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'provision_dialogs') }
+  let(:dialog_file) { 'MiqProvisionWorkflow-test_miq_provision_dialogs_template.yaml' }
+  let(:mod_dialog_file) { 'MiqProvisionWorkflow-test_miq_provision_dialogs_template_modified.yml' }
+  let(:dialog_one_name) { 'test_miq_provision_dialogs_template' }
+  let(:dialog_two_name) { 'test2_miq_provision_dialogs_template' }
+  let(:dialog_one_desc) { 'Test Sample VM Provisioning Dialog (Template)' }
+  let(:dialog_two_desc) { 'Test2 Sample VM Provisioning Dialog (Template)' }
+
+  describe "#import" do
+    let(:options) { { :source => source } }
+
+    describe "when the source is a directory" do
+      let(:source) { data_dir }
+
+      it 'imports all .yaml files in a specified directory' do
+        expect do
+          TaskHelpers::Imports::ProvisionDialogs.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_provision_dialog_one_present
+        assert_test_provision_dialog_two_present
+      end
+    end
+
+    describe "when the source is a file" do
+      let(:source) { "#{data_dir}/#{dialog_file}" }
+
+      it 'imports a specified file' do
+        expect do
+          TaskHelpers::Imports::ProvisionDialogs.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_provision_dialog_one_present
+        assert_test_provision_dialog_two_not_present
+      end
+    end
+
+    describe "when the source file modifies an existing file" do
+      let(:source) { "#{data_dir}/#{mod_dialog_file}" }
+
+      before do
+        TaskHelpers::Imports::ProvisionDialogs.new.import(:source => "#{data_dir}/#{dialog_file}")
+      end
+
+      it 'modifies an existing provisioning dialog' do
+        expect do
+          TaskHelpers::Imports::ProvisionDialogs.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_provision_dialog_one_modified
+      end
+    end
+  end
+
+  def assert_test_provision_dialog_one_present
+    d = MiqDialog.find_by(:name => dialog_one_name)
+    expect(d.description).to eq(dialog_one_desc)
+    expect(d.valid?).to be true
+  end
+
+  def assert_test_provision_dialog_two_present
+    d = MiqDialog.find_by(:name => dialog_two_name)
+    expect(d.description).to eq(dialog_two_desc)
+    expect(d.valid?).to be true
+    expect(d.content[:dialogs][:purpose][:fields][:vm_tags][:required_tags]).to contain_exactly("environment")
+  end
+
+  def assert_test_provision_dialog_two_not_present
+    d = MiqDialog.find_by(:name => dialog_two_name)
+    expect(d).to be nil
+  end
+
+  def assert_test_provision_dialog_one_modified
+    d = MiqDialog.find_by(:name => dialog_one_name)
+    expect(d.content[:dialogs][:hardware][:fields][:number_of_sockets][:values].keys).to contain_exactly(1, 2, 4, 8, 16)
+    expect(d.content[:dialogs][:hardware][:fields][:number_of_sockets][:values].values).to contain_exactly("1", "2", "4", "8", "16")
+    expect(d.content[:dialogs][:hardware][:fields][:vm_memory][:values].keys).to contain_exactly("2048", "4096", "8192", "12288", "16384", "32768")
+    expect(d.content[:dialogs][:hardware][:fields][:vm_memory][:values].values).to contain_exactly("2048", "4096", "8192", "12288", "16384", "32768")
+  end
+end


### PR DESCRIPTION
These rake scripts and classes provide functionality for exporting/importing of the following ManageIQ object types:

- Provision Dialogs

This PR uses the framework that was implemented for PRs #14126, #15256, #16717, and #16983 to export/import other ManageIQ object types.

These scripts are based on the CFME RH Consulting Scripts and are used by Red Hat consultants to enable storing customizations in Git and maintaining customizations between environments (e.g. dev/qa/prod) for an SDLC lifecycle.

Links [Optional]
----------------

* Tracking Issue: [Implement export/import functionality of Miq objects via command-line](#15350)

Steps for Testing/QA [Optional]
-------------------------------
**Exporting**

1. Create a directory for the exports 
```
mkdir /tmp/provision_dialogs
```
2. Export provision dialogs 
```
vmdb
bin/rake evm:export:provision_dialogs -- --directory /tmp/provision_dialogs
```


**Importing**

1. Import all provision dialog yaml files in a directory
```
# vmdb
# bin/rake evm:import:provision_dialogs -- --source /tmp/provision_dialogs
```
2. or Import specific provision_dialog yaml file
```
# vmdb
# bin/rake evm:import:provision_dialogs -- --source /tmp/provision_dialogs/Test_Dialog.yaml
```
