### PR TITLE
Added Audit logging to new user creation

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -49,9 +49,8 @@ module Authenticator
       user_or_taskid = nil
 
       begin
-        audit = {:event => audit_event, :userid => username}
-
         username = normalize_username(username)
+        audit = {:event => audit_event, :userid => username}
 
         authenticated = options[:authorize_only] || _authenticate(username, password, request)
         if authenticated

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -124,6 +124,7 @@ module Authenticator
           matching_groups = match_groups(groups_for(identity))
           userid, user = find_or_initialize_user(identity, username)
           update_user_attributes(user, userid, identity)
+          audit_new_user(audit, user) if user.new_record?
           user.miq_groups = matching_groups
 
           if matching_groups.empty?
@@ -193,6 +194,10 @@ module Authenticator
 
     def audit_event
       "authenticate_#{self.class.short_name}"
+    end
+
+    def audit_new_user(audit, user)
+      audit_success(audit.merge(:message => "User creation successful for User: #{user.name} with ID: #{user.userid}"))
     end
 
     def authorize?

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -121,12 +121,12 @@ describe Authenticator::Database do
       it "records two successful audit entries" do
         expect(AuditEvent).to receive(:success).with(
           :event   => 'authenticate_database',
-          :userid  => 'vInCeNt',
+          :userid  => 'vincent',
           :message => "User vincent successfully validated by EVM",
         )
         expect(AuditEvent).to receive(:success).with(
           :event   => 'authenticate_database',
-          :userid  => 'vInCeNt',
+          :userid  => 'vincent',
           :message => "Authentication successful for user vincent",
         )
         expect(AuditEvent).not_to receive(:failure)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -370,12 +370,18 @@ describe Authenticator::Httpd do
           expect(authenticate).to eq(123)
         end
 
-        it "records two successful audit entries" do
+        it "records three successful audit entries" do
+          expect(AuditEvent).to receive(:success).with(
+            :event   => 'authorize',
+            :userid  => 'bob',
+            :message => "User creation successful for User: Bob Builderson with ID: bob@example.com",
+          )
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
             :userid  => 'bOb',
             :message => "User bob successfully validated by External httpd",
           )
+
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
             :userid  => 'bOb',
@@ -405,7 +411,12 @@ describe Authenticator::Httpd do
             expect(authenticate).to eq(123)
           end
 
-          it "records two successful audit entries plus one failure" do
+          it "records three successful audit entries plus one failure" do
+            expect(AuditEvent).to receive(:success).with(
+              :event   => 'authorize',
+              :userid  => 'bob',
+              :message => "User creation successful for User: Bob Builderson with ID: bob@example.com",
+            )
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_httpd',
               :userid  => 'bOb',

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -345,12 +345,12 @@ describe Authenticator::Httpd do
         it "records one successful and one failing audit entry" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bOb',
+            :userid  => 'bob',
             :message => "User bob successfully validated by External httpd",
           )
           expect(AuditEvent).to receive(:failure).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bOb',
+            :userid  => 'bob',
             :message => "User bob authenticated but not defined in EVM",
           )
           authenticate rescue nil
@@ -378,13 +378,13 @@ describe Authenticator::Httpd do
           )
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bOb',
+            :userid  => 'bob',
             :message => "User bob successfully validated by External httpd",
           )
 
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_httpd',
-            :userid  => 'bOb',
+            :userid  => 'bob',
             :message => "Authentication successful for user bob",
           )
           expect(AuditEvent).not_to receive(:failure)
@@ -419,12 +419,12 @@ describe Authenticator::Httpd do
             )
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_httpd',
-              :userid  => 'bOb',
+              :userid  => 'bob',
               :message => "User bob successfully validated by External httpd",
             )
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_httpd',
-              :userid  => 'bOb',
+              :userid  => 'bob',
               :message => "Authentication successful for user bob",
             )
             expect(AuditEvent).to receive(:failure).with(

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -253,7 +253,7 @@ describe Authenticator::Ldap do
           expect(authenticate).to eq(123)
         end
 
-        it "records two successful audit entries" do
+        it "records three successful audit entries" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_ldap',
             :userid  => 'alice',
@@ -408,11 +408,16 @@ describe Authenticator::Ldap do
           expect(authenticate).to eq(123)
         end
 
-        it "records two successful audit entries" do
+        it "records three successful audit entries" do
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_ldap',
             :userid  => 'bob',
             :message => "User bob successfully validated by LDAP",
+          )
+          expect(AuditEvent).to receive(:success).with(
+            :event   => 'authorize',
+            :userid  => 'bob',
+            :message => "User creation successful for User: Bob Builderson with ID: bob",
           )
           expect(AuditEvent).to receive(:success).with(
             :event   => 'authenticate_ldap',
@@ -443,11 +448,16 @@ describe Authenticator::Ldap do
             expect(authenticate).to eq(123)
           end
 
-          it "records two successful audit entries plus one failure" do
+          it "records three successful audit entries plus one failure" do
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_ldap',
               :userid  => 'bob',
               :message => "User bob successfully validated by LDAP",
+            )
+            expect(AuditEvent).to receive(:success).with(
+              :event   => 'authorize',
+              :userid  => 'bob',
+              :message => "User creation successful for User: Bob Builderson with ID: bob",
             )
             expect(AuditEvent).to receive(:success).with(
               :event   => 'authenticate_ldap',


### PR DESCRIPTION
Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1602136

Raises an audit event when new external logins are auto-created for the first time.

Creates the following audit message:

`User creation successful for User: Bob Builderson with ID: bob`