### PR TITLE
Force a run of the setup playbook after a db failover

### DIFF
--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -29,12 +29,12 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   end
 
   def start
-    if configured? && !upgrade?
-      update_proxy_settings
-      services.each { |service| LinuxAdmin::Service.new(service).start.enable }
-    else
+    if run_setup_script?
       configure_secret_key
       run_setup_script(EXCLUDE_TAGS)
+    else
+      update_proxy_settings
+      services.each { |service| LinuxAdmin::Service.new(service).start.enable }
     end
 
     5.times do
@@ -98,6 +98,10 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   end
 
   private
+
+  def run_setup_script?
+    !configured? || upgrade?
+  end
 
   def upgrade?
     local_tower_version != tower_rpm_version

--- a/lib/embedded_ansible/appliance_embedded_ansible.rb
+++ b/lib/embedded_ansible/appliance_embedded_ansible.rb
@@ -100,7 +100,7 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
   private
 
   def run_setup_script?
-    !configured? || upgrade?
+    force_setup_run? || !configured? || upgrade?
   end
 
   def upgrade?
@@ -130,6 +130,7 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
       AwesomeSpawn.run!(SETUP_SCRIPT, :params => params)
     end
     write_setup_complete_file
+    remove_force_setup_marker_file
   rescue AwesomeSpawn::CommandResultError => e
     _log.error("EmbeddedAnsible setup script failed with: #{e.message}")
     miq_database.ansible_secret_key = nil
@@ -216,5 +217,17 @@ class ApplianceEmbeddedAnsible < EmbeddedAnsible
 
   def setup_complete_file
     Rails.root.join("tmp", "embedded_ansible_setup_complete")
+  end
+
+  def remove_force_setup_marker_file
+    FileUtils.rm_f(force_setup_run_marker_file)
+  end
+
+  def force_setup_run?
+    File.exist?(force_setup_run_marker_file)
+  end
+
+  def force_setup_run_marker_file
+    Rails.root.join("tmp", "embedded_ansible_force_setup_run")
   end
 end

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -156,6 +156,7 @@ class EvmDatabase
       ActiveRecord::Base.establish_connection(Rails.application.config.database_configuration[Rails.env])
 
       raise_server_event("db_failover_executed")
+      FileUtils.touch(Rails.root.join("tmp", "embedded_ansible_force_setup_run"))
       LinuxAdmin::Service.new("evmserverd").restart
     end
 

--- a/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
@@ -237,6 +237,24 @@ describe ApplianceEmbeddedAnsible do
       end
     end
 
+    describe "#start with the force setup run marker file" do
+      it "runs the setup playbook" do
+        file = Rails.root.join("tmp", "embedded_ansible_force_setup_run")
+        FileUtils.touch(file)
+
+        expect(subject).to receive(:configure_secret_key)
+        expect(subject).to receive(:alive?).and_return(true)
+        miq_database.set_ansible_admin_authentication(:password => "adminpassword")
+        miq_database.set_ansible_rabbitmq_authentication(:userid => "rabbituser", :password => "rabbitpassword")
+        miq_database.set_ansible_database_authentication(:userid => "databaseuser", :password => "databasepassword")
+
+        expect(AwesomeSpawn).to receive(:run!).with("ansible-tower-setup", anything)
+
+        subject.start
+        FileUtils.rm_f(file)
+      end
+    end
+
     describe "#start when not configured" do
       before do
         expect(subject).to receive(:configured?).and_return(false)


### PR DESCRIPTION
This should also update the ansible database configuration
which will allow embedded ansible to recover after a failover

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543340