### PR TITLE
Logging archived targets during C&U collection

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -131,6 +131,12 @@ module Metric::CiMixin::Capture
     end
     raise ArgumentError, _("end_time cannot be specified if start_time is nil") if start_time.nil? && !end_time.nil?
 
+    # if target (== self) is archived, skip it
+    if respond_to?(:ems_id) && ems_id.nil?
+      _log.warn("C&U collection's target is archived (no EMS associated), skipping. Target: #{log_target}")
+      return
+    end
+
     start_time, end_time = fix_capture_start_end_time(interval_name, start_time, end_time)
     start_range, end_range, counters_data = just_perf_capture(interval_name, start_time, end_time)
 


### PR DESCRIPTION
Currently when VM is archived, but queued to capture metrics it raises exception due to missing ems_id
Instead of raising exception it'll log message and doesn't try capturing

Links 
----------------
**Fixes BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1560691

Steps for Testing/QA 
-------------------------------
Look at BZ's steps to reproduce.
