### PR TITLE
Add a model for ConversionHosts

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,0 +1,7 @@
+class ConversionHost < ApplicationRecord
+  include NewWithTypeStiMixin
+
+  acts_as_miq_taggable
+
+  belongs_to :resource, :polymorphic => true
+end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -91,6 +91,7 @@ class Host < ApplicationRecord
                             :inverse_of => :host
   has_many                  :host_aggregate_hosts, :dependent => :destroy
   has_many                  :host_aggregates, :through => :host_aggregate_hosts
+  has_one                   :conversion_host, :as => :resource, :dependent => :destroy
 
   # Physical server reference
   belongs_to :physical_server, :inverse_of => :host

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -91,7 +91,7 @@ class Host < ApplicationRecord
                             :inverse_of => :host
   has_many                  :host_aggregate_hosts, :dependent => :destroy
   has_many                  :host_aggregates, :through => :host_aggregate_hosts
-  has_one                   :conversion_host, :as => :resource, :dependent => :destroy
+  has_one                   :conversion_host, :as => :resource, :dependent => :destroy, :inverse_of => :resource
 
   # Physical server reference
   belongs_to :physical_server, :inverse_of => :host

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -82,7 +82,7 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
 
-  has_one                   :conversion_host, :as => :resource, :dependent => :destroy
+  has_one                   :conversion_host, :as => :resource, :dependent => :destroy, :inverse_of => :resource
 
   belongs_to                :resource_group
 

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -82,6 +82,8 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :guest_applications, :dependent => :destroy
   has_many                  :patches, :dependent => :destroy
 
+  has_one                   :conversion_host, :as => :resource, :dependent => :destroy
+
   belongs_to                :resource_group
 
   # Accounts - Users and Groups


### PR DESCRIPTION
This adds a movel for Conversion Hosts which are polymorphically related
to other inventory like Vms/Hosts.

Depends on: ~~https://github.com/ManageIQ/manageiq-schema/pull/242~~