### PR TITLE
Add :cinder_volume_types to SupportsFeatureMixin

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -172,6 +172,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_total  :total_subnets,           :cloud_subnets
   virtual_column :supports_block_storage,  :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
+  virtual_column :supports_cinder_volume_types, :type => :boolean
 
   virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
   virtual_aggregate :total_memory, :hosts, :sum, :ram_size
@@ -585,6 +586,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_cloud_object_store_container_create
     supports_cloud_object_store_container_create?
+  end
+
+  def supports_cinder_volume_types
+    supports_cinder_volume_types?
   end
 
   def get_reserve(field)

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -72,6 +72,7 @@ module SupportsFeatureMixin
     :backup_create                       => 'CloudVolume backup creation',
     :backup_restore                      => 'CloudVolume backup restore',
     :cinder_service                      => 'Cinder storage service',
+    :cinder_volume_types                 => 'Cinder volume types',
     :create_floating_ip                  => 'Floating IP Creation',
     :create_host_aggregate               => 'Host Aggregate Creation',
     :create_security_group               => 'Security Group Creation',


### PR DESCRIPTION
Also adds "supports_cinder_volume_types" virtual column to ExtManagementSystem to accomodate accessing that field from the API.

Supports https://github.com/ManageIQ/manageiq-ui-classic/pull/4536, which needs to be able to determine feature support via the API.

