### PR TITLE
Do not duplicate same notification if user belongs to several groups

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -26,7 +26,7 @@ class NotificationType < ApplicationRecord
         subject.tenant
       elsif initiator.kind_of?(User)
         initiator.current_tenant
-      end.try(:user_ids)
+      end.try(:user_ids).try(:uniq)
     when AUDIENCE_SUPERADMIN
       User.superadmins.pluck(:id)
     when AUDIENCE_NONE

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -36,6 +36,11 @@ describe Notification, :type => :model do
         expect(user.unseen_notifications.count).to eq(1)
       end
 
+      it 'creates single record in notification_recipients table if recipent user belongs to several groups' do
+        user.miq_groups << FactoryGirl.create(:miq_group, :tenant => tenant)
+        expect(subject.recipients).to match_array([user])
+      end
+
       context 'asynchronous notifications' do
         before { stub_settings(:server => {:asynchronous_notifications => async}) }
         context 'enabled' do

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -13,7 +13,7 @@ describe NotificationType, :type => :model do
     end
   end
 
-  describe '#subscribers' do
+  describe '#subscribers_ids' do
     let(:user1) { FactoryGirl.create(:user) }
     let(:tenant2) { FactoryGirl.create(:tenant) }
     let!(:user2) { FactoryGirl.create(:user_with_group, :tenant => tenant2) }
@@ -36,6 +36,10 @@ describe NotificationType, :type => :model do
     context 'tenant specific notification type' do
       let(:notification) { FactoryGirl.create(:notification_type, :audience => 'tenant') }
       it 'returns the users in the tenant same tenant as concerned vm' do
+        is_expected.to match_array([user2.id])
+      end
+      it "returns single id if user belongs to different group" do
+        user2.miq_groups << FactoryGirl.create(:miq_group, :tenant => tenant2)
         is_expected.to match_array([user2.id])
       end
     end


### PR DESCRIPTION
**Issue**: When receiver of `Notification` is tenant and some user belongs to several group than that user receive the same notification  multiple times (for each group user belongs to)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1549898

@miq-bot add-label bug, core