### PR TITLE
Remove duplicated searches from db/fixtures/miq_searches.yml

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -350,17 +350,6 @@
     search_type: default
     db: Host
 - attributes:
-    name: default_Status / Stopped
-    description: Status / Stopped
-    filter: !ruby/object:MiqExpression
-      exp:
-        not:
-          INCLUDES:
-            field: Host-power_state
-            value: "on"
-    search_type: default
-    db: Host
-- attributes:
     name: default_Provisioning Scope / All
     description: Provisioning Scope / All
     filter: !ruby/object:MiqExpression
@@ -378,16 +367,6 @@
         "=":
           field: Host-ipmi_enabled
           value: true
-    search_type: default
-    db: Host
-- attributes:
-    name: default_Status / Running
-    description: Status / Running
-    filter: !ruby/object:MiqExpression
-      exp:
-        INCLUDES:
-          field: Host-power_state
-          value: "on"
     search_type: default
     db: Host
 - attributes:


### PR DESCRIPTION
This PR removes duplicates defining search filters in `db/fixtures/miq_searches.yml`

@miq-bot add-label technical debt 

