### PR TITLE
[GAPRINDASHVILI] Add requester info to log message

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -197,7 +197,7 @@ module RetirementMixin
   def raise_retirement_event(event_name, requester = nil)
     requester ||= User.current_user.try(:userid)
     q_options = retire_queue_options
-    $log.info("Raising Retirement Event for [#{name}] with queue options: #{q_options.inspect}")
+    $log.info("Requester [#{requester}] raising Retirement Event for [#{name}] with queue options: #{q_options.inspect}")
     MiqEvent.raise_evm_event(self, event_name, setup_event_hash(requester), q_options)
   end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1625320

This is the g/release version of https://github.com/ManageIQ/manageiq/pull/17898 which adds the requester information to the logging in raise_retirement_event. 
