### PR TITLE
Add CustomButtonEvent association to GenericObject.

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -6,6 +6,7 @@ class GenericObject < ApplicationRecord
 
   belongs_to :generic_object_definition
   has_one :picture, :through => :generic_object_definition
+  has_many :custom_button_events, -> { where(:type => "CustomButtonEvent") }, :class_name => "EventStream", :foreign_key => :target_id
 
   validates :name, :presence => true
 

--- a/spec/models/generic_object_spec.rb
+++ b/spec/models/generic_object_spec.rb
@@ -376,5 +376,13 @@ describe GenericObject do
         go.custom_action_buttons
       end
     end
+
+    describe '#custom_button_events' do
+      let(:cb_event) { FactoryGirl.create(:custom_button_event, :target => go) }
+
+      it 'returns list of custom button events' do
+        expect(go.custom_button_events).to match_array([cb_event])
+      end
+    end
   end
 end


### PR DESCRIPTION
Need to access these custom button events of a generic object instance.
Followup of #17764.

https://bugzilla.redhat.com/show_bug.cgi?id=1511126

@miq-bot assign @gmcculloug
@miq-bot add_label automate, enhancement, events
cc @skateman