### PR TITLE
Remove Debug Message

### DIFF
--- a/app/models/file_depot_s3.rb
+++ b/app/models/file_depot_s3.rb
@@ -33,7 +33,6 @@ class FileDepotS3 < FileDepot
   end
 
   def verify_credentials(auth_type = nil, options = {})
-    _log.debug("verifying credentials for auth_type [#{auth_type}] with options [#{options}]")
 
     connection_rescue_block do
       # EC2 does Lazy Connections, so call a cheap function


### PR DESCRIPTION
A debug log message in this file inadvertantly is printing the usernamd and password in clear text.
This is obvious incorrect and is being removed.

@carbonin @roliveri please review and merge.  In addition another similar PR is being pushed out against gems-pending (same issue).