### PR TITLE
Fix Physical Storage to Physical Disks inverse association

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -9,7 +9,7 @@ class PhysicalStorage < ApplicationRecord
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
   has_many :guest_devices, :through => :hardware
 
-  has_many :physical_disks, :dependent => :destroy, :inverse_of => :physical_storages
+  has_many :physical_disks, :dependent => :destroy, :inverse_of => :physical_storage
 
   def my_zone
     ems = ext_management_system


### PR DESCRIPTION
This PR is able to:
- Fix the inverse association between Physical Storage and Physical Disks

The problem happened because the previous inverse relation was `:physical_storages`, when actually multiple Physical Disks will exist inside only one Physical Storage.