### PR TITLE
Changes to CustomButtonEvent.

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -101,12 +101,15 @@ class CustomButton < ApplicationRecord
       :message    => 'Custom button launched',
       :source     => source,
       :target     => target,
+      :username   => args[:username],
       :user_id    => args[:user_id],
       :group_id   => args[:miq_group_id],
       :tenant_id  => args[:tenant_id],
       :full_data  => {
         :args                 => args,
-        :automate_entry_point => resource_action.ae_path
+        :automate_entry_point => resource_action.ae_path,
+        :button_id            => id,
+        :button_name          => name
       }
     )
   end

--- a/app/models/custom_button_event.rb
+++ b/app/models/custom_button_event.rb
@@ -1,2 +1,12 @@
 class CustomButtonEvent < EventStream
+  virtual_column :button_name, :type => :string
+  virtual_column :automate_entry_point, :type => :string
+
+  def automate_entry_point
+    full_data[:automate_entry_point].to_s
+  end
+
+  def button_name
+    CustomButton.find_by(:id => full_data[:button_id])&.name || full_data[:button_name].to_s
+  end
 end

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -3,6 +3,7 @@ module CustomActionsMixin
 
   included do
     has_many :custom_button_sets, :as => :owner, :dependent => :destroy
+    has_many :custom_button_events, -> { where(:type => "CustomButtonEvent") }, :class_name => "EventStream", :foreign_key => :target_id
     virtual_has_many :custom_buttons
     virtual_has_one :custom_actions, :class_name => "Hash"
     virtual_has_one :custom_action_buttons, :class_name => "Array"

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -38,6 +38,7 @@ class ResourceAction < ApplicationRecord
       args[:user_id] ||= user.id
       args[:miq_group_id] ||= user.current_group.id
       args[:tenant_id] ||= user.current_tenant.id
+      args[:username] ||= user.userid
     end
   end
 

--- a/spec/models/custom_button_event_spec.rb
+++ b/spec/models/custom_button_event_spec.rb
@@ -1,0 +1,42 @@
+describe CustomButtonEvent do
+  let(:custom_button) { FactoryGirl.create(:custom_button, :applies_to_class => "Vm", :name => "Test Button") }
+  let(:ae_entry_point) { "/SYSTEM/PROCESS/Request" }
+  let(:cb_event) do
+    FactoryGirl.create(:custom_button_event,
+                       :full_data => {
+                         :automate_entry_point => ae_entry_point,
+                         :button_id            => custom_button.id,
+                         :button_name          => custom_button.name
+                       })
+  end
+
+  context '#automate_entry_point' do
+    it 'returns a string' do
+      expect(cb_event.automate_entry_point).to eq(ae_entry_point)
+    end
+
+    it 'returns an empty string' do
+      cb_event.full_data.delete(:automate_entry_point)
+      cb_event.save!
+
+      expect(cb_event.automate_entry_point).to eq("")
+    end
+  end
+
+  context '#button_name' do
+    it "returns button's current name" do
+      expect(cb_event.button_name).to eq("Test Button")
+
+      custom_button.update_attributes(:name => "New Button Name")
+      expect(cb_event.button_name).to eq("New Button Name")
+    end
+
+    it 'returns button name from event data' do
+      cb_event.full_data[:button_id] = custom_button.id - 1
+      cb_event.save!
+      custom_button.update_attributes(:name => "New Button Name")
+
+      expect(cb_event.button_name).to eq("Test Button")
+    end
+  end
+end

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -14,6 +14,7 @@ describe ResourceAction do
         :user_id          => user.id,
         :miq_group_id     => user.current_group.id,
         :tenant_id        => user.current_tenant.id,
+        :username         => user.userid,
         :attrs            => ae_attributes,
       }
     end


### PR DESCRIPTION
Add association of CustomButtonEvent to its supporting classes.
Add button name and automate entry point virtual columns to CustomButtonEvent.

Followup of https://github.com/ManageIQ/manageiq/pull/17764.

https://bugzilla.redhat.com/show_bug.cgi?id=1511126

@miq-bot assign @gmcculloug 
@miq-bot add_label automate, enhancement, events

cc @h-kataria 