### PR TITLE
Handle a blank value for the http_proxy host

### DIFF
--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -3,7 +3,7 @@ module VMDB
     def self.http_proxy_uri(proxy_config = :default)
       proxy = ::Settings.http_proxy[proxy_config].to_hash
       proxy = ::Settings.http_proxy.to_hash unless proxy[:host]
-      return nil unless proxy[:host]
+      return nil if proxy[:host].blank?
 
       user     = proxy.delete(:user)
       user &&= CGI.escape(user)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -15,6 +15,12 @@ describe VMDB::Util do
       expect(described_class.http_proxy_uri).to be_nil
     end
 
+    it "with a blank host" do
+      # We couldn't save nil http_proxy host, so some host values will be ''
+      stub_settings_merge(:http_proxy => {:default => {:host => ''}})
+      expect(described_class.http_proxy_uri).to be_nil
+    end
+
     it "with host" do
       stub_settings_merge(:http_proxy => {:default => {:host => "1.2.3.4", :port => nil, :user => nil, :password => nil}})
       expect(described_class.http_proxy_uri).to eq(URI::Generic.build(:scheme => "http", :host => "1.2.3.4"))


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1637092

We have no way (in the UI) to remove a previously configured http_proxy host
in Settings.yml/advanced settings, so people were forced to save a ''
value.  This code was only checking for nil values and should really
check for blank values.  It doesn't make sense to reimplement the regex
used by the URI class to parse host values for validity but handling
some obvious blank values make sense here.