### PR TITLE
Fix specs using Zone.first instead of creating a zone

### DIFF
--- a/app/models/container_deployment.rb
+++ b/app/models/container_deployment.rb
@@ -57,7 +57,8 @@ class ContainerDeployment < ApplicationRecord
       :port      => options[:provider_port],
       :hostname  => options[:provider_hostname],
       :ipaddress => options[:provider_ipaddress],
-      :zone      => Zone.first)
+      :zone      => Zone.default_zone
+    )
     provider.save!
     provider.update_authentication(:bearer => {:auth_key => options[:auth_key], :save => true})
     valid_provider = provider.authentication_check.first

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     sequence(:hostname)  { |n| "ems-#{seq_padded_for_sorting(n)}" }
     sequence(:ipaddress) { |n| ip_from_seq(n) }
     guid                 { SecureRandom.uuid }
-    zone                 { Zone.first || FactoryGirl.create(:zone) }
+    zone                 { FactoryGirl.create(:zone) }
     storage_profiles     { [] }
 
     # Traits

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :provider do
     sequence(:name) { |n| "provider_#{seq_padded_for_sorting(n)}" }
     guid            { SecureRandom.uuid }
-    zone            { Zone.first || FactoryGirl.create(:zone) }
+    zone            { FactoryGirl.create(:zone) }
   end
 
   factory :provider_foreman, :class => "ManageIQ::Providers::Foreman::Provider", :parent => :provider do

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -39,8 +39,9 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
     end
 
     context "With a zone, server, ems, hosts, vmware vms" do
+      let(:zone) { FactoryGirl.create(:zone) }
       before do
-        server = EvmSpecHelper.local_miq_server(:is_master => true, :name => "test_server_main_server")
+        server = EvmSpecHelper.local_miq_server(:is_master => true, :name => "test_server_main_server", :zone => zone)
         (NUM_OF_SERVERS - 1).times do |i|
           FactoryGirl.create(:miq_server, :zone => server.zone, :name => "test_server_#{i}")
         end
@@ -56,7 +57,8 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
           :hosts    => NUM_OF_HOSTS,
           :storages => NUM_OF_STORAGES,
           :vms      => NUM_OF_VMS,
-          :repo_vms => NUM_OF_REPO_VMS
+          :repo_vms => NUM_OF_REPO_VMS,
+          :zone     => zone,
         )
       end
 

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -2,15 +2,16 @@ describe "JobProxyDispatcherVmMiqServerProxies" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do
+    let(:zone) { FactoryGirl.create(:zone) }
     before do
-      @server1 = EvmSpecHelper.local_miq_server
-      @server2 = FactoryGirl.create(:miq_server, :zone => @server1.zone)
+      @server1 = EvmSpecHelper.local_miq_server(:zone => zone)
+      @server2 = FactoryGirl.create(:miq_server, :zone => zone)
       allow_any_instance_of(MiqServer).to receive_messages(:is_vix_disk? => true)
     end
 
     context "with hosts with a miq_proxy, vmware vms on storages" do
       before do
-        @hosts, @proxies, @storages, @vms = build_entities
+        @hosts, @proxies, @storages, @vms = build_entities(:zone => zone)
         @vm = @vms.first
       end
 

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -1,13 +1,11 @@
 describe Metric::Statistic do
   context ".calculate_stat_columns" do
     let(:ems_openshift) do
-      FactoryGirl.create(:ems_openshift, :hostname => 't', :port => 8443, :name => 't',
-                         :zone => Zone.first)
+      FactoryGirl.create(:ems_openshift, :hostname => 't', :port => 8443, :name => 't')
     end
 
     let(:project) do
-      FactoryGirl.create(:container_project,
-                         :name => "project")
+      FactoryGirl.create(:container_project, :name => "project")
     end
 
     hour = Time.parse(Metric::Helper.nearest_hourly_timestamp(Time.now)).utc

--- a/spec/support/job_proxy_dispatcher_helper.rb
+++ b/spec/support/job_proxy_dispatcher_helper.rb
@@ -2,7 +2,7 @@ module Spec
   module Support
     module JobProxyDispatcherHelper
       def build_entities(options = {})
-        options = {:hosts => 2, :storages => 2, :vms => 3, :repo_vms => 3, :container_providers => [1, 2]}.merge(options)
+        options = {:hosts => 2, :storages => 2, :vms => 3, :repo_vms => 3, :container_providers => [1, 2], :zone => FactoryGirl.create(:zone)}.merge(options)
 
         proxies = []
         storages = []
@@ -11,7 +11,7 @@ module Spec
           storages << storage
         end
 
-        ems = FactoryGirl.create(:ems_vmware, :name => "ems1")
+        ems = FactoryGirl.create(:ems_vmware, :name => "ems1", :zone => options[:zone])
         hosts = []
         options[:hosts].times do |i|
           host = FactoryGirl.create(:host, :name => "test_host_#{i}", :hostname => "test_host_#{i}")
@@ -48,7 +48,7 @@ module Spec
 
         container_providers = []
         options[:container_providers].each_with_index do |images_count, i|
-          ems_openshift = FactoryGirl.create(:ems_openshift, :name => "test_container_provider_#{i}")
+          ems_openshift = FactoryGirl.create(:ems_openshift, :name => "test_container_provider_#{i}", :zone => options[:zone])
           container_providers << ems_openshift
           container_image_classes = ContainerImage.descendants.append(ContainerImage)
           images_count.times do |idx|


### PR DESCRIPTION
A number of specs were using Zone.first or relying on
the ExtManagementSystem factory creating a new one.