### PR TITLE
Add ems to infra provider host factory

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -186,7 +186,7 @@ FactoryGirl.define do
           :parent => :ems_openstack_infra do
     after :create do |x|
       x.orchestration_stacks << FactoryGirl.create(:orchestration_stack_openstack_infra)
-      4.times { x.hosts << FactoryGirl.create(:host_openstack_infra) }
+      4.times { x.hosts << FactoryGirl.create(:host_openstack_infra, :ext_management_system => FactoryGirl.create(:ems_openstack_infra)) }
     end
   end
 


### PR DESCRIPTION
This PR adds ems to infra provider host factory. It's needed for https://github.com/ManageIQ/manageiq-providers-openstack/pull/380



https://bugzilla.redhat.com/show_bug.cgi?id=1584770