### PR TITLE
Distinguish between no password provided and bad password in error message

### DIFF
--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -11,10 +11,10 @@ class GitWorktree
     raise ArgumentError, "Must specify path" unless options.key?(:path)
     @path          = options[:path]
     @email         = options[:email]
-    @username      = options[:username]
+    @username      = options[:username] || ""
     @bare          = options[:bare]
     @commit_sha    = options[:commit_sha]
-    @password      = options[:password]
+    @password      = options[:password] || ""
     @fast_forward_merge = options[:ff] || true
     @remote_name   = 'origin'
     @cred          = Rugged::Credentials::UserPassword.new(:username => @username,
@@ -168,7 +168,10 @@ class GitWorktree
   end
 
   def credentials_cb(url, _username, _types)
-    raise GitWorktreeException::InvalidCredentials, "Invalid credentials for URL #{url}" if @credentials_set
+    if @credentials_set
+      raise GitWorktreeException::InvalidCredentials, "Please provide username and password for URL #{url}" if @username.blank? || @password.blank?
+      raise GitWorktreeException::InvalidCredentials, "Invalid credentials for URL #{url}"
+    end
     @credentials_set = true
     @cred
   end

--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -324,15 +324,27 @@ describe GitWorktree do
     end
   end
 
-  describe 'credentials_cb' do
+  shared_examples_for '#credentials_cb' do |error_regex|
     let(:git_repo_path) { Rails.root.join("spec", "fixtures", "git_repos", "branch_and_tag.git") }
-    let(:test_repo) { GitWorktree.new(:path => git_repo_path.to_s) }
+    let(:test_repo) { GitWorktree.new(:path => git_repo_path.to_s, :username => username, :password => password) }
 
-    describe "#credentials_cb" do
-      it "call the credentials callback" do
-        expect(test_repo.credentials_cb("url", nil, nil).class).to eq(Rugged::Credentials::UserPassword)
-        expect { test_repo.credentials_cb("url", nil, nil) }.to raise_exception(GitWorktreeException::InvalidCredentials)
-      end
+    it "call the credentials callback" do
+      expect(test_repo.credentials_cb("url", nil, nil).class).to eq(Rugged::Credentials::UserPassword)
+      expect { test_repo.credentials_cb("url", nil, nil) }.to raise_error(GitWorktreeException::InvalidCredentials, error_regex)
     end
+  end
+
+  context "no username and password set" do
+    let(:username) { nil }
+    let(:password) { nil }
+
+    it_behaves_like '#credentials_cb', /provide username and password/
+  end
+
+  context "bad username or password" do
+    let(:username) { 'fred' }
+    let(:password) { 'incorrect' }
+
+    it_behaves_like '#credentials_cb', /Invalid credentials/
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443105

When invoking a GitRepository sync from rake task or from the UI
the user might not provide a userid and password. This PR puts out
different error messages
If the userid and password is missing
 * Please provide username and password for URL #{url}
If the userid and password is incorrect the message is
 * Invalid credentials for URL #{url}
