### PR TITLE
Credential.manager_ref need to be an integer for Tower 3.3

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -46,7 +46,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook <
 
     %i(credential vault_credential cloud_credential network_credential).each do |credential|
       cred_sym = "#{credential}_id".to_sym
-      params[credential] = Authentication.find(options[cred_sym]).manager_ref if options[cred_sym].present?
+      params[credential] = Authentication.find(options[cred_sym]).native_ref if options[cred_sym].present?
     end
 
     params.compact

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -95,7 +95,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     %i(credential vault_credential).each do |cred|
       cred_sym = "#{cred}_id".to_sym
       credential_id = job_options.delete(cred_sym)
-      job_options[cred] = Authentication.find(credential_id).manager_ref if credential_id.present?
+      job_options[cred] = Authentication.find(credential_id).native_ref if credential_id.present?
     end
 
     hosts = job_options[:hosts]

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -107,7 +107,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
 
     %i(credential vault_credential cloud_credential network_credential).each do |credential|
       cred_sym = "#{credential}_id".to_sym
-      params[credential] = Authentication.find(info[cred_sym]).manager_ref if info[cred_sym]
+      params[credential] = Authentication.find(info[cred_sym]).native_ref if info[cred_sym]
     end
 
     [tower, params.compact]

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -98,40 +98,48 @@ FactoryGirl.define do
           :parent => :authentication,
           :class  => "ManageIQ::Providers::EmbeddedAutomationManager::Authentication"
 
-  factory :ansible_cloud_credential,
+  factory :ansible_credential,
           :parent => :automation_manager_authentication,
+          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::Credential"
+
+  factory :ansible_cloud_credential,
+          :parent => :ansible_credential,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential"
 
   factory :ansible_machine_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :ansible_credential,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential"
 
   factory :ansible_vault_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :ansible_credential,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::VaultCredential"
 
   factory :ansible_network_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :ansible_credential,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential"
 
   factory :ansible_scm_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :ansible_credential,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential"
 
+  factory :embedded_ansible_credential,
+          :parent => :embedded_automation_manager_authentication,
+          :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential"
+
   factory :embedded_ansible_amazon_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential"
 
   factory :embedded_ansible_machine_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential"
 
   factory :embedded_ansible_vault_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential"
 
   factory :embedded_ansible_scm_credential,
-          :parent => :automation_manager_authentication,
+          :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential"
 
   factory :auth_key_pair_cloud,     :class => "ManageIQ::Providers::CloudManager::AuthKeyPair"

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
   let(:manager) { FactoryGirl.create(:embedded_automation_manager_ansible) }
-  let(:auth_one) { FactoryGirl.create(:authentication, :manager_ref => 6) }
-  let(:auth_two) { FactoryGirl.create(:authentication, :manager_ref => 8) }
+  let(:auth_one) { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '6') }
+  let(:auth_two) { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '8') }
   subject { FactoryGirl.create(:embedded_playbook, :manager => manager) }
 
   describe '#run' do
@@ -21,8 +21,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
         :extra_vars       => '{"a":"x"}',
         :playbook         => subject.name,
         :project          => 'mref',
-        :credential       => '6',
-        :vault_credential => '8'
+        :credential       => 6,
+        :vault_credential => 8
       )
 
       allow(subject).to receive(:configuration_script_source).and_return(double(:manager_ref => 'mref'))

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -4,10 +4,10 @@ describe(ServiceAnsiblePlaybook) do
   let(:basic_service)  { FactoryGirl.create(:service_ansible_playbook, :options => config_info_options) }
   let(:service)        { FactoryGirl.create(:service_ansible_playbook, :options => config_info_options.merge(dialog_options)) }
   let(:action)         { ResourceAction::PROVISION }
-  let(:credential_0)   { FactoryGirl.create(:authentication, :manager_ref => '1') }
-  let(:credential_1)   { FactoryGirl.create(:authentication, :manager_ref => 'a') }
-  let(:credential_2)   { FactoryGirl.create(:authentication, :manager_ref => 'b') }
-  let(:credential_3)   { FactoryGirl.create(:authentication, :manager_ref => '2') }
+  let(:credential_0)   { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '1') }
+  let(:credential_1)   { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '2') }
+  let(:credential_2)   { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '3') }
+  let(:credential_3)   { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '4') }
   let(:decrpyted_val)  { 'my secret' }
   let(:encrypted_val)  { MiqPassword.encrypt(decrpyted_val) }
   let(:encrypted_val2) { MiqPassword.encrypt(decrpyted_val + "new") }
@@ -97,7 +97,7 @@ describe(ServiceAnsiblePlaybook) do
         service.reload
         expect(service.options[:provision_job_options]).to include(
           :inventory  => 20,
-          :credential => credential_1.manager_ref,
+          :credential => credential_1.native_ref,
           :extra_vars => {'var1' => 'value1', 'var2' => 'value2', 'var3' => 'default_val3', 'pswd' => encrypted_val}
         )
       end
@@ -133,7 +133,7 @@ describe(ServiceAnsiblePlaybook) do
         service.reload
         expect(service.options[:provision_job_options]).to include(
           :inventory  => 30,
-          :credential => credential_2.manager_ref,
+          :credential => credential_2.native_ref,
           :extra_vars => {'var1' => 'new_val1', 'var2' => 'value2', 'var3' => 'default_val3', 'pswd' => encrypted_val2}
         )
       end

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -1,8 +1,8 @@
 describe ServiceTemplateAnsiblePlaybook do
   let(:user)     { FactoryGirl.create(:user_with_group) }
-  let(:auth_one) { FactoryGirl.create(:authentication, :manager_ref => 6) }
-  let(:auth_two) { FactoryGirl.create(:authentication, :manager_ref => 10) }
-  let(:auth_three) { FactoryGirl.create(:authentication, :manager_ref => 14) }
+  let(:auth_one) { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '6') }
+  let(:auth_two) { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '10') }
+  let(:auth_three) { FactoryGirl.create(:embedded_ansible_credential, :manager_ref => '14') }
 
   let(:script_source) { FactoryGirl.create(:configuration_script_source, :manager => ems) }
 
@@ -135,9 +135,9 @@ describe ServiceTemplateAnsiblePlaybook do
         :description        => description,
         :become_enabled     => true,
         :verbosity          => 3,
-        :credential         => '6',
-        :network_credential => '10',
-        :vault_credential   => '14'
+        :credential         => 6,
+        :network_credential => 10,
+        :vault_credential   => 14
       )
 
       expect(params.keys).to_not include(:extra_vars, :cloud_credentials)


### PR DESCRIPTION
Follow up of https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/134.

Change the callers of ```credential.manager_ref``` to use ```native_ref```.

Includes https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/138.
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1640533

@miq-bot assign @gmcculloug 
@miq-bot add_label blocker, bug, hammer/yes