### PR TITLE
switch back to require_nested due to linux load error

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -1,6 +1,30 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Providers::EmbeddedAutomationManager
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager
-  require_nested_all
+
+  require_nested :Credential
+  require_nested :AmazonCredential
+  require_nested :AzureCredential
+  require_nested :CloudCredential
+  require_nested :GoogleCredential
+  require_nested :MachineCredential
+  require_nested :VaultCredential
+  require_nested :NetworkCredential
+  require_nested :OpenstackCredential
+  require_nested :ScmCredential
+  require_nested :VmwareCredential
+  require_nested :RhvCredential
+
+  require_nested :ConfigurationScript
+  require_nested :ConfigurationScriptSource
+  require_nested :ConfigurationWorkflow
+  require_nested :ConfiguredSystem
+  require_nested :EventCatcher
+  require_nested :EventParser
+  require_nested :Inventory
+  require_nested :Job
+  require_nested :Playbook
+  require_nested :Refresher
+  require_nested :RefreshWorker
 
   def self.ems_type
     @ems_type ||= "embedded_ansible_automation".freeze

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -1,5 +1,10 @@
 class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::AutomationManager
-  require_nested_all
+  require_nested :Authentication
+  require_nested :ConfigurationScript
+  require_nested :ConfigurationScriptPayload
+  require_nested :ConfigurationScriptSource
+  require_nested :ConfiguredSystem
+  require_nested :OrchestrationStack
 
   def supported_catalog_types
     %w(generic_ansible_playbook)


### PR DESCRIPTION
Seems linux is having problem with this change in loading order. Revert these calls for now

@miq-bot add_labels bug

Reported issue on linux:

```
TypeError: superclass must be a Class (Module given)
app/models/manageiq/providers/embedded_ansible/automation_manager/cloud_credential.rb:2:in `<top (required)>'
app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb:1:in `<top (required)>'
lib/extensions/require_nested.rb:11:in `require_nested'
lib/extensions/require_nested.rb:23:in `block in require_nested_all'
lib/extensions/require_nested.rb:21:in `each'
lib/extensions/require_nested.rb:21:in `require_nested_all'
app/models/manageiq/providers/embedded_ansible/automation_manager.rb:3:in `<class:AutomationManager>'
app/models/manageiq/providers/embedded_ansible/automation_manager.rb:1:in `<top (required)>'
lib/extensions/descendant_loader.rb:235:in `load_subclasses'
lib/extensions/descendant_loader.rb:255:in `descendants'
app/models/blacklisted_event.rb:26:in `seed'
lib/evm_database.rb:80:in `block (2 levels) in seed'
lib/evm_database.rb:69:in `each'
lib/evm_database.rb:69:in `block in seed'
lib/extensions/ar_table_lock.rb:21:in `block (2 levels) in with_lock'
lib/extensions/ar_table_lock.rb:21:in `block in with_lock'
lib/extensions/ar_table_lock.rb:15:in `with_lock'
lib/evm_database.rb:68:in `seed'
db/seeds.rb:8:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```