### PR TITLE
 Add ability to run tagged core specs in plugin repos.

### DIFF
--- a/lib/generators/provider/templates/lib/tasks_private/spec.rake
+++ b/lib/generators/provider/templates/lib/tasks_private/spec.rake
@@ -4,7 +4,7 @@ namespace :spec do
 end
 
 desc "Run all specs"
-RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
+RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader", "app:test:providers_common"]) do |t|
   spec_dir = File.expand_path("../../spec", __dir__)
   EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
 end

--- a/lib/tasks/test_providers_common.rake
+++ b/lib/tasks/test_providers_common.rake
@@ -1,0 +1,15 @@
+require_relative './evm_test_helper'
+
+if defined?(RSpec)
+namespace :test do
+  desc "Run all specs tagged 'providers_common'"
+  RSpec::Core::RakeTask.new(:providers_common => ["test:initialize", "evm:compile_sti_loader"]) do |t|
+    EvmTestHelper.init_rspec_task(t, ['--tag', 'providers_common'])
+
+    if defined?(ENGINE_ROOT)
+      t.rspec_opts += ["--exclude-pattern", "manageiq/spec/tools/**/*_spec.rb"]
+      t.pattern = "manageiq/spec/**/*_spec.rb"
+    end
+  end
+end
+end

--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -3,17 +3,17 @@ describe EventStream do
     EventStream.event_groups.each do |group_name, group_data|
       EventStream::GROUP_LEVELS.each do |level|
         group_data[level]&.each do |typ|
-          it ":#{group_name}/:#{level}/#{typ} is string or regex" do
+          it ":#{group_name}/:#{level}/#{typ} is string or regex", :providers_common => true do
             expect(typ.kind_of?(Regexp) || typ.kind_of?(String)).to eq(true)
           end
 
           if typ.kind_of?(Regexp)
-            it ":#{group_name}/:#{level}/#{typ} is usable in SQL queries" do
+            it ":#{group_name}/:#{level}/#{typ} is usable in SQL queries", :providers_common => true do
               expect { EventStream.where("event_type ~ ?", typ.source).to_a }
                 .to_not raise_error
             end
 
-            it ":#{group_name}/:#{level}/#{typ} only uses case insensitivity option" do
+            it ":#{group_name}/:#{level}/#{typ} only uses case insensitivity option", :providers_common => true do
               expect(typ.options & (Regexp::EXTENDED | Regexp::MULTILINE)).to eq(0)
             end
           end


### PR DESCRIPTION
This commit specifically marks the EventStream definition specs as
common for all provider plugins.

---

In the provider repo all you have to do is add `'app:test:providers_common'` to the default spec (as is done here in the generator).  I will be blasting out a PR to all provider repos to update that.

@bdunne @agrare Please review.

cc @tadeboro 