### PR TITLE
Add support for load_values_on_init to text boxes.

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -1,6 +1,12 @@
 class DialogFieldTextBox < DialogField
   AUTOMATE_VALUE_FIELDS = %w(data_type protected required validator_rule validator_type read_only visible description).freeze
 
+  def initialize_value_context
+    if @value.blank?
+      @value = dynamic && load_values_on_init? ? values_from_automate : default_value
+    end
+  end
+
   def value
     return nil if @value.nil?
     convert_value_to_type
@@ -77,5 +83,10 @@ class DialogFieldTextBox < DialogField
 
   def value_supposed_to_be_int?
     data_type == "integer" && @value.to_s !~ /^[0-9]+$/
+  end
+
+  def load_values_on_init?
+    return true unless show_refresh_button
+    load_values_on_init
   end
 end

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -1,4 +1,66 @@
 describe DialogFieldTextBox do
+  describe "#initialize_value_context" do
+    let(:field) do
+      described_class.new(
+        :dynamic => dynamic,
+        :load_values_on_init => load_values_on_init,
+        :show_refresh_button => show_refresh_button,
+        :default_value => "default value"
+      )
+    end
+    let(:automate_value) { "value from automate" }
+    let(:load_values_on_init) { false }
+    let(:show_refresh_button) { false }
+
+    context "when the field is dynamic" do
+      let(:dynamic) { true }
+
+      before do
+        allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).and_return(automate_value)
+      end
+
+      context "when show_refresh_button is true" do
+        let(:show_refresh_button) { true }
+
+        context "when load_values_on_init is true" do
+          let(:load_values_on_init) { true }
+
+          it "sets the value to the automate value" do
+            field.initialize_value_context
+            expect(field.instance_variable_get(:@value)).to eq("value from automate")
+          end
+        end
+
+        context "when load_values_on_init is false" do
+          let(:load_values_on_init) { false }
+
+          it "uses the default value" do
+            field.initialize_value_context
+            expect(field.instance_variable_get(:@value)).to eq("default value")
+          end
+        end
+      end
+
+      context "when show_refresh_button is false" do
+        let(:show_refresh_button) { false }
+
+        it "sets the value to the automate value" do
+          field.initialize_value_context
+          expect(field.instance_variable_get(:@value)).to eq("value from automate")
+        end
+      end
+    end
+
+    context "when the field is not dynamic" do
+      let(:dynamic) { false }
+
+      it "uses the default value" do
+        field.initialize_value_context
+        expect(field.instance_variable_get(:@value)).to eq("default value")
+      end
+    end
+  end
+
   describe "#initial_values" do
     let(:dialog_field) { described_class.new }
 

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -2,10 +2,10 @@ describe DialogFieldTextBox do
   describe "#initialize_value_context" do
     let(:field) do
       described_class.new(
-        :dynamic => dynamic,
+        :dynamic             => dynamic,
         :load_values_on_init => load_values_on_init,
         :show_refresh_button => show_refresh_button,
-        :default_value => "default value"
+        :default_value       => "default value"
       )
     end
     let(:automate_value) { "value from automate" }


### PR DESCRIPTION
Add support for dynamic text and text area boxes for load_values_on_init to be respected when show refresh button is true.
This allows dynamic text boxes to not load on init similar to dialog_field_sorted_item used by drop downs and radio buttons.
