### PR TITLE
Move VIRTUAL_COL_USES translation to col_index method in ChargeableField

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -98,6 +98,7 @@ class ChargeableField < ApplicationRecord
 
   def self.col_index(column)
     @rate_cols ||= {}
+    column = VIRTUAL_COL_USES[column] || column
     @rate_cols[column] ||= cols_on_metric_rollup.index(column.to_s)
   end
 

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -71,7 +71,6 @@ class Chargeback
     end
 
     def sum(metric, sub_metric = nil)
-      metric = ChargeableField::VIRTUAL_COL_USES[metric] || metric
       values(metric, sub_metric).sum
     end
 

--- a/spec/factories/chargeable_field.rb
+++ b/spec/factories/chargeable_field.rb
@@ -46,7 +46,7 @@ FactoryGirl.define do
 
   factory :chargeable_field_cpu_cores_used, :parent => :chargeable_field do
     description 'Used CPU in Cores'
-    metric      'cpu_usage_rate_average'
+    metric      'v_derived_cpu_total_cores_used'
     group       'cpu_cores'
     source      'used'
   end


### PR DESCRIPTION
Caused by https://github.com/ManageIQ/manageiq/issues/17592

Chargeback for Projects is using `v_derived_cpu_total_cores_used` from yaml definition but 
we are using from `MetricRollup#cpu_usage_rate_average` to get metric value and use it in chargeback calculation.

But reason why **it was not caught by specs** is that we were using `cpu_usage_rate_average ` in rspec factories(instead of `v_derived_cpu_total_cores_used` as it is used in yaml) and thanks to that this case have not been covered.

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1602818


