### PR TITLE
Credential.manager_ref needs to be an integer for Tower 3.3 

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -125,6 +125,11 @@ class Authentication < ApplicationRecord
     end
   end
 
+  def native_ref
+    # to be overridden by individual provider/manager
+    manager_ref
+  end
+
   private
 
   def set_credentials_changed_on


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1640533
Related to https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/134
