### PR TITLE
Remove useless line in ConsumptionHistory

### DIFF
--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -1,7 +1,6 @@
 class Chargeback
   class ConsumptionHistory
     def self.for_report(cb_class, options, region)
-      base_rollup = base_rollup_scope.in_region(region)
       timerange = options.report_time_range
       interval_duration = options.duration_of_report_step
 


### PR DESCRIPTION
leftover after https://github.com/ManageIQ/manageiq/issues/17592

@miq-bot assign @gtanzillo 

@miq-bot add_label chargeback, technical debt