### PR TITLE
Remove line from metering_container_image_spec and FIX CI failure

### DIFF
--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -14,9 +14,6 @@ describe MeteringContainerImage do
   let(:metric_rollup_params) { {:parent_ems_id => ems.id, :tag_names => ""} }
 
   before do
-    # TODO: remove metering columns form specs
-    described_class.set_columns_hash(:metering_used_metric => :integer, :metering_used_cost => :float)
-
     MiqRegion.seed
     ChargebackRateDetailMeasure.seed
     ChargeableField.seed


### PR DESCRIPTION
Fixes CI failure 
https://travis-ci.org/ManageIQ/manageiq/jobs/426890608#L1472
after removals in https://github.com/ManageIQ/manageiq/pull/17934 and https://github.com/ManageIQ/manageiq/pull/17962

the line was adding dynamically column `metering_used_cost` to class `MeteringContainerImage` as descendant of Chargeback.

and this column has been returned by https://github.com/ManageIQ/manageiq/blob/4c32131eaa94be25ffd941efa5de2de58af223e1/spec/models/miq_report/formats_spec.rb#L28
a we don't have defined formatter `currency_precision_2` for this column`metering_used_cost`.

Please merge if any other unrelated sporadic failure will occur.

@miq-bot assign @gtanzillo 
@miq-bot add_label  bug/sporadic test failure, chargeback

error from travis:
```
Failures:
  1) MiqReport::Formats.default_format_for_path for chargebacks works
Failure/Error: expect(subj).to eq(:currency_precision_2)
  expected: :currency_precision_2
       got: :general_number_precision_2
  (compared using ==)
  Diff:
@@ -1,2 +1,2 @@
-:currency_precision_2
+:general_number_precision_2
# ./spec/models/miq_report/formats_spec.rb:34:in `block (5 levels) in <top (required)>'
# ./spec/models/miq_report/formats_spec.rb:30:in `each'
# ./spec/models/miq_report/formats_spec.rb:30:in `block (4 levels) in <top (required)>'
Finished in 10 minutes 27 seconds (files took 17.55 seconds to load)
5106 examples, 1 failure, 4 pending

```

Links 
-----
* https://travis-ci.org/ManageIQ/manageiq/jobs/426890608#L1472