### PR TITLE
Add pt_BR.yml for Brazilian Portuguese

### DIFF
--- a/locale/pt_BR.yml
+++ b/locale/pt_BR.yml
@@ -1,0 +1,7 @@
+pt-BR:
+  product:
+    name: ManageIQ
+    name_full: ManageIQ
+    copyright: "Copyright (c) 2018 ManageIQ. Sponsored by Red Hat Inc."
+    support_website: "http://www.manageiq.org"
+    support_website_text: "ManageIQ.org"


### PR DESCRIPTION
One effect of the change is correctly rendered browser title in Brazilian Portuguese.

Before:
![title-before](https://user-images.githubusercontent.com/6648365/43403103-907fffc6-9414-11e8-8c8c-6d0cb0ab3dbf.png)


After:
![title-after](https://user-images.githubusercontent.com/6648365/43403085-85288828-9414-11e8-9023-bb7ec49ac47a.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1609810

@miq-bot add_label gaprindashvili/yes