### PR TITLE
Support ':' character in parsing tag in MiqExpression::Tag

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -3,7 +3,7 @@ class MiqExpression::Tag < MiqExpression::Target
 (?<model_name>(?:[[:upper:]][[:alnum:]]*(?:::[[:upper:]][[:alnum:]]*)*)?)
 \.?(?<associations>([a-z_]+\.)*)
 (?<namespace>\bmanaged|user_tag\b)
--(?<column>[a-z]+[_[:alnum:]]+)
+-(?<column>[a-z]+[_:[:alnum:]]+)
 /x
 
   MANAGED_NAMESPACE      = 'managed'.freeze

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -1,5 +1,26 @@
 RSpec.describe MiqExpression::Tag do
   describe ".parse" do
+    it "with model.managed-amazon" do
+      tag = "Vm.managed-amazon:vm:name"
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/amazon:vm:name")
+    end
+
+    it "with model.managed-in_tag" do
+      tag = "Vm.managed-service_level"
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/service_level")
+    end
+
+    it "with model.managed-in_tag" do
+      tag = "Vm.managed-service_level"
+      expect(described_class.parse(tag)).to have_attributes(:model        => Vm,
+                                                            :associations => [],
+                                                            :namespace    => "/managed/service_level")
+    end
+
     it "with model.managed-in_tag" do
       tag = "Vm.managed-service_level"
       expect(described_class.parse(tag)).to have_attributes(:model        => Vm,

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2037,6 +2037,10 @@ describe MiqExpression do
   end
 
   context 'value2tag' do
+    it 'dotted notation with Taq' do
+      expect(described_class.value2tag('Vm.managed-amazon:vm:name', "mapped:smartstate")).to eq ["vm", "/managed/amazon:vm:name/mapped:smartstate"]
+    end
+
     it 'dotted notation with CountField' do
       expect(described_class.value2tag('Vm.disks')).to eq ['vm', '/virtual/disks']
     end


### PR DESCRIPTION
we need to parse also format described in specs. this format is used by labels mapped to tags.


# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1526000 (one part)
