### PR TITLE
[WIP] InventoryCollection builder_params -> default_values

### DIFF
--- a/app/models/manager_refresh/inventory_collection.rb
+++ b/app/models/manager_refresh/inventory_collection.rb
@@ -77,7 +77,7 @@ module ManagerRefresh
     attr_reader :model_class, :strategy, :attributes_blacklist, :attributes_whitelist, :custom_save_block, :parent,
                 :internal_attributes, :delete_method, :dependency_attributes, :manager_ref, :create_only,
                 :association, :complete, :update_only, :transitive_dependency_attributes, :check_changed, :arel,
-                :inventory_object_attributes, :name, :saver_strategy, :targeted_scope, :builder_params,
+                :inventory_object_attributes, :name, :saver_strategy, :targeted_scope, :default_values,
                 :targeted_arel, :targeted, :manager_ref_allowed_nil, :use_ar_object,
                 :created_records, :updated_records, :deleted_records,
                 :custom_reconnect_block, :batch_extra_attributes, :references_storage
@@ -276,14 +276,14 @@ module ManagerRefresh
     #               'vms' => {:ems_ref => manager_refs}
     #             )
     #        And etc. for the other Vm related records.
-    # @param builder_params [Hash] A hash of an attributes that will be added to every inventory object created by
+    # @param default_values [Hash] A hash of an attributes that will be added to every inventory object created by
     #        inventory_collection.build(hash)
     #
     #        Example: Given
     #          inventory_collection = InventoryCollection.new({
     #            :model_class    => ::Vm,
     #            :arel           => @ems.vms,
-    #            :builder_params => {:ems_id => 10}
+    #            :default_values => {:ems_id => 10}
     #          })
     #        And building the inventory_object like:
     #            inventory_object = inventory_collection.build(:ems_ref => "vm_1", :name => "vm1")
@@ -404,7 +404,7 @@ module ManagerRefresh
     def initialize(model_class: nil, manager_ref: nil, association: nil, parent: nil, strategy: nil,
                    custom_save_block: nil, delete_method: nil, dependency_attributes: nil,
                    attributes_blacklist: nil, attributes_whitelist: nil, complete: nil, update_only: nil,
-                   check_changed: nil, arel: nil, builder_params: {}, create_only: nil,
+                   check_changed: nil, arel: nil, default_values: {}, create_only: nil,
                    inventory_object_attributes: nil, name: nil, saver_strategy: nil,
                    parent_inventory_collections: nil, manager_uuids: [], all_manager_uuids: nil, targeted_arel: nil,
                    targeted: nil, manager_ref_allowed_nil: nil, secondary_refs: {}, use_ar_object: nil,
@@ -425,7 +425,7 @@ module ManagerRefresh
       @complete               = complete.nil? ? true : complete
       @update_only            = update_only.nil? ? false : update_only
       @create_only            = create_only.nil? ? false : create_only
-      @builder_params         = builder_params
+      @default_values         = default_values
       @name                   = name || association || model_class.to_s.demodulize.tableize
       @saver_strategy         = process_saver_strategy(saver_strategy)
       @use_ar_object          = use_ar_object || false

--- a/app/models/manager_refresh/inventory_collection/builder.rb
+++ b/app/models/manager_refresh/inventory_collection/builder.rb
@@ -131,11 +131,10 @@ module ManagerRefresh
         @inventory_object_attributes = []
       end
 
-      # Adds key/values to default values (InventoryCollection.builder_params) (part of @properties)
+      # Adds key/values to default values (InventoryCollection.default_values) (part of @properties)
       def add_default_values(params = {}, mode = :overwrite)
         @default_values = merge_hashes(@default_values, params, mode)
       end
-      alias add_builder_params add_default_values
 
       # Evaluates lambda blocks
       def evaluate_lambdas!(persister)
@@ -154,14 +153,13 @@ module ManagerRefresh
       end
 
       # Returns whole InventoryCollection properties
-      # TODO: default values converted to builder_params, change InventoryCollection and usages in next PR
       def to_hash
         add_inventory_attributes(auto_inventory_attributes) if @options[:auto_inventory_attributes]
 
         @properties[:inventory_object_attributes] ||= @inventory_object_attributes
 
-        @properties[:builder_params] ||= {}
-        @properties[:builder_params].merge!(@default_values)
+        @properties[:default_values] ||= {}
+        @properties[:default_values].merge!(@default_values)
 
         @properties[:dependency_attributes] ||= {}
         @properties[:dependency_attributes].merge!(@dependency_attributes)

--- a/app/models/manager_refresh/inventory_collection/data_storage.rb
+++ b/app/models/manager_refresh/inventory_collection/data_storage.rb
@@ -18,7 +18,7 @@ module ManagerRefresh
                :to => :index_proxy
 
       delegate :association_to_foreign_key_mapping,
-               :builder_params,
+               :default_values,
                :inventory_object?,
                :inventory_object_lazy?,
                :manager_ref,
@@ -156,13 +156,13 @@ module ManagerRefresh
         end
       end
 
-      # Returns new hash enriched by (see ManagerRefresh::InventoryCollection#builder_params) hash
+      # Returns new hash enriched by (see ManagerRefresh::InventoryCollection#default_values) hash
       #
       # @param hash [Hash] Input hash
-      # @return [Hash] Enriched hash by (see ManagerRefresh::InventoryCollection#builder_params)
+      # @return [Hash] Enriched hash by (see ManagerRefresh::InventoryCollection#default_values)
       def enrich_data(hash)
-        # This is 25% faster than builder_params.merge(hash)
-        {}.merge!(builder_params).merge!(hash)
+        # This is 25% faster than default_values.merge(hash)
+        {}.merge!(default_values).merge!(hash)
       end
     end
   end

--- a/app/models/manager_refresh/inventory_collection/index/type/skeletal.rb
+++ b/app/models/manager_refresh/inventory_collection/index/type/skeletal.rb
@@ -11,7 +11,7 @@ module ManagerRefresh
             @primary_index = primary_index
           end
 
-          delegate :builder_params,
+          delegate :default_values,
                    :new_inventory_object,
                    :named_ref,
                    :to => :inventory_collection
@@ -43,7 +43,7 @@ module ManagerRefresh
           #        needed for creating the record in the Database
           # @return [InventoryObject|nil] Returns built value or nil
           def build(attributes)
-            attributes = {}.merge!(builder_params).merge!(attributes)
+            attributes = {}.merge!(default_values).merge!(attributes)
 
             # If the primary index is already filled, we don't want populate skeletal index
             uuid = ::ManagerRefresh::InventoryCollection::Reference.build_stringified_reference(attributes, named_ref)

--- a/app/models/manager_refresh/inventory_object_lazy.rb
+++ b/app/models/manager_refresh/inventory_object_lazy.rb
@@ -104,7 +104,7 @@ module ManagerRefresh
     attr_writer :reference
 
     # Instead of loading the reference from the DB, we'll add the skeletal InventoryObject (having manager_ref and
-    # info from the builder_params) to the correct InventoryCollection. Which will either be found in the DB or
+    # info from the default_values) to the correct InventoryCollection. Which will either be found in the DB or
     # created as a skeletal object. The later refresh of the object will then fill the rest of the data, while not
     # touching the reference.
     #

--- a/spec/models/manager_refresh/inventory_collection/builder_spec.rb
+++ b/spec/models/manager_refresh/inventory_collection/builder_spec.rb
@@ -144,8 +144,8 @@ describe ManagerRefresh::InventoryCollection::Builder do
       builder.add_default_values(:tmp_id => 30)
     end.to_hash
 
-    expect(data[:builder_params][:ems_id]).to eq 20
-    expect(data[:builder_params][:tmp_id]).to eq 30
+    expect(data[:default_values][:ems_id]).to eq 20
+    expect(data[:default_values][:tmp_id]).to eq 30
   end
 
   it 'transforms lambdas in default_values' do
@@ -156,7 +156,7 @@ describe ManagerRefresh::InventoryCollection::Builder do
 
     data = bldr.to_hash
 
-    expect(data[:builder_params][:ems_id]).to eq(@persister.manager.id)
+    expect(data[:default_values][:ems_id]).to eq(@persister.manager.id)
   end
 
   # --- inventory object attributes ---


### PR DESCRIPTION
Issue: #17396 

- [x] **depends on** #17736 

- **dependent**: https://github.com/ManageIQ/manageiq-providers-azure/pull/281
- **dependent**: https://github.com/ManageIQ/manageiq-providers-vmware/pull/304

Removing "builder_params" term from all inventory_collection related classes
