### PR TITLE
Inform Rails that SecurityGroup now belongs to Router/Subnet

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -18,6 +18,7 @@ class CloudSubnet < ApplicationRecord
   has_many :network_ports, :through => :cloud_subnet_network_ports, :dependent => :destroy
   has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
   has_many :cloud_subnets, :foreign_key => :parent_cloud_subnet_id
+  has_many :security_groups, :dependent => :nullify
 
   has_one :public_network, :through => :network_router, :source => :cloud_network
 

--- a/app/models/network_router.rb
+++ b/app/models/network_router.rb
@@ -17,6 +17,7 @@ class NetworkRouter < ApplicationRecord
 
   has_many :floating_ips, :through => :cloud_network
   has_many :cloud_networks, -> { distinct }, :through => :cloud_subnets
+  has_many :security_groups, :dependent => :nullify
 
   alias private_networks cloud_networks
   alias public_network cloud_network

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -11,6 +11,8 @@ class SecurityGroup < ApplicationRecord
   belongs_to :cloud_tenant
   belongs_to :orchestration_stack
   belongs_to :network_group
+  belongs_to :cloud_subnet
+  belongs_to :network_router
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy
 
   has_many :network_port_security_groups, :dependent => :destroy


### PR DESCRIPTION
With this commit we inform Rails about the two new foreign keys on `:security_groups table`:

```ruby
security_group.cloud_subnet
security_group.network_router

cloud_subnet.security_groups
network_router.security_groups
```

Related schema PR: https://github.com/ManageIQ/manageiq-schema/pull/258 (already merged)

@miq-bot add_label enhancement
@miq-bot assign @agrare 

