### PR TITLE
Prevent auth validation if a Host is archived

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -744,6 +744,7 @@ class Host < ApplicationRecord
   end
 
   def verify_credentials(auth_type = nil, options = {})
+    raise MiqException::MiqHostError, _("The Host is not connected to an active Provider") unless has_active_ems?
     raise MiqException::MiqHostError, _("No credentials defined") if missing_credentials?(auth_type)
     if auth_type.to_s != 'ipmi' && os_image_name !~ /linux_*/
       raise MiqException::MiqHostError, _("Logon to platform [%{os_name}] not supported") % {:os_name => os_image_name}

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -201,8 +201,9 @@ describe Host do
     before do
       EvmSpecHelper.local_miq_server
 
+      ems = FactoryGirl.create(:ems_vmware)
       @password = "v2:{/OViaBJ0Ug+RSW9n7EFGqw==}"
-      @host = FactoryGirl.create(:host_vmware_esx)
+      @host = FactoryGirl.create(:host_vmware_esx, :ext_management_system => ems)
       @data = {:default => {:userid => "root", :password => @password}}
       @options = {:save => false}
     end
@@ -266,6 +267,17 @@ describe Host do
 
         @data[:default] = {:userid => "root", :password => @password}
         assert_default_credentials_validated
+      end
+    end
+
+    context "archived" do
+      let(:archived_host) { FactoryGirl.create(:host_vmware_esx).tap { |h| h.update_authentication(@data, @options) } }
+
+      context "default credentials" do
+        it "validate" do
+          expect { archived_host.verify_credentials(:default) }
+            .to raise_error(MiqException::MiqHostError, "The Host is not connected to an active Provider")
+        end
       end
     end
   end


### PR DESCRIPTION
If a host isn't connected to an EMS prevent credential validation.

![screenshot from 2018-08-06 15-29-46](https://user-images.githubusercontent.com/12851112/43737737-4b77d2a6-9990-11e8-97dc-a707502014e2.png)

https://bugzilla.redhat.com/show_bug.cgi?id=1609807