### PR TITLE
Add ext_management_system method to conversion host

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -6,10 +6,7 @@ class ConversionHost < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
-
-  def ext_management_system
-    resource.ext_management_system
-  end
+  delegate :ext_management_system, :to => :resource
 
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -7,6 +7,10 @@ class ConversionHost < ApplicationRecord
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
 
+  def ext_management_system
+    resource.ext_management_system
+  end
+
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)
   #  - Credentials are set on the resource and SSH connection works

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -6,7 +6,7 @@ class ConversionHost < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
-  delegate :ext_management_system, :to => :resource
+  delegate :ext_management_system, :to => :resource, :allow_nil => true
 
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -127,12 +127,6 @@ describe ConversionHost do
     end
   end
 
-  shared_examples_for "#ext_management_system" do
-    it "returns the EMS of resource" do
-      expect(conversion_host.ext_management_system).to eq(ems)
-    end
-  end
-
   shared_examples_for "#check_ssh_connection" do
     it "fails when SSH send an error" do
       allow(conversion_host).to receive(:connect).and_raise('Unexpected failure')
@@ -149,8 +143,6 @@ describe ConversionHost do
     let(:ems) { FactoryGirl.create(:ems_redhat, :zone => FactoryGirl.create(:zone)) }
     let(:host) { FactoryGirl.create(:host_redhat, :ext_management_system => ems) }
     let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => host, :vddk_transport_supported => true) }
-
-    it_behaves_like "#ext_management_system"
 
     context "host userid is nil" do
       before { allow(host).to receive(:authentication_userid).and_return(nil) }
@@ -176,8 +168,6 @@ describe ConversionHost do
     let(:ems) { FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.create(:zone)) }
     let(:vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
     let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
-
-    it_behaves_like "#ext_management_system"
 
     context "ems authentications is empty" do
       it { expect(conversion_host.check_ssh_connection).to be(false) }

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -127,6 +127,12 @@ describe ConversionHost do
     end
   end
 
+  shared_examples_for "#ext_management_system" do
+    it "returns the EMS of resource" do
+      expect(conversion_host.ext_management_system).to eq(ems)
+    end
+  end
+
   shared_examples_for "#check_ssh_connection" do
     it "fails when SSH send an error" do
       allow(conversion_host).to receive(:connect).and_raise('Unexpected failure')
@@ -143,6 +149,8 @@ describe ConversionHost do
     let(:ems) { FactoryGirl.create(:ems_redhat, :zone => FactoryGirl.create(:zone)) }
     let(:host) { FactoryGirl.create(:host_redhat, :ext_management_system => ems) }
     let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => host, :vddk_transport_supported => true) }
+
+    it_behaves_like "#ext_management_system"
 
     context "host userid is nil" do
       before { allow(host).to receive(:authentication_userid).and_return(nil) }
@@ -168,6 +176,8 @@ describe ConversionHost do
     let(:ems) { FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.create(:zone)) }
     let(:vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
     let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
+
+    it_behaves_like "#ext_management_system"
 
     context "ems authentications is empty" do
       it { expect(conversion_host.check_ssh_connection).to be(false) }


### PR DESCRIPTION
When working with the conversion host, it might be useful to filter by EMS. For example, when throttling the migrations, one of the metrics is the number of concurrent tasks per EMS. So, getting the conversion hosts per EMS will be useful. This PR adds the `ext_management_system` method that returns the EMS of the resource. Currently, throttling is done in Automate and this PR requires it: https://github.com/ManageIQ/manageiq-content/pull/441

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029