### PR TITLE
Lock Gemfile to tag reference for release builds

### DIFF
--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -20,10 +20,22 @@ task :release do
   version_file = root.join("VERSION")
   File.write(version_file, version)
 
-  # Create the commit and tag
-  exit $?.exitstatus unless system("git add #{version_file}")
+  # Change git based gem source to tag reference in Gemfile
+  gemfile = root.join("Gemfile")
+  content = gemfile.read
+  gemfile.write(content.gsub(":branch => \"#{branch}\"", ":tag => \"#{version}\""))
+
+  # Commit
+  exit $?.exitstatus unless system("git add #{version_file} #{gemfile}")
   exit $?.exitstatus unless system("git commit -m 'Release #{version}'")
+
+  # Tag
   exit $?.exitstatus unless system("git tag #{version}")
+
+  # Revert the Gemfile update
+  gemfile.write(content)
+  exit $?.exitstatus unless system("git add #{gemfile}")
+  exit $?.exitstatus unless system("git commit -m 'Revert Gemfile tag reference update and put back branch reference'")
 
   puts
   puts "The commit on #{branch} with the tag #{version} has been created"


### PR DESCRIPTION
Release builds should use tag reference (e.g. `gaprindashvili-5`) in Gemfile by default.

The Gemfile will be updated to tag reference when cutting a release, then reverted after tagging so the branch will continue to use the branch reference.