### PR TITLE
Converge request user roles to match API and UI

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -1,7 +1,7 @@
 class MiqProductFeature < ApplicationRecord
   SUPER_ADMIN_FEATURE = "everything".freeze
   REPORT_ADMIN_FEATURE  = "miq_report_superadmin".freeze
-  REQUEST_ADMIN_FEATURE = "miq_request_superadmin".freeze
+  REQUEST_ADMIN_FEATURE = "miq_request_approval".freeze
   ADMIN_FEATURE = REPORT_ADMIN_FEATURE
   TENANT_ADMIN_FEATURE = "rbac_tenant".freeze
 

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -180,10 +180,6 @@
       :description: Edit a Request
       :feature_type: admin
       :identifier: miq_request_edit
-  - :name: Request Admin
-    :description: Edit other user's requests
-    :feature_type: admin
-    :identifier: miq_request_superadmin
 
 # MiqRequest under Automation/Automate tab for Automate Requests
 - :name: Requests

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -66,7 +66,7 @@
   - miq_report
   - miq_report_superadmin
   - miq_request
-  - miq_request_superadmin
+  - miq_request_approval
   - miq_template
   - orchestration_stack
   - physical_rack


### PR DESCRIPTION
FOLLOWUP:

- [ ] https://github.com/ManageIQ/manageiq-api/pull/447 change identifier in tests only
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/4487 uses helper method

We introduced feature miq_request_superadmin in f6c02e81 / #17444 
The feature miq_request_approval already existed.
Merging the 2 together.

This fixes an inconsistency between API and UI
The issue existed before this feature was introduced
so this works with https://github.com/ManageIQ/manageiq/pull/17444 to fix the BZ


https://bugzilla.redhat.com/show_bug.cgi?id=1608554
