### PR TITLE
Fix Exception due to missing #merged_uri parameters in FileDepot parent class

### DIFF
--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -33,7 +33,7 @@ class FileDepot < ApplicationRecord
     @file = file
   end
 
-  def merged_uri(uri, _api_port)
+  def merged_uri(_uri, _api_port)
     uri
   end
 end

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -33,7 +33,7 @@ class FileDepot < ApplicationRecord
     @file = file
   end
 
-  def merged_uri
+  def merged_uri(uri, _api_port)
     uri
   end
 end

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -118,8 +118,12 @@ describe FileDepotFtp do
   end
 
   context "#merged_uri" do
-    it "should return the same uri" do
-      expect(file_depot_ftp.merged_uri(uri, nil)).to eq uri
+    before do
+      file_depot_ftp.uri = uri
+    end
+
+    it "should return the uri attribute from the file depot object and ignore the parameter" do
+      expect(file_depot_ftp.merged_uri(nil, nil)).to eq uri
     end
   end
 end

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -4,7 +4,8 @@ describe FileDepotFtp do
   end
 
   let(:connection)     { double("FtpConnection") }
-  let(:file_depot_ftp) { FileDepotFtp.new(:uri => "ftp://server.example.com/uploads") }
+  let(:uri)            { "ftp://server.example.com/uploads" }
+  let(:file_depot_ftp) { FileDepotFtp.new(:uri => uri) }
   let(:log_file)       { LogFile.new(:resource => @miq_server, :local_file => "/tmp/file.txt") }
   let(:ftp_mock) do
     Class.new do
@@ -113,6 +114,12 @@ describe FileDepotFtp do
       expect(connection).to receive(:close)
 
       file_depot_ftp.upload_file(log_file)
+    end
+  end
+
+  context "#merged_uri" do
+    it "should return the same uri" do
+      expect(file_depot_ftp.merged_uri(uri, nil)).to eq uri
     end
   end
 end

--- a/spec/models/file_depot_nfs_spec.rb
+++ b/spec/models/file_depot_nfs_spec.rb
@@ -1,0 +1,14 @@
+describe FileDepotNfs do
+  let(:uri)           { "nfs://foo.com/directory" }
+  let(:file_depot_nfs) { FileDepotNfs.new(:uri => uri) }
+
+  it "should return a valid prefix" do
+    expect(FileDepotNfs.uri_prefix).to eq "nfs"
+  end
+
+  describe "#merged_uri" do
+    it "should return the same uri submitted" do
+      expect(file_depot_nfs.merged_uri(uri, nil)).to eq uri
+    end
+  end
+end

--- a/spec/models/file_depot_nfs_spec.rb
+++ b/spec/models/file_depot_nfs_spec.rb
@@ -1,5 +1,6 @@
 describe FileDepotNfs do
-  let(:uri)           { "nfs://foo.com/directory" }
+  let(:uri)            { "nfs://foo.com/directory" }
+  let(:swift_uri)      { "swift://foo_bucket/doo_directory" }
   let(:file_depot_nfs) { FileDepotNfs.new(:uri => uri) }
 
   it "should return a valid prefix" do
@@ -7,8 +8,16 @@ describe FileDepotNfs do
   end
 
   describe "#merged_uri" do
-    it "should return the same uri submitted" do
-      expect(file_depot_nfs.merged_uri(uri, nil)).to eq uri
+    before do
+      file_depot_nfs.uri = uri
+    end
+
+    it "should return the uri set on the depot object and ignore the uri parameter" do
+      expect(file_depot_nfs.merged_uri(swift_uri, nil)).to eq uri
+    end
+
+    it "should return the uri set on the depot object and ignore an empty uri parameter" do
+      expect(file_depot_nfs.merged_uri(nil, nil)).to eq uri
     end
   end
 end


### PR DESCRIPTION
The #merged_uri method in FileDepot was added by a previous PR but it was
missing its parameters, causing an exception when a derived class other than FileDepotSwift
is invoked.

Fix the parent FileDepot class, and add tests in two derived classes -
FileDepotNfs (which previously had no tests) and FileDepotFtp.
It is already tested in FileDepotSwift.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643106

@yrudman @roliveri please review.  @carbonin FYI.



Links [Optional]
----------------

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1643106

Steps for Testing/QA
-------------------------------

Schedule a DB backup on an NFS File Depot.  It should not cause an exception.