### PR TITLE
[GAPRINDASHVILI] Add ruby parser as development dependency in gaprindashvili

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -215,6 +215,8 @@ unless ENV["APPLIANCE"]
     gem "foreman"
     gem "haml_lint",        "~>0.20.0", :require => false
     gem "rubocop",          "~>0.52.1", :require => false
+    # ruby_parser is required for i18n string extraction
+    gem "ruby_parser",                  :require => false
     gem "scss_lint",        "~>0.48.0", :require => false
     gem "yard"
   end


### PR DESCRIPTION
The gem is needed for gettext string extraction (hence devel mode only).

This is just a gaprindashvili version of https://github.com/ManageIQ/manageiq/pull/16724