### PR TITLE
Backend-initiated notifications in v2v for Successful and Failed Requests

### DIFF
--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -28,4 +28,13 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
     update_attributes(:cancelation_status => MiqRequest::CANCEL_STATUS_REQUESTED)
     miq_request_tasks.each(&:cancel)
   end
+
+  def update_request_status
+    super
+    if request_state == 'finished' && status == 'Ok'
+      Notification.create(:type => "transformation_plan_request_succeeded", :options => {:plan_name => description})
+    elsif request_state == 'finished' && status != 'Ok'
+      Notification.create(:type => "transformation_plan_request_failed", :options => {:plan_name => description}, :subject => self)
+    end
+  end
 end

--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -39,6 +39,17 @@
   :expires_in: 14.days
   :level: :warning
   :audience: group
+- :name: transformation_plan_request_succeeded
+  :message: Plan %{plan_name} has completed successfully
+  :expires_in: 14.days
+  :level: :success
+  :audience: global
+- :name: transformation_plan_request_failed
+  :message: Plan %{plan_name} has completed with errors
+  :expires_in: 14.days
+  :level: :error
+  :audience: global
+  :link_to: "subject"
 - :name: automate_user_success
   :message: '%{message}'
   :expires_in: 24.hours


### PR DESCRIPTION
Fixes ManageIQ/manageiq-v2v#265
Fixes ManageIQ/manageiq-v2v#578

<img width="1428" alt="screen shot 2018-09-21 at 12 53 09 pm" src="https://user-images.githubusercontent.com/1538216/45903880-028cd080-bda0-11e8-95c4-f9cafb54bf52.png">

