### PR TITLE
L10N - Add the missing pb and eb types for storage_units 

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1101,3 +1101,11 @@ en:
     ui_title:
       foreman:             Foreman
       ansible_tower:       Ansible Tower
+
+  # Used in NumberHelper.number_to_human_size() and NumberHelper.number_to_human()
+  number:
+    human:
+      storage_units:
+        units:
+          pb: "PB"
+          eb: "EB"

--- a/locale/es.yml
+++ b/locale/es.yml
@@ -5,3 +5,11 @@ es:
     copyright: "Copyright (c) 2018 ManageIQ. Sponsored by Red Hat Inc."
     support_website: "http://www.manageiq.org"
     support_website_text: "ManageIQ.org"
+
+  # Used in NumberHelper.number_to_human_size() and NumberHelper.number_to_human()
+  number:
+    human:
+      storage_units:
+        units:
+          pb: "PB"
+          eb: "EB"

--- a/locale/fr.yml
+++ b/locale/fr.yml
@@ -5,3 +5,11 @@ fr:
     copyright: "Copyright (c) 2018 ManageIQ. Sponsored by Red Hat Inc."
     support_website: "http://www.manageiq.org"
     support_website_text: "ManageIQ.org"
+
+  # Used in NumberHelper.number_to_human_size() and NumberHelper.number_to_human()
+  number:
+    human:
+      storage_units:
+        units:
+          pb: "Po"
+          eb: "Eo"

--- a/locale/ja.yml
+++ b/locale/ja.yml
@@ -9,3 +9,11 @@ ja:
     support_website: "http://www.manageiq.org"
     support_website_text: "ManageIQ.org"
 
+  # Used in NumberHelper.number_to_human_size() and NumberHelper.number_to_human()
+  number:
+    human:
+      storage_units:
+        units:
+          pb: "PB"
+          eb: "EB"
+

--- a/locale/pt_BR.yml
+++ b/locale/pt_BR.yml
@@ -5,3 +5,11 @@ pt-BR:
     copyright: "Copyright (c) 2018 ManageIQ. Sponsored by Red Hat Inc."
     support_website: "http://www.manageiq.org"
     support_website_text: "ManageIQ.org"
+
+  # Used in NumberHelper.number_to_human_size() and NumberHelper.number_to_human()
+  number:
+    human:
+      storage_units:
+        units:
+          pb: "PB"
+          eb: "EB"

--- a/locale/zh_CN.yml
+++ b/locale/zh_CN.yml
@@ -5,3 +5,11 @@ zh-CN:
     copyright: "Copyright (c) 2018 ManageIQ。由红帽赞助。"
     support_website: "http://www.manageiq.org"
     support_website_text: "ManageIQ.org"
+
+  # Used in NumberHelper.number_to_human_size() and NumberHelper.number_to_human()
+  number:
+    human:
+      storage_units:
+        units:
+          pb: "PB"
+          eb: "EB"


### PR DESCRIPTION
Temporary fix until the rails-i18N gem is updated ( https://github.com/svenfuchs/rails-i18n/pull/790)

L10N - Add the missing pb and eb types for storage_units for JA

@mzazrivec  - thanks

Links
----------------
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610586


Steps for Testing/QA

Before - 500 errror

After:
![screenshot from 2018-08-06 10-27-20](https://user-images.githubusercontent.com/12769982/43724404-e1f0077c-9967-11e8-90b5-dfee701f5edf.png)

-------------------------------
Test on a Japanese appliance with a datastore with total_space in the PB range
