### PR TITLE
Export/Import consistency cleanup

### DIFF
--- a/lib/task_helpers/exports/alert_sets.rb
+++ b/lib/task_helpers/exports/alert_sets.rb
@@ -4,9 +4,11 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        MiqAlertSet.order(:id).all.each do |a|
-          fname = Exports.safe_filename(a.description, options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", a.export_to_yaml)
+        MiqAlertSet.order(:id).all.each do |alert_set|
+          $log.info("Exporting Alert Profile: #{alert_set.description} (ID: #{alert_set.id})")
+
+          filename = Exports.safe_filename(alert_set.description, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", alert_set.export_to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/alerts.rb
+++ b/lib/task_helpers/exports/alerts.rb
@@ -4,9 +4,11 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        MiqAlert.order(:id).all.each do |a|
-          fname = Exports.safe_filename(a.description, options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", a.export_to_yaml)
+        MiqAlert.order(:id).all.each do |alert|
+          $log.info("Exporting Alert: #{alert.description} (ID: #{alert.id})")
+
+          filename = Exports.safe_filename(alert.description, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", alert.export_to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/custom_buttons.rb
+++ b/lib/task_helpers/exports/custom_buttons.rb
@@ -6,7 +6,7 @@ module TaskHelpers
         def self.export_object(obj, hash)
           class_name = obj.class.name.underscore
 
-          $log.send(:info, "Exporting #{obj.class.name} [#{obj.try('name')}] with ID: #{obj&.id}")
+          $log.info("Exporting #{obj.class.name}: #{obj.try('name')} (ID: #{obj&.id})")
           (hash[class_name] ||= []) << item = { 'attributes' => build_attr_list(obj.try(:attributes)) }
           create_association_list(obj, item)
           descendant_list(obj, item)

--- a/lib/task_helpers/exports/policies.rb
+++ b/lib/task_helpers/exports/policies.rb
@@ -4,15 +4,13 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        policies = if options[:all]
-                     MiqPolicy.order(:id).all
-                   else
-                     MiqPolicy.order(:id).where(:read_only => [false, nil])
-                   end
+        policies = options[:all] ? MiqPolicy.all : MiqPolicy.where(:read_only => [false, nil])
 
-        policies.each do |p|
-          fname = Exports.safe_filename(p.description, options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", p.export_to_yaml)
+        policies.order(:id).each do |policy|
+          $log.info("Exporting Policy: #{policy.description} (ID: #{policy.id})")
+
+          filename = Exports.safe_filename(policy.description, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", policy.export_to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/policy_sets.rb
+++ b/lib/task_helpers/exports/policy_sets.rb
@@ -4,15 +4,13 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        policy_sets = if options[:all]
-                        MiqPolicySet.order(:id).all
-                      else
-                        MiqPolicySet.order(:id).where(:read_only => [false, nil])
-                      end
+        policy_sets = options[:all] ? MiqPolicySet.all : MiqPolicySet.where(:read_only => [false, nil])
 
-        policy_sets.each do |p|
-          fname = Exports.safe_filename(p.description, options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", p.export_to_yaml)
+        policy_sets.order(:id).each do |policy_set|
+          $log.info("Exporting Policy Profile: #{policy_set.description} (ID: #{policy_set.id})")
+
+          filename = Exports.safe_filename(policy_set.description, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", policy_set.export_to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/provision_dialogs.rb
+++ b/lib/task_helpers/exports/provision_dialogs.rb
@@ -1,20 +1,19 @@
 module TaskHelpers
   class Exports
     class ProvisionDialogs
+      EXCLUDE_ATTRS = %i(file_mtime created_at updated_at id class).freeze
       def export(options = {})
         export_dir = options[:directory]
 
         dialogs = options[:all] ? MiqDialog.all : MiqDialog.where(:default => [false, nil])
 
-        dialogs.order(:id).to_a.collect! do |dialog|
-          Exports.exclude_attributes(dialog.to_model_hash, %i(file_mtime created_at updated_at id class))
-        end
+        dialogs.order(:id).each do |dialog|
+          $log.info("Exporting #{dialog.dialog_type} Provision Dialog: #{dialog.name} (ID: #{dialog.id})")
 
-        dialogs.each do |dialog|
-          $log.info("Exporting Provision Dialog: #{dialog[:name]} (#{dialog[:description]})")
+          dialog_hash = Exports.exclude_attributes(dialog.to_model_hash, EXCLUDE_ATTRS)
 
-          fname = Exports.safe_filename("#{dialog[:dialog_type]}-#{dialog[:name]}", options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", dialog.to_yaml)
+          filename = Exports.safe_filename("#{dialog_hash[:dialog_type]}-#{dialog_hash[:name]}", options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", dialog_hash.to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/roles.rb
+++ b/lib/task_helpers/exports/roles.rb
@@ -1,22 +1,19 @@
 module TaskHelpers
   class Exports
     class Roles
+      EXCLUDE_ATTRS = %w(created_at updated_at id).freeze
       def export(options = {})
         export_dir = options[:directory]
 
-        roles = if options[:all]
-                  MiqUserRole.order(:id).all
-                else
-                  MiqUserRole.order(:id).where(:read_only => [false, nil])
-                end
+        roles = options[:all] ? MiqUserRole.all : MiqUserRole.where(:read_only => [false, nil])
 
-        roles = roles.collect do |role|
-          Exports.exclude_attributes(role.attributes, %w(created_at updated_at id)).merge('feature_identifiers' => role.feature_identifiers.sort)
-        end.compact
+        roles.order(:id).each do |role|
+          $log.info("Exporting Role: #{role.name} (ID: #{role.id})")
 
-        roles.each do |r|
-          fname = Exports.safe_filename(r['name'], options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", [r].to_yaml)
+          role_hash = Exports.exclude_attributes(role.attributes, EXCLUDE_ATTRS).merge('feature_identifiers' => role.feature_identifiers.sort)
+
+          filename = Exports.safe_filename(role_hash['name'], options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", [role_hash].to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/scan_profiles.rb
+++ b/lib/task_helpers/exports/scan_profiles.rb
@@ -4,26 +4,22 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        scan_item_sets = if options[:all]
-                           ScanItemSet.order(:id).all
-                         else
-                           ScanItemSet.order(:id).where(:read_only => [false, nil])
-                         end
+        scan_item_sets = options[:all] ? ScanItemSet.all : ScanItemSet.where(:read_only => [false, nil])
 
-        scan_item_sets.each do |p|
-          $log.send(:info, "Exporting Scan Profile: #{p.name} (#{p.description})")
+        scan_item_sets.order(:id).each do |scan_item_set|
+          $log.info("Exporting Scan Profile: #{scan_item_set.name} (ID: #{scan_item_set.id})")
 
-          profile = ScanItem.get_profile(p.name).first.dup
+          profile = ScanItem.get_profile(scan_item_set.name).first.dup
 
-          %w(id created_on updated_on).each { |k| profile.delete(k) }
+          %w(id created_on updated_on).each { |key| profile.delete(key) }
           profile['definition'].each do |dd|
-            %w(id created_on updated_on description).each { |k| dd.delete(k) }
+            %w(id created_on updated_on description).each { |key| dd.delete(key) }
           end
 
           scan_profile = profile.to_yaml
 
-          file = Exports.safe_filename(p.name, options[:keep_spaces])
-          File.write("#{export_dir}/ScanProfile_#{file}.yaml", scan_profile)
+          filename = Exports.safe_filename(scan_item_set.name, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", scan_profile)
         end
       end
     end

--- a/lib/task_helpers/exports/service_dialogs.rb
+++ b/lib/task_helpers/exports/service_dialogs.rb
@@ -4,11 +4,15 @@ module TaskHelpers
       def export(options = {})
         export_dir = options[:directory]
 
-        dialogs = DialogSerializer.new.serialize(Dialog.order(:id).all)
+        dialogs = Dialog.order(:id).all
 
         dialogs.each do |dialog|
-          fname = Exports.safe_filename(dialog['label'], options[:keep_spaces])
-          File.write("#{export_dir}/#{fname}.yaml", [dialog].to_yaml)
+          $log.info("Exporting Service Dialog: #{dialog.name} (ID: #{dialog.id})")
+
+          dialog_hash = DialogSerializer.new.serialize([dialog])
+
+          filename = Exports.safe_filename(dialog_hash.first['label'], options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", dialog_hash.to_yaml)
         end
       end
     end

--- a/lib/task_helpers/exports/tags.rb
+++ b/lib/task_helpers/exports/tags.rb
@@ -27,10 +27,13 @@ module TaskHelpers
                end
 
         tags.each do |category|
-          fname = Exports.safe_filename(category.description, options[:keep_spaces])
-          cat = category.export_to_array
-          cat.first["ns"] = category.ns unless category.ns == '/managed'
-          File.write("#{export_dir}/#{fname}.yaml", cat.to_yaml)
+          $log.info("Exporting Tag Category: #{category.description} (ID: #{category.id})")
+
+          category_array = category.export_to_array
+          category_array.first["ns"] = category.ns unless category.ns == '/managed'
+
+          filename = Exports.safe_filename(category.description, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", category_array.to_yaml)
         end
       end
     end

--- a/lib/task_helpers/imports/alert_sets.rb
+++ b/lib/task_helpers/imports/alert_sets.rb
@@ -3,12 +3,15 @@ module TaskHelpers
     class AlertSets
       def import(options)
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Alert Profiles from: #{filename}")
+
           begin
-            alertsets = YAML.load_file(fname)
+            alertsets = YAML.load_file(filename)
             import_alert_sets(alertsets)
-          rescue => e
-            $stderr.puts "Error importing #{fname} : #{e.message}"
+          rescue StandardError => err
+            $log.error("Error importing #{filename} : #{err.message}")
+            warn("Error importing #{filename} : #{err.message}")
           end
         end
       end

--- a/lib/task_helpers/imports/alerts.rb
+++ b/lib/task_helpers/imports/alerts.rb
@@ -3,12 +3,15 @@ module TaskHelpers
     class Alerts
       def import(options)
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Alerts from: #{filename}")
+
           begin
-            alerts = YAML.load_file(fname)
+            alerts = YAML.load_file(filename)
             import_alerts(alerts)
-          rescue => e
-            $stderr.puts "Error importing #{fname} : #{e.message}"
+          rescue StandardError => err
+            $log.error("Error importing #{filename} : #{err.message}")
+            warn("Error importing #{filename} : #{err.message}")
           end
         end
       end

--- a/lib/task_helpers/imports/custom_buttons.rb
+++ b/lib/task_helpers/imports/custom_buttons.rb
@@ -5,6 +5,8 @@ module TaskHelpers
         return unless options[:source]
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
         Dir.glob(glob) do |filename|
+          $log.info("Importing Custom Buttons from: #{filename}")
+
           begin
             import_custom_buttons(filename)
           rescue StandardError

--- a/lib/task_helpers/imports/policies.rb
+++ b/lib/task_helpers/imports/policies.rb
@@ -5,12 +5,14 @@ module TaskHelpers
         return unless options[:source]
 
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Policies from: #{filename}")
+
           begin
-            policies = YAML.load_file(fname)
+            policies = YAML.load_file(filename)
             import_policies(policies)
-          rescue => e
-            $stderr.puts "Error importing #{fname} : #{e.message}"
+          rescue StandardError => err
+            warn("Error importing #{filename} : #{err.message}")
           end
         end
       end

--- a/lib/task_helpers/imports/policy_sets.rb
+++ b/lib/task_helpers/imports/policy_sets.rb
@@ -5,12 +5,14 @@ module TaskHelpers
         return unless options[:source]
 
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Policy Profiles from: #{filename}")
+
           begin
-            policysets = YAML.load_file(fname)
+            policysets = YAML.load_file(filename)
             import_policysets(policysets)
-          rescue => e
-            $stderr.puts "Error importing #{fname} : #{e.message}"
+          rescue StandardError => err
+            warn("Error importing #{filename} : #{err.message}")
           end
         end
       end

--- a/lib/task_helpers/imports/provision_dialogs.rb
+++ b/lib/task_helpers/imports/provision_dialogs.rb
@@ -5,10 +5,10 @@ module TaskHelpers
         return unless options[:source]
 
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
-          $log.info("Importing Provision Dialog from: #{fname}")
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Provision Dialog from: #{filename}")
 
-          dialog = YAML.load_file(fname)
+          dialog = YAML.load_file(filename)
 
           miq_dialog = MiqDialog.find_by(:name => dialog[:name], :dialog_type => dialog[:dialog_type])
 

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -5,12 +5,15 @@ module TaskHelpers
         return unless options[:source]
 
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Roles from: #{filename}")
+
           begin
-            roles = YAML.load_file(fname)
+            roles = YAML.load_file(filename)
             import_roles(roles)
-          rescue ActiveRecord::RecordInvalid => e
-            warn("Error importing #{fname} : #{e.message}")
+          rescue ActiveRecord::RecordInvalid => err
+            $log.error("Error importing #{filename} : #{err.message}")
+            warn("Error importing #{filename} : #{err.message}")
           end
         end
       end
@@ -20,12 +23,12 @@ module TaskHelpers
       def import_roles(roles)
         available_features = MiqProductFeature.all
 
-        roles.each do |r|
-          r['miq_product_feature_ids'] = available_features.collect do |f|
-            f.id if r['feature_identifiers']&.include?(f.identifier)
+        roles.each do |role|
+          role['miq_product_feature_ids'] = available_features.collect do |feature|
+            feature.id if role['feature_identifiers']&.include?(feature.identifier)
           end.compact
-          role = MiqUserRole.find_or_create_by(:name => r['name'])
-          role.update_attributes!(r.reject { |k| k == 'feature_identifiers' })
+          role = MiqUserRole.find_or_create_by(:name => role['name'])
+          role.update_attributes!(role.reject { |key| key == 'feature_identifiers' })
         end
       end
     end

--- a/lib/task_helpers/imports/roles.rb
+++ b/lib/task_helpers/imports/roles.rb
@@ -27,8 +27,8 @@ module TaskHelpers
           role['miq_product_feature_ids'] = available_features.collect do |feature|
             feature.id if role['feature_identifiers']&.include?(feature.identifier)
           end.compact
-          role = MiqUserRole.find_or_create_by(:name => role['name'])
-          role.update_attributes!(role.reject { |key| key == 'feature_identifiers' })
+          found_role = MiqUserRole.find_or_create_by(:name => role['name'])
+          found_role.update_attributes!(role.reject { |key| key == 'feature_identifiers' })
         end
       end
     end

--- a/lib/task_helpers/imports/scan_profiles.rb
+++ b/lib/task_helpers/imports/scan_profiles.rb
@@ -6,10 +6,13 @@ module TaskHelpers
 
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/ScanProfile_*.yaml"
         Dir.glob(glob) do |filename|
+          $log.info("Importing Scan Profiles from: #{filename}")
+
           begin
             import_scan_profile(filename)
-          rescue
-            warn("Error importing #{options[:source]}")
+          rescue StandardError => err
+            $log.error("Error importing #{filename} : #{err.message}")
+            warn("Error importing #{filename} : #{err.message}")
           end
         end
       end

--- a/lib/task_helpers/imports/service_dialogs.rb
+++ b/lib/task_helpers/imports/service_dialogs.rb
@@ -5,8 +5,10 @@ module TaskHelpers
         return unless options[:source]
 
         glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
-        Dir.glob(glob) do |fname|
-          DialogImportService.new.import_all_service_dialogs_from_yaml_file(fname)
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Service Dialogs from: #{filename}")
+
+          DialogImportService.new.import_all_service_dialogs_from_yaml_file(filename)
         end
       end
     end

--- a/spec/lib/task_helpers/exports/roles_spec.rb
+++ b/spec/lib/task_helpers/exports/roles_spec.rb
@@ -26,19 +26,19 @@ describe TaskHelpers::Exports::Roles do
     FileUtils.remove_entry export_dir
   end
 
+  let(:filename1) { "#{export_dir}/Test_Role.yaml" }
+  let(:filename2) { "#{export_dir}/EvmRole-super_administrator.yaml" }
+
   it 'exports user roles to a given directory' do
     TaskHelpers::Exports::Roles.new.export(:directory => export_dir)
-    file_contents = File.read("#{export_dir}/Test_Role.yaml")
-    expect(YAML.safe_load(file_contents)).to eq(role_test_export)
+    expect(YAML.load_file(filename1)).to eq(role_test_export)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
   end
 
   it 'exports all roles to a given directory' do
     TaskHelpers::Exports::Roles.new.export(:directory => export_dir, :all => true)
-    file_contents = File.read("#{export_dir}/Test_Role.yaml")
-    file_contents2 = File.read("#{export_dir}/EvmRole-super_administrator.yaml")
-    expect(YAML.safe_load(file_contents)).to eq(role_test_export)
-    expect(YAML.safe_load(file_contents2)).to eq(role_super_export)
+    expect(YAML.load_file(filename1)).to eq(role_test_export)
+    expect(YAML.load_file(filename2)).to eq(role_super_export)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
   end
 end


### PR DESCRIPTION
This PR cleans up some technical debt. 

Logging was added to all of the export and import types. For the types that already had logging the format of the log messages was updated to be consistent across all types.

if/then/else statements were changed the ternary operator when selecting the objects to export so all export types use the same logic format.

Some Rubocop issues were also cleaned up.