### PR TITLE
Adjust VM validity correctly while editing a ServiceTemplate record

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -12,7 +12,7 @@ class TransformationMapping < ApplicationRecord
   end
 
   # vm_list: collection of hashes, each descriping a VM.
-  def search_vms_and_validate(vm_list = nil)
-    VmMigrationValidator.new(self, vm_list).validate
+  def search_vms_and_validate(vm_list = nil, service_template_id = nil)
+    VmMigrationValidator.new(self, vm_list, service_template_id).validate
   end
 end

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -13,7 +13,7 @@ class TransformationMapping::VmMigrationValidator
   def initialize(mapping, vm_list = nil, service_template_id = nil)
     @mapping = mapping
     @vm_list = vm_list
-    @service_template_id = service_template_id
+    @service_template_id = service_template_id.try(:to_i)
   end
 
   def validate
@@ -99,7 +99,7 @@ class TransformationMapping::VmMigrationValidator
     return VM_MIGRATED unless vm_as_resources.where(:status => ServiceResource::STATUS_COMPLETED).empty?
 
     # VM failed in previous migration
-    vm_as_resources.all? { |rsc| rsc.status == ServiceResource::STATUS_FAILED || rsc.service_template_id.to_s == @service_template_id  } ? VM_VALID : VM_IN_OTHER_PLAN
+    vm_as_resources.all? { |rsc| rsc.status == ServiceResource::STATUS_FAILED || rsc.service_template_id == @service_template_id  } ? VM_VALID : VM_IN_OTHER_PLAN
   end
 
   def no_mapping_list(invalid_list, data_type, new_records)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -10,9 +10,10 @@ class TransformationMapping::VmMigrationValidator
   VM_NOT_EXIST = "not_exist".freeze
   VM_VALID = "ok".freeze
 
-  def initialize(mapping, vm_list = nil)
+  def initialize(mapping, vm_list = nil, service_template_id = nil)
     @mapping = mapping
     @vm_list = vm_list
+    @service_template_id = service_template_id
   end
 
   def validate
@@ -98,7 +99,7 @@ class TransformationMapping::VmMigrationValidator
     return VM_MIGRATED unless vm_as_resources.where(:status => ServiceResource::STATUS_COMPLETED).empty?
 
     # VM failed in previous migration
-    vm_as_resources.all? { |rsc| rsc.status == ServiceResource::STATUS_FAILED } ? VM_VALID : VM_IN_OTHER_PLAN
+    vm_as_resources.all? { |rsc| rsc.status == ServiceResource::STATUS_FAILED || rsc.service_template_id.to_s == @service_template_id  } ? VM_VALID : VM_IN_OTHER_PLAN
   end
 
   def no_mapping_list(invalid_list, data_type, new_records)


### PR DESCRIPTION
Currently VM belonging to a migration plan is being categorized as an invalid VM (`in_other_plan`) when the plan is being edited.
This is incorrect since the VM is already part of the plan and should be evaluated to a valid VM.


Fixes ManageIQ/manageiq-v2v#677