### PR TITLE
[WIP] Mark child services as retired

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -152,6 +152,14 @@ module RetirementMixin
 
   def finish_retirement
     raise _("%{name} already retired") % {:name => name} if retired?
+    mark_as_retired
+
+    if kind_of?(Service)
+      all_service_children&.each { |child| child.mark_as_retired unless child.retired? }
+    end
+  end
+
+  def mark_as_retired
     $log.info("Finishing Retirement for [#{name}]")
     requester = retirement_requester
     update_attributes(:retires_on => Time.zone.now, :retired => true, :retirement_state => "retired")

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -685,6 +685,18 @@ describe Service do
       service = FactoryGirl.build(:service, :retired => nil)
       expect(service).not_to be_valid
     end
+
+    context "retires service children" do
+      let(:service) { FactoryGirl.create(:service) }
+      let(:child_service) { FactoryGirl.create(:service) }
+
+      it 'associates a child_service to the service' do
+        child_service.add_to_service(service)
+        service.finish_retirement
+
+        expect(service.direct_service_children.first.retired).to eq(true)
+      end
+    end
   end
 
   describe '#orchestration_stacks' do


### PR DESCRIPTION
The retirement as a request changes omitted marking all_service_children of services as retired. Previously if the parent was already retired we ran the end of the retirement, finish_retirement, and bailed. This marks the children as retired on services with children. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608958. 