### PR TITLE
Add retireable check to service retire task

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -32,12 +32,7 @@ class ServiceRetireTask < MiqRetireTask
   def create_retire_subtasks(parent_service)
     parent_service.direct_service_children.each { |child| create_retire_subtasks(child) }
     parent_service.service_resources.collect do |svc_rsc|
-      next unless svc_rsc.resource.present? && svc_rsc.resource.respond_to?(:retire_now)
-      next if svc_rsc.resource.type.blank?
-      next if svc_rsc.resource_type == "ServiceTemplate" &&
-              !self.class.include_service_template?(self,
-                                                    svc_rsc.resource.id,
-                                                    parent_service)
+      next unless retireable(svc_rsc, parent_service)
       nh = attributes.except("id", "created_on", "updated_on", "type", "state", "status", "message")
       nh['options'] = options.except(:child_tasks)
       # Initial Options[:dialog] to an empty hash so we do not pass down dialog values to child services tasks
@@ -58,5 +53,13 @@ class ServiceRetireTask < MiqRetireTask
       new_task.deliver_to_automate
       new_task
     end.compact!
+  end
+
+  def retireable(svc_rsc, parent_service)
+    srr = svc_rsc.resource
+    srr.present? &&
+      srr.respond_to?(:retire_now) &&
+      srr.type.present? &&
+      (svc_rsc.resource_type != "ServiceTemplate" || self.class.include_service_template?(self, srr.id, parent_service))
   end
 end


### PR DESCRIPTION
Checks to create subtasks for service retirement should live in the models associated, in a retireable method, but first, @mkanoor and @tinaafitz suggested pulling this logic out into a separate method to make it easier to refactor into the related models. 
