### PR TITLE
Detect and log long running http(s) requests

### DIFF
--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -33,4 +33,22 @@ module MiqWebServerRunnerMixin
       server.start
     end
   end
+
+  def do_heartbeat_work
+    log_long_running_requests
+  end
+
+  CHECK_LONG_RUNNING_REQUESTS_INTERVAL = 30.seconds
+  def log_long_running_requests
+    @last_checked_hung_requests ||= Time.now.utc
+    return if @last_checked_hung_requests > CHECK_LONG_RUNNING_REQUESTS_INTERVAL.ago
+
+    RequestStartedOnMiddleware.long_running_requests.each do |request, duration, thread|
+      message = "Long running http(s) request: '#{request}' handled by ##{Process.pid}:#{thread.object_id.to_s(16)}, running for #{duration.round(2)} seconds"
+      _log.warn(message)
+      Rails.logger.warn(message)
+    end
+
+    @last_checked_hung_requests = Time.now.utc
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,6 +109,8 @@ module Vmdb
 
     config.autoload_once_paths << Rails.root.join("lib", "vmdb", "console_methods.rb").to_s
 
+    config.middleware.use 'RequestStartedOnMiddleware'
+
     # config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled.
     # Defaults to every folder in the app directory of the application.
 

--- a/lib/request_started_on_middleware.rb
+++ b/lib/request_started_on_middleware.rb
@@ -1,0 +1,57 @@
+# Add to config/application.rb:
+#
+#     config.middleware.use 'RequestStartedOnMiddleware'
+#
+class RequestStartedOnMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    start_request(env['PATH_INFO'], Time.now.utc)
+    @app.call(env)
+  ensure
+    complete_request
+  end
+
+  def start_request(path, started_on)
+    Thread.current[:current_request] = path
+    Thread.current[:current_request_started_on] = started_on
+  end
+
+  def complete_request
+    Thread.current[:current_request] = nil
+    Thread.current[:current_request_started_on] = nil
+  end
+
+  def self.long_running_requests
+    requests = []
+    timed_out_request_started_on = request_timeout.ago.utc
+
+    relevant_thread_list.each do |thread|
+      request    = thread[:current_request]
+      started_on = thread[:current_request_started_on]
+
+      # There's a race condition where the complete_request method runs in another
+      # thread after we set one or more of the above local variables. The fallout
+      # of this is we return a false positive for a request that finished very close
+      # to the 2 minute timeout.
+      if request.present? && started_on.kind_of?(Time) && timed_out_request_started_on > started_on
+        duration = (Time.now.utc - started_on).to_f
+        requests << [request, duration, thread]
+      end
+    end
+
+    requests
+  end
+
+  REQUEST_TIMEOUT = 2.minutes
+  private_class_method def self.request_timeout
+    REQUEST_TIMEOUT
+  end
+
+  # For testing: mocking Thread.list feels dangerous
+  private_class_method def self.relevant_thread_list
+    Thread.list
+  end
+end

--- a/spec/lib/request_started_on_middleware_spec.rb
+++ b/spec/lib/request_started_on_middleware_spec.rb
@@ -1,0 +1,28 @@
+describe RequestStartedOnMiddleware do
+  context ".long_running_requests" do
+    before do
+      allow(described_class).to receive(:relevant_thread_list) { fake_threads }
+      allow(described_class).to receive(:request_timeout).and_return(2.minutes)
+    end
+
+    let(:fake_threads) { [@fake_thread] }
+
+    it "returns request, duration and thread" do
+      @fake_thread = {:current_request => "/api/ping", :current_request_started_on => 3.minutes.ago}
+      long_requests = described_class.long_running_requests.first
+      expect(long_requests[0]).to eql "/api/ping"
+      expect(long_requests[1]).to be_within(0.1).of(Time.now.utc - 3.minutes.ago)
+      expect(long_requests[2]).to eql @fake_thread
+    end
+
+    it "skips threads that haven't timed out yet" do
+      @fake_thread = {:current_request => "/api/ping", :current_request_started_on => 30.seconds.ago}
+      expect(described_class.long_running_requests).to be_empty
+    end
+
+    it "skips threads with no requests" do
+      @fake_thread = {}
+      expect(described_class.long_running_requests).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
When a request is made through apache, we have 2 minutes to complete this request before apache throws a timeout, resulting in a browser 502 error.  This pull request provides a mechanism for people who encounter these 502 errors to figure out which request and parameters are causing this problem.  Typically, the request is really slow and needs to be optimized, but we have had deadlock(s) occur so it's very helpful to minimize the work required to narrow the problem down.

https://bugzilla.redhat.com/show_bug.cgi?id=1614918

* Add a middleware to detect long running requests

This middleware tracks each request and when it started using thread
local variables.  `long_running_requests` traverses these thread local
variables to find requests beyond the 2 minute timeout.  This
information can be retrieved by another thread, such as the heartbeating
thread of a puma worker, which can then respond to a timed out request.

* Log long running requests via RequestStartedOnMiddleware

For puma based workers, we implement `do_heartbeat_work` to
`log_long_running_requests`. This method is run very frequently per minute,
so we ensure this check happens at most every 30 seconds.
The log message includes the requested URI path, the thread (in the same
PID:TID format that we log elsewhere) and the request duration so far.
Using the PID:TID information, users can then find the request
parameters by searching the logs for this PID:TID.

**Example logging**:

```
[----] I, [2018-08-10T14:57:10.587334 #2788:357b5f4]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:10 -0400
[----] I, [2018-08-10T14:57:11.231264 #2788:357b5f4]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.232892 #2788:357b5f4]  INFO -- : Completed 200 OK in 1ms (Views: 0.2ms | ActiveRecord: 0.0ms)
[----] I, [2018-08-10T14:57:11.235108 #2788:357b8d8]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.237800 #2788:357b8d8]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.245526 #2788:357b324]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.247653 #2788:357b324]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.259623 #2788:357b5f4]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.261375 #2788:357b5f4]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.261793 #2788:357b5f4]  INFO -- : Completed 200 OK in 0ms (Views: 0.1ms | ActiveRecord: 0.0ms)
[----] I, [2018-08-10T14:57:11.265736 #2788:357b5f4]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.267544 #2788:357b5f4]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.268136 #2788:357b5f4]  INFO -- : Completed 200 OK in 0ms (Views: 0.2ms | ActiveRecord: 0.0ms)
[----] I, [2018-08-10T14:57:11.278956 #2788:357b5f4]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.280813 #2788:357b5f4]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.281137 #2788:357b5f4]  INFO -- : Completed 200 OK in 0ms (Views: 0.1ms | ActiveRecord: 0.0ms)
[----] I, [2018-08-10T14:57:11.285687 #2788:357b5f4]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.287741 #2788:357b5f4]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.288111 #2788:357b5f4]  INFO -- : Completed 200 OK in 0ms (Views: 0.1ms | ActiveRecord: 0.0ms)
[----] I, [2018-08-10T14:57:11.293100 #2788:357b5f4]  INFO -- : Started GET "/api/ping" for 127.0.0.1 at 2018-08-10 14:57:11 -0400
[----] I, [2018-08-10T14:57:11.295267 #2788:357b5f4]  INFO -- : Processing by Api::PingController#index as JSON
[----] I, [2018-08-10T14:57:11.295688 #2788:357b5f4]  INFO -- : Completed 200 OK in 0ms (Views: 0.1ms | ActiveRecord: 0.0ms)
[----] W, [2018-08-10T14:59:35.108849 #2788:eb7c4c]  WARN -- : Long running http(s) request: '/api/ping' handled by #2788:357b8d8, running for 143.87 seconds
[----] W, [2018-08-10T14:59:35.109085 #2788:eb7c4c]  WARN -- : Long running http(s) request: '/api/ping' handled by #2788:357b324, running for 143.86 seconds
[----] W, [2018-08-10T15:00:11.132154 #2788:eb7c4c]  WARN -- : Long running http(s) request: '/api/ping' handled by #2788:357b8d8, running for 179.9 seconds
[----] W, [2018-08-10T15:00:11.132362 #2788:eb7c4c]  WARN -- : Long running http(s) request: '/api/ping' handled by #2788:357b324, running for 179.89 seconds
[----] I, [2018-08-10T15:00:11.239419 #2788:357b8d8]  INFO -- : Completed 200 OK in 180001ms (Views: 0.2ms | ActiveRecord: 0.0ms)
[----] I, [2018-08-10T15:00:11.248699 #2788:357b324]  INFO -- : Completed 200 OK in 180001ms (Views: 0.2ms | ActiveRecord: 0.0ms)
```

Note, above, I have 2 requests that take 3 minutes to finish.  Each one is logged twice.