### PR TITLE
Add default of admin to requester in make retire request

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -10,7 +10,7 @@ module RetirementMixin
   end
 
   module ClassMethods
-    def make_retire_request(*src_ids, requester)
+    def make_retire_request(*src_ids, requester = User.find_by(:userid => 'admin'))
       klass = (name.demodulize + "RetireRequest").constantize
       options = {:src_ids => src_ids.presence, :__request_type__ => klass.request_types.first}
       klass.make_request(nil, options, requester, true)


### PR DESCRIPTION
Since the merge of  https://github.com/ManageIQ/manageiq/pull/17951, which adds a system_context for retirement, make_retire_request takes a user.

Brandon [thinks make_retire_request should have a default user](https://github.com/ManageIQ/manageiq-api/pull/497#discussion_r226362758), and Tina thinks if we must have one, it should be admin. So. Boooya. 

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1618530

related:
https://github.com/ManageIQ/manageiq-api/pull/497