### PR TITLE
Options hash should not contain AR objects

### DIFF
--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -194,7 +194,7 @@ module Spec
       end
 
       def build_vmware_service_item
-        options = {:src_vm_id => @vm_template.id, :requester => @user}.merge(vmware_requested_quota_values)
+        options = {:src_vm_id => @vm_template.id, :requester_id => @user.id}.merge(vmware_requested_quota_values)
         model = {"vmware_service_item" => {:type      => 'atomic',
                                            :prov_type => 'vmware',
                                            :request   => options}}
@@ -206,7 +206,7 @@ module Spec
         @small_flavor = FactoryGirl.create(:flavor_google, :ems_id => @ems.id, :cloud_subnet_required => false,
                                           :cpus => 1, :cpu_cores => 1, :memory => 1024)
 
-        options = {:src_vm_id => @vm_template.id, :requester => @user}.merge(google_requested_quota_values)
+        options = {:src_vm_id => @vm_template.id, :requester_id => @user.id}.merge(google_requested_quota_values)
         model = {"google_service_item" => {:type      => 'atomic',
                                            :prov_type => 'google',
                                            :request   => options}}

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -6,6 +6,10 @@ module Spec
         build_all_composites(hash)
       end
 
+      def get_user(options)
+        options[:requester] || User.find(options[:requester_id])
+      end
+
       def build_all_atomics(hash)
         hash.each do |name, value|
           next unless value[:type] == "atomic"
@@ -19,7 +23,7 @@ module Spec
           options ||= {}
           options[:dialog] = {}
           mprt = FactoryGirl.create(:miq_provision_request_template,
-                                    :requester => options[:requester],
+                                    :requester => get_user(options),
                                     :src_vm_id => options[:src_vm_id],
                                     :options   => options)
           add_st_resource(item, mprt)


### PR DESCRIPTION
The spec helper was storing user objects into the options hash
leading to DRbUnknown error when the options hash was being accessed
from Automate Method. Fixed the spec helpers to pass in id in the
options hash.

