### PR TITLE
Populate timestamp of CustomButtonEvent.

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -105,6 +105,7 @@ class CustomButton < ApplicationRecord
       :user_id    => args[:user_id],
       :group_id   => args[:miq_group_id],
       :tenant_id  => args[:tenant_id],
+      :timestamp  => Time.now.utc,
       :full_data  => {
         :args                 => args,
         :automate_entry_point => resource_action.ae_path,

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -306,7 +306,10 @@ describe CustomButton do
     %i(invoke invoke_async).each do |method|
       describe "##{method}" do
         it "publishes CustomButtonEvent" do
-          User.with_user(user) { custom_button.send(method, vm, 'UI') }
+          Timecop.freeze(Time.now.utc) do
+            User.with_user(user) { custom_button.send(method, vm, 'UI') }
+            expect(CustomButtonEvent.first.timestamp).to be_within(0.01).of(Time.now.utc)
+          end
 
           expect(CustomButtonEvent.count).to eq(1)
           expect(CustomButtonEvent.first).to have_attributes(


### PR DESCRIPTION
A timestamp without value would break MiqReport.

Followup of #17764.

https://bugzilla.redhat.com/show_bug.cgi?id=1511126

@miq-bot assign @gmcculloug
@miq-bot add_label automate, enhancement, events
cc @skateman 