### PR TITLE
Properly create tenant default group for population

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -229,9 +229,11 @@ class MiqGroup < ApplicationRecord
 
     create_with(
       :description         => "Tenant #{tenant_full_name} access",
-      :group_type          => TENANT_GROUP,
       :default_tenant_role => MiqUserRole.default_tenant_role
-    ).find_or_create_by!(:tenant_id => tenant.id)
+    ).find_or_create_by!(
+      :group_type => TENANT_GROUP,
+      :tenant_id  => tenant.id,
+    )
   end
 
   def self.sort_by_desc


### PR DESCRIPTION
When creating a tenant, if there are already groups in the database,
it would assign a random group.

This can only happen for customers who had a database before tenancy
was introduced in 2015

The fix: it will now only assign a tenant group.

https://bugzilla.redhat.com/show_bug.cgi?id=1625788

I'm also adding a migration to automatically fix customer's databases
