### PR TITLE
Force targets to be an array so we can each them in cb run on multiple objects

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -96,7 +96,7 @@ class CustomButton < ApplicationRecord
   end
 
   def publish_event(source, target, args)
-    target.kind_of?(Array) ? target.each { |t| create_event(source, t, args) } : create_event(source, target, args)
+    Array(target).each { |t| create_event(source, t, args) }
   end
 
   def create_event(source, target, args)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628224

... https://github.com/ManageIQ/manageiq/pull/18042 failed cause it's sometimes not an array that we should be checking for when running CBs on multiple things, mea culpa. 



