### PR TITLE
Move Graph Refresh Settings to EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -718,6 +718,14 @@ class ExtManagementSystem < ApplicationRecord
     n_('Manager', 'Managers', number)
   end
 
+  def inventory_object_refresh?
+    Settings.ems_refresh.fetch_path(emstype, :inventory_object_refresh)
+  end
+
+  def allow_targeted_refresh?
+    Settings.ems_refresh.fetch_path(emstype, :allow_targeted_refresh)
+  end
+
   private
 
   def build_connection(options = {})

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -132,7 +132,7 @@ module ManageIQ
         # override this method and return an array of:
         #   [[target1, inventory_for_target1], [target2, inventory_for_target2]]
 
-        return [[ems, nil]] unless inventory_object_refresh?
+        return [[ems, nil]] unless ems.inventory_object_refresh?
 
         provider_module = ManageIQ::Providers::Inflector.provider_module(ems.class).name
 
@@ -251,14 +251,6 @@ module ManageIQ
 
       def format_ems_for_logging(ems)
         "EMS: [#{ems.name}], id: [#{ems.id}]"
-      end
-
-      def inventory_object_refresh?
-        refresher_options.try(:[], :inventory_object_refresh)
-      end
-
-      def allow_targeted_refresh?
-        refresher_options.try(:[], :allow_targeted_refresh)
       end
     end
   end

--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -51,16 +51,16 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
       clone_task_ref = phase_context.delete(:clone_task_ref)
       phase_context[:new_vm_ems_ref] = clone_task_ref
 
-      manager_settings = Settings.ems_refresh[source.ext_management_system.class.ems_type]
-      if manager_settings && manager_settings[:inventory_object_refresh] && manager_settings[:allow_targeted_refresh]
+      manager = source.ext_management_system
+      if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
         # Queue new targeted refresh if allowed
-        vm_target = ManagerRefresh::Target.new(:manager     => source.ext_management_system,
+        vm_target = ManagerRefresh::Target.new(:manager     => manager,
                                                :association => :vms,
                                                :manager_ref => {:ems_ref => clone_task_ref})
         EmsRefresh.queue_refresh(vm_target)
       else
         # Otherwise queue a full refresh
-        EmsRefresh.queue_refresh(source.ext_management_system)
+        EmsRefresh.queue_refresh(manager)
       end
       signal :poll_destination_in_vmdb
     else

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -166,8 +166,7 @@ class OrchestrationStack < ApplicationRecord
       raise _("Provider failed last authentication check")
     end
 
-    manager_settings = Settings.ems_refresh[manager.class.ems_type]
-    if manager_settings && manager_settings[:inventory_object_refresh] && manager_settings[:allow_targeted_refresh]
+    if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
       # Queue new targeted refresh if allowed
       orchestration_stack_target = ManagerRefresh::Target.new(:manager     => manager,
                                                               :association => :orchestration_stacks,


### PR DESCRIPTION
Move inventory_object_refresh? and allow_targeted_refresh? to
ext_management_system so that code outside the Refresher can get away
from checking settings directly.

Follow-up to https://github.com/ManageIQ/manageiq/pull/17916