### PR TITLE
Add ems_cluster_id to vms returned by validator

### DIFF
--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -132,7 +132,8 @@ class TransformationMapping::VmMigrationValidator
           "cluster"        => vm.ems_cluster.try(:name) || '',
           "path"           => vm.ext_management_system ? "#{vm.ext_management_system.name}/#{vm.v_parent_blue_folder_display_path}" : '',
           "allocated_size" => vm.allocated_disk_storage,
-          "id"             => vm.id.to_s
+          "id"             => vm.id.to_s,
+          "ems_cluster_id" => vm.ems_cluster_id.to_s
         )
       end
 

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -116,6 +116,7 @@ describe TransformationMapping do
       it 'returns valid vms' do
         result = mapping.search_vms_and_validate(['name' => vm.name])
         expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
+        expect(result['valid'].first.ems_cluster_id).to eq(vm.ems_cluster_id.to_s)
       end
 
       it 'returns conflict vms' do


### PR DESCRIPTION
This attribute was added in https://github.com/ManageIQ/manageiq/pull/17876,
but accidentally left out of the refactor done in https://github.com/ManageIQ/manageiq/pull/17364

This is necessary for creating `ServiceTemplateTransformationPlan` with OSP as a target provider in manageiq-v2v 
