### PR TITLE
For database dumps don't modify the directory name

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -114,7 +114,13 @@ class EvmDatabaseOps
         connect_opts[:uri] = File.dirname(connect_opts[:uri])
       else
         connect_opts[:remote_file_name] ||= File.basename(backup_file_name(action))
-        backup_folder = action == :dump ? "db_dump" : "db_backup"
+        backup_folder = if connect_opts[:skip_directory]
+                          []
+                        elsif action == :dump
+                          "db_dump"
+                        else
+                          "db_backup"
+                        end
         #
         # If the passed in URI contains query parameters, ignore them
         # when creating the dump file name. They'll be used in the session object.

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -114,19 +114,14 @@ class EvmDatabaseOps
         connect_opts[:uri] = File.dirname(connect_opts[:uri])
       else
         connect_opts[:remote_file_name] ||= File.basename(backup_file_name(action))
-        backup_folder = if connect_opts[:skip_directory]
-                          []
-                        elsif action == :dump
-                          "db_dump"
-                        else
-                          "db_backup"
-                        end
         #
         # If the passed in URI contains query parameters, ignore them
         # when creating the dump file name. They'll be used in the session object.
         #
-        connect_opts_uri = connect_opts[:uri].split('?')[0]
-        uri = File.join(connect_opts_uri, backup_folder, connect_opts[:remote_file_name])
+        uri_parts = [connect_opts[:uri].split('?')[0]]
+        uri_parts << (action == :dump ? "db_dump" : "db_backup") unless connect_opts[:skip_directory]
+        uri_parts << connect_opts[:remote_file_name]
+        uri = File.join(uri_parts)
       end
     else
       uri = db_opts[:local_file]

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -58,7 +58,7 @@ module EvmDba
     db_opts
   end
 
-  CONNECT_OPT_KEYS = [:uri, :uri_username, :uri_password, :aws_region, :remote_file_name, :skip_directory].freeze
+  CONNECT_OPT_KEYS = %i(uri uri_username uri_password aws_region remote_file_name skip_directory).freeze
   def self.collect_connect_opts(opts)
     connect_opts = {}
     CONNECT_OPT_KEYS.each { |k| connect_opts[k] = opts[k] if opts[k] }

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -33,6 +33,7 @@ module EvmDba
         when :local_file
           opt :local_file,         "Destination file",             :type => :string, :required => true
         when :remote_file
+          opt :skip_directory,     "Don't add backup directory",   :type => :boolean, :default => false
           opt :remote_file_name,   "Destination depot filename",   :type => :string
         when :splitable
           opt :byte_count,         "Size to split files into",     :type => :string
@@ -57,7 +58,7 @@ module EvmDba
     db_opts
   end
 
-  CONNECT_OPT_KEYS = [:uri, :uri_username, :uri_password, :aws_region, :remote_file_name].freeze
+  CONNECT_OPT_KEYS = [:uri, :uri_username, :uri_password, :aws_region, :remote_file_name, :skip_directory].freeze
   def self.collect_connect_opts(opts)
     connect_opts = {}
     CONNECT_OPT_KEYS.each { |k| connect_opts[k] = opts[k] if opts[k] }


### PR DESCRIPTION
### overview

Typically `"db_dump"` or `"db_backup"` is added the remote path for backup upload.

This PR gives the rake task the `--skip-directory` option so `"db_backup"` is not added to the target directory name

related to:
- https://bugzilla.redhat.com/show_bug.cgi?id=1632433
- https://github.com/ManageIQ/manageiq-appliance_console/pull/65

### before:

```
bundle exec rake evm:db:dump:remote -- --uri ftp://ftp.example.com/incoming/ \
                                       --remote-file-name test-db3.backup

# target: ftp://ftp.example.com/incoming/db_dump/the_file.tgz
```

### after (using this option):

```
bundle exec rake evm:db:dump:remote -- --uri ftp://ftp.example.com/incoming/ \
                                       --remote-file-name test-db3.backup --skip-directory

# target: ftp://ftp.example.com/incoming/the_file.tgz
```
