### PR TITLE
Add new rename_queue method to VM operations

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -77,7 +77,7 @@ module VmOrTemplate::Operations
 
   def rename_queue(userid, new_name)
     task_opts = {
-      :action => "Renanimg VM for user #{userid}",
+      :action => "Renaming VM for user #{userid}",
       :userid => userid
     }
 

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -75,6 +75,24 @@ module VmOrTemplate::Operations
     raw_rename(new_name)
   end
 
+  def rename_queue(userid, new_name)
+    task_opts = {
+      :action => "Renanimg VM for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'rename',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [new_name]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
   private
 
   #


### PR DESCRIPTION
**Related RFE:** https://bugzilla.redhat.com/show_bug.cgi?id=1559184
UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4351

This PR adds a new `rename_queue` method needed for the UI to get a proper `task_id` while renaming a VM (only VMWare).
