### PR TITLE
Send the notification ID when propagating a notification through WS

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -55,8 +55,7 @@ class Notification < ApplicationRecord
   def emit_message
     return unless ::Settings.server.asynchronous_notifications
     notification_recipients.pluck(:id, :user_id).each do |id, user|
-      to_h[:id] = id
-      ActionCable.server.broadcast("notifications_#{user}", to_h)
+      ActionCable.server.broadcast("notifications_#{user}", to_h.merge(:id => id.to_s))
     end
   end
 


### PR DESCRIPTION
The `to_h[:id]` doesn't make any sense if it's not used afterwards, this is a function and not a variable. Also the value should be sent as a string, because JS handles large numbers in a crazy way.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label bug, gaprindashvili/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1618705