### PR TITLE
Rails 5.0/5.1 prepare_binds_for_database is gone

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1448,7 +1448,7 @@ class MiqExpression
 
       arel  = relation.arel
       binds = relation.bound_attributes
-      binds = connection.prepare_binds_for_database(binds)
+      binds = binds.collect(&:value_for_database)
       binds.map! { |value| connection.quote(value) }
       collect = visitor.accept(arel.ast, Arel::Collectors::Bind.new)
       collect.substitute_binds(binds).join


### PR DESCRIPTION
To avoid relying on the connection to type cast the binds, this method was
removed.  It was replaced with the underlying implementation of the
method, which is also used here to replace our usage.

https://github.com/rails/rails/commit/5465508abe9ab49ccc01d2a9b43c5cfc2a70aea5

Extracted from #18076