### PR TITLE
Adding default properties to inventory collections

### DIFF
--- a/app/models/manager_refresh/inventory_collection/builder/persister_helper.rb
+++ b/app/models/manager_refresh/inventory_collection/builder/persister_helper.rb
@@ -100,8 +100,11 @@ module ManagerRefresh::InventoryCollection::Builder::PersisterHelper
 
   # @return [Hash] kwargs shared for all InventoryCollection objects
   def shared_options
-    # can be implemented in a subclass
-    {}
+    {
+      :strategy => strategy,
+      :targeted => targeted?,
+      :parent   => manager.presence
+    }
   end
 
   # Returns list of target's ems_refs


### PR DESCRIPTION
Almost all providers defines the same `shared_options` for inventory collection in persisters:
- strategy
- targeted
- parent

This PR extracts them to core