### PR TITLE
Skip tags without classification in assigments

### DIFF
--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -100,7 +100,8 @@ module AssignmentMixin
         result[:objects] << object unless object.nil?
       when :tag
         tag = Tag.find_by(:name => "/" + parts.join("/"))
-        result[:tags] << [Classification.find_by(:tag_id => tag.id), klass] if tag
+        classification = Classification.find_by(:tag_id => tag.id) if tag
+        result[:tags] << [classification, klass] if classification
       when :label
         label = if AssignmentMixin.escaped?(parts[1])
                   name = AssignmentMixin.unescape(parts[1])

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -100,7 +100,7 @@ module AssignmentMixin
         result[:objects] << object unless object.nil?
       when :tag
         tag = Tag.find_by(:name => "/" + parts.join("/"))
-        result[:tags] << [Classification.find_by(:tag_id => tag.id), klass] unless tag.nil?
+        result[:tags] << [Classification.find_by(:tag_id => tag.id), klass] if tag
       when :label
         label = if AssignmentMixin.escaped?(parts[1])
                   name = AssignmentMixin.unescape(parts[1])

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -79,28 +79,24 @@ describe AssignmentMixin do
   end
 
   describe "#get_assigned_tos" do
-    it "returns objects and tags" do
-      cc_classification = FactoryGirl.create(:classification_cost_center)
-      classification_tag = FactoryGirl.create(:classification_tag, :parent => cc_classification)
-      vm = FactoryGirl.create(:vm)
-      alert_set = FactoryGirl.create(:miq_alert_set)
+    let(:cc_classification)  { FactoryGirl.create(:classification_cost_center) }
+    let(:classification_tag) { FactoryGirl.create(:classification_tag, :parent => cc_classification) }
+    let(:vm)                 { FactoryGirl.create(:vm) }
+    let(:alert_set)          { FactoryGirl.create(:miq_alert_set) }
 
+    before do
       alert_set.assign_to_objects([vm])
       alert_set.assign_to_tags([classification_tag], "vms")
+    end
 
+    it "returns objects and tags" do
       assigned_tos = alert_set.get_assigned_tos
       expect(assigned_tos[:objects]).to include(vm)
       expect(assigned_tos[:tags]).to include([classification_tag, "vms"])
     end
 
     it "doesn't return tags when classification is missing" do
-      cc_classification = FactoryGirl.create(:classification_cost_center)
-      classification_tag = FactoryGirl.create(:classification_tag, :parent => cc_classification)
-      vm = FactoryGirl.create(:vm)
-      alert_set = FactoryGirl.create(:miq_alert_set)
       classification_tag.destroy
-      alert_set.assign_to_objects([vm])
-      alert_set.assign_to_tags([classification_tag], "vms")
 
       assigned_tos = alert_set.get_assigned_tos
       expect(assigned_tos[:objects]).to include(vm)

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -92,6 +92,20 @@ describe AssignmentMixin do
       expect(assigned_tos[:objects]).to include(vm)
       expect(assigned_tos[:tags]).to include([classification_tag, "vms"])
     end
+
+    it "doesn't return tags when classification is missing" do
+      cc_classification = FactoryGirl.create(:classification_cost_center)
+      classification_tag = FactoryGirl.create(:classification_tag, :parent => cc_classification)
+      vm = FactoryGirl.create(:vm)
+      alert_set = FactoryGirl.create(:miq_alert_set)
+      classification_tag.destroy
+      alert_set.assign_to_objects([vm])
+      alert_set.assign_to_tags([classification_tag], "vms")
+
+      assigned_tos = alert_set.get_assigned_tos
+      expect(assigned_tos[:objects]).to include(vm)
+      expect(alert_set.get_assigned_tos[:tags]).to be_empty
+    end
   end
 
   describe ".all_assignments" do


### PR DESCRIPTION
Not sure how this could be possible but I found it in customer's DB when I came to the 
CI -> Chargeback Assigments

it was causing issue here because ` ChargebackRate.get_assignments("Compute")` was returning:

`[[Classification object, "vm"], [nil, "vm"], ...]` and the such second element is  causing bug in UI.


@miq-bot assign @gtanzillo 
@miq-bot add_label chargeback, bug