### PR TITLE
RestClient: Support percent encoded proxy user/pass

### DIFF
--- a/lib/patches/rest_client_patch.rb
+++ b/lib/patches/rest_client_patch.rb
@@ -1,0 +1,29 @@
+require 'restclient/version'
+if RestClient::VERSION >= "2.0.0" && RestClient::VERSION <= "2.1.0"
+  require 'restclient/request'
+  RestClient::Request.module_eval do
+    def net_http_object(hostname, port)
+      p_uri = proxy_uri
+
+      if p_uri.nil?
+        # no proxy set
+        Net::HTTP.new(hostname, port)
+      elsif !p_uri
+        # proxy explicitly set to none
+        Net::HTTP.new(hostname, port, nil, nil, nil, nil)
+      else
+        pass = p_uri.password ? CGI.unescape(p_uri.password) : nil
+        user = p_uri.user     ? CGI.unescape(p_uri.user)     : nil
+        Net::HTTP.new(hostname, port,
+                      p_uri.hostname, p_uri.port, user, pass)
+
+      end
+    end
+  end
+else
+  # The above patched method was last modified in 2015 and should be stable in
+  # patch releases. With 2.1 or newer, we need verify PR below was included or
+  # if this monkey patch needs to change
+  # https://github.com/rest-client/rest-client/pull/665
+  warn "This RestClient patch for proxy's with percent encoded user/password is for versions ~> 2.0.0.  Please check if this patch is required for version #{RestClient::VERSION}, see: #{__FILE__}"
+end

--- a/lib/vmdb_helper.rb
+++ b/lib/vmdb_helper.rb
@@ -20,6 +20,7 @@ require 'active_record_query_parts'
 
 # Include monkey-patches
 $:.push("#{File.dirname(__FILE__)}/patches")
+require 'rest_client_patch'
 require 'ruport_patch'
 
 APPLIANCE_DATA_VOL = File.directory?("/var/www/miq/vmdb") ? "/var/lib/data" : Rails.root.join("tmp")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1566615

Monkey patch RestClient for patch releases of rest-client 2.0.0.
The underlying method, net_http_object, has not been modified since 2015
so it should be relatively safe to monkey patch this until the upstream
PR gets merged/released.

Upstream PR: https://github.com/rest-client/rest-client/pull/665

To verify this works, run bin/rails console:

Before:

```
irb(main):004:0> r = RestClient::Request.new(method: :get, url:
'http://127.0.0.1/api', proxy: 'http://%24myuser:%24%3Fxxxx@127.0.0.1')
=> <RestClient::Request @method="get", @url="http://127.0.0.1/api">=>
<RestClient::Request @method="get", @url="https://127.0.0.1/api">
irb(main):002:0> r.net_http_object('host', 80).proxy_user
=> "%24myuser"
irb(main):003:0> r.net_http_object('host', 80).proxy_pass
=> "%24%3Fxxxx"
```

After:

```
irb(main):004:0> r = RestClient::Request.new(method: :get, url:
'http://127.0.0.1/api', proxy: 'http://%24myuser:%24%3Fxxxx@127.0.0.1')
=> <RestClient::Request @method="get", @url="http://127.0.0.1/api">=>
<RestClient::Request @method="get", @url="https://127.0.0.1/api">
irb(main):002:0> r.net_http_object('host', 80).proxy_user
=> "$myuser"
irb(main):003:0> r.net_http_object('host', 80).proxy_pass
=> "$?xxxx"
```