### PR TITLE
Don't use interpolation in gettext strings

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -601,7 +601,7 @@ class MiqRequest < ApplicationRecord
   end
 
   def cancel
-    raise _("Cancel operation is not supported for #{self.class.name}")
+    raise _("Cancel operation is not supported for %{class}") % {:class => self.class.name}
   end
 
   def cancel_requested?

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -214,7 +214,7 @@ class MiqRequestTask < ApplicationRecord
   end
 
   def cancel
-    raise _("Cancel operation is not supported for #{self.class.name}")
+    raise _("Cancel operation is not supported for %{class}") % {:class => self.class.name}
   end
 
   def cancel_requested?


### PR DESCRIPTION
Fixes the following CI failure:

```
 1) placeholders gettext strings do not contain interpolations
     Failure/Error: expect(errors).to be_empty
       expected `["\"Cancel operation is not supported for \#{self.class.name}\""].empty?` to return true, got false
     Shared Example Group: :placeholders called from ./spec/i18n/placeholders_spec.rb:2
     # ./spec/shared/i18n/placeholders.rb:49:in `block (2 levels) in <top (required)>'
```

@miq-bot add_label internationalization, hammer/yes