### PR TITLE
Adding product features for PhysicalInfra Overview page

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4667,6 +4667,17 @@
     :feature_type: view
     :identifier: ems_infra_dashboard_view
 
+# Physical Infra Provider Overview
+- :name: Physical Infra Providers Overview
+  :description: Physical Infra Providers Overview
+  :feature_type: node
+  :identifier: physical_infra_overview
+  :children:
+  - :name: View
+    :description: View Physical Infra Providers Overview
+    :feature_type: view
+    :identifier: physical_infra_overview_view
+
 # Foreman
 - :name: Configuration Management
   :description: Everything under Configuration Management


### PR DESCRIPTION
Add config into product features to display the overview page for Physical providers.
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/4372