### PR TITLE
Add log messages to Chargeback

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -32,12 +32,17 @@ class Chargeback < ActsAsArModel
 
     data = {}
     rates = RatesCache.new(options)
+    _log.debug("With report options: #{options.inspect}")
 
     MiqRegion.all.each do |region|
+      _log.debug("For region #{region.region}")
+
       ConsumptionHistory.for_report(self, options, region.region) do |consumption|
         rates_to_apply = rates.get(consumption)
 
         key = report_row_key(consumption)
+        _log.debug("Report row key #{key}")
+
         data[key] ||= new(options, consumption, region.region)
 
         chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
@@ -55,6 +60,21 @@ class Chargeback < ActsAsArModel
     _log.info("Calculating chargeback costs...Complete")
 
     [data.values]
+  end
+
+  def self.log_rates(rates)
+    rates.each do |rate|
+      _log.debug("Rate: #{rate.description}")
+      rate.chargeback_rate_details.each do |rate_detail|
+        chargeable_field = rate_detail.chargeable_field
+        _log.debug("Description #{chargeable_field.description}")
+        _log.debug("Metric: #{chargeable_field.metric} Group: #{chargeable_field.group} Source: #{chargeable_field.source}")
+
+        rate_detail.chargeback_tiers.each do |tier|
+          _log.debug("Start: #{tier.start} Finish: #{tier.finish} Fixed Rate: #{tier.fixed_rate} Variable Rate: #{tier.variable_rate}")
+        end
+      end
+    end
   end
 
   def self.report_row_key(consumption)
@@ -169,11 +189,14 @@ class Chargeback < ActsAsArModel
     self.class.try(:refresh_dynamic_metric_columns)
 
     rates.each do |rate|
+      _log.debug("Calculation with rate: #{rate.description}(#{rate.rate_type})")
       rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
+        _log.debug("Metric: #{r.chargeable_field.metric} Group: #{r.chargeable_field.group} Source: #{r.chargeable_field.source}")
         r.charge(consumption, @options).each do |field, value|
           next if @options.skip_field_accumulation?(field, self[field])
-
+          _log.debug("Calculation with field: #{field} and with value: #{value}")
           (self[field] = self[field].kind_of?(Numeric) ? (self[field] || 0) + value : value)
+          _log.debug("Accumulated value: #{self[field]}")
         end
       end
     end

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -174,7 +174,7 @@ class Chargeback < ActsAsArModel
     self.class.try(:refresh_dynamic_metric_columns)
 
     rates.each do |rate|
-      _log.debug("Calculation with rate: #{rate.description}(#{rate.rate_type})")
+      _log.debug("Calculation with rate: #{rate.id} #{rate.description}(#{rate.rate_type})")
       rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
         _log.debug("Metric: #{r.chargeable_field.metric} Group: #{r.chargeable_field.group} Source: #{r.chargeable_field.source}")
         r.chargeback_tiers.each do |tier|

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -172,7 +172,7 @@ class Chargeback < ActsAsArModel
   def calculate_costs(consumption, rates)
     calculate_fixed_compute_metric(consumption)
     self.class.try(:refresh_dynamic_metric_columns)
-
+    _log.debug("Consumption Type: #{consumption.class}")
     rates.each do |rate|
       _log.debug("Calculation with rate: #{rate.id} #{rate.description}(#{rate.rate_type})")
       rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -62,21 +62,6 @@ class Chargeback < ActsAsArModel
     [data.values]
   end
 
-  def self.log_rates(rates)
-    rates.each do |rate|
-      _log.debug("Rate: #{rate.description}")
-      rate.chargeback_rate_details.each do |rate_detail|
-        chargeable_field = rate_detail.chargeable_field
-        _log.debug("Description #{chargeable_field.description}")
-        _log.debug("Metric: #{chargeable_field.metric} Group: #{chargeable_field.group} Source: #{chargeable_field.source}")
-
-        rate_detail.chargeback_tiers.each do |tier|
-          _log.debug("Start: #{tier.start} Finish: #{tier.finish} Fixed Rate: #{tier.fixed_rate} Variable Rate: #{tier.variable_rate}")
-        end
-      end
-    end
-  end
-
   def self.report_row_key(consumption)
     ts_key = @options.start_of_report_step(consumption.timestamp)
     if @options[:groupby_tag].present?
@@ -192,6 +177,9 @@ class Chargeback < ActsAsArModel
       _log.debug("Calculation with rate: #{rate.description}(#{rate.rate_type})")
       rate.rate_details_relevant_to(relevant_fields, self.class.attribute_names).each do |r|
         _log.debug("Metric: #{r.chargeable_field.metric} Group: #{r.chargeable_field.group} Source: #{r.chargeable_field.source}")
+        r.chargeback_tiers.each do |tier|
+          _log.debug("Start: #{tier.start} Finish: #{tier.finish} Fixed Rate: #{tier.fixed_rate} Variable Rate: #{tier.variable_rate}")
+        end
         r.charge(consumption, @options).each do |field, value|
           next if @options.skip_field_accumulation?(field, self[field])
           _log.debug("Calculation with field: #{field} and with value: #{value}")

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -7,7 +7,9 @@ class Chargeback
       extra_resources = cb_class.try(:extra_resources_without_rollups, region) || []
       timerange.step_value(interval_duration).each_cons(2) do |query_start_time, query_end_time|
         extra_resources.each do |resource|
+          _log.info("Using ConsumptionWithoutRollups for resource #{resource.id} #{resource.class} for time range #{[query_start_time, query_end_time].inspect}")
           consumption = ConsumptionWithoutRollups.new(resource, query_start_time, query_end_time)
+          _log.info("Consumed Hours for ConsumptionWithoutRollups: #{consumption.consumed_hours_in_interval}")
           yield(consumption) unless consumption.consumed_hours_in_interval.zero?
         end
 

--- a/app/models/chargeback/consumption_history.rb
+++ b/app/models/chargeback/consumption_history.rb
@@ -24,6 +24,7 @@ class Chargeback
         # values are grouped by resource_id and timestamp (query_start_time...query_end_time)
         records.each_value do |rollup_record_ids|
           metric_rollup_records = MetricRollup.where(:id => rollup_record_ids).order(:resource_type, :resource_id, :timestamp).pluck(*ChargeableField.cols_on_metric_rollup)
+          _log.debug("Count of Metric Rollups for consumption: #{metric_rollup_records.count}")
           consumption = ConsumptionWithRollups.new(metric_rollup_records, query_start_time, query_end_time)
           yield(consumption) unless consumption.consumed_hours_in_interval.zero?
         end

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -241,6 +241,9 @@ class ChargebackRateDetail < ApplicationRecord
   def metric_and_cost_by(consumption, options)
     metric_value = chargeable_field.measure(consumption, options, sub_metric)
     hourly_cost = hourly_cost(metric_value, consumption)
+
+    _log.debug("Consumption interval: #{consumption.consumption_start} -  #{consumption.consumption_end}")
+    _log.debug("Consumed hours: #{consumption.consumed_hours_in_interval}")
     cost = chargeable_field.metering? ? hourly_cost : hourly_cost * consumption.consumed_hours_in_interval
     [metric_value, cost]
   end

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -182,7 +182,7 @@ module AssignmentMixin
     # @option options :parents
     # @option options :tag_list
     def get_assigned_for_target(target, options = {})
-      _log.debug("Input for get_assigned_for_target id: #{target.id} class: #{target.class}")
+      _log.debug("Input for get_assigned_for_target id: #{target.id} class: #{target.class}") if target
       if options[:parents]
         parents = options[:parents]
         _log.debug("Parents are passed from parameter")
@@ -194,12 +194,10 @@ module AssignmentMixin
         parents << target
       end
 
-      parents.each do |parent|
-        _log.debug("parent id: #{parent.id} class: #{parent.class}")
-      end if parents.kind_of?(Array)
+      parents.each { |parent| _log.debug("parent id: #{parent.id} class: #{parent.class}") } if parents.kind_of?(Array)
 
       tlist =  parents.collect { |p| "#{p.class.base_model.name.underscore}/id/#{p.id}" } # Assigned directly to parents
-      if options[:tag_list]  # Assigned to target (passed in)
+      if options[:tag_list] # Assigned to target (passed in)
         tlist += options[:tag_list]
         _log.debug("Using tag list: #{options[:tag_list].join(', ')}")
       end
@@ -208,7 +206,7 @@ module AssignmentMixin
 
       individually_assigned_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
 
-      _log.debug("Individually assigned resources: #{individually_assigned_resources.map {|x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
+      _log.debug("Individually assigned resources: #{individually_assigned_resources.map { |x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
 
       # look for alert_set running off of tags (not individual tags)
       # TODO: we may need to change taggings-related code to use base_model too
@@ -221,7 +219,7 @@ module AssignmentMixin
       _log.debug("Tags assigned to parents: #{tlist.join(', ')}")
       tagged_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
 
-      _log.debug("Tagged resources: #{individually_assigned_resources.map {|x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
+      _log.debug("Tagged resources: #{individually_assigned_resources.map { |x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
       (individually_assigned_resources + tagged_resources).uniq
     end
 

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -182,19 +182,33 @@ module AssignmentMixin
     # @option options :parents
     # @option options :tag_list
     def get_assigned_for_target(target, options = {})
+      _log.debug("Input for get_assigned_for_target id: #{target.id} class: #{target.class}")
       if options[:parents]
         parents = options[:parents]
+        _log.debug("Parents are passed from parameter")
       else
+        _log.debug("Parents are not passed from parameter")
         parents = self::ASSIGNMENT_PARENT_ASSOCIATIONS.flat_map do |rel|
           (rel == :my_enterprise ? MiqEnterprise.my_enterprise : target.try(rel)) || []
         end
         parents << target
       end
 
+      parents.each do |parent|
+        _log.debug("parent id: #{parent.id} class: #{parent.class}")
+      end if parents.kind_of?(Array)
+
       tlist =  parents.collect { |p| "#{p.class.base_model.name.underscore}/id/#{p.id}" } # Assigned directly to parents
-      tlist += options[:tag_list] if options[:tag_list]                        # Assigned to target (passed in)
+      if options[:tag_list]  # Assigned to target (passed in)
+        tlist += options[:tag_list]
+        _log.debug("Using tag list: #{options[:tag_list].join(', ')}")
+      end
+
+      _log.debug("Directly assigned to parents: #{tlist.join(', ')}")
 
       individually_assigned_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
+
+      _log.debug("Individually assigned resources: #{individually_assigned_resources.map {|x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
 
       # look for alert_set running off of tags (not individual tags)
       # TODO: we may need to change taggings-related code to use base_model too
@@ -203,7 +217,11 @@ module AssignmentMixin
                      .references(:tag).includes(:tag).map do |t|
         "#{tag_class(t.taggable_type)}/tag#{t.tag.name}"
       end
+
+      _log.debug("Tags assigned to parents: #{tlist.join(', ')}")
       tagged_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
+
+      _log.debug("Tagged resources: #{individually_assigned_resources.map {|x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
       (individually_assigned_resources + tagged_resources).uniq
     end
 


### PR DESCRIPTION
```
 MIQ(ChargebackVm.build_results_for_report_chargeback) Calculating chargeback costs...
MIQ(ChargebackVm.build_results_for_report_chargeback) With report options: #<struct Chargeback::ReportOptions interval="daily", interval_size=35, end_interval_offset=0, owner="seplag", tenant_id=nil, tag=nil, report_cols=["start_date", "display_range", "vm_name", "provider_name", "cpu_allocated_metric", "cpu_allocated_cost", "memory_allocated_metric", "storage_allocated_metric", "fixed_compute_1_cost", "fixed_compute_metric", "chargeback_rates"], provide_id=nil, entity_id=nil, service_id=nil, groupby="date", groupby_tag=nil, groupby_label=nil, userid="admin", ext_options={:tz=>"Brasilia", :time_profile=>nil}, include_metrics=true, method_for_allocated_metrics=:max, :group_by_tenant?=nil, cumulative_rate_calculation=true>
MIQ(ChargebackVm.build_results_for_report_chargeback) For region 1
MIQ(Chargeback::ConsumptionHistory.for_report) Found 24 records for time range [Fri, 20 Jul 2018 00:00:00 -03 -03:00, Sat, 21 Jul 2018 00:00:00 -03 -03:00]
MIQ(Chargeback::ConsumptionHistory.for_report) Count of Metric Rollups for consumption: 24
MIQ(ChargebackRate.get_assigned_for_target) Input for get_assigned_for_target id: 1000000000114 class: ManageIQ::Providers::Amazon::CloudManager::Vm
MIQ(ChargebackRate.get_assigned_for_target) Parents are passed from parameter
MIQ(ChargebackRate.get_assigned_for_target) parent id: 1000000000006 class: ManageIQ::Providers::Amazon::StorageManager::Ebs::CloudVolume
MIQ(ChargebackRate.get_assigned_for_target) parent id: 1000000000002 class: ManageIQ::Providers::Amazon::CloudManager
MIQ(ChargebackRate.get_assigned_for_target) parent id: 1000000000004 class: Tenant
MIQ(ChargebackRate.get_assigned_for_target) parent id: 1000000000001 class: MiqEnterprise
MIQ(ChargebackRate.get_assigned_for_target) Using tag list: vm/tag/managed/customer/seplag, vm/tag/managed/prov_scope/g_seplag, vm/tag/managed/aws_instance_flavor/t2_small
MIQ(ChargebackRate.get_assigned_for_target) Directly assigned to parents: cloud_volume/id/1000000000006, ext_management_system/id/1000000000002, tenant/id/1000000000004, miq_enterprise/id/1000000000001, vm/tag/managed/customer/seplag, vm/tag/managed/prov_scope/g_seplag, vm/tag/managed/aws_instance_flavor/t2_small
MIQ(ChargebackRate.get_assigned_for_target) Individually assigned resources: id:1000000000008 class:ChargebackRate, id:1000000000006 class:ChargebackRate, id:1000000000013 class:ChargebackRate
MIQ(ChargebackRate.get_assigned_for_target) Tags assigned to parents: tenant/tag/managed/customer/seplag, tenant/tag/managed/prov_scope/g_seplag, ext_management_system/tag/managed/prov_scope/g_etice_comercial, ext_management_system/tag/managed/prov_scope/g_pge, ext_management_system/tag/managed/prov_scope/g_redhat, ext_management_system/tag/managed/prov_scope/g_seplag, ext_management_system/tag/managed/prov_scope/g_sesa, ext_management_system/tag/managed/prov_scope/g_casacivil, ext_management_system/tag/managed/prov_scope/g_cge, ext_management_system/tag/managed/prov_scope/g_metrofor, storage/tag/managed/customer/seplag, storage/tag/managed/prov_scope/g_seplag
MIQ(ChargebackRate.get_assigned_for_target) Tagged resources: id:1000000000008 class:ChargebackRate, id:1000000000006 class:ChargebackRate, id:1000000000013 class:ChargebackRate
MIQ(ChargebackVm.build_results_for_report_chargeback) Report row key 1000000000114_2018-07-20 00:00:00 -0300
MIQ(ChargebackVm#calculate_costs) Calculation with rate: AWS(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 2.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.027 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_metric and with value: 2048.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 2048.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Amazon - t2_small linux(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.041 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 49.632000000000005
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Storage - Geral(Storage)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_allocated_disk_storage Group: storage Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.5 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-20 00:00:00 -0300 -  2018-07-21 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_rate and with value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_metric and with value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 109.63200000000001
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(Chargeback::ConsumptionHistory.for_report) Found 24 records for time range [Sat, 21 Jul 2018 00:00:00 -03 -03:00, Sun, 22 Jul 2018 00:00:00 -03 -03:00]
MIQ(Chargeback::ConsumptionHistory.for_report) Count of Metric Rollups for consumption: 24
MIQ(ChargebackVm.build_results_for_report_chargeback) Report row key 1000000000114_2018-07-21 00:00:00 -0300
MIQ(ChargebackVm#calculate_costs) Calculation with rate: AWS(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 2.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.027 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_metric and with value: 2048.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 2048.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Amazon - t2_small linux(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.041 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 49.632000000000005
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Storage - Geral(Storage)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_allocated_disk_storage Group: storage Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.5 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-21 00:00:00 -0300 -  2018-07-22 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_rate and with value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_metric and with value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 109.63200000000001
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(Chargeback::ConsumptionHistory.for_report) Found 24 records for time range [Sun, 22 Jul 2018 00:00:00 -03 -03:00, Mon, 23 Jul 2018 00:00:00 -03 -03:00]
MIQ(Chargeback::ConsumptionHistory.for_report) Count of Metric Rollups for consumption: 24
MIQ(ChargebackVm.build_results_for_report_chargeback) Report row key 1000000000114_2018-07-22 00:00:00 -0300
MIQ(ChargebackVm#calculate_costs) Calculation with rate: AWS(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 2.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.027 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_metric and with value: 2048.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 2048.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Amazon - t2_small linux(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.041 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 49.632000000000005
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Storage - Geral(Storage)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_allocated_disk_storage Group: storage Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.5 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-22 00:00:00 -0300 -  2018-07-23 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_rate and with value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_metric and with value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 109.63200000000001
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(Chargeback::ConsumptionHistory.for_report) Found 24 records for time range [Mon, 23 Jul 2018 00:00:00 -03 -03:00, Tue, 24 Jul 2018 00:00:00 -03 -03:00]
MIQ(Chargeback::ConsumptionHistory.for_report) Count of Metric Rollups for consumption: 24
MIQ(ChargebackVm.build_results_for_report_chargeback) Report row key 1000000000114_2018-07-23 00:00:00 -0300
MIQ(ChargebackVm#calculate_costs) Calculation with rate: AWS(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 2.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/2.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 48.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.0
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.027 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.027/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_metric and with value: 1.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 0.648
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_metric and with value: 2048.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 2048.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Amazon - t2_small linux(Compute)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_numvcpus Group: cpu Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.041 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_rate and with value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.041/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_allocated_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 49.632000000000005
MIQ(ChargebackVm#calculate_costs) Calculation with field: cpu_cost and with value: 0.984
MIQ(ChargebackVm#calculate_costs) Accumulated value: 48.984
MIQ(ChargebackVm#calculate_costs) Metric: fixed_compute_1 Group: fixed Source: compute_1
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_rate and with value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_compute_1_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: fixed_cost and with value: 24.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 24.648
MIQ(ChargebackVm#calculate_costs) Metric: derived_memory_available Group: memory Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 0.0 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_rate and with value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_allocated_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 73.632
MIQ(ChargebackVm#calculate_costs) Calculation with field: memory_cost and with value: 0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 0.0
MIQ(ChargebackVm#calculate_costs) Calculation with rate: Storage - Geral(Storage)
MIQ(ChargebackVm#calculate_costs) Metric: derived_vm_allocated_disk_storage Group: storage Source: allocated
MIQ(ChargebackVm#calculate_costs) Start: 0.0 Finish: Infinity Fixed Rate: 1.5 Variable Rate: 0.0
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumption interval: 2018-07-23 00:00:00 -0300 -  2018-07-24 00:00:00 -0300
MIQ(ChargebackRateDetail#metric_and_cost_by) Consumed hours: 24
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_rate and with value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 1.5/0.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_metric and with value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 32212254720.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 109.63200000000001
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_allocated_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(ChargebackVm#calculate_costs) Calculation with field: total_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 109.63200000000001
MIQ(ChargebackVm#calculate_costs) Calculation with field: storage_cost and with value: 36.0
MIQ(ChargebackVm#calculate_costs) Accumulated value: 36.0
MIQ(ChargebackVm.build_results_for_report_chargeback) Calculating chargeback costs...Complete
```