### PR TITLE
Include the request_type when creating a retirement request

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -11,8 +11,9 @@ module RetirementMixin
 
   module ClassMethods
     def make_retire_request(*src_ids)
-      options = {:src_ids => src_ids.presence || id}
-      (name.demodulize + "RetireRequest").constantize.make_request(nil, options, User.current_user, true)
+      klass = (name.demodulize + "RetireRequest").constantize
+      options = {:src_ids => src_ids.presence || id, :__request_type__ => klass.request_types.first}
+      klass.make_request(nil, options, User.current_user, true)
     end
 
     def retire(ids, options = {})

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -83,13 +83,13 @@ describe "Service Retirement Management" do
 
   it "with one src_id" do
     User.current_user = user
-    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => ['yabadabadoo'] }, User.current_user, true)
+    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => ['yabadabadoo'], :__request_type__ => "service_retire"}, User.current_user, true)
     @service.class.to_s.demodulize.constantize.make_retire_request('yabadabadoo')
   end
 
   it "with many src_ids" do
     User.current_user = user
-    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [1, 2, 3]}, User.current_user, true)
+    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [1, 2, 3], :__request_type__ => "service_retire"}, User.current_user, true)
     @service.class.to_s.demodulize.constantize.make_retire_request(1, 2, 3)
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -87,13 +87,13 @@ describe "VM Retirement Management" do
   describe "retire request" do
     it "with one src_id" do
       User.current_user = user
-      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => ['yabadabadoo'] }, User.current_user, true)
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => ['yabadabadoo'], :__request_type__ => "vm_retire"}, User.current_user, true)
       @vm.class.to_s.demodulize.constantize.make_retire_request('yabadabadoo')
     end
 
     it "with many src_ids" do
       User.current_user = user
-      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [1, 2, 3]}, User.current_user, true)
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [1, 2, 3], :__request_type__ => "vm_retire"}, User.current_user, true)
       @vm.class.to_s.demodulize.constantize.make_retire_request(1, 2, 3)
     end
   end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-api/pull/439

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1604016