### PR TITLE
Don't queue metrics capture if metrics unsupported

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -62,6 +62,11 @@ module ManageIQ::Providers
       end
     end
 
+    # TODO: move this to supports_feature_mixin
+    def supports_metrics?
+      true
+    end
+
     # required by aggregate_hardware
     alias :all_computer_systems :computer_systems
     alias :all_computer_system_ids :computer_system_ids

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -55,6 +55,8 @@ module Metric::Targets
 
     targets = []
     emses.each do |ems|
+      next unless ems.supports_metrics?
+
       targets += with_archived(ems.all_container_nodes)
       targets += with_archived(ems.all_container_groups)
       targets += with_archived(ems.all_containers)


### PR DESCRIPTION
If metrics capture is unsupported by the provider then do not queue
perf_capture for targets on that EMS.

https://bugzilla.redhat.com/show_bug.cgi?id=1610449