### PR TITLE
Create custom button events for each object in target list

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -96,7 +96,11 @@ class CustomButton < ApplicationRecord
   end
 
   def publish_event(source, target, args)
-    CustomButtonEvent.create(
+    target.kind_of?(Array) ? target.each { |t| create_event(source, t, args) } : create_event(source, target, args)
+  end
+
+  def create_event(source, target, args)
+    CustomButtonEvent.create!(
       :event_type => 'button.trigger.start',
       :message    => 'Custom button launched',
       :source     => source,

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -293,8 +293,10 @@ describe CustomButton do
     expect { button.copy(:applies_to => service_template2) }.to change { CustomButton.count }.by(1)
   end
 
-  context do
+  describe "publish custom button event" do
     let(:vm)              { FactoryGirl.create(:vm_vmware) }
+    let(:vm2)             { FactoryGirl.create(:vm_vmware) }
+    let(:vm3)             { FactoryGirl.create(:vm_vmware) }
     let(:user)            { FactoryGirl.create(:user_with_group) }
     let(:resource_action) { FactoryGirl.create(:resource_action, :ae_namespace => 'SYSTEM', :ae_class => 'PROCESS', :ae_instance => 'Request') }
     let(:custom_button)   { FactoryGirl.create(:custom_button, :applies_to => vm.class, :resource_action => resource_action) }
@@ -304,8 +306,8 @@ describe CustomButton do
     end
 
     %i(invoke invoke_async).each do |method|
-      describe "##{method}" do
-        it "publishes CustomButtonEvent" do
+      describe "##{method}", "publishes CustomButtonEvent(s)" do
+        it "with a single VM" do
           Timecop.freeze(Time.now.utc) do
             User.with_user(user) { custom_button.send(method, vm, 'UI') }
             expect(CustomButtonEvent.first.timestamp).to be_within(0.01).of(Time.now.utc)
@@ -318,10 +320,26 @@ describe CustomButton do
             :target_type => 'VmOrTemplate',
             :type        => 'CustomButtonEvent',
             :event_type  => 'button.trigger.start',
-            :user_id     => user.id
+            :user_id     => user.id,
+            :full_data   => a_hash_including(:automate_entry_point => "/SYSTEM/PROCESS/Request")
           )
-          expect(CustomButtonEvent.first[:full_data]).to include(
-            :automate_entry_point => "/SYSTEM/PROCESS/Request"
+        end
+
+        it "with multiple vms" do
+          Timecop.freeze(Time.now.utc) do
+            User.with_user(user) { custom_button.send(method, [vm, vm2, vm3], 'UI') }
+            expect(CustomButtonEvent.first.timestamp).to be_within(0.01).of(Time.now.utc)
+          end
+
+          expect(CustomButtonEvent.count).to eq(3)
+          expect(CustomButtonEvent.first).to have_attributes(
+            :source      => 'UI',
+            :target_id   => vm.id,
+            :target_type => 'VmOrTemplate',
+            :type        => 'CustomButtonEvent',
+            :event_type  => 'button.trigger.start',
+            :user_id     => user.id,
+            :full_data   => a_hash_including(:automate_entry_point => "/SYSTEM/PROCESS/Request")
           )
         end
       end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628224

[When we originally added CustomButtonEvents](https://github.com/ManageIQ/manageiq/pull/17764/files) we didn't account for CustomButtons being run on multiple objects at once. I think we should be creating events for all the objects a custom button runs on. 