### PR TITLE
Vmdb::Plugins::AssetPath - add node_modules, development_gem?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ tmp/*
 # vendor/
 vendor/bundle
 vendor/assets/bower_components/
+vendor/node_root/
 
 # npm
 node_modules/

--- a/lib/vmdb/plugins/asset_path.rb
+++ b/lib/vmdb/plugins/asset_path.rb
@@ -7,6 +7,7 @@ module Vmdb
       attr_reader :name
       attr_reader :path
       attr_reader :namespace
+      attr_reader :node_modules
 
       def self.asset_path(engine)
         engine.root.join('app', 'javascript')
@@ -20,9 +21,25 @@ module Vmdb
         asset_path = self.class.asset_path(engine)
         raise "#{asset_path} does not exist" unless asset_path.directory?
 
-        @name      = engine.name
-        @path      = engine.root
-        @namespace = name.chomp("::Engine").underscore.tr("/", "-")
+        @name            = engine.name
+        @path            = engine.root
+        @namespace       = name.chomp("::Engine").underscore.tr("/", "-")
+        @in_bundler_gems = engine.root.expand_path.to_s.start_with?(Bundler.install_path.expand_path.to_s)
+
+        @node_modules = if @in_bundler_gems
+                          self.class.node_root.join(@namespace)
+                        else
+                          @path
+                        end.join('node_modules')
+      end
+
+      def development_gem?
+        !@in_bundler_gems
+      end
+
+      # also used in update:ui task to determine where to copy config files
+      def self.node_root
+        Rails.root.join('vendor', 'node_root')
       end
     end
   end


### PR DESCRIPTION
AssetPath now knows about the path and name of each engine.

But to move node_modules outside of gem directories, we also need to know whether the engine is a gem or not, and need to compute the path to node_modules accordingly.

This (together with https://github.com/ManageIQ/manageiq-ui-classic/pull/4435) will enable the ui tasks to use a different node_modules path for gems, no longer polluting the gem dir.

Cc @Fryguy 

---

@miq-bot add_label wip

There are currently two TODO items on this side:

* ~~`is_gem` - I'm not quite sure matching the pathname against `bundler/gems` is the right way of telling~~
* ~~`/tmp/test/@namespace/node_modules` may not be the most universal place for these~~