### PR TITLE
[POC][WIP] ActiveSupport::Notifications approach to determining slow requests

### DIFF
--- a/lib/workers/rails_request_monitor.rb
+++ b/lib/workers/rails_request_monitor.rb
@@ -1,0 +1,40 @@
+# Autoload ActionController::LogSubscriber to make sure it subscribes
+# ActiveSupport::Notifications and generates a @queue_key for this thread and
+# child threads (they will all be the same)
+ActionController::LogSubscriber
+
+class RailsRequestMonitor
+  THREAD_VAR_KEY = "ActiveSupport::SubscriberQueueRegistry".freeze
+  QUEUE_KEY      = ActiveSupport::Subscriber.subscribers.detect { |sub| 
+                     sub.kind_of? ActionController::LogSubscriber
+                   }.instance_variable_get(:@queue_key).dup.freeze
+
+  class << self
+    def log_long_running_requests(with_backtrace = false)
+      now = Time.now
+      Thread.list.each do |thread|
+        if thread[THREAD_VAR_KEY] && queue = thread[THREAD_VAR_KEY].get_queue(QUEUE_KEY)
+          queue.each do |request|
+            next unless request.time < too_slow
+
+            duration = (now - request.time).to_f  # don't use event.duration, will mutate
+            message  = "Long running http(s) request: "                                 \
+                       "'#{request.payload[:controller]}##{request.payload[:action]}' " \
+                       "handled by ##{Process.pid}:#{thread.object_id.to_s(16)}, "      \
+                       "running for #{duration.round(2)} seconds"
+            message << "\n#{thread.backtrace}" if with_backtrace
+
+            Rails.logger.warn(message)
+          end
+        end
+      end
+    end
+
+    private
+
+    # TODO:  Maybe make this a setting?
+    def too_slow
+      10.seconds.ago
+    end
+  end
+end

--- a/lib/workers/rails_request_monitor.rb
+++ b/lib/workers/rails_request_monitor.rb
@@ -11,10 +11,13 @@ class RailsRequestMonitor
 
   class << self
     def log_long_running_requests(with_backtrace = false)
-      now = Time.now
       Thread.list.each do |thread|
         if thread[THREAD_VAR_KEY] && queue = thread[THREAD_VAR_KEY].get_queue(QUEUE_KEY)
+          now      ||= nil
+          too_slow ||= nil
           queue.each do |request|
+            now      ||= Time.now
+            too_slow ||= now - long_request_time
             next unless request.time < too_slow
 
             duration = (now - request.time).to_f  # don't use event.duration, will mutate
@@ -33,8 +36,10 @@ class RailsRequestMonitor
     private
 
     # TODO:  Maybe make this a setting?
-    def too_slow
-      10.seconds.ago
+    # LONG_REQUEST = 10.seconds
+    LONG_REQUEST = 10 # seconds
+    def long_request_time
+      LONG_REQUEST
     end
   end
 end


### PR DESCRIPTION
This is a different approach to https://github.com/ManageIQ/manageiq/pull/17842


Description
-----------

This peers into the private APIs of `ActiveSupport` and `ActionController::LogSubscriber` to check the status of the queued up events for 'process_action.action_controller', and see if any are larger than 10 seconds (will probably update this to 1 minute).  If they are, it will report them to the Rails.logger.

**Pros**

- Zero object allocations and stacklevel weight added to requests
- Almost zero object allocations in the watching thread

**Cons**

- Very "Rails internal API" focused (aka "confusing as F...")
- Touching internal thread variables that are used elsewhere (more unknowns)


Usage
-----

This can be instrumented in many ways, but the easiest is via a `config/initializer` for local development use:

```ruby
 # config/initializers/request_watcher.local.rb
if ENV['WATCH_FOR_LONG_REQUESTS']
 require 'workers/rails_request_monitor'

  Thread.new do
   loop do
     sleep 10
     RailsRequestMonitor.log_long_running_requests
   end
 end.abort_on_exception = true
end
```

And running a development server by running:

```console
$ WATCH_FOR_LONG_REQUESTS=1 bin/rails s
```

This will check every 10 seconds, and when long requests are found, they will be output to the Rails.log on level WARN.

This can also be instrumented in `MiqWebServerRunnerMixin` with relative ease:

```ruby
 # app/models/mixins/miq_web_server_runner_mixin.rb

+
+ def do_heartbeat_work
+   RailsRequestMonitor.log_long_running_requests
+ end
```

Or anywhere that it makes sense (signal handlers, etc.)


Links
-----

* https://github.com/ManageIQ/manageiq/pull/17842


Steps for Testing/QA
--------------------

The steps in the BZ from https://github.com/ManageIQ/manageiq/pull/17842 is a good start, but this is what I did:

1. Get the code from this branch:  `git apply <(curl -L https://github.com/ManageIQ/manageiq/pull/17958.path)`
  
2. Update the API (`bundle open manageiq-api`) to include this code in `app/controllers/api/ping_controller.rb`:
  
  ```ruby
  module Api
    class PingController < ActionController::API
      def index
        sleep 60 if rand(5) == 0
        render :plain => 'pong'
      end
    end
  end
  ```
  
3. Add the initializer from above to `config/initializers/`.
  
4. Run a rails server:  `$ WATCH_FOR_LONG_REQUESTS=1 bin/rails s`
  
5. Hit `localhost:3000/api/ping` until you get a few requests that take a while a bunch of times and watch the logs
  
  - continuing to refresh regardless if you get a response is probably the best technique here
  
6. You should see [WARN] messages eventually for the requests that don't complete immediately.