### PR TITLE
[GAPRINDASHVILI] Add requester info to raise_retirement_event

### DIFF
--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -1,4 +1,5 @@
 describe "Service Retirement Management" do
+  let(:user) { FactoryGirl.create(:user) }
   before(:each) do
     @miq_server = EvmSpecHelper.local_miq_server
     @stack = FactoryGirl.create(:orchestration_stack)
@@ -32,20 +33,18 @@ describe "Service Retirement Management" do
   it "#retire_now with userid" do
     expect(@stack.retirement_state).to be_nil
     event_name = 'request_orchestration_stack_retire'
-    event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
-                  :retirement_initiator => "user", :userid => "freddy"}
+    event_hash = {:userid => user.userid, :orchestration_stack => @stack, :type => "OrchestrationStack"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, {}).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, :user_id => user.id).once
 
-    @stack.retire_now('freddy')
+    @stack.retire_now(user.userid)
     @stack.reload
   end
 
   it "#retire_now without userid" do
     expect(@stack.retirement_state).to be_nil
     event_name = 'request_orchestration_stack_retire'
-    event_hash = {:orchestration_stack => @stack, :type => "OrchestrationStack",
-                  :retirement_initiator => "system"}
+    event_hash = {:userid => nil, :orchestration_stack => @stack, :type => "OrchestrationStack"}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, {}).once
 
@@ -128,9 +127,9 @@ describe "Service Retirement Management" do
   it "#raise_retirement_event" do
     event_name = 'foo'
     event_hash = {
-      :orchestration_stack  => @stack,
-      :type                 => "OrchestrationStack",
-      :retirement_initiator => "system"
+      :userid              => nil,
+      :orchestration_stack => @stack,
+      :type                => "OrchestrationStack",
     }
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, {})

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -1,4 +1,5 @@
 describe "Service Retirement Management" do
+  let(:user) { FactoryGirl.create(:user) }
   before(:each) do
     @server = EvmSpecHelper.local_miq_server
     @service = FactoryGirl.create(:service)
@@ -51,19 +52,17 @@ describe "Service Retirement Management" do
   it "#retire_now with userid" do
     expect(@service.retirement_state).to be_nil
     event_name = 'request_service_retire'
-    event_hash = {:service => @service, :type => "Service",
-                  :retirement_initiator => "user", :userid => "freddy"}
+    event_hash = {:userid => user.userid, :service => @service, :type => "Service"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {}).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, :user_id => user.id).once
 
-    @service.retire_now('freddy')
+    @service.retire_now(user.userid)
   end
 
   it "#retire_now without userid" do
     expect(@service.retirement_state).to be_nil
     event_name = 'request_service_retire'
-    event_hash = {:service => @service, :type => "Service",
-                  :retirement_initiator => "system"}
+    event_hash = {:userid => nil, :service => @service, :type => "Service"}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {}).once
 
@@ -199,7 +198,7 @@ describe "Service Retirement Management" do
 
   it "#raise_retirement_event" do
     event_name = 'foo'
-    event_hash = {:service => @service, :type => "Service", :retirement_initiator => "system"}
+    event_hash = {:userid => nil, :service => @service, :type => "Service"}
     expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {})
     @service.raise_retirement_event(event_name)
   end


### PR DESCRIPTION
It's the g-branch start to [the horror that got merged earlier today](https://github.com/ManageIQ/manageiq/pull/17951) for https://bugzilla.redhat.com/show_bug.cgi?id=1618530

It's an attempt to 1) delete the system retirer that was previously in place, 2) add the requester info to the raise_retirement_event, and 3) remove User.current_user references from all places in retirement except through the UI, as well as 4) fixing the listed bug. 