### PR TITLE
Removed boolean return value from provision testing method

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1223,26 +1223,6 @@ class Host < ApplicationRecord
   end
   alias_method :ipmi_enabled, :ipmi_config_valid?
 
-  def self.ready_for_provisioning(ids)
-    errors = ActiveModel::Errors.new(self)
-    hosts = where(:id => ids)
-    missing = ids - hosts.collect(&:id)
-    errors.add(:missing_ids, "Unable to find Hosts with the following ids #{missing.inspect}") unless missing.empty?
-
-    hosts.each do |host|
-      begin
-        if host.ipmi_config_valid?(true) == false
-          errors.add(:"Error -", _("Host not available for provisioning. Name: [%{host_name}]") % {:host_name => host.name})
-        end
-      rescue => err
-        errors.add(:error_checking, _("Error, '%{error_message}, checking Host for provisioning: Name: [%{host_name}]") %
-          {:error_message => err.message, :host_name => host.name})
-      end
-    end
-
-    errors
-  end
-
   def set_custom_field(attribute, value)
     return unless is_vmware?
     raise _("Host has no EMS, unable to set custom attribute") unless ext_management_system

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1223,7 +1223,7 @@ class Host < ApplicationRecord
   end
   alias_method :ipmi_enabled, :ipmi_config_valid?
 
-  def self.ready_for_provisioning?(ids)
+  def self.ready_for_provisioning(ids)
     errors = ActiveModel::Errors.new(self)
     hosts = where(:id => ids)
     missing = ids - hosts.collect(&:id)
@@ -1240,7 +1240,7 @@ class Host < ApplicationRecord
       end
     end
 
-    errors.empty? ? true : errors
+    errors
   end
 
   def set_custom_field(attribute, value)


### PR DESCRIPTION
~~Merge together with https://github.com/ManageIQ/manageiq-ui-classic/pull/4598~~

~~Changing the `ready_for_provision?` method to better fit to Ruby standards.
The method now returns array with errors~~

~~The test for emptiness is moved to https://github.com/ManageIQ/manageiq-ui-classic/pull/4598/files#diff-55c5b7aecfb519d0e4880eaf2788eb6eR1749~~

Update: Method is dead since merging https://github.com/ManageIQ/manageiq-ui-classic/pull/4169

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/issues/1134
* https://github.com/ManageIQ/manageiq-ui-classic/pull/4598