### PR TITLE
Prefix the method name with the class name for validation errors

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -23,4 +23,8 @@ class ApplicationRecord < ActiveRecord::Base
   def self.display_name(number = 1)
     n_(model_name.singular.titleize, model_name.plural.titleize, number)
   end
+
+  def self.human_attribute_name(attribute, *args)
+    "#{name}: #{super}"
+  end
 end

--- a/spec/lib/services/dialog_import_service_spec.rb
+++ b/spec/lib/services/dialog_import_service_spec.rb
@@ -489,7 +489,7 @@ describe DialogImportService do
 
       expect do
         dialog_import_service.import(dialogs.first)
-      end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Name is not unique within region/)
+      end.to raise_error(ActiveRecord::RecordInvalid, /Validation failed: Dialog: Name is not unique within region/)
     end
   end
 

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,0 +1,13 @@
+describe ApplicationRecord do
+  context ".human_attribute_name includes the class name in the validation error for easier troubleshooting" do
+    it "single level" do
+      Zone.create!(:name => "example", :description => "example")
+      expect { Zone.create!(:name => "example", :description => "example") }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Zone: Name is not unique within region #{MiqRegion.my_region_number}")
+    end
+
+    it "nested" do
+      Zone.create!(:name => "example", :description => "example")
+      expect { MiqSchedule.create!(:zone => Zone.create!(:name => "example", :description => "example")) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Zone: Name is not unique within region #{MiqRegion.my_region_number}")
+    end
+  end
+end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -54,7 +54,7 @@ describe Endpoint do
 
     it "raises when provided and already exists" do
       Endpoint.create!(:url => "abc")
-      expect { Endpoint.create!(:url => "abc") }.to raise_error("Validation failed: Url has already been taken")
+      expect { Endpoint.create!(:url => "abc") }.to raise_error("Validation failed: Endpoint: Url has already been taken")
     end
   end
 

--- a/spec/models/miq_ae_namespace_spec.rb
+++ b/spec/models/miq_ae_namespace_spec.rb
@@ -55,7 +55,7 @@ describe MiqAeNamespace do
         # domain/ns1/NAMESPACE
         expect do
           FactoryGirl.create(:miq_ae_namespace, :name => 'NAMESPACE', :parent_id => ns1.id)
-        end.to raise_error("Validation failed: Name has already been taken")
+        end.to raise_error("Validation failed: MiqAeNamespace: Name has already been taken")
       end
     end
   end

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -569,7 +569,7 @@ describe MiqAlert do
         )
       end.to raise_error(
         ActiveRecord::RecordInvalid,
-        'Validation failed: Notifications Datawarehouse alerts must have a 0 notification frequency'
+        'Validation failed: MiqAlert: Notifications Datawarehouse alerts must have a 0 notification frequency'
       )
     end
   end

--- a/spec/models/miq_alert_status_action_spec.rb
+++ b/spec/models/miq_alert_status_action_spec.rb
@@ -8,22 +8,21 @@ describe MiqAlertStatusAction do
       expect do
         FactoryGirl.create(:miq_alert_status_action, :action_type => 'churn', :user => user,
                            :miq_alert_status => alert)
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Action type must be accepted")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatusAction: Action type must be accepted")
     end
 
     it "must be linked to a user" do
       expect do
         FactoryGirl.create(:miq_alert_status_action, :action_type => 'unassign', :user => nil,
                            :miq_alert_status => alert)
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User can't be blank")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatusAction: User can't be blank")
     end
 
     it "must have a comment if the action_type is comment" do
       expect do
         FactoryGirl.create(:miq_alert_status_action, :action_type => 'comment', :user => user, :comment => nil,
                            :miq_alert_status => alert)
-      end.to raise_error(ActiveRecord::RecordInvalid,
-                         "Validation failed: Comment can't be blank")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatusAction: Comment can't be blank")
     end
 
     it "can have a comment if the action_type isn't comment" do
@@ -37,14 +36,14 @@ describe MiqAlertStatusAction do
       expect do
         FactoryGirl.create(:miq_alert_status_action, :action_type => 'unassign', :user => user, :assignee => user,
                            :miq_alert_status => alert)
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Assignee must be blank")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatusAction: Assignee must be blank")
     end
 
     it "must have an assignee if the action_type is assign" do
       expect do
         FactoryGirl.create(:miq_alert_status_action, :action_type => 'assign', :user => user, :assignee => nil,
                            :miq_alert_status => alert)
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Assignee can't be blank")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatusAction: Assignee can't be blank")
     end
 
     it "should allow the currently assigned user to acknoledge the alert" do
@@ -80,7 +79,7 @@ describe MiqAlertStatusAction do
           :user             => user2,
           :miq_alert_status => alert
         )
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: User that is not assigned cannot acknowledge")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatusAction: User that is not assigned cannot acknowledge")
     end
   end
 end

--- a/spec/models/miq_alert_status_spec.rb
+++ b/spec/models/miq_alert_status_spec.rb
@@ -22,7 +22,7 @@ describe MiqAlertStatus do
     it "should reject unexpected severities" do
       expect do
         FactoryGirl.create(:miq_alert_status, :severity => 'awesome')
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Severity must be accepted")
+      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqAlertStatus: Severity must be accepted")
     end
   end
 

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -30,13 +30,13 @@ describe MiqPolicy do
 
     it "should raise an error with empty description" do
       @description = nil
-      expect { subject.description }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Description can't be blank")
+      expect { subject.description }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqPolicy: Description can't be blank")
     end
 
     it "should raise an error when description is reset to empty" do
       @description = "a" * 30
       subject.description = nil
-      expect { subject.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Description can't be blank")
+      expect { subject.save! }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqPolicy: Description can't be blank")
     end
   end
 

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -75,7 +75,7 @@ describe ServiceTemplateTransformationPlan do
     it 'validates unique name' do
       described_class.create_catalog_item(catalog_item_options)
       expect { described_class.create_catalog_item(catalog_item_options) }.to raise_error(
-        ActiveRecord::RecordInvalid, 'Validation failed: Name has already been taken'
+        ActiveRecord::RecordInvalid, 'Validation failed: ServiceTemplateTransformationPlan: Name has already been taken'
       )
     end
   end


### PR DESCRIPTION
instance.errors.full_messages will now produce something like:
["SomeClass: The attribute can't be blank"]

Full disclosure... I have no idea what else this will effect (especially in the UI) ¯\\\_(ツ)_/¯