### PR TITLE
Add resource ems_ref and ip addresses to virt-v2v options hash

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -8,6 +8,7 @@ class ConversionHost < ApplicationRecord
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :to => :resource, :allow_nil => true
   delegate :hostname, :to => :resource, :allow_nil => true
+  delegate :ems_ref, :to => :resource, :allow_nil => true
 
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -6,9 +6,7 @@ class ConversionHost < ApplicationRecord
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
-  delegate :ext_management_system, :to => :resource, :allow_nil => true
-  delegate :hostname, :to => :resource, :allow_nil => true
-  delegate :ems_ref, :to => :resource, :allow_nil => true
+  delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -55,6 +55,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     destination_cluster
     virtv2v_disks
     network_mappings
+    raise if destination_ems.emstype == 'openstack' && source.power_state == 'off'
     true
   rescue
     false
@@ -284,17 +285,19 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   def conversion_options_destination_provider_openstack(cluster, storage)
     {
       :osp_environment            => {
-        :os_no_cache         => true,
-        :os_auth_url         => URI::Generic.build(
+        :os_auth_url             => URI::Generic.build(
           :scheme => destination_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
           :host   => destination_ems.hostname,
           :port   => destination_ems.port,
-          :path   => destination_ems.api_version
+          :path   => '/' + destination_ems.api_version
         ),
-        :os_user_domain_name => destination_ems.uid_ems,
-        :os_username         => destination_ems.authentication_userid,
-        :os_password         => destination_ems.authentication_password,
-        :os_project_name     => cluster.name
+        :os_identity_api_version => '3',
+        :os_volume_api_version   => '3',
+        :os_user_domain_name     => destination_ems.uid_ems,
+        :os_project_domain_name  => destination_ems.uid_ems,
+        :os_username             => destination_ems.authentication_userid,
+        :os_password             => destination_ems.authentication_password,
+        :os_project_name         => cluster.name
       },
       :osp_server_id              => conversion_host.ems_ref,
       :osp_destination_project_id => cluster.ems_ref,

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -292,9 +292,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
           :path   => '/' + destination_ems.api_version
         ),
         :os_identity_api_version => '3',
-        :os_volume_api_version   => '3',
         :os_user_domain_name     => destination_ems.uid_ems,
-        :os_project_domain_name  => destination_ems.uid_ems,
         :os_username             => destination_ems.authentication_userid,
         :os_password             => destination_ems.authentication_password,
         :os_project_name         => cluster.name

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -104,7 +104,8 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       {
         :source      => source_network.name,
         :destination => destination_network_ref(destination_network),
-        :mac_address => nic.address
+        :mac_address => nic.address,
+        :ip_address  => nic.network.try(:ipaddress)
       }
     end
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -295,6 +295,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :os_password         => destination_ems.authentication_password,
         :os_project_name     => cluster.name
       },
+      :osp_server_id              => conversion_host.ems_ref,
       :osp_destination_project_id => cluster.ems_ref,
       :osp_volume_type_id         => storage.ems_ref,
       :osp_flavor_id              => destination_flavor.ems_ref,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -569,9 +569,7 @@ describe ServiceTemplateTransformationPlanTask do
                   :path   => '/v3'
                 ),
                 :os_identity_api_version => '3',
-                :os_volume_api_version   => '3',
                 :os_user_domain_name     => dst_ems.uid_ems,
-                :os_project_domain_name  => dst_ems.uid_ems,
                 :os_username             => dst_ems.authentication_userid,
                 :os_password             => dst_ems.authentication_password,
                 :os_project_name         => dst_cloud_tenant.name
@@ -605,9 +603,7 @@ describe ServiceTemplateTransformationPlanTask do
                   :path   => '/v3'
                 ),
                 :os_identity_api_version => '3',
-                :os_volume_api_version   => '3',
                 :os_user_domain_name     => dst_ems.uid_ems,
-                :os_project_domain_name  => dst_ems.uid_ems,
                 :os_username             => dst_ems.authentication_userid,
                 :os_password             => dst_ems.authentication_password,
                 :os_project_name         => dst_cloud_tenant.name

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -514,7 +514,8 @@ describe ServiceTemplateTransformationPlanTask do
         let(:dst_cloud_network_2) { FactoryGirl.create(:cloud_network) }
         let(:dst_flavor) { FactoryGirl.create(:flavor) }
         let(:dst_security_group) { FactoryGirl.create(:security_group) }
-        let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => FactoryGirl.create(:vm, :ext_management_system => dst_ems)) }
+        let(:conversion_host_vm) { FactoryGirl.create(:vm, :ext_management_system => dst_ems) }
+        let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => conversion_host_vm) }
 
         let(:mapping) do
           FactoryGirl.create(
@@ -570,7 +571,7 @@ describe ServiceTemplateTransformationPlanTask do
                 :os_password         => dst_ems.authentication_password,
                 :os_project_name     => dst_cloud_tenant.name
               },
-              :osp_server_id              => conversion_host.ems_ref,
+              :osp_server_id              => conversion_host_vm.ems_ref,
               :osp_destination_project_id => dst_cloud_tenant.ems_ref,
               :osp_volume_type_id         => dst_cloud_volume_type.ems_ref,
               :osp_flavor_id              => dst_flavor.ems_ref,
@@ -604,7 +605,7 @@ describe ServiceTemplateTransformationPlanTask do
                 :os_password         => dst_ems.authentication_password,
                 :os_project_name     => dst_cloud_tenant.name
               },
-              :osp_server_id              => conversion_host.ems_ref,
+              :osp_server_id              => conversion_host_vm.ems_ref,
               :osp_destination_project_id => dst_cloud_tenant.ems_ref,
               :osp_volume_type_id         => dst_cloud_volume_type.ems_ref,
               :osp_flavor_id              => dst_flavor.ems_ref,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -570,6 +570,7 @@ describe ServiceTemplateTransformationPlanTask do
                 :os_password         => dst_ems.authentication_password,
                 :os_project_name     => dst_cloud_tenant.name
               },
+              :osp_server_id              => conversion_host.ems_ref,
               :osp_destination_project_id => dst_cloud_tenant.ems_ref,
               :osp_volume_type_id         => dst_cloud_volume_type.ems_ref,
               :osp_flavor_id              => dst_flavor.ems_ref,
@@ -603,6 +604,7 @@ describe ServiceTemplateTransformationPlanTask do
                 :os_password         => dst_ems.authentication_password,
                 :os_project_name     => dst_cloud_tenant.name
               },
+              :osp_server_id              => conversion_host.ems_ref,
               :osp_destination_project_id => dst_cloud_tenant.ems_ref,
               :osp_volume_type_id         => dst_cloud_volume_type.ems_ref,
               :osp_flavor_id              => dst_flavor.ems_ref,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -311,12 +311,15 @@ describe ServiceTemplateTransformationPlanTask do
       let(:src_vm_1) { FactoryGirl.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
       let(:src_vm_2) { FactoryGirl.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
 
+      let(:src_network) { FactoryGirl.create(:network, :ipaddress => '10.0.0.1') }
+
       # Disks have to be stubbed because there's no factory for Disk class
       before do
         allow(src_hardware).to receive(:disks).and_return([src_disk_1, src_disk_2])
         allow(src_disk_1).to receive(:storage).and_return(src_storage)
         allow(src_disk_2).to receive(:storage).and_return(src_storage)
         allow(src_vm_1).to receive(:allocated_disk_storage).and_return(34_359_738_368)
+        allow(src_nic_1).to receive(:network).and_return(src_network)
         allow(src_host).to receive(:thumbprint_sha1).and_return('01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67')
         allow(src_host).to receive(:authentication_userid).and_return('esx_user')
         allow(src_host).to receive(:authentication_password).and_return('esx_passwd')
@@ -451,8 +454,8 @@ describe ServiceTemplateTransformationPlanTask do
         it "checks network mappings and generates network_mappings hash" do
           expect(task_1.network_mappings).to eq(
             [
-              { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address },
-              { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address }
+              { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.0.1' },
+              { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address, :ip_address => nil }
             ]
           )
         end
@@ -540,8 +543,8 @@ describe ServiceTemplateTransformationPlanTask do
         it "checks network mappings and generates network_mappings hash" do
           expect(task_1.network_mappings).to eq(
             [
-              { :source => src_lan_1.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address },
-              { :source => src_lan_2.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address }
+              { :source => src_lan_1.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.0.1' },
+              { :source => src_lan_2.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address, :ip_address => nil }
             ]
           )
         end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -510,7 +510,7 @@ describe ServiceTemplateTransformationPlanTask do
       end
 
       context 'destination is openstack' do
-        let(:dst_ems) { FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.create(:zone)) }
+        let(:dst_ems) { FactoryGirl.create(:ems_openstack, :api_version => 'v3', :zone => FactoryGirl.create(:zone)) }
         let(:dst_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => dst_ems) }
         let(:dst_cloud_volume_type) { FactoryGirl.create(:cloud_volume_type) }
         let(:dst_cloud_network_1) { FactoryGirl.create(:cloud_network) }
@@ -562,17 +562,19 @@ describe ServiceTemplateTransformationPlanTask do
               :vmware_uri                 => "esx://esx_user@10.0.0.1/?no_verify=1",
               :vmware_password            => 'esx_passwd',
               :osp_environment            => {
-                :os_no_cache         => true,
-                :os_auth_url         => URI::Generic.build(
+                :os_auth_url             => URI::Generic.build(
                   :scheme => dst_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
                   :host   => dst_ems.hostname,
                   :port   => dst_ems.port,
-                  :path   => dst_ems.api_version
+                  :path   => '/v3'
                 ),
-                :os_user_domain_name => dst_ems.uid_ems,
-                :os_username         => dst_ems.authentication_userid,
-                :os_password         => dst_ems.authentication_password,
-                :os_project_name     => dst_cloud_tenant.name
+                :os_identity_api_version => '3',
+                :os_volume_api_version   => '3',
+                :os_user_domain_name     => dst_ems.uid_ems,
+                :os_project_domain_name  => dst_ems.uid_ems,
+                :os_username             => dst_ems.authentication_userid,
+                :os_password             => dst_ems.authentication_password,
+                :os_project_name         => dst_cloud_tenant.name
               },
               :osp_server_id              => conversion_host_vm.ems_ref,
               :osp_destination_project_id => dst_cloud_tenant.ems_ref,
@@ -596,17 +598,19 @@ describe ServiceTemplateTransformationPlanTask do
               :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/#{src_storage.name}/#{src_vm_1.location}",
               :transport_method           => 'ssh',
               :osp_environment            => {
-                :os_no_cache         => true,
-                :os_auth_url         => URI::Generic.build(
+                :os_auth_url             => URI::Generic.build(
                   :scheme => dst_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
                   :host   => dst_ems.hostname,
                   :port   => dst_ems.port,
-                  :path   => dst_ems.api_version
+                  :path   => '/v3'
                 ),
-                :os_user_domain_name => dst_ems.uid_ems,
-                :os_username         => dst_ems.authentication_userid,
-                :os_password         => dst_ems.authentication_password,
-                :os_project_name     => dst_cloud_tenant.name
+                :os_identity_api_version => '3',
+                :os_volume_api_version   => '3',
+                :os_user_domain_name     => dst_ems.uid_ems,
+                :os_project_domain_name  => dst_ems.uid_ems,
+                :os_username             => dst_ems.authentication_userid,
+                :os_password             => dst_ems.authentication_password,
+                :os_project_name         => dst_cloud_tenant.name
               },
               :osp_server_id              => conversion_host_vm.ems_ref,
               :osp_destination_project_id => dst_cloud_tenant.ems_ref,


### PR DESCRIPTION
When build the virt-v2v options hash for OpenStack, the ServiceTemplateTransformationPlanTask needs the `ems_ref` of the conversion host to expose it as `osp_server_id` in the options hash. This PR exposes the resource `ems_ref` in ConversionHost and enrich the options hash.

This PR also adds the IP address to the network mappings in options hash, as it is required to generate the network ports that will be attached to the instance.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029