### PR TITLE
Rails 5.0/5.1: Update to ancestry 3.0.0+ for rails 5.1 fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ manageiq_plugin "manageiq-schema"
 gem "activerecord-id_regions",        "~>0.2.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
-gem "ancestry",                       "~>2.2.1",       :require => false
+gem "ancestry",                       "~>3.0.2",       :require => false
 gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"


### PR DESCRIPTION
Rails exists? with empty hash in ancestry 2.2.x was broken by rails PR: 28699

Fixed in ancestry 3.0.0:
https://github.com/stefankroes/ancestry/commit/8c43482b91dcd63be6d401dbe346c2ba6e0452c9

Extracted from https://github.com/ManageIQ/manageiq/pull/18076