### PR TITLE
Fixed error with replication setup when default exclude list used

### DIFF
--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -144,7 +144,9 @@ class MiqPglogical
   end
 
   def self.save_remote_region(exclusion_list)
+    # part of `MiqRegion.replication_type=` is initialization of default subscription list
     MiqRegion.replication_type = :remote
+    # UI is passing empty 'exclution_list' if there are no changes to default subscription list
     refresh_excludes(YAML.safe_load(exclusion_list)) unless exclusion_list.empty?
   end
 

--- a/lib/miq_pglogical.rb
+++ b/lib/miq_pglogical.rb
@@ -145,7 +145,7 @@ class MiqPglogical
 
   def self.save_remote_region(exclusion_list)
     MiqRegion.replication_type = :remote
-    refresh_excludes(YAML.safe_load(exclusion_list))
+    refresh_excludes(YAML.safe_load(exclusion_list)) unless exclusion_list.empty?
   end
 
   def self.save_global_region(subscriptions_to_save, subscriptions_to_remove)

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -159,7 +159,7 @@ describe MiqPglogical do
       described_class.save_remote_region(tables)
     end
 
-    it "does not updates list of tables to be excluded from replication if passed paramere is empty" do
+    it "does not updates list of tables to be excluded from replication if passed parameter is empty" do
       allow(MiqRegion).to receive(:replication_type=)
       expect(described_class).not_to receive(:refresh_excludes)
       described_class.save_remote_region("")

--- a/spec/replication/util/miq_pglogical_spec.rb
+++ b/spec/replication/util/miq_pglogical_spec.rb
@@ -158,6 +158,12 @@ describe MiqPglogical do
       expect(described_class).to receive(:refresh_excludes).with(YAML.safe_load(tables))
       described_class.save_remote_region(tables)
     end
+
+    it "does not updates list of tables to be excluded from replication if passed paramere is empty" do
+      allow(MiqRegion).to receive(:replication_type=)
+      expect(described_class).not_to receive(:refresh_excludes)
+      described_class.save_remote_region("")
+    end
   end
 
   describe ".save_global_region" do


### PR DESCRIPTION
Fixing error  when when default list of tables to exclude from replication used during remote region. This bug was introduced in  https://github.com/ManageIQ/manageiq/pull/17956 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1630517

@miq-bot add-label bug