### PR TITLE
Add flag for init of defaults in fields

### DIFF
--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -104,7 +104,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       dialog.target_resource = @target
       if options[:display_view_only]
         dialog.init_fields_with_values_for_request(values)
-      elsif options[:provision_workflow]
+      elsif options[:provision_workflow] || options[:init_defaults]
         dialog.initialize_value_context(values)
         dialog.load_values_into_fields(values, false)
       elsif options[:refresh] || options[:submit_workflow]

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -422,13 +422,7 @@ class ServiceTemplate < ApplicationRecord
   def provision_workflow(user, dialog_options = nil, request_options = {})
     dialog_options ||= {}
     request_options.delete(:provision_workflow) if request_options[:submit_workflow]
-
-    ra_options = {
-      :target             => self,
-      :initiator          => request_options[:initiator],
-      :submit_workflow    => request_options[:submit_workflow],
-      :provision_workflow => request_options[:provision_workflow]
-    }
+    ra_options = request_options.slice(:initiator, :init_defaults, :provision_workflow, :submit_workflow).merge(:target => self)
 
     ResourceActionWorkflow.new(dialog_options, user, provision_action, ra_options).tap do |wf|
       wf.request_options = request_options

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -980,6 +980,7 @@
   :name:
   :maindb: ExtManagementSystem
   :container_deployment_wizard: false
+  :run_automate_methods_on_service_api_submit: false
 :prototype:
   :queue_type: miq_queue
   :artemis:

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -228,6 +228,16 @@ describe ResourceActionWorkflow do
       end
     end
 
+    context "when the options set init_defaults to true" do
+      let(:options) { {:init_defaults => true} }
+
+      it "calls init_fields_with_values_for_request" do
+        expect(dialog).to receive(:initialize_value_context).with(values).ordered
+        expect(dialog).to receive(:load_values_into_fields).with(values, false).ordered
+        ResourceActionWorkflow.new(values, nil, resource_action, options)
+      end
+    end
+
     context "when the options are set to a refresh request" do
       let(:options) { {:refresh => true} }
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -882,6 +882,29 @@ describe ServiceTemplate do
     context "#provision_request" do
       let(:arg1) { {'ordered_by' => 'fred'} }
 
+      context "with init_defaults" do
+        let(:arg2) { {:init_defaults => true} }
+
+        it "provisions a service template without errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return([])
+          expect(resource_action_workflow).to receive(:make_request).and_return(miq_request)
+          expect(resource_action_workflow).to receive(:request_options=).with(
+            :init_defaults => true, :provision_workflow => true
+          )
+
+          expect(service_template.provision_request(user, arg1, arg2)).to eq(miq_request)
+        end
+
+        it "provisions a service template with errors" do
+          expect(resource_action_workflow).to receive(:validate_dialog).and_return(%w(Error1 Error2))
+          expect(resource_action_workflow).to receive(:request_options=).with(
+            :init_defaults => true, :provision_workflow => true
+          )
+
+          expect { service_template.provision_request(user, arg1, arg2) }.to raise_error(RuntimeError)
+        end
+      end
+
       context "with submit_workflow" do
         let(:arg2) { {:initiator => 'control', :submit_workflow => true} }
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1635673

At this point if a service dialog gets ordered via the API, it will not honor defaults on static fields. To remedy this, this adds a flag to the call to also let us call ```load_values_into_fields(values, false)```, thus honoring the default values. This builds on the recent changes to https://github.com/ManageIQ/manageiq/pull/17844



## Related:
https://github.com/ManageIQ/manageiq-api/pull/485