### PR TITLE
Allow tenant admins to see all groups within the scope of their tenant

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -3,6 +3,8 @@ class MiqProductFeature < ApplicationRecord
   REPORT_ADMIN_FEATURE  = "miq_report_superadmin".freeze
   REQUEST_ADMIN_FEATURE = "miq_request_superadmin".freeze
   ADMIN_FEATURE = REPORT_ADMIN_FEATURE
+  TENANT_ADMIN_FEATURE = "rbac_tenant".freeze
+
   acts_as_tree
 
   has_and_belongs_to_many :miq_user_roles, :join_table => :miq_roles_features

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -108,6 +108,10 @@ class MiqUserRole < ApplicationRecord
     allows?(:identifier => MiqProductFeature::SUPER_ADMIN_FEATURE)
   end
 
+  def tenant_admin_user?
+    allows?(:identifier => MiqProductFeature::TENANT_ADMIN_FEATURE)
+  end
+
   def report_admin_user?
     allows?(:identifier => MiqProductFeature::REPORT_ADMIN_FEATURE)
   end

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -173,6 +173,7 @@ describe MiqUserRole do
   end
 
   let(:super_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::SUPER_ADMIN_FEATURE) }
+  let(:tenant_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::TENANT_ADMIN_FEATURE) }
   let(:report_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::REPORT_ADMIN_FEATURE) }
   let(:request_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::REQUEST_ADMIN_FEATURE) }
   let(:regular_role) { FactoryGirl.create(:miq_user_role) }
@@ -205,6 +206,20 @@ describe MiqUserRole do
     it "detects non-admin" do
       expect(regular_role).not_to be_admin_user
       expect(regular_role).not_to be_report_admin_user
+    end
+  end
+
+  describe "#tenant_admin" do
+    it "detects tenant_admin" do
+      expect(tenant_admin_role).to be_tenant_admin_user
+    end
+
+    it "detects super_admin" do
+      expect(super_admin_role).to be_tenant_admin_user
+    end
+
+    it "does not detect regular role" do
+      expect(regular_role).not_to be_tenant_admin_user
     end
   end
 


### PR DESCRIPTION
Tenant admin users were only able to see groups in which they had membership. That meant that a tenant admin could create a new group but not have the ability to see it.

This change allows tenant admin users visibility to all groups with in the scope of their tenant. That means they can see all groups in their immediate tenant and all child tenants of that tenant. The only exception to this is that they are not able to see any groups that have a super admin role. That condition existed before this change.

/cc @jrafanie @kbrock 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596639
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1596266
