### PR TITLE
Add a patch to ActiveRecord::Migration for tracking replicated migrations

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -113,8 +113,12 @@ class MiqRegion < ApplicationRecord
             _("Region [%{region_id}] does not match the database's region [%{db_id}]") % {:region_id => my_region_id,
                                                                                           :db_id     => db_region_id}
     end
+    create_params = {
+      :description    => "Region #{my_region_id}",
+      :migrations_ran => ActiveRecord::SchemaMigration.normalized_versions
+    }
 
-    create_with(:description => "Region #{my_region_id}").find_or_create_by!(:region => my_region_id) do
+    create_with(create_params).find_or_create_by!(:region => my_region_id) do
       _log.info("Creating Region [#{my_region_id}]")
     end
   end

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,0 +1,45 @@
+module ArPglogicalMigration
+  module ArPglogicalMigrationHelper
+    def self.migrations_column_present?
+      ActiveRecord::Base.connection.columns("miq_regions").any? { |c| c.name == "migrations_ran" }
+    end
+
+    def self.wait_for_remote_region_migration(subscription, version, wait_time = 1)
+      return unless ArPglogicalMigrationHelper.migrations_column_present?
+      region = MiqRegion.find_by(:region => subscription.provider_region)
+      until region.migrations_ran&.include?(version)
+        subscription.disable
+        subscription.enable
+        sleep(wait_time)
+        region.reload
+      end
+    end
+
+    def self.update_local_migrations_ran(version, direction)
+      return unless ArPglogicalMigrationHelper.migrations_column_present?
+      return unless (region = MiqRegion.my_region)
+
+      new_migrations = ActiveRecord::SchemaMigration.normalized_versions
+      new_migrations << version if direction == :up
+      migrations_value = ActiveRecord::Base.connection.quote(PG::TextEncoder::Array.new.encode(new_migrations))
+
+      ActiveRecord::Base.connection.exec_query(<<~SQL)
+        UPDATE miq_regions
+        SET migrations_ran = #{migrations_value}
+        WHERE id = #{region.id}
+      SQL
+    end
+  end
+
+  def migrate(direction)
+    PglogicalSubscription.all.each do |s|
+      ArPglogicalMigrationHelper.wait_for_remote_region_migration(s, version.to_s)
+    end
+
+    ret = super
+    ArPglogicalMigrationHelper.update_local_migrations_ran(version.to_s, direction)
+    ret
+  end
+end
+
+ActiveRecord::Migration.prepend(ArPglogicalMigration)

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -15,7 +15,7 @@ module ArPglogicalMigration
     end
 
     def self.wait_for_remote_region_migration(subscription, version, wait_time = 1)
-      return unless ArPglogicalMigrationHelper.migrations_column_present?
+      return unless migrations_column_present?
       region = MiqRegion.find_by(:region => subscription.provider_region)
       until region.migrations_ran&.include?(version)
         restart_subscription(subscription)
@@ -25,7 +25,7 @@ module ArPglogicalMigration
     end
 
     def self.update_local_migrations_ran(version, direction)
-      return unless ArPglogicalMigrationHelper.migrations_column_present?
+      return unless migrations_column_present?
       return unless (region = MiqRegion.my_region)
 
       new_migrations = ActiveRecord::SchemaMigration.normalized_versions

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -38,7 +38,8 @@ module ArPglogicalMigration
     attr_reader :region, :subscription, :version
 
     def initialize(subscription, version)
-      @region       = MiqRegion.find_by(:region => subscription.provider_region)
+      region_class  = Class.new(ApplicationRecord) { self.table_name = "miq_regions" }
+      @region       = region_class.find_by(:region => subscription.provider_region)
       @subscription = subscription
       @version      = version
     end

--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -5,6 +5,7 @@ module ArPglogicalMigration
     end
 
     def self.my_region_number
+      # Use ApplicationRecord here because we need to query region information
       @my_region_number ||= ApplicationRecord.my_region_number
     end
 
@@ -38,7 +39,7 @@ module ArPglogicalMigration
     attr_reader :region, :subscription, :version
 
     def initialize(subscription, version)
-      region_class  = Class.new(ApplicationRecord) { self.table_name = "miq_regions" }
+      region_class  = Class.new(ActiveRecord::Base) { self.table_name = "miq_regions" }
       @region       = region_class.find_by(:region => subscription.provider_region)
       @subscription = subscription
       @version      = version

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -48,6 +48,7 @@ describe ArPglogicalMigration::ArPglogicalMigrationHelper do
       let(:subscription) { double("Subscription", :enable => nil, :disable => nil, :provider_region => my_region.region) }
 
       it "sleeps until the migration is added" do
+        allow(described_class).to receive(:restart_subscription)
         my_region.update_attributes!(:migrations_ran => nil)
         t = Thread.new do
           Thread.current.abort_on_exception = true

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -1,0 +1,89 @@
+describe ArPglogicalMigration::ArPglogicalMigrationHelper do
+  let!(:my_region) do
+    MiqRegion.seed
+    MiqRegion.my_region
+  end
+
+  context "without the migrations ran column" do
+    before do
+      column_list = %w(id region created_at updated_at description guid).map { |n| double(:name => n) }
+      allow(ActiveRecord::Base.connection).to receive(:columns).with("miq_regions").and_return(column_list)
+    end
+
+    describe ".migrations_column_present?" do
+      it "is falsey" do
+        expect(described_class.migrations_column_present?).to be_falsey
+      end
+    end
+
+    describe ".wait_for_remote_region_migrations" do
+      it "does nothing" do
+        expect(MiqRegion).not_to receive(:find)
+        described_class.wait_for_remote_region_migration(double("subscription"), "12345")
+      end
+    end
+
+    describe ".update_local_migrations_ran" do
+      it "does nothing" do
+        expect(MiqRegion).not_to receive(:my_region)
+        described_class.update_local_migrations_ran("12345", :up)
+      end
+    end
+  end
+
+  describe ".migrations_column_present?" do
+    it "is truthy" do
+      # we never want to remove this column so we can just test directly
+      expect(described_class.migrations_column_present?).to be_truthy
+    end
+  end
+
+  context "with a dummy version" do
+    let(:version) { "1234567890" }
+
+    # sanity check - if this is somehow a version we have, these tests will make no sense
+    before { expect(my_region.migrations_ran).not_to include(version) }
+
+    describe ".wait_for_remote_region_migration" do
+      let(:subscription) { double("Subscription", :enable => nil, :disable => nil, :provider_region => my_region.region) }
+
+      it "sleeps until the migration is added" do
+        my_region.update_attributes!(:migrations_ran => nil)
+        t = Thread.new do
+          Thread.current.abort_on_exception = true
+          # need to stub these because the thread uses a separate connection object which won't be in the same transaction
+          allow(MiqRegion).to receive(:find_by).with(:region => my_region.region).and_return(my_region)
+          allow(my_region).to receive(:reload)
+          described_class.wait_for_remote_region_migration(subscription, version, 0)
+        end
+
+        # Try to pass execution to the created thread
+        # NOTE: This is could definitely be a source of weird spec timing issues because
+        #       we're relying on the thread scheduler to pass to the next thread
+        #       when we sleep, but if this isn't here we likely won't execute the conditional
+        #       block in .wait_for_remote_region_migrations
+        sleep 1
+
+        expect(t.alive?).to be true
+        my_region.update_attributes!(:migrations_ran => ActiveRecord::SchemaMigration.normalized_versions << version)
+
+        # Wait a max of 5 seconds so we don't disrupt the whole test suite if something terrible happens
+        t = t.join(5)
+        expect(t.status).to be false
+      end
+    end
+
+    describe ".update_local_migrations_ran" do
+      it "adds the given version when the direction is :up" do
+        described_class.update_local_migrations_ran(version, :up)
+        expect(my_region.reload.migrations_ran).to match_array(ActiveRecord::SchemaMigration.normalized_versions << version)
+      end
+
+      it "doesn't blow up when there is no region" do
+        MiqRegion.destroy_all
+        MiqRegion.my_region_clear_cache
+        described_class.update_local_migrations_ran(version, :up)
+      end
+    end
+  end
+end

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -4,6 +4,8 @@ describe ArPglogicalMigration::ArPglogicalMigrationHelper do
     MiqRegion.my_region
   end
 
+  before { allow(described_class).to receive_messages(:puts => nil, :print => nil) }
+
   context "without the migrations ran column" do
     before do
       column_list = %w(id region created_at updated_at description guid).map { |n| double(:name => n) }

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -30,7 +30,7 @@ context "with a region seeded" do
 
       describe ".update_local_migrations_ran" do
         it "does nothing" do
-          expect(MiqRegion).not_to receive(:my_region)
+          expect(ActiveRecord::SchemaMigration).not_to receive(:normalized_versions)
           described_class.update_local_migrations_ran("12345", :up)
         end
       end

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -1,63 +1,94 @@
-describe ArPglogicalMigration::ArPglogicalMigrationHelper do
+shared_context "without the migrations ran column" do
+  before do
+    column_list = %w(id region created_at updated_at description guid).map { |n| double(:name => n) }
+    allow(ActiveRecord::Base.connection).to receive(:columns).with("miq_regions").and_return(column_list)
+  end
+end
+
+shared_context "with a dummy version" do
+  let(:version) { "1234567890" }
+
+  # sanity check - if this is somehow a version we have, these tests will make no sense
+  before { expect(my_region.migrations_ran).not_to include(version) }
+end
+
+context "with a region seeded" do
   let!(:my_region) do
     MiqRegion.seed
     MiqRegion.my_region
   end
 
-  before { allow(described_class).to receive_messages(:puts => nil, :print => nil) }
+  describe ArPglogicalMigration::PglogicalMigrationHelper do
+    context "without the migrations ran column" do
+      include_context "without the migrations ran column"
 
-  context "without the migrations ran column" do
-    before do
-      column_list = %w(id region created_at updated_at description guid).map { |n| double(:name => n) }
-      allow(ActiveRecord::Base.connection).to receive(:columns).with("miq_regions").and_return(column_list)
-    end
+      describe ".migrations_column_present?" do
+        it "is falsey" do
+          expect(described_class.migrations_column_present?).to be_falsey
+        end
+      end
 
-    describe ".migrations_column_present?" do
-      it "is falsey" do
-        expect(described_class.migrations_column_present?).to be_falsey
+      describe ".update_local_migrations_ran" do
+        it "does nothing" do
+          expect(MiqRegion).not_to receive(:my_region)
+          described_class.update_local_migrations_ran("12345", :up)
+        end
       end
     end
 
-    describe ".wait_for_remote_region_migrations" do
-      it "does nothing" do
-        expect(MiqRegion).not_to receive(:find)
-        described_class.wait_for_remote_region_migration(double("subscription"), "12345")
+    describe ".migrations_column_present?" do
+      it "is truthy" do
+        # we never want to remove this column so we can just test directly
+        expect(described_class.migrations_column_present?).to be_truthy
       end
     end
 
     describe ".update_local_migrations_ran" do
-      it "does nothing" do
-        expect(MiqRegion).not_to receive(:my_region)
-        described_class.update_local_migrations_ran("12345", :up)
+      include_context "with a dummy version"
+
+      it "adds the given version when the direction is :up" do
+        described_class.update_local_migrations_ran(version, :up)
+        expect(my_region.reload.migrations_ran).to match_array(ActiveRecord::SchemaMigration.normalized_versions << version)
+      end
+
+      it "doesn't blow up when there is no region" do
+        MiqRegion.destroy_all
+        MiqRegion.my_region_clear_cache
+        described_class.update_local_migrations_ran(version, :up)
       end
     end
   end
 
-  describe ".migrations_column_present?" do
-    it "is truthy" do
-      # we never want to remove this column so we can just test directly
-      expect(described_class.migrations_column_present?).to be_truthy
+  describe ArPglogicalMigration::RemoteRegionMigrationWatcher do
+    include_context "with a dummy version"
+
+    let(:subscription) { double("Subscription", :enable => nil, :disable => nil, :provider_region => my_region.region) }
+
+    subject do
+      described_class.new(subscription, version).tap do |s|
+        allow(s).to receive_messages(:puts => nil, :print => nil)
+      end
     end
-  end
 
-  context "with a dummy version" do
-    let(:version) { "1234567890" }
+    describe "#wait_for_remote_region_migrations" do
+      context "without the migrations ran column present" do
+        include_context "without the migrations ran column"
 
-    # sanity check - if this is somehow a version we have, these tests will make no sense
-    before { expect(my_region.migrations_ran).not_to include(version) }
-
-    describe ".wait_for_remote_region_migration" do
-      let(:subscription) { double("Subscription", :enable => nil, :disable => nil, :provider_region => my_region.region) }
+        it "does nothing" do
+          expect(Vmdb.rails_logger).not_to receive(:info)
+          subject.wait_for_remote_region_migration
+        end
+      end
 
       it "sleeps until the migration is added" do
-        allow(described_class).to receive(:restart_subscription)
-        my_region.update_attributes!(:migrations_ran => nil)
+        allow(subject).to receive(:restart_subscription)
+        allow(subject.region).to receive(:reload)
+
+        subject.region.update_attributes!(:migrations_ran => nil)
+
         t = Thread.new do
           Thread.current.abort_on_exception = true
-          # need to stub these because the thread uses a separate connection object which won't be in the same transaction
-          allow(MiqRegion).to receive(:find_by).with(:region => my_region.region).and_return(my_region)
-          allow(my_region).to receive(:reload)
-          described_class.wait_for_remote_region_migration(subscription, version, 0)
+          subject.wait_for_remote_region_migration(0)
         end
 
         # Try to pass execution to the created thread
@@ -68,24 +99,11 @@ describe ArPglogicalMigration::ArPglogicalMigrationHelper do
         sleep 1
 
         expect(t.alive?).to be true
-        my_region.update_attributes!(:migrations_ran => ActiveRecord::SchemaMigration.normalized_versions << version)
+        subject.region.update_attributes!(:migrations_ran => ActiveRecord::SchemaMigration.normalized_versions << version)
 
         # Wait a max of 5 seconds so we don't disrupt the whole test suite if something terrible happens
         t = t.join(5)
         expect(t.status).to be false
-      end
-    end
-
-    describe ".update_local_migrations_ran" do
-      it "adds the given version when the direction is :up" do
-        described_class.update_local_migrations_ran(version, :up)
-        expect(my_region.reload.migrations_ran).to match_array(ActiveRecord::SchemaMigration.normalized_versions << version)
-      end
-
-      it "doesn't blow up when there is no region" do
-        MiqRegion.destroy_all
-        MiqRegion.my_region_clear_cache
-        described_class.update_local_migrations_ran(version, :up)
       end
     end
   end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -67,6 +67,10 @@ describe MiqRegion do
       allow(MiqRegion).to receive_messages(:my_region_number => @region_number + 1)
       expect { MiqRegion.seed }.to raise_error(Exception)
     end
+
+    it "sets the migrations_ran column" do
+      expect(MiqRegion.first.migrations_ran).to match_array(ActiveRecord::SchemaMigration.normalized_versions)
+    end
   end
 
   describe ".replication_type" do


### PR DESCRIPTION
This will fix https://bugzilla.redhat.com/show_bug.cgi?id=1601015 by only allowing the global region to execute a particular migration if it is sure that migration was successfully executed and replicated from all of the remote regions.

This ensures that we will never "miss" a schema state and get ourselves into a situation where we cannot continue replicating changes from a remote region.

Requires: https://github.com/ManageIQ/manageiq-schema/pull/266
Alternative to: https://github.com/ManageIQ/manageiq-schema/pull/264