### PR TITLE
Bower cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,6 @@ tmp/*
 
 # vendor/
 vendor/bundle
-vendor/assets/bower_components/
 vendor/node_root/
 
 # npm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ before_script:
 test:vmdb:
   script:
   - bundle update
-  - bundle exec rake update:bower
+  - bundle exec rake update:ui
   - bundle exec rake test:vmdb:setup
   - bundle exec rake test:vmdb
 test:brakeman:

--- a/bin/setup
+++ b/bin/setup
@@ -21,7 +21,7 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.install_bundler
   ManageIQ::Environment.bundle_update
 
-  ManageIQ::Environment.while_updating_bower do
+  ManageIQ::Environment.while_updating_ui do
     unless ENV["SKIP_DATABASE_SETUP"]
       ManageIQ::Environment.create_database
       ManageIQ::Environment.migrate_database

--- a/bin/update
+++ b/bin/update
@@ -23,7 +23,7 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.install_bundler
   ManageIQ::Environment.bundle_update
 
-  ManageIQ::Environment.while_updating_bower do
+  ManageIQ::Environment.while_updating_ui do
     unless ENV["SKIP_DATABASE_SETUP"]
       ManageIQ::Environment.migrate_database
       ManageIQ::Environment.seed_database
@@ -33,7 +33,8 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
     ManageIQ::Environment.reset_automate_domain  unless ENV["SKIP_AUTOMATE_RESET"]
   end
 
-  # Make sure bower is done before compiling assets
+  # Make sure update_ui is done before compiling assets
   ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
+
   ManageIQ::Environment.clear_logs_and_temp
 end

--- a/bin/update
+++ b/bin/update
@@ -36,5 +36,4 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   # Make sure bower is done before compiling assets
   ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
   ManageIQ::Environment.clear_logs_and_temp
-  ManageIQ::Environment.clear_obsolete
 end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -106,19 +106,6 @@ module ManageIQ
       run_rake_task("log:clear tmp:clear")
     end
 
-    # In development, when switching branches to old versions prior to the
-    # ui-classic split, it's possible that bower_components end up cached in
-    # manageiq proper as well as manageiq-ui-classic, which causes duplicate
-    # sets of dependencies, with different versions, that bower can't handle.
-    #
-    # Once we no longer support versions of manageiq prior to the ui-classic
-    # split, this can be removed.
-    def self.clear_obsolete
-      return unless APP_ROOT.join("vendor/assets/bower_components").exist?
-      puts "\n== Removing obsolete bower install =="
-      FileUtils.rm_rf(APP_ROOT.join("vendor/assets/bower_components"))
-    end
-
     def self.create_database_user
       system!(%q(psql -c "CREATE USER root SUPERUSER PASSWORD 'smartvm';" -U postgres))
     end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -44,18 +44,20 @@ module ManageIQ
       Dir.mkdir(logdir) unless Dir.exist?(logdir)
     end
 
-    def self.while_updating_bower
-      # Run bower in a thread and continue to do the non-js stuff
-      puts "\n== Updating bower assets in parallel =="
-      bower_thread = Thread.new do
+    def self.while_updating_ui
+      # Run update:ui in a thread and continue to do the non-js stuff
+      puts "\n== Updating UI assets (in parallel) =="
+
+      ui_thread = Thread.new do
         update_ui
-        puts "\n== Updating bower assets complete =="
+        puts "\n== Updating UI assets complete =="
       end
-      bower_thread.abort_on_exception = true
+
+      ui_thread.abort_on_exception = true
 
       yield
 
-      bower_thread.join
+      ui_thread.join
     end
 
     def self.install_bundler(root = APP_ROOT)


### PR DESCRIPTION
After removing bower from ui-classic (ManageIQ/manageiq-ui-classic#3734), there's still a few mentions here, removing:

* gitlab - call `update:ui` instead of `update:bower`
* `.gitignore` - don't gitignore bower
* remove `ManageIQ::Environment.clear_obsolete` (the equivalent is still happening in ui-classic as part of ui:clean)
* `s/while_updating_bower/while_updating_ui/`
* `s/bower_thread/ui_thread/`

Cc @Fryguy 
The only remaining bower references are in `CHANGELOG.md`.