### PR TITLE
Fix metering report for resources without rollups

### DIFF
--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -64,6 +64,7 @@ class Chargeback
     end
     alias avg current_value
     alias max current_value
+    alias sum current_value
     alias sum_of_maxes_from_grouped_values current_value
     private :current_value
   end


### PR DESCRIPTION
Metering reports are for resources with rollups. But for SCVMM  there is exception. Resource from SCVMM are also considered in metering reports even if that there are metric rollups used.

This fix is adding  sum method to fix the error message. 


Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1595696


@miq-bot assign @gtanzillo 
@miq-bot add_label chargeback, bug