### PR TITLE
Added ability to create default dashboard for group

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -50,6 +50,9 @@ class MiqWidgetSet < ApplicationRecord
         end.compact
         h
       end
+
+      owner = attrs.delete("owner_description")
+      attrs["owner_id"] = MiqGroup.find_by(:description => owner).try(:id) if owner
     end
 
     if ws


### PR DESCRIPTION
**BEFORE:** We have one default dashboards (supplied with installation).
This dashboard defined in `product/dashboard/dashboards/default.yaml`

**AFTER**: ability to supply group specific default dashboard.

**TESTING** creating dashboard for group `EvmGroup-support` with the same set of widgets as existing default dashboard:
- copy `product/dashboard/dashboards/default.yaml` to `product/dashboard/dashboards/some_file.yaml`
- edit `some_file.yaml` by changing `name:` and `description:` and adding `owner_type: MiqGroup` and `owner_description: EvmGroup-support`. It will look like:
```
name: Default for Support
read_only: t
set_type: MiqWidgetSet
description: Default Dashboard for Support group
owner_type: MiqGroup
owner_description: EvmGroup-support
set_data_by_description:
  :col1:
  - chart_vendor_and_guest_os
  - rss_newest_hosts
  - report_top_memory_consumers_weekly
  :col2:
  - report_top_cpu_consumers_weekly
  - chart_virtual_infrastructure_platforms
  :col3:
  - chart_guest_os_information_any_os
  - rss_newest_vms
  - report_top_storage_consumers
```
Executing `MiqWidgetSet.seed` from Rails console will add new dashboard for `EvmGroup-support`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610299

@miq-bot add-label enhancement, reporting

\cc @gtanzillo 
