### PR TITLE
Empty project dir no longer needed

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -25,8 +25,6 @@ module Ansible
 
       def run_via_cli(env_vars, extra_vars, playbook_path)
         Dir.mktmpdir("ansible-runner") do |base_dir|
-          Dir.mkdir(File.join(base_dir, 'project')) # without this, there is a silent fail of the ansible-runner command see https://github.com/ansible/ansible-runner/issues/88
-
           result = AwesomeSpawn.run!(ansible_command(base_dir),
                                      :env    => env_vars,
                                      :params => [{:cmdline  => "--extra-vars '#{JSON.dump(extra_vars)}'",


### PR DESCRIPTION
Empty project dir no longer needed

Fixed in https://github.com/ansible/ansible-runner/issues/88, fix released in 1.0.5