### PR TITLE
Removed experimental uri method type

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -17,7 +17,7 @@ class MiqAeMethod < ApplicationRecord
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES
-  AVAILABLE_LOCATIONS = %w(builtin inline uri expression playbook).freeze
+  AVAILABLE_LOCATIONS = %w(builtin inline expression playbook).freeze
   validates_inclusion_of  :location,  :in => AVAILABLE_LOCATIONS
   AVAILABLE_SCOPES     = ["class", "instance"]
   validates_inclusion_of  :scope,     :in => AVAILABLE_SCOPES


### PR DESCRIPTION
Automate had  an experimental URI method type which has not been used.
Removed it to avoid confusion.

In the UI you would see
![after_uri_removed](https://user-images.githubusercontent.com/6452699/46423237-23d8af80-c704-11e8-9f13-7809fd7c6bd2.png)

Previously you would see this


![before_uri_removed](https://user-images.githubusercontent.com/6452699/46423260-305d0800-c704-11e8-9b42-2d6e2f9789d7.png)
