### PR TITLE
human_attribute_name():  add ui option to be able to call original (super) method

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -25,6 +25,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def self.human_attribute_name(attribute, options = {})
+    return super if options.delete(:ui) == true
     "#{name}: #{super}"
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -24,7 +24,7 @@ class ApplicationRecord < ActiveRecord::Base
     n_(model_name.singular.titleize, model_name.plural.titleize, number)
   end
 
-  def self.human_attribute_name(attribute, *args)
+  def self.human_attribute_name(attribute, options = {})
     "#{name}: #{super}"
   end
 end


### PR DESCRIPTION
This PR:
* changes the `human_attribute_name()` prototype, instead of `*args` we should use `options = {}` to match the prototype of original parent function
* adds `options[:ui]` parameter for us to be able to call the original, i.e. `super` method.

`human_attribute_name()` is used in UI to automatically construct labels in textual summaries. With the change that I'm suggesting we're gonna be back to labels like `Name` instead of `ManageIQ::Providers::Openstack::CloudManager::CloudVolume Name`.

See https://github.com/ManageIQ/manageiq/pull/17754 for the original motivation to override `human_attribute_name()`.