### PR TITLE
Use images to get registry pods using the registry instead of running it.

### DIFF
--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -3,7 +3,7 @@ class ContainerImageRegistry < ApplicationRecord
   has_many :container_images, :dependent => :nullify
   has_many :containers, :through => :container_images
   has_many :container_services
-  has_many :container_groups, :through => :container_services
+  has_many :container_groups, :through => :container_images
 
   acts_as_miq_taggable
   virtual_column :full_name, :type => :string

--- a/app/models/container_image_registry.rb
+++ b/app/models/container_image_registry.rb
@@ -1,9 +1,15 @@
 class ContainerImageRegistry < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => "ems_id"
+
+  # Associated with images in the registry.
   has_many :container_images, :dependent => :nullify
   has_many :containers, :through => :container_images
-  has_many :container_services
   has_many :container_groups, :through => :container_images
+
+  # Associated with serving the registry itself - for openshift's internal
+  # image registry. These will be empty for external registries.
+  has_many :container_services
+  has_many :service_container_groups, :through => :container_services, :as => :container_groups
 
   acts_as_miq_taggable
   virtual_column :full_name, :type => :string


### PR DESCRIPTION
**Description**

Currently, `number of pods` is the number of pods that **run the registry-service**.
It makes more seance that  `number of pods` will count the number of pods **using the registry-service**.

This PR changes the meaning of `Container Pods` from **running** the registry to **using** it.

**Screenshot**
![manageiq image registries](https://user-images.githubusercontent.com/2181522/47781555-a013e200-dd06-11e8-8dc0-979096864141.png)

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1599696