### PR TITLE
Removing unused method for action's support testing

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -834,16 +834,6 @@ class Storage < ApplicationRecord
     with_relationship_type("vm_scan_storage_affinity") { parents }
   end
 
-  def self.batch_operation_supported?(operation, ids)
-    Storage.where(:id => ids).all? do |s|
-      if s.respond_to?("supports_#{operation}?")
-        s.public_send("supports_#{operation}?")
-      else
-        s.public_send("validate_#{operation}")[:available]
-      end
-    end
-  end
-
   # @param [String, Storage] store_type upcased version of the storage type
   def self.supports?(store_type)
     Storage::SUPPORTED_STORAGE_TYPES.include?(store_type)

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -430,23 +430,6 @@ describe Storage do
     end
   end
 
-  context ".batch_operation_supported?" do
-    before do
-      @storage =  FactoryGirl.create(:storage)
-    end
-
-    it "returns false when queried whether the storage supports smarstate analysis" do
-      expect(Storage.batch_operation_supported?(:smartstate_analysis, [@storage.id])).to eq(false)
-    end
-
-    it "returns true when queried whether the storage supports smarstate analysis" do
-      FactoryGirl.create(:host_vmware,
-                         :ext_management_system => FactoryGirl.create(:ems_vmware_with_valid_authentication),
-                         :storages              => [@storage])
-      expect(Storage.batch_operation_supported?(:smartstate_analysis, [@storage.id])).to eq(true)
-    end
-  end
-
   describe "#update_vm_perf" do
     it "will update a vm_perf with an attributes hash keyed with symbols" do
       storage = FactoryGirl.create(:storage)


### PR DESCRIPTION
## Merge after https://github.com/ManageIQ/manageiq-ui-classic/pull/4604

Removing the `batch_operation_supported?` method and it's specs, that will be unused after merging https://github.com/ManageIQ/manageiq-ui-classic/pull/4604

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/4604
