### PR TITLE
Drop postgresql < 9.5 references

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -2,8 +2,8 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   def initialize(*args)
     super
 
-    if postgresql_version < 90400
-      raise "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (9.4+ required)"
+    if postgresql_version < 90500
+      raise "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (9.5 required)"
     end
 
     if postgresql_version >= 90600

--- a/lib/extensions/ar_adapter/ar_dba.rb
+++ b/lib/extensions/ar_adapter/ar_dba.rb
@@ -502,7 +502,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
        INNER JOIN pg_class i ON d.indexrelid = i.oid
        WHERE i.relkind = 'i'
          AND t.relkind = 't'
-         AND i.oid = #{postgresql_version >= 90400 ? 'd.indexrelid' : 't.reltoastidxid'}
+         AND i.oid = d.indexrelid
          AND t.relname = '#{table_name}'
          AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = 'pg_toast' )
       ORDER BY i.relname

--- a/lib/extensions/ar_table_lock.rb
+++ b/lib/extensions/ar_table_lock.rb
@@ -7,7 +7,7 @@ module ArTableLock
   #     It is self-exclusive so that only one session can hold it at a time.
   #
   # details on locks can be found on postgres docs:
-  #   can be fount http://www.postgresql.org/docs/9.4/static/explicit-locking.html
+  #   http://www.postgresql.org/docs/9.5/static/explicit-locking.html
   #
   def with_lock(timeout = 60.seconds)
     lock = "SHARE ROW EXCLUSIVE"

--- a/spec/models/vmdb_database_spec.rb
+++ b/spec/models/vmdb_database_spec.rb
@@ -73,7 +73,6 @@ describe VmdbDatabase do
 
   context ".report_client_connections" do
     it "will return an array of hashes and verify hash keys for client connections query" do
-      skip("awaiting CI database upgrade to 9.2.4") if (described_class.connection.send(:postgresql_version) rescue nil).to_i < 90200
       connections = described_class.report_client_connections
       expect(connections).to be_kind_of(Array)
 


### PR DESCRIPTION
only 9.5 is supported now, no point in keeping references and workarounds for older versions :).