### PR TITLE
Queue reporting work for any zone

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -197,7 +197,6 @@ class MiqQueue < ApplicationRecord
       # TODO: can we transition to zone = nil
     when "notifier"
       options[:role] = service
-      options[:zone] = nil # any zone
     when "reporting"
       options[:queue_name] = "generic"
       options[:role] = service
@@ -205,6 +204,9 @@ class MiqQueue < ApplicationRecord
       options[:queue_name] = "smartproxy"
       options[:role] = "smartproxy"
     end
+
+    # Note, options[:zone] is set in 'put' via 'determine_queue_zone' and handles setting
+    # a nil (any) zone for regional roles.  Therefore, regional roles don't need to set zone here.
     put(options)
   end
 

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -164,8 +164,8 @@ module MiqReport::Generator
     if sync
       _async_generate_table(task.id, options)
     else
-      MiqQueue.put(
-        :queue_name  => "reporting",
+      MiqQueue.submit_job(
+        :service     => "reporting",
         :class_name  => self.class.name,
         :instance_id => id,
         :method_name => "_async_generate_table",
@@ -792,9 +792,8 @@ module MiqReport::Generator
     _log.info("Adding generate report task to the message queue...")
     task = MiqTask.create(:name => "Generate Report: '#{name}'", :userid => options[:userid])
 
-    MiqQueue.put(
-      :queue_name  => "reporting",
-      :role        => "reporting",
+    MiqQueue.submit_job(
+      :service     => "reporting",
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "build_report_result",

--- a/app/models/miq_report/generator/async.rb
+++ b/app/models/miq_report/generator/async.rb
@@ -55,7 +55,6 @@ module MiqReport::Generator::Async
       if self.new_record?
         MiqQueue.submit_job(
           :service      => "reporting",
-          :role         => "reporting",
           :class_name   => self.class.to_s,
           :method_name  => "_async_generate_table",
           :args         => [task.id, self, options],

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -108,6 +108,7 @@ class MiqWidget < ApplicationRecord
     MiqQueue.create_with(callback).put_unless_exists(
       :queue_name  => "reporting",
       :role        => "reporting",
+      :zone        => nil, # any zone
       :class_name  => self.class.to_s,
       :instance_id => id,
       :msg_timeout => 3600,

--- a/spec/models/miq_report/async_spec.rb
+++ b/spec/models/miq_report/async_spec.rb
@@ -1,5 +1,38 @@
 describe MiqReport do
   context "Generator::Async" do
+    context ".async_generate_tables" do
+      let(:report) do
+        MiqReport.new(
+          :name      => "Custom VM report",
+          :title     => "Custom VM report",
+          :rpt_group => "Custom",
+          :rpt_type  => "Custom",
+          :db        => "ManageIQ::Providers::InfraManager::Vm",
+        )
+      end
+
+      it "creates task, queue, audit event" do
+        User.seed
+        EvmSpecHelper.local_miq_server
+        ServerRole.seed
+        expect(AuditEvent).to receive(:success)
+
+        described_class.async_generate_tables(:reports => [report])
+        task = MiqTask.first
+        expect(task.name).to eq("Generate Reports: [\"#{report.name}\"]")
+
+        message = MiqQueue.find_by(:method_name => "_async_generate_tables")
+        expect(message).to have_attributes(
+          :role        => "reporting",
+          :zone        => nil,
+          :class_name  => report.class.name,
+          :method_name => "_async_generate_tables"
+        )
+
+        expect(message.args.first).to eq(task.id)
+      end
+    end
+
     context "._async_generate_tables" do
       it "unknown taskid" do
         expect { MiqReport._async_generate_tables(111111, :reports => []) }.to raise_error(MiqException::Error)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -273,6 +273,7 @@ describe MiqWidget do
 
       @q_options = {:queue_name  => "reporting",
                     :role        => "reporting",
+                    :zone        => nil,
                     :class_name  => @widget.class.name,
                     :instance_id => @widget.id,
                     :msg_timeout => 3600


### PR DESCRIPTION
Because reporting is a regional role, meaning, it's possible to do the same reporting work from different zones in the same region, we need to queue reporting work for the nil ("any") zone.  By allowing queue put to choose the current server's zone, it was possible for UI appliances without the reporting role to create reporting queue messages that would never get processed.

https://bugzilla.redhat.com/show_bug.cgi?id=1629945