### PR TITLE
Fix possible spec failure due to array ordering

### DIFF
--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -226,14 +226,14 @@ describe EvmApplication do
 
     it "groups zone together" do
       tgt_time = 2.hours.ago
-      zone1 = FactoryGirl.create(:zone)
-      zone2 = FactoryGirl.create(:zone)
+      zone1 = FactoryGirl.create(:zone, :name => "zone1")
+      zone2 = FactoryGirl.create(:zone, :name => "zone2")
       MiqQueue.put(:zone => zone1.name, :class_name => "X", :method_name => "x", :created_on => tgt_time)
       MiqQueue.put(:zone => zone2.name, :class_name => "X", :method_name => "x", :created_on => tgt_time)
-      expect(described_class.queue_status).to match_array(
+      expect(described_class.queue_status).to eq(
         [
           {
-            "Zone"   => zone1.name,
+            "Zone"   => "zone1",
             "Queue"  => "generic",
             "Role"   => nil,
             "method" => "X.x",
@@ -241,7 +241,7 @@ describe EvmApplication do
             "count"  => 1,
           },
           {
-            "Zone"   => zone2.name,
+            "Zone"   => "zone2",
             "Queue"  => "generic",
             "Role"   => nil,
             "method" => "X.x",

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -230,7 +230,7 @@ describe EvmApplication do
       zone2 = FactoryGirl.create(:zone)
       MiqQueue.put(:zone => zone1.name, :class_name => "X", :method_name => "x", :created_on => tgt_time)
       MiqQueue.put(:zone => zone2.name, :class_name => "X", :method_name => "x", :created_on => tgt_time)
-      expect(described_class.queue_status).to eq(
+      expect(described_class.queue_status).to match_array(
         [
           {
             "Zone"   => zone1.name,


### PR DESCRIPTION
Introduced in bf66236a6db960c8cab4225182a6bee80697bcf2

Example failure: https://travis-ci.org/ManageIQ/manageiq/jobs/431577113

```
  1) EvmApplication.queue_status groups zone together
     Failure/Error:
       expect(described_class.queue_status).to eq(
         [
           {
             "Zone"   => zone1.name,
             "Queue"  => "generic",
             "Role"   => nil,
             "method" => "X.x",
             "oldest" => tgt_time.strftime("%Y-%m-%d"),
             "count"  => 1,
           },
       expected: [{"Zone"=>"Zone 9", "Queue"=>"generic", "Role"=>nil, "method"=>"X.x", "oldest"=>"2018-09-21", "count"..."=>"Zone 10", "Queue"=>"generic", "Role"=>nil, "method"=>"X.x", "oldest"=>"2018-09-21", "count"=>1}]
            got: [{"Zone"=>"Zone 10", "Queue"=>"generic", "Role"=>nil, "method"=>"X.x", "oldest"=>"2018-09-21", "count...e"=>"Zone 9", "Queue"=>"generic", "Role"=>nil, "method"=>"X.x", "oldest"=>"2018-09-21", "count"=>1}]
       (compared using ==)
       Diff:
       @@ -1,10 +1,10 @@
       -[{"Zone"=>"Zone 9",
       +[{"Zone"=>"Zone 10",
          "Queue"=>"generic",
          "Role"=>nil,
          "method"=>"X.x",
          "oldest"=>"2018-09-21",
          "count"=>1},
       - {"Zone"=>"Zone 10",
       + {"Zone"=>"Zone 9",
          "Queue"=>"generic",
          "Role"=>nil,
          "method"=>"X.x",
     # ./spec/lib/tasks/evm_application_spec.rb:233:in `block (3 levels) in <top (required)>'

```

Backport status will be the same as https://github.com/ManageIQ/manageiq/pull/17987