### PR TITLE
Add tests for event type mapping

### DIFF
--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -1,0 +1,24 @@
+describe EventStream do
+  describe ".event_groups" do
+    EventStream.event_groups.each do |group_name, group_data|
+      EventStream::GROUP_LEVELS.each do |level|
+        group_data[level]&.each do |typ|
+          it ":#{group_name}/:#{level}/#{typ} is string or regex" do
+            expect(typ.kind_of?(Regexp) || typ.kind_of?(String)).to eq(true)
+          end
+
+          if typ.kind_of?(Regexp)
+            it ":#{group_name}/:#{level}/#{typ} is usable in SQL queries" do
+              expect { EventStream.where("event_type ~ ?", typ.source).to_a }
+                .to_not raise_error
+            end
+
+            it ":#{group_name}/:#{level}/#{typ} only uses case insensitivity option" do
+              expect(typ.options & (Regexp::EXTENDED | Regexp::MULTILINE)).to eq(0)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Test try to ensure that event type mappings are valid by checking that:

 1. all event types specifications are either strings or regexes,
 2. regexes can be used by PostgreSQL and
 3. regexes do not use unsupported options.

In order to give as much information about the failures to developers as possible, we check each event type in separate `it` block, labeling it with path in the settings file (group name, level and value of type being checked).