### PR TITLE
Memoize cols_on_metric_rollup in chargeback

### DIFF
--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -93,7 +93,9 @@ class ChargeableField < ApplicationRecord
   end
 
   def self.cols_on_metric_rollup
-    (%w(id tag_names resource_id) + chargeable_cols_on_metric_rollup).uniq
+    @cols_on_metric_rollup ||= begin
+      (%w(id tag_names resource_id) + chargeable_cols_on_metric_rollup).uniq
+    end
   end
 
   def self.col_index(column)
@@ -136,8 +138,10 @@ class ChargeableField < ApplicationRecord
   end
 
   def self.chargeable_cols_on_metric_rollup
-    existing_cols = MetricRollup.attribute_names
-    chargeable_cols = pluck(:metric) & existing_cols
-    chargeable_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.sort
+    @chargeable_cols_on_metric_rollup ||= begin
+      existing_cols = MetricRollup.attribute_names
+      chargeable_cols = pluck(:metric) & existing_cols
+      chargeable_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.sort
+    end
   end
 end

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -141,7 +141,7 @@ class ChargeableField < ApplicationRecord
     @chargeable_cols_on_metric_rollup ||= begin
       existing_cols = MetricRollup.attribute_names
       chargeable_cols = pluck(:metric) & existing_cols
-      chargeable_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.sort
+      chargeable_cols.map! { |x| VIRTUAL_COL_USES[x] || x }.sort.uniq
     end
   end
 end


### PR DESCRIPTION
Pulled out from https://github.com/ManageIQ/manageiq/pull/17591 done during work on this https://github.com/ManageIQ/manageiq/issues/17592

Links 
------

*https://github.com/ManageIQ/manageiq/issues/17592

@miq-bot add_label performance, chargeback

@miq-bot assign @gtanzillo 