### PR TITLE
Remove local variable from RssFeed generate()

### DIFF
--- a/app/models/miq_widget/rss_content.rb
+++ b/app/models/miq_widget/rss_content.rb
@@ -24,7 +24,7 @@ class MiqWidget::RssContent < MiqWidget::ContentGeneration
 
   def internal_feed(user_or_group)
     resource.options[:limit_to_count] = widget_options[:row_count] || 5
-    SimpleRSS.parse(resource.generate(nil, nil, nil, user_or_group))
+    SimpleRSS.parse(resource.generate(nil, nil, user_or_group))
   end
 
   def external_feed

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -16,7 +16,7 @@ class RssFeed < ApplicationRecord
     "#{host_url}#{link}"
   end
 
-  def generate(host = nil, local = false, proto = nil, user_or_group = nil)
+  def generate(host = nil, proto = nil, user_or_group = nil)
     require 'resource_feeder/lib/resource_feeder'
 
     proto ||= ::Settings.webservices.consume_protocol
@@ -43,8 +43,7 @@ class RssFeed < ApplicationRecord
     end
 
     filtered_items = Rbac::Filterer.filtered(find_items, rbac_options)
-    feed = ResourceFeeder::Rss.rss_feed_for(filtered_items, options)
-    local ? feed : {:text => feed, :content_type => Mime[:rss]}
+    ResourceFeeder::Rss.rss_feed_for(filtered_items, options)
   end
 
   def self.to_html(feed, options)

--- a/spec/models/rss_feed/rss_feed_spec.rb
+++ b/spec/models/rss_feed/rss_feed_spec.rb
@@ -20,9 +20,9 @@ describe RssFeed do
     it "#generate 1 vms with owner_tenant tenant in newest_vms rss" do
       [owner_group, owner_user].each do |user_or_group|
         User.with_user(owner_user) do
-          feed_container = rss_feed.generate(nil, nil, nil, user_or_group)
+          feed_container = rss_feed.generate(nil, nil, user_or_group)
 
-          expect(feed_container[:text]).to eq <<-EOXML
+          expect(feed_container).to eq <<-EOXML
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <rss version=\"2.0\">
   <channel>
@@ -41,8 +41,6 @@ describe RssFeed do
   </channel>
 </rss>
           EOXML
-
-          expect(feed_container[:content_type]).to eq('application/rss+xml')
         end
       end
     end
@@ -57,7 +55,7 @@ describe RssFeed do
     it "#generate 2 hosts in newest_hosts rss" do
       RssFeed.sync_from_yml_file("newest_hosts")
       feed_container = RssFeed.where(:name => "newest_hosts").first.generate
-      expect(feed_container[:text]).to eq <<-EOXML
+      expect(feed_container).to eq <<-EOXML
 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <rss version=\"2.0\">
   <channel>
@@ -83,7 +81,6 @@ describe RssFeed do
   </channel>
 </rss>
 EOXML
-      expect(feed_container[:content_type]).to eq('application/rss+xml')
     end
   end
 


### PR DESCRIPTION
The `generate()` routine, as it is being used, is always invoked with `local => false` (or `nil`).

Additionaly, the `generate()` routine will be returning just the xml feed (`String`) rather than complete hash for `render()`.

@martinpovolny 