### PR TITLE
Add a validation for conversion hosts

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -84,6 +84,9 @@ class ExtManagementSystem < ApplicationRecord
   has_many :service_offerings, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :service_parameters_sets, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
 
+  has_many :host_conversion_hosts, :through => :hosts, :source => :conversion_host
+  has_many :vm_conversion_hosts, :through => :vms, :source => :conversion_host
+
   validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
   validates :hostname, :presence => true, :if => :hostname_required?
   validate :hostname_uniqueness_valid?, :hostname_format_valid?, :if => :hostname_required?
@@ -609,6 +612,10 @@ class ExtManagementSystem < ApplicationRecord
   def vm_log_user_event(_vm, user_event)
     $log.info(user_event)
     $log.warn("User event logging is not available on [#{self.class.name}] Name:[#{name}]")
+  end
+
+  def conversion_hosts
+    host_conversion_hosts + vm_conversion_hosts
   end
 
   #

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -16,10 +16,11 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   end
 
   def validate_conversion_hosts
-    transformation_mapping.transformation_mapping_items.select { |item| %w(EmsCluster CloudTenant).include?(item.source_type) }.each do |item|
-      return false if item.destination.ext_management_system.conversion_hosts.empty?
+    transformation_mapping.transformation_mapping_items.select do |item|
+      %w(EmsCluster CloudTenant).include?(item.source_type)
+    end.all? do |item|
+      item.destination.ext_management_system.conversion_hosts.present?
     end
-    true
   end
 
   def validate_vm(_vm_id)

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -16,11 +16,8 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   end
 
   def validate_conversion_hosts
-    transformation_mapping.transformation_mapping_items.each do |item|
-      next unless %w(EmsCluster CloudTenant).include?(item.source_type)
-      ems = item.destination_type.constantize.find(item.destination_id).ext_management_system
-      conversion_hosts = ConversionHost.all.select { |ch| ch.ext_management_system == ems }
-      return false if conversion_hosts.empty?
+    transformation_mapping.transformation_mapping_items.select { |item| %w(EmsCluster CloudTenant).include?(item.source_type) }.each do |item|
+      return false if item.destination.ext_management_system.conversion_hosts.empty?
     end
     true
   end

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -15,6 +15,16 @@ class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
     vm_resources.where(:status => [ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_FAILED]).pluck(:resource_id)
   end
 
+  def validate_conversion_hosts
+    transformation_mapping.transformation_mapping_items.each do |item|
+      next unless %w(EmsCluster CloudTenant).include?(item.source_type)
+      ems = item.destination_type.constantize.find(item.destination_id).ext_management_system
+      conversion_hosts = ConversionHost.all.select { |ch| ch.ext_management_system == ems }
+      return false if conversion_hosts.empty?
+    end
+    true
+  end
+
   def validate_vm(_vm_id)
     # TODO: enhance the logic to determine whether this VM can be included in this request
     true

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -6,31 +6,6 @@ describe ServiceTemplateTransformationPlanRequest do
     end
   end
 
-  let(:dst_ems) { FactoryGirl.create(:ext_management_system) }
-  let(:src_cluster) { FactoryGirl.create(:ems_cluster) }
-  let(:dst_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => dst_ems) }
-
-  let(:mapping) do
-    FactoryGirl.create(
-      :transformation_mapping,
-      :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
-    )
-  end
-
-  let(:catalog_item_options) do
-    {
-      :name        => 'Transformation Plan',
-      :description => 'a description',
-      :config_info => {
-        :transformation_mapping_id => mapping.id,
-        :actions                   => [
-          {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
-          {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
-        ],
-      }
-    }
-  end
-
   let(:plan) { FactoryGirl.create(:service_template_transformation_plan, :service_resources => vm_requests) }
   let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
 
@@ -55,21 +30,112 @@ describe ServiceTemplateTransformationPlanRequest do
   end
 
   describe '#validate_conversion_hosts' do
-    let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
-    let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
-
     context 'no conversion host exists in EMS' do
-      let(:host) { FactoryGirl.create(:host, :ext_management_system => FactoryGirl.create(:ext_management_system, :zone => FactoryGirl.create(:zone))) }
-      let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => host) }
+      let(:dst_ems) { FactoryGirl.create(:ext_management_system) }
+      let(:src_cluster) { FactoryGirl.create(:ems_cluster) }
+      let(:dst_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => dst_ems) }
 
-      it { expect(request.validate_conversion_hosts).to eq(false) }
+      let(:mapping) do
+        FactoryGirl.create(
+          :transformation_mapping,
+          :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
+        )
+      end
+
+      let(:catalog_item_options) do
+        {
+          :name        => 'Transformation Plan',
+          :description => 'a description',
+          :config_info => {
+            :transformation_mapping_id => mapping.id,
+            :actions                   => [
+              {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
+              {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
+            ],
+          }
+        }
+      end
+
+      let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+      let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
+
+      it 'returns false' do
+        host = FactoryGirl.create(:host, :ext_management_system => FactoryGirl.create(:ext_management_system, :zone => FactoryGirl.create(:zone)))
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => host)
+        expect(request.validate_conversion_hosts).to be false
+      end
     end
 
-    context 'conversion host exists in EMS' do
-      let(:host) { FactoryGirl.create(:host, :ext_management_system => dst_ems) }
-      let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => host) }
+    context 'conversion host exists in EMS and resource is a Host' do
+      let(:dst_ems) { FactoryGirl.create(:ems_redhat) }
+      let(:src_cluster) { FactoryGirl.create(:ems_cluster) }
+      let(:dst_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => dst_ems) }
 
-      it { expect(request.validate_conversion_hosts).to eq(false) }
+      let(:mapping) do
+        FactoryGirl.create(
+          :transformation_mapping,
+          :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
+        )
+      end
+
+      let(:catalog_item_options) do
+        {
+          :name        => 'Transformation Plan',
+          :description => 'a description',
+          :config_info => {
+            :transformation_mapping_id => mapping.id,
+            :actions                   => [
+              {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
+              {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
+            ],
+          }
+        }
+      end
+
+      let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+      let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
+
+      it 'returns true' do
+        host = FactoryGirl.create(:host, :ext_management_system => dst_ems, :ems_cluster => dst_cluster)
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => host)
+        expect(request.validate_conversion_hosts).to be true
+      end
+    end
+
+    context 'conversion host exists in EMS and resource is a Vm' do
+      let(:dst_ems) { FactoryGirl.create(:ems_openstack) }
+      let(:src_cluster) { FactoryGirl.create(:ems_cluster) }
+      let(:dst_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => dst_ems) }
+
+      let(:mapping) do
+        FactoryGirl.create(
+          :transformation_mapping,
+          :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cloud_tenant)]
+        )
+      end
+
+      let(:catalog_item_options) do
+        {
+          :name        => 'Transformation Plan',
+          :description => 'a description',
+          :config_info => {
+            :transformation_mapping_id => mapping.id,
+            :actions                   => [
+              {:vm_id => vms.first.id.to_s, :pre_service => false, :post_service => false},
+              {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
+            ],
+          }
+        }
+      end
+
+      let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+      let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
+
+      it 'returns true' do
+        vm = FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant)
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => vm)
+        expect(request.validate_conversion_hosts).to be true
+      end
     end
   end
 

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -14,11 +14,11 @@ describe ServiceTemplateTransformationPlanRequest do
     FactoryGirl.create(
       :transformation_mapping,
       :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
-    )   
-  end 
+    )
+  end
 
   let(:catalog_item_options) do
-    {   
+    {
       :name        => 'Transformation Plan',
       :description => 'a description',
       :config_info => {
@@ -28,8 +28,8 @@ describe ServiceTemplateTransformationPlanRequest do
           {:vm_id => vms.last.id.to_s, :pre_service => false, :post_service => false},
         ],
       }
-    }   
-  end 
+    }
+  end
 
   let(:plan) { FactoryGirl.create(:service_template_transformation_plan, :service_resources => vm_requests) }
   let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }


### PR DESCRIPTION
When a no conversion host is configured in the destination EMS, the migration tasks will stall because the throttler won't be able to assign a conversion host. To avoid hanging requests, we should check that at least one conversion host is available in the destination EMS. This PR implements a validation method in ServiceTemplateTransformationPlanRequest, that will be exposed in Automate.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1640816