### PR TITLE
Seed Ansible Roles for Vmdb Plugins

### DIFF
--- a/lib/tasks/evm_ansible.rake
+++ b/lib/tasks/evm_ansible.rake
@@ -5,26 +5,30 @@ namespace :evm do
   namespace :ansible do
     desc "Seed galaxy roles for provider playbooks"
     task :seed do
-      plugins_with_req_yml = Vmdb::Plugins.select do |p|
-        req_yml_path = p.root.join('content_tmp', 'ansible', 'requirements.yml')
+      plugins_with_req_yml = Vmdb::Plugins.select do |plugin|
+        req_yml_path = plugin.root.join('content_tmp', 'ansible', 'requirements.yml')
         File.file?(req_yml_path)
       end
 
-      plugins_with_req_yml.each do |p|
-        puts "Seeding roles for #{p.name.split("::Engine").first}..."
+      plugins_with_req_yml.each do |plugin|
+        puts "Seeding roles for #{plugin.name}..."
 
-        roles_path = p.root.join('content_tmp', 'ansible', 'roles')
-        role_file  = p.root.join('content_tmp', 'ansible', 'requirements.yml')
+        roles_path = plugin.root.join('content_tmp', 'ansible', 'roles')
+        role_file  = plugin.root.join('content_tmp', 'ansible', 'requirements.yml')
 
-        AwesomeSpawn.run!(
-          "ansible-galaxy",
-          :params => {
-            nil          => "install",
-            :roles_path= => roles_path,
-            :role_file=  => role_file
-          }
-        )
-        puts "Seeding roles for #{p.name.split("::Engine").first}...Complete"
+        params = {
+          nil          => "install",
+          :roles_path= => roles_path,
+          :role_file=  => role_file
+        }
+
+        begin
+          AwesomeSpawn.run!("ansible-galaxy", :params => params)
+          puts "Seeding roles for #{plugin.name}...Complete"
+        rescue AwesomeSpawn::CommandResultError => err
+          puts "Seeding roles for #{plugin.name}...Failed - #{err.result.error}"
+          raise
+        end
       end
     end
   end

--- a/lib/tasks/evm_ansible.rake
+++ b/lib/tasks/evm_ansible.rake
@@ -1,0 +1,31 @@
+require 'awesome_spawn'
+require "vmdb/plugins"
+
+namespace :evm do
+  namespace :ansible do
+    desc "Seed galaxy roles for provider playbooks"
+    task :seed do
+      plugins_with_req_yml = Vmdb::Plugins.select do |p|
+        req_yml_path = p.root.join('content_tmp', 'ansible', 'requirements.yml')
+        File.file?(req_yml_path)
+      end
+
+      plugins_with_req_yml.each do |p|
+        puts "Seeding roles for #{p.name.split("::Engine").first}..."
+
+        roles_path = p.root.join('content_tmp', 'ansible', 'roles')
+        role_file  = p.root.join('content_tmp', 'ansible', 'requirements.yml')
+
+        AwesomeSpawn.run!(
+          "ansible-galaxy",
+          :params => {
+            nil          => "install",
+            :roles_path= => roles_path,
+            :role_file=  => role_file
+          }
+        )
+        puts "Seeding roles for #{p.name.split("::Engine").first}...Complete"
+      end
+    end
+  end
+end

--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -5,16 +5,11 @@ namespace :evm do
   namespace :ansible_runner do
     desc "Seed galaxy roles for provider playbooks"
     task :seed do
-      plugins_with_req_yml = Vmdb::Plugins.select do |plugin|
-        req_yml_path = plugin.root.join('content', 'ansible_tmp', 'requirements.yml')
-        File.file?(req_yml_path)
-      end
-
-      plugins_with_req_yml.each do |plugin|
+      Vmdb::Plugins.ansible_runner_content.each do |plugin, content_dir|
         puts "Seeding roles for #{plugin.name}..."
 
-        roles_path = plugin.root.join('content', 'ansible_tmp', 'roles')
-        role_file  = plugin.root.join('content', 'ansible_tmp', 'requirements.yml')
+        roles_path = content_dir.join('roles')
+        role_file  = content_dir.join('requirements.yml')
 
         params = ["install", :roles_path= => roles_path, :role_file= => role_file]
 

--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -16,11 +16,7 @@ namespace :evm do
         roles_path = plugin.root.join('content_tmp', 'ansible', 'roles')
         role_file  = plugin.root.join('content_tmp', 'ansible', 'requirements.yml')
 
-        params = {
-          nil          => "install",
-          :roles_path= => roles_path,
-          :role_file=  => role_file
-        }
+        params = ["install", :roles_path= => roles_path, :role_file= => role_file]
 
         begin
           AwesomeSpawn.run!("ansible-galaxy", :params => params)

--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -2,7 +2,7 @@ require 'awesome_spawn'
 require "vmdb/plugins"
 
 namespace :evm do
-  namespace :ansible do
+  namespace :ansible_runner do
     desc "Seed galaxy roles for provider playbooks"
     task :seed do
       plugins_with_req_yml = Vmdb::Plugins.select do |plugin|

--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -6,15 +6,15 @@ namespace :evm do
     desc "Seed galaxy roles for provider playbooks"
     task :seed do
       plugins_with_req_yml = Vmdb::Plugins.select do |plugin|
-        req_yml_path = plugin.root.join('content_tmp', 'ansible', 'requirements.yml')
+        req_yml_path = plugin.root.join('content', 'ansible_tmp', 'requirements.yml')
         File.file?(req_yml_path)
       end
 
       plugins_with_req_yml.each do |plugin|
         puts "Seeding roles for #{plugin.name}..."
 
-        roles_path = plugin.root.join('content_tmp', 'ansible', 'roles')
-        role_file  = plugin.root.join('content_tmp', 'ansible', 'requirements.yml')
+        roles_path = plugin.root.join('content', 'ansible_tmp', 'roles')
+        role_file  = plugin.root.join('content', 'ansible_tmp', 'requirements.yml')
 
         params = ["install", :roles_path= => roles_path, :role_file= => role_file]
 

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -40,6 +40,17 @@ module Vmdb
       end
     end
 
+    def ansible_runner_content
+      @ansible_runner_content ||= begin
+        map do |engine|
+          content_dir = engine.root.join("content", "ansible_tmp")
+          next unless File.exist?(content_dir.join("requirements.yml"))
+
+          [engine, content_dir]
+        end.compact
+      end
+    end
+
     def automate_domains
       @automate_domains ||= begin
         require_relative 'plugins/automate_domain'


### PR DESCRIPTION
Allow plugins to add a requirements.yml file to specify roles from
galaxy/github/etc... and seed them locally.

If I have an example requirements.yml:
```
cat content_tmp/ansible/requirements.yml 
- src: yatesr.timezone
```

And I seed the roles
```
bundle exec rake evm:ansible_runner:seed
** override_gem: manageiq-providers-vmware, [{:path=>"/home/agrare/src/manageiq/manageiq-providers-vmware"}], caller: /home/agrare/src/manageiq/manageiq/bundler.d/plugins.rb
Seeding roles for ManageIQ::Providers::Vmware::Engine...
Seeding roles for ManageIQ::Providers::Vmware::Engine...Complete

ls -l ../manageiq-providers-vmware/content_tmp/ansible/roles/
total 0
drwxr-xr-x 1 agrare agrare  78 Jul 30 11:08 yatesr.timezone
```

And an example failure:
```
>../manageiq-providers-vmware/content_tmp/ansible/requirements.yml

bundle exec rake evm:ansible_runner:seed
Seeding roles for ManageIQ::Providers::Vmware::Engine...
Seeding roles for ManageIQ::Providers::Vmware::Engine...Failed - ERROR! No roles found in file: /home/agrare/src/manageiq/manageiq-providers-vmware/content_tmp/ansible/requirements.yml
rake aborted!
AwesomeSpawn::CommandResultError: ansible-galaxy exit code: 1
```