### PR TITLE
Prepare compat for vmdb config removal

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -2,6 +2,10 @@ module MiqServer::ConfigurationManagement
   extend ActiveSupport::Concern
   include ConfigurationManagementMixin
 
+  def settings
+    (is_local? ? ::Settings : settings_for_resource).to_hash
+  end
+
   def get_config(type = "vmdb")
     if is_local?
       VMDB::Config.new(type)

--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -24,7 +24,7 @@ module MiqServer::ConfigurationManagement
 
   # The purpose of this method is to do special activation of things
   #   that can only happen once per server.  Normally, the
-  #   VMDB::Config::Activator would be used, however the activations
+  #   Vmdb::Settings::Activator would be used, however the activations
   #   will end up occurring once per worker on the entire server, which
   #   can be detrimental.
   #
@@ -41,7 +41,7 @@ module MiqServer::ConfigurationManagement
     [self]
   end
 
-  # Callback from VMDB::Config::Activator#activate when the configuration has
+  # Callback from Vmdb::Settings::Activator#activate when the configuration has
   #   changed for this server
   def config_activated(data)
     # Check that the column exists in the table and we are passed data that does not match
@@ -80,7 +80,7 @@ module MiqServer::ConfigurationManagement
   end
 
   def sync_log_level
-    # TODO: Can this be removed since the VMDB::Config::Activator will do this anyway?
+    # TODO: Can this be removed since the Vmdb::Settings::Activator will do this anyway?
     Vmdb::Loggers.apply_config(::Settings.log)
   end
 end

--- a/app/models/miq_server/ntp_management.rb
+++ b/app/models/miq_server/ntp_management.rb
@@ -11,7 +11,7 @@ module MiqServer::NtpManagement
 
     # Bust the settings cache allowing this worker to apply any recent changes made by another (UI) worker
     Vmdb::Settings.reload!
-    ntp_settings = get_config("vmdb").config[:ntp]
+    ntp_settings = settings[:ntp]
 
     if @ntp_settings && @ntp_settings == ntp_settings
       _log.info("Skipping reload of ntp settings since they are unchanged")

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -189,8 +189,7 @@ class MiqWorker < ApplicationRecord
     settings = {}
 
     unless miq_server.nil?
-      server_config = options[:config] || miq_server.get_config("vmdb")
-      server_config = server_config.config if server_config.respond_to?(:config)
+      server_config = options[:config] || miq_server.settings
       # Get the configuration values
       section = server_config[:workers]
       unless section.nil?

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -293,7 +293,7 @@ class MiqWorker::Runner
   end
 
   def sync_log_level
-    # TODO: Can this be removed since the VMDB::Config::Activator will do this anyway?
+    # TODO: Can this be removed since the Vmdb::Settings::Activator will do this anyway?
     Vmdb::Loggers.apply_config(::Settings.log)
   end
 

--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -36,7 +36,7 @@ module EvmSettings
 
   def self.config_import(import_hash)
     if import_hash.present?
-      full_config_hash = MiqServer.my_server.get_config.config
+      full_config_hash = MiqServer.my_server.settings
       MiqServer.my_server.set_config(full_config_hash.deep_merge(import_hash))
     end
   end

--- a/lib/vmdb/config.rb
+++ b/lib/vmdb/config.rb
@@ -26,12 +26,12 @@ module VMDB
     end
 
     def validate
-      valid, @errors = Validator.new(self).validate
+      valid, @errors = Vmdb::Settings::Validator.new(self).validate
       valid
     end
 
     def activate
-      Activator.new(self).activate
+      Vmdb::Settings::Activator.new(self).activate
     end
 
     # Get the worker settings as they are in the yaml: 1.seconds, 1, etc.

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -48,11 +48,11 @@ module Vmdb
     end
 
     def self.activate
-      VMDB::Config::Activator.new(::Settings).activate
+      Vmdb::Settings::Activator.new(::Settings).activate
     end
 
     def self.validator(settings = ::Settings)
-      VMDB::Config::Validator.new(settings)
+      Vmdb::Settings::Validator.new(settings)
     end
     private_class_method :validator
 

--- a/lib/vmdb/settings/activator.rb
+++ b/lib/vmdb/settings/activator.rb
@@ -18,11 +18,11 @@ module Vmdb
         raise "configuration invalid, see errors for details" unless Validator.new(@config).valid?
 
         @config.each_key do |k|
-          if respond_to?(k.to_s, true)
-            _log.debug("Activating #{k}")
-            ost = OpenStruct.new(@config[k].stringify_keys)
-            send(k.to_s, ost)
-          end
+          next unless respond_to?(k.to_s, true)
+
+          _log.debug("Activating #{k}")
+          ost = OpenStruct.new(@config[k].stringify_keys)
+          send(k.to_s, ost)
         end
       end
 
@@ -38,7 +38,9 @@ module Vmdb
       end
 
       def server(data)
-        MiqServer.my_server.config_activated(data) unless MiqServer.my_server.nil? rescue nil
+        MiqServer.my_server&.config_activated(data)
+      rescue StandardError
+        nil
       end
     end
   end

--- a/lib/vmdb/settings/activator.rb
+++ b/lib/vmdb/settings/activator.rb
@@ -1,5 +1,5 @@
-module VMDB
-  class Config
+module Vmdb
+  class Settings
     class Activator
       include Vmdb::Logging
 

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -22,20 +22,16 @@ module Vmdb
         @errors = {}
         valid = true
         @config.each_key do |k|
-          if respond_to?(k.to_s, true)
-            _log.debug("Validating #{k}")
-            ost = OpenStruct.new(@config[k].stringify_keys)
-            section_valid, errors = send(k.to_s, ost)
+          next unless respond_to?(k.to_s, true)
 
-            unless section_valid
-              _log.debug("  Invalid: #{errors}")
-              errors.each do |e|
-                key, msg = e
-                @errors[[k, key].join("-")] = msg
-              end
-              valid = false
-            end
-          end
+          _log.debug("Validating #{k}")
+          ost = OpenStruct.new(@config[k].stringify_keys)
+          section_valid, errors = send(k.to_s, ost)
+          next if section_valid
+
+          _log.debug("  Invalid: #{errors}")
+          errors.each { |key, msg| @errors["#{k}-#{key}"] = msg }
+          valid = false
         end
         return valid, @errors
       end
@@ -47,12 +43,12 @@ module Vmdb
 
         keys = data.each_pair.to_a.transpose.first.to_set
 
-        if keys.include?(:mode) && !["invoke", "disable"].include?(data.mode)
+        if keys.include?(:mode) && !%w(invoke disable).include?(data.mode)
           valid = false
           errors << [:mode, "webservices mode, \"#{data.mode}\", invalid. Should be one of: invoke or disable"]
         end
 
-        if keys.include?(:contactwith) && !["ipaddress", "hostname"].include?(data.contactwith)
+        if keys.include?(:contactwith) && !%w(ipaddress hostname).include?(data.contactwith)
           valid = false
           errors << [:contactwith, "webservices contactwith, \"#{data.contactwith}\", invalid. Should be one of: ipaddress or hostname"]
         end
@@ -136,7 +132,7 @@ module Vmdb
           end
         end
 
-        if keys.include?(:session_store) && !["sql", "memory", "cache"].include?(data.session_store)
+        if keys.include?(:session_store) && !%w(sql memory cache).include?(data.session_store)
           valid = false
           errors << [:session_store, "session_store, \"#{data.session_store}\", invalid. Should be one of \"sql\", \"memory\", \"cache\""]
         end
@@ -156,7 +152,7 @@ module Vmdb
 
         keys = data.each_pair.to_a.transpose.first.to_set
 
-        if keys.include?(:authentication) && !["login", "plain", "none"].include?(data.authentication)
+        if keys.include?(:authentication) && !%w(login plain none).include?(data.authentication)
           valid = false
           errors << [:mode, "authentication, \"#{data.mode}\", invalid. Should be one of: login, plain, or none"]
         end

--- a/lib/vmdb/settings/validator.rb
+++ b/lib/vmdb/settings/validator.rb
@@ -1,5 +1,5 @@
-module VMDB
-  class Config
+module Vmdb
+  class Settings
     class Validator
       include Vmdb::Logging
 

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -1,4 +1,4 @@
-describe VMDB::Config::Validator do
+describe Vmdb::Settings::Validator do
   describe ".new" do
     it "with a Hash" do
       validator = described_class.new(:session => {:timeout => 123})

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -29,9 +29,9 @@ describe Vmdb::Settings::Validator do
     {:webservices => {:timeout => 123}},   true,
     {:webservices => {:timeout => "xxx"}}, false,
 
-    {:authentication => {:mode => "ldaps"}}, false,
+    {:authentication => {:mode => "ldaps"}},                     false,
     {:authentication => {:mode => "ldaps", :ldaphost => "foo"}}, true,
-    {:authentication => {:mode => "xxx"}},   false,
+    {:authentication => {:mode => "xxx"}},                       false,
 
     {:authentication => {:mode => "ldap", :ldaphost => "foo"}}, true,
     {:authentication => {:mode => "ldap", :ldaphost => nil}},   false,

--- a/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
+++ b/spec/tools/miqldap_to_sssd/configure_appliance_settings_spec.rb
@@ -30,10 +30,10 @@ describe MiqLdapToSssd::ConfigureApplianceSettings do
 
       described_class.new.configure
 
-      config = miq_server.get_config("vmdb")
-      expect(config.config.fetch_path(:authentication, :mode)).to eq("httpd")
-      expect(config.config.fetch_path(:authentication, :ldap_role)).to eq(false)
-      expect(config.config.fetch_path(:authentication, :httpd_role)).to eq(true)
+      settings = miq_server.settings
+      expect(settings.fetch_path(:authentication, :mode)).to eq("httpd")
+      expect(settings.fetch_path(:authentication, :ldap_role)).to eq(false)
+      expect(settings.fetch_path(:authentication, :httpd_role)).to eq(true)
     end
   end
 end

--- a/tools/change_server_zone.rb
+++ b/tools/change_server_zone.rb
@@ -23,8 +23,8 @@ end
 server.zone = zone
 server.save!
 
-settings = server.get_config("vmdb")
-settings.config[:server][:zone] = zone.name
+settings = server.settings
+settings[:server][:zone] = zone.name
 server.set_config(settings)
 
 server.save!

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -89,7 +89,7 @@ end
 puts "Setting [#{opts[:path]}], old value: [#{path[key]}], new value: [#{newval}]"
 path[key] = newval
 
-valid, errors = VMDB::Config::Validator.new(settings).validate
+valid, errors = Vmdb::Settings.validate(settings)
 unless valid
   puts "ERROR: Configuration is invalid:"
   errors.each { |k, v| puts "\t#{k}: #{v}" }

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -70,9 +70,9 @@ unless server
   exit 1
 end
 
-settings = server.get_config("vmdb")
+settings = server.settings
 
-path = settings.config
+path = settings
 keys = opts[:path].split("/")
 key = keys.pop.to_sym
 keys.each { |p| path = path[p.to_sym] }


### PR DESCRIPTION
This PR is mainly about adding new `MiqServer#settings` method that server as a almost-drop-in replacement for `MiqServer#get_config`. This way consumers of `MiqServer#get_config` and `MiqServer#set_config` can migrate to `MiqServer#settings` and `MiqServer#add_settings_for_resource` without being broken during the transition.

@miq-bot assign @carbonin 