### PR TITLE
update attribute_builder for rails change

### DIFF
--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -981,6 +981,15 @@ describe VirtualFields do
   end
 end
 
+describe "ActiveRecord attributes" do
+  it "doesn't botch up the attributes" do
+    hardware = Hardware.select(:id, :model).find(FactoryGirl.create(:hardware).id)
+    expect(hardware.attributes.size).to eq(2)
+    hardware.save
+    expect(hardware.attributes.size).to eq(2)
+  end
+end
+
 describe "ApplicationRecord class" do
   describe ".virtual_attribute_names" do
     it "class immediately under ApplicationRecord" do


### PR DESCRIPTION
rails 5.0.7 [[changed]](https://github.com/rails/rails/commit/7fa95ff22f03dbb5f01696464655be2cc6d0b07e) the way `attribute_builder` works.
This updates `attribute_builder` to work accordingly

The [[old code]](https://github.com/rails/rails/blob/7fa95ff22f03dbb5f01696464655be2cc6d0b07e%5E/activerecord/lib/active_record/model_schema.rb#L334) used a block. The [[new code]](https://github.com/rails/rails/blob/7fa95ff22f03dbb5f01696464655be2cc6d0b07e/activerecord/lib/active_record/model_schema.rb#L334) uses an array - We are now modifying the array instead of passing the block.

Also, 5.0.0 changed the way dirty worked.
Think the change to `forgetting_assignment` introduced this problem for
all rails users, but it is subtle and would only be noticed by
people who use lots of non-database attributes (e.g.: us)
The bug remains in 5.1.0 but the code changes significantly in 5.2

This fixes an issue seen by https://github.com/ManageIQ/manageiq/pull/17912 

Thnx @gmcculloug and @d-m-u for tracking down the bug and the pairing. Looks like it was introduced in rails 5.0.7
/cc @NickLaMuro @jrafanie you guys saw this original patch.

The `Attribute` change should go into rails proper, but they won't patch anything before 5.2 (we're on 5.0.7 right now), and the code has changed so much that I'm not sure it is even necessary.