### PR TITLE
virtual column for `default_security_group` to make it accessible via the API

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -35,6 +35,8 @@ class CloudTenant < ApplicationRecord
 
   virtual_total :total_vms, :vms
 
+  virtual_column :default_security_group, :uses => :security_groups
+
   def self.class_by_ems(ext_management_system)
     ext_management_system && ext_management_system.class::CloudTenant
   end


### PR DESCRIPTION
The `default_security_group` method for `cloud_tenants` was added here - https://github.com/ManageIQ/manageiq-providers-openstack/pull/347

We need the virtual column for `default_security_group`  so that it is accessible via the API

`default_security_group` is a requirement for v2v OSP support.
