### PR TITLE
Clean up mapped tenants after a CloudManager is destroyed

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -40,6 +40,8 @@ module ManageIQ::Providers
     include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
 
+    after_destroy :destroy_mapped_tenants
+
     # Development helper method for Rails console for opening a browser to the EMS.
     #
     # This method is NOT meant to be called from production code.
@@ -139,6 +141,14 @@ module ManageIQ::Providers
 
     def self.display_name(number = 1)
       n_('Cloud Manager', 'Cloud Managers', number)
+    end
+
+    def destroy_mapped_tenants
+      if source_tenant
+        source_tenant.all_subtenants.destroy_all
+        source_tenant.all_subprojects.destroy_all
+        source_tenant.destroy
+      end
     end
   end
 end

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -192,6 +192,17 @@ describe EmsCloud do
           expect_created_tenant_tree
         end
 
+        it "cleans up created tenant tree when the ems is destroyed" do
+          ems_cloud.sync_cloud_tenants_with_tenants
+          expect_created_tenant_tree
+          # 4 cloud tenants, plus the provider tenant and root tenant
+          expect(Tenant.count).to eq(6)
+          ems_cloud.destroy
+          # only the root tenant should remain after destroying the ems
+          expect(Tenant.count).to eq(1)
+          expect(Tenant.first.name).to eq("My Company")
+        end
+
         let(:vm_5) { FactoryGirl.create(:vm_openstack) }
 
         let(:ct_5) do


### PR DESCRIPTION
Tenants created by cloud tenant mapping are not destroyed when their provider is destroyed, which prevents tenant mapping from working if the provider is readded with the same name. This PR causes the mapped tenant tree to be destroyed along with the provider.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1547740