### PR TITLE
Fix typo in get_conversion_log method

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -60,7 +60,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def get_conversion_log(path)
-    connect_ssh { |ssu| ssu.get_file_file(path, nil) }
+    connect_ssh { |ssu| ssu.get_file(path, nil) }
   rescue => e
     raise "Could not get conversion log '#{path}' from '#{resource.name}' with [#{e.class}: #{e}"
   end 


### PR DESCRIPTION
This PR fixes a typo that prevents downloading conversion log.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1643561