### PR TITLE
Add CustomButton event emiter

### DIFF
--- a/app/models/custom_button_event.rb
+++ b/app/models/custom_button_event.rb
@@ -1,0 +1,2 @@
+class CustomButtonEvent < EventStream
+end

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -292,4 +292,36 @@ describe CustomButton do
     button = FactoryGirl.create(:custom_button, :applies_to => service_template1)
     expect { button.copy(:applies_to => service_template2) }.to change { CustomButton.count }.by(1)
   end
+
+  context do
+    let(:vm)              { FactoryGirl.create(:vm_vmware) }
+    let(:user)            { FactoryGirl.create(:user_with_group) }
+    let(:resource_action) { FactoryGirl.create(:resource_action, :ae_namespace => 'SYSTEM', :ae_class => 'PROCESS', :ae_instance => 'Request') }
+    let(:custom_button)   { FactoryGirl.create(:custom_button, :applies_to => vm.class, :resource_action => resource_action) }
+
+    before do
+      EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
+    end
+
+    %i(invoke invoke_async).each do |method|
+      describe "##{method}" do
+        it "publishes CustomButtonEvent" do
+          User.with_user(user) { custom_button.send(method, vm, 'UI') }
+
+          expect(CustomButtonEvent.count).to eq(1)
+          expect(CustomButtonEvent.first).to have_attributes(
+            :source      => 'UI',
+            :target_id   => vm.id,
+            :target_type => 'VmOrTemplate',
+            :type        => 'CustomButtonEvent',
+            :event_type  => 'button.trigger.start',
+            :user_id     => user.id
+          )
+          expect(CustomButtonEvent.first[:full_data]).to include(
+            :automate_entry_point => "/SYSTEM/PROCESS/Request"
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When `CustomButton` is invoked, let's create a `CustomEvent` logging the activity.

Tracked data:
- requester (user, group, tenant)
- target (id, class)
- source (UI or API - currently UI only)
- event type (`button.trigger.start`)
- full data (task args, entry point for automate)

Design: [GDoc](https://docs.google.com/document/d/1wtgC3fQLLoR-g2jVMzINgYAeoojB0FkzQQR3pyv5Cns/edit)
RFE: [BUGZILLA 1511126](https://bugzilla.redhat.com/show_bug.cgi?id=1511126)
Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/4363