### PR TITLE
system_context_requester User needs to be scoped by region

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -252,7 +252,7 @@ module RetirementMixin
       User.find(evm_owner_id)
     else
       $log.info("System context defaulting to admin user because owner of #{name} not set.")
-      User.find_by(:userid => 'admin')
+      User.in_my_region.find_by(:userid => 'admin')
     end
   end
 


### PR DESCRIPTION
The system_context_requester User needs to be scoped by region on master too. Found when working on https://github.com/ManageIQ/manageiq/pull/18106#issuecomment-430747576
