### PR TITLE
Create generic task notifications

### DIFF
--- a/app/models/mixins/notification_mixin.rb
+++ b/app/models/mixins/notification_mixin.rb
@@ -1,0 +1,25 @@
+module NotificationMixin
+  extend ActiveSupport::Concern
+
+  def notify_task_start(message, user_id, subject = self)
+    notify_task_emit(:generic_task_start, message, user_id, subject)
+  end
+
+  def notify_task_finish(message, user_id, subject = self)
+    notify_task_emit(:generic_task_finish, message, user_id, subject)
+  end
+
+  def notify_task_fail(message, user_id, subject = self)
+    notify_task_emit(:generic_task_fail, message, user_id, subject)
+  end
+
+  def notify_task_update(message, user_id, subject = self)
+    notify_task_emit(:generic_task_update, message, user_id, subject)
+  end
+
+  private
+
+  def notify_task_emit(type, message, user_id, subject)
+    Notification.create(:type => type, :subject => subject, :user_id => user_id, :options => {:message => message})
+  end
+end

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -289,3 +289,23 @@
   :expires_in: 24.hours
   :level: error
   :audience: global
+- :name: generic_task_start
+  :message: '%{message}'
+  :expires_in: 7.days
+  :level: success
+  :audience: user
+- :name: generic_task_finish
+  :message: '%{message}'
+  :expires_in: 7.days
+  :level: success
+  :audience: user
+- :name: generic_task_fail
+  :message: '%{message}'
+  :expires_in: 7.days
+  :level: error
+  :audience: user
+- :name: generic_task_update
+  :message: '%{message}'
+  :expires_in: 7.days
+  :level: success
+  :audience: user


### PR DESCRIPTION
These notifications types are intended to be use with provider-initiated tasks when there is a need to notify the user about the progress. The `expires_in` and `audience` values are just my assumptions and they might be wrong, this is one of the reasons why this is WIP.

I also added helper methods for initiating these notifications from models, you just have to include the `NotificationMixin` concern and you can use the `notify_task(start|finish|fail|update)` methods.

```ruby
notify_task_xxx(_('your awesome message'), user_to_notify, optional_task_record)
```
If the last argument is omitted, the given record will be set as the notification subject automatically.

Related demo: https://github.com/ManageIQ/manageiq-providers-amazon/pull/468

@miq-bot add_reviewer @martinpovolny 