### PR TITLE
Consolidate option parsing to EvmDba in evm_dba.rake

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -201,12 +201,12 @@ namespace :evm do
       task :local do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file,           "Destination file",       :type => :string, :required => true
-          opt :username,             "Username",               :type => :string
-          opt :password,             "Password",               :type => :string
-          opt :hostname,             "Hostname",               :type => :string
-          opt :dbname,               "Database name",          :type => :string
-          opt :"exclude-table-data", "Tables to exclude data", :type => :strings
+          opt :local_file,         "Destination file",       :type => :string, :required => true
+          opt :username,           "Username",               :type => :string
+          opt :password,           "Password",               :type => :string
+          opt :hostname,           "Hostname",               :type => :string
+          opt :dbname,             "Database name",          :type => :string
+          opt :exclude_table_data, "Tables to exclude data", :type => :strings
         end
 
         opts.delete_if { |_, v| v.nil? }
@@ -219,19 +219,19 @@ namespace :evm do
       task :remote do
         require 'trollop'
         opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,                  "Destination depot URI",      :type => :string, :required => true
-          opt :uri_username,         "Destination depot username", :type => :string
-          opt :uri_password,         "Destination depot password", :type => :string
-          opt :remote_file_name,     "Destination depot filename", :type => :string
-          opt :username,             "Username",                   :type => :string
-          opt :password,             "Password",                   :type => :string
-          opt :hostname,             "Hostname",                   :type => :string
-          opt :dbname,               "Database name",              :type => :string
-          opt :"exclude-table-data", "Tables to exclude data",     :type => :strings
+          opt :uri,                "Destination depot URI",      :type => :string, :required => true
+          opt :uri_username,       "Destination depot username", :type => :string
+          opt :uri_password,       "Destination depot password", :type => :string
+          opt :remote_file_name,   "Destination depot filename", :type => :string
+          opt :username,           "Username",                   :type => :string
+          opt :password,           "Password",                   :type => :string
+          opt :hostname,           "Hostname",                   :type => :string
+          opt :dbname,             "Database name",              :type => :string
+          opt :exclude_table_data, "Tables to exclude data",     :type => :strings
         end
 
         db_opts = {}
-        [:dbname, :username, :password, :hostname, :"exclude-table-data"].each { |k| db_opts[k] = opts[k] if opts[k] }
+        [:dbname, :username, :password, :hostname, :exclude_table_data].each { |k| db_opts[k] = opts[k] if opts[k] }
 
         connect_opts = {}
         [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -18,6 +18,51 @@ module EvmDba
     return false unless config['adapter'] == 'postgresql'
     return %w( 127.0.0.1 localhost ).include?(config['host']) || config['host'].blank?
   end
+
+  def self.with_options(*option_types, &block)
+    require 'trollop'
+
+    Trollop.options(EvmRakeHelper.extract_command_options) do
+      option_types.each do |type|
+        case type
+        when :db_credentials
+          opt :username,           "Username",                     :type => :string
+          opt :password,           "Password",                     :type => :string
+          opt :hostname,           "Hostname",                     :type => :string
+          opt :dbname,             "Database name",                :type => :string
+        when :local_file
+          opt :local_file,         "Destination file",             :type => :string, :required => true
+        when :remote_file
+          opt :remote_file_name,   "Destination depot filename",   :type => :string
+        when :remote_uri
+          opt :uri,                "Destination depot URI",        :type => :string, :required => true
+          opt :uri_username,       "Destination depot username",   :type => :string
+          opt :uri_password,       "Destination depot password",   :type => :string
+        when :aws
+          opt :aws_region,         "Destination depot AWS region", :type => :string
+        when :exclude_table_data
+          opt :exclude_table_data, "Tables to exclude data",       :type => :strings
+        end
+      end
+      instance_exec(&block) if block_given?
+    end.delete_nils
+  end
+
+  DB_OPT_KEYS = [:dbname, :username, :password, :hostname, :exclude_table_data].freeze
+  def self.collect_db_opts(opts)
+    db_opts = {}
+    DB_OPT_KEYS.each { |k| db_opts[k] = opts[k] if opts[k] }
+    db_opts
+  end
+
+  CONNECT_OPT_KEYS = [:uri, :uri_username, :uri_password, :aws_region, :remote_file_name].freeze
+  def self.collect_connect_opts(opts)
+    connect_opts = {}
+    CONNECT_OPT_KEYS.each { |k| connect_opts[k] = opts[k] if opts[k] }
+    connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
+    connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+    connect_opts
+  end
 end
 
 namespace :evm do
@@ -57,12 +102,7 @@ namespace :evm do
 
     desc "clean up database"
     task :gc do
-      require 'trollop'
-      opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-        opt :username,   "Username",         :type => :string
-        opt :password,   "Password",         :type => :string
-        opt :hostname,   "Hostname",         :type => :string
-        opt :dbname,     "Database name",    :type => :string
+      opts = EvmDba.with_options(:db_credentials) do
         opt :aggressive, "Aggressive gc: vaccume with all options and reindexing"
         opt :vacuum,     "Vacuum database"
         opt :reindex,    "Reindex database (or table if --table specified)"
@@ -73,7 +113,7 @@ namespace :evm do
         opt :table,      "Tablename to reindex (if only perorm on one)", :type => :string
       end
 
-      opts = opts.delete_if { |_k, v| v.nil? || v == false }
+      opts = opts.delete_if { |_, v| v == false }
       EvmDatabaseOps.gc(opts)
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
@@ -106,8 +146,7 @@ namespace :evm do
 
     desc 'Set the region of the current ManageIQ EVM Database (VMDB)'
     task :region do
-      require 'trollop'
-      opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+      opts = EvmDba.with_options do
         opt :region, "Region number", :type => :integer, :required => ENV["REGION"].blank?
       end
 
@@ -150,16 +189,8 @@ namespace :evm do
       require File.expand_path(File.join(Rails.root, "lib", "evm_database_ops"))
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file, "Destination file", :type => :string, :required => true
-          opt :username,   "Username",         :type => :string
-          opt :password,   "Password",         :type => :string
-          opt :hostname,   "Hostname",         :type => :string
-          opt :dbname,     "Database name",    :type => :string
-        end
+        opts = EvmDba.with_options(:local_file, :db_credentials)
 
-        opts.delete_if { |k,v| v.nil? }
         EvmDatabaseOps.backup(opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
@@ -167,27 +198,10 @@ namespace :evm do
 
       desc 'Backup the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",        :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",   :type => :string
-          opt :uri_password,     "Destination depot password",   :type => :string
-          opt :aws_region,       "Destination depot AWS region", :type => :string
-          opt :remote_file_name, "Destination depot filename",   :type => :string
-          opt :username,         "Username",                     :type => :string
-          opt :password,         "Password",                     :type => :string
-          opt :hostname,         "Hostname",                     :type => :string
-          opt :dbname,           "Database name",                :type => :string
-        end
+        opts = EvmDba.with_options(:remote_uri, :aws, :remote_file, :db_credentials)
 
-        db_opts = {}
-        [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
-
-        connect_opts = {}
-        [:uri, :uri_username, :uri_password, :aws_region, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
-        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
-        connect_opts[:region]   = connect_opts.delete(:aws_region)   if connect_opts[:aws_region]
+        db_opts      = EvmDba.collect_db_opts(opts)
+        connect_opts = EvmDba.collect_connect_opts(opts)
 
         EvmDatabaseOps.backup(db_opts, connect_opts)
 
@@ -199,17 +213,8 @@ namespace :evm do
       require Rails.root.join("lib", "evm_database_ops").expand_path.to_s
       desc 'Dump the local ManageIQ EVM Database (VMDB) to a local file'
       task :local do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file,         "Destination file",       :type => :string, :required => true
-          opt :username,           "Username",               :type => :string
-          opt :password,           "Password",               :type => :string
-          opt :hostname,           "Hostname",               :type => :string
-          opt :dbname,             "Database name",          :type => :string
-          opt :exclude_table_data, "Tables to exclude data", :type => :strings
-        end
+        opts = EvmDba.with_options(:local_file, :db_credentials, :exclude_table_data)
 
-        opts.delete_if { |_, v| v.nil? }
         EvmDatabaseOps.dump(opts)
 
         exit # exit so that parameters to the first rake task are not run as rake tasks
@@ -217,26 +222,10 @@ namespace :evm do
 
       desc 'Dump the local ManageIQ EVM Database (VMDB) to a remote file'
       task :remote do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,                "Destination depot URI",      :type => :string, :required => true
-          opt :uri_username,       "Destination depot username", :type => :string
-          opt :uri_password,       "Destination depot password", :type => :string
-          opt :remote_file_name,   "Destination depot filename", :type => :string
-          opt :username,           "Username",                   :type => :string
-          opt :password,           "Password",                   :type => :string
-          opt :hostname,           "Hostname",                   :type => :string
-          opt :dbname,             "Database name",              :type => :string
-          opt :exclude_table_data, "Tables to exclude data",     :type => :strings
-        end
+        opts = EvmDba.with_options(:remote_uri, :remote_file, :db_credentials, :exclude_table_data)
 
-        db_opts = {}
-        [:dbname, :username, :password, :hostname, :exclude_table_data].each { |k| db_opts[k] = opts[k] if opts[k] }
-
-        connect_opts = {}
-        [:uri, :uri_username, :uri_password, :remote_file_name].each { |k| connect_opts[k] = opts[k] if opts[k] }
-        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
+        db_opts      = EvmDba.collect_db_opts(opts)
+        connect_opts = EvmDba.collect_connect_opts(opts)
 
         EvmDatabaseOps.dump(db_opts, connect_opts)
 
@@ -247,16 +236,7 @@ namespace :evm do
     namespace :restore do
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a local backup file'
       task :local => :environment do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :local_file, "Destination file", :type => :string, :required => true
-          opt :username,   "Username",         :type => :string
-          opt :password,   "Password",         :type => :string
-          opt :hostname,   "Hostname",         :type => :string
-          opt :dbname,     "Database name",    :type => :string
-        end
-
-        opts.delete_if { |k,v| v.nil? }
+        opts = EvmDba.with_options(:local_file, :db_credentials)
 
         # If running through runner, disconnect any local connections
         ActiveRecord::Base.clear_all_connections! if ActiveRecord && ActiveRecord::Base
@@ -268,26 +248,10 @@ namespace :evm do
 
       desc 'Restore the local ManageIQ EVM Database (VMDB) from a remote backup file'
       task :remote => :environment do
-        require 'trollop'
-        opts = Trollop.options(EvmRakeHelper.extract_command_options) do
-          opt :uri,              "Destination depot URI",        :type => :string, :required => true
-          opt :uri_username,     "Destination depot username",   :type => :string
-          opt :uri_password,     "Destination depot password",   :type => :string
-          opt :aws_region,       "Destination depot AWS region", :type => :string
-          opt :username,         "Username",                     :type => :string
-          opt :password,         "Password",                     :type => :string
-          opt :hostname,         "Hostname",                     :type => :string
-          opt :dbname,           "Database name",                :type => :string
-        end
+        opts = EvmDba.with_options(:remote_uri, :aws, :db_credentials)
 
-        db_opts = {}
-        [:dbname, :username, :password, :hostname].each { |k| db_opts[k] = opts[k] if opts[k] }
-
-        connect_opts = {}
-        [:uri, :uri_username, :uri_password, :aws_region].each { |k| connect_opts[k] = opts[k] if opts[k] }
-        connect_opts[:username] = connect_opts.delete(:uri_username) if connect_opts[:uri_username]
-        connect_opts[:password] = connect_opts.delete(:uri_password) if connect_opts[:uri_password]
-        connect_opts[:region]   = connect_opts.delete(:aws_region)   if connect_opts[:aws_region]
+        db_opts      = EvmDba.collect_db_opts(opts)
+        connect_opts = EvmDba.collect_connect_opts(opts)
 
         # If running through runner, disconnect any local connections
         ActiveRecord::Base.clear_all_connections! if ActiveRecord && ActiveRecord::Base


### PR DESCRIPTION
Lifted from https://github.com/ManageIQ/manageiq/pull/17652
Requires https://github.com/ManageIQ/manageiq-gems-pending/pull/362 to be merged.

DRY's up the option parsing in `lib/tasks/evm_dba.rake` to use the `EvmDba` module to handled shared parsing logic between tasks.

Also addresses [a comment](https://github.com/ManageIQ/manageiq/pull/17652#discussion_r199013548) in #17652 to switch to a non-dashed key, since both `AwesomeSpawn` and `Trollop` handle converting them already.


Links
-----
* Prerequisite PR:  https://github.com/ManageIQ/manageiq-gems-pending/pull/362
* PR where this was originally included from:  https://github.com/ManageIQ/manageiq/pull/17652
* Comment addressing hash keys:  https://github.com/ManageIQ/manageiq/pull/17652#discussion_r199013548


Steps for Testing/QA
--------------------

Try any one of the following tasks:

- `evm:db:gc`
- `evm:db:region`
- `evm:db:backup:local`
- `evm:db:backup:remote`
- `evm:db:dump:local`
- `evm:db:dump:remote`
- `evm:db:restore:local`
- `evm:db:restore:remote`

Before and after this change, with the `-- --help` flag, and the help documentation should be the same.