### PR TITLE
Include task_id in result of ResourceActionWorkflow#process_request

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -38,7 +38,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       result[:request] = generate_request(state, values)
     else
       ra = load_resource_action(values)
-      ra.deliver_to_automate_from_dialog(values, @target, @requester)
+      result[:task_id] = ra.deliver_to_automate_from_dialog(values, @target, @requester).id
     end
 
     result


### PR DESCRIPTION
When invoking a custom button action with a dialog through the API, it is needed to access the created task. This one-liner should include the required task id in the result which can be propagated further in the API.

@miq-bot add_reviewer @pkomanek 
@miq-bot add_reviewer @ZitaNemeckova 
@miq-bot add_label gaprindashvili/yes, bug

https://bugzilla.redhat.com/show_bug.cgi?id=1602023