### PR TITLE
Conversion script for mapped tags/classification from remote regions to global

### DIFF
--- a/tools/convert_mapped_tags.rb
+++ b/tools/convert_mapped_tags.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+
+require 'trollop'
+
+options = Trollop.options(ARGV) do
+  banner "USAGE:  #{__FILE__} -c|--commit\n" \
+         "Example (Commit):  #{__FILE__} --commit\n" \
+         "Example (Dry Run): #{__FILE__}         \n" \
+
+  opt :commit, "Commit to database. The default behavior is to do a dry run", :short => "c"
+end
+
+read_only = !options[:commit]
+
+puts
+puts
+
+if read_only
+  puts "READ ONLY MODE"
+else
+  puts "COMMIT MODE"
+end
+
+puts
+
+ActiveRecord::Base.transaction do
+  condition_for_mapped_tags = ContainerLabelTagMapping::TAG_PREFIXES.map { "tags.name LIKE ?" }.join(' OR ')
+  tag_values = ContainerLabelTagMapping::TAG_PREFIXES.map { |x| "#{x}%:%" }
+
+  Classification.where.not(:id => Classification.region_to_range) # only other regions(not current, we expected that current region is global)
+                .where(:classifications => {:parent_id => 0}) # only categories
+                .includes(:tag, :children).references(:tag, :children)
+                .where(condition_for_mapped_tags, *tag_values) # only mapped categories
+                .find_each do |category|
+    new_parent_category = Classification.in_my_region.find_by(:description => category.description)
+
+    if new_parent_category
+      print "Using..."
+    else
+      new_parent_category = category.dup
+      new_parent_category.save unless read_only # create in current region (global region is expected), it will create also tag instance
+      print "Creating..."
+    end
+
+    puts "parent category #{new_parent_category.description} with tag: #{new_parent_category.tag.name} - from region #{category.region_id} to region #{new_parent_category.region_id}"
+
+    category.entries.each do |entry|
+      new_entry = Classification.in_my_region.find_by(:description => entry.description)
+      if new_entry
+        print "Using...."
+      else
+        new_entry = entry.dup
+        new_entry.parent_id = new_parent_category.id
+        new_entry.save unless read_only # it will create also tag instance
+        print "Creating..."
+      end
+      puts "entry category #{new_entry.description} of #{new_parent_category.description} - from region #{category.region_id} to region #{new_entry.region_id}"
+    end
+  end
+end
+
+puts
+
+if read_only
+  puts "READ ONLY MODE - no changes have been applied"
+else
+  puts "COMMIT MODE - changes have been applied"
+end
+
+puts
+
+Trollop.educate if !options[:help] && !options[:commit] # display help message only in Dry Run


### PR DESCRIPTION
## What we need
In global region, create and filter report according to tags from remote regions.


## How
Create tag/categories in global regions:


1. Find mapped categories (Classifications) in remote regions
2. If categories don't exist in global then create them.
3. Create Tags of these categories in remotes regions.

## Usage
```
USAGE:  ./tools/convert_mapped_tags.rb -c|--commit
Example (Commit):  ./tools/convert_mapped_tags.rb --commit
Example (Dry Run): ./tools/convert_mapped_tags.rb         
  -c, --commit    Commit to database. The default behavior is to do a dry run
  -h, --help      Show this message
```

- we created MyNewCategory category for mapping


**read only mode:**
`./tools/convert_mapped_tags.rb`
will output (just tag 'bronagh1213' doesn't exist): 

```
READ ONLY MODE

Using...parent category `MyNewCategory` with tag: /managed/amazon:vm:name - from region 0 to region 99
Using....entry category smartstate of MyNewCategory - from region 0 to region 99
Using....entry category mslemr of MyNewCategory - from region 0 to region 99
Using....entry category hsong-centos of MyNewCategory - from region 0 to region 99
Using....entry category bronagh of MyNewCategory - from region 0 to region 99
Using....entry category ssa-docker of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOn-VPC of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpecStack of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOff of MyNewCategory - from region 0 to region 99
Using....entry category ladas_ansible_test_2__1 of MyNewCategory - from region 0 to region 99
Using....entry category ladas_ansible_test_2__0 of MyNewCategory - from region 0 to region 99
Using....entry category mslemr-test4 of MyNewCategory - from region 0 to region 99
Using....entry category ladas-test-foreman.ec2.internal of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOn-Basic3 of MyNewCategory - from region 0 to region 99
Using....entry category ladas_ansible_test_2 of MyNewCategory - from region 0 to region 99
Using....entry category julian_le_noir of MyNewCategory - from region 0 to region 99
Creating...entry category bronagh1213 of MyNewCategory - from region 0 to region 99
Using....entry category stomsa of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOn-VPC1 of MyNewCategory - from region 0 to region 99
Using....entry category james of MyNewCategory - from region 0 to region 99

READ ONLY MODE - no changes have been applied

USAGE:  ./tools/convert_mapped_tags.rb -c|--commit
Example (Commit):  ./tools/convert_mapped_tags.rb --commit
Example (Dry Run): ./tools/convert_mapped_tags.rb         
  -c, --commit    Commit to database. The default behavior is to do a dry run
  -h, --help      Show this message

```

**write mode:**
` ./tools/convert_mapped_tags.rb WRITE`

```

COMMIT MODE

Using...parent category MyNewCategory with tag: /managed/amazon:vm:name - from region 0 to region 99
Using....entry category smartstate of MyNewCategory - from region 0 to region 99
Using....entry category mslemr of MyNewCategory - from region 0 to region 99
Using....entry category hsong-centos of MyNewCategory - from region 0 to region 99
Using....entry category bronagh of MyNewCategory - from region 0 to region 99
Using....entry category ssa-docker of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOn-VPC of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpecStack of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOff of MyNewCategory - from region 0 to region 99
Using....entry category ladas_ansible_test_2__1 of MyNewCategory - from region 0 to region 99
Using....entry category ladas_ansible_test_2__0 of MyNewCategory - from region 0 to region 99
Using....entry category mslemr-test4 of MyNewCategory - from region 0 to region 99
Using....entry category ladas-test-foreman.ec2.internal of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOn-Basic3 of MyNewCategory - from region 0 to region 99
Using....entry category ladas_ansible_test_2 of MyNewCategory - from region 0 to region 99
Using....entry category julian_le_noir of MyNewCategory - from region 0 to region 99
Creating...entry category bronagh1213 of MyNewCategory - from region 0 to region 99
Using....entry category stomsa of MyNewCategory - from region 0 to region 99
Using....entry category EmsRefreshSpec-PoweredOn-VPC1 of MyNewCategory - from region 0 to region 99
Using....entry category james of MyNewCategory - from region 0 to region 99

COMMIT MODE - change have been applied
```
## Note
This script is not enabling tags to be able assign them in Tag Control. - To reach behaviour we need also this PRs:
https://github.com/ManageIQ/manageiq/pull/18046
https://github.com/ManageIQ/manageiq-ui-classic/pull/4723

Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1526000
https://github.com/ManageIQ/manageiq/pull/18015 this PR is needed for the BZ

