### PR TITLE
Allow ems to terminate connection after use

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -403,7 +403,13 @@ class ExtManagementSystem < ApplicationRecord
   def with_provider_connection(options = {})
     raise _("no block given") unless block_given?
     _log.info("Connecting through #{self.class.name}: [#{name}]")
-    yield connect(options)
+    connection = connect(options)
+    yield connection
+  ensure
+    disconnect(connection) if connection
+  end
+
+  def disconnect(_connection)
   end
 
   def self.refresh_all_ems_timer


### PR DESCRIPTION
This commit adds a simple disconnect hook that allows ext management
systems (providers) to terminate connection after it is no longer
needed.

Use case for such functionality is provider that needs to delete user
session after the operation since user sessions are long-lived and
number of concurrent live sessions is limited.

@miq-bot assign @agrare 