### PR TITLE
Configure and start the failover monitor from the core app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "linux_admin",                    "~>1.2.1",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.3.1",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
+gem "manageiq-postgres_ha_admin",     "~>3.0",         :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
 gem "more_core_extensions",           "~>3.5"

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -14,15 +14,21 @@ module MiqServer::RoleManagement
     before_save    :check_server_roles
   end
 
-  def log_role_changes
-    _log.info("Server's roles have changed:")
+  def role_changes
     o = @active_role_names
     n = active_role_names
     adds      = (n - o)
     deletes   = (o - n)
     unchanged = (o & n)
-    _log.info("  Old roles:       #{o.inspect}")
-    _log.info("  New roles:       #{n.inspect}")
+
+    return adds, deletes, unchanged
+  end
+
+  def log_role_changes
+    _log.info("Server's roles have changed:")
+    adds, deletes, unchanged = role_changes
+    _log.info("  Old roles:       #{@active_role_names.inspect}")
+    _log.info("  New roles:       #{active_role_names.inspect}")
     _log.info("  Roles removed:   #{deletes.inspect}")
     _log.info("  Roles added:     #{adds.inspect}")
     _log.info("  Roles unchanged: #{unchanged.inspect}")

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -133,6 +133,8 @@ module MiqServer::WorkerManagement::Monitor
     resync_needed         = config_changed || roles_changed || sync_interval_reached
     sync_message          = nil
 
+    roles_added, roles_deleted, _roles_unchanged = role_changes
+
     if resync_needed
       @last_sync = Time.now.utc
       sync_message = "sync_config"
@@ -145,6 +147,8 @@ module MiqServer::WorkerManagement::Monitor
 
       stop_apache                if roles_changed && !apache_needed?
       start_apache               if roles_changed &&  apache_needed?
+
+      EvmDatabase.restart_failover_monitor_service if (roles_added | roles_deleted).include?("database_operations")
 
       reset_queue_messages       if config_changed || roles_changed
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -32,9 +32,11 @@ class PglogicalSubscription < ActsAsArModel
     nil
   end
 
-  def save!
+  def save!(reload_failover_monitor = true)
     assert_different_region!
     id ? update_subscription : create_subscription
+  ensure
+    EvmDatabase.restart_failover_monitor_service_queue if reload_failover_monitor
   end
 
   def save
@@ -48,11 +50,13 @@ class PglogicalSubscription < ActsAsArModel
     errors = []
     subscription_list.each do |s|
       begin
-        s.save!
+        s.save!(false)
       rescue => e
         errors << "Failed to save subscription to #{s.host}: #{e.message}"
       end
     end
+
+    EvmDatabase.restart_failover_monitor_service_queue
 
     unless errors.empty?
       raise errors.join("\n")
@@ -60,17 +64,20 @@ class PglogicalSubscription < ActsAsArModel
     subscription_list
   end
 
-  def delete
+  def delete(reload_failover_monitor_service = true)
     pglogical.subscription_drop(id, true)
     MiqRegion.destroy_region(connection, provider_region)
     if self.class.count == 0
       pglogical.node_drop(MiqPglogical.local_node_name, true)
       pglogical.disable
     end
+    EvmDatabase.restart_failover_monitor_service_queue if reload_failover_monitor_service
   end
 
   def self.delete_all
-    find(:all).each(&:delete)
+    find(:all).each { |sub| sub.delete(false) }
+    EvmDatabase.restart_failover_monitor_service_queue
+    nil
   end
 
   def disable

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -113,6 +113,10 @@ class EvmDatabase
     MiqEvent.raise_evm_event_queue(MiqServer.my_server, event, :event_details => msg)
   end
 
+  def self.restart_failover_monitor_service
+    LinuxAdmin::Service.new("evm-failover-monitor").restart
+  end
+
   def self.run_failover_monitor
     require 'manageiq-postgres_ha_admin'
     ManageIQ::PostgresHaAdmin.logger = Vmdb.logger

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -114,7 +114,8 @@ class EvmDatabase
   end
 
   def self.restart_failover_monitor_service
-    LinuxAdmin::Service.new("evm-failover-monitor").restart
+    service = LinuxAdmin::Service.new("evm-failover-monitor")
+    service.restart if service.running?
   end
 
   def self.restart_failover_monitor_service_queue

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -117,6 +117,15 @@ class EvmDatabase
     LinuxAdmin::Service.new("evm-failover-monitor").restart
   end
 
+  def self.restart_failover_monitor_service_queue
+    MiqQueue.put(
+      :class_name  => name,
+      :method_name => 'restart_failover_monitor_service',
+      :role        => 'database_operations',
+      :zone        => nil
+    )
+  end
+
   def self.run_failover_monitor
     require 'manageiq-postgres_ha_admin'
     ManageIQ::PostgresHaAdmin.logger = Vmdb.logger

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -150,6 +150,8 @@ class EvmDatabase
   private_class_method :configure_rails_handler
 
   def self.configure_pglogical_handlers(monitor)
+    return unless MiqServer.my_server.has_active_role?("database_operations")
+
     local_db_conninfo = ActiveRecord::Base.connection.raw_connection.conninfo_hash.delete_blanks
     PglogicalSubscription.all.each do |s|
       handler = ManageIQ::PostgresHaAdmin::PglogicalConfigHandler.new(:subscription => s.id, :conn_info => local_db_conninfo)

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -112,4 +112,56 @@ class EvmDatabase
     msg = "Server IP: #{MiqServer.my_server.ipaddress}, Server Host Name: #{MiqServer.my_server.hostname}"
     MiqEvent.raise_evm_event_queue(MiqServer.my_server, event, :event_details => msg)
   end
+
+  def self.run_failover_monitor
+    require 'manageiq-postgres_ha_admin'
+    ManageIQ::PostgresHaAdmin.logger = Vmdb.logger
+
+    monitor = ManageIQ::PostgresHaAdmin::FailoverMonitor.new(Rails.root.join("config", "ha_admin.yml"))
+
+    configure_rails_handler(monitor)
+    configure_pglogical_handlers(monitor)
+
+    _log.info("Starting database failover monitor")
+    monitor.monitor_loop
+  end
+
+  def self.configure_rails_handler(monitor)
+    file_path = Rails.root.join("config", "database.yml")
+    rails_handler = ManageIQ::PostgresHaAdmin::RailsConfigHandler.new(:file_path => file_path, :environment => Rails.env)
+    _log.info("Configuring database failover for #{file_path}'s #{Rails.env} environment")
+
+    rails_handler.before_failover { LinuxAdmin::Service.new("evmserverd").stop }
+    rails_handler.after_failover do
+      # refresh the rails connection info after the config handler changed database.yml
+      begin
+        ActiveRecord::Base.remove_connection
+      rescue PG::Error
+        # We expect this to fail because it cannot access the database in the cached config
+      end
+      ActiveRecord::Base.establish_connection(Rails.application.config.database_configuration[Rails.env])
+
+      raise_server_event("db_failover_executed")
+      LinuxAdmin::Service.new("evmserverd").restart
+    end
+
+    monitor.add_handler(rails_handler)
+  end
+  private_class_method :configure_rails_handler
+
+  def self.configure_pglogical_handlers(monitor)
+    local_db_conninfo = ActiveRecord::Base.connection.raw_connection.conninfo_hash.delete_blanks
+    PglogicalSubscription.all.each do |s|
+      handler = ManageIQ::PostgresHaAdmin::PglogicalConfigHandler.new(:subscription => s.id, :conn_info => local_db_conninfo)
+      _log.info("Configuring database failover for replication subscription #{s.id} ")
+
+      handler.after_failover do |new_conn_info|
+        s.delete
+        PglogicalSubscription.new(new_conn_info.slice(:dbname, :host, :user, :password, :port)).save
+      end
+
+      monitor.add_handler(handler)
+    end
+  end
+  private_class_method :configure_pglogical_handlers
 end

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -126,11 +126,11 @@ class EvmDatabase
     )
   end
 
-  def self.run_failover_monitor
+  def self.run_failover_monitor(monitor = nil)
     require 'manageiq-postgres_ha_admin'
     ManageIQ::PostgresHaAdmin.logger = Vmdb.logger
 
-    monitor = ManageIQ::PostgresHaAdmin::FailoverMonitor.new(Rails.root.join("config", "ha_admin.yml"))
+    monitor ||= ManageIQ::PostgresHaAdmin::FailoverMonitor.new(Rails.root.join("config", "ha_admin.yml"))
 
     configure_rails_handler(monitor)
     configure_pglogical_handlers(monitor)

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -43,6 +43,26 @@ describe EvmDatabase do
     end
   end
 
+  describe ".restart_failover_monitor_service" do
+    let(:service) { instance_double(LinuxAdmin::SystemdService) }
+
+    before do
+      expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+    end
+
+    it "restarts the service when running" do
+      expect(service).to receive(:running?).and_return(true)
+      expect(service).to receive(:restart)
+      described_class.restart_failover_monitor_service
+    end
+
+    it "doesn't restart the service when it isn't running" do
+      expect(service).to receive(:running?).and_return(false)
+      expect(service).not_to receive(:restart)
+      described_class.restart_failover_monitor_service
+    end
+  end
+
   describe ".restart_failover_monitor_service_queue" do
     it "queues a message for the correct role and zone" do
       subject.restart_failover_monitor_service_queue

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -1,3 +1,5 @@
+require 'manageiq-postgres_ha_admin'
+
 describe EvmDatabase do
   subject { described_class }
   context "#local?" do
@@ -38,6 +40,63 @@ describe EvmDatabase do
       expect(record.class_name). to eq "MiqEvent"
       expect(record.method_name).to eq "raise_evm_event"
       expect(record.args[1]).to eq "db_failover_executed"
+    end
+  end
+
+  describe ".restart_failover_monitor_service_queue" do
+    it "queues a message for the correct role and zone" do
+      subject.restart_failover_monitor_service_queue
+
+      messages = MiqQueue.where(:method_name => 'restart_failover_monitor_service')
+      expect(messages.count).to eq(1)
+
+      message = messages.first
+      expect(message.class_name).to eq(described_class.name)
+      expect(message.role).to eq('database_operations')
+      expect(message.zone).to be_nil
+    end
+  end
+
+  describe ".run_failover_monitor" do
+    let!(:server) { EvmSpecHelper.local_guid_miq_server_zone[1] }
+    let(:monitor) { ManageIQ::PostgresHaAdmin::FailoverMonitor.new }
+    let(:subscriptions) do
+      [
+        PglogicalSubscription.new(:id => "sub_id_1"),
+        PglogicalSubscription.new(:id => "sub_id_2")
+      ]
+    end
+
+    before do
+      allow(PglogicalSubscription).to receive(:all).and_return(subscriptions)
+      expect(monitor).to receive(:monitor_loop)
+    end
+
+    it "adds a rails handler for the environment in database.yml" do
+      subject.run_failover_monitor(monitor)
+      handlers = monitor.config_handlers.map(&:first)
+
+      expect(handlers.count).to eq(1)
+      h = handlers.first
+      expect(h).to be_an_instance_of(ManageIQ::PostgresHaAdmin::RailsConfigHandler)
+      expect(h.file_path.to_s.split('/').last).to eq("database.yml")
+      expect(h.environment).to eq("test")
+    end
+
+    it "adds a pglogical config handler for every subscription when our server has the database_operations role" do
+      ServerRole.seed
+      server.role = "database_operations"
+      server.activate_all_roles
+
+      subject.run_failover_monitor(monitor)
+      handlers = monitor.config_handlers.map(&:first)
+
+      expect(handlers.count).to eq(3)
+      handlers.delete_if { |h| h.kind_of?(ManageIQ::PostgresHaAdmin::RailsConfigHandler) }
+      expect(handlers.count).to eq(2)
+      expect(%w(sub_id_1 sub_id_2)).to include(handlers.first.subscription)
+      expect(%w(sub_id_1 sub_id_2)).to include(handlers.last.subscription)
+      expect(handlers.first.subscription).not_to eq(handlers.last.subscription)
     end
   end
 end


### PR DESCRIPTION
We need the PglogicalSubscription model to properly remove, add, and query for subscriptions. Pushing this into the application makes this much easier.

This PR also adds the manageiq-postgres_ha_admin gem to the core Gemfile.

Depends on https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/10

https://bugzilla.redhat.com/show_bug.cgi?id=1391095