### PR TITLE
Openstack Swift DB Backups

### DIFF
--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -1,8 +1,9 @@
 class DatabaseBackup < ApplicationRecord
   SUPPORTED_DEPOTS = {
-    'smb' => 'Samba',
-    'nfs' => 'Network File System',
-    's3'  => 'AWS S3'
+    'smb'   => 'Samba',
+    'nfs'   => 'Network File System',
+    's3'    => 'AWS S3',
+    'swift' => 'Openstack Swift'
   }.freeze
 
   def self.supported_depots

--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -3,7 +3,7 @@ class DatabaseBackup < ApplicationRecord
     'smb'   => 'Samba',
     'nfs'   => 'Network File System',
     's3'    => 'AWS S3',
-    'swift' => 'Openstack Swift'
+    'swift' => 'OpenStack Swift'
   }.freeze
 
   def self.supported_depots

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -32,4 +32,8 @@ class FileDepot < ApplicationRecord
   def upload_file(file)
     @file = file
   end
+
+  def merged_uri
+    uri
+  end
 end

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -54,6 +54,7 @@ class FileDepotSwift < FileDepot
   end
 
   def merged_uri(uri, api_port)
+    uri            = URI(uri)
     uri.port       = api_port.presence || 5000
     query_elements = []
     query_elements << "region=#{openstack_region}"              if openstack_region.present?
@@ -61,6 +62,6 @@ class FileDepotSwift < FileDepot
     query_elements << "domain_id=#{v3_domain_ident}"            if v3_domain_ident.present?
     query_elements << "security_protocol=#{security_protocol}"  if security_protocol.present?
     uri.query = query_elements.join('&').presence
-    uri
+    uri.to_s
   end
 end

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -32,8 +32,8 @@ class FileDepotSwift < FileDepot
       begin
         OpenstackHandle::Handle.new(username, password, address, port, keystone_api_version, security_protocol, extra_options)
       rescue => err
-        logger.error("Error connecting to Swift host #{address}. #{err}")
         msg = "Error connecting to Swift host #{address}. #{err}"
+        logger.error(msg)
         raise err, msg, err.backtrace
       end
     end
@@ -45,11 +45,11 @@ class FileDepotSwift < FileDepot
     connect(options.merge(:auth_type => auth_type))
   rescue Excon::Errors::Unauthorized => err
     msg = "Access to Swift host #{host} failed due to a bad username or password."
-    logger.error("Access to Swift host #{host} failed due to a bad username or password. #{err}")
+    logger.error("#{msg} #{err}")
     raise msg
   rescue => err
-    logger.error("Error connecting to Swift host #{host}. #{err}")
     msg = "Error connecting to Swift host #{host}. #{err}"
+    logger.error(msg)
     raise err, msg, err.backtrace
   end
 

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -56,8 +56,7 @@ class FileDepotSwift < FileDepot
   end
 
   def merged_uri(uri, api_port)
-    port           = api_port.presence || 5000
-    uri            = URI.parse("#{URI(uri).scheme}://#{URI(uri).host}:#{port}#{URI(uri).path}")
+    uri.port       = api_port.presence || 5000
     query_elements = []
     query_elements << "region=#{openstack_region}"              if openstack_region.present?
     query_elements << "api_version=#{keystone_api_version}"     if keystone_api_version.present?

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -1,0 +1,74 @@
+class FileDepotSwift < FileDepot
+  attr_accessor :swift
+
+  def self.uri_prefix
+    "swift"
+  end
+
+  def self.validate_settings(settings)
+    new(:uri => settings[:uri]).verify_credentials(nil, settings.slice(:username, :password))
+  end
+
+  def connect(options = {})
+    uri  = options[:uri]
+    host = URI(uri).host
+    openstack_handle(options).connect(options)
+  rescue Excon::Errors::Unauthorized => err
+    logger.error("Access to Swift host #{host} failed due to a bad username or password. #{err}")
+    nil
+  rescue => err
+    logger.error("Error connecting to Swift host #{host}. #{err}")
+    msg = "Error connecting to Swift host #{host}. #{err}"
+    raise err, msg, err.backtrace
+  end
+
+  def openstack_handle(options = {})
+    require 'manageiq/providers/openstack/legacy/openstack_handle'
+    @openstack_handle ||= begin
+
+      username = options[:username] || authentication_userid(options[:auth_type])
+      password = options[:password] || authentication_password(options[:auth_type])
+      uri      = options[:uri]
+      address  = URI(uri).host
+      port     = URI(uri).port
+
+      extra_options = {
+        :ssl_ca_file    => ::Settings.ssl.ssl_ca_file,
+        :ssl_ca_path    => ::Settings.ssl.ssl_ca_path,
+        :ssl_cert_store => OpenSSL::X509::Store.new
+      }
+      extra_options[:domain_id]         = v3_domain_ident
+      extra_options[:service]           = "Compute"
+      extra_options[:omit_default_port] = ::Settings.ems.ems_openstack.excon.omit_default_port
+      extra_options[:read_timeout]      = ::Settings.ems.ems_openstack.excon.read_timeout
+      begin
+        OpenstackHandle::Handle.new(username, password, address, port, keystone_api_version, security_protocol, extra_options)
+      rescue => err
+        logger.error("Error connecting to Swift host #{address}. #{err}")
+        msg = "Error connecting to Swift host #{address}. #{err}"
+        raise err, msg, err.backtrace
+      end
+    end
+  end
+
+  def verify_credentials(auth_type = nil, options = {})
+    auth_type ||= 'default'
+
+    options[:auth_type] = auth_type
+    connect(options.merge(:auth_type => auth_type))
+  rescue => err
+    logger.error("Error connecting to Swift host #{host}. #{err}")
+    msg = "Error connecting to Swift host #{host}. #{err}"
+    raise err, msg, err.backtrace
+  end
+
+  def merged_uri(uri, api_port)
+    port      = api_port.blank? ? 5000 : api_port
+    uri       = URI.parse("#{URI(uri).scheme}://#{URI(uri).host}:#{port}#{URI(uri).path}")
+    uri.query = [uri.query, "region=#{openstack_region}"].compact.join('&') unless openstack_region.blank?
+    uri.query = [uri.query, "api_version=#{keystone_api_version}"].compact.join('&') unless keystone_api_version.blank?
+    uri.query = [uri.query, "domain_id=#{v3_domain_ident}"].compact.join('&') unless v3_domain_ident.blank?
+    uri.query = [uri.query, "security_protocol=#{security_protocol}"].compact.join('&') unless security_protocol.blank?
+    uri
+  end
+end

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -25,7 +25,6 @@ class FileDepotSwift < FileDepot
   def openstack_handle(options = {})
     require 'manageiq/providers/openstack/legacy/openstack_handle'
     @openstack_handle ||= begin
-
       username = options[:username] || authentication_userid(options[:auth_type])
       password = options[:password] || authentication_password(options[:auth_type])
       uri      = options[:uri]
@@ -63,12 +62,12 @@ class FileDepotSwift < FileDepot
   end
 
   def merged_uri(uri, api_port)
-    port      = api_port.blank? ? 5000 : api_port
+    port      = api_port.presence || 5000
     uri       = URI.parse("#{URI(uri).scheme}://#{URI(uri).host}:#{port}#{URI(uri).path}")
-    uri.query = [uri.query, "region=#{openstack_region}"].compact.join('&') unless openstack_region.blank?
-    uri.query = [uri.query, "api_version=#{keystone_api_version}"].compact.join('&') unless keystone_api_version.blank?
-    uri.query = [uri.query, "domain_id=#{v3_domain_ident}"].compact.join('&') unless v3_domain_ident.blank?
-    uri.query = [uri.query, "security_protocol=#{security_protocol}"].compact.join('&') unless security_protocol.blank?
+    uri.query = [uri.query, "region=#{openstack_region}"].compact.join('&') if openstack_region.present?
+    uri.query = [uri.query, "api_version=#{keystone_api_version}"].compact.join('&') if keystone_api_version.present?
+    uri.query = [uri.query, "domain_id=#{v3_domain_ident}"].compact.join('&') if v3_domain_ident.present?
+    uri.query = [uri.query, "security_protocol=#{security_protocol}"].compact.join('&') if security_protocol.present?
     uri
   end
 end

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -10,16 +10,7 @@ class FileDepotSwift < FileDepot
   end
 
   def connect(options = {})
-    uri  = options[:uri]
-    host = URI(uri).host
     openstack_handle(options).connect(options)
-  rescue Excon::Errors::Unauthorized => err
-    logger.error("Access to Swift host #{host} failed due to a bad username or password. #{err}")
-    nil
-  rescue => err
-    logger.error("Error connecting to Swift host #{host}. #{err}")
-    msg = "Error connecting to Swift host #{host}. #{err}"
-    raise err, msg, err.backtrace
   end
 
   def openstack_handle(options = {})
@@ -51,8 +42,13 @@ class FileDepotSwift < FileDepot
   end
 
   def verify_credentials(auth_type = 'default', options = {})
+    host = URI(options[:uri]).host
     options[:auth_type] = auth_type
     connect(options.merge(:auth_type => auth_type))
+  rescue Excon::Errors::Unauthorized => err
+    msg = "Access to Swift host #{host} failed due to a bad username or password."
+    logger.error("Access to Swift host #{host} failed due to a bad username or password. #{err}")
+    raise msg
   rescue => err
     logger.error("Error connecting to Swift host #{host}. #{err}")
     msg = "Error connecting to Swift host #{host}. #{err}"

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -50,9 +50,7 @@ class FileDepotSwift < FileDepot
     end
   end
 
-  def verify_credentials(auth_type = nil, options = {})
-    auth_type ||= 'default'
-
+  def verify_credentials(auth_type = 'default', options = {})
     options[:auth_type] = auth_type
     connect(options.merge(:auth_type => auth_type))
   rescue => err
@@ -62,12 +60,14 @@ class FileDepotSwift < FileDepot
   end
 
   def merged_uri(uri, api_port)
-    port      = api_port.presence || 5000
-    uri       = URI.parse("#{URI(uri).scheme}://#{URI(uri).host}:#{port}#{URI(uri).path}")
-    uri.query = [uri.query, "region=#{openstack_region}"].compact.join('&') if openstack_region.present?
-    uri.query = [uri.query, "api_version=#{keystone_api_version}"].compact.join('&') if keystone_api_version.present?
-    uri.query = [uri.query, "domain_id=#{v3_domain_ident}"].compact.join('&') if v3_domain_ident.present?
-    uri.query = [uri.query, "security_protocol=#{security_protocol}"].compact.join('&') if security_protocol.present?
+    port           = api_port.presence || 5000
+    uri            = URI.parse("#{URI(uri).scheme}://#{URI(uri).host}:#{port}#{URI(uri).path}")
+    query_elements = []
+    query_elements << "region=#{openstack_region}"              if openstack_region.present?
+    query_elements << "api_version=#{keystone_api_version}"     if keystone_api_version.present?
+    query_elements << "domain_id=#{v3_domain_ident}"            if v3_domain_ident.present?
+    query_elements << "security_protocol=#{security_protocol}"  if security_protocol.present?
+    uri.query = query_elements.join('&').presence
     uri
   end
 end

--- a/app/models/file_depot_swift.rb
+++ b/app/models/file_depot_swift.rb
@@ -1,6 +1,4 @@
 class FileDepotSwift < FileDepot
-  attr_accessor :swift
-
   def self.uri_prefix
     "swift"
   end

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -331,16 +331,23 @@ class MiqSchedule < ApplicationRecord
   end
 
   def verify_file_depot(params)  # TODO: This logic belongs in the UI, not sure where
-    depot_class      = FileDepot.supported_protocols[params[:uri_prefix]]
-    depot            = file_depot.class.name == depot_class ? file_depot : build_file_depot(:type => depot_class)
-    depot.name       = params[:name]
-    depot.uri        = params[:uri]
-    depot.aws_region = params[:aws_region]
+    depot_class                = FileDepot.supported_protocols[params[:uri_prefix]]
+    depot                      = file_depot.class.name == depot_class ? file_depot : build_file_depot(:type => depot_class)
+    depot.name                 = params[:name]
+    uri                        = params[:uri]
+    api_port                   = params[:swift_api_port]
+    depot.aws_region           = params[:aws_region]
+    depot.openstack_region     = params[:openstack_region]
+    depot.keystone_api_version = params[:keystone_api_version]
+    depot.v3_domain_ident      = params[:v3_domain_ident]
+    depot.security_protocol    = params[:security_protocol]
+    depot.uri                  = api_port.blank? ?  uri : depot.merged_uri(uri, api_port)
+    _log.debug("uri is [#{uri}]")
     if params[:save]
       file_depot.save!
       file_depot.update_authentication(:default => {:userid => params[:username], :password => params[:password]}) if (params[:username] || params[:password]) && depot.class.requires_credentials?
     else
-      depot.verify_credentials(nil, params.slice(:username, :password)) if depot.class.requires_credentials?
+      depot.verify_credentials(nil, params) if depot.class.requires_credentials?
     end
   end
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -341,13 +341,13 @@ class MiqSchedule < ApplicationRecord
     depot.keystone_api_version = params[:keystone_api_version]
     depot.v3_domain_ident      = params[:v3_domain_ident]
     depot.security_protocol    = params[:security_protocol]
-    depot.uri                  = api_port.blank? ?  uri : depot.merged_uri(uri, api_port)
+    depot.uri                  = api_port.blank? ? uri : depot.merged_uri(uri, api_port)
     _log.debug("uri is [#{uri}]")
     if params[:save]
       file_depot.save!
       file_depot.update_authentication(:default => {:userid => params[:username], :password => params[:password]}) if (params[:username] || params[:password]) && depot.class.requires_credentials?
-    else
-      depot.verify_credentials(nil, params) if depot.class.requires_credentials?
+    elsif depot.class.requires_credentials?
+      depot.verify_credentials(nil, params)
     end
   end
 

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -341,7 +341,7 @@ class MiqSchedule < ApplicationRecord
     depot.keystone_api_version = params[:keystone_api_version]
     depot.v3_domain_ident      = params[:v3_domain_ident]
     depot.security_protocol    = params[:security_protocol]
-    depot.uri                  = api_port.blank? ? uri : depot.merged_uri(uri, api_port)
+    depot.uri                  = api_port.blank? ? uri : depot.merged_uri(URI(uri), api_port)
     if params[:save]
       file_depot.save!
       file_depot.update_authentication(:default => {:userid => params[:username], :password => params[:password]}) if (params[:username] || params[:password]) && depot.class.requires_credentials?

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -342,7 +342,6 @@ class MiqSchedule < ApplicationRecord
     depot.v3_domain_ident      = params[:v3_domain_ident]
     depot.security_protocol    = params[:security_protocol]
     depot.uri                  = api_port.blank? ? uri : depot.merged_uri(uri, api_port)
-    _log.debug("uri is [#{uri}]")
     if params[:save]
       file_depot.save!
       file_depot.update_authentication(:default => {:userid => params[:username], :password => params[:password]}) if (params[:username] || params[:password]) && depot.class.requires_credentials?

--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -7,7 +7,7 @@ module FileDepotMixin
     'smb'   => 'Samba',
     'nfs'   => 'Network File System',
     's3'    => 'Amazon Web Services',
-    'swift' => 'Openstack Swift'
+    'swift' => 'OpenStack Swift'
   }.freeze
 
   included do

--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -4,9 +4,10 @@ require 'mount/miq_generic_mount_session'
 module FileDepotMixin
   extend ActiveSupport::Concern
   SUPPORTED_DEPOTS = {
-    'smb' => 'Samba',
-    'nfs' => 'Network File System',
-    's3'  => 'Amazon Web Services'
+    'smb'   => 'Samba',
+    'nfs'   => 'Network File System',
+    's3'    => 'Amazon Web Services',
+    'swift' => 'Openstack Swift'
   }.freeze
 
   included do

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -115,7 +115,12 @@ class EvmDatabaseOps
       else
         connect_opts[:remote_file_name] ||= File.basename(backup_file_name(action))
         backup_folder = action == :dump ? "db_dump" : "db_backup"
-        uri = File.join(connect_opts[:uri], backup_folder, connect_opts[:remote_file_name])
+        #
+        # If the passed in URI contains query parameters, ignore them
+        # when creating the dump file name. They'll be used in the session object.
+        #
+        connect_opts_uri = connect_opts[:uri].split('?')[0]
+        uri = File.join(connect_opts_uri, backup_folder, connect_opts[:remote_file_name])
       end
     else
       uri = db_opts[:local_file]

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -730,6 +730,7 @@ en:
       FileDepotFtpAnonymous:    Anonymous FTP
       FileDepotNfs:             NFS
       FileDepotS3:              AWS S3
+      FileDepotSwift:           Openstack Swift
       FileDepotSmb:             Samba
       Filesystem:               File
       Flavor:                   Flavor

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -730,7 +730,7 @@ en:
       FileDepotFtpAnonymous:    Anonymous FTP
       FileDepotNfs:             NFS
       FileDepotS3:              AWS S3
-      FileDepotSwift:           Openstack Swift
+      FileDepotSwift:           OpenStack Swift
       FileDepotSmb:             Samba
       Filesystem:               File
       Flavor:                   Flavor

--- a/spec/models/file_depot_spec.rb
+++ b/spec/models/file_depot_spec.rb
@@ -4,5 +4,6 @@ describe FileDepot do
     expect(described_class.depot_description_to_class("NFS")).to eq(FileDepotNfs)
     expect(described_class.depot_description_to_class("Samba")).to eq(FileDepotSmb)
     expect(described_class.depot_description_to_class("Anonymous FTP")).to eq(FileDepotFtpAnonymous)
+    expect(described_class.depot_description_to_class("OpenStack Swift")).to eq(FileDepotSwift)
   end
 end

--- a/spec/models/file_depot_swift_spec.rb
+++ b/spec/models/file_depot_swift_spec.rb
@@ -1,7 +1,7 @@
 describe FileDepotSwift do
-  let(:uri) { URI("swift://server.example.com/bucket") }
-  let(:merged_uri) { URI("swift://server.example.com:5678/bucket?region=test_openstack_region&api_version=v3&domain_id=default") }
-  let(:merged_default_uri) { URI("swift://server.example.com:5000/bucket?region=test_openstack_region&api_version=v3&domain_id=default") }
+  let(:uri) { "swift://server.example.com/bucket" }
+  let(:merged_uri) { "swift://server.example.com:5678/bucket?region=test_openstack_region&api_version=v3&domain_id=default" }
+  let(:merged_default_uri) { "swift://server.example.com:5000/bucket?region=test_openstack_region&api_version=v3&domain_id=default" }
   let(:file_depot_swift) { FileDepotSwift.new(:uri => uri) }
   it "should require credentials" do
     expect(FileDepotSwift.requires_credentials?).to eq true

--- a/spec/models/file_depot_swift_spec.rb
+++ b/spec/models/file_depot_swift_spec.rb
@@ -1,6 +1,7 @@
 describe FileDepotSwift do
   let(:uri) { URI("swift://server.example.com/bucket") }
-  let(:merged_uri) { URI("swift://server.example.com:5000/bucket?region=test_openstack_region&api_version=v3&domain_id=default") }
+  let(:merged_uri) { URI("swift://server.example.com:5678/bucket?region=test_openstack_region&api_version=v3&domain_id=default") }
+  let(:merged_default_uri) { URI("swift://server.example.com:5000/bucket?region=test_openstack_region&api_version=v3&domain_id=default") }
   let(:file_depot_swift) { FileDepotSwift.new(:uri => uri) }
   it "should require credentials" do
     expect(FileDepotSwift.requires_credentials?).to eq true
@@ -18,11 +19,11 @@ describe FileDepotSwift do
     end
 
     it "should return a merged uri with query strings given an empty port" do
-      expect(file_depot_swift.merged_uri(uri, nil)).to eq merged_uri
+      expect(file_depot_swift.merged_uri(uri, nil)).to eq merged_default_uri
     end 
 
     it "should return a merged uri with query strings when given a valid port" do
-      expect(file_depot_swift.merged_uri(uri, "5000")).to eq merged_uri
+      expect(file_depot_swift.merged_uri(uri, "5678")).to eq merged_uri
     end 
   end
 end

--- a/spec/models/file_depot_swift_spec.rb
+++ b/spec/models/file_depot_swift_spec.rb
@@ -11,7 +11,7 @@ describe FileDepotSwift do
     expect(FileDepotSwift.uri_prefix).to eq "swift"
   end
 
-  context "valid merged uri" do
+  describe "#merged_uri" do
     before do
       file_depot_swift.openstack_region = "test_openstack_region"
       file_depot_swift.keystone_api_version = "v3"

--- a/spec/models/file_depot_swift_spec.rb
+++ b/spec/models/file_depot_swift_spec.rb
@@ -1,0 +1,28 @@
+describe FileDepotSwift do
+  let(:uri) { URI("swift://server.example.com/bucket") }
+  let(:merged_uri) { URI("swift://server.example.com:5000/bucket?region=test_openstack_region&api_version=v3&domain_id=default") }
+  let(:file_depot_swift) { FileDepotSwift.new(:uri => uri) }
+  it "should require credentials" do
+    expect(FileDepotSwift.requires_credentials?).to eq true
+  end
+
+  it "should return a valid prefix" do
+    expect(FileDepotSwift.uri_prefix).to eq "swift"
+  end
+
+  context "valid merged uri" do
+    before do
+      file_depot_swift.openstack_region = "test_openstack_region"
+      file_depot_swift.keystone_api_version = "v3"
+      file_depot_swift.v3_domain_ident = "default"
+    end
+
+    it "should return a merged uri with query strings given an empty port" do
+      expect(file_depot_swift.merged_uri(uri, nil)).to eq merged_uri
+    end 
+
+    it "should return a merged uri with query strings when given a valid port" do
+      expect(file_depot_swift.merged_uri(uri, "5000")).to eq merged_uri
+    end 
+  end
+end


### PR DESCRIPTION
In support of the RFE described in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1615488.

Add a new FileDepot subclass for Swift.
Since we need to pass info in to the Mount Session (in gems-pending) regarding the Openstack
connection, utilize the URI with Query Parameters to do so.

@carbonin @NickLaMuro @roliveri please review.  

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1615488
* https://github.com/ManageIQ/manageiq-schema/pull/259
* https://github.com/ManageIQ/manageiq-gems-pending

