### PR TITLE
[WIP] Update upload/download workflow for MiqS3Session

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -53,11 +53,9 @@ class EvmDatabaseOps
     #   :password => 'Zug-drep5s',
     #   :remote_file_name => "backup_1",     - Provide a base file name for the uploaded file
 
-    uri = with_mount_session(:backup, db_opts, connect_opts) do |database_opts, session, remote_file_uri|
+    uri = with_mount_session(:backup, db_opts, connect_opts) do |database_opts|
       validate_free_space(database_opts)
-      backup_result = PostgresAdmin.backup(database_opts)
-      session&.add(database_opts[:local_file], remote_file_uri)
-      backup_result
+      PostgresAdmin.backup(database_opts)
     end
     _log.info("[#{merged_db_opts(db_opts)[:dbname]}] database has been backed up to file: [#{uri}]")
     uri
@@ -66,7 +64,7 @@ class EvmDatabaseOps
   def self.dump(db_opts, connect_opts = {})
     # db_opts and connect_opts similar to .backup
 
-    uri = with_mount_session(:dump, db_opts, connect_opts) do |database_opts, _session, _remote_file_uri|
+    uri = with_mount_session(:dump, db_opts, connect_opts) do |database_opts|
       # For database dumps, this isn't going to be as accurate (since the dump
       # size will probably be larger than the calculated BD size), but it still
       # won't hurt to do as a generic way to get a rough idea if we have enough
@@ -89,10 +87,7 @@ class EvmDatabaseOps
     #   :username => 'samba_one',
     #   :password => 'Zug-drep5s',
 
-    uri = with_mount_session(:restore, db_opts, connect_opts) do |database_opts, session, remote_file_uri|
-      if session && !File.exist?(database_opts[:local_file])
-        database_opts[:local_file] = session.download(database_opts[:local_file], remote_file_uri)
-      end
+    uri = with_mount_session(:restore, db_opts, connect_opts) do |database_opts|
       prepare_for_restore(database_opts[:local_file])
 
       # remove all the connections before we restore; AR will reconnect on the next query
@@ -124,10 +119,25 @@ class EvmDatabaseOps
       db_opts[:local_file] = session.uri_to_local_path(uri)
     end
 
-    block_result = yield(db_opts, session, uri) if block_given?
+    download_from_mount_if_needed(action, session, uri, db_opts)
+    block_result = yield(db_opts) if block_given?
+    upload_to_mount_if_needed(action, session, uri, db_opts)
     uri || block_result
   ensure
     session.disconnect if session
+  end
+
+  private_class_method def self.download_from_mount_if_needed(action, session, uri, db_opts)
+    if action == :restore && session.kind_of?(MiqS3Session) && !File.exist?(db_opts[:local_file])
+      db_opts[:local_file] = session.download(db_opts[:local_file], uri)
+    end
+  end
+
+  private_class_method def self.upload_to_mount_if_needed(action, session, uri, db_opts)
+    if action == :backup && session.kind_of?(MiqS3Session)
+      session.add(db_opts[:local_file], uri)
+      FileUtils.rm_rf db_opts[:local_file] if false # TODO: consider doing this
+    end
   end
 
   private_class_method def self.prepare_for_restore(filename)

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -37,14 +37,12 @@ describe EvmDatabaseOps do
     it "remotely" do
       @db_opts[:local_file] = nil
       @connect_opts[:remote_file_name] = "custom_backup"
-      expect(session).to receive(:add).and_return("smb://myserver.com/share/db_backup/custom_backup")
       expect(EvmDatabaseOps.backup(@db_opts, @connect_opts)).to eq("smb://myserver.com/share/db_backup/custom_backup")
     end
 
     it "remotely without a remote file name" do
       @db_opts[:local_file] = nil
       @connect_opts[:remote_file_name] = nil
-      expect(session).to receive(:add)
       expect(EvmDatabaseOps.backup(@db_opts, @connect_opts)).to match(/smb:\/\/myserver.com\/share\/db_backup\/miq_backup_.*/)
     end
 
@@ -58,7 +56,6 @@ describe EvmDatabaseOps do
       expect(described_class).to receive(:_log).twice.and_return(log_stub)
       expect(log_stub).to        receive(:info).with(any_args)
       expect(log_stub).to        receive(:info).with("[vmdb_production] database has been backed up to file: [smb://myserver.com/share/db_backup/miq_backup]")
-      expect(session).to receive(:add).and_return("smb://myserver.com/share/db_backup/miq_backup")
 
       EvmDatabaseOps.backup(@db_opts, @connect_opts)
     end


### PR DESCRIPTION
This is an update to the changes made in https://github.com/ManageIQ/manageiq/pull/17689 in regards to the changes to `EvmDatabaseOps` only.

The changes here are necessary to allow https://github.com/ManageIQ/manageiq/pull/17652 to function again, which will be updated to include these changes as well.


Background
----------

The process in which the FTP and S3 support for database backups took two different approaches to handling them.

For S3 route, it was planned to treat it as a psuedo mount, but that meant that the upload for the backup, and the download for the restore had to be done manually (unlike the other mounted filesystems).

The plan for splitting files (and eventually FTP), was to use the file splitter to pipe the results into the FTP endpoint, and that would work the same for the mounts (sans the FTP bit) since they are just file systems and it will dump the files locally as it does.


Links
-----

* PR adding the original changes:  https://github.com/ManageIQ/manageiq/pull/17689
* PR needing the changes from this PR:  https://github.com/ManageIQ/manageiq/pull/17652
* Gist for testing:  https://gist.github.com/NickLaMuro/8438015363d90a2d2456be650a2b9bc6


Steps for Testing/QA
--------------------

Like my other PRs, I have been using [the gist from above](https://gist.github.com/NickLaMuro/8438015363d90a2d2456be650a2b9bc6) to test the changes against all the current file systems in the console.  This does not, however, test `MiqS3Session` since I was unaware of it existing previously, so testing that will need to happen separately.