### PR TITLE
[WIP] [GAPRINDASHVILI] [WIP] The ruby ripper parser update would've been nice to be on the gap branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "rails",                          "~>5.0.2"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
-gem "ripper_ruby_parser",             "~>1.1.2",       :require => false
+gem "ripper_ruby_parser",             "~>1.2.0",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.1",       :require => false
 gem "rugged",                         "~>0.25.0",      :require => false


### PR DESCRIPTION
... otherwise there's a lil bit of a gap...

Okay, fine, I just wanted the points for opening this. But really.  

So this issue got fixed but we're still running the old ruby ripper on the g/branch so this error is still around... 

https://github.com/mvz/ripper_ruby_parser/issues/35 got fixed by https://github.com/ManageIQ/manageiq/pull/16818 and it's marked g/no but it really should be g/yes because I can't run g with the old version. 

For those of us who're foolishly running other ruby versions that what we're sposed to 😆 
