### PR TITLE
Rails 5.0/5.1 compatibility: Define through association before has many through

### DIFF
--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -18,7 +18,6 @@ class Storage < ApplicationRecord
   has_many :storage_files,       :dependent => :destroy
   has_many :storage_files_files, -> { where("rsc_type = 'file'") }, :class_name => "StorageFile", :foreign_key => "storage_id"
   has_many :files,               -> { where("rsc_type = 'file'") }, :class_name => "StorageFile", :foreign_key => "storage_id"
-  has_many :host_storages
 
   has_many :miq_events, :as => :target, :dependent => :destroy
 

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -1,7 +1,7 @@
 class Vm < VmOrTemplate
   default_scope { where(:template => false) }
-  has_one :container_deployment, :through => :container_deployment_node
   has_one :container_deployment_node
+  has_one :container_deployment, :through => :container_deployment_node
 
   virtual_has_one :supported_consoles, :class_name => "Hash"
 


### PR DESCRIPTION
Rails 5.1+ complains about has_many through associations if the through
association is not yet defined.

Extracted from #18076