### PR TITLE
Move log dir creation location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
 addons:
   postgresql: '9.5'
 before_install:
-- mkdir ${TRAVIS_BUILD_DIR}/log
 - source ${TRAVIS_BUILD_DIR}/tools/ci/before_install.sh
 before_script:
 - bundle exec rake test:$TEST_SUITE:setup

--- a/bin/setup
+++ b/bin/setup
@@ -16,7 +16,6 @@ end
 
 Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.ensure_config_files
-  Dir.mkdir("log") unless File.exist?("log")
 
   puts '== Installing dependencies =='
   ManageIQ::Environment.install_bundler

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -39,6 +39,9 @@ module ManageIQ
         puts "Copying #{file} from template..."
         FileUtils.cp(APP_ROOT.join(source), file)
       end
+
+      logdir = APP_ROOT.join("log")
+      Dir.mkdir(logdir) unless Dir.exist?(logdir)
     end
 
     def self.while_updating_bower


### PR DESCRIPTION
in ab4fa873 we removed the creation of the log directory
In production / appliances, we don't want an actual
log directory.

Unfortunatly the current solution caused issues for
plugins

Instead, the log creation was moved to the environment setup.
So all plugins travis builds will get the benefit

changes https://github.com/ManageIQ/manageiq/pull/17663

ASIDE: I do wish this was parallel to the `ensure_config_files` method. But this method is part of `bin/setup`, `bin/update`, and the travis build processes (both master, ui, and plugins) - so this should fix it. And it isn't too out of place. (thanks @himdel for the pointer)