### PR TITLE
Load all the values along with their key names into the field update method

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -93,7 +93,7 @@ class Dialog < ApplicationRecord
 
     dialog_field_hash.each_value do |field|
       field.dialog = self
-      new_value = values[field.automate_key_name] || values[field.name]
+      new_value = values[field.automate_key_name] || values[field.name] || values.dig("parameters", field.name)
       new_value ||= field.value unless overwrite
 
       field.value = new_value

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -31,7 +31,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   def update_dialog_field_values(data)
-    @dialog.load_values_into_fields(data.values.first)
+    @dialog.load_values_into_fields(data)
   end
 
   def process_request(state)

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -455,6 +455,25 @@ describe Dialog do
         dialog.load_values_into_fields(vars)
         expect(dialog_field1.value).to eq("10.8.99.248")
       end
+
+      it "sets field value when in a hash with a key of 'parameters'" do
+        vars = {"parameters" => {"field1" => "10.8.99.248"}}
+        dialog.load_values_into_fields(vars)
+        expect(dialog_field1.value).to eq("10.8.99.248")
+      end
+
+      context "with multiple fields" do
+        let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1, dialog_field2]) }
+        let(:dialog_field1) { DialogField.new(:value => "123", :name => "field1") }
+        let(:dialog_field2) { DialogField.new(:value => "12", :name => "field2") }
+
+        it "sets multiple field values" do
+          vars = {"field1" => "10.8.99.248", "field2" => "new_value"}
+          dialog.load_values_into_fields(vars)
+          expect(dialog_field1.value).to eq("10.8.99.248")
+          expect(dialog_field2.value).to eq("new_value")
+        end
+      end
     end
 
     context "symbol values" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594469.

The main changes that [got merged a little while ago](https://github.com/ManageIQ/manageiq/pull/17844), combined with https://github.com/ManageIQ/manageiq/pull/17855, break the custom actions API specs on https://github.com/ManageIQ/manageiq-api/pull/448 because I'm an idiot who wrote [that line that's breaking this to start with](https://github.com/ManageIQ/manageiq/pull/17973/files#diff-15cdc4277e807ab3a1e33750361631e0L34) which shouldn't be just loading the values and definitely shouldn't just be loading the first one. Mea maxima culpa. 