### PR TITLE
Move from apache module mod_auth_kerb to mod_auth_gssapi

### DIFF
--- a/tools/miqldap_to_sssd/configure_apache.rb
+++ b/tools/miqldap_to_sssd/configure_apache.rb
@@ -43,7 +43,7 @@ module MiqLdapToSssd
 
       begin
         miq_ext_auth = File.read("#{HTTPD_CONF_DIR}/manageiq-external-auth.conf")
-        miq_ext_auth[/(\s*)KrbAuthRealms(\s*)(.*)/, 3] = initial_settings[:domain]
+        miq_ext_auth[/(\s*)KrbAuthRealms(\s*)(.*)/, 3] = initial_settings[:domain] if miq_ext_auth.include?("KrbAuthRealms")
         File.write("#{HTTPD_CONF_DIR}/manageiq-external-auth.conf", miq_ext_auth)
       rescue Errno::ENOENT, IndexError => err
         LOGGER.fatal(err.message)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/160659028

This PR is one of a set that will implement moving external authentication support from
the Apache module mod_auth_kerb to mod_auth_gssapi

Once all of the PRs are available I will remove the WIP flag

I also fixed the heredoc delimiters that rubocop did not like.