### PR TITLE
Add `virtual_has_one` for `transformation_mapping` for API accessibility

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -1,5 +1,6 @@
 class ServiceTemplateTransformationPlan < ServiceTemplate
   include_concern 'ValidateConfigInfo'
+  virtual_has_one :transformation_mapping, :uses => :transformation_mapping
   def request_class
     ServiceTemplateTransformationPlanRequest
   end


### PR DESCRIPTION
Expose the `transformation_mapping` in the API below -

```
api/service_templates?filter[]=type=ServiceTemplateTransformationPlan&attributes=transformation_mapping
```

With this change, we don't need a second API call in the UI.
Noticeable improvement in the Migration Plan list loading time