### PR TITLE
Add CloudTenant to tag_classes in miq_expression.yml

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -248,6 +248,7 @@
   ContainerTemplate: container_template
   PersistentVolume: persistent_volume
   Flavor: flavor
+  CloudTenant: cloud_tenant
 :exclude_from_relats:
   ManageIQ::Providers::CloudManager:
   - hosts


### PR DESCRIPTION
Enables the use of CloudTenant tags in expressions and reports.

The primary motivation for this PR is to allow tag descriptions to be included in reports based on Cloud Tenants, but this also allows CloudTenant tags in searches, filters, etc.