### PR TITLE
Allow providers to handle supports_

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,8 @@ class Provider < ApplicationRecord
   include EmsRefresh::Manager
   include TenancyMixin
 
+  include SupportsFeatureMixin
+
   belongs_to :tenant
   belongs_to :zone
   has_many :managers, :class_name => "ExtManagementSystem"


### PR DESCRIPTION
This helps Providers answer `supports_*?` questions 

An "Ems" for AnsibleTower returns a `Provider` and not an `InfraManager` / `CloudManager`.
That class did not have the mixin necessary to handle those questions.

This fixes an issue when calling ems#supports_streaming_refresh?

fixes https://github.com/ManageIQ/manageiq-api/pull/447 (among other failed builds)