### PR TITLE
Fixed MiqExpression evaluation on tagged Services 

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -220,7 +220,7 @@ class Condition < ApplicationRecord
         attr, val = o.split("=")
         ohash[attr.strip.downcase.to_sym] = val.strip.downcase
       end
-      if ohash[:ref] != rec.class.to_s.downcase
+      if ohash[:ref] != rec.class.to_s.downcase && !exclude_from_object_ref_substitution(ohash[:ref], rec)
         ref = rec.send(val) if val && rec.respond_to?(val)
       end
 
@@ -230,6 +230,13 @@ class Condition < ApplicationRecord
       end
     end
     return ohash, ref, object
+  end
+
+  def self.exclude_from_object_ref_substitution(reference, rec)
+    case reference
+    when "service"
+      rec.kind_of?(Service)
+    end
   end
 
   def self.registry_data(ref, name, ohash)

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -164,4 +164,12 @@ describe Condition do
       expect(condition.expression.exp).to eq("not" => {">" => {"field" => "Vm-cpu_num", "value" => 2}})
     end
   end
+
+  describe ".options2hash" do
+    it 'returns the same record if it is descendant from Service class and passed reference is "service" ' do
+      record = ServiceContainerTemplate.new
+      _, result_record, _ = described_class.options2hash("ref=service", record)
+      expect(result_record).to be(record)
+    end
+  end
 end


### PR DESCRIPTION
Before `MiqExpression` evaluating expression, it is trying to resolve referenced associations (if any).
It is done by compare passed reference to a run-time object. 
If passed object's class not the same as passed reference than `MiqExpression` consider that passed reference is an association and  trying to obtain associated object.

**ISSUE:** If  reference passed to `MiqExpression` is `"service"` and run-time object when evaluating expression is descendant class,( like `ServiceContainerTemplate`) than MiqExpression will try to substitute passed object by invoking  `service` on passed object, which will return nil
  
**FIX:** Do not attempt to substitute original (runtime) object passed to MiqExpression if that object descendant from `Service` and reference passed to `MiqExpression` is `"service"`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628727

@miq-bot add-label bug, blocker, gaprindashvili/yes 

\cc @gtanzillo 