### PR TITLE
Fix ServiceTemplateTransformationPlan edit action

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -1,4 +1,5 @@
 class ServiceTemplateTransformationPlan < ServiceTemplate
+  include_concern 'ValidateConfigInfo'
   def request_class
     ServiceTemplateTransformationPlanRequest
   end
@@ -70,41 +71,4 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   def enforce_single_service_parent(_resource)
   end
 
-  def self.validate_config_info(options)
-    config_info = options[:config_info]
-
-    mapping = if config_info[:transformation_mapping_id]
-                TransformationMapping.find(config_info[:transformation_mapping_id])
-              else
-                config_info[:transformation_mapping]
-              end
-
-    raise _('Must provide an existing transformation mapping') if mapping.blank?
-
-    pre_service_id  = config_info[:pre_service].try(:id) || config_info[:pre_service_id]
-    post_service_id = config_info[:post_service].try(:id) || config_info[:post_service_id]
-
-    vms = []
-    if config_info[:actions]
-      vm_objects = VmOrTemplate.where(:id => config_info[:actions].collect { |vm_hash| vm_hash[:vm_id] }.compact).index_by(&:id).stringify_keys
-      config_info[:actions].each do |vm_hash|
-        vm_obj = vm_objects[vm_hash[:vm_id]] || vm_hash[:vm]
-        next if vm_obj.nil?
-
-        vm_options = {}
-        vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
-        vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
-        vms << {:vm => vm_obj, :options => vm_options}
-      end
-    end
-
-    raise _('Must select a list of valid vms') if vms.blank?
-
-    {
-      :transformation_mapping => mapping,
-      :vms                    => vms,
-      :provision              => config_info[:provision] || {}
-    }
-  end
-  private_class_method :validate_config_info
 end

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -1,0 +1,46 @@
+module ServiceTemplateTransformationPlan::ValidateConfigInfo
+  extend ActiveSupport::Concern
+
+  def validate_config_info(options)
+    self.class.validate_config_info(options)
+  end
+
+  module ClassMethods
+    def validate_config_info(options)
+      config_info = options[:config_info]
+
+      mapping = if config_info[:transformation_mapping_id]
+                  TransformationMapping.find(config_info[:transformation_mapping_id])
+                else
+                  config_info[:transformation_mapping]
+                end
+
+      raise _('Must provide an existing transformation mapping') if mapping.blank?
+
+      pre_service_id  = config_info[:pre_service].try(:id) || config_info[:pre_service_id]
+      post_service_id = config_info[:post_service].try(:id) || config_info[:post_service_id]
+
+      vms = []
+      if config_info[:actions]
+        vm_objects = VmOrTemplate.where(:id => config_info[:actions].collect { |vm_hash| vm_hash[:vm_id] }.compact).index_by(&:id).stringify_keys
+        config_info[:actions].each do |vm_hash|
+          vm_obj = vm_objects[vm_hash[:vm_id]] || vm_hash[:vm]
+          next if vm_obj.nil?
+
+          vm_options = {}
+          vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
+          vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
+          vms << {:vm => vm_obj, :options => vm_options}
+        end
+      end
+
+      raise _('Must select a list of valid vms') if vms.blank?
+
+      {
+        :transformation_mapping => mapping,
+        :vms                    => vms,
+        :provision              => config_info[:provision] || {}
+      }
+    end
+  end
+end

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -17,9 +17,11 @@ describe ServiceTemplateTransformationPlan do
   end
 
   let(:transformation_mapping) { FactoryGirl.create(:transformation_mapping) }
+  let(:transformation_mapping2) { FactoryGirl.create(:transformation_mapping) }
   let(:apst) { FactoryGirl.create(:service_template_ansible_playbook) }
   let(:vm1) { FactoryGirl.create(:vm_or_template) }
   let(:vm2) { FactoryGirl.create(:vm_or_template) }
+  let(:vm3) { FactoryGirl.create(:vm_or_template) }
 
   let(:catalog_item_options) do
     {
@@ -36,6 +38,73 @@ describe ServiceTemplateTransformationPlan do
       }
     }
   end
+
+  let(:updated_catalog_item_options_with_vms_added) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
+          {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true},
+          {:vm_id => vm3.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:updated_catalog_item_options_with_vms_removed) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false}
+        ],
+      }
+    }
+  end
+
+  let(:updated_catalog_item_options_with_vms_added_and_removed) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
+          {:vm_id => vm3.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:updated_options_with_updated_transformation_mapping) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping2.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
+          {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:miq_requests) { [FactoryGirl.create(:service_template_transformation_plan_request, :request_state => "finished")] }
+  let(:miq_requests_with_in_progress_request) { [FactoryGirl.create(:service_template_transformation_plan_request, :request_state => "active")] }
 
   describe '.public_service_templates' do
     it 'display public service templates' do
@@ -88,6 +157,145 @@ describe ServiceTemplateTransformationPlan do
       expect { described_class.create_catalog_item(catalog_item_options) }.to raise_error(
         ActiveRecord::RecordInvalid, 'Validation failed: ServiceTemplateTransformationPlan: Name has already been taken'
       )
+    end
+  end
+
+  describe '#update_catalog_item' do
+    it 'updates the associated transformation mapping' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_options_with_updated_transformation_mapping)
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping2)
+    end
+
+    it 'updates by adding new VMs to existing VMs and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2, vm3])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates by removing some VMs from the existing VMs and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_removed)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_removed[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates by adding new VMs to the existing VMs and removing some VMs from the existing VMs and returns a transformation plan' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_added_and_removed)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm3])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added_and_removed[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates only the basic attributes' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(:name => "Name updated", :description => "description updated")
+
+      expect(service_template.name).to eq('Name updated')
+      expect(service_template.description).to eq('description updated')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
+      expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'updates only the basic attributes when completed miq_requests are present' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = miq_requests
+      service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+
+      expect(service_template.name).to eq('Transformation Plan Updated')
+      expect(service_template.description).to eq('an updated description')
+      expect(service_template.transformation_mapping).to eq(transformation_mapping)
+      expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+      expect(service_template.config_info).to eq(catalog_item_options[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+    end
+
+    it 'raises an exception when miq_request is in progress' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = miq_requests_with_in_progress_request
+      expect do
+        service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+      end.to raise_error(StandardError, 'Editing a plan in progress is prohibited')
+    end
+
+    it 'requires a transformation mapping' do
+      updated_catalog_item_options_with_vms_added[:config_info].delete(:transformation_mapping_id)
+
+      service_template = described_class.create_catalog_item(catalog_item_options)
+
+      expect do
+        service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+      end.to raise_error(StandardError, 'Must provide an existing transformation mapping')
+    end
+
+    it 'requires selected vms' do
+      updated_catalog_item_options_with_vms_added[:config_info].delete(:actions)
+
+      service_template = described_class.create_catalog_item(catalog_item_options)
+
+      expect do
+        service_template.update_catalog_item(updated_catalog_item_options_with_vms_added)
+      end.to raise_error(StandardError, 'Must select a list of valid vms')
     end
   end
 end


### PR DESCRIPTION
While adding a new v2v UI feature for editing a Migration Plan (`ServiceTemplateTransformationPlan`) in https://github.com/ManageIQ/manageiq-v2v/pull/620, we noticed a couple of issues related to VM discovery, such as -

- new VMs added to an existing Migration plan during Edit, were being discovered again
- VMs that were being removed from an existing Migration plan during Edit, were not being discovered by other plans

Above issues have been fixed in this PR