### PR TITLE
Expose ems_cluster_id on VMs for use in V2V OpenStack support

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -87,6 +87,7 @@ class TransformationMapping < ApplicationRecord
       "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.parent_blue_folder_path(:exclude_non_display_folders => true)}" : '',
       "allocated_size" => vm.allocated_disk_storage,
       "id"             => vm.id,
+      "ems_cluster_id" => vm.ems_cluster_id,
       "reason"         => reason
     }
   end


### PR DESCRIPTION
This PR adds the `ems_cluster_id` property to a VM, to support correlating VMs to a source cluster (and subsequently a target cluster) so that we can add a new Target Cluster column in the new OSP Instance Properties UI table, in the Migration Plan wizard.