### PR TITLE
Fix sporadic failure  in roles_spec

### DIFF
--- a/spec/lib/task_helpers/imports/roles_spec.rb
+++ b/spec/lib/task_helpers/imports/roles_spec.rb
@@ -71,7 +71,7 @@ describe TaskHelpers::Imports::Roles do
     r = MiqUserRole.find_by(:name => role_two_name)
     expect(r.name).to eq(role_two_name)
     expect(r.read_only).to be false
-    expect(r.feature_identifiers).to eq(%w(dashboard vm))
+    expect(r.feature_identifiers).to match_array(%w(dashboard vm))
     expect(r.settings).to be nil
   end
 end


### PR DESCRIPTION
to avoid sporadic failures caused by unspecified orderding

## Links 

* https://travis-ci.org/ManageIQ/manageiq/jobs/421114934

@miq-bot assign @jrafanie 

@miq-bot add_label sporadic failure, test