### PR TITLE
[GAPRINDASHVILI] FIX CI Remove useless line from chargeback_vm_spec

### DIFF
--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -822,7 +822,6 @@ describe ChargebackVm do
 
             ChargebackRate.set_assignments(:storage, [rate_assignment_options])
 
-            @rate = Chargeback::RatesCache.new.get(consumption).first
             expect(subject).to be_nil
           end
         end
@@ -1212,13 +1211,5 @@ describe ChargebackVm do
     include_examples "ChargebackVm"
   end
 
-  context "New Chargeback" do
-    before do
-      ManageIQ::Consumption::ShowbackInputMeasure.seed
 
-      stub_settings(:new_chargeback => '1')
-    end
-
-    include_examples "ChargebackVm", :skip
-  end
 end


### PR DESCRIPTION
this line is useless is it was refactored in
master because this line is already present in
subject statement here:
https://github.com/manageiq/manageiq/blob/a63ea70d70c780f9bcecdaf9ad4f6be54d698c76/spec/models/chargeback_vm_spec.rb#L809

caused by https://github.com/ManageIQ/manageiq/pull/17795

# Links
https://github.com/ManageIQ/manageiq/pull/17795

cc @gtanzillo 
@miq-bot assign @simaishi 