### PR TITLE
Add replication set-up methods to be queued on UI side

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -75,16 +75,9 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def self.delete_all(list = nil)
-    errors = []
-    (list.nil? ? find(:all) : list)&.each do |sub|
-      begin
-        sub.delete(false)
-      rescue => e
-        errors << "Failed to delete subscription to #{sub.host}: #{e.message}"
-      end
-    end
+    (list.nil? ? find(:all) : list)&.each { |sub| sub.delete(false) }
     EvmDatabase.restart_failover_monitor_service_queue
-    errors
+    nil
   end
 
   def disable

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -74,10 +74,17 @@ class PglogicalSubscription < ActsAsArModel
     EvmDatabase.restart_failover_monitor_service_queue if reload_failover_monitor_service
   end
 
-  def self.delete_all
-    find(:all).each { |sub| sub.delete(false) }
+  def self.delete_all(list = nil)
+    errors = []
+    (list.nil? ? find(:all) : list)&.each do |sub|
+      begin
+        sub.delete(false)
+      rescue => e
+        errors << "Failed to delete subscription to #{sub.host}: #{e.message}"
+      end
+    end
     EvmDatabase.restart_failover_monitor_service_queue
-    nil
+    errors
   end
 
   def disable

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -143,39 +143,15 @@ class MiqPglogical
     YAML.load_file(Rails.root.join("config/default_replication_exclude_tables.yml"))[:exclude_tables] | ALWAYS_EXCLUDED_TABLES
   end
 
-  def self.save_replication_type(type)
-    error = []
-    begin
-      MiqRegion.replication_type = type
-    rescue => e
-      error << "Failed to update replication type: #{e.message}"
-    end
-    error
-  end
-
   def self.save_remote_region(exclusion_list)
-    errors = save_replication_type(:remote)
-    return errors unless errors.empty?
-
-    begin
-      refresh_excludes(YAML.safe_load(exclusion_list))
-    rescue => e
-      errors << "Failed to update exclution list: #{e.message}"
-    end
-    errors
+    MiqRegion.replication_type = :remote
+    refresh_excludes(YAML.safe_load(exclusion_list))
   end
 
   def self.save_global_region(subscriptions_to_save, subscriptions_to_remove)
-    errors = save_replication_type(:global)
-    return errors unless errors.empty?
-
-    errors = PglogicalSubscription.delete_all(subscriptions_to_remove)
-    begin
-      PglogicalSubscription.save_all!(subscriptions_to_save)
-    rescue => e
-      errors << e.message
-    end
-    errors
+    MiqRegion.replication_type = :global
+    PglogicalSubscription.delete_all(subscriptions_to_remove)
+    PglogicalSubscription.save_all!(subscriptions_to_save)
   end
 
   private

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -313,6 +313,28 @@ describe PglogicalSubscription do
     end
   end
 
+  describe ".delete_all" do
+    let(:subscription1) { double }
+    let(:subscription2) { double }
+
+    after do
+      expect(MiqQueue.where(:method_name => "restart_failover_monitor_service").count).to eq(1)
+    end
+
+    it "deletes all subscriptions if no parameter passed" do
+      allow(described_class).to receive(:find).with(:all).and_return([subscription1, subscription2])
+      expect(subscription1).to receive(:delete)
+      expect(subscription2).to receive(:delete)
+      described_class.delete_all
+    end
+
+    it "only deletes subscriptions listed in parameter if parameter passed" do
+      expect(subscription1).to receive(:delete)
+      expect(subscription2).not_to receive(:delete)
+      described_class.delete_all([subscription1])
+    end
+  end
+
   describe ".save_all!" do
     after do
       expect(MiqQueue.where(:method_name => "restart_failover_monitor_service").count).to eq(1)

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -1,145 +1,147 @@
 describe MiqPglogical do
-  let(:connection) { ApplicationRecord.connection }
-  let(:pglogical)  { connection.pglogical }
+  context "requires pglogical been installed" do
+    let(:connection) { ApplicationRecord.connection }
+    let(:pglogical)  { connection.pglogical }
 
-  before do
-    skip "pglogical must be installed" unless pglogical.installed?
-    MiqServer.seed
-  end
-
-  describe "#active_excludes" do
-    it "returns an empty array if a provider is not configured" do
-      expect(subject.active_excludes).to eq([])
-    end
-  end
-
-  describe "#provider?" do
-    it "is false when a provider is not configured" do
-      expect(subject.provider?).to be false
-    end
-  end
-
-  describe "#node?" do
-    it "is false when a provider is not configured" do
-      expect(subject.node?).to be false
-    end
-  end
-
-  describe "#configure_provider" do
-    it "enables the extenstion and creates the replication set" do
-      subject.configure_provider
-      expect(pglogical.enabled?).to be true
-      expect(pglogical.replication_sets).to include(described_class::REPLICATION_SET_NAME)
-    end
-
-    it "does not enable the extension when an exception is raised" do
-      expect(subject).to receive(:create_replication_set).and_raise(PG::UniqueViolation)
-      expect { subject.configure_provider }.to raise_error(PG::UniqueViolation)
-      expect(pglogical.enabled?).to be false
-    end
-  end
-
-  context "when configured as a provider" do
     before do
-      subject.configure_provider
+      skip "pglogical must be installed" unless pglogical.installed?
+      MiqServer.seed
     end
 
     describe "#active_excludes" do
-      it "returns the initial set of excluded tables" do
-        expect(subject.active_excludes).to eq(connection.tables - subject.included_tables)
+      it "returns an empty array if a provider is not configured" do
+        expect(subject.active_excludes).to eq([])
       end
     end
 
     describe "#provider?" do
-      it "is true" do
-        expect(subject.provider?).to be true
+      it "is false when a provider is not configured" do
+        expect(subject.provider?).to be false
       end
     end
 
     describe "#node?" do
-      it "is true" do
-        expect(subject.node?).to be true
-      end
-    end
-
-    describe "#destroy_provider" do
-      it "removes the provider configuration" do
-        subject.destroy_provider
-        expect(subject.provider?).to be false
+      it "is false when a provider is not configured" do
         expect(subject.node?).to be false
-        expect(connection.extension_enabled?("pglogical")).to be false
       end
     end
 
-    describe "#create_replication_set" do
-      it "creates the correct initial set" do
-        expected_excludes = subject.configured_excludes
-        extra_excludes = subject.configured_excludes - connection.tables
-        actual_excludes = connection.tables - subject.included_tables
-        expect(actual_excludes | extra_excludes).to match_array(expected_excludes)
+    describe "#configure_provider" do
+      it "enables the extenstion and creates the replication set" do
+        subject.configure_provider
+        expect(pglogical.enabled?).to be true
+        expect(pglogical.replication_sets).to include(described_class::REPLICATION_SET_NAME)
+      end
+
+      it "does not enable the extension when an exception is raised" do
+        expect(subject).to receive(:create_replication_set).and_raise(PG::UniqueViolation)
+        expect { subject.configure_provider }.to raise_error(PG::UniqueViolation)
+        expect(pglogical.enabled?).to be false
       end
     end
 
-    describe ".refresh_excludes" do
-      it "sets the configured excludes and calls refresh on an instance" do
-        pgl = described_class.new
-        expect(described_class).to receive(:new).and_return(pgl)
-        expect(pgl).to receive(:refresh_excludes)
+    context "when configured as a provider" do
+      before do
+        subject.configure_provider
+      end
 
-        new_excludes = %w(my new exclude tables)
-        described_class.refresh_excludes(new_excludes)
+      describe "#active_excludes" do
+        it "returns the initial set of excluded tables" do
+          expect(subject.active_excludes).to eq(connection.tables - subject.included_tables)
+        end
+      end
 
-        expect(pgl.configured_excludes).to match_array(new_excludes | described_class::ALWAYS_EXCLUDED_TABLES)
+      describe "#provider?" do
+        it "is true" do
+          expect(subject.provider?).to be true
+        end
+      end
+
+      describe "#node?" do
+        it "is true" do
+          expect(subject.node?).to be true
+        end
+      end
+
+      describe "#destroy_provider" do
+        it "removes the provider configuration" do
+          subject.destroy_provider
+          expect(subject.provider?).to be false
+          expect(subject.node?).to be false
+          expect(connection.extension_enabled?("pglogical")).to be false
+        end
+      end
+
+      describe "#create_replication_set" do
+        it "creates the correct initial set" do
+          expected_excludes = subject.configured_excludes
+          extra_excludes = subject.configured_excludes - connection.tables
+          actual_excludes = connection.tables - subject.included_tables
+          expect(actual_excludes | extra_excludes).to match_array(expected_excludes)
+        end
+      end
+
+      describe ".refresh_excludes" do
+        it "sets the configured excludes and calls refresh on an instance" do
+          pgl = described_class.new
+          expect(described_class).to receive(:new).and_return(pgl)
+          expect(pgl).to receive(:refresh_excludes)
+
+          new_excludes = %w(my new exclude tables)
+          described_class.refresh_excludes(new_excludes)
+
+          expect(pgl.configured_excludes).to match_array(new_excludes | described_class::ALWAYS_EXCLUDED_TABLES)
+        end
+      end
+
+      describe "#refresh_excludes" do
+        it "adds a new non excluded table" do
+          connection.exec_query(<<-SQL)
+            CREATE TABLE test (id INTEGER PRIMARY KEY)
+          SQL
+          subject.refresh_excludes
+          expect(subject.included_tables).to include("test")
+        end
+
+        it "removes a newly excluded table" do
+          table = subject.included_tables.first
+          subject.configured_excludes += [table]
+
+          expect(subject.active_excludes).not_to include(table)
+          expect(subject.included_tables).to include(table)
+
+          subject.refresh_excludes
+
+          expect(subject.active_excludes).to include(table)
+          expect(subject.included_tables).not_to include(table)
+        end
+
+        it "adds a newly included table" do
+          current_excludes = subject.configured_excludes
+          table = current_excludes.pop
+          subject.configured_excludes = current_excludes
+
+          expect(subject.active_excludes).to include(table)
+          expect(subject.included_tables).not_to include(table)
+
+          subject.refresh_excludes
+
+          expect(subject.active_excludes).not_to include(table)
+          expect(subject.included_tables).to include(table)
+        end
       end
     end
 
-    describe "#refresh_excludes" do
-      it "adds a new non excluded table" do
-        connection.exec_query(<<-SQL)
-          CREATE TABLE test (id INTEGER PRIMARY KEY)
-        SQL
-        subject.refresh_excludes
-        expect(subject.included_tables).to include("test")
-      end
-
-      it "removes a newly excluded table" do
-        table = subject.included_tables.first
-        subject.configured_excludes += [table]
-
-        expect(subject.active_excludes).not_to include(table)
-        expect(subject.included_tables).to include(table)
-
-        subject.refresh_excludes
-
-        expect(subject.active_excludes).to include(table)
-        expect(subject.included_tables).not_to include(table)
-      end
-
-      it "adds a newly included table" do
-        current_excludes = subject.configured_excludes
-        table = current_excludes.pop
-        subject.configured_excludes = current_excludes
-
-        expect(subject.active_excludes).to include(table)
-        expect(subject.included_tables).not_to include(table)
-
-        subject.refresh_excludes
-
-        expect(subject.active_excludes).not_to include(table)
-        expect(subject.included_tables).to include(table)
+    describe ".region_to_node_name" do
+      it "returns the correct name" do
+        expect(described_class.region_to_node_name(4)).to eq("region_4")
       end
     end
-  end
 
-  describe ".region_to_node_name" do
-    it "returns the correct name" do
-      expect(described_class.region_to_node_name(4)).to eq("region_4")
-    end
-  end
-
-  describe ".node_name_to_region" do
-    it "returns the correct region" do
-      expect(described_class.node_name_to_region("region_5")).to eq(5)
+    describe ".node_name_to_region" do
+      it "returns the correct region" do
+        expect(described_class.node_name_to_region("region_5")).to eq(5)
+      end
     end
   end
 


### PR DESCRIPTION
Add replication set-up methods to be queued on UI side

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1562956

Corresponding PR on UI side: https://github.com/ManageIQ/manageiq-ui-classic/pull/4628

@miq-bot add-label core