### PR TITLE
Load dialog fields with updated values on workflow submit

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -21,12 +21,17 @@ class ResourceActionWorkflow < MiqRequestWorkflow
 
   Vmdb::Deprecation.deprecate_methods(self, :dialogs => :dialog)
 
-  def submit_request
+  def submit_request(data = {})
+    update_dialog_field_values(data) if data.present?
     process_request(ServiceOrder::STATE_ORDERED)
   end
 
   def add_request_to_cart
     process_request(ServiceOrder::STATE_CART)
+  end
+
+  def update_dialog_field_values(data)
+    @dialog.load_values_into_fields(data.values.first)
   end
 
   def process_request(state)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594469

We need to run load_values_into_fields inside the resource action workflow, not [where they're currently running ](https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/base_controller/generic.rb#L210) because with the changes to how and when we load field values, this functionality broke. 

I think that the api needs to be passing the changed field values into the resource action workflow when we make [the submit workflow call](https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/base_controller/generic.rb#L211). Otherwise the field values automate sees by the time we get to https://github.com/ManageIQ/manageiq/blob/master/app/models/resource_action_workflow.rb#L81 will be the default values only, not the updated fields you changed on the dialog. 

The setup this applies to is a custom button on a generic object.  

# Related to 
https://github.com/ManageIQ/manageiq-api/pull/448