### PR TITLE
rake locale:plugin:find fixes

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -152,7 +152,7 @@ namespace :locale do
 
   desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
   task "plugin:find", :engine do |_, args|
-    unless args.key?(:engine)
+    unless args[:engine]
       $stderr.puts "You need to specify a plugin name: rake locale:plugin:find[plugin_name]"
       exit 1
     end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -157,7 +157,12 @@ namespace :locale do
       exit 1
     end
     @domain = args[:engine].gsub('::', '_')
-    @engine = "#{args[:engine].camelize}::Engine".constantize
+    begin
+      @engine = "#{args[:engine].camelize}::Engine".constantize
+    rescue NameError
+      warn "The specified plugin #{args[:engine]} does not exist."
+      exit 1
+    end
     @engine_root = @engine.root
 
     # extract plugin's yaml strings


### PR DESCRIPTION
Two fixes:
* use `args[:engine]` rather than `args.key?(:engine)` -- for some reason the later would always return `nil`.
* for non-existent plugin (e.g. type), print nice error rather than an ugly traceback. 