### PR TITLE
virtual column for parent blue folder path with excluded non-display folders

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -84,7 +84,7 @@ class TransformationMapping < ApplicationRecord
     {
       "name"           => vm.name,
       "cluster"        => vm.ems_cluster.try(:name) || '',
-      "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.parent_blue_folder_path(:exclude_non_display_folders => true)}" : '',
+      "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.v_parent_blue_folder_display_path}" : '',
       "allocated_size" => vm.allocated_disk_storage,
       "id"             => vm.id,
       "ems_cluster_id" => vm.ems_cluster_id,

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -151,6 +151,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :v_owning_blue_folder,                 :type => :string,     :uses => :all_relationships
   virtual_column :v_owning_blue_folder_path,            :type => :string,     :uses => :all_relationships
   virtual_column :v_datastore_path,                     :type => :string,     :uses => :storage
+  virtual_column :v_parent_blue_folder_display_path,    :type => :string,     :uses => :all_relationships
   virtual_column :thin_provisioned,                     :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :used_storage,                         :type => :integer,    :uses => [:used_disk_storage, :mem_cpu]
   virtual_column :used_storage_by_state,                :type => :integer,    :uses => :used_storage
@@ -802,6 +803,11 @@ class VmOrTemplate < ApplicationRecord
     ems_cluster.try(:parent_datacenter)
   end
   alias_method :owning_datacenter, :parent_datacenter
+
+  def parent_blue_folder_display_path
+    parent_blue_folder_path(:exclude_non_display_folders => true)
+  end
+  alias_method :v_parent_blue_folder_display_path, :parent_blue_folder_display_path
 
   def lans
     !hardware.nil? ? hardware.nics.collect(&:lan).compact : []


### PR DESCRIPTION
The new virtual column has been added to make the `v_folder_path_no_non_display_folders` attribute accessible via the `api/vms` API.

In v2v UI, we currently display the path info via API for VMs which internally calls this method - https://github.com/ManageIQ/manageiq/blob/master/app/models/transformation_mapping.rb#L83

We are currently in the process of adding Edit support for Plans, where we will need this attribute accessible to us via `api/vms` API
