### PR TITLE
Don't translate FileDepot types

### DIFF
--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -9,7 +9,7 @@ class FileDepot < ApplicationRecord
   attr_accessor         :file
 
   def self.supported_depots
-    @supported_depots ||= descendants.each_with_object({}) { |klass, hash| hash[klass.name] = Dictionary.gettext(klass.name, :type => :model, :notfound => :titleize) }.freeze
+    @supported_depots ||= descendants.each_with_object({}) { |klass, hash| hash[klass.name] = Dictionary.gettext(klass.name, :type => :model, :notfound => :titleize, :translate => false) }.freeze
   end
 
   def self.supported_protocols


### PR DESCRIPTION
The types (NFS, AWS, ...) as they come from the backend should remain untranslated. Gettext should be applied in UI (if needed).

@miq-bot add_label internationalization, hammer/yes