### PR TITLE
Correctly pass dialog field values through request

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -89,6 +89,7 @@ class Dialog < ApplicationRecord
   end
 
   def load_values_into_fields(values)
+    values = values.with_indifferent_access
     dialog_field_hash.each_value do |field|
       field.dialog = self
       field.value = values[field.automate_key_name] || values[field.name]

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -379,7 +379,8 @@ class ServiceTemplate < ApplicationRecord
   end
   private_class_method :create_from_options
 
-  def provision_request(user, options = nil, request_options = nil)
+  def provision_request(user, options = nil, request_options = {})
+    request_options[:submit_workflow] = true
     result = order(user, options, request_options)
     raise result[:errors].join(", ") if result[:errors].any?
     result[:request]

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -458,6 +458,29 @@ describe Dialog do
     end
   end
 
+  describe "#load_values_into_fields" do
+    let(:dialog) { described_class.new(:dialog_tabs => [dialog_tab]) }
+    let(:dialog_tab) { DialogTab.new(:dialog_groups => [dialog_group]) }
+    let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1]) }
+    let(:dialog_field1) { DialogField.new(:value => "123", :name => "field1") }
+
+    context "string values" do
+      it "sets field value" do
+        vars = {"field1" => "10.8.99.248"}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+    end
+
+    context "symbol values" do
+      it "sets field value" do
+        vars = {:field1 => "10.8.99.248"}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+    end
+  end
+
   describe "#init_fields_with_values_for_request" do
     let(:dialog) { described_class.new(:dialog_tabs => [dialog_tab]) }
     let(:dialog_tab) { DialogTab.new(:dialog_groups => [dialog_group]) }

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -905,14 +905,14 @@ describe ServiceTemplate do
         it "provisions a service template without errors" do
           expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
           expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
-          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control', :submit_workflow => true)
 
           expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
         end
 
         it "provisions a service template with errors" do
           expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
-          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control', :submit_workflow => true)
 
           expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
         end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613935

This is two small changes. 

## with_indifferent_access added to dialog field lookup 
https://github.com/ManageIQ/manageiq/pull/17642 broke our setting values in fields because previously we were [setting the names to strings in the lookup](https://github.com/ManageIQ/manageiq/blob/master/app/models/dialog.rb#L125)

## submit_workflow utilized in requests
The submit_workflow option is used to funnel values correctly through requests.  
