### PR TITLE
No need to create named classes in test

### DIFF
--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -9,33 +9,35 @@ describe Authenticator::Ldap do
     }
   end
 
-  class FakeLdap
-    def initialize(user_data)
-      @user_data = user_data
-    end
+  let(:fake_ldap) do
+    Class.new do
+      def initialize(user_data)
+        @user_data = user_data
+      end
 
-    def bind(username, password)
-      @user_data[username].try(:[], :password) == password
-    end
+      def bind(username, password)
+        @user_data[username].try(:[], :password) == password
+      end
 
-    def fqusername(username)
-      username.delete('X')
-    end
+      def fqusername(username)
+        username.delete('X')
+      end
 
-    def get_user_object(username)
-      @user_data[username]
-    end
+      def get_user_object(username)
+        @user_data[username]
+      end
 
-    def get_memberships(user_obj, _max_depth)
-      user_obj.fetch(:groups)
-    end
+      def get_memberships(user_obj, _max_depth)
+        user_obj.fetch(:groups)
+      end
 
-    def get_attr(user_obj, attr_name)
-      user_obj.fetch(attr_name)
-    end
+      def get_attr(user_obj, attr_name)
+        user_obj.fetch(attr_name)
+      end
 
-    def normalize(dn)
-      dn
+      def normalize(dn)
+        dn
+      end
     end
   end
 
@@ -114,7 +116,7 @@ describe Authenticator::Ldap do
   end
 
   before do
-    allow(MiqLdap).to receive(:new) { FakeLdap.new(user_data) }
+    allow(MiqLdap).to receive(:new) { fake_ldap.new(user_data) }
     allow(MiqLdap).to receive(:using_ldap?) { true }
   end
 

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -6,6 +6,57 @@ describe FileDepotFtp do
   let(:connection)     { double("FtpConnection") }
   let(:file_depot_ftp) { FileDepotFtp.new(:uri => "ftp://server.example.com/uploads") }
   let(:log_file)       { LogFile.new(:resource => @miq_server, :local_file => "/tmp/file.txt") }
+  let(:ftp_mock) do
+    Class.new do
+      attr_reader :pwd, :content
+      def initialize(content = {})
+        @pwd = '/'
+        @content = content
+      end
+
+      def chdir(dir)
+        newpath = (Pathname.new(pwd) + dir).to_s
+        if local(newpath).kind_of? Hash
+          @pwd = newpath
+        end
+      end
+
+      private
+
+      def local(path)
+        local = @content
+        path.split('/').each do |dir|
+          next if dir.empty?
+          local = local[dir]
+          raise Net::FTPPermError, '550 Failed to change directory.' if local.nil?
+        end
+        local
+      end
+    end
+  end
+
+  let(:vsftpd_mock) do
+    Class.new(ftp_mock) do
+      def nlst(path = '')
+        l = local(pwd + path)
+        l.respond_to?(:keys) ? l.keys : []
+      rescue
+        return []
+      end
+
+      def mkdir(dir)
+        l = local(pwd)
+        l[dir] = {}
+      end
+
+      def putbinaryfile(local_path, remote_path)
+        dir, base = Pathname.new(remote_path).split
+        l = local(dir.to_s)
+        l[base.to_s] = local_path
+      end
+    end
+  end
+
 
   context "#file_exists?" do
     it "true if file exists" do
@@ -30,7 +81,7 @@ describe FileDepotFtp do
 
   context "#upload_file" do
     it 'uploads file to vsftpd with existing directory structure' do
-      vsftpd = VsftpdMock.new('uploads' =>
+      vsftpd = vsftpd_mock.new('uploads' =>
                               {"#{@zone.name}_#{@zone.id}" =>
                               {"#{@miq_server.name}_#{@miq_server.id}" => {}}})
       expect(file_depot_ftp).to receive(:connect).and_return(vsftpd)
@@ -43,7 +94,7 @@ describe FileDepotFtp do
     end
 
     it 'uploads file to vsftpd with empty /uploads directory' do
-      vsftpd = VsftpdMock.new('uploads' => {})
+      vsftpd = vsftpd_mock.new('uploads' => {})
       expect(file_depot_ftp).to receive(:connect).and_return(vsftpd)
       file_depot_ftp.upload_file(log_file)
       expect(vsftpd.content).to eq('uploads' =>
@@ -62,53 +113,6 @@ describe FileDepotFtp do
       expect(connection).to receive(:close)
 
       file_depot_ftp.upload_file(log_file)
-    end
-  end
-
-  class FtpMock
-    attr_reader :pwd, :content
-    def initialize(content = {})
-      @pwd = '/'
-      @content = content
-    end
-
-    def chdir(dir)
-      newpath = (Pathname.new(pwd) + dir).to_s
-      if local(newpath).kind_of? Hash
-        @pwd = newpath
-      end
-    end
-
-    private
-
-    def local(path)
-      local = @content
-      path.split('/').each do |dir|
-        next if dir.empty?
-        local = local[dir]
-        raise Net::FTPPermError, '550 Failed to change directory.' if local.nil?
-      end
-      local
-    end
-  end
-
-  class VsftpdMock < FtpMock
-    def nlst(path = '')
-      l = local(pwd + path)
-      l.respond_to?(:keys) ? l.keys : []
-    rescue
-      return []
-    end
-
-    def mkdir(dir)
-      l = local(pwd)
-      l[dir] = {}
-    end
-
-    def putbinaryfile(local_path, remote_path)
-      dir, base = Pathname.new(remote_path).split
-      l = local(dir.to_s)
-      l[base.to_s] = local_path
     end
   end
 end

--- a/spec/models/manager_refresh/graph_spec.rb
+++ b/spec/models/manager_refresh/graph_spec.rb
@@ -6,15 +6,17 @@ describe ManagerRefresh::Graph do
   let(:edges) { [[node1, node2], [node1, node3], [node2, node4]] }
   let(:fixed_edges) { [] }
 
-  class TestGraph < described_class
-    def initialize(nodes, edges, fixed_edges)
-      @nodes = nodes
-      @edges = edges
-      @fixed_edges = fixed_edges
+  let(:test_graph_class) do
+    Class.new(described_class) do
+      def initialize(nodes, edges, fixed_edges)
+        @nodes = nodes
+        @edges = edges
+        @fixed_edges = fixed_edges
+      end
     end
   end
 
-  let(:graph) { TestGraph.new([node1, node2, node3, node4], edges, fixed_edges) }
+  let(:graph) { test_graph_class.new([node1, node2, node3, node4], edges, fixed_edges) }
 
   describe '#to_graphviz' do
     it 'prints the graph' do

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -199,9 +199,8 @@ describe SupportsFeatureMixin do
 
   context "guards against unqueriable features" do
     it "when defining a class with :supports_not" do
-      stub_const("MegaPost", Class.new)
       expect do
-        class MegaPost
+        Class.new do
           include SupportsFeatureMixin
           supports_not :mega
         end
@@ -209,9 +208,8 @@ describe SupportsFeatureMixin do
     end
 
     it "when defining a class with :supports" do
-      stub_const("MegaPost", Class.new)
       expect do
-        class MegaPost
+        Class.new do
           include SupportsFeatureMixin
           supports :mega
         end


### PR DESCRIPTION
Avoid unexpected naming conflicts