### PR TITLE
Fix travis failure in manageiq-content repo.

### DIFF
--- a/app/models/service_ansible_tower.rb
+++ b/app/models/service_ansible_tower.rb
@@ -10,15 +10,15 @@ class ServiceAnsibleTower < Service
 
   def launch_job
     job_class = "#{job_template.class.parent.name}::#{job_template.class.stack_type}".constantize
-    job_options.deep_merge!(
+    options = job_options.with_indifferent_access.deep_merge(
       :extra_vars => {
         'manageiq'            => service_manageiq_env,
         'manageiq_connection' => manageiq_connection_env(evm_owner)
       }
     )
     _log.info("Launching Ansible Tower job with options:")
-    $log.log_hashes(job_options)
-    @job = job_class.create_job(job_template, job_options)
+    $log.log_hashes(options)
+    @job = job_class.create_job(job_template, options)
     add_resource(@job)
     @job
   ensure
@@ -49,7 +49,7 @@ class ServiceAnsibleTower < Service
 
     raise _("job template was not set") if job_template.nil?
 
-    build_stack_options_from_dialog(dialog_options).with_indifferent_access
+    build_stack_options_from_dialog(dialog_options)
   end
 
   def save_launch_options


### PR DESCRIPTION
When launching Ansible jobs, the job options may be expected with string hash keys. The change proposed in this PR would ensure the job options passed down to Ansible Tower always support  string hash keys.

When getting a value of a hash with indifferent access based on a key, the key can be written as either string or symbol. But internally the hash key is in string format which can lead to test failures when comparing the hash.  
(See the `with_indifferent_access` example here: [RSpec: comparing a hash with string keys against a hash with symbol keys?]( https://stackoverflow.com/questions/11832906/rspec-comparing-a-hash-with-string-keys-against-a-hash-with-symbol-keys))

This PR moves the `with_indifferent_access` call from `build_stack_create_options` to `job_options`.  The `job_options` method, which is an alias of `stack_options`, calls `build_stack_create_options`  if the data is not provided by `get_option(:create_options)` here https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/service_orchestration_options_mixin.rb

By moving `with_indifferent_access` this change ensure it is called on the hash returned from `job_options` regardless of the source of the hash.

Followup of https://github.com/ManageIQ/manageiq/pull/18057.

Blocks https://github.com/ManageIQ/manageiq-content/pull/451.

@miq-bot assign @gmcculloug
@miq-bot add_label enhancement, services

cc @mkanoor