### PR TITLE
Don't log the deprecation debug messages in production

### DIFF
--- a/lib/vmdb/deprecation.rb
+++ b/lib/vmdb/deprecation.rb
@@ -30,7 +30,7 @@ module Vmdb
       return unless default_log
       proc do |message, callstack|
         default_log.warn(message)
-        default_log.debug(callstack.join("\n  ")) if default_log.debug?
+        default_log.debug { callstack.join("\n  ") } unless Rails.env.production?
       end
     end
     private_class_method :proc_for_default_log


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1609905

Deprecation warning debug messages aren't so helpful in production and add a lot more noise to the logs.