### PR TITLE
require_nested_all instead of individual require_nest calls

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -1,30 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Providers::EmbeddedAutomationManager
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
-
-  require_nested :Credential
-  require_nested :AmazonCredential
-  require_nested :AzureCredential
-  require_nested :CloudCredential
-  require_nested :GoogleCredential
-  require_nested :MachineCredential
-  require_nested :VaultCredential
-  require_nested :NetworkCredential
-  require_nested :OpenstackCredential
-  require_nested :ScmCredential
-  require_nested :VmwareCredential
-  require_nested :RhvCredential
-
-  require_nested :ConfigurationScript
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfigurationWorkflow
-  require_nested :ConfiguredSystem
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Inventory
-  require_nested :Job
-  require_nested :Playbook
-  require_nested :Refresher
-  require_nested :RefreshWorker
+  require_nested_all
 
   def self.ems_type
     @ems_type ||= "embedded_ansible_automation".freeze

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -1,10 +1,5 @@
 class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::AutomationManager
-  require_nested :Authentication
-  require_nested :ConfigurationScript
-  require_nested :ConfigurationScriptPayload
-  require_nested :ConfigurationScriptSource
-  require_nested :ConfiguredSystem
-  require_nested :OrchestrationStack
+  require_nested_all
 
   def supported_catalog_types
     %w(generic_ansible_playbook)

--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -15,6 +15,14 @@ module RequireNested
       Object.require_nested name
     end
   end
+
+  def require_nested_all
+    path = File.join(caller(1, 1).first.split('.rb').first, "*.rb") # determining caller file location
+    Dir.glob(path).sort.each do |full_path|
+      name = File.basename(full_path, '.rb')
+      require_nested(name.classify.to_sym)
+    end
+  end
 end
 
 Module.include RequireNested


### PR DESCRIPTION
`require_nested_all` instead of `require_nested` individual ones

Forgetting to add/remove a `require_nest` is not easily detected and causes runtime error that's sometimes hard to debug.

In most of the cases (probably all) we actually needs to `require_nest` all in the folder.  Using this would save typings and typos.