### PR TITLE
[WIP] Fix for user specified method calls on generic_objects.

### DIFF
--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -125,6 +125,19 @@ class GenericObject < ApplicationRecord
     @tenant ||= @user.current_tenant
   end
 
+  def public_send(method_name, *args)
+    m = method_name.to_s.chomp("=")
+
+    return _call_automate(m, *args) if property_method_defined?(m)
+
+    if property_attribute_defined?(m) || property_association_defined?(m)
+      return method_name.to_s.end_with?('=') ? _property_setter(m, args.first) : _property_getter(m)
+    end
+
+    super
+  end
+  alias go_send public_send
+
   private
 
   # The properties column contains raw data that are converted during read/write.
@@ -135,18 +148,6 @@ class GenericObject < ApplicationRecord
   end
 
   def properties=(options)
-    super
-  end
-
-  def method_missing(method_name, *args)
-    m = method_name.to_s.chomp("=")
-
-    return _call_automate(m, *args) if property_method_defined?(m)
-
-    if property_attribute_defined?(m) || property_association_defined?(m)
-      return method_name.to_s.end_with?('=') ? _property_setter(m, args.first) : _property_getter(m)
-    end
-
     super
   end
 

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -95,7 +95,7 @@ describe GenericObjectDefinition do
       obj = definition.create_object(:name => 'test', :max_number => 100)
       expect(obj).to be_a_kind_of(GenericObject)
       expect(obj.generic_object_definition).to eq(definition)
-      expect(obj.max_number).to eq(100)
+      expect(obj.go_send(:max_number)).to(eq(100))
     end
   end
 
@@ -239,7 +239,7 @@ describe GenericObjectDefinition do
       vm = FactoryGirl.create(:vm)
       go = FactoryGirl.create(:generic_object, :name => 'test', :generic_object_definition => definition)
       go.add_to_property_association('vms', vm)
-      expect(go.vms.size).to eq(1)
+      expect(go.go_send(:vms).size).to(eq(1))
 
       definition.delete_property_association(:vms)
       expect(go.reload.send(:properties)["vms"]).to be_nil
@@ -284,7 +284,7 @@ describe GenericObjectDefinition do
       3.times { vm << FactoryGirl.create(:vm_vmware) }
 
       definition.add_property_association(:vms, 'vm')
-      @g1.vms = [vm[0], vm[1], vm[2]]
+      @g1.go_send(:vms=, [vm[0], vm[1], vm[2]])
       @g1.save!
 
       @options = {:vms => [vm[0].id, vm[1].id]}


### PR DESCRIPTION
Description
----------------
Adding the new method `#go_send` for `generic_object`(GO) model. This change is part of the fix for the BZ bellow. This new method calls the user specified methods at the first place, then it tries to call the native built-in method. This PR fixs the bug with calling the custom method with the name from native built-in methods. It also removes the `method_missing` method from GO model, so every attempt to call custom method should go through `#go_send` method.

This new method is used in PR: https://github.com/ManageIQ/manageiq-automation_engine/pull/223.

Links
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1607940
