### PR TITLE
Add Vmdb::Plugins#versions

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -31,6 +31,12 @@ module Vmdb
       register_models
     end
 
+    def versions
+      each_with_object({}) do |engine, hash|
+        hash[engine] = version(engine)
+      end
+    end
+
     def ansible_content
       @ansible_content ||= begin
         require_relative 'plugins/ansible_content'
@@ -79,6 +85,48 @@ module Vmdb
     end
 
     private
+
+    # Determine the version of the specified engine
+    #
+    # If the gem is
+    # - git based, pointing to a branch:   <branch>@<sha>
+    # - git based, pointing to a tag:      <tag>@<sha>
+    # - git based, pointing to a sha:      <sha>
+    # - path based, with git, on a branch: <branch>@<sha>
+    # - path based, with git, on a tag:    <tag>@<sha>
+    # - path based, with git, on a sha:    <sha>
+    # - path based, without git:           nil
+    # - a real gem:                        <gem_version>
+    def version(engine)
+      spec = bundler_specs_by_path[engine.root.to_s]
+
+      case spec.source
+      when Bundler::Source::Git
+        [
+          spec.source.branch || spec.source.options["tag"],
+          spec.source.revision.presence[0, 8]
+        ].compact.join("@").presence
+      when Bundler::Source::Path
+        if engine.root.join(".git").exist?
+          branch = sha = nil
+          Dir.chdir(engine.root) do
+            branch   = `git rev-parse --abbrev-ref HEAD 2>/dev/null`.strip.presence
+            branch   = nil if branch == "HEAD"
+            branch ||= `git describe --tags --exact-match HEAD 2>/dev/null`.strip.presence
+
+            sha = `git rev-parse HEAD 2>/dev/null`.strip[0, 8].presence
+          end
+
+          [branch, sha].compact.join("@").presence
+        end
+      when Bundler::Source::Rubygems
+        spec.version
+      end
+    end
+
+    def bundler_specs_by_path
+      @bundler_specs_by_path ||= Bundler.environment.specs.index_by(&:full_gem_path)
+    end
 
     def content_directories(engine, subfolder)
       Dir.glob(engine.root.join("content", subfolder, "*"))

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -71,4 +71,134 @@ describe Vmdb::Plugins do
       ManageIQ::UI::Classic::Engine
     )
   end
+
+  it ".versions" do
+    versions = described_class.versions
+
+    expect(versions).to be_kind_of(Hash)
+    expect(versions.keys).to match_array described_class.all
+  end
+
+  describe ".version (private)" do
+    subject { described_class.send(:instance).send(:version, engine) }
+
+    let(:engine) { Class.new(Rails::Engine) }
+
+    def clear_versions_caches
+      described_class.send(:instance).instance_variable_set(:@bundler_specs_by_path, nil)
+    end
+
+    before { clear_versions_caches }
+    after  { clear_versions_caches }
+
+    def with_temp_dir(_options)
+      Dir.mktmpdir("plugins_spec") do |dir|
+        allow(engine).to receive(:root).and_return(Pathname.new(dir))
+        yield dir
+      end
+    end
+
+    def with_temp_git_dir(options)
+      with_temp_dir(options) do |dir|
+        sha = nil
+
+        Dir.chdir(dir) do
+          `
+          git init &&
+          touch foo  && git add -A && git commit -m "Added foo" &&
+          touch foo2 && git add -A && git commit -m "Added foo2"
+          `
+
+          if options[:branch] == "master"
+            sha = `git rev-parse HEAD`.strip
+          else
+            sha = `git rev-parse HEAD~`.strip
+            `git checkout #{"-b #{options[:branch]}" if options[:branch]} #{sha} 2>/dev/null`
+            `git tag #{options[:tag]}` if options[:tag]
+          end
+        end
+
+        yield dir, sha
+      end
+    end
+
+    def with_spec(type, options = {})
+      raise "Unexpected type '#{type}'" unless %i(git path_with_git path).include?(type)
+
+      source =
+        if type == :git
+          instance_double(Bundler::Source::Git, :branch => options[:branch], :options => {"tag" => options[:tag]})
+        else
+          instance_double(Bundler::Source::Path)
+        end
+
+      allow(Bundler::Source::Git).to receive(:===).with(source).and_return(type == :git)
+      allow(Bundler::Source::Path).to receive(:===).with(source).and_return(type != :git)
+
+      method = (type == :path ? :with_temp_dir : :with_temp_git_dir)
+
+      send(method, options) do |dir, sha|
+        expect(source).to receive(:revision).and_return(sha) if type == :git
+
+        spec = instance_double(Gem::Specification, :full_gem_path => dir, :source => source)
+        expect(Bundler.environment).to receive(:specs).and_return([spec])
+
+        yield(sha && sha[0, 8])
+      end
+    end
+
+    it "git based, on master" do
+      with_spec(:git, :branch => "master") do |sha|
+        expect(subject).to eq("master@#{sha}")
+      end
+    end
+
+    it "git based, on a branch" do
+      with_spec(:git, :branch => "my_branch") do |sha|
+        expect(subject).to eq("my_branch@#{sha}")
+      end
+    end
+
+    it "git based, on a tag" do
+      with_spec(:git, :tag => "my_tag") do |sha|
+        expect(subject).to eq("my_tag@#{sha}")
+      end
+    end
+
+    it "git based, on a sha" do
+      with_spec(:git) do |sha|
+        expect(subject).to eq(sha)
+      end
+    end
+
+    it "path based, with git, on master" do
+      with_spec(:path_with_git, :branch => "master") do |sha|
+        expect(subject).to eq("master@#{sha}")
+      end
+    end
+
+    it "path based, with git, on a branch" do
+      with_spec(:path_with_git, :branch => "my_branch") do |sha|
+        expect(subject).to eq("my_branch@#{sha}")
+      end
+    end
+
+    it "path based, with git, on a tag" do
+      with_spec(:path_with_git, :tag => "my_tag") do |sha|
+        expect(subject).to eq("my_tag@#{sha}")
+      end
+    end
+
+    it "path based, with git, on a sha" do
+      with_spec(:path_with_git) do |sha|
+        expect(subject).to eq(sha)
+      end
+    end
+
+    it "path based, without git" do
+      with_spec(:path) do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-v2v/issues/422
https://bugzilla.redhat.com/show_bug.cgi?id=1594348

With these override combinations:

```ruby
# 1. git based, pointing to the master branch (default Gemfile reference)
gem "manageiq-content", :git => "https://github.com/ManageIQ/manageiq-content", :branch => "master"

# 2. git based, pointing to my_branch_1 branch
override_gem "manageiq-providers-ovirt", :git => "https://github.com/Fryguy/manageiq-providers-ovirt", :branch => "my_branch_1"

# 3. git based, pointing to my_tag_1 tag
override_gem "manageiq-providers-amazon", :git => "https://github.com/Fryguy/manageiq-providers-amazon", :tag => "my_tag_1"

# 4. git based, pointing to sha 5598b27
override_gem "manageiq-providers-openstack", :git => "https://github.com/ManageIQ/manageiq-providers-openstack", :ref => "5598b27"

# 5. path based, with git, on the master branch
override_gem "manageiq-ui-classic", :path => File.expand_path("~/dev/manageiq-ui-classic")

# 6. path based, with git, on my_branch_1 local branch
override_gem "manageiq-api", :path => File.expand_path("~/dev/manageiq-api")

# 7. path based, with git, on my_tag_1 tag
override_gem "manageiq-providers-azure", :path => File.expand_path("~/dev/manageiq-providers-azure")

# 8. path based, with git, on sha b7a0e17
override_gem "manageiq-v2v", :path => File.expand_path("~/dev/miq_v2v_ui_plugin")

# 9. path based, without git
override_gem "manageiq-providers-vmware", :path => File.expand_path("~/dev/manageiq-providers-vmware")
```

Example output:

```ruby
[1] pry(main)> Vmdb::Plugins.versions
=> {ManageIQ::Api::Engine                     => "my_branch_1@9d143228",  # #6
    ManageIQ::AutomationEngine::Engine        => "master@06af67f5",
    ManageIQ::Content::Engine                 => "master@54eb45d3",       # #1
    ManageIQ::GraphQL::Engine                 => "master@5f68621f",
    ManageIQ::Providers::Amazon::Engine       => "my_tag_1@414002be",     # #3
    ManageIQ::Providers::AnsibleTower::Engine => "master@205e4b5d",
    ManageIQ::Providers::Azure::Engine        => "my_tag_1@9813132",      # #7
    ManageIQ::Providers::Foreman::Engine      => "master@1736186b",
    ManageIQ::Providers::Google::Engine       => "master@3b86b8c2",
    ManageIQ::Providers::Kubernetes::Engine   => "master@0968969d",
    ManageIQ::Providers::Kubevirt::Engine     => "master@c31b0650",
    ManageIQ::Providers::Lenovo::Engine       => "master@1dd5282f",
    ManageIQ::Providers::Nuage::Engine        => "master@dbd2a1bb",
    ManageIQ::Providers::Openshift::Engine    => "master@16a47af1",
    ManageIQ::Providers::Openstack::Engine    => "5598b270",              # #4
    ManageIQ::Providers::Ovirt::Engine        => "my_branch_1@824cb700",  # #2
    ManageIQ::Providers::Redfish::Engine      => "master@4effccdc",
    ManageIQ::Providers::Scvmm::Engine        => "master@b0e66d16",
    ManageIQ::Providers::Vmware::Engine       => nil,                     # #9
    ManageIQ::Showback::Engine                => "master@a558f35b",
    ManageIQ::UI::Classic::Engine             => "master@9a6582d17",      # #5
    ManageIQ::V2V::Engine                     => "b7a0e17"}               # #8
```

@bdunne Please review
cc @AparnaKarve @priley86 