### PR TITLE
rake evm:db:restore:remote mods for S3

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -172,6 +172,7 @@ namespace :evm do
           opt :uri,              "Destination depot URI",       :type => :string, :required => true
           opt :uri_username,     "Destination depot username",  :type => :string
           opt :uri_password,     "Destination depot password",  :type => :string
+          opt :uri_region,       "Destination depot region",    :type => :string
           opt :remote_file_name, "Destination depot filename",  :type => :string
           opt :username,         "Username",                    :type => :string
           opt :password,         "Password",                    :type => :string
@@ -183,9 +184,10 @@ namespace :evm do
         [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
 
         connect_opts = {}
-        [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
+        [:uri, :uri_username, :uri_password, :uri_region, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
         connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
         connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+        connect_opts[:region]   = connect_opts.delete(:uri_region)   if connect_opts[:uri_region]
 
         EvmDatabaseOps.backup(db_opts, connect_opts)
 
@@ -271,6 +273,7 @@ namespace :evm do
           opt :uri,              "Destination depot URI",       :type => :string, :required => true
           opt :uri_username,     "Destination depot username",  :type => :string
           opt :uri_password,     "Destination depot password",  :type => :string
+          opt :uri_region,       "Destination depot region",    :type => :string
           opt :username,         "Username",                    :type => :string
           opt :password,         "Password",                    :type => :string
           opt :hostname,         "Hostname",                    :type => :string
@@ -281,9 +284,10 @@ namespace :evm do
         [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
 
         connect_opts = {}
-        [:uri, :uri_username, :uri_password].each { |k| connect_opts[k] = opts[k] if opts[k] }
+        [:uri, :uri_username, :uri_password, :uri_region].each { |k| connect_opts[k] = opts[k] if opts[k] }
         connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
         connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+        connect_opts[:region]   = connect_opts.delete(:uri_region)   if connect_opts[:uri_region]
 
         # If running through runner, disconnect any local connections
         ActiveRecord::Base.clear_all_connections! if ActiveRecord && ActiveRecord::Base

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -169,25 +169,25 @@ namespace :evm do
       task :remote do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",       :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",  :type => :string
-          opt :uri_password,     "Destination depot password",  :type => :string
-          opt :uri_region,       "Destination depot region",    :type => :string
-          opt :remote_file_name, "Destination depot filename",  :type => :string
-          opt :username,         "Username",                    :type => :string
-          opt :password,         "Password",                    :type => :string
-          opt :hostname,         "Hostname",                    :type => :string
-          opt :dbname,           "Database name",               :type => :string
+          opt :uri,              "Destination depot URI",        :type => :string, :required => true
+          opt :uri_username,     "Destination depot username",   :type => :string
+          opt :uri_password,     "Destination depot password",   :type => :string
+          opt :aws_region,       "Destination depot AWS region", :type => :string
+          opt :remote_file_name, "Destination depot filename",   :type => :string
+          opt :username,         "Username",                     :type => :string
+          opt :password,         "Password",                     :type => :string
+          opt :hostname,         "Hostname",                     :type => :string
+          opt :dbname,           "Database name",                :type => :string
         end
 
         db_opts = {}
         [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
 
         connect_opts = {}
-        [:uri, :uri_username, :uri_password, :uri_region, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
+        [:uri, :uri_username, :uri_password, :aws_region, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
         connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
         connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
-        connect_opts[:region]   = connect_opts.delete(:uri_region)   if connect_opts[:uri_region]
+        connect_opts[:region]   = connect_opts.delete(:aws_region)   if connect_opts[:aws_region]
 
         EvmDatabaseOps.backup(db_opts, connect_opts)
 
@@ -270,24 +270,24 @@ namespace :evm do
       task :remote => :environment do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",       :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",  :type => :string
-          opt :uri_password,     "Destination depot password",  :type => :string
-          opt :uri_region,       "Destination depot region",    :type => :string
-          opt :username,         "Username",                    :type => :string
-          opt :password,         "Password",                    :type => :string
-          opt :hostname,         "Hostname",                    :type => :string
-          opt :dbname,           "Database name",               :type => :string
+          opt :uri,              "Destination depot URI",        :type => :string, :required => true
+          opt :uri_username,     "Destination depot username",   :type => :string
+          opt :uri_password,     "Destination depot password",   :type => :string
+          opt :aws_region,       "Destination depot AWS region", :type => :string
+          opt :username,         "Username",                     :type => :string
+          opt :password,         "Password",                     :type => :string
+          opt :hostname,         "Hostname",                     :type => :string
+          opt :dbname,           "Database name",                :type => :string
         end
 
         db_opts = {}
         [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
 
         connect_opts = {}
-        [:uri, :uri_username, :uri_password, :uri_region].each { |k| connect_opts[k] = opts[k] if opts[k] }
+        [:uri, :uri_username, :uri_password, :aws_region].each { |k| connect_opts[k] = opts[k] if opts[k] }
         connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
         connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
-        connect_opts[:region]   = connect_opts.delete(:uri_region)   if connect_opts[:uri_region]
+        connect_opts[:region]   = connect_opts.delete(:aws_region)   if connect_opts[:aws_region]
 
         # If running through runner, disconnect any local connections
         ActiveRecord::Base.clear_all_connections! if ActiveRecord && ActiveRecord::Base


### PR DESCRIPTION
When rake evm:db:restore:remote is issued with an S3 URI,
specify the AWS region as an argument to be passed to EvmDatabaseOps

As part of several PRs required for the RFE described in https://bugzilla.redhat.com/show_bug.cgi?id=1513520, this will change the rake process invoked from appliance_console when the DB is
restored from S3.  Another PR for appliance_console is to be added and noted herein.

@carbonin, @NickLaMuro, @roliveri please review and merge when appropriate.  Thanks.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1513520
* 

Steps for Testing/QA 
-------------------------------

After backing up a DB to S3, use appliance_console to restore the DB.  Use option 4 to request a restore, and option 4 again to restore from S3.  Enter the valid URI, userid, password, and region.