### PR TITLE
Lock down trollop gem to v2.1.3, since it is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "rugged",                         "~>0.25.0",      :require => false
 gem "simple-rss",                     "~>1.3.1",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sqlite3",                                         :require => false
-gem "trollop",                        "~>2.0",         :require => false
+gem "trollop",                        "~>2.1.3",       :require => false
 
 # Modified gems (forked on Github)
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"


### PR DESCRIPTION
trollop is deprecated, and ManageIQ's loose versioning is pulling in the deprecated version which will show warnings on usage.

A separate PR is needed to bump to https://github.com/ManageIQ/optimist

@kbrock Please review.