### PR TITLE
Pass multiple objects to automate by object class

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -20,8 +20,7 @@ class ResourceAction < ApplicationRecord
     elsif target.kind_of?(Hash)
       override_values = target
     elsif target.kind_of?(Array) || target.kind_of?(ActiveRecord::Relation)
-      klass = target.first.id.class
-      object_ids = target.collect { |t| "#{klass}::#{t.id}" }.join(",")
+      object_ids = target.collect { |t| "#{t.class.name.demodulize}::#{t.id}" }.join(",")
       override_attrs = {:target_object_type        => target.first.class.base_class.name,
                         'Array::target_object_ids' => object_ids}.merge(override_attrs || {})
       override_values = {}

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -62,8 +62,7 @@ describe ResourceAction do
       it "validates queue entry" do
         targets = [FactoryGirl.create(:vm_vmware), FactoryGirl.create(:vm_vmware)]
         ae_attributes[:target_object_type] = targets.first.class.base_class.name
-        klass = targets.first.id.class
-        ae_attributes['Array::target_object_ids'] = targets.collect { |t| "#{klass}::#{t.id}" }.join(",")
+        ae_attributes['Array::target_object_ids'] = targets.collect { |t| "#{t.class.name.demodulize}::#{t.id}" }.join(",")
         expect(MiqQueue).to receive(:put).with(q_options).once
         ra.deliver_to_automate_from_dialog({}, targets, user)
       end


### PR DESCRIPTION
I think we should be passing the array of multiple objects from a custom button run on many vms or hosts or whatevers as the class name rather than running class on an id and getting an Integer which will fail on https://github.com/ManageIQ/manageiq-automation_engine/blob/1975fe20dbcd622c4e8b0363e793d2a477c4c430/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb#L562. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628224
