### PR TITLE
Add method to allow access for tenant quotas

### DIFF
--- a/app/models/mixins/tenant_quotas_mixin.rb
+++ b/app/models/mixins/tenant_quotas_mixin.rb
@@ -1,0 +1,13 @@
+module TenantQuotasMixin
+  extend ActiveSupport::Concern
+
+  def tenant_quotas_allowed?
+    current_user = User.current_user
+    return true if current_user.super_admin_user?
+    return true unless current_user.miq_user_role.tenant_admin_user?
+
+    current_tenant = current_user.current_tenant
+    # don't allow tenant quotas for current tenant and for ancestors
+    !(current_tenant == self || current_tenant.ancestor_ids.include?(id))
+  end
+end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -8,6 +8,7 @@ class Tenant < ApplicationRecord
 
   include ActiveVmAggregationMixin
   include CustomActionsMixin
+  include TenantQuotasMixin
 
   acts_as_miq_taggable
 

--- a/spec/models/mixins/tenant_quotas_mixin_spec.rb
+++ b/spec/models/mixins/tenant_quotas_mixin_spec.rb
@@ -1,0 +1,44 @@
+describe TenantQuotasMixin do
+  before do
+    Tenant.seed
+  end
+
+  let(:root_tenant) do
+    Tenant.root_tenant
+  end
+
+  let(:super_admin_role)  { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::SUPER_ADMIN_FEATURE) }
+  let(:tenant_admin_role) { FactoryGirl.create(:miq_user_role, :features => MiqProductFeature::TENANT_ADMIN_FEATURE) }
+
+  let(:tenant_1)   { FactoryGirl.create(:tenant, :parent => root_tenant) }
+  let(:tenant_1_1) { FactoryGirl.create(:tenant, :parent => tenant_1) }
+  let(:tenant_1_2) { FactoryGirl.create(:tenant, :parent => tenant_1, :divisible => false) }
+
+  let(:group_tenant_1_tenant_admin) { FactoryGirl.create(:miq_group, :miq_user_role => tenant_admin_role, :tenant => tenant_1) }
+  let(:user_tenant_1_tenant_admin)  { FactoryGirl.create(:user, :miq_groups => [group_tenant_1_tenant_admin]) }
+
+  let(:group_tenant_1_super_admin) { FactoryGirl.create(:miq_group, :miq_user_role => super_admin_role, :tenant => tenant_1) }
+  let(:user_tenant_1_super_admin)  { FactoryGirl.create(:user, :miq_groups => [group_tenant_1_super_admin]) }
+
+  describe "#tenant_quotas_allowed?" do
+    it "allows managing on all tenant quotas when user is super admin" do
+      User.with_user(user_tenant_1_super_admin) do
+        expect(root_tenant.tenant_quotas_allowed?).to be_truthy
+        expect(tenant_1.tenant_quotas_allowed?).to be_truthy
+        expect(tenant_1_1.tenant_quotas_allowed?).to be_truthy
+        expect(tenant_1_2.tenant_quotas_allowed?).to be_truthy
+      end
+    end
+
+    context "user has tenant-admin role" do
+      it "allows managing on tenant quotas" do
+        User.with_user(user_tenant_1_tenant_admin) do
+          expect(root_tenant.tenant_quotas_allowed?).to be_falsey
+          expect(tenant_1.tenant_quotas_allowed?).to be_falsey
+          expect(tenant_1_1.tenant_quotas_allowed?).to be_truthy
+          expect(tenant_1_2.tenant_quotas_allowed?).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**In DB**
Tenant has many Tenant Quotas

let's have tenant tree (in brackets are users)
```
My Company (S1)
 |-T1  (U1)
   |- T2 (U2)
   |- T3 (U3)
```
and users S1 (with super-admin role) and U1 (with tenant-admin role)

From BZ is requested that user with tenant-admin role should not be able manage quotas from his tenant and ancestor but only from his children otherwise as before.
**`manage` means all operations:read, create, edit, delete.**

**Example:**
 U1 can manage quotas just for T2 and T3.

## Technically

This rule doesn't fit to our existing models RBAC or MiqProductFeature permissions. It is like MiqProductFeature permission with some special RBAC behaviour. But maybe I just need different point of view.

## Suggested next steps
This method is planned to be added to restrict all needed parts in the application:
**UI**: to toolbar buttons(create, edit, delete), templates(view) 
**API**: CRUD

_Note: to include it in RBAC could eventually help partly but after moment when quotas are created and quotas are created - at moment when you press button SAVE in form of tenant quotas - it is late. But we can include to ensure view operations for tenant_quotas like RBAC::Filterer.filtered(TenantQuotas)_
 
At this moment I just created this backend method and I am opened discussion, ideas comments, if needed.

# TODOs

- [ ] add to RBAC
- [ ] add to API
- [ ] add to UI




Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1468795

@miq-bot assign @gtanzillo 