### PR TITLE
Fix bug with EvmDatabaseOps.dump

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -72,7 +72,7 @@ class EvmDatabaseOps
       # won't hurt to do as a generic way to get a rough idea if we have enough
       # disk space or the appliance for the task.
       validate_free_space(database_opts)
-      PostgresAdmin.backup(database_opts)
+      PostgresAdmin.backup_pg_dump(database_opts)
     end
     _log.info("[#{merged_db_opts(db_opts)[:dbname]}] database has been dumped up to file: [#{uri}]")
     uri


### PR DESCRIPTION
This was a copy-pasta error when adding `EvmDatabaseOps.dump` back in https://github.com/ManageIQ/manageiq/pull/17483, and should have called `PostgresAdmin.backup_pg_dump`, not `PostgresAdmin.backup`.

I had this fix in https://github.com/ManageIQ/manageiq/pull/17652, but that will probably not be merged in it's current state, and this is busted in the nightlies, so we should get it merged.

Links
-----
* Offending PR:  https://github.com/ManageIQ/manageiq/pull/17483
* Lifted from https://github.com/ManageIQ/manageiq/pull/17652