### PR TITLE
Add PhysicalDisks into Canisters

### DIFF
--- a/app/models/canister.rb
+++ b/app/models/canister.rb
@@ -4,6 +4,7 @@ class Canister < ApplicationRecord
   has_one :computer_system, :as => :managed_entity, :dependent => :destroy, :inverse_of => false
   has_one :hardware, :through => :computer_system
 
+  has_many :physical_disks, :dependent => :destroy, :inverse_of => :canister
   has_many :guest_devices, :through => :hardware
   has_many :physical_network_ports, :through => :guest_devices
 

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -115,9 +115,9 @@ module EmsRefresh::SaveInventoryPhysicalInfra
   end
 
   #
-  # Saves the disks information of a resource
+  # Saves the disks information of a storage
   #
-  def save_physical_disks_inventory(parent, hashes)
+  def save_physical_disks_inventory(physical_storage, hashes)
     return if hashes.nil?
 
     # Update the associated ids
@@ -125,7 +125,7 @@ module EmsRefresh::SaveInventoryPhysicalInfra
       h[:canister_id] = h.delete(:canister).try(:[], :id)
     end
 
-    save_inventory_multi(parent.physical_disks, hashes, :use_association, [:ems_ref])
+    save_inventory_multi(physical_storage.physical_disks, hashes, :use_association, [:ems_ref])
   end
 
   #

--- a/app/models/ems_refresh/save_inventory_physical_infra.rb
+++ b/app/models/ems_refresh/save_inventory_physical_infra.rb
@@ -115,17 +115,17 @@ module EmsRefresh::SaveInventoryPhysicalInfra
   end
 
   #
-  # Saves the disks information of a storage
+  # Saves the disks information of a resource
   #
-  def save_physical_disks_inventory(physical_storage, hashes)
+  def save_physical_disks_inventory(parent, hashes)
     return if hashes.nil?
 
     # Update the associated ids
     hashes.each do |h|
-      h[:physical_storage_id] = h.delete(:physical_storage).try(:[], :id)
+      h[:canister_id] = h.delete(:canister).try(:[], :id)
     end
 
-    save_inventory_multi(physical_storage.physical_disks, hashes, :use_association, [:physical_storage_id])
+    save_inventory_multi(parent.physical_disks, hashes, :use_association, [:ems_ref])
   end
 
   #

--- a/app/models/physical_disk.rb
+++ b/app/models/physical_disk.rb
@@ -1,5 +1,6 @@
 class PhysicalDisk < ApplicationRecord
   belongs_to :physical_storage, :foreign_key => :physical_storage_id, :inverse_of => :physical_disks
+  belongs_to :canister, :foreign_key => :canister_id, :inverse_of => :physical_disks
 
   acts_as_miq_taggable
 end

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -868,6 +868,7 @@ en:
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalRack:      Physical Rack (Lenovo)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis:   Physical Chassis (Lenovo)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer:    Physical Server (Lenovo)
+      ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalStorage:    Physical Storage (Lenovo)
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch:    Physical Switch (Lenovo)
       ManageIQ::Providers::Redfish::PhysicalInfraManager::PhysicalServer:   Physical Server (Redfish)
       MeteringContainerImage:   Metering for Image


### PR DESCRIPTION
This PR is able to:
- Add PhysicalDisks into Canister model
- Modify `save_inventory_infra` for PhysicalDisks
- Remove `physical_storage` deletion from physical disks inventory saving (bug fix)

Depends on:
- [ManageIQ/manageiq-schema#285](https://github.com/ManageIQ/manageiq-schema/pull/285)