### PR TITLE
Add product setting default for allowing API service ordering

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -981,6 +981,7 @@
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
   :run_automate_methods_on_service_api_submit: false
+  :allow_api_service_ordering: true
 :prototype:
   :queue_type: miq_queue
   :artemis:


### PR DESCRIPTION
As an addition to [this PR](https://github.com/ManageIQ/manageiq-api/pull/476), @bdunne suggested I change the product setting to a positive name and default the value to `true`.

https://bugzilla.redhat.com/show_bug.cgi?id=1632416

I know there's not much to "review" here, but @bdunne, can you give it a look? 👀 

/cc @tinaafitz 

@miq-bot add_label bug