### PR TITLE
[WIP] Make provider's enable/disable methods protected

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -72,6 +72,7 @@ class ExtManagementSystem < ApplicationRecord
   has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   belongs_to :zone
+  belongs_to :backup_zone, :class_name => "Zone", :inverse_of => :paused_ext_management_systems # used for maintenance mode
 
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
@@ -185,6 +186,43 @@ class ExtManagementSystem < ApplicationRecord
   alias_attribute :to_s, :name
 
   default_value_for :enabled, true
+
+  after_save :change_maintenance_for_child_managers, :if => proc { |ems| ems.changed_attributes.include?('enabled') }
+
+  def disable!
+    _log.info("Disabling EMS [#{name}] id [#{id}].")
+    update!(:enabled => false)
+    _log.info("Disabling EMS [#{name}] id [#{id}] successful.")
+  end
+
+  def enable!
+    _log.info("Enabling EMS [#{name}] id [#{id}].")
+    update!(:enabled => true)
+    _log.info("Enabling EMS [#{name}] id [#{id}] successful.")
+  end
+
+  # Move ems to maintenance zone and backup current one
+  # @param orig_zone [Zone] children original zones can be replaced in provider-specific callbacks
+  def pause!(orig_zone = nil)
+    _log.info("Pausing EMS [#{name}] id [#{id}].")
+    update!(
+      :backup_zone => orig_zone || zone,
+      :zone        => Zone.maintenance_zone,
+      :enabled     => false
+    )
+    _log.info("Pausing EMS [#{name}] id [#{id}] successful.")
+  end
+
+  # Move ems to original zone, reschedule task/jobs/.. collected during maintenance
+  def resume!
+    _log.info("Resuming EMS [#{name}] id [#{id}].")
+    update!(
+      :backup_zone => nil,
+      :zone        => backup_zone || Zone.default_zone,
+      :enabled     => true
+    )
+    _log.info("Resuming EMS [#{name}] id [#{id}] successful.")
+  end
 
   def self.with_ipaddress(ipaddress)
     joins(:endpoints).where(:endpoints => {:ipaddress => ipaddress})
@@ -453,16 +491,6 @@ class ExtManagementSystem < ApplicationRecord
 
   def self.ems_physical_infra_discovery_types
     @ems_physical_infra_discovery_types ||= %w(lenovo_ph_infra)
-  end
-
-  def disable!
-    _log.info("Disabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => false)
-  end
-
-  def enable!
-    _log.info("Enabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => true)
   end
 
   # override destroy_queue from AsyncDeleteMixin
@@ -745,6 +773,17 @@ class ExtManagementSystem < ApplicationRecord
 
   private
 
+  # Child managers went to/from maintenance mode with parent
+  def change_maintenance_for_child_managers
+    child_managers.each do |child_ems|
+      if enabled?
+        child_ems.resume!
+      else
+        child_ems.pause!(backup_zone)
+      end
+    end
+  end
+
   def build_connection(options = {})
     build_endpoint_by_role(options[:endpoint])
     build_authentication_by_role(options[:authentication])
@@ -765,7 +804,7 @@ class ExtManagementSystem < ApplicationRecord
     role = options.delete(:role)
     creds = {}
     creds[role] = options
-    update_authentication(creds,options)
+    update_authentication(creds, options)
   end
 
   def clear_association_cache

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -89,6 +89,8 @@ class ExtManagementSystem < ApplicationRecord
   validates :hostname, :presence => true, :if => :hostname_required?
   validate :hostname_uniqueness_valid?, :hostname_format_valid?, :if => :hostname_required?
 
+  validate :validate_ems_enabled_when_zone_changed?, :validate_zone_visible_when_ems_enabled?
+
   scope :with_eligible_manager_types, ->(eligible_types) { where(:type => eligible_types) }
 
   serialize :options
@@ -108,6 +110,22 @@ class ExtManagementSystem < ApplicationRecord
   def hostname_format_valid?
     return if hostname.ipaddress? || hostname.hostname?
     errors.add(:hostname, _("format is invalid."))
+  end
+
+  # validation - Zone cannot be changed when enabled == false
+  def validate_ems_enabled_when_zone_changed?
+    return if changed_attributes.include?('enabled')
+
+    if changed_attributes.include?('zone_id') && !enabled?
+      errors.add(:zone, N_("cannot be changed when provider paused"))
+    end
+  end
+
+  # validation - Zone has to be visible when enabled == true
+  def validate_zone_visible_when_ems_enabled?
+    if enabled? && zone.present? && !zone.visible?
+      errors.add(:zone, N_("cannot be invisible when provider active"))
+    end
   end
 
   include NewWithTypeStiMixin

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -72,7 +72,7 @@ class ExtManagementSystem < ApplicationRecord
   has_one  :iso_datastore, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
   belongs_to :zone
-  belongs_to :backup_zone, :class_name => "Zone", :inverse_of => :paused_ext_management_systems # used for maintenance mode
+  belongs_to :zone_before_pause, :class_name => "Zone", :inverse_of => :paused_ext_management_systems # used for maintenance mode
 
   has_many :metrics,        :as => :resource  # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource  # Destroy will be handled by purger
@@ -223,9 +223,9 @@ class ExtManagementSystem < ApplicationRecord
   def pause!
     _log.info("Pausing EMS [#{name}] id [#{id}].")
     update!(
-      :backup_zone => zone,
-      :zone        => Zone.maintenance_zone,
-      :enabled     => false
+      :zone_before_pause => zone,
+      :zone              => Zone.maintenance_zone,
+      :enabled           => false
     )
     _log.info("Pausing EMS [#{name}] id [#{id}] successful.")
   end
@@ -234,9 +234,9 @@ class ExtManagementSystem < ApplicationRecord
   def resume!
     _log.info("Resuming EMS [#{name}] id [#{id}].")
     update!(
-      :backup_zone => nil,
-      :zone        => backup_zone || Zone.default_zone,
-      :enabled     => true
+      :zone_before_pause => nil,
+      :zone              => zone_before_pause || Zone.default_zone,
+      :enabled           => true
     )
     _log.info("Resuming EMS [#{name}] id [#{id}] successful.")
   end

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -220,11 +220,10 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   # Move ems to maintenance zone and backup current one
-  # @param orig_zone [Zone] children original zones can be replaced in provider-specific callbacks
-  def pause!(orig_zone = nil)
+  def pause!
     _log.info("Pausing EMS [#{name}] id [#{id}].")
     update!(
-      :backup_zone => orig_zone || zone,
+      :backup_zone => zone,
       :zone        => Zone.maintenance_zone,
       :enabled     => false
     )
@@ -793,12 +792,10 @@ class ExtManagementSystem < ApplicationRecord
 
   # Child managers went to/from maintenance mode with parent
   def change_maintenance_for_child_managers
-    child_managers.each do |child_ems|
-      if enabled?
-        child_ems.resume!
-      else
-        child_ems.pause!(backup_zone)
-      end
+    if enabled?
+      child_managers.each(&:enable!)
+    else
+      child_managers.each(&:disable!)
     end
   end
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -207,18 +207,6 @@ class ExtManagementSystem < ApplicationRecord
 
   after_save :change_maintenance_for_child_managers, :if => proc { |ems| ems.changed_attributes.include?('enabled') }
 
-  def disable!
-    _log.info("Disabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => false)
-    _log.info("Disabling EMS [#{name}] id [#{id}] successful.")
-  end
-
-  def enable!
-    _log.info("Enabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => true)
-    _log.info("Enabling EMS [#{name}] id [#{id}] successful.")
-  end
-
   # Move ems to maintenance zone and backup current one
   def pause!
     _log.info("Pausing EMS [#{name}] id [#{id}].")
@@ -788,14 +776,28 @@ class ExtManagementSystem < ApplicationRecord
     Settings.ems_refresh.fetch_path(emstype, :allow_targeted_refresh)
   end
 
+  protected
+
+  def disable!
+    _log.info("Disabling EMS [#{name}] id [#{id}].")
+    update!(:enabled => false)
+    _log.info("Disabling EMS [#{name}] id [#{id}] successful.")
+  end
+
+  def enable!
+    _log.info("Enabling EMS [#{name}] id [#{id}].")
+    update!(:enabled => true)
+    _log.info("Enabling EMS [#{name}] id [#{id}] successful.")
+  end
+
   private
 
   # Child managers went to/from maintenance mode with parent
   def change_maintenance_for_child_managers
     if enabled?
-      child_managers.each(&:enable!)
+      child_managers.each { |ems| ems.enable! }
     else
-      child_managers.each(&:disable!)
+      child_managers.each { |ems| ems.disable! }
     end
   end
 

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -128,6 +128,11 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
+    if options[:zone] == Zone::MAINTENANCE_ZONE_NAME
+      _log.debug("MiqQueue#put skipped: #{options.inspect}")
+      return
+    end
+
     create_with_options = all.values[:create_with] || {}
     options[:priority]    ||= create_with_options[:priority] || NORMAL_PRIORITY
     options[:queue_name]  ||= create_with_options[:queue_name] || "generic"

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -128,7 +128,7 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
-    if options[:zone] == Zone::MAINTENANCE_ZONE_NAME
+    if options[:zone] == Zone.maintenance_zone&.name
       _log.debug("MiqQueue#put skipped: #{options.inspect}")
       return
     end
@@ -180,7 +180,6 @@ class MiqQueue < ApplicationRecord
   def self.submit_job(options)
     service = options.delete(:service) || "generic"
     resource = options.delete(:affinity)
-
     case service
     when "automate"
       # options[:queue_name] = "generic"

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -128,7 +128,7 @@ class MiqQueue < ApplicationRecord
       :handler_id   => nil,
     )
 
-    if options[:zone] == Zone.maintenance_zone&.name
+    if options[:zone].present? && options[:zone] == Zone.maintenance_zone&.name
       _log.debug("MiqQueue#put skipped: #{options.inspect}")
       return
     end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -175,6 +175,7 @@ class MiqQueue < ApplicationRecord
   def self.submit_job(options)
     service = options.delete(:service) || "generic"
     resource = options.delete(:affinity)
+
     case service
     when "automate"
       # options[:queue_name] = "generic"

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -1,4 +1,6 @@
 class MiqRegion < ApplicationRecord
+  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_regions
+
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger
   has_many :vim_performance_states, :as => :resource # Destroy will be handled by purger

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -1,5 +1,5 @@
 class MiqRegion < ApplicationRecord
-  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_regions
+  belongs_to :maintenance_zone, :class_name => 'Zone', :inverse_of => :maintenance_zone_region
 
   has_many :metrics,        :as => :resource # Destroy will be handled by purger
   has_many :metric_rollups, :as => :resource # Destroy will be handled by purger

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -39,6 +39,8 @@ class MiqServer < ApplicationRecord
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
   virtual_delegate :description, :to => :zone, :prefix => true
 
+  validate :validate_zone_visible?, :if => proc { |server| server.zone.present? }
+
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze
   STATUS_RESTARTING     = 'restarting'.freeze
@@ -52,6 +54,10 @@ class MiqServer < ApplicationRecord
   STATUSES_ALIVE   = STATUSES_ACTIVE + [STATUS_RESTARTING, STATUS_QUIESCE]
 
   RESTART_EXIT_STATUS = 123
+
+  def validate_zone_visible?
+    errors.add(:zone, N_('has to be visible')) unless zone.visible?
+  end
 
   def hostname
     h = super

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -4,11 +4,12 @@ class Zone < ApplicationRecord
 
   serialize :settings, Hash
 
-  belongs_to      :log_file_depot, :class_name => "FileDepot"
+  belongs_to :log_file_depot, :class_name => "FileDepot"
 
   has_many :miq_servers
   has_many :ext_management_systems
-  has_many :paused_ext_management_systems, :class_name => 'ExtManagementSystem', :inverse_of => :backup_zone
+  has_many :paused_ext_management_systems, :class_name => 'ExtManagementSystem', :inverse_of => :zone_before_pause
+  has_one  :maintenance_zone_region, :class_name => 'MiqRegion', :inverse_of => :maintenance_zone
   has_many :container_managers, :class_name => "ManageIQ::Providers::ContainerManager"
   has_many :miq_schedules, :dependent => :destroy
   has_many :providers
@@ -40,7 +41,7 @@ class Zone < ApplicationRecord
   scope :visible, -> { where(:visible => true) }
   default_value_for :visible, true
 
-  MAINTENANCE_ZONE_NAME = '__maintenance__'.freeze
+  MAINTENANCE_ZONE_NAME_PREFIX = '__maintenance__'.freeze
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)
@@ -54,10 +55,38 @@ class Zone < ApplicationRecord
     active_miq_servers.detect(&:is_master?)
   end
 
-  def self.seed
-    create_with(:description => "Maintenance Zone", :visible => false).find_or_create_by!(:name => MAINTENANCE_ZONE_NAME) do |_z|
-      _log.info("Creating maintenance zone...")
+  def self.create_maintenance_zone
+    if maintenance_zone.nil?
+      # 1) Create region, if not exists
+      MiqRegion.seed
+
+      # 2) Create Maintenance zone
+      threshold = 100 # avoiding infinite loop
+      zone = nil
+      (1..threshold).each do |idx|
+        zone = create(:name        => "#{MAINTENANCE_ZONE_NAME_PREFIX}#{idx}",
+                      :description => "Maintenance Zone",
+                      :visible     => false)
+        break if zone.valid?
+      end
+
+      # 3) Assign zone to region
+      if zone&.valid?
+        region = zone.miq_region
+        region&.maintenance_zone = zone
+        unless region&.save
+          _log.error("Saving Maintenance zone to region failed with: #{region&.errors&.messages.inspect}")
+        end
+        _log.info("Creating maintenance zone...")
+      else
+        _log.error("Maintenance zone not created in #{threshold} attempts")
+      end
     end
+  end
+
+  def self.seed
+    create_maintenance_zone
+
     create_with(:description => "Default Zone").find_or_create_by!(:name => 'default') do |_z|
       _log.info("Creating default zone...")
     end
@@ -87,9 +116,9 @@ class Zone < ApplicationRecord
     in_my_region.find_by(:name => "default")
   end
 
-  # Zone for suspended providers (no servers in it), not visible by default
+  # Zone for paused providers (no servers in it), not visible by default
   def self.maintenance_zone
-    in_my_region.find_by(:name => MAINTENANCE_ZONE_NAME)
+    MiqRegion.find_by(:region => my_region_number)&.maintenance_zone
   end
 
   def remote_cockpit_ws_miq_server
@@ -223,7 +252,7 @@ class Zone < ApplicationRecord
 
   def check_zone_in_use_on_destroy
     raise _("cannot delete default zone") if name == "default"
-    raise _("cannot delete maintenance zone") if name == MAINTENANCE_ZONE_NAME
+    raise _("cannot delete maintenance zone") if self == miq_region&.maintenance_zone
     raise _("zone name '%{name}' is used by a server") % {:name => name} unless miq_servers.blank?
   end
 end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -38,6 +38,7 @@ class Zone < ApplicationRecord
   include ConfigurationManagementMixin
 
   scope :visible, -> { where(:visible => true) }
+  default_value_for :visible, true
 
   def active_miq_servers
     MiqServer.active_miq_servers.where(:zone_id => id)

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     sequence(:hostname)  { |n| "ems-#{seq_padded_for_sorting(n)}" }
     sequence(:ipaddress) { |n| ip_from_seq(n) }
     guid                 { SecureRandom.uuid }
-    zone                 { Zone.first || FactoryGirl.create(:zone) }
+    zone                 { Zone.visible.first || FactoryGirl.create(:zone) }
     storage_profiles     { [] }
 
     # Traits

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -397,7 +397,7 @@ describe ExtManagementSystem do
   end
 
   context "#pause!" do
-    it 'disables an ems with child managers and moves them to maintenance zone' do
+    it 'disables an ems with child managers and moves parent to maintenance zone' do
       zone  = FactoryGirl.create(:zone)
       ems   = FactoryGirl.create(:ext_management_system, :zone => zone)
       child = FactoryGirl.create(:ext_management_system, :zone => zone)
@@ -411,13 +411,11 @@ describe ExtManagementSystem do
 
       child.reload
       expect(child.enabled).to be_falsy
-      expect(child.zone).to eq(Zone.maintenance_zone)
-      expect(child.backup_zone).to eq(zone)
     end
   end
 
   context "#resume" do
-    it "enables an ems with child managers and move them from maintenance zone" do
+    it "enables an ems with child managers and move parent from maintenance zone" do
       zone = FactoryGirl.create(:zone)
       ems = FactoryGirl.create(:ext_management_system,
                                :backup_zone => zone,
@@ -425,9 +423,8 @@ describe ExtManagementSystem do
                                :enabled     => false)
 
       child = FactoryGirl.create(:ext_management_system,
-                                 :backup_zone => zone,
-                                 :zone        => Zone.maintenance_zone,
-                                 :enabled     => false)
+                                 :zone    => zone,
+                                 :enabled => false)
       ems.child_managers << child
 
       ems.resume!
@@ -438,8 +435,6 @@ describe ExtManagementSystem do
 
       child.reload
       expect(child.enabled).to be_truthy
-      expect(child.zone).to eq(zone)
-      expect(child.backup_zone).to be_nil
     end
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -407,7 +407,7 @@ describe ExtManagementSystem do
 
       expect(ems.enabled).to be_falsy
       expect(ems.zone).to eq(Zone.maintenance_zone)
-      expect(ems.backup_zone).to eq(zone)
+      expect(ems.zone_before_pause).to eq(zone)
 
       child.reload
       expect(child.enabled).to be_falsy
@@ -418,9 +418,9 @@ describe ExtManagementSystem do
     it "enables an ems with child managers and move parent from maintenance zone" do
       zone = FactoryGirl.create(:zone)
       ems = FactoryGirl.create(:ext_management_system,
-                               :backup_zone => zone,
-                               :zone        => Zone.maintenance_zone,
-                               :enabled     => false)
+                               :zone_before_pause => zone,
+                               :zone              => Zone.maintenance_zone,
+                               :enabled           => false)
 
       child = FactoryGirl.create(:ext_management_system,
                                  :zone    => zone,
@@ -431,7 +431,7 @@ describe ExtManagementSystem do
 
       expect(ems.enabled).to be_truthy
       expect(ems.zone).to eq(zone)
-      expect(ems.backup_zone).to be_nil
+      expect(ems.zone_before_pause).to be_nil
 
       child.reload
       expect(child.enabled).to be_truthy

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -443,6 +443,36 @@ describe ExtManagementSystem do
     end
   end
 
+  context "changing zone" do
+    it 'is allowed when enabled' do
+      zones = (1..2).collect { FactoryGirl.create(:zone) }
+      ems   = FactoryGirl.create(:ext_management_system, :zone => zones[0])
+
+      ems.zone = zones[1]
+      expect(ems.save).to be_truthy
+    end
+
+    it 'is denied when disabled' do
+      zones = (1..2).collect { FactoryGirl.create(:zone) }
+      ems   = FactoryGirl.create(:ext_management_system, :zone => zones[0], :enabled => false)
+
+      ems.zone = zones[1]
+      expect(ems.save).to be_falsy
+      expect(ems.errors.messages[:zone]).to be_present
+    end
+
+    it 'to invisible is not possible when provider enabled' do
+      zone_visible = FactoryGirl.create(:zone)
+      zone_invisible = FactoryGirl.create(:zone, :visible => false)
+
+      ems = FactoryGirl.create(:ext_management_system, :zone => zone_visible, :enabled => true)
+
+      ems.zone = zone_invisible
+      expect(ems.save).to be_falsy
+      expect(ems.errors.messages[:zone]).to be_present
+    end
+  end
+
   context "destroy" do
     it "destroys an ems with no active workers" do
       ems = FactoryGirl.create(:ext_management_system)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -396,6 +396,53 @@ describe ExtManagementSystem do
     end
   end
 
+  context "#pause!" do
+    it 'disables an ems with child managers and moves them to maintenance zone' do
+      zone  = FactoryGirl.create(:zone)
+      ems   = FactoryGirl.create(:ext_management_system, :zone => zone)
+      child = FactoryGirl.create(:ext_management_system, :zone => zone)
+      ems.child_managers << child
+
+      ems.pause!
+
+      expect(ems.enabled).to be_falsy
+      expect(ems.zone).to eq(Zone.maintenance_zone)
+      expect(ems.backup_zone).to eq(zone)
+
+      child.reload
+      expect(child.enabled).to be_falsy
+      expect(child.zone).to eq(Zone.maintenance_zone)
+      expect(child.backup_zone).to eq(zone)
+    end
+  end
+
+  context "#resume" do
+    it "enables an ems with child managers and move them from maintenance zone" do
+      zone = FactoryGirl.create(:zone)
+      ems = FactoryGirl.create(:ext_management_system,
+                               :backup_zone => zone,
+                               :zone        => Zone.maintenance_zone,
+                               :enabled     => false)
+
+      child = FactoryGirl.create(:ext_management_system,
+                                 :backup_zone => zone,
+                                 :zone        => Zone.maintenance_zone,
+                                 :enabled     => false)
+      ems.child_managers << child
+
+      ems.resume!
+
+      expect(ems.enabled).to be_truthy
+      expect(ems.zone).to eq(zone)
+      expect(ems.backup_zone).to be_nil
+
+      child.reload
+      expect(child.enabled).to be_truthy
+      expect(child.zone).to eq(zone)
+      expect(child.backup_zone).to be_nil
+    end
+  end
+
   context "destroy" do
     it "destroys an ems with no active workers" do
       ems = FactoryGirl.create(:ext_management_system)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -368,6 +368,19 @@ describe MiqQueue do
       expect(MiqQueue.get).to eq(nil)
     end
 
+    it "should skip putting message on queue in maintenance zone" do
+      Zone.seed
+
+      msg = MiqQueue.put(
+        :class_name  => 'MyClass',
+        :method_name => 'method1',
+        :args        => [1, 2],
+        :zone        => Zone.maintenance_zone&.name
+      )
+
+      expect(MiqQueue.get).to eq(nil)
+    end
+
     it "should accept non-Array args (for now)" do
       begin
         class MiqQueueSpecNonArrayArgs

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -91,6 +91,14 @@ describe MiqServer do
       expect(@miq_server.zone.name).to eq(@zone.name)
     end
 
+    it "cannot have invisible zone" do
+      zone = FactoryGirl.create(:zone, :visible => false)
+
+      @miq_server.zone = zone
+      expect(@miq_server.save).to be_falsy
+      expect(@miq_server.errors.messages[:zone]).to be_present
+    end
+
     it "shutdown will raise an event and quiesce" do
       expect(MiqEvent).to receive(:raise_evm_event)
       expect(@miq_server).to receive(:quiesce)

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,5 +1,5 @@
 describe Zone do
-  include_examples ".seed called multiple times"
+  include_examples ".seed called multiple times", 2
 
   context "with two small envs" do
     before do

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -192,6 +192,37 @@ describe Zone do
     end
   end
 
+  context "maintenance zone" do
+    it "creates missing region during seed" do
+      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)).to be_nil
+      described_class.seed
+      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)).to be_present
+    end
+
+    it "is seeded with relation to region" do
+      described_class.seed
+      zone = Zone.where("name LIKE ?", "#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}%").first
+
+      expect(described_class.maintenance_zone).to be_present
+      expect(described_class.maintenance_zone.id).to eq(zone.id)
+      expect(MiqRegion.find_by(:region => MiqRegion.my_region_number)&.maintenance_zone).to eq(zone)
+    end
+
+    it "is not visible" do
+      described_class.seed
+      expect(described_class.maintenance_zone.visible).to be_falsey
+    end
+
+    it "is created when default name exists" do
+      (1..5).each do |idx|
+        FactoryGirl.create(:zone, :name => "#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}#{idx}")
+      end
+      described_class.seed
+
+      expect(Zone.maintenance_zone.name).to eq("#{Zone::MAINTENANCE_ZONE_NAME_PREFIX}6")
+    end
+  end
+
   context "validate multi region" do
     let!(:other_region_id)         { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
     let!(:default_in_other_region) { described_class.create(:name => "default", :description => "Default Zone", :id => other_region_id) }


### PR DESCRIPTION
`ExtManagementSystem.enable!` and `disable!`  should be used only by parent EMS to children or by `pause!`/`resume`, not as public methods

**Issue**: #17489

**depends on**:
- [ ] https://github.com/ManageIQ/manageiq/pull/17452
- - [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/4269
- - [ ] https://github.com/ManageIQ/manageiq-api/pull/434
