### PR TITLE
Add regex for dialog password fields.

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -27,7 +27,7 @@ class MiqRequestWorkflow
   end
 
   def self.encrypted_options_field_regs
-    encrypted_options_fields.map { |f| /\[:#{f}\]/ }
+    encrypted_options_fields.map { |f| /\[:#{f}\]/ } + [/password::/]
   end
 
   def self.all_encrypted_options_fields

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -638,4 +638,10 @@ describe MiqRequestWorkflow do
       expect(workflow.storage_to_hash_struct(storage).storage_clusters).to be_nil
     end
   end
+
+  context '.encrypted_options_field_regs' do
+    it 'includes "password::"' do
+      expect(MiqRequestWorkflow.encrypted_options_field_regs).to include(/password::/)
+    end
+  end
 end


### PR DESCRIPTION
To hide the password value in evm.log like these:
```
[----] I, [2018-09-04T11:52:30.068959 #12301:c27108]  INFO -- : Q-task_id([miq_provision_3]) MIQ(ManageIQ::Providers::Vmware::InfraManager::Provision#log_clone_options) Prov Options: [:"password::password_field"](String) = "v2:{SEZAjnaOSeyzt387/rAooQ==}"
[----] I, [2018-09-04T11:52:30.069053 #12301:c27108]  INFO -- : Q-task_id([miq_provision_3]) MIQ(ManageIQ::Providers::Vmware::InfraManager::Provision#log_clone_options) Prov Options: [:"password::dialog_password_field"](String) = "v2:{SEZAjnaOSeyzt387/rAooQ==}"
```

Part of https://github.com/ManageIQ/manageiq-automation_engine/pull/228.

https://bugzilla.redhat.com/show_bug.cgi?id=1619385

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, gaprindashvili/yes, automate