### PR TITLE
Ansible runner allow to run roles without playbook

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -68,7 +68,7 @@ module Ansible
         [shared_params(:extra_vars => extra_vars).merge(role_or_playbook_params)]
       end
 
-      def playbook_params(playbook_path: playbook_path)
+      def playbook_params(playbook_path:)
         {:playbook => playbook_path}
       end
 


### PR DESCRIPTION
Ansible runner allow to run roles without playbook

The example usage is:

```ruby
Ansible::Runner.run_role(ext_management_system.parent_manager.ansible_env_vars,
                             {
                               :vpc_id                      => options["vpc_id"],
                               :security_group_name         => options["security_group_name"],
                               :security_group_description  => options["security_group_description"],
                               :security_group_rules        => options["security_group_rules"],
                               :security_group_rules_egress => options["security_group_rules_egress"],
                             },
                             "create_security_group",
                             :roles_path => File.join(ext_management_system.parent_manager.ansible_root, "roles")

    )
```

So we run a role directly and we do not need to write a playbook like https://github.com/ManageIQ/manageiq-providers-amazon/pull/453/files#diff-043bd0af7eaf90b61c703f5629a40845 , since that will be generated for us