### PR TITLE
Properly serialize OrchestrationStack class name for MiqRetireTask.request_type

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -58,7 +58,7 @@ class ServiceRetireTask < MiqRetireTask
         :parent_service_id   => parent_service.id,
         :parent_task_id      => parent_task.id,
       )
-      task.request_type = svc_rsc.resource.type.demodulize.downcase + "_retire"
+      task.request_type = svc_rsc.resource.type.demodulize.underscore.downcase + "_retire"
       task.source = svc_rsc.resource
       parent_task.miq_request_tasks << task
       task.save!


### PR DESCRIPTION
With this commit we make sure retirement request validation succeeds, because right now it's failing with:

```
[ActiveRecord::RecordInvalid]: Validation failed: OrchestrationStackRetireTask:
    Request type should be orchestration_stack_retire
```

Reason for the error above ^ is that `OrchestrationStack.class.name` gets transformed into `orchestrationstack` while validation expects underscore inbetween: `orchestration_stack`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1632239

@miq-bot add_label enhancement,gaprindashvili/yes,hammer/yes
@miq-bot assign @tinaafitz

/cc @d-m-u @agrare 

Related PRs:
- https://github.com/ManageIQ/manageiq-content/pull/432
- https://github.com/ManageIQ/manageiq-providers-vmware/pull/324 (merged)
- https://github.com/ManageIQ/manageiq-ui-classic/pull/4710
