### PR TITLE
Remove leftovers about metering column from chargeback

### DIFF
--- a/app/models/chargeback_container_image.rb
+++ b/app/models/chargeback_container_image.rb
@@ -103,8 +103,6 @@ class ChargebackContainerImage < Chargeback
       "fixed_cost"                 => {:grouping => [:total]},
       "memory_used_cost"           => {:grouping => [:total]},
       "memory_used_metric"         => {:grouping => [:total]},
-      "metering_used_metric"       => {:grouping => [:total]},
-      "metering_used_cost"         => {:grouping => [:total]},
       "memory_allocated_cost"      => {:grouping => [:total]},
       "memory_allocated_metric"    => {:grouping => [:total]},
       "net_io_used_cost"           => {:grouping => [:total]},

--- a/app/models/chargeback_container_project.rb
+++ b/app/models/chargeback_container_project.rb
@@ -64,8 +64,6 @@ class ChargebackContainerProject < Chargeback
       "fixed_cost"            => {:grouping => [:total]},
       "memory_used_cost"      => {:grouping => [:total]},
       "memory_used_metric"    => {:grouping => [:total]},
-      "metering_used_metric"  => {:grouping => [:total]},
-      "metering_used_cost"    => {:grouping => [:total]},
       "net_io_used_cost"      => {:grouping => [:total]},
       "net_io_used_metric"    => {:grouping => [:total]},
       "total_cost"            => {:grouping => [:total]}

--- a/db/fixtures/miq_report_formats.yml
+++ b/db/fixtures/miq_report_formats.yml
@@ -56,7 +56,6 @@
     :memory_used_cost: :currency_precision_2
     :memory_allocated_cost: :currency_precision_2
     :memory_cost: :currency_precision_2
-    :metering_used_cost: :currency_precision_2
     :storage_used_cost: :currency_precision_2
     :storage_allocated_cost: :currency_precision_2
     :storage_cost: :currency_precision_2

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -42,7 +42,6 @@ FactoryGirl.define do
           chargeback_rate_detail_memory_allocated
           chargeback_rate_detail_memory_used
           chargeback_rate_detail_net_io_used
-          chargeback_rate_detail_metering_used
         ).each do |factory_name|
           chargeback_rate.chargeback_rate_details << FactoryGirl.create(factory_name,
                                                                         :tiers_with_three_intervals,

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -102,8 +102,4 @@ FactoryGirl.define do
   factory :chargeback_rate_detail_fixed_compute_cost, :traits => [:daily], :parent => :chargeback_rate_detail do
     chargeable_field { FactoryGirl.build(:chargeable_field_fixed_compute_1) }
   end
-
-  factory :chargeback_rate_detail_metering_used, :traits => [:daily], :parent => :chargeback_rate_detail do
-    chargeable_field { FactoryGirl.build(:chargeable_field_metering_used) }
-  end
 end

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -19,7 +19,6 @@ describe ChargebackContainerImage do
     let(:detail_params) do
       {
         :chargeback_rate_detail_fixed_compute_cost  => {:tiers => [hourly_variable_tier_rate]},
-        :chargeback_rate_detail_metering_used       => {:tiers => [hourly_variable_tier_rate]},
         :chargeback_rate_detail_cpu_cores_allocated => {:tiers => [count_hourly_variable_tier_rate]},
         :chargeback_rate_detail_memory_allocated    => {:tiers => [hourly_variable_tier_rate]}
       }
@@ -32,9 +31,6 @@ describe ChargebackContainerImage do
     let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
     before do
-      # TODO: remove metering columns form specs
-      described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
-
       MiqRegion.seed
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed
@@ -96,11 +92,6 @@ describe ChargebackContainerImage do
         expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
       end
 
-      it 'calculates metering used hours and cost' do
-        expect(subject.metering_used_metric).to eq(hours_in_day)
-        expect(subject.metering_used_cost).to eq(hours_in_day * hourly_rate)
-      end
-
       it "allocated fields" do
         skip('this feature needs to be added to new chargeback rating') if Settings.new_chargeback
         expect(subject.cpu_cores_allocated_cost).to eq(@container.limit_cpu_cores * count_hourly_rate * hours_in_day)
@@ -127,11 +118,6 @@ describe ChargebackContainerImage do
       it "fixed_compute" do
         # .to be_within(0.01) is used since theres a float error here
         expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
-      end
-
-      it 'calculates metering used hours and cost' do
-        expect(subject.metering_used_metric).to eq(hours_in_month)
-        expect(subject.metering_used_cost).to eq(hours_in_month * hourly_rate)
       end
 
       it "allocated fields" do

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -19,8 +19,7 @@ describe ChargebackContainerProject do
           :chargeback_rate_detail_fixed_compute_cost => {:tiers => [hourly_variable_tier_rate]},
           :chargeback_rate_detail_cpu_cores_used     => {:tiers => [hourly_variable_tier_rate]},
           :chargeback_rate_detail_net_io_used        => {:tiers => [hourly_variable_tier_rate]},
-          :chargeback_rate_detail_memory_used        => {:tiers => [hourly_variable_tier_rate]},
-          :chargeback_rate_detail_metering_used      => {:tiers => [hourly_variable_tier_rate]}
+          :chargeback_rate_detail_memory_used        => {:tiers => [hourly_variable_tier_rate]}
       }
     end
 
@@ -31,9 +30,6 @@ describe ChargebackContainerProject do
     let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
     before do
-      # TODO: remove metering columns form specs
-      described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
-
       MiqRegion.seed
       ChargebackRateDetailMeasure.seed
       ChargeableField.seed
@@ -106,11 +102,6 @@ describe ChargebackContainerProject do
         expect(subject.fixed_compute_1_cost).to eq(hourly_rate * hours_in_day)
         expect(subject.fixed_compute_metric).to eq(@metric_size)
       end
-
-      it 'calculates metering used hours and cost' do
-        expect(subject.metering_used_metric).to eq(hours_in_day)
-        expect(subject.metering_used_cost).to eq(hours_in_day * hourly_rate)
-      end
     end
 
     context "Monthly" do
@@ -144,11 +135,6 @@ describe ChargebackContainerProject do
         # .to be_within(0.01) is used since theres a float error here
         expect(subject.fixed_compute_1_cost).to be_within(0.01).of(hourly_rate * hours_in_month)
         expect(subject.fixed_compute_metric).to eq(@metric_size)
-      end
-
-      it 'calculates metering used hours and cost' do
-        expect(subject.metering_used_metric).to eq(hours_in_month)
-        expect(subject.metering_used_cost).to eq(hours_in_month * hourly_rate)
       end
     end
 


### PR DESCRIPTION
after moving metering related columns from chargeback to metering report in PR https://github.com/ManageIQ/manageiq/pull/16342

we need to remove some leftovers - it was confusing.

We need metering hours used column just in chargeable field yaml because it is used in metering report calculations for example: [here](https://github.com/ManageIQ/manageiq/blob/e63d3cea5782905e7a20e0fab623165705fad398/app/models/metering.rb#L42)


@miq-bot add_label technical_debt, chargeback

@miq-bot assign @gtanzillo 

found during work on https://bugzilla.redhat.com/show_bug.cgi?id=1583215 
# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1583215 (just for note - the BZ is not done by this BZ)
https://github.com/ManageIQ/manageiq/pull/16342





