### PR TITLE
Filter out orphaned hosts and cloud instances from list of running

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -139,6 +139,7 @@ class Host < ApplicationRecord
   virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true
   virtual_column :vmm_vendor_display,           :type => :string
   virtual_column :ipmi_enabled,                 :type => :boolean
+  virtual_column :archived, :type => :boolean
 
   virtual_has_many   :resource_pools,                               :uses => :all_relationships
   virtual_has_many   :miq_scsi_luns,                                :uses => {:hardware => {:storage_adapters => {:miq_scsi_targets => :miq_scsi_luns}}}
@@ -1768,6 +1769,7 @@ class Host < ApplicationRecord
   def archived?
     ems_id.nil?
   end
+  alias archived archived?
 
   def normalized_state
     return 'archived' if archived?

--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -329,13 +329,27 @@
     search_type: default
     db: Host
 - attributes:
+    name: default_Status / Orhaned
+    description: Status / Orhaned
+    filter: !ruby/object:MiqExpression
+      exp:
+        "=":
+          field: Host-archived
+          value: "true"
+    search_type: default
+    db: Host
+- attributes:
     name: default_Status / Running
     description: Status / Running
     filter: !ruby/object:MiqExpression
       exp:
-        INCLUDES:
-          field: Host-power_state
-          value: "on"
+        and:
+        - INCLUDES:
+            field: Host-power_state
+            value: "on"
+        - "=":
+            field: Host-archived
+            value: "false"
     search_type: default
     db: Host
 - attributes:

--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -957,9 +957,13 @@
     description: Status / Running
     filter: !ruby/object:MiqExpression
       exp:
-        "=":
-          field: VmCloud-power_state
-          value: "on"
+        and:
+        - "=":
+            field: VmCloud-power_state
+            value: "on"
+        - "=":
+            field: VmCloud-archived
+            value: "false"
     search_type: default
     db: ManageIQ::Providers::CloudManager::Vm
 - attributes:


### PR DESCRIPTION
This PR:
- adds virtual column `Host#archived`
- modifies `MiqExpression`in `db/fixtures/miq_searches.yml` to filter out orphaned hosts and cloud instances

Depends on https://github.com/ManageIQ/manageiq/pull/17819

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1612982

**BEFORE:**
![before - host running](https://user-images.githubusercontent.com/6556758/43860750-b0945d42-9b22-11e8-8f92-8b5e791cbe68.png)
![before - cloud instances running](https://user-images.githubusercontent.com/6556758/43860752-b38b637e-9b22-11e8-81c8-c4b246d7a3db.png)

**AFTER:**
![after host running](https://user-images.githubusercontent.com/6556758/43860774-c45f4954-9b22-11e8-9cc0-7f6fe3da8937.png)
![after - cloud instances running](https://user-images.githubusercontent.com/6556758/43860792-d0235b68-9b22-11e8-9204-183361bc0ef6.png)





@miq-bot add-label bug, reporting