### PR TITLE
Conversion Host - Try hostname for SSH and fix MiqSshUtil args

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -122,7 +122,7 @@ class ConversionHost < ApplicationRecord
 
   def connect_ssh
     require 'MiqSshUtil'
-    MiqSshUtil.shell_with_su(miq_ssh_util_args) do |ssu, _shell|
+    MiqSshUtil.shell_with_su(*miq_ssh_util_args) do |ssu, _shell|
       yield(ssu)
     end  
   rescue Exception => e

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -136,7 +136,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
-    [ hostname || ipaddress, resource.authentication_userid, resource.authentication_password, nil, nil ]
+    [hostname || ipaddress, resource.authentication_userid, resource.authentication_password, nil, nil]
   end 
 
   def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
@@ -144,7 +144,7 @@ class ConversionHost < ApplicationRecord
                              .where(:authtype => 'ssh_keypair')
                              .where.not(:userid => nil, :auth_key => nil)
                              .first
-    [ hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+    [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
   end
 
   def ansible_playbook(playbook, extra_vars, connection)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -34,6 +34,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def ipaddress(family = 'ipv4')
+    return resource.hostname if resource.hostname
     return address if address && IPAddr.new(address).send("#{family}?")
     resource.ipaddresses.detect { |ip| IPAddr.new(ip).send("#{family}?") }
   end 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -88,41 +88,28 @@ describe ConversionHost do
     end
 
     context "#ipaddress" do
-      context "when hostname is not set" do
-        before do
-          allow(host).to receive(:hostname).and_return(nil)
-          allow(vm).to receive(:hostname).and_return(nil)
-        end
-
-        it "returns first IP address if 'address' is nil" do
-          expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
-          expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
-          expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
-          expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
-          expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
-          expect(conversion_host_2.ipaddress('ipv6')).to eq('FE80::0202:B3FF:FE1E:3267')
-        end
-
-        context "when address is set" do
-          before do
-            allow(conversion_host_1).to receive(:address).and_return('172.16.0.1')
-            allow(conversion_host_2).to receive(:address).and_return('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-          end
-
-          it "returns 'address' if family matches, is invalid or is nil" do
-            expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
-            expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
-            expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
-            expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
-            expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
-            expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
-          end
-        end
+      it "returns first IP address if 'address' is nil" do
+        expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
+        expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+        expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+        expect(conversion_host_2.ipaddress('ipv6')).to eq('FE80::0202:B3FF:FE1E:3267')
       end
 
-      context "when hostname is set" do
-        it "returns hostname" do
-          expect(conversion_host_1.ipaddress).to eq(host.hostname)
+      context "when address is set" do
+        before do
+          allow(conversion_host_1).to receive(:address).and_return('172.16.0.1')
+          allow(conversion_host_2).to receive(:address).and_return('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+        end
+
+        it "returns 'address' if family matches, is invalid or is nil" do
+          expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
+          expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
+          expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+          expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+          expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
         end
       end
     end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -88,28 +88,42 @@ describe ConversionHost do
     end
 
     context "#ipaddress" do
-      it "returns first IP address if 'address' is nil" do
-        expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
-        expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
-        expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
-        expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
-        expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
-        expect(conversion_host_2.ipaddress('ipv6')).to eq('FE80::0202:B3FF:FE1E:3267')
-      end
-
-      context "when address is set" do
+      context "when hostname is not set" do
         before do
-          allow(conversion_host_1).to receive(:address).and_return('172.16.0.1')
-          allow(conversion_host_2).to receive(:address).and_return('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          allow(host).to receive(:hostname).and_return(nil)
+          allow(vm).to receive(:hostname).and_return(nil)
         end
 
-        it "returns 'address' if family matches, is invalid or is nil" do
-          expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
+        it "returns first IP address if 'address' is nil" do
+          expect(conversion_host_1.ipaddress).to eq('10.0.0.1')
           expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
-          expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
+          expect(conversion_host_1.ipaddress('ipv4')).to eq('10.0.0.1')
           expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
           expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
-          expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          expect(conversion_host_2.ipaddress('ipv6')).to eq('FE80::0202:B3FF:FE1E:3267')
+        end
+
+        context "when address is set" do
+          before do
+            allow(conversion_host_1).to receive(:address).and_return('172.16.0.1')
+            allow(conversion_host_2).to receive(:address).and_return('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          end
+
+          it "returns 'address' if family matches, is invalid or is nil" do
+            expect(conversion_host_1.ipaddress).to eq('172.16.0.1')
+            expect(conversion_host_2.ipaddress).to eq('10.0.1.1')
+            expect(conversion_host_1.ipaddress('ipv4')).to eq('172.16.0.1')
+            expect(conversion_host_2.ipaddress('ipv4')).to eq('10.0.1.1')
+            expect(conversion_host_1.ipaddress('ipv6')).to eq('FE80:0000:0000:0000:0202:B3FF:FE1E:8329')
+            expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
+          end
+        end
+
+      end
+
+      context "when hostname is set" do
+        it "returns hostname" do
+          expect(conversion_host_1.ipaddress).to eq(host.hostname)
         end
       end
     end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -118,7 +118,6 @@ describe ConversionHost do
             expect(conversion_host_2.ipaddress('ipv6')).to eq('2001:0DB8:85A3:0000:0000:8A2E:0370:7334')
           end
         end
-
       end
 
       context "when hostname is set" do


### PR DESCRIPTION
The IP addresses of a virtual machine or a host are not ordered accordingly to their interface name or role. So, when trying to connect to a conversion host, the IP address might not be correct. Returning the hostname when it's available mimics the behavior of Host.connect_ssh method.

This PR also fixes the parameters for `MiqSshUtil.shell_with_su` by passing the array correctly.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029