### PR TITLE
Add groupdate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
+gem "groupdate",                      "~>4.0.1"
 gem "hamlit",                         "~>2.8.5"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false


### PR DESCRIPTION
This PR adds the `groupdate` gem to the list of dependencies. With this we can do nice things like:

`Vm.group_by_day(:created_on, :range => 3.days.ago.utc..Time.now.utc, :format => '%Y-%m-%d').count`

For more information on the groupdate gem, please visit https://github.com/ankane/groupdate.

Part one of a solution for https://github.com/ManageIQ/manageiq-ui-classic/pull/4447