### PR TITLE
Remove backtick from dialog_properties_spec.rb

### DIFF
--- a/spec/models/service/dialog_properties_spec.rb
+++ b/spec/models/service/dialog_properties_spec.rb
@@ -9,7 +9,7 @@ describe Service::DialogProperties do
     expect(described_class.parse(options, nil)).to eq({})
   end
 
-  it `will call the Retirement class` do
+  it 'will call the Retirement class' do
     expect(Service::DialogProperties::Retirement).to receive(:parse).with({}, nil).and_return({})
     described_class.parse(nil, nil)
   end


### PR DESCRIPTION
The backtick causes the spec to shell out, but the `will` command
doesn't exist, so instead you get "No such file or directory - will" in
STDERR.

@bdunne Please review
cc @gmcculloug 