### PR TITLE
Rails 5.0/5.1 Use o.reload.assoc, assoc(true) is gone

### DIFF
--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -1,7 +1,7 @@
 class ServiceTemplateAnsibleTower < ServiceTemplate
   include ServiceConfigurationMixin
 
-  before_save :remove_invalid_resource
+  before_update :remove_invalid_resource
 
   alias job_template configuration_script
   alias job_template= configuration_script=
@@ -24,7 +24,7 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
 
   def remove_invalid_resource
     # remove the resource from both memory and table
-    service_resources.to_a.delete_if { |r| r.destroy unless r.resource(true) }
+    service_resources.to_a.delete_if { |r| r.destroy unless r.reload.resource.present? }
   end
 
   def create_subtasks(_parent_service_task, _parent_service)


### PR DESCRIPTION
Note, the before_save was calling remove_invalid_resource on create
which didn't make sense because it was trying to find service_resources
with orphaned resources, which can't happen unless the service_template
itself has been saved.  Because of this, it makes sense to change this
to before_update instead of adding r.persisted? checks in the
remove_invalid_resource method.

The force reload parameter was removed from associations in:
rails/rails@09cac8c

It was previously deprecated here:
rails/rails@6eae366

From that commit:

For collections:
@user.posts.reload   # Instead of @user.posts(true)

For singular associations:
@user.reload.profile # Instead of @user.profile(true)

Extracted from #18076