### PR TITLE
Check if value represents valid field in MiqExpression.quote

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -658,7 +658,7 @@ class MiqExpression
   end
 
   def self.quote(val, typ)
-    if Field.is_field?(val)
+    if Field.attribute?(val)
       ref, value = value2tag(val)
       col_type = get_col_type(val) || "string"
       return ref ? "<value ref=#{ref}, type=#{col_type}>#{value}</value>" : "<value type=#{col_type}>#{value}</value>"

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -31,6 +31,12 @@ class MiqExpression::Field < MiqExpression::Target
     !!(model < ApplicationRecord)
   end
 
+  def self.attribute?(val)
+    parse(val).valid?
+  rescue LoadError, StandardError
+    false
+  end
+
   def to_s
     "#{[model, *associations].join(".")}-#{column}"
   end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -354,4 +354,16 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.is_field?("ManageIQ-name")).to be(false)
     end
   end
+
+  describe ".attribute?" do
+    it "returns false if parameter does not represent valid attribute" do
+      expect(described_class.attribute?("Vm-hello")).to be(false)
+      expect(described_class.attribute?("VM-name")).to be(false)
+    end
+
+    it "returns true if parameter represent valid attribute" do
+      expect(described_class.attribute?("Vm-name")).to be(true)
+      expect(described_class.attribute?("Vm.hardware-cpu_type")).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
**Issue:** `MiqExpression` engine throw error when expression type is `REGULAR EXPRESSION` and  field looks like "Model-field" but does not represent existing attribute from existing model.
**Example:** if there is vm named "Lan-yuri" than this expression 
`Virtual Machine : Name REGULAR EXPRESSION MATCHES "L+"` would trigger error

**Cause of issue:** modification to `MiqExpression.quote` in  https://github.com/ManageIQ/manageiq/pull/11445 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1581853

**Note:** This PR does not fully resolve ambiguity for parameter in `MiqExpression.quote`,
and would not help if vm in example was named "Lan-name".

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/43271327-38cd4a24-90c5-11e8-8733-fbba611645ed.gif)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/43271342-3e747650-90c5-11e8-9bf2-4afcb5ffe733.gif)


@miq-bot add-label bug, core, gaprindashvili/yes, blocker