### PR TITLE
Fix OpenStack virt-v2v-wrapper options hash

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -290,12 +290,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
           :host   => destination_ems.hostname,
           :port   => destination_ems.port,
           :path   => '/' + destination_ems.api_version
-        ),
+        ).to_s,
         :os_identity_api_version => '3',
         :os_user_domain_name     => destination_ems.uid_ems,
         :os_username             => destination_ems.authentication_userid,
         :os_password             => destination_ems.authentication_password,
-        :os_project_name         => cluster.name
+        :os_project_name         => conversion_host.resource.cloud_tenant.name
       },
       :osp_server_id              => conversion_host.ems_ref,
       :osp_destination_project_id => cluster.ems_ref,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -509,11 +509,13 @@ describe ServiceTemplateTransformationPlanTask do
 
       context 'destination is openstack' do
         let(:dst_ems) { FactoryGirl.create(:ems_openstack, :api_version => 'v3', :zone => FactoryGirl.create(:zone)) }
-        let(:dst_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :ext_management_system => dst_ems) }
+        let(:dst_cloud_tenant) { FactoryGirl.create(:cloud_tenant, :name => 'fake tenant', :ext_management_system => dst_ems) }
         let(:dst_cloud_volume_type) { FactoryGirl.create(:cloud_volume_type) }
         let(:dst_cloud_network_1) { FactoryGirl.create(:cloud_network) }
         let(:dst_cloud_network_2) { FactoryGirl.create(:cloud_network) }
-        let(:conversion_host_vm) { FactoryGirl.create(:vm, :ext_management_system => dst_ems) }
+        let(:dst_flavor) { FactoryGirl.create(:flavor) }
+        let(:dst_security_group) { FactoryGirl.create(:security_group) }
+        let(:conversion_host_vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant) }
         let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => conversion_host_vm) }
 
         let(:mapping) do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -563,7 +563,7 @@ describe ServiceTemplateTransformationPlanTask do
                   :host   => dst_ems.hostname,
                   :port   => dst_ems.port,
                   :path   => '/v3'
-                ),
+                ).to_s,
                 :os_identity_api_version => '3',
                 :os_user_domain_name     => dst_ems.uid_ems,
                 :os_username             => dst_ems.authentication_userid,
@@ -597,7 +597,7 @@ describe ServiceTemplateTransformationPlanTask do
                   :host   => dst_ems.hostname,
                   :port   => dst_ems.port,
                   :path   => '/v3'
-                ),
+                ).to_s,
                 :os_identity_api_version => '3',
                 :os_user_domain_name     => dst_ems.uid_ems,
                 :os_username             => dst_ems.authentication_userid,


### PR DESCRIPTION
When migrating the to OpenStack, the hash passed to virt-v2v-wrapper contains the OpenStack authentication URL and the authentication project name. There was an error and this PR fixes it.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1644069