### PR TITLE
Test deliver_to_automate gets called in vms, services, orch stack retire tasks

### DIFF
--- a/app/models/orchestration_stack_retire_task.rb
+++ b/app/models/orchestration_stack_retire_task.rb
@@ -1,4 +1,6 @@
 class OrchestrationStackRetireTask < MiqRetireTask
+  default_value_for :request_type, "orchestration_stack_retire"
+
   def self.base_model
     OrchestrationStackRetireTask
   end

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -1,4 +1,6 @@
 class ServiceRetireTask < MiqRetireTask
+  default_value_for :request_type, "service_retire"
+
   def self.base_model
     ServiceRetireTask
   end

--- a/app/models/vm_retire_task.rb
+++ b/app/models/vm_retire_task.rb
@@ -1,5 +1,6 @@
 class VmRetireTask < MiqRetireTask
   alias_attribute :vm, :source
+  default_value_for :request_type, "vm_retire"
 
   def self.base_model
     VmRetireTask

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -38,12 +38,19 @@ FactoryGirl.define do
     state        'pending'
     request_type 'clone_to_service'
   end
-  factory :service_retire_task,             :parent => :miq_retire_task,  :class => "ServiceRetireTask" do
-    request_type 'service_retire'
-    state        'pending'
-  end
 
   factory :service_template_transformation_plan_task, :parent => :service_template_provision_task, :class => 'ServiceTemplateTransformationPlanTask' do
     request_type 'transformation_plan'
+  end
+
+  # Retire Tasks
+  factory :service_retire_task,             :parent => :miq_retire_task, :class => "ServiceRetireTask" do
+    state        'pending'
+  end
+  factory :vm_retire_task,                  :parent => :miq_retire_task, :class => "VmRetireTask" do
+    state        'pending'
+  end
+  factory :orchestration_stack_retire_task, :parent => :miq_retire_task, :class => "OrchestrationStackRetireTask" do
+    state        'pending'
   end
 end

--- a/spec/models/orchestration_stack_retire_task_spec.rb
+++ b/spec/models/orchestration_stack_retire_task_spec.rb
@@ -1,0 +1,27 @@
+describe OrchestrationStackRetireTask do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:orchestration_stack) { FactoryGirl.create(:orchestration_stack) }
+  let(:miq_request) { FactoryGirl.create(:orchestration_stack_retire_request, :requester => user) }
+  let(:orchestration_stack_retire_task) { FactoryGirl.create(:orchestration_stack_retire_task, :source => orchestration_stack, :miq_request => miq_request, :options => {:src_ids => [orchestration_stack.id] }) }
+  let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
+
+  it "should initialize properly" do
+    expect(orchestration_stack_retire_task).to have_attributes(:state => "pending", :status => "Ok")
+  end
+
+  describe "deliver_to_automate" do
+    before do
+      allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
+      miq_request.approve(approver, "why not??")
+    end
+
+    it "updates the task state to pending" do
+      expect(orchestration_stack_retire_task).to receive(:update_and_notify_parent).with(
+        :state   => 'pending',
+        :status  => 'Ok',
+        :message => 'Automation Starting'
+      )
+      orchestration_stack_retire_task.deliver_to_automate
+    end
+  end
+end

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -3,8 +3,7 @@ describe ServiceRetireTask do
   let(:vm) { FactoryGirl.create(:vm) }
   let(:service) { FactoryGirl.create(:service) }
   let(:miq_request) { FactoryGirl.create(:service_retire_request, :requester => user) }
-  let(:miq_request_task) { FactoryGirl.create(:miq_request_task, :miq_request_id => miq_request.id) }
-  let(:service_retire_task) { FactoryGirl.create(:service_retire_task, :source => service, :miq_request_task_id => miq_request_task.id, :miq_request_id => miq_request.id, :options => {:src_ids => [service.id] }) }
+  let(:service_retire_task) { FactoryGirl.create(:service_retire_task, :source => service, :miq_request => miq_request, :options => {:src_ids => [service.id] }) }
   let(:reason) { "Why Not?" }
   let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
   let(:zone) { FactoryGirl.create(:zone, :name => "fred") }
@@ -21,8 +20,7 @@ describe ServiceRetireTask do
   end
 
   it "should initialize properly" do
-    expect(service_retire_task.state).to eq('pending')
-    expect(service_retire_task.status).to eq('Ok')
+    expect(service_retire_task).to have_attributes(:state => 'pending', :status => 'Ok')
   end
 
   describe "respond to update_and_notify_parent" do
@@ -104,7 +102,6 @@ describe ServiceRetireTask do
     end
 
     it "updates the task state to pending" do
-      allow(MiqQueue).to receive(:put)
       expect(service_retire_task).to receive(:update_and_notify_parent).with(
         :state   => 'pending',
         :status  => 'Ok',

--- a/spec/models/vm_retire_task_spec.rb
+++ b/spec/models/vm_retire_task_spec.rb
@@ -1,0 +1,27 @@
+describe VmRetireTask do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:vm) { FactoryGirl.create(:vm) }
+  let(:miq_request) { FactoryGirl.create(:vm_retire_request, :requester => user) }
+  let(:vm_retire_task) { FactoryGirl.create(:vm_retire_task, :source => vm, :miq_request => miq_request, :options => {:src_ids => [vm.id] }) }
+  let(:approver) { FactoryGirl.create(:user_miq_request_approver) }
+
+  it "should initialize properly" do
+    expect(vm_retire_task).to have_attributes(:state => 'pending', :status => 'Ok')
+  end
+
+  describe "deliver_to_automate" do
+    before do
+      allow(MiqServer).to receive(:my_zone).and_return(Zone.seed.name)
+      miq_request.approve(approver, "why not??")
+    end
+
+    it "updates the task state to pending" do
+      expect(vm_retire_task).to receive(:update_and_notify_parent).with(
+        :state   => 'pending',
+        :status  => 'Ok',
+        :message => 'Automation Starting'
+      )
+      vm_retire_task.deliver_to_automate
+    end
+  end
+end


### PR DESCRIPTION
Since the addition of https://github.com/ManageIQ/manageiq/pull/18084/files, the attrs we pass to deliver_to_automate for retirement should be correct, and, better yet, ought to be tested. 
