### PR TITLE
Alter describe to avoid warning in TaskHelper

### DIFF
--- a/spec/lib/task_helpers/imports/customization_templates_spec.rb
+++ b/spec/lib/task_helpers/imports/customization_templates_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::CustomizationTemplate do
+describe TaskHelpers::Imports::CustomizationTemplates do
   describe "#import" do
     let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'customization_templates') }
     let(:ct_file) { "existing_ct_and_pit.yaml" }


### PR DESCRIPTION
Changes `TaskHelpers::Imports::CustomizationTemplate` to `TaskHelpers::Imports::CustomizationTemplates` (plural) to avoid a toplevel constant warning, as well as because that's what it's actually testing.