### PR TITLE
Delegate verify_ssl & verify_ssl= to default endpoint

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -142,6 +142,8 @@ class ExtManagementSystem < ApplicationRecord
            :port=,
            :security_protocol,
            :security_protocol=,
+           :verify_ssl,
+           :verify_ssl=,
            :certificate_authority,
            :certificate_authority=,
            :to => :default_endpoint,


### PR DESCRIPTION
Creating a provider via the API we need to specify the setting
for verify_ssl.

Continues work from this PR https://github.com/ManageIQ/manageiq-api/pull/431

Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1605210