### PR TITLE
Parse automation attrs correctly

### DIFF
--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -34,7 +34,7 @@ class MiqRetireTask < MiqRequestTask
         :tenant_id     => 1,
       }
 
-      args[:attrs].merge!(MiqAeEngine.create_automation_attributes(source.class.base_model.name => source))
+      MiqAeEngine::set_automation_attributes_from_objects(source, args[:attrs])
 
       zone ||= source.respond_to?(:my_zone) ? source.my_zone : MiqServer.my_zone
       MiqQueue.put(


### PR DESCRIPTION
This should fix the last OrchestrationStack retirement bug as described in https://bugzilla.redhat.com/show_bug.cgi?id=1632239. 

When we deliver things to automate they should be in the format ```{"OrchestrationStack::orchestration_stack"=>1122}``` rather than ```{"OrchestrationStack::OrchestrationStack"=>1122}```.  