### PR TITLE
Log the exception message if refresh fails

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -43,7 +43,7 @@ module ManageIQ
           rescue => e
             raise if EmsRefresh.debug_failures
 
-            _log.error("#{log_ems_target} Refresh failed")
+            _log.error("#{log_ems_target} Refresh failed: #{e.truncate(255)}")
             _log.log_backtrace(e)
             _log.error("#{log_ems_target} Unable to perform refresh for the following targets:")
             targets.each do |target|


### PR DESCRIPTION
Prior to this we were only logging the backtrace and not the exception
message if a refresh failed.

https://bugzilla.redhat.com/show_bug.cgi?id=1610924