### PR TITLE
Validate towhat policy field

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -1,6 +1,16 @@
 # TODO: Import/Export support
 
 class MiqPolicy < ApplicationRecord
+  TOWHAT_APPLIES_TO_CLASSES = %w(Host
+                                 Vm
+                                 ContainerReplicator
+                                 ContainerGroup
+                                 ContainerNode
+                                 ContainerImage
+                                 ContainerProject
+                                 ExtManagementSystem
+                                 PhysicalServer).freeze
+
   acts_as_miq_taggable
   acts_as_miq_set_member
   include_concern 'ImportExport'
@@ -29,6 +39,7 @@ class MiqPolicy < ApplicationRecord
   validates_presence_of     :name, :description, :guid
   validates_uniqueness_of   :name, :description, :guid
   validates :mode, :inclusion => { :in => %w(compliance control) }
+  validates :towhat, :inclusion => { :in => TOWHAT_APPLIES_TO_CLASSES }
 
   scope :with_mode,   ->(mode)   { where(:mode => mode) }
   scope :with_towhat, ->(towhat) { where(:towhat => towhat) }

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -1,15 +1,15 @@
 # TODO: Import/Export support
 
 class MiqPolicy < ApplicationRecord
-  TOWHAT_APPLIES_TO_CLASSES = %w(Host
-                                 Vm
-                                 ContainerReplicator
-                                 ContainerGroup
-                                 ContainerNode
+  TOWHAT_APPLIES_TO_CLASSES = %w(ContainerGroup
                                  ContainerImage
+                                 ContainerNode
                                  ContainerProject
+                                 ContainerReplicator
                                  ExtManagementSystem
-                                 PhysicalServer).freeze
+                                 Host
+                                 PhysicalServer
+                                 Vm).freeze
 
   acts_as_miq_taggable
   acts_as_miq_set_member

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -310,19 +310,11 @@ describe MiqPolicy do
 
   context '.validates' do
     it 'validates towhat' do
-      expect(described_class.create!(:towhat      => "Host",
-                                     :active      => false,
-                                     :description => 'x',)).to have_attributes(:towhat => "Host",
-                                                                               :active => false)
+      expect(FactoryGirl.build(:miq_policy, :towhat => "Host")).to be_valid
     end
 
     it 'reports invalid towhat' do
-      expect do
-        described_class.create!(:towhat      => "BobsYourUncle",
-                                :active      => false,
-                                :description => 'x')
-      end.to raise_error(ActiveRecord::RecordInvalid,
-                         "Validation failed: MiqPolicy: Towhat is not included in the list")
+      expect(FactoryGirl.build(:miq_policy, :towhat => "BobsYourUncle")).not_to be_valid
     end
   end
 end

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -307,4 +307,25 @@ describe MiqPolicy do
       )
     end
   end
+
+  context '.validates' do
+    it 'validates towhat and mode' do
+      expect(described_class.create!(:towhat      => "Host",
+                                     :mode        => "compliance",
+                                     :active      => false,
+                                     :description => 'x',)).to have_attributes(:towhat => "Host",
+                                                                               :active => false,
+                                                                               :mode   => "compliance")
+    end
+
+    it 'reports invalid towhat' do
+      expect do
+        described_class.create!(:towhat      => "BobsYourUncle",
+                                :mode        => "compliance",
+                                :active      => false,
+                                :description => 'x')
+      end.to raise_error(ActiveRecord::RecordInvalid,
+                         "Validation failed: MiqPolicy: Towhat is not included in the list")
+    end
+  end
 end

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -309,19 +309,16 @@ describe MiqPolicy do
   end
 
   context '.validates' do
-    it 'validates towhat and mode' do
+    it 'validates towhat' do
       expect(described_class.create!(:towhat      => "Host",
-                                     :mode        => "compliance",
                                      :active      => false,
                                      :description => 'x',)).to have_attributes(:towhat => "Host",
-                                                                               :active => false,
-                                                                               :mode   => "compliance")
+                                                                               :active => false)
     end
 
     it 'reports invalid towhat' do
       expect do
         described_class.create!(:towhat      => "BobsYourUncle",
-                                :mode        => "compliance",
                                 :active      => false,
                                 :description => 'x')
       end.to raise_error(ActiveRecord::RecordInvalid,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1435780

Invalid values for policy field `towhat` are not recognized, result in the policy being
created using the API.

The validations for `mode` were added in [PR 14519](https://github.com/ManageIQ/manageiq/pull/14519

The list of valid values for `towhat` were arrived at by examination of what is supported via
the UI [tree_builder_policy.rb](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/presenters/tree_builder_policy.rb#L17-L35)

Steps for Testing/QA
-------------------------------

Attempt to create a policy with the following data:

        {
          "action": "create",  
          "resources": [{
            "name": "test policy bobsyouruncle",
            "description": "Desc bobsyouruncle",
            "mode": "control",
            "towhat": "bobsyouruncle",      
            "conditions_ids": [ 2000, 3000 ],
            "policy_contents": [{             
              "event_id": 2,
              "actions": [ {"action_id": 1, "opts": { "qualifier": "failure" } } ]
            }]
          }]
        }

e.g.:

```bash
$MY_MIQ_REPO/manageiq/tools/rest_api.rb  -l https://10.8.99.50 get /api/policies

<when prompted enter>

        {
          "action": "create",  
          "resources": [{
            "name": "test policy bobsyouruncle",
            "description": "Desc bobsyouruncle",
            "mode": "control",
            "towhat": "bobsyouruncle",      
            "conditions_ids": [ 2000, 3000 ],
            "policy_contents": [{             
              "event_id": 2,
              "actions": [ {"action_id": 1, "opts": { "qualifier": "failure" } } ]
            }]
          }]
        }

```
