### PR TITLE
Fixing Computer System relationship on Physical Storage

### DIFF
--- a/app/models/physical_storage.rb
+++ b/app/models/physical_storage.rb
@@ -9,11 +9,13 @@ class PhysicalStorage < ApplicationRecord
   has_one :asset_detail, :as => :resource, :dependent => :destroy, :inverse_of => false
 
   has_many :canisters, :dependent => :destroy, :inverse_of => false
-  has_many :computer_system, :through => :canisters
-  has_many :hardware, :through => :computer_system
-  has_many :guest_devices, :through => :canisters
-
   has_many :physical_disks, :dependent => :destroy, :inverse_of => :physical_storage
+
+  has_one :computer_system, :as => :managed_entity, :dependent => :destroy
+  has_one :hardware, :through => :computer_system
+
+  has_many :canister_computer_systems, :through => :canisters, :source => :computer_system
+  has_many :guest_devices, :through => :hardware
 
   supports :refresh_ems
 


### PR DESCRIPTION
This PR is able to:
- Keep Computer System on PhysicalStorage for any provider to use and allow it to have Computer Systems through Canisters.