### PR TITLE
Don't use special characters in ansible passwords

### DIFF
--- a/lib/embedded_ansible.rb
+++ b/lib/embedded_ansible.rb
@@ -99,7 +99,7 @@ class EmbeddedAnsible
   end
 
   def generate_password
-    SecureRandom.base64(18).tr("+/", "-_")
+    SecureRandom.hex(18)
   end
 
   def miq_database

--- a/spec/lib/embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible_spec.rb
@@ -231,5 +231,14 @@ describe EmbeddedAnsible do
         expect(auth).to have_attributes(:userid => "awx", :password => "mypassword")
       end
     end
+
+    describe "#generate_password (private)" do
+      it "doesn't include special characters" do
+        100.times do
+          pass = subject.send(:generate_password)
+          expect(pass).to match(/^[a-zA-Z0-9]+$/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The rabbitmq password has always needed to be URL-safe, but recently
the tower team added a preflight-check in their setup playbook which
just bans all special characters.

This was causing setup failures even though our passwords were URL
safe.

Now, we just generate hex passwords.

https://bugzilla.redhat.com/show_bug.cgi?id=1638009

Also of note, this change will cause upgrades to fail so this will also either require a data migration, or we can check and change the password in the code here if we are being strict about no more migrations in the hammer branch. @Fryguy @bdunne thoughts here?
