### PR TITLE
Don't start memcached in any container runtime

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -6,7 +6,7 @@ module MiqEnvironment
 
     def self.supports_memcached?
       return @supports_memcached unless @supports_memcached.nil?
-      @supports_memcached = is_linux? && is_appliance? && !is_podified? && supports_command?('memcached') && supports_command?('memcached-tool') && supports_command?('service')
+      @supports_memcached = is_linux? && is_appliance? && !is_container? && supports_command?('memcached') && supports_command?('memcached-tool') && supports_command?('service')
     end
 
     def self.supports_apache?


### PR DESCRIPTION
This was originally fixed in 3d3f716481d but was then broken again in 0735aecc184

This will allow the monolithic container image to run properly
cc @simaishi 