### PR TITLE
Fix of inventory building and refactoring

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -165,8 +165,8 @@ module ManageIQ
           log_header = format_ems_for_logging(ems)
           _log.debug("#{log_header} Parsing inventory...")
           persister, = Benchmark.realtime_block(:parse_inventory) do
-            persister = ManageIQ::Providers::Inventory.persister_class_for(target.class).new(ems, target)
-            parser = ManageIQ::Providers::Inventory.parser_class_for(target.class).new
+            persister = ManageIQ::Providers::Inventory.persister_class_for(ems, target.class).new(ems, target)
+            parser = ManageIQ::Providers::Inventory.parser_class_for(ems, target.class).new
 
             i = ManageIQ::Providers::Inventory.new(persister, collector, parser)
             i.parse

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -165,8 +165,8 @@ module ManageIQ
           log_header = format_ems_for_logging(ems)
           _log.debug("#{log_header} Parsing inventory...")
           persister, = Benchmark.realtime_block(:parse_inventory) do
-            persister = ManageIQ::Providers::Inventory.persister_class_for(ems, target.class).new(ems, target)
-            parser = ManageIQ::Providers::Inventory.parser_class_for(ems, target.class).new
+            persister = ManageIQ::Providers::Inventory.persister_class_for(ems, target, target.class.name.demodulize).new(ems, target)
+            parser = ManageIQ::Providers::Inventory.parser_class_for(ems, target, target.class.name.demodulize).new
 
             i = ManageIQ::Providers::Inventory.new(persister, collector, parser)
             i.parse

--- a/app/models/manageiq/providers/inventory.rb
+++ b/app/models/manageiq/providers/inventory.rb
@@ -49,11 +49,12 @@ module ManageIQ::Providers
 
     # Based on the given provider/manager class, this returns correct collector class
     #
-    # @param target class of the Provider/Manager
+    # @param ems class of the Provider/Manager
+    # @param target class of refresh's target
     # @return [Class] Correct class name of the collector
-    def self.collector_class_for(ems, target = nil)
+    def self.collector_class_for(ems, target = nil, manager_name = nil)
       target = ems if target.nil?
-      class_for(ems, target, 'Collector')
+      class_for(ems, target, 'Collector', manager_name)
     end
 
     # Based on the given provider/manager class, this returns correct persister class
@@ -61,18 +62,19 @@ module ManageIQ::Providers
     # @param ems class of the Provider/Manager
     # @param target class of refresh's target
     # @return [Class] Correct class name of the persister
-    def self.persister_class_for(ems, target = nil)
+    def self.persister_class_for(ems, target = nil, manager_name = nil)
       target = ems if target.nil?
-      class_for(ems, target, 'Persister')
+      class_for(ems, target, 'Persister', manager_name)
     end
 
     # Based on the given provider/manager class, this returns correct parser class
     #
-    # @param target class of the Provider/Manager
+    # @param ems class of the Provider/Manager
+    # @param target class of refresh's target
     # @return [Class] Correct class name of the Parser
-    def self.parser_class_for(ems, target = nil)
+    def self.parser_class_for(ems, target = nil, manager_name = nil)
       target = ems if target.nil?
-      class_for(ems, target, 'Parser')
+      class_for(ems, target, 'Parser', manager_name)
     end
 
     # @param ems [ExtManagementSystem]

--- a/app/models/manageiq/providers/inventory.rb
+++ b/app/models/manageiq/providers/inventory.rb
@@ -8,9 +8,11 @@ module ManageIQ::Providers
 
     # Entry point for building inventory
     def self.build(ems, target)
+      collector = collector_class_for(ems, target).new(ems, target)
+      persister = persister_class_for(ems, target).new(ems, target)
       new(
-        class_for(ems, target, 'Persister').new(ems, target),
-        class_for(ems, target, 'Collector').new(ems, target),
+        persister,
+        collector,
         parser_classes_for(ems, target).map(&:new)
       )
     end
@@ -45,26 +47,32 @@ module ManageIQ::Providers
       parse.inventory_collections
     end
 
+    # Based on the given provider/manager class, this returns correct collector class
+    #
+    # @param target class of the Provider/Manager
+    # @return [Class] Correct class name of the collector
+    def self.collector_class_for(ems, target = nil)
+      target = ems if target.nil?
+      class_for(ems, target, 'Collector')
+    end
+
     # Based on the given provider/manager class, this returns correct persister class
     #
-    # @param klass class of the Provider/Manager
+    # @param ems class of the Provider/Manager
+    # @param target class of refresh's target
     # @return [Class] Correct class name of the persister
-    def self.persister_class_for(klass)
-      provider_module = ManageIQ::Providers::Inflector.provider_module(klass)
-      "#{provider_module}::Inventory::Persister::#{klass.name.demodulize}".safe_constantize
-    rescue ManageIQ::Providers::Inflector::ObjectNotNamespacedError => _err
-      nil
+    def self.persister_class_for(ems, target = nil)
+      target = ems if target.nil?
+      class_for(ems, target, 'Persister')
     end
 
     # Based on the given provider/manager class, this returns correct parser class
     #
-    # @param klass class of the Provider/Manager
+    # @param target class of the Provider/Manager
     # @return [Class] Correct class name of the Parser
-    def self.parser_class_for(klass)
-      provider_module = ManageIQ::Providers::Inflector.provider_module(klass)
-      "#{provider_module}::Inventory::Parser::#{klass.name.demodulize}".safe_constantize
-    rescue ManageIQ::Providers::Inflector::ObjectNotNamespacedError => _err
-      nil
+    def self.parser_class_for(ems, target = nil)
+      target = ems if target.nil?
+      class_for(ems, target, 'Parser')
     end
 
     # @param ems [ExtManagementSystem]
@@ -72,7 +80,8 @@ module ManageIQ::Providers
     # @param type [String] 'Persister' | 'Collector' | 'Parser'
     # @param manager_name [String, nil] @see default_manager_name
     def self.class_for(ems, target, type, manager_name = nil)
-      provider_module = ManageIQ::Providers::Inflector.provider_module(ems.class)
+      ems_class = ems.class == Class ? ems : ems.class
+      provider_module = ManageIQ::Providers::Inflector.provider_module(ems_class)
 
       manager_name = parsed_manager_name(target) if manager_name.nil?
 
@@ -110,7 +119,7 @@ module ManageIQ::Providers
     # Multiple parser classes
     # Can be implemented in subclass when custom set needed (mainly for TargetCollection)
     def self.parser_classes_for(ems, target)
-      [class_for(ems, target, 'Parser')]
+      [parser_class_for(ems, target)]
     end
   end
 end


### PR DESCRIPTION
`ManageIQ::Providers::Inventory.build()` creates persister and collector classes in bad order, which causes problem with non-collected data in persister.

- Fix of PR: https://github.com/ManageIQ/manageiq/pull/17907

Next provides helpers `collector_class_for`, `parser_class_for` and `persister_class_for`. 
Existing ones are using `class_for` method now. 
