### PR TITLE
Add hardware attr to VMs returned by validator

### DIFF
--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -132,7 +132,8 @@ class TransformationMapping::VmMigrationValidator
           "cluster"        => vm.ems_cluster.try(:name) || '',
           "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.v_parent_blue_folder_display_path}" : '',
           "allocated_size" => vm.allocated_disk_storage,
-          "id"             => vm.id.to_s
+          "id"             => vm.id.to_s,
+          "hardware"       => vm.hardware
         )
       end
 


### PR DESCRIPTION
This additional information will be used in manageiq-v2v for creating OSP transformation plans, specifically when pre-selecting a flavor for the target tenant of a VM.  We would like to use the VM's `memory_mb` attribute to determine a "closest fit flavor"  in the case that the `best_fit_flavor` response returns nothing.
