### PR TITLE
Rails 5.1/5.0 compatibility: Use constant since string/symbol was removed

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -109,7 +109,8 @@ module Vmdb
 
     config.autoload_once_paths << Rails.root.join("lib", "vmdb", "console_methods.rb").to_s
 
-    config.middleware.use 'RequestStartedOnMiddleware'
+    require_relative '../lib/request_started_on_middleware'
+    config.middleware.use RequestStartedOnMiddleware
 
     # config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled.
     # Defaults to every folder in the app directory of the application.


### PR DESCRIPTION
Rails 5.1 removed support for specifying a string/symbol for the
middleware class.  You must now use a constant. For fun, autoload
doesn't work in application.rb, so you have to either
do it in an config/initializers or require the file.

https://github.com/rails/rails/commit/83b767ce
Rails issue: #25525

Extracted from https://github.com/ManageIQ/manageiq/pull/18076