### PR TITLE
ActiveRecord::Base models must have tables

### DIFF
--- a/app/models/compute_node.rb
+++ b/app/models/compute_node.rb
@@ -1,7 +1,0 @@
-class ComputeNode < ApplicationRecord
-  include NewWithTypeStiMixin
-
-  acts_as_miq_taggable
-
-  belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::PhysicalInfraManager"
-end

--- a/spec/automated_review/ar_models_must_have_tables_spec.rb
+++ b/spec/automated_review/ar_models_must_have_tables_spec.rb
@@ -1,0 +1,5 @@
+describe "ApplicationRecord backed models must be backed by a table" do
+  (ApplicationRecord.descendants - [MiqRegionRemote, VmdbDatabaseConnection, VmdbDatabaseLock]).each do |model|
+    it("#{model} has a table") { expect(model.table_exists?).to be(true) }
+  end
+end


### PR DESCRIPTION
ComputeNode doesn't have a table
Add a test to prevent that from happening again