### PR TITLE
Create a physical infrastructure user group

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -1252,3 +1252,8 @@
   - sui_services_view
   - sui_orders_view
   - sui_notifications
+
+- :name: EvmRole-physical_infrastructure
+  :read_only: true
+  :miq_product_feature_identifiers:
+  - everything

--- a/db/fixtures/role_map.yaml
+++ b/db/fixtures/role_map.yaml
@@ -17,3 +17,4 @@ EvmGroup-consumption_administrator: consumption_administrator
 EvmGroup-container_administrator: container_administrator
 EvmGroup-container_operator: container_operator
 EvmGroup-reader: reader
+EvmGroup-physical_infrastructure: physical_infrastructure

--- a/product/dashboard/dashboards/physical_infrastructure_default.yaml
+++ b/product/dashboard/dashboards/physical_infrastructure_default.yaml
@@ -1,0 +1,13 @@
+name: Default for Physical Infrastructure
+read_only: t
+set_type: MiqWidgetSet
+description: Default Dashboard for Physical Infrastructure Group
+owner_type: MiqGroup
+owner_description: EvmGroup-physical_infrastructure
+set_data_by_description:
+  :col1:
+  - chart_server_health
+  :col2:
+  - chart_server_availability
+  :col3:
+  - rss_newest_servers

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -1,6 +1,6 @@
 describe MiqUserRole do
   before do
-    @expected_user_role_count = 18
+    @expected_user_role_count = 19
   end
 
   context ".seed" do


### PR DESCRIPTION
This PR adds a new physical infrastructure user group and a default dashboard for the new group. The default dashboard contains a few physical server widgets.