### PR TITLE
Remove admin_user? method

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -2,7 +2,6 @@ class MiqProductFeature < ApplicationRecord
   SUPER_ADMIN_FEATURE = "everything".freeze
   REPORT_ADMIN_FEATURE  = "miq_report_superadmin".freeze
   REQUEST_ADMIN_FEATURE = "miq_request_approval".freeze
-  ADMIN_FEATURE = REPORT_ADMIN_FEATURE
   TENANT_ADMIN_FEATURE = "rbac_tenant".freeze
 
   acts_as_tree

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -116,8 +116,6 @@ class MiqUserRole < ApplicationRecord
     allows?(:identifier => MiqProductFeature::REPORT_ADMIN_FEATURE)
   end
 
-  alias admin_user? report_admin_user?
-
   def request_admin_user?
     allows?(:identifier => MiqProductFeature::REQUEST_ADMIN_FEATURE)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
 
   delegate   :miq_user_role, :current_tenant, :get_filters, :has_filters?, :get_managed_filters, :get_belongsto_filters,
              :to => :current_group, :allow_nil => true
-  delegate   :super_admin_user?, :admin_user?, :self_service?, :limited_self_service?, :report_admin_user?,
+  delegate   :super_admin_user?, :request_admin_user?, :self_service?, :limited_self_service?, :report_admin_user?,
              :to => :miq_user_role, :allow_nil => true
 
   validates_presence_of   :name, :userid

--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -25,8 +25,6 @@ FactoryGirl.define do
           # admins now using a feature instead of a roll
           if evaluator.role == "super_administrator"
             e_features = MiqProductFeature::SUPER_ADMIN_FEATURE
-          elsif evaluator.role == "administrator"
-            e_features = MiqProductFeature::ADMIN_FEATURE
           end
         end
       end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -999,10 +999,6 @@ describe Rbac::Filterer do
           FactoryGirl.create(:miq_user_role, :role => "super_administrator")
         end
 
-        let!(:administrator_user_role) do
-          FactoryGirl.create(:miq_user_role, :role => "administrator")
-        end
-
         let(:group) do
           FactoryGirl.create(:miq_group, :tenant => default_tenant, :miq_user_role => tenant_administrator_user_role)
         end
@@ -1018,12 +1014,12 @@ describe Rbac::Filterer do
         let!(:user) { FactoryGirl.create(:user, :miq_groups => [group]) }
 
         it 'can see all roles except for EvmRole-super_administrator' do
-          expect(MiqUserRole.count).to eq(4)
-          get_rbac_results_for_and_expect_objects(MiqUserRole, [tenant_administrator_user_role, administrator_user_role, user_role])
+          expect(MiqUserRole.count).to eq(3)
+          get_rbac_results_for_and_expect_objects(MiqUserRole, [tenant_administrator_user_role, user_role])
         end
 
         it 'can see all groups except for group with role EvmRole-super_administrator' do
-          expect(MiqUserRole.count).to eq(4)
+          expect(MiqUserRole.count).to eq(3)
           default_group_for_tenant = user.current_tenant.miq_groups.where(:group_type => "tenant").first
           super_admin_group
           get_rbac_results_for_and_expect_objects(MiqGroup, [group, other_group, default_group_for_tenant])

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -64,7 +64,7 @@ describe MiqReportResult do
       end
 
       it "returns report all results, admin user logged" do
-        admin_role = FactoryGirl.create(:miq_user_role, :role => "administrator", :read_only => false)
+        admin_role = FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::REPORT_ADMIN_FEATURE, :read_only => false)
         User.current_user.current_group.miq_user_role = admin_role
         report_result = MiqReportResult.with_current_user_groups
         expected_reports = [@report_result1, @report_result2, @report_result3, @report_result_nil_report_id]

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -16,6 +16,8 @@ describe MiqUserRole do
     end
 
     it "with existing records" do
+      # administrator is a role that we know is provide with the product
+      # this is not testing administrator privileges
       changed   = FactoryGirl.create(:miq_user_role, :name => "EvmRole-administrator", :read_only => false)
       unchanged = FactoryGirl.create(:miq_user_role, :name => "xxx", :read_only => false)
       unchanged_orig_updated_at = unchanged.updated_at

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -192,19 +192,16 @@ describe MiqUserRole do
     end
   end
 
-  describe "#admin_user?", "#report_admin_user?" do
+  describe "#report_admin_user?" do
     it "detects super admin" do
-      expect(super_admin_role).to be_admin_user
       expect(super_admin_role).to be_report_admin_user
     end
 
     it "detects admin" do
-      expect(report_admin_role).to be_admin_user
       expect(report_admin_role).to be_report_admin_user
     end
 
     it "detects non-admin" do
-      expect(regular_role).not_to be_admin_user
       expect(regular_role).not_to be_report_admin_user
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -143,18 +143,6 @@ describe User do
         expect(user.super_admin_user?).to be_falsey
       end
     end
-
-    describe "#admin_user?" do
-      let(:role_name) { "administrator" }
-
-      it "should check Admin Roles" do
-        expect(user.admin_user?).to be_truthy
-        expect(user.super_admin_user?).to be_falsey
-
-        user.current_group = nil
-        expect(user.admin_user?).to be_falsey
-      end
-    end
   end
 
   context "#authorize_ldap" do


### PR DESCRIPTION
Kinda related to https://github.com/ManageIQ/manageiq/pull/17849

In #17444 (and related PRs) We transitioned generic references of `admin_user?` to more specialized functionality like `request_admin_user?`

All references to `admin_user?` were removed. This removes the method ✂️✂️✂️