### PR TITLE
Add methods to access graph refresh settings

### DIFF
--- a/app/models/manageiq/providers/base_manager/manager_refresher.rb
+++ b/app/models/manageiq/providers/base_manager/manager_refresher.rb
@@ -39,7 +39,7 @@ module ManageIQ
 
           _log.info("Filtering inventory for #{target.class} [#{target_name}] id: [#{target.id}]...")
 
-          if refresher_options.try(:[], :inventory_object_refresh)
+          if inventory_object_refresh?
             inventory = builder_class_for(ems.class).build_inventory(ems, target)
           end
 
@@ -62,7 +62,7 @@ module ManageIQ
         log_header = format_ems_for_logging(ems)
         _log.debug("#{log_header} Parsing inventory...")
         hashes_or_persister, = Benchmark.realtime_block(:parse_inventory) do
-          if refresher_options.try(:[], :inventory_object_refresh)
+          if inventory_object_refresh?
             inventory.parse
           else
             parsed, _ = Benchmark.realtime_block(:parse_legacy_inventory) { parse_legacy(ems) }
@@ -89,7 +89,7 @@ module ManageIQ
           all_targets, sub_ems_targets = targets.partition { |x| x.kind_of?(ExtManagementSystem) }
 
           unless sub_ems_targets.blank?
-            if refresher_options.try(:[], :allow_targeted_refresh)
+            if allow_targeted_refresh?
               # We can disable targeted refresh with a setting, then we will just do full ems refresh on any event
               ems_event_collection = ManagerRefresh::TargetCollection.new(:targets    => sub_ems_targets,
                                                                           :manager_id => ems_id)

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -132,7 +132,7 @@ module ManageIQ
         # override this method and return an array of:
         #   [[target1, inventory_for_target1], [target2, inventory_for_target2]]
 
-        return [[ems, nil]] unless refresher_options.inventory_object_refresh
+        return [[ems, nil]] unless inventory_object_refresh?
 
         provider_module = ManageIQ::Providers::Inflector.provider_module(ems.class).name
 
@@ -251,6 +251,14 @@ module ManageIQ
 
       def format_ems_for_logging(ems)
         "EMS: [#{ems.name}], id: [#{ems.id}]"
+      end
+
+      def inventory_object_refresh?
+        refresher_options.try(:[], :inventory_object_refresh)
+      end
+
+      def allow_targeted_refresh?
+        refresher_options.try(:[], :allow_targeted_refresh)
       end
     end
   end


### PR DESCRIPTION
Add some methods to the base manager refresher to access graph refresh
settings instead of the same logic sprinkled around.