### PR TITLE
Creating miq_request for CustomButton request call with open_url.

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -221,4 +221,8 @@ class CustomButton < ApplicationRecord
   def self.display_name(number = 1)
     n_('Button', 'Buttons', number)
   end
+
+  def open_url?
+    options[:open_url] == true
+  end
 end

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -14,7 +14,7 @@ class ResourceAction < ApplicationRecord
     resource.readonly? if resource.kind_of?(ServiceTemplate)
   end
 
-  def automate_queue_hash(target, override_attrs, user)
+  def automate_queue_hash(target, override_attrs, user, open_url_task_id = nil)
     if target.nil?
       override_values = {}
     elsif target.kind_of?(Hash)
@@ -33,6 +33,7 @@ class ResourceAction < ApplicationRecord
       :class_name       => ae_class,
       :instance_name    => ae_instance,
       :automate_message => ae_message,
+      :open_url_task_id => open_url_task_id,
       :attrs            => (ae_attributes || {}).merge(override_attrs || {}),
     }.merge(override_values).tap do |args|
       args[:user_id] ||= user.id
@@ -66,12 +67,19 @@ class ResourceAction < ApplicationRecord
     uri
   end
 
-  def deliver_to_automate_from_dialog(dialog_hash_values, target, user)
+  def deliver_to_automate_from_dialog(dialog_hash_values, target, user, task_id = nil)
     _log.info("Queuing <#{self.class.name}:#{id}> for <#{resource_type}:#{resource_id}>")
-    MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user),
+    MiqAeEngine.deliver_queue(automate_queue_hash(target, dialog_hash_values[:dialog], user, task_id),
                               :zone     => target.try(:my_zone),
                               :priority => MiqQueue::HIGH_PRIORITY,
                               :task_id  => "#{self.class.name.underscore}_#{id}")
+  end
+
+  def deliver_to_automate_from_dialog_with_miq_task(dialog_hash_values, target, user)
+    task = MiqTask.create(:name => "Automate method task for open_url", :userid => user.userid)
+    deliver_to_automate_from_dialog(dialog_hash_values, target, user, task.id)
+    task.update_status(MiqTask::STATE_QUEUED, MiqTask::STATUS_OK, 'MiqTask has been queued.')
+    task.id
   end
 
   def deliver_to_automate_from_dialog_field(dialog_hash_values, target, user)

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -38,7 +38,11 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       result[:request] = generate_request(state, values)
     else
       ra = load_resource_action(values)
-      ra.deliver_to_automate_from_dialog(values, @target, @requester)
+      if ra.resource.try(:open_url?)
+        result[:task_id] = ra.deliver_to_automate_from_dialog_with_miq_task(values, @target, @requester)
+      else
+        ra.deliver_to_automate_from_dialog(values, @target, @requester)
+      end
     end
 
     result

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -15,6 +15,7 @@ describe ResourceAction do
         :miq_group_id     => user.current_group.id,
         :tenant_id        => user.current_tenant.id,
         :attrs            => ae_attributes,
+        :open_url_task_id => nil
       }
     end
     let(:q_options) do
@@ -64,6 +65,16 @@ describe ResourceAction do
         ae_attributes['Array::target_object_ids'] = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
         expect(MiqQueue).to receive(:put).with(q_options).once
         ra.deliver_to_automate_from_dialog({}, targets, user)
+      end
+    end
+
+    context '#deliver_to_automate_from_dialog_with_miq_task' do
+      it '' do
+        allow(ra).to(receive(:deliver_to_automate_from_dialog))
+        miq_task = MiqTask.find(ra.deliver_to_automate_from_dialog_with_miq_task({}, nil, user))
+        expect(miq_task.state).to(eq(MiqTask::STATE_QUEUED))
+        expect(miq_task.status).to(eq(MiqTask::STATUS_OK))
+        expect(miq_task.message).to(eq('MiqTask has been queued.'))
       end
     end
   end


### PR DESCRIPTION
Creating a new miq_task for CustomButton request call with open_url. This miq_task is used to track ae_method progress, which is used to open specified url when the method is finished. This PR is based on BZ bellow and it is also part of the https://github.com/ManageIQ/manageiq-ui-classic/pull/4334.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1602023
