### PR TITLE
Include resource_action type and ID in linked components error message

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -182,7 +182,8 @@ class Dialog < ApplicationRecord
 
   def reject_if_has_resource_actions
     if resource_actions.length > 0
-      raise _("Dialog cannot be deleted because it is connected to other components.")
+      connected_components = resource_actions.collect { |ra| ra.resource_type.constantize.find(ra.resource_id) }
+      raise _("Dialog cannot be deleted because it is connected to other components: #{connected_components.map { |cc| cc.class.name + ":" + cc.id.to_s + " - " + cc.try(:name) }}")
     end
   end
 

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -89,9 +89,9 @@ describe Dialog do
 
     it "destroy with resource_action association" do
       dialog = FactoryGirl.create(:dialog)
-      FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog)
+      FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog, :resource_type => Dialog, :resource_id => dialog.id)
       expect { dialog.destroy }
-        .to raise_error(RuntimeError, /Dialog cannot be deleted.*connected to other components/)
+      .to raise_error(RuntimeError, "Dialog cannot be deleted because it is connected to other components: [\"Dialog:#{dialog.id} - #{dialog.name}\"]")
       expect(Dialog.count).to eq(1)
     end
   end


### PR DESCRIPTION
Will help debug https://bugzilla.redhat.com/show_bug.cgi?id=1644320. 

When trying to delete a service dialog, if the dialog has connected components, it can't be deleted but this enhances the error message to tell you if what is still connected to the dialog. 

before: 
<img width="824" alt="screen shot 2018-10-31 at 4 27 59 pm" src="https://user-images.githubusercontent.com/16326669/47816751-51783f00-dd2a-11e8-9614-7a0300c018fc.png">
after: 
![screen shot 2018-11-01 at 9 06 00 am](https://user-images.githubusercontent.com/16326669/47854480-36541080-ddb8-11e8-9b8f-9c29b3acd412.png)

