### PR TITLE
Remove Hard-Coded AWS Region

### DIFF
--- a/app/models/file_depot_s3.rb
+++ b/app/models/file_depot_s3.rb
@@ -13,8 +13,6 @@ class FileDepotS3 < FileDepot
     require 'aws-sdk'
     username = options[:username] || authentication_userid(options[:auth_type])
     password = options[:password] || authentication_password(options[:auth_type])
-    # Note: The hard-coded aws_region will be removed after manageiq-ui-class implements region selection
-    aws_region = options[:region] || "us-east-1"
 
     Aws::S3::Resource.new(
       :access_key_id     => username,


### PR DESCRIPTION
The aws_region was hard-coded to "us-east-1" during testing
pending implementation of a drop-down region list in the UI.
Unfortunately the code to override an empty region setting was never
removed.  Missed in prior S3 PR.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1640740

@h-kataria @roliveri @carbonin please review.

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1640740


Steps for Testing/QA 
-------------------------------

Run an adhoc database backup to S3.  Enter Depot Name, URI, user and password, but do not modify the Region drop-down.  Validate.  It should fail.  If you select a region, it should succeed.