### PR TITLE
Use MiqPassword method to not double encrypt a protected password field

### DIFF
--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -31,7 +31,7 @@ class DialogFieldTextBox < DialogField
 
   def automate_output_value
     return nil if @value.nil?
-    return MiqPassword.encrypt(@value) if self.protected? && !value_is_already_encrypted?
+    return MiqPassword.try_encrypt(@value) if self.protected?
     convert_value_to_type
   end
 
@@ -88,9 +88,5 @@ class DialogFieldTextBox < DialogField
   def load_values_on_init?
     return true unless show_refresh_button
     load_values_on_init
-  end
-
-  def value_is_already_encrypted?
-    return true if MiqPassword.encrypted?(@value)
   end
 end

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -118,18 +118,6 @@ describe DialogFieldTextBox do
     it "#automate_key_name" do
       expect(df.automate_key_name).to eq("password::dialog_test field")
     end
-
-    context "when the value is already encrypted" do
-      before do
-        allow(MiqPassword).to receive(:encrypted?).and_return(true)
-      end
-
-      it "does not double encrypt it" do
-        df.value = MiqPassword.encrypt("test")
-
-        expect(df.automate_output_value).to be_encrypted("test")
-      end
-    end
   end
 
   context "validation" do


### PR DESCRIPTION
As @mkanoor pointed out to me, `MiqPassword` already has a method for doing what we wanted in #18031. This just makes the code simpler.

https://bugzilla.redhat.com/show_bug.cgi?id=1602883

/cc @mkanoor 
@miq-bot assign @gmcculloug 