### PR TITLE
Use correct factory in PhysicalInfraManager spec

### DIFF
--- a/spec/factories/physical_infra_manager.rb
+++ b/spec/factories/physical_infra_manager.rb
@@ -1,4 +1,0 @@
-FactoryGirl.define do
-  factory :generic_physical_infra,
-          :class => "ManageIQ::Providers::PhysicalInfraManager"
-end

--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::PhysicalInfraManager do
 
   it 'will count physical servers' do
     ps = FactoryGirl.create(:physical_server)
-    pim = FactoryGirl.create(:generic_physical_infra,
+    pim = FactoryGirl.create(:ems_physical_infra,
                              :name     => "LXCA",
                              :hostname => "0.0.0.0")
 
@@ -16,7 +16,7 @@ describe ManageIQ::Providers::PhysicalInfraManager do
   it 'will count hosts' do
     ps = FactoryGirl.create(:physical_server)
     host = FactoryGirl.create(:host)
-    pim = FactoryGirl.create(:generic_physical_infra,
+    pim = FactoryGirl.create(:ems_physical_infra,
                              :name     => "LXCA",
                              :hostname => "0.0.0.0")
 
@@ -29,7 +29,7 @@ describe ManageIQ::Providers::PhysicalInfraManager do
     ps = FactoryGirl.create(:physical_server)
     host = FactoryGirl.create(:host)
     vm = FactoryGirl.create(:vm)
-    pim = FactoryGirl.create(:generic_physical_infra,
+    pim = FactoryGirl.create(:ems_physical_infra,
                              :name     => "LXCA",
                              :hostname => "0.0.0.0")
 
@@ -40,21 +40,21 @@ describe ManageIQ::Providers::PhysicalInfraManager do
   end
 
   it 'will check supports_console returns false' do
-    ps = FactoryGirl.create(:generic_physical_infra,
+    ps = FactoryGirl.create(:ems_physical_infra,
                             :name     => "LXCA",
                             :hostname => "0.0.0.0")
     expect(ps.supports_console?).to be(false)
   end
 
   it 'will return false if console is not supported' do
-    ps = FactoryGirl.create(:generic_physical_infra,
+    ps = FactoryGirl.create(:ems_physical_infra,
                             :name     => "LXCA",
                             :hostname => "0.0.0.0")
     expect(ps.console_supported?).to be(false)
   end
 
   it 'will raise  exception for cnosle url if  console is not supported' do
-    ps = FactoryGirl.create(:generic_physical_infra,
+    ps = FactoryGirl.create(:ems_physical_infra,
                             :name     => "LXCA",
                             :hostname => "0.0.0.0")
     expect { ps.console_url }.to raise_error(MiqException::Error)


### PR DESCRIPTION
The physical infra manager spec was using a different factory for a
"generic_physical_infra" manager which wasn't using the parent properly
leading to no zone being created.  There was already an
ems_physical_infra in the main ext_management_system factory file that
should be used instead.