### PR TITLE
Add support for exporting and importing customization templates

### DIFF
--- a/lib/task_helpers/exports/customization_templates.rb
+++ b/lib/task_helpers/exports/customization_templates.rb
@@ -11,9 +11,9 @@ module TaskHelpers
           $log.info("Exporting Customization Template: #{customization_template.name} (ID: #{customization_template.id})")
 
           ct_hash = Exports.exclude_attributes(customization_template.to_model_hash, EXCLUDE_ATTRS)
-          ct_hash.merge!(pxe_image(customization_template.pxe_image_type))
+          ct_hash.merge!(pxe_image_type_hash(customization_template.pxe_image_type))
 
-          image_type_name = ct_hash[:pxe_image_type][:name] ? ct_hash[:pxe_image_type][:name] : "Examples"
+          image_type_name = ct_hash.fetch_path(:pxe_image_type, :name) || "Examples"
           filename = Exports.safe_filename("#{image_type_name}-#{ct_hash[:name]}", options[:keep_spaces])
           File.write("#{export_dir}/#{filename}.yaml", ct_hash.to_yaml)
         end
@@ -21,9 +21,9 @@ module TaskHelpers
 
       private
 
-      def pxe_image(pxe_image)
-        if pxe_image
-          { :pxe_image_type => pxe_image.to_model_hash.reject { |key| EXCLUDE_ATTRS.include?(key) } }
+      def pxe_image_type_hash(pxe_image_type)
+        if pxe_image_type
+          { :pxe_image_type => pxe_image_type.to_model_hash.reject { |key| EXCLUDE_ATTRS.include?(key) } }
         else
           { :pxe_image_type => {} }
         end

--- a/lib/task_helpers/exports/customization_templates.rb
+++ b/lib/task_helpers/exports/customization_templates.rb
@@ -1,0 +1,33 @@
+module TaskHelpers
+  class Exports
+    class CustomizationTemplates
+      EXCLUDE_ATTRS = %i(created_at updated_at id pxe_image_type_id class).freeze
+      def export(options = {})
+        export_dir = options[:directory]
+
+        customization_templates = options[:all] ? CustomizationTemplate.all : CustomizationTemplate.where(:system => [false, nil])
+
+        customization_templates.order(:id).each do |customization_template|
+          $log.info("Exporting Customization Template: #{customization_template.name} (ID: #{customization_template.id})")
+
+          ct_hash = Exports.exclude_attributes(customization_template.to_model_hash, EXCLUDE_ATTRS)
+          ct_hash.merge!(pxe_image(customization_template.pxe_image_type))
+
+          image_type_name = ct_hash[:pxe_image_type][:name] ? ct_hash[:pxe_image_type][:name] : "Examples"
+          filename = Exports.safe_filename("#{image_type_name}-#{ct_hash[:name]}", options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", ct_hash.to_yaml)
+        end
+      end
+
+      private
+
+      def pxe_image(pxe_image)
+        if pxe_image
+          { :pxe_image_type => pxe_image.to_model_hash.reject { |key| EXCLUDE_ATTRS.include?(key) } }
+        else
+          { :pxe_image_type => {} }
+        end
+      end
+    end
+  end
+end

--- a/lib/task_helpers/imports/customization_templates.rb
+++ b/lib/task_helpers/imports/customization_templates.rb
@@ -1,0 +1,92 @@
+module TaskHelpers
+  class Imports
+    class CustomizationTemplates
+      class CustomizationTemplateYamlError < StandardError
+        attr_accessor :details
+
+        def initialize(message = nil, details = nil)
+          super(message)
+          self.details = details
+        end
+      end
+
+      def import(options = {})
+        return unless options[:source]
+
+        glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Customization Template from: #{filename}")
+
+          begin
+            custom_template_hash = YAML.load_file(filename)
+            import_customization_template(custom_template_hash)
+          rescue CustomizationTemplateYamlError => err
+            $log.error("Error importing #{filename} : #{err.message}")
+            warn("Error importing #{filename} : #{err.message}")
+            err.details.each do |detail|
+              $log.error(detail.to_s)
+              warn("\t#{detail}")
+            end
+          end
+        end
+      end
+
+      private
+
+      def import_customization_template(custom_template_hash)
+        CustomizationTemplate.transaction do
+          unless validate_type(custom_template_hash[:type])
+            raise CustomizationTemplateYamlError.new("Customization Template error",
+                                                     ["Invalid type: #{custom_template_hash[:type]}"])
+          end
+
+          if custom_template_hash[:system]
+            raise CustomizationTemplateYamlError.new("Customization Template error",
+                                                     ["Cannot import because :system is set to true"])
+          end
+
+          pxe_image_type_hash                   = custom_template_hash.delete(:pxe_image_type)
+          custom_template_hash[:pxe_image_type] = get_pxe_image_type(pxe_image_type_hash)
+
+          customization_template = CustomizationTemplate.find_by(:name           => custom_template_hash[:name],
+                                                                 :pxe_image_type => custom_template_hash[:pxe_image_type])
+
+          if customization_template
+            customization_template.update(custom_template_hash)
+          else
+            imported_ct = CustomizationTemplate.create(custom_template_hash)
+
+            unless imported_ct.valid?
+              raise CustomizationTemplateYamlError.new("Customization Template error",
+                                                       imported_ct.errors.full_messages)
+            end
+          end
+        end
+      end
+
+      def get_pxe_image_type(pxe_image_hash)
+        unless pxe_image_hash.key?(:name)
+          raise CustomizationTemplateYamlError.new("Customization Template error",
+                                                   ["Cannot import because there is no :name for :pxe_image_type"])
+        end
+
+        if pxe_image_hash.key?(:provision_type) && !%w(vm host).include?(pxe_image_hash[:provision_type])
+          raise CustomizationTemplateYamlError.new("Customization Template error",
+                                                   ["Cannot import because :provision_type for :pxe_image_type must be vm or host"])
+        end
+
+        pit = PxeImageType.find_or_create_by(pxe_image_hash)
+
+        raise CustomizationTemplateYamlError.new("Customization Template error", pit.errors.full_messages) unless pit.valid?
+
+        pit
+      end
+
+      def validate_type(custom_template_type)
+        valid_types = CustomizationTemplate.descendants.collect(&:name)
+
+        valid_types.include?(custom_template_type) ? true : false
+      end
+    end
+  end
+end

--- a/lib/task_helpers/imports/customization_templates.rb
+++ b/lib/task_helpers/imports/customization_templates.rb
@@ -35,7 +35,7 @@ module TaskHelpers
 
       def import_customization_template(custom_template_hash)
         CustomizationTemplate.transaction do
-          unless validate_type(custom_template_hash[:type])
+          unless valid_type?(custom_template_hash[:type])
             raise CustomizationTemplateYamlError.new("Customization Template error",
                                                      ["Invalid type: #{custom_template_hash[:type]}"])
           end
@@ -82,10 +82,8 @@ module TaskHelpers
         pit
       end
 
-      def validate_type(custom_template_type)
-        valid_types = CustomizationTemplate.descendants.collect(&:name)
-
-        valid_types.include?(custom_template_type) ? true : false
+      def valid_type?(custom_template_type)
+        CustomizationTemplate.descendants.collect(&:name).include?(custom_template_type)
       end
     end
   end

--- a/lib/tasks/evm_export_import.rake
+++ b/lib/tasks/evm_export_import.rake
@@ -5,6 +5,9 @@
 #   * Tags
 #   * Service Dialogs
 #   * Provision Dialogs
+#   * Custom Buttons
+#   * SmartState Analysis Scan Profiles
+#   * Customization Templates
 
 namespace :evm do
   namespace :export do
@@ -85,6 +88,14 @@ namespace :evm do
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end
+
+    desc 'Exports all customization templates to individual YAML files'
+    task :customization_templates => :environment do
+      options = TaskHelpers::Exports.parse_options
+      TaskHelpers::Exports::CustomizationTemplates.new.export(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
   end
 
   namespace :import do
@@ -162,6 +173,14 @@ namespace :evm do
     task :custom_buttons => :environment do
       options = TaskHelpers::Imports.parse_options
       TaskHelpers::Imports::CustomButtons.new.import(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
+
+    desc 'Imports all customization templates from individual YAML files'
+    task :customization_templates => :environment do
+      options = TaskHelpers::Imports.parse_options
+      TaskHelpers::Imports::CustomizationTemplates.new.import(options)
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end

--- a/spec/lib/task_helpers/exports/customization_templates_spec.rb
+++ b/spec/lib/task_helpers/exports/customization_templates_spec.rb
@@ -1,0 +1,107 @@
+describe TaskHelpers::Exports::CustomizationTemplates do
+  let(:template_name) { "Basic root pass template" }
+  let(:template_type) { "CustomizationTemplateCloudInit" }
+  let(:template_desc) { "This template takes use of rootpassword defined in the UI" }
+  let(:template_script) { "#cloud-config\nchpasswd:\n  list: |\n    root:<%= MiqPassword.decrypt(evm[:root_password]) %>\n  expire: False" }
+  let(:image_type_name1) { "CentOS-6" }
+  let(:image_type_name2) { "RHEL-7" }
+  let(:provision_type2) { "vm" }
+
+  let(:content1) do
+    { :name           => template_name,
+      :description    => template_desc,
+      :script         => template_script,
+      :type           => template_type,
+      :pxe_image_type => {
+        :name => image_type_name1
+      } }
+  end
+
+  let(:content2) do
+    { :name           => template_name,
+      :description    => template_desc,
+      :script         => template_script,
+      :type           => template_type,
+      :pxe_image_type => {
+        :name           => image_type_name2,
+        :provision_type => provision_type2
+      } }
+  end
+
+  let(:content3) do
+    { :name           => template_name,
+      :description    => template_desc,
+      :script         => template_script,
+      :type           => template_type,
+      :system         => true,
+      :pxe_image_type => {} }
+  end
+
+  let(:export_dir) do
+    Dir.mktmpdir('miq_exp_dir')
+  end
+
+  before do
+    pit1 = FactoryGirl.create(:pxe_image_type,
+                              :name => image_type_name1)
+
+    pit2 = FactoryGirl.create(:pxe_image_type,
+                              :name           => image_type_name2,
+                              :provision_type => provision_type2)
+
+    FactoryGirl.create(:customization_template,
+                       :name           => template_name,
+                       :type           => template_type,
+                       :description    => template_desc,
+                       :script         => template_script,
+                       :pxe_image_type => pit1)
+
+    FactoryGirl.create(:customization_template,
+                       :name           => template_name,
+                       :type           => template_type,
+                       :description    => template_desc,
+                       :script         => template_script,
+                       :pxe_image_type => pit2)
+
+    CustomizationTemplate.create!(:name        => template_name,
+                                  :type        => template_type,
+                                  :description => template_desc,
+                                  :system      => true,
+                                  :script      => template_script)
+  end
+
+  after do
+    FileUtils.remove_entry export_dir
+  end
+
+  describe "when --all is not specified" do
+    let(:template_filename1) { "#{export_dir}/#{image_type_name1}-Basic_root_pass_template.yaml" }
+    let(:template_filename2) { "#{export_dir}/#{image_type_name2}-Basic_root_pass_template.yaml" }
+
+    it 'exports user customization templates to a given directory with unique filenames' do
+      TaskHelpers::Exports::CustomizationTemplates.new.export(:directory => export_dir)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
+      customization_template1 = YAML.load_file(template_filename1)
+      expect(customization_template1).to eq(content1)
+      customization_template2 = YAML.load_file(template_filename2)
+      expect(customization_template2).to eq(content2)
+    end
+  end
+
+  describe "when --all is specified" do
+    let(:template_filename1) { "#{export_dir}/#{image_type_name1}-Basic_root_pass_template.yaml" }
+    let(:template_filename2) { "#{export_dir}/#{image_type_name2}-Basic_root_pass_template.yaml" }
+    let(:template_filename3) { "#{export_dir}/Examples-Basic_root_pass_template.yaml" }
+
+    it 'exports all provision dialogs to a given directory with unique filenames' do
+      TaskHelpers::Exports::CustomizationTemplates.new.export(:directory => export_dir, :all => true)
+      expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(3)
+      customization_template1 = YAML.load_file(template_filename1)
+      expect(customization_template1).to eq(content1)
+      customization_template2 = YAML.load_file(template_filename2)
+      expect(customization_template2).to eq(content2)
+      customization_template3 = YAML.load_file(template_filename3)
+      expect(customization_template3).to eq(content3)
+    end
+  end
+end

--- a/spec/lib/task_helpers/imports/customization_templates_spec.rb
+++ b/spec/lib/task_helpers/imports/customization_templates_spec.rb
@@ -1,18 +1,12 @@
 describe TaskHelpers::Imports::CustomizationTemplate do
-  let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'customization_templates') }
-  let(:ct_file) { "existing_ct_and_pit.yaml" }
-  let(:update_file) { "update_existing.yml" }
-  let(:ct_system_file) { "system_ct.yml" }
-  let(:invalid_pt_file) { "invalid_pit_pt.yml" }
-  let(:no_pit_name_file) { "no_pit_name.yml" }
-  let(:diff_pt_file) { "pit_existing_name_new_pt.yml" }
-  let(:ct_name) { "Basic root pass template" }
-  let(:ct_desc) { "This template takes use of rootpassword defined in the UI" }
-  let(:existing_pit_name) { "RHEL-6" }
-  let(:new_pit_name) { "RHEL-7" }
-  let(:new_pit_pt) { "vm" }
-
   describe "#import" do
+    let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'customization_templates') }
+    let(:ct_file) { "existing_ct_and_pit.yaml" }
+    let(:ct_name) { "Basic root pass template" }
+    let(:ct_desc) { "This template takes use of rootpassword defined in the UI" }
+    let(:existing_pit_name) { "RHEL-6" }
+    let(:new_pit_name) { "RHEL-7" }
+    let(:new_pit_pt) { "vm" }
     let(:options) { { :source => source } }
 
     describe "when the source is a directory" do
@@ -41,6 +35,7 @@ describe TaskHelpers::Imports::CustomizationTemplate do
     end
 
     describe "when the source file modifies an existing file" do
+      let(:update_file) { "update_existing.yml" }
       let(:source) { "#{data_dir}/#{update_file}" }
 
       before do
@@ -57,6 +52,7 @@ describe TaskHelpers::Imports::CustomizationTemplate do
 
     describe "when the source file has invalid settings" do
       describe "when :system is true" do
+        let(:ct_system_file) { "system_ct.yml" }
         let(:source) { "#{data_dir}/#{ct_system_file}" }
 
         it 'fails to import' do
@@ -67,6 +63,7 @@ describe TaskHelpers::Imports::CustomizationTemplate do
       end
 
       describe "when there is no :pxe_image_type[:name]" do
+        let(:no_pit_name_file) { "no_pit_name.yml" }
         let(:source) { "#{data_dir}/#{no_pit_name_file}" }
 
         it 'fails to import' do
@@ -77,6 +74,7 @@ describe TaskHelpers::Imports::CustomizationTemplate do
       end
 
       describe "when the :pxe_image_type[:provision_type] is invalid" do
+        let(:invalid_pt_file) { "invalid_pit_pt.yml" }
         let(:source) { "#{data_dir}/#{invalid_pt_file}" }
 
         it 'fails to import' do
@@ -87,6 +85,7 @@ describe TaskHelpers::Imports::CustomizationTemplate do
       end
 
       describe "when the :pxe_image_type[:name] is found with a different provision_type"
+      let(:diff_pt_file) { "pit_existing_name_new_pt.yml" }
       let(:source) { "#{data_dir}/#{diff_pt_file}" }
 
       before do
@@ -102,7 +101,6 @@ describe TaskHelpers::Imports::CustomizationTemplate do
   end
 
   def assert_test_ct_one_present(pit)
-    # pit = PxeImageType.find_by(:name => existing_pit_name)
     custom_template = CustomizationTemplate.find_by(:name => ct_name, :pxe_image_type => pit)
     expect(custom_template.description).to eq(ct_desc)
     expect(custom_template.pxe_image_type).to eq(pit)

--- a/spec/lib/task_helpers/imports/customization_templates_spec.rb
+++ b/spec/lib/task_helpers/imports/customization_templates_spec.rb
@@ -1,0 +1,124 @@
+describe TaskHelpers::Imports::CustomizationTemplate do
+  let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'customization_templates') }
+  let(:ct_file) { "existing_ct_and_pit.yaml" }
+  let(:update_file) { "update_existing.yml" }
+  let(:ct_system_file) { "system_ct.yml" }
+  let(:invalid_pt_file) { "invalid_pit_pt.yml" }
+  let(:no_pit_name_file) { "no_pit_name.yml" }
+  let(:diff_pt_file) { "pit_existing_name_new_pt.yml" }
+  let(:ct_name) { "Basic root pass template" }
+  let(:ct_desc) { "This template takes use of rootpassword defined in the UI" }
+  let(:existing_pit_name) { "RHEL-6" }
+  let(:new_pit_name) { "RHEL-7" }
+  let(:new_pit_pt) { "vm" }
+
+  describe "#import" do
+    let(:options) { { :source => source } }
+
+    describe "when the source is a directory" do
+      let(:source) { data_dir }
+
+      it 'imports all .yaml files in a specified directory' do
+        pit = PxeImageType.create(:name => existing_pit_name)
+        expect do
+          TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_ct_one_present(pit)
+        assert_test_ct_two_present
+      end
+    end
+
+    describe "when the source is a file" do
+      let(:source) { "#{data_dir}/#{ct_file}" }
+
+      it 'imports a specified file' do
+        pit = PxeImageType.create(:name => existing_pit_name)
+        expect do
+          TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_ct_one_present(pit)
+      end
+    end
+
+    describe "when the source file modifies an existing file" do
+      let(:source) { "#{data_dir}/#{update_file}" }
+
+      before do
+        TaskHelpers::Imports::CustomizationTemplates.new.import(:source => "#{data_dir}/#{ct_file}")
+      end
+
+      it 'modifies an existing customization template' do
+        expect do
+          TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+        end.to_not output.to_stderr
+        assert_test_ct_one_modified
+      end
+    end
+
+    describe "when the source file has invalid settings" do
+      describe "when :system is true" do
+        let(:source) { "#{data_dir}/#{ct_system_file}" }
+
+        it 'fails to import' do
+          expect do
+            TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+          end.to output.to_stderr
+        end
+      end
+
+      describe "when there is no :pxe_image_type[:name]" do
+        let(:source) { "#{data_dir}/#{no_pit_name_file}" }
+
+        it 'fails to import' do
+          expect do
+            TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+          end.to output.to_stderr
+        end
+      end
+
+      describe "when the :pxe_image_type[:provision_type] is invalid" do
+        let(:source) { "#{data_dir}/#{invalid_pt_file}" }
+
+        it 'fails to import' do
+          expect do
+            TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+          end.to output.to_stderr
+        end
+      end
+
+      describe "when the :pxe_image_type[:name] is found with a different provision_type"
+      let(:source) { "#{data_dir}/#{diff_pt_file}" }
+
+      before do
+        PxeImageType.create(:name => existing_pit_name)
+      end
+
+      it 'fails to import' do
+        expect do
+          TaskHelpers::Imports::CustomizationTemplates.new.import(options)
+        end.to output.to_stderr
+      end
+    end
+  end
+
+  def assert_test_ct_one_present(pit)
+    # pit = PxeImageType.find_by(:name => existing_pit_name)
+    custom_template = CustomizationTemplate.find_by(:name => ct_name, :pxe_image_type => pit)
+    expect(custom_template.description).to eq(ct_desc)
+    expect(custom_template.pxe_image_type).to eq(pit)
+  end
+
+  def assert_test_ct_two_present
+    pit             = PxeImageType.find_by(:name => new_pit_name, :provision_type => new_pit_pt)
+    custom_template = CustomizationTemplate.find_by(:name => ct_name, :pxe_image_type => pit)
+    expect(custom_template.description).to eq(ct_desc)
+    expect(custom_template.pxe_image_type).to eq(pit)
+  end
+
+  def assert_test_ct_one_modified
+    pit             = PxeImageType.find_by(:name => existing_pit_name)
+    custom_template = CustomizationTemplate.find_by(:name => ct_name, :pxe_image_type => pit)
+    expect(custom_template.description).to include("updated")
+    expect(custom_template.script).to include("This line added")
+  end
+end

--- a/spec/lib/task_helpers/imports/data/customization_templates/existing_ct_and_pit.yaml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/existing_ct_and_pit.yaml
@@ -1,0 +1,12 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+:type: CustomizationTemplateCloudInit
+:pxe_image_type:
+  :name: RHEL-6

--- a/spec/lib/task_helpers/imports/data/customization_templates/invalid_pit_pt.yml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/invalid_pit_pt.yml
@@ -1,0 +1,13 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+:type: CustomizationTemplateCloudInit
+:pxe_image_type:
+  :name: Invalid-Prov-Type
+  :provision_type: notgood

--- a/spec/lib/task_helpers/imports/data/customization_templates/new_ct_and_pit.yaml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/new_ct_and_pit.yaml
@@ -1,0 +1,13 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+:type: CustomizationTemplateCloudInit
+:pxe_image_type:
+  :name: RHEL-7
+  :provision_type: vm

--- a/spec/lib/task_helpers/imports/data/customization_templates/no_pit_name.yml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/no_pit_name.yml
@@ -1,0 +1,11 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+:type: CustomizationTemplateCloudInit
+:pxe_image_type: {}

--- a/spec/lib/task_helpers/imports/data/customization_templates/pit_existing_name_new_pt.yml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/pit_existing_name_new_pt.yml
@@ -1,0 +1,13 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+:type: CustomizationTemplateCloudInit
+:pxe_image_type:
+  :name: RHEL-6
+  :provision_type: vm

--- a/spec/lib/task_helpers/imports/data/customization_templates/system_ct.yml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/system_ct.yml
@@ -1,0 +1,12 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+:type: CustomizationTemplateCloudInit
+:system: true
+:pxe_image_type: {}

--- a/spec/lib/task_helpers/imports/data/customization_templates/update_existing.yml
+++ b/spec/lib/task_helpers/imports/data/customization_templates/update_existing.yml
@@ -1,0 +1,13 @@
+---
+:name: Basic root pass template
+:description: This template takes use of rootpassword defined in the UI updated
+:script: |-
+  #cloud-config
+  chpasswd:
+    list: |
+      root:<%= MiqPassword.decrypt(evm[:root_password]) %>
+    expire: False
+  This line added
+:type: CustomizationTemplateCloudInit
+:pxe_image_type:
+  :name: RHEL-6


### PR DESCRIPTION
These rake scripts and classes provide functionality for exporting/importing of the following ManageIQ object types:

- Customization Templates

This PR uses the framework that was implemented for PRs #14126, #15256, #16717, and others to export/import other ManageIQ object types.

These scripts are based on the CFME RH Consulting Scripts and are used by Red Hat consultants to enable storing customizations in Git and maintaining customizations between environments (e.g. dev/qa/prod) for an SDLC lifecycle.

Links [Optional]
----------------

* Tracking Issue: [Implement export/import functionality of Miq objects via command-line](#15350)

Steps for Testing/QA [Optional]
-------------------------------
**Exporting**

1. Create a directory for the exports 
```
mkdir /tmp/customization_templates
```
2. Export user defined customization templates 
```
vmdb
bin/rake evm:export:customization_templates -- --directory /tmp/customization_templates
```


**Importing**

1. Import all provision dialog yaml files in a directory
```
# vmdb
# bin/rake evm:import:customization_templates -- --source /tmp/customization_templates
```
2. or Import specific customization template yaml file
```
# vmdb
# bin/rake evm:import:customization_templates -- --source /tmp/customization_templates/Test_customization_template.yaml
```
