### PR TITLE
Disable transactions in locking examples

### DIFF
--- a/spec/models/vmdb_database_connection_spec.rb
+++ b/spec/models/vmdb_database_connection_spec.rb
@@ -1,16 +1,12 @@
 require "concurrent/atomic/event"
 
 describe VmdbDatabaseConnection do
-  before do
-    @db = FactoryGirl.create(:vmdb_database)
-  end
-
+  self.use_transactional_tests = false
   after :all do
     # HACK: Some other tests (around Automate) rely on the fact there's
     # only one connection in the pool. It's totally unfair to blame this
     # spec for using the API in a perfectly ordinary way.. but it solves
     # the immediate problem.
-
     VmdbDatabaseConnection.connection_pool.disconnect!
   end
 


### PR DESCRIPTION
These tests are creating threads and explicit transactions to verify
when we're locked or not locked in the database.  The Rails 5.1 release
notes mention that this type of behavior can cause a deadlock, which
we've seen with rails 5.1, and to instead disable transactional tests.

From the rails 5.1 release notes:

"Transactional tests now wrap all Active Record connections in database
transactions.

When a test spawns additional threads, and those threads obtain database
connections, those connections are now handled specially:

The threads will share a single connection, which is inside the managed
transaction. This ensures all threads see the database in the same
state, ignoring the outermost transaction. Previously, such additional
connections were unable to see the fixture rows, for example.

When a thread enters a nested transaction, it will temporarily obtain
exclusive use of the connection, to maintain isolation.

If your tests currently rely on obtaining a separate,
outside-of-transaction, connection in a spawned thread, you'll need to
switch to more explicit connection management.

If your tests spawn threads and those threads interact while also using
explicit database transactions, this change may introduce a deadlock.

The easy way to opt out of this new behavior is to disable transactional
tests on any test cases it affects."

https://guides.rubyonrails.org/5_1_release_notes.html