### PR TITLE
Add scope in model ability to RBAC

### DIFF
--- a/app/models/custom_button_event.rb
+++ b/app/models/custom_button_event.rb
@@ -2,6 +2,14 @@ class CustomButtonEvent < EventStream
   virtual_column :button_name, :type => :string
   virtual_column :automate_entry_point, :type => :string
 
+  def self.rbac_scope_for_model(user)
+    if user.super_admin_user?
+      all
+    else
+      none
+    end
+  end
+
   def automate_entry_point
     full_data[:automate_entry_point].to_s
   end

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -6,7 +6,7 @@ class GenericObject < ApplicationRecord
 
   belongs_to :generic_object_definition
   has_one :picture, :through => :generic_object_definition
-  has_many :custom_button_events, -> { where(:type => "CustomButtonEvent") }, :class_name => "EventStream", :foreign_key => :target_id
+  has_many :custom_button_events, :foreign_key => :target_id, :dependent => :destroy
 
   validates :name, :presence => true
 

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -3,7 +3,7 @@ module CustomActionsMixin
 
   included do
     has_many :custom_button_sets, :as => :owner, :dependent => :destroy
-    has_many :custom_button_events, -> { where(:type => "CustomButtonEvent") }, :class_name => "EventStream", :foreign_key => :target_id
+    has_many :custom_button_events, :foreign_key => :target_id, :dependent => :destroy
     virtual_has_many :custom_buttons
     virtual_has_one :custom_actions, :class_name => "Hash"
     virtual_has_one :custom_action_buttons, :class_name => "Array"

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -543,6 +543,10 @@ module Rbac
         scope = scope_to_cloud_tenant(scope, user, miq_group)
       end
 
+      if klass.respond_to?(:rbac_scope_for_model)
+        scope = scope.rbac_scope_for_model(user)
+      end
+
       if apply_rbac_directly?(klass)
         filtered_ids = calc_filtered_ids(scope, rbac_filters, user, miq_group, nil)
         scope_by_ids(scope, filtered_ids)


### PR DESCRIPTION
created for @skateman 🎁 

he wanted to restrict visibility of `CustomButtonEvents` for non super-admin.

_NOTE: admin user has been removed by @kbrock's recent work(probably last PR  ot the work https://github.com/ManageIQ/manageiq/pull/17850) in order to have just specialized admin users._   -  **So this PR is allowing visibility just for super_admins.**

### Implementation 

I decided to add to RBAC a other concept(`scope_for_model?`) - it will allow to define scope in models to reach required behaviour. (maybe similar to `scope_for_user_role_group`) 

### Example of future usage( for other models)
This will be also usable for MiqSchedule, when you look in UI you will see  on couple places:
```
if User.super_admin?
                # Super admins see all report schedules
                MiqSchedule.where(:towhat => 'MiqReport')
              else
                MiqSchedule.where(:towhat => 'MiqReport', :userid => User.current_user.userid)
              end
```

@miq-bot assign @gtanzillo 


## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1511126

