### PR TITLE
Currently on a successful ActionResult (start / stop) we return nil

### DIFF
--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -77,6 +77,7 @@ module InterRegionApiMethodRelay
     case result
     when ManageIQ::API::Client::ActionResult
       raise InterRegionApiMethodRelayError, result.message if result.failed?
+      result.attributes
     when ManageIQ::API::Client::Resource
       instance_for_resource(result)
     else

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -231,24 +231,24 @@ describe InterRegionApiMethodRelay do
       it "calls the given action with the given args" do
         args = {:my => "args", :here => 123}
         expect(api_collection).to receive(action).with(args).and_return(api_success_result)
-        described_class.exec_api_call(region, collection_name, action, args)
+        expect(described_class.exec_api_call(region, collection_name, action, args)).to eq(api_success_result.attributes)
       end
 
       it "defaults the args to an empty hash" do
         expect(api_collection).to receive(action).with({}).and_return(api_success_result)
-        described_class.exec_api_call(region, collection_name, action)
+        expect(described_class.exec_api_call(region, collection_name, action)).to eq(api_success_result.attributes)
       end
 
       it "defaults the args to an empty hash when nil is explicitly passed as args" do
         expect(api_collection).to receive(action).with({}).and_return(api_success_result)
-        described_class.exec_api_call(region, collection_name, action, nil)
+        expect(described_class.exec_api_call(region, collection_name, action, nil)).to eq(api_success_result.attributes)
       end
 
       it "calls a method on an instance if id is passed" do
         instance = double("instance")
         expect(api_collection).to receive(:find).with(4).and_return(instance)
         expect(instance).to receive(action).and_return(api_success_result)
-        described_class.exec_api_call(region, collection_name, action, nil, 4)
+        expect(described_class.exec_api_call(region, collection_name, action, nil, 4)).to eq(api_success_result.attributes)
       end
     end
   end


### PR DESCRIPTION
Returning the result of the api call would at least be a positive result
https://bugzilla.redhat.com/show_bug.cgi?id=1628658