### PR TITLE
Script to copy reports access from group to role

### DIFF
--- a/spec/tools/copy_reports_structure_spec.rb
+++ b/spec/tools/copy_reports_structure_spec.rb
@@ -61,4 +61,37 @@ describe ReportStructure do
       end
     end
   end
+
+  context "reset reports structure" do
+    describe ".reset_for_group" do
+      it "reset report structure to default for group" do
+        ReportStructure.reset_for_group(source_group.description)
+        source_group.reload
+        expect(source_group.settings).to be nil
+      end
+    end
+
+    describe ".reset_for_role" do
+      before do
+        source_group.update(:miq_user_role => role)
+        destination_group.update(:settings => settings)
+      end
+
+      it "reset reports structure to default for role" do
+        ReportStructure.reset_for_role(role.name)
+        source_group.reload
+        destination_group.reload
+        expect(source_group.settings).to be nil
+        expect(destination_group.settings).to be nil
+      end
+
+      it "does not reset reports if dry_run is set to true" do
+        ReportStructure.reset_for_role(role.name, true)
+        source_group.reload
+        destination_group.reload
+        expect(source_group.settings).to eq(settings)
+        expect(destination_group.settings).to eq(settings)
+      end
+    end
+  end
 end

--- a/spec/tools/copy_reports_structure_spec.rb
+++ b/spec/tools/copy_reports_structure_spec.rb
@@ -1,0 +1,64 @@
+$LOAD_PATH << Rails.root.join("tools").to_s
+
+require 'copy_reports_structure/report_structure'
+
+describe ReportStructure do
+  let(:group_name) { "SourceGroup" }
+  let(:settings) { {"reports_menus" => [["Configuration Management", ["Virtual Machines", ["Vendor and Type"]]]]} }
+  let(:role)  { FactoryGirl.create(:miq_user_role) }
+  let(:source_group) {  FactoryGirl.create(:miq_group, :settings => settings) }
+  let(:destination_group) { FactoryGirl.create(:miq_group, :miq_user_role => role) }
+
+  context "copy reports structure" do
+    describe ".duplicate_for_group" do
+      it "copies reports structure from one group to another" do
+        ReportStructure.duplicate_for_group(source_group.description, destination_group.description)
+        destination_group.reload
+        expect(destination_group.settings).to eq(settings)
+      end
+
+      it "does not copy reports structure if dry_run is set to true" do
+        ReportStructure.duplicate_for_group(source_group.description, destination_group.description, true)
+        destination_group.reload
+        expect(destination_group.settings).to be nil
+      end
+
+      it "does not change reports structure on destination group is source group not found" do
+        expect(ReportStructure).to receive(:abort)
+        ReportStructure.duplicate_for_group("Some_Not_existed_Group", source_group.description)
+        source_group.reload
+        expect(source_group.settings).to eq(settings)
+      end
+    end
+
+    describe ".duplicate_for_role" do
+      before do
+        @destination_group2 = FactoryGirl.create(:miq_group, :miq_user_role => destination_group.miq_user_role)
+      end
+
+      it "copies reports structure from one group to role (to all groups having that role)" do
+        ReportStructure.duplicate_for_role(source_group.description, role.name)
+        destination_group.reload
+        expect(destination_group.settings).to eq(settings)
+        @destination_group2.reload
+        expect(@destination_group2.settings).to eq(settings)
+      end
+
+      it "does not copy reports structure if dry_run is set to true" do
+        ReportStructure.duplicate_for_role(source_group.description, role.name, true)
+        destination_group.reload
+        expect(destination_group.settings).to be nil
+        @destination_group2.reload
+        expect(@destination_group2.settings).to be nil
+      end
+
+      it "does not change reports structure on group with destination role is source group not found" do
+        destination_group.update(:settings => settings)
+        expect(ReportStructure).to receive(:abort)
+        ReportStructure.duplicate_for_role("Some_Not_existed_Group", role.name)
+        destination_group.reload
+        expect(destination_group.settings).to eq(settings)
+      end
+    end
+  end
+end

--- a/tools/copy_reports_structure.rb
+++ b/tools/copy_reports_structure.rb
@@ -65,28 +65,28 @@ opts = Trollop.options(ARGV) do
          "  - make report structure configured for a group available to another group\n" \
          "  - make report structure configured for a group available to role\n" \
          "  - reset report access to default for group or role\n" \
-         "Example (Duplicate for Group): bundle exec ruby #{__FILE__} -s EvmGroup -g SomeGroup\n" \
-         "Example (Duplicate for Role): bundle exec ruby #{__FILE__} -s EvmGroup  -r SomeRole\n" \
-         "Example (Reset to Default for Group): bundle exec ruby #{__FILE__} -d SomeGroup\n" \
-         "Example (Reset to Default for Role):  bundle exec ruby #{__FILE__} -p SomeRole\n"
-  opt :source_group, "Source group to take report structure from", :short => "s", :type => :string
-  opt :group, "Destination group", :short => "g", :type => :string
-  opt :role, "Destination role", :short => "r", :type => :string
-  opt :delete_group, "Group to reset reports structure to default", :short => "d", :type => :string
-  opt :delete_role, "Role to reset reports structure to default", :short => "p", :type => :string
+         "Example (Duplicate for Group): bundle exec ruby #{__FILE__} --source-group=EvmGroup --target-group=SomeGroup\n" \
+         "Example (Duplicate for Role): bundle exec ruby #{__FILE__} --source-group=EvmGroup  --target-role=SomeRole\n" \
+         "Example (Reset to Default for Group): bundle exec ruby #{__FILE__} --reset-group=SomeGroup\n" \
+         "Example (Reset to Default for Role):  bundle exec ruby #{__FILE__} --reset-role=SomeRole\n"
+  opt :source_group, "Source group to take report structure from", :short => :none, :type => :string
+  opt :target_group, "Target group to get report menue from source group", :short => :none, :type => :string
+  opt :target_role, "Target role to get report menue from source group", :short => :none, :type => :string
+  opt :reset_group, "Group to reset reports structure to default", :short => :none, :type => :string
+  opt :reset_role, "Role to reset reports structure to default", :short => :none, :type => :string
 end
 
 if opts[:source_group_given]
-  msg = ":source_group argument can not be used with :delete_group" if opts[:delete_group_given]
-  msg ||= ":source_group argument can not be used with :delete_role" if opts[:delete_role_given]
-  msg ||= "either :group or :role arguments requiered" unless opts[:group_given] || opts[:role_given]
+  msg = ":source-group argument can not be used with :reset-group" if opts[:reset_group_given]
+  msg ||= ":source-group argument can not be used with :reset-role" if opts[:reset_role_given]
+  msg ||= "either :target-group or :target-role arguments requiered" unless opts[:target_group_given] || opts[:target_role_given]
   abort(msg) unless msg.nil?
-  duplicate_for_group(opts[:source_group], opts[:group]) if opts[:group_given]
-  duplicate_for_role(opts[:source_group], opts[:role]) if opts[:role_given]
+  duplicate_for_group(opts[:source_group], opts[:target_group]) if opts[:target_group_given]
+  duplicate_for_role(opts[:source_group], opts[:target_role]) if opts[:target_role_given]
 else
-  unless opts[:delete_group_given] || opts[:delete_role_given]
-    abort("use either :delete_group or :delete_role parameter for resetting report structure to default")
+  unless opts[:reset_group_given] || opts[:reset_role_given]
+    abort("use either :reset_group or :reset_role parameter for resetting report structure to default")
   end
-  reset_for_group(opts[:delete_group]) if opts[:delete_group_given]
-  reset_for_role(opts[:delete_role]) if opts[:delete_role_given]
+  reset_for_group(opts[:reset_group]) if opts[:reset_group_given]
+  reset_for_role(opts[:reset_role]) if opts[:reset_role_given]
 end

--- a/tools/copy_reports_structure.rb
+++ b/tools/copy_reports_structure.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+require 'bundler/setup'
+require 'trollop'
+
+def find_group(group_name)
+  group = MiqGroup.where(:description => group_name).first
+  abort("MiqGroup  '#{group_name}' not found") if group.nil?
+  group
+end
+
+def find_role(role_name)
+  role = MiqUserRole.where(:name => role_name).first
+  abort("MiqUserRole  '#{role_name}' not found") if role.nil?
+  role
+end
+
+def duplicate_for_group(source_group_name, destination_group_name)
+  destination_group = find_group(destination_group_name)
+  destination_group.settings = find_group(source_group_name).settings
+  destination_group.save!
+  puts "Reports structure was succesfully cloned from '#{source_group_name}' to '#{destination_group_name}'"
+rescue StandardError => e
+  $stderr.puts e.message
+end
+
+def duplicate_for_role(source_group_name, destination_role_name)
+  puts "Copying report structure from group '#{source_group_name}' to role ' #{destination_role_name}' ..."
+  source_group = find_group(source_group_name)
+  find_role(destination_role_name).miq_groups.each do |destination_group|
+    begin
+      destination_group.settings = source_group.settings
+      destination_group.save!
+      puts "  Reports structure was succesfully copied from '#{source_group_name}' to '#{destination_group.description}'"
+    rescue StandardError => e
+      $stderr.puts e.message
+    end
+  end
+end
+
+def reset_for_group(group_name)
+  group = find_group(group_name)
+  group.settings = nil
+  group.save!
+  puts "Succsefully removed custom report structure for group '#{group_name}'"
+rescue StandardError => e
+  $stderr.puts e.message
+end
+
+def reset_for_role(role_name)
+  puts "Removing custom report structure for role '#{role_name}'..."
+  find_role(role_name).miq_groups.each do |group|
+    begin
+      group.settings = nil
+      group.save!
+      puts "Succsefully removed custom report structure for group '#{group.description}'"
+    rescue StandardError => e
+      $stderr.puts e.message
+    end
+  end
+end
+
+opts = Trollop.options(ARGV) do
+  banner "Utility to: \n" \
+         "  - make report structure configured for a group available to another group\n" \
+         "  - make report structure configured for a group available to role\n" \
+         "  - reset report access to default for group or role\n" \
+         "Example (Duplicate for Group): bundle exec ruby #{__FILE__} -s EvmGroup -g SomeGroup\n" \
+         "Example (Duplicate for Role): bundle exec ruby #{__FILE__} -s EvmGroup  -r SomeRole\n" \
+         "Example (Reset to Default for Group): bundle exec ruby #{__FILE__} -d SomeGroup\n" \
+         "Example (Reset to Default for Role):  bundle exec ruby #{__FILE__} -p SomeRole\n"
+  opt :source_group, "Source group to take report structure from", :short => "s", :type => :string
+  opt :group, "Destination group", :short => "g", :type => :string
+  opt :role, "Destination role", :short => "r", :type => :string
+  opt :delete_group, "Group to reset reports structure to default", :short => "d", :type => :string
+  opt :delete_role, "Role to reset reports structure to default", :short => "p", :type => :string
+end
+
+if opts[:source_group_given]
+  msg = ":source_group argument can not be used with :delete_group" if opts[:delete_group_given]
+  msg ||= ":source_group argument can not be used with :delete_role" if opts[:delete_role_given]
+  msg ||= "either :group or :role arguments requiered" unless opts[:group_given] || opts[:role_given]
+  abort(msg) unless msg.nil?
+  duplicate_for_group(opts[:source_group], opts[:group]) if opts[:group_given]
+  duplicate_for_role(opts[:source_group], opts[:role]) if opts[:role_given]
+else
+  unless opts[:delete_group_given] || opts[:delete_role_given]
+    abort("use either :delete_group or :delete_role parameter for resetting report structure to default")
+  end
+  reset_for_group(opts[:delete_group]) if opts[:delete_group_given]
+  reset_for_role(opts[:delete_role]) if opts[:delete_role_given]
+end

--- a/tools/copy_reports_structure/report_structure.rb
+++ b/tools/copy_reports_structure/report_structure.rb
@@ -1,0 +1,60 @@
+class ReportStructure
+
+  def self.duplicate_for_group(source_group_name, destination_group_name, dry_run = false)
+    puts "Copying report structure from group '#{source_group_name}' to group ' #{destination_group_name}' ..."
+    destination_group = find_group(destination_group_name)
+    destination_group.update!(:settings => find_group(source_group_name).settings) unless dry_run
+    puts "Reports structure was successfully copied from '#{source_group_name}' to '#{destination_group_name}'"
+  rescue StandardError => e
+    $stderr.puts "Copying failed: #{e.message}"
+  end
+
+  def self.duplicate_for_role(source_group_name, destination_role_name, dry_run = false)
+    puts "Copying report structure from group '#{source_group_name}' to role ' #{destination_role_name}' ..."
+    source_group = find_group(source_group_name)
+    find_role(destination_role_name).miq_groups.each do |destination_group|
+      begin
+        destination_group.update!(:settings => source_group.settings) unless dry_run
+        puts "  Reports structure was successfully copied from '#{source_group_name}' to '#{destination_group.description}'"
+      rescue StandardError => e
+        $stderr.puts "Copying failed: #{e.message}"
+      end
+    end
+  end
+
+  def self.reset_for_group(group_name, dry_run = false)
+    puts "Removing custom report structure for group '#{group_name}'..."
+    group = find_group(group_name)
+    begin
+      group.update!(:settings => nil) unless dry_run
+      puts "Successfully removed custom report structure for group '#{group_name}'"
+    rescue StandardError => e
+      $stderr.puts "Removing failed: #{e.message}"
+    end
+  end
+
+  def self.reset_for_role(role_name, dry_run = false)
+    puts "Removing custom report structure for role '#{role_name}'..."
+    find_role(role_name).miq_groups.each do |group|
+      begin
+        group.update!(:settings => nil) unless dry_run
+        puts "Successfully removed custom report structure for group '#{group.description}'"
+      rescue  StandardError => e
+        $stderr.puts "Removing failed: #{e.message}"
+      end
+    end
+  end
+
+  def self.find_group(group_name)
+    group = MiqGroup.where(:description => group_name).first
+    abort("MiqGroup  '#{group_name}' not found") if group.nil?
+    group
+  end
+
+  def self.find_role(role_name)
+    role = MiqUserRole.where(:name => role_name).first
+    abort("MiqUserRole  '#{role_name}' not found") if role.nil?
+    role
+  end
+end
+


### PR DESCRIPTION
Requested functionality: 
Provide utility to duplicate customized report menu from some group to another group or role

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1634673

Usage:
      # help
`bundle exec ruby ./tools/copy_reports_structure.rb --help`
     # copy reports menu from `EvmGroup` to `SomeGroup`
`bundle exec ruby ./tools/copy_reports_structure.rb --source-group=EvmGroup --target-group=SomeGroup`
    # copy reports menu from `EvmGroup` to every group which has `SomeRole`
`bundle exec ruby ./tools/copy_reports_structure.rb --source-group=EvmGroup --target-role=SomeRole`
    # reset to default reports menu for `SomeGroup` 
`bundle exec ruby ./tools/copy_reports_structure.rb --reset-group=SomeGroup`

@miq-bot add-label  enhancement
