### PR TITLE
Always return 0 for missing num_cpu

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1526,7 +1526,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def num_cpu
-    hardware.nil? ? 0 : hardware.cpu_sockets
+    hardware.try(:cpu_sockets) || 0
   end
 
   def num_disks


### PR DESCRIPTION
Always return 0 for missing num_cpu

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1624535