### PR TITLE
Mark Cloud Tenant as required for Openstack provisioning

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_openstack_dialogs_template.yaml
@@ -160,7 +160,8 @@
             :method: :allowed_cloud_tenants
           :auto_select_single: false
           :description: Cloud Tenant
-          :required: false
+          :required_method: :validate_placement
+          :required: true
           :display: :edit
           :data_type: :integer
         :cloud_network:


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-providers-openstack/pull/223
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1610736 in combination with https://github.com/ManageIQ/manageiq-providers-openstack/pull/331