### PR TITLE
Save Aws Region in File Depot for DB Backup

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -331,10 +331,11 @@ class MiqSchedule < ApplicationRecord
   end
 
   def verify_file_depot(params)  # TODO: This logic belongs in the UI, not sure where
-    depot_class = FileDepot.supported_protocols[params[:uri_prefix]]
-    depot       = file_depot.class.name == depot_class ? file_depot : build_file_depot(:type => depot_class)
-    depot.name  = params[:name]
-    depot.uri   = params[:uri]
+    depot_class      = FileDepot.supported_protocols[params[:uri_prefix]]
+    depot            = file_depot.class.name == depot_class ? file_depot : build_file_depot(:type => depot_class)
+    depot.name       = params[:name]
+    depot.uri        = params[:uri]
+    depot.aws_region = params[:aws_region]
     if params[:save]
       file_depot.save!
       file_depot.update_authentication(:default => {:userid => params[:username], :password => params[:password]}) if (params[:username] || params[:password]) && depot.class.requires_credentials?


### PR DESCRIPTION
The AWS region for S3 file depots was not being saved when passed in from the UI.

In coordination with https://github.com/ManageIQ/manageiq-ui-classic/pull/4300 which is setting the AWS region from a drop down list, we need to set the region in the file_depot for S3 DB backups.

@h-kataria @roliveri @carbonin @NickLaMuro fyi & review.

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/4300
* https://bugzilla.redhat.com/show_bug.cgi?id=1513520

