### PR TITLE
Add best fit logic for transformations moving vms to openstack

### DIFF
--- a/app/models/transformation_mapping/cloud_best_fit.rb
+++ b/app/models/transformation_mapping/cloud_best_fit.rb
@@ -1,0 +1,20 @@
+class TransformationMapping
+  class CloudBestFit
+    attr_reader :source_vm, :destination_manager
+    def initialize(source_vm, destination_manager)
+      @source_vm = source_vm
+      @destination_manager = destination_manager
+    end
+
+    def available_fit_flavors
+      @available_fit_flavors ||= destination_manager.flavors.where(
+        :cpus   => source_vm.cpu_total_cores..Float::INFINITY,
+        :memory => (source_vm.hardware.memory_mb * 1.megabyte)..Float::INFINITY
+      ).order(:cpus, :memory)
+    end
+
+    def best_fit_flavor
+      available_fit_flavors.first
+    end
+  end
+end

--- a/spec/models/transformation_mapping/cloud_best_fit_spec.rb
+++ b/spec/models/transformation_mapping/cloud_best_fit_spec.rb
@@ -1,0 +1,37 @@
+describe TransformationMapping::CloudBestFit do
+  let(:ems)         { FactoryGirl.create(:ems_openstack) }
+  let(:vm)          { FactoryGirl.create(:vm_vmware, :hardware => vm_hardware) }
+  let(:vm_hardware) { FactoryGirl.create(:hardware, :cpu1x2, :ram1GB) }
+
+  subject { described_class.new(vm, ems) }
+
+  it "no flavors on the provider" do
+    expect(subject.available_fit_flavors).to match_array([])
+    expect(subject.best_fit_flavor).to be_nil
+  end
+
+  it "no flavors match" do
+    ems.flavors.create!(:cpus => 1, :memory => 512.megabytes)
+
+    expect(subject.available_fit_flavors).to match_array([])
+    expect(subject.best_fit_flavor).to be_nil
+  end
+
+  it "one flavor matches" do
+    ems.flavors.create!(:cpus => 2, :memory => 512.megabytes)
+    flavor = ems.flavors.create!(:cpus => 2, :memory => 1.gigabyte)
+
+    expect(subject.available_fit_flavors).to match_array([flavor])
+    expect(subject.best_fit_flavor).to eq(flavor)
+  end
+
+  it "multiple flavors match" do
+    ems.flavors.create!(:cpus => 2, :memory => 512.megabytes)
+    flavor1 = ems.flavors.create!(:cpus => 2, :memory => 1.gigabyte)
+    flavor2 = ems.flavors.create!(:cpus => 2, :memory => 2.gigabytes)
+    flavor3 = ems.flavors.create!(:cpus => 4, :memory => 1.gigabyte)
+
+    expect(subject.available_fit_flavors).to match_array([flavor1, flavor2, flavor3])
+    expect(subject.best_fit_flavor).to eq(flavor1)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/b90ZCyNm/183-extend-cf-api-for-mapping-of-osp-flavors-and-security-groups