### PR TITLE
Add CiFeatureMixin

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::Providers::EmbeddedAutomationManager::OrchestrationStack
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Job
+  include CiFeatureMixin
 
   require_nested :Status
 
@@ -18,5 +19,9 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
     end
 
     super(userid, format, 'embedded_ansible')
+  end
+
+  def retireable?
+    false
   end
 end

--- a/app/models/mixins/ci_feature_mixin.rb
+++ b/app/models/mixins/ci_feature_mixin.rb
@@ -1,7 +1,5 @@
 module CiFeatureMixin
-  extend ActiveSupport::Concern
-
   def retireable?
-    resource.present? && resource.respond_to?(:retire_now) && resource.type.present?
+    true
   end
 end

--- a/app/models/mixins/ci_feature_mixin.rb
+++ b/app/models/mixins/ci_feature_mixin.rb
@@ -1,0 +1,7 @@
+module CiFeatureMixin
+  extend ActiveSupport::Concern
+
+  def retireable?
+    resource.present? && resource.respond_to?(:retire_now) && resource.type.present?
+  end
+end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -11,6 +11,7 @@ class OrchestrationStack < ApplicationRecord
   include TenantIdentityMixin
   include CustomActionsMixin
   include SupportsFeatureMixin
+  include CiFeatureMixin
 
   acts_as_miq_taggable
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -66,6 +66,7 @@ class Service < ApplicationRecord
   include ProcessTasksMixin
   include TenancyMixin
   include SupportsFeatureMixin
+  include CiFeatureMixin
   include Metric::CiMixin
 
   include_concern 'RetirementManagement'

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -215,6 +215,10 @@ class Service < ApplicationRecord
     children.present?
   end
 
+  def retireable?
+    type.present?
+  end
+
   def atomic?
     children.empty?
   end

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -32,7 +32,7 @@ class ServiceRetireTask < MiqRetireTask
   def create_retire_subtasks(parent_service)
     parent_service.direct_service_children.each { |child| create_retire_subtasks(child) }
     parent_service.service_resources.collect do |svc_rsc|
-      next unless svc_rsc.try(:retireable?)
+      next unless svc_rsc.resource.try(:retireable?)
       # TODO: the next line deals with the filtering for provisioning
       # (https://github.com/ManageIQ/manageiq/blob/3921e87915b5a69937b9d4a70bb24ab71b97c165/app/models/service_template/filter.rb#L5)
       # which should be extended to retirement as part of later work

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -32,7 +32,11 @@ class ServiceRetireTask < MiqRetireTask
   def create_retire_subtasks(parent_service)
     parent_service.direct_service_children.each { |child| create_retire_subtasks(child) }
     parent_service.service_resources.collect do |svc_rsc|
-      next unless retireable?(svc_rsc, parent_service)
+      next unless svc_rsc.try(:retireable?)
+      # TODO: the next line deals with the filtering for provisioning
+      # (https://github.com/ManageIQ/manageiq/blob/3921e87915b5a69937b9d4a70bb24ab71b97c165/app/models/service_template/filter.rb#L5)
+      # which should be extended to retirement as part of later work
+      # svc_rsc.resource_type != "ServiceTemplate" || self.class.include_service_template?(self, srr.id, parent_service)
       nh = attributes.except("id", "created_on", "updated_on", "type", "state", "status", "message")
       nh['options'] = options.except(:child_tasks)
       # Initial Options[:dialog] to an empty hash so we do not pass down dialog values to child services tasks
@@ -43,14 +47,6 @@ class ServiceRetireTask < MiqRetireTask
       new_task.deliver_to_automate
       new_task
     end.compact!
-  end
-
-  def retireable?(svc_rsc, parent_service)
-    srr = svc_rsc.resource
-    srr.present? &&
-      srr.respond_to?(:retire_now) &&
-      srr.type.present? &&
-      (svc_rsc.resource_type != "ServiceTemplate" || self.class.include_service_template?(self, srr.id, parent_service))
   end
 
   def create_task(svc_rsc, parent_service, nh)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -41,6 +41,7 @@ class ServiceTemplate < ApplicationRecord
   include NewWithTypeStiMixin
   include TenancyMixin
   include ArchivedMixin
+  include CiFeatureMixin
   include_concern 'Filter'
 
   belongs_to :tenant

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -7,6 +7,7 @@ class Vm < VmOrTemplate
 
   extend InterRegionApiMethodRelay
   include CustomActionsMixin
+  include CiFeatureMixin
 
   include_concern 'Operations'
 

--- a/spec/models/mixins/ci_feature_mixin_spec.rb
+++ b/spec/models/mixins/ci_feature_mixin_spec.rb
@@ -1,0 +1,41 @@
+describe CiFeatureMixin do
+  let(:service) { FactoryGirl.create(:service) }
+  describe "#retireable?" do
+    it "vm is retireable" do
+      FactoryGirl.create(:service_resource, :service => service, :resource => FactoryGirl.create(:vm))
+
+      expect(service.service_resources.first.resource.retireable?).to eq(true)
+    end
+
+    it "orchestration stack is retireable" do
+      FactoryGirl.create(:service_resource, :service => service, :resource => FactoryGirl.create(:orchestration_stack_amazon))
+
+      expect(service.service_resources.first.resource.retireable?).to eq(true)
+    end
+
+    it "job not retireable" do
+      FactoryGirl.create(:service_resource, :service => service, :resource => FactoryGirl.create(:embedded_ansible_job))
+
+      expect(service.service_resources.first.resource.retireable?).to eq(false)
+    end
+
+    context "service" do
+      context "with type" do
+        let(:service1) { FactoryGirl.create(:service_ansible_tower, :type => ServiceAnsibleTower) }
+        it "is retireable" do
+          FactoryGirl.create(:service_resource, :service => service, :resource => service1)
+
+          expect(service.service_resources.first.resource.retireable?).to eq(true)
+        end
+      end
+
+      context "without type" do
+        it "is not retireable" do
+          FactoryGirl.create(:service_resource, :service => service, :resource => FactoryGirl.create(:service))
+
+          expect(service.service_resources.first.resource.retireable?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -97,58 +97,6 @@ describe ServiceRetireTask do
     end
   end
 
-  describe "#retireable?" do
-    include_context "service_bundle"
-
-    context "without srr" do
-      it "is not retireable" do
-        service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service_c1.id, :resource_id => nil)
-        @service_retire_task = FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => nil, :miq_request_id => @miq_request.id, :options => {:src_ids => [service.id] })
-
-        expect(@service_retire_task.retireable?(service.service_resources.first, service)).to be(false)
-      end
-    end
-
-    context "srr nonresponsive to retireable?" do
-      it "is not retireable" do
-        service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service_c1.id, :resource_id => User.first.id)
-        @service_retire_task = FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => nil, :miq_request_id => @miq_request.id, :options => {:src_ids => [service.id] })
-
-        expect(@service_retire_task.retireable?(service.service_resources.first, service)).to be(false)
-      end
-    end
-
-    context "srr sans type" do
-      let(:vm_without_type) { FactoryGirl.create(:vm, :type => nil) }
-      it "is not retireable" do
-        service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service_c1.id, :resource_id => vm_without_type.id)
-        @service_retire_task = FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => nil, :miq_request_id => @miq_request.id, :options => {:src_ids => [service.id] })
-
-        expect(@service_retire_task.retireable?(service.service_resources.first, service)).to be(false)
-      end
-    end
-
-    context "svc_rsc resource_type is not ServiceTemplate" do
-      it "is not retireable" do
-        service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service_c1.id, :resource_id => service_c1.id)
-        @service_retire_task = FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => nil, :miq_request_id => @miq_request.id, :options => {:src_ids => [service.id] })
-        allow(@service_retire_task.class).to receive(:include_service_template?).with(@service_retire_task, service.service_resources.first.id, service).and_return(true)
-
-        expect(@service_retire_task.retireable?(service.service_resources.first, service)).to be(false)
-      end
-    end
-
-    context "class includes service template" do
-      it "is not retireable" do
-        service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "ServiceTemplate", :service_id => service_c1.id, :resource_id => vm.id)
-        @service_retire_task = FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => nil, :miq_request_id => @miq_request.id, :options => {:src_ids => [service.id] })
-        allow(@service_retire_task.class).to receive(:include_service_template?).with(@service_retire_task, service.service_resources.first.id, service).and_return(false)
-
-        expect(@service_retire_task.retireable?(service.service_resources.first, service)).to be(false)
-      end
-    end
-  end
-
   describe "deliver_to_automate" do
     before do
       allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1614356

All the [checks for whether a service resource is of the right type to create subtasks](https://github.com/ManageIQ/manageiq/blob/master/app/models/service_retire_task.rb#L48) should really be pushed down into the classes themselves. Per conversation on Aug 22nd, Wednesday, with @tinaafitz and @mkanoor, we determined that this logic belongs in a mixin ... so this is creation of that mixin.

The name is due to the fact that this mixin can also be used later to implement a reconfigureable method on services and vms and all ci things. 

The check on line 53 in the linked file needs to be returned to at a later time, it's for filtering code that applies only to provisioning at the moment as explained [here](https://github.com/ManageIQ/manageiq/pull/17896/files#diff-013d241c8182c4fc2d05399f2657e09bR36)