### PR TITLE
Fix for $evm.execute not honoring dialog options

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -89,6 +89,8 @@ class Dialog < ApplicationRecord
   end
 
   def load_values_into_fields(values)
+    values = values.with_indifferent_access
+
     dialog_field_hash.each_value do |field|
       field.dialog = self
       field.value = values[field.automate_key_name] || values[field.name]

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -88,12 +88,15 @@ class Dialog < ApplicationRecord
     result
   end
 
-  def load_values_into_fields(values)
+  def load_values_into_fields(values, overwrite = true)
     values = values.with_indifferent_access
 
     dialog_field_hash.each_value do |field|
       field.dialog = self
-      field.value = values[field.automate_key_name] || values[field.name]
+      new_value = values[field.automate_key_name] || values[field.name]
+      new_value ||= field.value unless overwrite
+
+      field.value = new_value
     end
   end
 

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -95,6 +95,9 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       dialog.target_resource = @target
       if options[:display_view_only]
         dialog.init_fields_with_values_for_request(values)
+      elsif options[:provision_workflow]
+        dialog.initialize_value_context(values)
+        dialog.load_values_into_fields(values)
       elsif options[:refresh] || options[:submit_workflow]
         dialog.load_values_into_fields(values)
       elsif options[:reconfigure]

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -97,7 +97,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
         dialog.init_fields_with_values_for_request(values)
       elsif options[:provision_workflow]
         dialog.initialize_value_context(values)
-        dialog.load_values_into_fields(values)
+        dialog.load_values_into_fields(values, false)
       elsif options[:refresh] || options[:submit_workflow]
         dialog.load_values_into_fields(values)
       elsif options[:reconfigure]

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -395,7 +395,7 @@ class ServiceTemplate < ApplicationRecord
     )
   end
 
-  def order(user_or_id, options = nil, request_options = nil, schedule_time = nil)
+  def order(user_or_id, options = nil, request_options = {}, schedule_time = nil)
     user     = user_or_id.kind_of?(User) ? user_or_id : User.find(user_or_id)
     workflow = provision_workflow(user, options, request_options)
     if schedule_time

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -379,7 +379,8 @@ class ServiceTemplate < ApplicationRecord
   end
   private_class_method :create_from_options
 
-  def provision_request(user, options = nil, request_options = nil)
+  def provision_request(user, options = nil, request_options = {})
+    request_options[:provision_workflow] = true
     result = order(user, options, request_options)
     raise result[:errors].join(", ") if result[:errors].any?
     result[:request]
@@ -421,13 +422,15 @@ class ServiceTemplate < ApplicationRecord
     end
   end
 
-  def provision_workflow(user, dialog_options = nil, request_options = nil)
+  def provision_workflow(user, dialog_options = nil, request_options = {})
     dialog_options ||= {}
-    request_options ||= {}
+    request_options.delete(:provision_workflow) if request_options[:submit_workflow]
+
     ra_options = {
-      :target          => self,
-      :initiator       => request_options[:initiator],
-      :submit_workflow => request_options[:submit_workflow]
+      :target             => self,
+      :initiator          => request_options[:initiator],
+      :submit_workflow    => request_options[:submit_workflow],
+      :provision_workflow => request_options[:provision_workflow]
     }
 
     ResourceActionWorkflow.new(dialog_options, user, provision_action, ra_options).tap do |wf|

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -458,6 +458,29 @@ describe Dialog do
     end
   end
 
+  describe "#load_values_into_fields" do
+    let(:dialog) { described_class.new(:dialog_tabs => [dialog_tab]) }
+    let(:dialog_tab) { DialogTab.new(:dialog_groups => [dialog_group]) }
+    let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1]) }
+    let(:dialog_field1) { DialogField.new(:value => "123", :name => "field1") }
+
+    context "string values" do
+      it "sets field value" do
+        vars = {"field1" => "10.8.99.248"}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+    end
+
+    context "symbol values" do
+      it "sets field value" do
+        vars = {:field1 => "10.8.99.248"}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+    end
+  end
+
   describe "#init_fields_with_values_for_request" do
     let(:dialog) { described_class.new(:dialog_tabs => [dialog_tab]) }
     let(:dialog_tab) { DialogTab.new(:dialog_groups => [dialog_group]) }

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -470,6 +470,12 @@ describe Dialog do
         dialog.load_values_into_fields(vars)
         expect(dialog_field1.value).to eq("10.8.99.248")
       end
+
+      it "sets field value when prefixed with 'dialog'" do
+        vars = {"dialog_field1" => "10.8.99.248"}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
     end
 
     context "symbol values" do
@@ -477,6 +483,33 @@ describe Dialog do
         vars = {:field1 => "10.8.99.248"}
         dialog.load_values_into_fields(vars)
         expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+
+      it "sets field value when prefixed with 'dialog'" do
+        vars = {:dialog_field1 => "10.8.99.248"}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+    end
+
+    context "when the incoming values are missing keys" do
+      let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1, dialog_field2]) }
+      let(:dialog_field2) { DialogField.new(:value => "321", :name => "field2") }
+
+      context "when overwrite is true" do
+        it "sets nil values" do
+          vars = {:field1 => "10.8.99.248"}
+          dialog.load_values_into_fields(vars)
+          expect(dialog_field2.value).to eq(nil)
+        end
+      end
+
+      context "when overwrite is false" do
+        it "does not set nil values" do
+          vars = {:field1 => "10.8.99.248"}
+          dialog.load_values_into_fields(vars, false)
+          expect(dialog_field2.value).to eq("321")
+        end
       end
     end
   end

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -158,6 +158,16 @@ describe ResourceActionWorkflow do
       end
     end
 
+    context "when the options are set to a provision workflow request" do
+      let(:options) { {:provision_workflow => true} }
+
+      it "initializes the value context and then loads the values into fields" do
+        expect(dialog).to receive(:initialize_value_context).with(values).ordered
+        expect(dialog).to receive(:load_values_into_fields).with(values).ordered
+        ResourceActionWorkflow.new(values, nil, resource_action, options)
+      end
+    end
+
     context "when neither display_view_only nor refresh are true" do
       let(:options) { {} }
 

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -163,7 +163,7 @@ describe ResourceActionWorkflow do
 
       it "initializes the value context and then loads the values into fields" do
         expect(dialog).to receive(:initialize_value_context).with(values).ordered
-        expect(dialog).to receive(:load_values_into_fields).with(values).ordered
+        expect(dialog).to receive(:load_values_into_fields).with(values, false).ordered
         ResourceActionWorkflow.new(values, nil, resource_action, options)
       end
     end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -880,20 +880,25 @@ describe ServiceTemplate do
 
     context "#provision_request" do
       let(:arg1) { {'ordered_by' => 'fred'} }
+
       context "with submit_workflow" do
         let(:arg2) { {:initiator => 'control', :submit_workflow => true} }
 
         it "provisions a service template without errors" do
           expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
           expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
-          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control', :submit_workflow => true)
+          expect(resource_action_workflow).to receive(:request_options=).with(
+            :initiator => 'control', :submit_workflow => true
+          )
 
           expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
         end
 
         it "provisions a service template with errors" do
           expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
-          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control', :submit_workflow => true)
+          expect(resource_action_workflow).to receive(:request_options=).with(
+            :initiator => 'control', :submit_workflow => true
+          )
 
           expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
         end
@@ -905,16 +910,37 @@ describe ServiceTemplate do
         it "provisions a service template without errors" do
           expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
           expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
-          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+          expect(resource_action_workflow).to receive(:request_options=).with(
+            :initiator => 'control', :provision_workflow => true
+          )
 
           expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
         end
 
         it "provisions a service template with errors" do
           expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
-          expect(resource_action_workflow).to receive(:request_options=).with(:initiator => 'control')
+          expect(resource_action_workflow).to receive(:request_options=).with(
+            :initiator => 'control', :provision_workflow => true
+          )
 
           expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
+        end
+      end
+
+      context "without any request options" do
+        it "provisions a service template without errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
+          expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
+          expect(resource_action_workflow).to receive(:request_options=).with(:provision_workflow => true)
+
+          expect(service_template.provision_request(user, arg1)).to eq(miq_request)
+        end
+
+        it "provisions a service template with errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
+          expect(resource_action_workflow).to receive(:request_options=).with(:provision_workflow => true)
+
+          expect { service_template.provision_request(user, arg1) }.to raise_error(RuntimeError)
         end
       end
     end


### PR DESCRIPTION
This is kind of a replacement of https://github.com/ManageIQ/manageiq/pull/17839 after talking a bit about it with @d-m-u and @gmcculloug. It essentially takes the `with_indifferent_access` part and then forces the control flow by using a different option instead of `submit_workflow`.

The problem is that when ordering a service via the UI, there is a two step process, first the user loads the dialog which may need to go through automate and determine default values. The user is then presented with the loaded dialog and they can make changes. After making any changes, they can then submit, which is a separate call, but still is going through the same `ResourceActionWorkflow` logic. This is why `submit_workflow` was created in the first place.

However, doing this through automate, for example as in the BZ (`$evm.execute`), the dialog is never actually shown to the user in the first place. So, coming through the same code as the `submit_workflow` won't work, because it doesn't get the defaults they want, only the values they've supplied.

So, therefore, this PR creates another new flow option, named `provision_workflow` after the method, which first initializes the value context (which is what potentially calls automate to set up the default values), and then secondly loads the values provided by the `$evm.execute` call into the fields before being "submitted". We need the `with_indifferent_access` portion because we are trying to look up the values in the hash with either the `field.automate_key_name` or `field.name`, both of which are strings, where the values being passed in are symbols. This is only really relevant for this case because the other way uses the API which handles everything with strings.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613935

@miq-bot assign @gmcculloug 
@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot add_reviewer @d-m-u 