### PR TITLE
Add a 'name' parameter to backup restore, and make volumeid optional

### DIFF
--- a/app/models/cloud_volume_backup.rb
+++ b/app/models/cloud_volume_backup.rb
@@ -11,7 +11,7 @@ class CloudVolumeBackup < ApplicationRecord
   belongs_to :cloud_volume
   has_one :cloud_tenant, :through => :cloud_volume
 
-  def restore_queue(userid, volumeid)
+  def restore_queue(userid, volumeid = nil, name = nil)
     task_opts = {
       :action => "Restoring Cloud Volume Backup for user #{userid}",
       :userid => userid
@@ -22,13 +22,13 @@ class CloudVolumeBackup < ApplicationRecord
       :instance_id => id,
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,
-      :args        => [volumeid]
+      :args        => [volumeid, name]
     }
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
-  def restore(volume)
-    raw_restore(volume)
+  def restore(volume = nil, name = nil)
+    raw_restore(volume, name)
   end
 
   def raw_restore(*)


### PR DESCRIPTION
Allows supporting the Cinder API's ability to restore backups to brand new volumes.

See also:
https://github.com/ManageIQ/manageiq-providers-openstack/pull/345
https://github.com/ManageIQ/manageiq-ui-classic/pull/4623
https://github.com/fog/fog-openstack/pull/419
https://bugzilla.redhat.com/show_bug.cgi?id=1514970