### PR TITLE
Fix to handle the case when default value of internal is nil

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -80,7 +80,7 @@ class ServiceTemplate < ApplicationRecord
   scope :without_service_template_catalog_id,       ->         { where(:service_template_catalog_id => nil) }
   scope :with_existent_service_template_catalog_id, ->         { where.not(:service_template_catalog_id => nil) }
   scope :displayed,                                 ->         { where(:display => true) }
-  scope :public_service_templates,                  ->         { where.not(:internal => true) }
+  scope :public_service_templates,                  ->         { where(:internal => [false, nil]) }
 
   def self.catalog_item_types
     ci_types = Set.new(Rbac.filtered(ExtManagementSystem.all).flat_map(&:supported_catalog_types))


### PR DESCRIPTION
Handle the missing case when internal attribute is nil.

Related PR:
https://github.com/ManageIQ/manageiq/pull/17781