### PR TITLE
Add CPU, CPU cores and MEMORY metering allocation to Metering reports

### DIFF
--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -129,6 +129,14 @@ class Chargeback
       @metering_used_fields_present ||= @rollup_array.count { |rollup| metering_used_fields_present?(rollup) }
     end
 
+    def metering_allocated_for(metric)
+      @metering_allocated_metric ||= {}
+      @metering_allocated_metric[metric] ||= @rollup_array.count do |rollup|
+        rollup_record = rollup[ChargeableField.col_index(metric)]
+        rollup_record.present? && rollup_record.nonzero?
+      end
+    end
+
     def resource_tag_names(rollup)
       tags_names = rollup[ChargeableField.col_index(:tag_names)]
       tags_names ? tags_names.split('|') : []

--- a/app/models/chargeback/consumption_without_rollups.rb
+++ b/app/models/chargeback/consumption_without_rollups.rb
@@ -45,6 +45,10 @@ class Chargeback
       0 # we don't count used hours in metering report
     end
 
+    def metering_allocated_for(_metric)
+      1 # we count allocated hours in metering report
+    end
+
     def current_value(metric, sub_metric = nil)
       # Return the last seen allocation for charging purposes.
       @value ||= {}

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -1,6 +1,7 @@
 module Metering
   extend ActiveSupport::Concern
   DISALLOWED_SUFFIXES = %w(_cost chargeback_rates).freeze
+  METERING_ALLOCATED_FIELDS = %w(metering_allocated_cpu_cores_metric metering_allocated_cpu_metric metering_allocated_memory_metric).freeze
 
   included do
     def self.attribute_names
@@ -12,6 +13,23 @@ module Metering
     self.fixed_compute_metric = consumption.chargeback_fields_present if consumption.chargeback_fields_present
     self.metering_used_metric = consumption.metering_used_fields_present if consumption.metering_used_fields_present
     self.existence_hours_metric = consumption.consumed_hours_in_interval
+
+    case self
+    when MeteringVm
+      self.metering_allocated_cpu_metric = consumption.metering_allocated_for(:derived_vm_numvcpus)
+      self.metering_allocated_memory_metric = consumption.metering_allocated_for(:derived_memory_available)
+    when MeteringContainerProject
+      self.metering_allocated_cpu_cores_metric = consumption.metering_allocated_for(:cpu_usage_rate_average)
+      self.metering_allocated_memory_metric = consumption.metering_allocated_for(:derived_memory_available)
+    when MeteringContainerImage
+      cpu_allocation = consumption.current_value(:derived_vm_numvcpu_cores.to_s, nil)
+      count_cpu_allocation = cpu_allocation.present? && cpu_allocation.nonzero?
+      self.metering_allocated_cpu_cores_metric = count_cpu_allocation ? existence_hours_metric : 0
+      memory_allocation = consumption.current_value(:derived_memory_available.to_s, nil)
+      count_memory_allocation = memory_allocation.present? && memory_allocation.nonzero?
+      self.metering_allocated_memory_metric = count_memory_allocation ? existence_hours_metric : 0
+    end
+
     self.beginning_of_resource_existence_in_report_interval = consumption.consumption_start
     self.end_of_resource_existence_in_report_interval = consumption.consumption_end
 
@@ -40,7 +58,7 @@ module Metering
       end
 
       chargable_field = ChargeableField.find_by(:group => group, :source => source)
-      next if field == "existence_hours_metric" || field == "fixed_compute_metric" || chargable_field && chargable_field.metering?
+      next if METERING_ALLOCATED_FIELDS.include?(field) || field == "existence_hours_metric" || field == "fixed_compute_metric" || chargable_field&.metering?
       value = chargable_field.measure_metering(consumption, @options) if chargable_field
       self[field] = (value || 0)
     end

--- a/app/models/metering_container_image.rb
+++ b/app/models/metering_container_image.rb
@@ -1,5 +1,7 @@
 class MeteringContainerImage < ChargebackContainerImage
   set_columns_hash(
+    :metering_allocated_cpu_cores_metric                => :integer,
+    :metering_allocated_memory_metric                   => :integer,
     :metering_used_metric                               => :integer,
     :existence_hours_metric                             => :integer,
     :beginning_of_resource_existence_in_report_interval => :datetime,
@@ -10,14 +12,16 @@ class MeteringContainerImage < ChargebackContainerImage
 
   def self.report_col_options
     {
-      "cpu_cores_allocated_metric" => {:grouping => [:total]},
-      "cpu_cores_used_metric"      => {:grouping => [:total]},
-      "existence_hours_metric"     => {:grouping => [:total]},
-      "fixed_compute_metric"       => {:grouping => [:total]},
-      "memory_allocated_metric"    => {:grouping => [:total]},
-      "memory_used_metric"         => {:grouping => [:total]},
-      "metering_used_metric"       => {:grouping => [:total]},
-      "net_io_used_metric"         => {:grouping => [:total]},
+      "cpu_cores_allocated_metric"          => {:grouping => [:total]},
+      "cpu_cores_used_metric"               => {:grouping => [:total]},
+      "existence_hours_metric"              => {:grouping => [:total]},
+      "fixed_compute_metric"                => {:grouping => [:total]},
+      "memory_allocated_metric"             => {:grouping => [:total]},
+      "metering_allocated_cpu_cores_metric" => {:grouping => [:total]},
+      "metering_allocated_memory_metric"    => {:grouping => [:total]},
+      "memory_used_metric"                  => {:grouping => [:total]},
+      "metering_used_metric"                => {:grouping => [:total]},
+      "net_io_used_metric"                  => {:grouping => [:total]},
     }
   end
 

--- a/app/models/metering_container_project.rb
+++ b/app/models/metering_container_project.rb
@@ -1,5 +1,7 @@
 class MeteringContainerProject < ChargebackContainerProject
   set_columns_hash(
+    :metering_allocated_cpu_cores_metric                => :integer,
+    :metering_allocated_memory_metric                   => :integer,
     :metering_used_metric                               => :integer,
     :existence_hours_metric                             => :integer,
     :beginning_of_resource_existence_in_report_interval => :datetime,
@@ -10,12 +12,14 @@ class MeteringContainerProject < ChargebackContainerProject
 
   def self.report_col_options
     {
-      "cpu_cores_used_metric"  => {:grouping => [:total]},
-      "existence_hours_metric" => {:grouping => [:total]},
-      "fixed_compute_metric"   => {:grouping => [:total]},
-      "memory_used_metric"     => {:grouping => [:total]},
-      "metering_used_metric"   => {:grouping => [:total]},
-      "net_io_used_metric"     => {:grouping => [:total]},
+      "cpu_cores_used_metric"               => {:grouping => [:total]},
+      "existence_hours_metric"              => {:grouping => [:total]},
+      "fixed_compute_metric"                => {:grouping => [:total]},
+      "metering_allocated_cpu_cores_metric" => {:grouping => [:total]},
+      "metering_allocated_memory_metric"    => {:grouping => [:total]},
+      "memory_used_metric"                  => {:grouping => [:total]},
+      "metering_used_metric"                => {:grouping => [:total]},
+      "net_io_used_metric"                  => {:grouping => [:total]},
     }
   end
 

--- a/app/models/metering_vm.rb
+++ b/app/models/metering_vm.rb
@@ -1,5 +1,7 @@
 class MeteringVm < ChargebackVm
   set_columns_hash(
+    :metering_allocated_cpu_metric                      => :integer,
+    :metering_allocated_memory_metric                   => :integer,
     :metering_used_metric                               => :integer,
     :existence_hours_metric                             => :integer,
     :beginning_of_resource_existence_in_report_interval => :datetime,
@@ -10,17 +12,19 @@ class MeteringVm < ChargebackVm
 
   def self.report_col_options
     {
-      "cpu_allocated_metric"     => {:grouping => [:total]},
-      "cpu_used_metric"          => {:grouping => [:total]},
-      "disk_io_used_metric"      => {:grouping => [:total]},
-      "existence_hours_metric"   => {:grouping => [:total]},
-      "fixed_compute_metric"     => {:grouping => [:total]},
-      "memory_allocated_metric"  => {:grouping => [:total]},
-      "memory_used_metric"       => {:grouping => [:total]},
-      "metering_used_metric"     => {:grouping => [:total]},
-      "net_io_used_metric"       => {:grouping => [:total]},
-      "storage_allocated_metric" => {:grouping => [:total]},
-      "storage_used_metric"      => {:grouping => [:total]},
+      "cpu_allocated_metric"             => {:grouping => [:total]},
+      "cpu_used_metric"                  => {:grouping => [:total]},
+      "disk_io_used_metric"              => {:grouping => [:total]},
+      "existence_hours_metric"           => {:grouping => [:total]},
+      "fixed_compute_metric"             => {:grouping => [:total]},
+      "memory_allocated_metric"          => {:grouping => [:total]},
+      "metering_allocated_cpu_metric"    => {:grouping => [:total]},
+      "metering_allocated_memory_metric" => {:grouping => [:total]},
+      "memory_used_metric"               => {:grouping => [:total]},
+      "metering_used_metric"             => {:grouping => [:total]},
+      "net_io_used_metric"               => {:grouping => [:total]},
+      "storage_allocated_metric"         => {:grouping => [:total]},
+      "storage_used_metric"              => {:grouping => [:total]},
     }
   end
 

--- a/db/fixtures/chargeable_fields.yml
+++ b/db/fixtures/chargeable_fields.yml
@@ -66,3 +66,15 @@
   :group: metering
   :source: used
   :description: Metering - Hours Used
+- :metric: metering_allocated_cpu
+  :group: metering
+  :source: allocated_cpu
+  :description: Metering - Hours Allocated CPU
+- :metric: metering_allocated_memory
+  :group: metering
+  :source: allocated_memory
+  :description: Metering - Hours Allocated Memory
+- :metric: metering_allocated_cpu_cores
+  :group: metering
+  :source: allocated_cpu_cores
+  :description: Metering - Hours Allocated Memory

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -58,18 +58,45 @@ describe MeteringContainerImage do
       expect(subject.beginning_of_resource_existence_in_report_interval).to eq(month_beginning)
       expect(subject.end_of_resource_existence_in_report_interval).to eq(month_beginning + 1.month)
     end
+
+    it 'calculates metering values' do
+      expect(subject.metering_used_metric).to eq(60)
+      expect(subject.existence_hours_metric).to eq(month_beginning.end_of_month.day * 24)
+    end
+
+    context 'count of used hours is different than count of metric rollups' do
+      it 'calculates metering used hours only from allocated metrics' do
+        expect(subject.metering_allocated_cpu_cores_metric).to eq(720)
+        expect(subject.metering_allocated_memory_metric).to eq(720)
+      end
+
+      context 'with uncompleted allocation of cpu and mem' do
+        before do
+          @container.limit_cpu_cores = 0
+          @container.limit_memory_bytes = 0
+          @container.save
+        end
+
+        it 'calculates metering used hours only from allocated metrics' do
+          expect(subject.metering_allocated_cpu_cores_metric).to eq(0)
+          expect(subject.metering_allocated_memory_metric).to eq(0)
+        end
+      end
+    end
   end
 
   let(:report_col_options) do
     {
-      "cpu_cores_allocated_metric" => {:grouping => [:total]},
-      "cpu_cores_used_metric"      => {:grouping => [:total]},
-      "existence_hours_metric"     => {:grouping => [:total]},
-      "fixed_compute_metric"       => {:grouping => [:total]},
-      "memory_allocated_metric"    => {:grouping => [:total]},
-      "memory_used_metric"         => {:grouping => [:total]},
-      "metering_used_metric"       => {:grouping => [:total]},
-      "net_io_used_metric"         => {:grouping => [:total]},
+      "cpu_cores_allocated_metric"          => {:grouping => [:total]},
+      "cpu_cores_used_metric"               => {:grouping => [:total]},
+      "existence_hours_metric"              => {:grouping => [:total]},
+      "fixed_compute_metric"                => {:grouping => [:total]},
+      "metering_allocated_cpu_cores_metric" => {:grouping => [:total]},
+      "metering_allocated_memory_metric"    => {:grouping => [:total]},
+      "memory_allocated_metric"             => {:grouping => [:total]},
+      "memory_used_metric"                  => {:grouping => [:total]},
+      "metering_used_metric"                => {:grouping => [:total]},
+      "net_io_used_metric"                  => {:grouping => [:total]},
     }
   end
 

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -170,6 +170,23 @@ describe MeteringVm do
         expect(subject.metering_used_metric).to eq(40)
         expect(subject.metering_used_metric).not_to eq(subject.fixed_compute_metric)
       end
+
+      it 'calculates metering used hours only from allocated metrics' do
+        expect(subject.metering_allocated_cpu_metric).to eq(60)
+        expect(subject.metering_allocated_memory_metric).to eq(60)
+      end
+
+      context 'with uncompleted allocation of cpu and mem' do
+        before do
+          vm.metric_rollups.limit(20).each { |record| record.update(:derived_vm_numvcpus => 0) }
+          vm.metric_rollups.limit(25).each { |record| record.update(:derived_memory_available => 0) }
+        end
+
+        it 'calculates metering used hours only from allocated metrics' do
+          expect(subject.metering_allocated_cpu_metric).to eq(40)
+          expect(subject.metering_allocated_memory_metric).to eq(35)
+        end
+      end
     end
   end
 
@@ -198,6 +215,8 @@ describe MeteringVm do
        net_io_used_metric
        storage_allocated_metric
        storage_used_metric
+       metering_allocated_cpu_metric
+       metering_allocated_memory_metric
        metering_used_metric
        existence_hours_metric
        tenant_name
@@ -212,17 +231,19 @@ describe MeteringVm do
 
   let(:report_col_options) do
     {
-      "cpu_allocated_metric"     => {:grouping => [:total]},
-      "cpu_used_metric"          => {:grouping => [:total]},
-      "disk_io_used_metric"      => {:grouping => [:total]},
-      "existence_hours_metric"   => {:grouping => [:total]},
-      "fixed_compute_metric"     => {:grouping => [:total]},
-      "memory_allocated_metric"  => {:grouping => [:total]},
-      "memory_used_metric"       => {:grouping => [:total]},
-      "metering_used_metric"     => {:grouping => [:total]},
-      "net_io_used_metric"       => {:grouping => [:total]},
-      "storage_allocated_metric" => {:grouping => [:total]},
-      "storage_used_metric"      => {:grouping => [:total]},
+      "cpu_allocated_metric"             => {:grouping => [:total]},
+      "cpu_used_metric"                  => {:grouping => [:total]},
+      "disk_io_used_metric"              => {:grouping => [:total]},
+      "existence_hours_metric"           => {:grouping => [:total]},
+      "fixed_compute_metric"             => {:grouping => [:total]},
+      "memory_allocated_metric"          => {:grouping => [:total]},
+      "metering_allocated_cpu_metric"    => {:grouping => [:total]},
+      "metering_allocated_memory_metric" => {:grouping => [:total]},
+      "memory_used_metric"               => {:grouping => [:total]},
+      "metering_used_metric"             => {:grouping => [:total]},
+      "net_io_used_metric"               => {:grouping => [:total]},
+      "storage_allocated_metric"         => {:grouping => [:total]},
+      "storage_used_metric"              => {:grouping => [:total]},
     }
   end
 


### PR DESCRIPTION
we have already **Metering Used Metric** and this PR is adding same thing but for allocation and concretely for CPU (VMs),CPU Cores(ContainerProject/Image) and Memory.

**In Report Definitoin it looks like:**
<img width="638" alt="screen shot 2018-09-04 at 10 10 37" src="https://user-images.githubusercontent.com/14937244/45019016-8e2a0180-b02b-11e8-81e1-0089035f4aaf.png">
<img width="685" alt="screen shot 2018-09-04 at 10 03 24" src="https://user-images.githubusercontent.com/14937244/45019021-8ff3c500-b02b-11e8-9a7f-6746182c4942.png">

**In Report Result:**
<img width="1417" alt="screen shot 2018-09-04 at 10 17 46" src="https://user-images.githubusercontent.com/14937244/45019131-dc3f0500-b02b-11e8-8481-d125658d50c5.png">

Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1583215


@miq-bot add_label enhancement

@miq-bot assign @gtanzillo 

