### PR TITLE
Add possibility to group by date only in chargeback

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -68,6 +68,8 @@ class Chargeback < ActsAsArModel
     elsif @options.group_by_tenant?
       tenant = @options.tenant_for(consumption)
       "#{tenant ? tenant.id : 'none'}_#{ts_key}"
+    elsif @options.group_by_date_only?
+      ts_key
     else
       default_key(consumption, ts_key)
     end
@@ -151,8 +153,19 @@ class Chargeback < ActsAsArModel
     end
   end
 
+  def calculate_fixed_compute_metric(consumption)
+    return unless consumption.chargeback_fields_present
+
+    if @options.group_by_date_only?
+      self.fixed_compute_metric ||= 0
+      self.fixed_compute_metric += consumption.chargeback_fields_present
+    else
+      self.fixed_compute_metric = consumption.chargeback_fields_present
+    end
+  end
+
   def calculate_costs(consumption, rates)
-    self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
+    calculate_fixed_compute_metric(consumption)
     self.class.try(:refresh_dynamic_metric_columns)
 
     rates.each do |rate|
@@ -185,7 +198,9 @@ class Chargeback < ActsAsArModel
   def self.set_chargeback_report_options(rpt, group_by, header_for_tag, groupby_label, tz)
     rpt.cols = %w(start_date display_range)
 
-    static_cols       = group_by == "project" ? report_static_cols - ["image_name"] : report_static_cols
+    static_cols       = report_static_cols
+    static_cols      -= ["image_name"] if group_by == "project"
+    static_cols      -= ["vm_name"] if group_by == "date-only"
     static_cols       = group_by == "tag" ? [report_tag_field] : static_cols
     static_cols       = group_by == "label" ? [report_label_field] : static_cols
     static_cols       = group_by == "tenant" ? ['tenant_name'] : static_cols

--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -19,6 +19,7 @@ class Chargeback
     :include_metrics,      # enable charging allocated resources with C & U
     :method_for_allocated_metrics,
     :group_by_tenant?,
+    :group_by_date_only?,
     :cumulative_rate_calculation,
   ) do
     def self.new_from_h(hash)
@@ -143,6 +144,10 @@ class Chargeback
 
     def group_by_tenant?
       self[:groupby] == 'tenant'
+    end
+
+    def group_by_date_only?
+      self[:groupby] == 'date-only'
     end
 
     private


### PR DESCRIPTION
Backend part for https://github.com/ManageIQ/manageiq-ui-classic/pull/4523

Option group by date and by vm had identical behaviour. This PR adds backend part to reach report grouped only per day(vm name is removed):

![screen shot 2018-08-22 at 18 48 51](https://user-images.githubusercontent.com/14937244/44477852-298aa200-a63c-11e8-8f5f-7274342a771d.png)

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1530221
* https://github.com/ManageIQ/manageiq-ui-classic/pull/4523 
* https://github.com/ManageIQ/manageiq-ui-classic/pull/4517

@miq-bot add_label gaprindashvili/yes, chargeback, improvement
@miq-bot assign @gtanzillo 
