### PR TITLE
Remove compatibility ManagerRefresh::Inventory

### DIFF
--- a/app/models/manager_refresh/inventory.rb
+++ b/app/models/manager_refresh/inventory.rb
@@ -1,5 +1,0 @@
-class ManagerRefresh::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-end

--- a/app/models/manager_refresh/inventory/collector.rb
+++ b/app/models/manager_refresh/inventory/collector.rb
@@ -1,2 +1,0 @@
-class ManagerRefresh::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-end

--- a/app/models/manager_refresh/inventory/parser.rb
+++ b/app/models/manager_refresh/inventory/parser.rb
@@ -1,2 +1,0 @@
-class ManagerRefresh::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-end

--- a/app/models/manager_refresh/inventory/persister.rb
+++ b/app/models/manager_refresh/inventory/persister.rb
@@ -1,2 +1,0 @@
-class ManagerRefresh::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-end


### PR DESCRIPTION
Remove the temporary compatibility library ManagerRefresh::Inventory in
favor of ManageIQ::Providers::Inventory so that the rest of
ManagerRefresh can be extracted.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/284
- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/24
- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/137
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/114
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/121
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/478
- [x] https://github.com/ManageIQ/manageiq-providers-dummy_provider/pull/15