### PR TITLE
Refactor ": nil" in ternary operators

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -32,7 +32,7 @@ class Condition < ApplicationRecord
 
   def self.evaluate(cond, rec, inputs = {}, attr = :expression)
     expression = cond.send(attr)
-    name = cond.respond_to?(:description) ? cond.description : cond.respond_to?(:name) ? cond.name : nil
+    name = cond.respond_to?(:description) ? cond.description : cond.respond_to?(:name) ? cond.try(:name)
     if expression.kind_of?(MiqExpression)
       mode = "object"
     else

--- a/app/models/miq_cockpit_ws_worker/authenticator.rb
+++ b/app/models/miq_cockpit_ws_worker/authenticator.rb
@@ -38,7 +38,7 @@ module MiqCockpitWsWorker::Authenticator
   def creds_for_vm(vm)
     return nil unless vm
     creds = vm.container_deployment.try(:ssh_auth)
-    creds = vm.respond_to?(:key_pairs) ? vm.key_pairs.first : nil unless creds
+    creds = vm.respond_to?(:key_pairs) ? vm.key_pairs.try(:first) unless creds
     creds ? creds : Authentication.new
   end
 


### PR DESCRIPTION
This PR refactors some ": nil" in ternary operators according to #11955.