### PR TITLE
Only reload settings for servers in current region

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -62,7 +62,11 @@ class MiqRegion < ApplicationRecord
   end
 
   def servers_for_settings_reload
-    miq_servers.where(:status => "started")
+    # This method is used to queue reload_settings for the resources which
+    # had settings changed.  If those servers are in a different region it is
+    # not possible to queue methods for them so we want to filter the
+    # returned servers to just ones in the current region.
+    miq_servers.in_my_region.where(:status => "started")
   end
 
   def active_miq_servers


### PR DESCRIPTION
When changing settings for a different region, only queue a settings
reload for servers in the current region.

Fixes test failures e.g https://travis-ci.org/ManageIQ/manageiq-api/jobs/430035513#L2033-L2045