### PR TITLE
Revert "Include task_id in result of ResourceActionWorkflow#process_request

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -38,7 +38,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       result[:request] = generate_request(state, values)
     else
       ra = load_resource_action(values)
-      result[:task_id] = ra.deliver_to_automate_from_dialog(values, @target, @requester).id
+      ra.deliver_to_automate_from_dialog(values, @target, @requester)
     end
 
     result

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -53,12 +53,9 @@ describe ResourceActionWorkflow do
       end
     end
 
-    describe "#submit_request" do
+    context "#submit_request" do
       subject { ResourceActionWorkflow.new({}, admin, resource_action, :target => target) }
       let(:resource_action) { @resource_action }
-      let(:task) { double }
-
-      before { allow(task).to receive(:id).and_return(123) }
 
       context "with request class" do
         let(:target) { FactoryGirl.create(:service) }
@@ -87,10 +84,10 @@ describe ResourceActionWorkflow do
           EvmSpecHelper.local_miq_server
           expect(subject).not_to receive(:make_request)
           expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog).and_call_original
-          expect(MiqAeEngine).to receive(:deliver_queue).and_return(task) # calls into automate
+          expect(MiqAeEngine).to receive(:deliver_queue) # calls into automate
           expect(AuditEvent).not_to receive(:success)
           response = subject.submit_request
-          expect(response).to eq(:errors => [], :task_id => 123)
+          expect(response).to eq(:errors => [])
         end
       end
 
@@ -104,7 +101,7 @@ describe ResourceActionWorkflow do
 
         it "calls automate" do
           expect(subject).not_to receive(:make_request)
-          expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog).and_return(task)
+          expect_any_instance_of(ResourceAction).to receive(:deliver_to_automate_from_dialog)
 
           subject.submit_request
         end


### PR DESCRIPTION
[This](https://github.com/ManageIQ/manageiq/pull/17788) was a wrong idea as the method doesn't return the task's id but a MiqQueue records's ID that is useless. So reverting ... sorry.

@miq-bot assign @gmcculloug 

This reverts commit 25be3128d9da2de74612f4149f8c2177fb2511d6.