### PR TITLE
relationships: remove duplicate method calls

### DIFF
--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -127,7 +127,7 @@ module RelationshipMixin
   def parent_rels(*args)
     options = args.extract_options!
     pri = parent_rel_ids
-    rels = pri.kind_of?(Array) && pri.empty? ? Relationship.none : Relationship.where(:id => parent_rel_ids)
+    rels = pri.kind_of?(Array) && pri.empty? ? Relationship.none : Relationship.where(:id => pri)
     Relationship.filter_by_resource_type(rels, options)
   end
 
@@ -504,7 +504,6 @@ module RelationshipMixin
     options = args.extract_options!
     root_id = relationship.try(:root_id)
     return {relationship_for_isolated_root => {}} if root_id.nil?
-    Relationship.subtree_of(root_id).arrange
     Relationship.filter_by_resource_type(Relationship.subtree_of(root_id), options).arrange
   end
 


### PR DESCRIPTION
over refactoring/rebasing, looks like a few methods are
getting called twice

`parent_rel_ids` are cached, so the duplicate call, while unnecessary, will probably not be that big of a deal.

`MiqRequestWorkflow#get_ems_metadata_tree` is probably the main benefactor since the nodes will not need to be arranged twice in `fulltree_rels_arranged` - possibly even avoiding a query