### PR TITLE
Order CustomButtons in PostgreSQL 9.4

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -1,9 +1,8 @@
 class CustomButton < ApplicationRecord
   has_one :resource_action, :as => :resource, :dependent => :destroy, :autosave => true
 
-  scope :with_array_order, lambda { |ids, column = :id, column_type = :bigint|
-    order = sanitize_sql_array(["array_position(ARRAY[?]::#{column_type}[], #{table_name}.#{column}::#{column_type})", ids])
-    order(order)
+  scope :with_array_order, lambda { |ids, column = :id|
+    order(sanitize_sql_array(["position(#{column}::text in ?)", ids.join(',')]))
   }
 
   serialize :options, Hash

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -13,7 +13,7 @@ describe CustomButton do
 
       context 'by string column' do
         it 'orders by name column' do
-          expect(CustomButton.with_array_order(%w(BBB AAA CCC), :name, :text).ids).to eq([custom_button_2.id, custom_button_1.id, custom_button_3.id])
+          expect(CustomButton.with_array_order(%w(BBB AAA CCC), :name).ids).to eq([custom_button_2.id, custom_button_1.id, custom_button_3.id])
         end
       end
     end


### PR DESCRIPTION
according to @himdel's comment https://github.com/ManageIQ/manageiq/pull/18060#issuecomment-428869074 we need to use method which is working for PostgreSQL 9.4.

this method is called `position`
https://www.postgresql.org/docs/9.1/static/functions-string.html

Links
-----
* https://github.com/ManageIQ/manageiq/pull/18060
* https://bugzilla.redhat.com/show_bug.cgi?id=1628737


@miq-bot assign @gtanzillo 

@miq-bot add_label hammer/yes
@miq-bot add_label gaprindashvili/yes
