### PR TITLE
Fix flavor and security group collection

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -124,11 +124,11 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def destination_flavor
-    Flavor.find_by(:id => miq_request.source.options[:config_info][:osp_flavor])
+    Flavor.find_by(:id => vm_resource.options["osp_flavor_id"])
   end
 
   def destination_security_group
-    SecurityGroup.find_by(:id => miq_request.source.options[:config_info][:osp_security_group])
+    SecurityGroup.find_by(:id => vm_resource.options["osp_security_group_id"])
   end
 
   def transformation_log

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -235,10 +235,8 @@ describe ServiceTemplateTransformationPlanTask do
           :transformation_mapping_id => mapping.id,
           :pre_service_id            => apst.id,
           :post_service_id           => apst.id,
-          :osp_flavor                => dst_flavor.id,
-          :osp_security_group        => dst_security_group.id,
           :actions                   => [
-            {:vm_id => src_vm_1.id.to_s, :pre_service => true, :post_service => true},
+            {:vm_id => src_vm_1.id.to_s, :pre_service => true, :post_service => true, :osp_flavor_id => dst_flavor.id, :osp_security_group_id => dst_security_group.id},
             {:vm_id => src_vm_2.id.to_s, :pre_service => false, :post_service => false},
           ],
         }
@@ -515,8 +513,6 @@ describe ServiceTemplateTransformationPlanTask do
         let(:dst_cloud_volume_type) { FactoryGirl.create(:cloud_volume_type) }
         let(:dst_cloud_network_1) { FactoryGirl.create(:cloud_network) }
         let(:dst_cloud_network_2) { FactoryGirl.create(:cloud_network) }
-        let(:dst_flavor) { FactoryGirl.create(:flavor) }
-        let(:dst_security_group) { FactoryGirl.create(:security_group) }
         let(:conversion_host_vm) { FactoryGirl.create(:vm, :ext_management_system => dst_ems) }
         let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => conversion_host_vm) }
 


### PR DESCRIPTION
The current code looks for flavor and security group in the miq_request, while it is stored in the VM resource of the request. This breaks migration to OpenStack. This PR fixes it.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1644601
