### PR TITLE
Backport methods from Automate to conversion_host - part2

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -39,7 +39,7 @@ class ConversionHost < ApplicationRecord
   end 
 
   def run_conversion(conversion_options)
-    connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', conversion_options.to_json, true) }
+    connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', nil, nil, conversion_options.to_json) }
   rescue => e
     raise "Starting conversion failed on '#{resource.name}' with [#{e.class}: #{e}]"
   end
@@ -146,7 +146,7 @@ class ConversionHost < ApplicationRecord
                              .where(:authtype => 'ssh_keypair')
                              .where.not(:userid => nil, :auth_key => nil)
                              .first
-    [ ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key }]
+    [ ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
   end
 
   def ansible_playbook(playbook, extra_vars, connection)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -32,10 +32,9 @@ class ConversionHost < ApplicationRecord
     return 'ssh' if ssh_transport_supported
   end
 
-  def ipaddress(family = nil)
-    ips = ipaddresses
-    return ips.first unless %w(ipv4 ipv6).include?(family)
-    ips.select { |ip| IPAddr.new(ip).send("#{family}?") }.first
+  def ipaddress(family = 'ipv4')
+    return address if address && IPAddr.new(address).send("#{family}?")
+    resource.ipaddresses.detect { |ip| IPAddr.new(ip).send("#{family}?") }
   end 
 
   def run_conversion(conversion_options)
@@ -96,10 +95,6 @@ class ConversionHost < ApplicationRecord
   end
 
   private
-
-  def ipaddresses
-    resource.ipaddresses.unshift(address).unshift(resource.try(:ipaddress)).reject(&:blank?)
-  end 
 
   def check_resource_credentials(fatal = false, extra_msg = nil)
     success = send("check_resource_credentials_#{resource.ext_management_system.emstype}")

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -42,7 +42,7 @@ class ConversionHost < ApplicationRecord
   end 
 
   def run_conversion(conversion_options)
-    res = remote_command('/usr/bin/virt-v2v-wrapper.py', conversion_options.to_json)
+    res = remote_command('/usr/bin/virt-v2v-wrapper.py', conversion_options.to_json, true)
     raise "Starting conversion failed with error: #{res[:stderr]}" unless res[:rc].zero?
     res[:stdout]
   end
@@ -148,7 +148,7 @@ class ConversionHost < ApplicationRecord
                              .where(:authtype => 'ssh_keypair')
                              .where.not(:userid => nil, :auth_key => nil)
                              .first
-    [ ipaddress, authentication.userid, { :key_data => authentication.auth_key, :keys_only => true, :passwordless_sudo => true }]
+    [ ipaddress, authentication.userid, { :key_data => authentication.auth_key, :keys => [], :keys_only => true }]
   end
 
   def file_exists?(path)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,4 +1,7 @@
 class ConversionHost < ApplicationRecord
+  require 'net/ssh'
+  require 'net/sftp'
+
   include NewWithTypeStiMixin
 
   acts_as_miq_taggable
@@ -9,10 +12,10 @@ class ConversionHost < ApplicationRecord
 
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)
-  #  - Credentials are set on the resource
+  #  - Credentials are set on the resource and SSH connection works
   #  - The number of concurrent tasks has not reached the limit
   def eligible?
-    source_transport_method.present? && check_resource_credentials && check_concurrent_tasks
+    source_transport_method.present? && check_ssh_connection && check_concurrent_tasks
   end
 
   def check_concurrent_tasks
@@ -20,8 +23,11 @@ class ConversionHost < ApplicationRecord
     active_tasks.size < max_tasks
   end
 
-  def check_resource_credentials
-    send("check_resource_credentials_#{resource.ext_management_system.emstype}")
+  def check_ssh_connection(remember_host = false)
+    ssh_session({:remember_host => remember_host})
+    true
+  rescue => e
+    false
   end
 
   def source_transport_method
@@ -29,41 +35,77 @@ class ConversionHost < ApplicationRecord
     return 'ssh' if ssh_transport_supported
   end
 
-  def ipaddresses
-    resource.ipaddresses.unshift(address).unshift(resource.try(:ipaddress)).reject(&:blank?)
-  end 
-
   def ipaddress(family = nil)
     ips = ipaddresses
     return ips.first unless %w(ipv4 ipv6).include?(family)
     ips.select { |ip| IPAddr.new(ip).send("#{family}?") }.first
   end 
 
-  def ssh_credentials
-    send("ssh_credentials_#{resource.type.gsub('::', '_').downcase}")
-  end 
-
   def run_conversion(conversion_options)
-    connect_ssh.su_exec('/usr/bin/virt-v2v-wrapper.py', nil, conversion_options.to_json)
+    res = remote_command('/usr/bin/virt-v2v-wrapper.py', conversion_options.to_json)
+    raise "Starting conversion failed with error: #{res[:stderr]}" unless res[:rc].zero?
+    res[:stdout]
   end
 
-  def conversion_log(path)
-    unless check_resource_credentials
-      msg = "Credential was not found for host #{host.resource.name}. Download of transformation log aborted."
-      _log.error(msg)
-      raise MiqException::Error, msg 
-    end 
+  def kill_process(pid, signal = 'TERM')
+    res = remote_command("/bin/kill -s #{signal} #{pid}")
+    res[:rc].zero?
+  end
 
-    begin
-      Net::SCP.download!(ipaddress, resourcece.authentication_userid, path, nil, :ssh => {:password => resource.authentication_password})
-    rescue Net::SCP::Error => scp_err
-      _log.error("Download of transformation log for #{description} with ID [#{id}] failed with error: #{scp_err.message}")
-      raise scp_err
-    end 
+  def get_conversion_state(state_file)
+    JSON.parse(download_file(state_file))
+  end
+
+  def get_conversion_log(path)
+    download_file(path)
   end 
+
+  def check_conversion_host_role
+    install_conversion_host_module
+    playbook = "/usr/share/doc/ovirt-ansible-v2v-conversion-host-1.2.0/examples/conversion_host_check.yml"
+    extra_vars = { :v2v_manageiq_conversion_host_check => true }
+    res = ansible_playbook(playbook, extra_vars)
+    status = result[:rc].zero? ? 'enabled' : 'disabled'
+    tag_resource(status)
+  end
+
+  def enable_conversion_host_role
+    install_conversion_host_module
+    playbook = "/usr/share/doc/ovirt-ansible-v2v-conversion-host-1.2.0/examples/conversion_host_enable.yml"
+    extra_vars = {
+      :v2v_vddk_package_name => "VMware-vix-disklib-stable.tar.gz",
+      :v2v_vddk_package_url  => "http://#{resource.ext_management_system.hostname}/vddk/VMware-vix-disklib-stable.tar.gz"
+    }
+    res = ansible_playbook(playbook, extra_vars)
+    status = result[:rc].zero? ? 'enabled' : 'disabled'
+    tag_resource(status)
+  end
+
+  def disable_conversion_host_role
+    install_conversion_host_module
+    playbook = "/usr/share/doc/ovirt-ansible-v2v-conversion-host-1.2.0/examples/conversion_host_disable.yml"
+    extra_vars = {}
+    res = ansible_playbook(playbook, extra_vars)
+    status = result[:rc].zero? ? 'disabled' : 'enabled'
+    tag_resource(status)
+  end
 
   private
 
+  def ipaddresses
+    resource.ipaddresses.unshift(address).unshift(resource.try(:ipaddress)).reject(&:blank?)
+  end 
+
+  def check_resource_credentials(fatal = false, extra_msg = nil)
+    success = send("check_resource_credentials_#{resource.ext_management_system.emstype}")
+    if !success and fatal
+      msg = "Credential not found for #{resource.name}."
+      msg += " #{extra_msg}" unless extra_msg.blank?
+      _log.error(:msg)
+      raise MiqException::Error, msg
+    end
+    success
+  end
 
   def check_resource_credentials_rhevm
     !(resource.authentication_userid.nil? || resource.authentication_password.nil?)
@@ -76,38 +118,109 @@ class ConversionHost < ApplicationRecord
     !ssh_authentications.empty?
   end
 
-  def ssh_credentials_options_manageiq_providers_redhat_inframanager_host
-    raise "Userid for #{resource.name} is empty" if resource.authentication_userid.blank?
-    raise "Password for #{resource.name} is empty" if resource.authentication_password.blank?
-    return resource.authentication_userid, resource.authentication_password, nil, nil, {}
+  def ssh_session(ssh_session_options = {})
+    check_resource_credentials(true, "SSH connection aborted.") 
+    first_try = true
+
+    Net::SSH.start(*ssh_start_args) do |ssh|
+      yield(ssh)
+    end
+  rescue Net::SSH::HostKeyMismatch => e
+    if ssh_session_options[:remember_host] && first_try
+      first_try = false
+      e.remember_host!
+      retry
+    else
+      raise e
+    end 
   end 
 
-  def ssh_credentials_manageiq_providers_openstack_cloudmanager_vm
-    ems = resource.ext_management_system
-    authentication = ems.authentication.where(:authtype => 'ssh_keypair').first
-    raise "SSH authentication for #{ems.name} does not exist" if authentication.nil?
-    raise "Authentication user for #{ems.name} is empty" if authentication.userid.blank?
-    raise "Authentication private key for #{ems.name} is empty" if authentication.auth_key.blank?
-    return authentication.userid, nil, 'root', nil, { :key_data => authentication.auth_key, :keys_only => true, :passwordless_sudo => true }
+  def ssh_start_args
+    send("ssh_start_args_#{resource.type.gsub('::', '_').downcase}")
   end
 
-  def connect_ssh(options = {}) 
-    require 'MiqSshUtil'
-
-    rl_user, rl_password, su_user, su_password, additional_options = ssh_credentials
-    options.merge!(ssh_session_options)
-
-    prompt_delay = ::Settings.ssh.try(:authentication_prompt_delay)
-    options[:authentication_prompt_delay] = prompt_delay unless prompt_delay.nil?
-
-    users = su_user.nil? ? rl_user : "#{rl_user}/#{su_user}"
-    _log.info("Initiating SSH connection to Host:[#{name}] using [#{hostname}] for user:[#{users}].  Options:[#{logged_options.inspect}]")
-    begin
-      MiqSshUtil.shell_with_su(ipaddress, rl_user, rl_password, su_user, su_password, options) do |ssu, _shell|
-        yield(ssu)
-      end  
-    rescue Exception => err 
-      raise err 
-    end  
+  def ssh_start_args_manageiq_providers_redhat_inframanager_host
+    [ ipaddress, resource.authentication_userid, { :password => resource.authentication_password }]
   end 
+
+  def ssh_start_args_manageiq_providers_openstack_cloudmanager_vm
+    authentication = resource.ext_management_system.authentications
+                             .where(:authtype => 'ssh_keypair')
+                             .where.not(:userid => nil, :auth_key => nil)
+                             .first
+    [ ipaddress, authentication.userid, { :key_data => authentication.auth_key, :keys_only => true, :passwordless_sudo => true }]
+  end
+
+  def file_exists?(path)
+    ssh_session do |ssh|
+      ssh.sftp.stat!(path) do |response|
+        response.ok?
+      end
+    end
+  rescue Net::SFTP::Exception => e
+      _log.error("Existence check of #{source} failed with error: #{e.message}")
+      raise e
+  end
+
+  def download_file(source, destination = nil)
+    ssh_session do |ssh|
+      ssh.sftp.download!(source, destination)
+    end
+  rescue Net::SFTP::Exception => e
+      _log.error("Download of #{source} failed with error: #{e.message}")
+      raise e
+  end
+
+  def remote_command(command, stdin = nil, run_as = nil)
+    require "net/ssh"
+    command = "sudo -u #{run_as} #{command}" unless run_as.nil?
+    rc, stdout, stderr, exit_code = nil, '', ''
+    begin
+      ssh_session do |ssh|
+        ssh.open_channel do |channel|
+          channel.request_pty unless run_as.nil?
+          channel.exec(command) do |ch, exec_success|
+            raise "Could not execute command '#{command}'" unless exec_success
+            ch.on_data { |_, data| stdout += data.to_s }
+            ch.on_extended_data { |_, data| stderr += data.to_s }
+            ch.on_request("exit-status") { |_, data| rc = data.read_long }
+            unless stdin.nil?
+              ch.send_data(stdin)
+              ch.eof!
+            end
+          end
+          channel.wait
+        end
+      end
+    rescue Net::SSH::Exception => e
+      _log.error("Execution of '#{command}' on #{resource.name} has failed with error: #{e.message} ")
+      raise e
+    end
+    { :rc => return_code, :stdout => stdout, :stderr => stderr }
+  end
+
+  def ansible_playbook(playbook, extra_vars)
+    command = "ansible-playbook -i #{host.name}, #{playbook}"
+    extra_vars.each { |k, v| command += " -e '#{k}=#{v}'" }
+    remote_command(command)
+  end
+
+  def install_conversion_host_module
+    res = remote_command("yum install -y ovirt-ansible-v2v-conversion-host")
+    raise "Ansible module installation failed with error: #{res[:stderr]}" unless res[:rc].zero?
+  end
+
+  def tag_resource(status)
+    send("tag_resource_as_#{status}")
+  end
+
+  def tag_resource_as_enabled
+    resource.tag_add('v2v_transformation_host/true')
+    resource.tag_add('v2v_transformation_method/vddk')
+  end
+
+  def tag_resource_as_disable
+    resource.tag_add('v2v_transformation_host/false')
+    resource.tag_remove('v2v_transformation_method/vddk')
+  end
 end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -29,7 +29,41 @@ class ConversionHost < ApplicationRecord
     return 'ssh' if ssh_transport_supported
   end
 
+  def ipaddresses
+    resource.ipaddresses.unshift(address).unshift(resource.try(:ipaddress)).reject(&:blank?)
+  end 
+
+  def ipaddress(family = nil)
+    ips = ipaddresses
+    return ips.first unless %w(ipv4 ipv6).include?(family)
+    ips.select { |ip| IPAddr.new(ip).send("#{family}?") }.first
+  end 
+
+  def ssh_credentials
+    send("ssh_credentials_#{resource.type.gsub('::', '_').downcase}")
+  end 
+
+  def run_conversion(conversion_options)
+    connect_ssh.su_exec('/usr/bin/virt-v2v-wrapper.py', nil, conversion_options.to_json)
+  end
+
+  def conversion_log(path)
+    unless check_resource_credentials
+      msg = "Credential was not found for host #{host.resource.name}. Download of transformation log aborted."
+      _log.error(msg)
+      raise MiqException::Error, msg 
+    end 
+
+    begin
+      Net::SCP.download!(ipaddress, resourcece.authentication_userid, path, nil, :ssh => {:password => resource.authentication_password})
+    rescue Net::SCP::Error => scp_err
+      _log.error("Download of transformation log for #{description} with ID [#{id}] failed with error: #{scp_err.message}")
+      raise scp_err
+    end 
+  end 
+
   private
+
 
   def check_resource_credentials_rhevm
     !(resource.authentication_userid.nil? || resource.authentication_password.nil?)
@@ -41,4 +75,39 @@ class ConversionHost < ApplicationRecord
                                   .where.not(:userid => nil, :auth_key => nil)
     !ssh_authentications.empty?
   end
+
+  def ssh_credentials_options_manageiq_providers_redhat_inframanager_host
+    raise "Userid for #{resource.name} is empty" if resource.authentication_userid.blank?
+    raise "Password for #{resource.name} is empty" if resource.authentication_password.blank?
+    return resource.authentication_userid, resource.authentication_password, nil, nil, {}
+  end 
+
+  def ssh_credentials_manageiq_providers_openstack_cloudmanager_vm
+    ems = resource.ext_management_system
+    authentication = ems.authentication.where(:authtype => 'ssh_keypair').first
+    raise "SSH authentication for #{ems.name} does not exist" if authentication.nil?
+    raise "Authentication user for #{ems.name} is empty" if authentication.userid.blank?
+    raise "Authentication private key for #{ems.name} is empty" if authentication.auth_key.blank?
+    return authentication.userid, nil, 'root', nil, { :key_data => authentication.auth_key, :keys_only => true, :passwordless_sudo => true }
+  end
+
+  def connect_ssh(options = {}) 
+    require 'MiqSshUtil'
+
+    rl_user, rl_password, su_user, su_password, additional_options = ssh_credentials
+    options.merge!(ssh_session_options)
+
+    prompt_delay = ::Settings.ssh.try(:authentication_prompt_delay)
+    options[:authentication_prompt_delay] = prompt_delay unless prompt_delay.nil?
+
+    users = su_user.nil? ? rl_user : "#{rl_user}/#{su_user}"
+    _log.info("Initiating SSH connection to Host:[#{name}] using [#{hostname}] for user:[#{users}].  Options:[#{logged_options.inspect}]")
+    begin
+      MiqSshUtil.shell_with_su(ipaddress, rl_user, rl_password, su_user, su_password, options) do |ssu, _shell|
+        yield(ssu)
+      end  
+    rescue Exception => err 
+      raise err 
+    end  
+  end 
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -1,3 +1,6 @@
+require "net/ssh"
+require "net/sftp"
+
 describe ConversionHost do
   let(:apst) { FactoryGirl.create(:service_template_ansible_playbook) }
 
@@ -13,9 +16,43 @@ describe ConversionHost do
     before do
       allow(conversion_host_1).to receive(:active_tasks).and_return([task_1])
       allow(conversion_host_2).to receive(:active_tasks).and_return([task_3])
+
+      allow(host).to receive(:ipaddresses).and_return(['10.0.0.1', 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329', '192.168.0.1'])
+      allow(host).to receive(:ipaddress).and_return(nil)
+      allow(vm).to receive(:ipaddresses).and_return(['10.0.1.1', 'FE80::0202:B3FF:FE1E:3267', '192.168.1.1'])
     end
 
-    describe "#check_concurrent_tasks" do
+    context "#eligible?" do
+      it "fails when no source transport method is enabled" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return(nil)
+        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(true)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "fails when no source transport method is enabled" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(false)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "fails when no source transport method is enabled" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(true)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(false)
+        expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "succeeds when all criteria are met" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(true)
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(true)
+      end
+    end
+
+    context "#check_concurrent_tasks" do
       context "default max concurrent tasks is equal to current active tasks" do
         before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 1}}) }
         it { expect(conversion_host_1.check_concurrent_tasks).to eq(false) }
@@ -50,16 +87,94 @@ describe ConversionHost do
         end
       end
     end
+
+    context "#ipaddress" do
+      it "it returns first IP addess if 'address' is nil" do
+        expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('invalid')).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress('invalid')).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+        expect(conversion_host_2.ipaddress('ipv6')).to eq('FE80::0202:B3FF:FE1E:3267')
+      end
+
+      context "when address is set" do
+        before do
+          allow(conversion_host_1).to receive(:address).and_return('172.16.0.1')
+          allow(conversion_host_2).to receive(:address).and_return('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+        end
+
+        it "returns 'address' if family matches, is invalid or is nil" do
+          expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          expect(conversion_host_1.ipaddress('invalid')).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress('invalid')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+          expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+          expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+        end
+
+        context "when resource.ipaddress is set" do
+          before do
+            allow(host).to receive(:ipaddress).and_return('192.168.0.1')
+          end
+
+          it "returns resource.ipaddress when resource is a Host" do
+            expect(conversion_host_1.ipaddress).to eq('192.168.0.1')
+            expect(conversion_host_2.ipaddress).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+            expect(conversion_host_1.ipaddress('invalid')).to eq('192.168.0.1')
+            expect(conversion_host_2.ipaddress('invalid')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+            expect(conversion_host_1.ipaddress('ipv4')).to eq('192.168.0.1')
+            expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+            expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+            expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          end
+        end
+      end
+    end
+
+    context "#kill_process" do
+      it "returns false if if kill command failed" do
+        allow(conversion_host_1).to receive(:remote_command).with('/bin/kill -s KILL 1234').and_return(:rc => 1, :stdout => '', :stderr => 'failed')
+        expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(false)
+      end 
+
+      it "returns true if if kill command succeeded" do
+        allow(conversion_host_1).to receive(:remote_command).with('/bin/kill -s KILL 1234').and_return(:rc => 0, :stdout => 'killed', :stderr => '') 
+        expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(true)
+      end 
+    end
+  end
+
+  shared_examples_for "#check_ssh_connection" do
+    it "fails when SSH send an error" do
+      allow(Net::SSH).to receive(:start).and_raise(Net::SSH::Exception, 'Unexpected failure')
+      expect(conversion_host.check_ssh_connection).to eq(false)
+    end
+
+    it "fails because SSH key is not known and :remember_host is false" do
+      allow(Net::SSH).to receive(:start).once.and_raise(Net::SSH::HostKeyMismatch)
+      allow(Net::SSH::HostKeyMismatch).to receive(:remember_host!).and_return(true)
+      expect(conversion_host.check_ssh_connection).to eq(false)
+    end
+
+    it "succeeds because :remember_host is true" do
+      allow(Net::SSH).to receive(:start).and_return(true)
+      expect(conversion_host.check_ssh_connection(true)).to eq(true)
+    end
   end
 
   context "resource provider is rhevm" do
     let(:ems) { FactoryGirl.create(:ems_redhat, :zone => FactoryGirl.create(:zone)) }
-    let(:host) { FactoryGirl.create(:host, :ext_management_system => ems) }
+    let(:host) { FactoryGirl.create(:host_redhat, :ext_management_system => ems) }
     let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => host, :vddk_transport_supported => true) }
 
     context "host userid is nil" do
       before { allow(host).to receive(:authentication_userid).and_return(nil) }
-      it { expect(conversion_host.check_resource_credentials).to eq(false) }
+      it { expect(conversion_host.check_ssh_connection).to eq(false) }
     end
 
     context "host userid is set" do
@@ -67,35 +182,36 @@ describe ConversionHost do
 
       context "and host password is nil" do
         before { allow(host).to receive(:authentication_password).and_return(nil) }
-        it { expect(conversion_host.check_resource_credentials).to eq(false) }
+        it { expect(conversion_host.check_ssh_connection).to eq(false) }
       end
 
       context "and host password is set" do
         before { allow(host).to receive(:authentication_password).and_return('password') }
-        it { expect(conversion_host.check_resource_credentials).to eq(true) }
+        it_behaves_like "#check_ssh_connection"
       end
     end
   end
 
   context "resource provider is openstack" do
     let(:ems) { FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.create(:zone)) }
-    let(:vm) { FactoryGirl.create(:vm, :ext_management_system => ems) }
+    let(:vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
     let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
 
     context "ems authentications is empty" do
-      it { expect(conversion_host.check_resource_credentials).to be(false) }
+      it { expect(conversion_host.check_ssh_connection).to be(false) }
     end
 
     context "ems authentications contains ssh_auth" do
       let(:ssh_auth) { FactoryGirl.create(:authentication_ssh_keypair, :resource => ems) }
 
-      it "with fake auth" do
+      before do
         allow(ems).to receive(:authentications).and_return(ssh_auth)
         allow(ssh_auth).to receive(:where).with(:authype => 'ssh_keypair').and_return(ssh_auth)
         allow(ssh_auth).to receive(:where).and_return(ssh_auth)
         allow(ssh_auth).to receive(:not).with(:userid => nil, :auth_key => nil).and_return([ssh_auth])
-        expect(conversion_host.check_resource_credentials).to be(true)
       end
+
+      it_behaves_like "#check_ssh_connection"
     end
   end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -88,11 +88,9 @@ describe ConversionHost do
     end
 
     context "#ipaddress" do
-      it "it returns first IP addess if 'address' is nil" do
+      it "returns first IP address if 'address' is nil" do
         expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
         expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
-        expect(conversion_host_1.ipaddress('invalid')).to eq('10.0.0.1')
-        expect(conversion_host_2.ipaddress('invalid')).to eq('10.0.1.1')
         expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
         expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
         expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
@@ -107,30 +105,11 @@ describe ConversionHost do
 
         it "returns 'address' if family matches, is invalid or is nil" do
           expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
-          expect(conversion_host_2.ipaddress).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-          expect(conversion_host_1.ipaddress('invalid')).to eq('172.16.0.1')
-          expect(conversion_host_2.ipaddress('invalid')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
           expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
           expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
           expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
           expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-        end
-
-        context "when resource.ipaddress is set" do
-          before do
-            allow(host).to receive(:ipaddress).and_return('192.168.0.1')
-          end
-
-          it "returns resource.ipaddress when resource is a Host" do
-            expect(conversion_host_1.ipaddress).to eq('192.168.0.1')
-            expect(conversion_host_2.ipaddress).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-            expect(conversion_host_1.ipaddress('invalid')).to eq('192.168.0.1')
-            expect(conversion_host_2.ipaddress('invalid')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-            expect(conversion_host_1.ipaddress('ipv4')).to eq('192.168.0.1')
-            expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
-            expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
-            expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-          end
         end
       end
     end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -323,6 +323,11 @@ describe ServiceTemplateTransformationPlanTask do
         task_1.options[:transformation_host_id] = conversion_host.id
       end
 
+      it "fails when cluster is not mapped" do
+        allow(task_1).to receive(:transformation_destination).with(src_cluster).and_return(nil)
+        expect { task_1.destination_cluster }.to raise_error("[#{src_vm_1.name}] Cluster #{src_cluster} has no mapping.")
+      end
+
       it "finds the source ems based on source vm" do
         expect(task_1.source_ems).to eq(src_ems)
       end
@@ -439,6 +444,8 @@ describe ServiceTemplateTransformationPlanTask do
           task_1.conversion_host = conversion_host
         end
 
+        it { expect(task_1.destination_cluster).to eq(dst_cluster) }
+
         it_behaves_like "#virtv2v_disks"
 
         it "checks network mappings and generates network_mappings hash" do
@@ -524,6 +531,8 @@ describe ServiceTemplateTransformationPlanTask do
         before do
           task_1.conversion_host = conversion_host
         end
+
+        it { expect(task_1.destination_cluster).to eq(dst_cloud_tenant) }
 
         it_behaves_like "#virtv2v_disks"
 


### PR DESCRIPTION
This PR is the continuation of https://github.com/ManageIQ/manageiq/pull/18033 to backport Conversion Host related code to the ConversionHost model. In this PR, we handle the methods that execute through SSH.

Depends on:

- https://github.com/ManageIQ/manageiq-gems-pending/pull/379
- https://github.com/ManageIQ/manageiq-gems-pending/pull/382
- https://github.com/ManageIQ/manageiq-providers-vmware/pull/328

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029