### PR TITLE
Send link with the text_bindings in notifications when link_to is set

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -83,13 +83,17 @@ class Notification < ApplicationRecord
   def text_bindings
     [:initiator, :subject, :cause].each_with_object(text_bindings_dynamic) do |key, result|
       value = public_send(key)
+      next unless value
+
+      # Set the link based on the notification_type.link_to
+      result[:link] = {
+        :id    => value.id,
+        :model => value.class.name
+      } if notification_type.link_to.try(:to_sym) == key
+
       result[key] = {
-        :link => {
-          :id    => value.id,
-          :model => value.class.name,
-        },
         :text => value.try(:name) || value.try(:description)
-      } if value
+      }
     end
   end
 

--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -9,6 +9,7 @@ class NotificationType < ApplicationRecord
   has_many :notifications
   validates :message, :presence => true
   validates :level, :inclusion => { :in => %w(success error warning info) }
+  validates :link_to, :inclusion => { :in => %w(subject initiator cause) }, :allow_blank => true
   validates :audience, :inclusion => {
     :in => [AUDIENCE_USER, AUDIENCE_GROUP, AUDIENCE_TENANT, AUDIENCE_GLOBAL, AUDIENCE_SUPERADMIN]
   }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -106,11 +106,21 @@ describe Notification, :type => :model do
         :level      => notification.notification_type.level,
         :created_at => notification.created_at,
         :text       => notification.notification_type.message,
-        :bindings   => a_hash_including(:initiator => a_hash_including(:text => user.name,
-                                                                       :link => a_hash_including(:id, :model)),
+        :bindings   => a_hash_including(:initiator => a_hash_including(:text => user.name),
                                         :extra     => a_hash_including(:text => 'information')
                                        )
       )
+    end
+
+    context 'link_to is set' do
+      let(:notification) do
+        FactoryGirl.create(:notification, :initiator         => user,
+                                          :notification_type => FactoryGirl.create(:notification_type, :link_to => 'initiator'))
+      end
+
+      it 'contains the link to the initiator' do
+        expect(notification.to_h).to include(:bindings => a_hash_including(:link => a_hash_including(:model => 'User', :id => user.id)))
+      end
     end
 
     context "subject text" do


### PR DESCRIPTION
Each notification can have a `subject`, `initiator` and a `cause` relation. Each of these are polymorphic and can point to a given entity. When displaying a notification, we would like to have a *View details* link that could redirect to one of these entities. This can be specified at the [notification type](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/notification_types.yml) declaration by setting the [`link_to`](https://github.com/ManageIQ/manageiq-schema/pull/263) parameter.

Based on this parameter I adjusted the `text_bindings` to have at most a single `link` attribute if the `link_to` is set properly to one of the possible values.

Related issue: https://github.com/ManageIQ/manageiq-v2v/issues/578
Depends on: https://github.com/ManageIQ/manageiq-schema/pull/263
UI part: https://github.com/ManageIQ/manageiq-ui-classic/pull/4492

@miq-bot add_label gaprindashvili/no