### PR TITLE
New and improved Field.is_field?()

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -18,17 +18,7 @@ class MiqExpression::Field < MiqExpression::Target
   end
 
   def self.is_field?(field)
-    return false unless field.kind_of?(String)
-    match = REGEX.match(field)
-    return false unless match
-    model =
-      begin
-        match[:model_name].safe_constantize
-      rescue LoadError
-        nil
-      end
-    return false unless model
-    !!(model < ApplicationRecord)
+    parse(field)&.valid? || false
   end
 
   def to_s
@@ -36,7 +26,8 @@ class MiqExpression::Field < MiqExpression::Target
   end
 
   def valid?
-    target.column_names.include?(column) || virtual_attribute? || custom_attribute_column?
+    (target < ApplicationRecord) &&
+      (target.column_names.include?(column) || virtual_attribute? || custom_attribute_column?)
   end
 
   def attribute_supported_by_sql?

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -9,11 +9,16 @@ class MiqExpression::Target
   # returns hash:
   # {:model_name => Host<ApplicationRecord> , :associations => ['vms']<Array>, :column_name => 'host_name' <String>}
   def self.parse_params(field)
+    return unless field.kind_of?(String)
     match = self::REGEX.match(field) || return
     # convert matches to hash to format
     # {:model_name => 'User', :associations => ...}
     parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]
-    parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize
+    begin
+      parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize
+    rescue LoadError # issues for case sensitivity (e.g.: VM vs vm)
+      parsed_params[:model_name] = nil
+    end
     parsed_params[:associations] = parsed_params[:associations].to_s.split(".")
     parsed_params
   end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -351,7 +351,11 @@ RSpec.describe MiqExpression::Field do
 
     it "does not detect a string to looks like a field but isn't" do
       expect(MiqExpression::Field.is_field?("NetworkManager-team")).to be_falsey
-      expect(described_class.is_field?("ManageIQ-name")).to be(false)
+      expect(described_class.is_field?("ManageIQ-name")).to be_falsey
+    end
+
+    it "handles regular expression" do
+      expect(MiqExpression::Field.is_field?(/x/)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
@yrudman and I had discussed this and I wanted to capture my local code before I lost it.
This is an alternate to https://github.com/ManageIQ/manageiq/pull/17760

Fixes issue when MiqExpression engine is a regular expression
and the field looks like "Model-field" but the attribute doesn't exist

Example: if there is vm named "Lan-yuri" than this expression
Virtual Machine : Name REGULAR EXPRESSION MATCHES "L+" triggers error

https://bugzilla.redhat.com/show_bug.cgi?id=1581853
