### PR TITLE
Add product feature for displaying custom button events

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6308,6 +6308,17 @@
         :description: Display Individual Event Streams
         :feature_type: view
         :identifier: event_streams_show
+  - :name: Custom Button Events
+    :description: Everything under Custom Button Events
+    :hidden: true
+    :feature_type: node
+    :identifier: custom_button_events
+    :children:
+    - :name: List
+      :description: Display List of Custom Button Events
+      :hidden: true
+      :feature_type: view
+      :identifier: custom_button_events_show_list
 # SUI
 - :name: Service UI
   :description: Features for the Service UI


### PR DESCRIPTION
This new feature is required for an [API PR](https://github.com/ManageIQ/manageiq-api/pull/464) to pass. It will allow to list custom button events for users, groups and tenants through the API. @lpichler promised me that he will sort out the missing part where this (hidden) feature will be restricted to admin and super admin roles.

@miq-bot add_label enhancement, gaprindashvili/no, rbac
@miq-bot add_reviewer @lpichler

https://bugzilla.redhat.com/show_bug.cgi?id=1511126