### PR TITLE
[GAPRINDASHVILI] Remove doubled call to retire service parts in bundle

### DIFF
--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -7,8 +7,6 @@ module Service::RetirementManagement
   end
 
   def retire_service_resources
-    direct_service_children.each(&:retire_service_resources)
-
     service_resources.each do |sr|
       if sr.resource.respond_to?(:retire_now)
         $log.info("Retiring service resource for service: #{name} resource ID: #{sr.id}")


### PR DESCRIPTION
This isn't necessary on master because it's a no-op that is actually a TODO: https://github.com/ManageIQ/manageiq/blob/33d994ae207105a508d9e214d39d9ec66ac066dd/app/models/service/retirement_management.rb#L11 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1622652

We were previously calling service retirement on both direct_service_children and also service_resources which results in a doubled service retirement call for the parts. This removes the direct_service_children retirement call. 

Because this is gaprindashvili, it's important to note that this was pre-RAAR (retirement as a request). Thus, the changed code is in the old app/models/service/retirement_management.rb.  
