### PR TITLE
Remove OpenShift deployment wizard

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -979,7 +979,6 @@
 :product:
   :name:
   :maindb: ExtManagementSystem
-  :container_deployment_wizard: false
   :run_automate_methods_on_service_api_submit: false
 :prototype:
   :queue_type: miq_queue

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3810,10 +3810,6 @@
       :description: Add a Containers Provider
       :feature_type: admin
       :identifier: ems_container_new
-    - :name: deploy
-      :description: Deploy a New Containers Provider
-      :feature_type: admin
-      :identifier: ems_container_deployment
 
 # EmsNetwork
 - :name: Network Providers

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -35,7 +35,6 @@
   - event_streams
   - container_dashboard
   - ems_container
-  - ems_container_deployment
   - configuration_job
   - container_project
   - container_route

--- a/lib/services/container_deployment_service.rb
+++ b/lib/services/container_deployment_service.rb
@@ -53,10 +53,6 @@ class ContainerDeploymentService
     end
   end
 
-  def self.hide_deployment_wizard?
-    !Settings.product.container_deployment_wizard
-  end
-
   def optional_deployment_types
     ContainerDeployment::DEPLOYMENT_TYPES
   end


### PR DESCRIPTION
According to
https://github.com/ManageIQ/manageiq-ui-classic/issues/2161#issuecomment-429574622 ,
the openshift deployment wizard is dead.

Since this was never enabled except under a product feature, removing.
Corresponding UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4770

Introduced in https://github.com/ManageIQ/manageiq/pull/7620,
the still-relevant parts were moved to core in https://github.com/ManageIQ/manageiq-ui-classic/pull/838 & https://github.com/ManageIQ/manageiq/pull/14563 (not removing those).
