### PR TITLE
Fix typo in message if VM has no provider

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -66,7 +66,7 @@ module VmOrTemplate::Operations
 
   def raw_rename(new_name)
     unless ext_management_system
-      raise _("VM has no Provider, unable to renamey VM")
+      raise _("VM has no Provider, unable to rename VM")
     end
     run_command_via_parent(:vm_rename, :new_name => new_name)
   end


### PR DESCRIPTION
**What:**
This PR fixes small typo in message if VM has no provider, while renaming a VM.

**Note:**
Renaming VMs is supported only for VMs of VMWare provider.