### PR TITLE
[wip]Add support for hook_object in Ansible runner

### DIFF
--- a/app/models/manageiq/providers/ansible_role_workflow.rb
+++ b/app/models/manageiq/providers/ansible_role_workflow.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::AnsibleRoleWorkflow < ManageIQ::Providers::AnsibleRunnerWorkflow
-  def self.job_options(env_vars, extra_vars, role_options, timeout, poll_interval)
+  def self.job_options(env_vars, extra_vars, role_options, timeout, poll_interval, hook_object)
     {
       :env_vars        => env_vars,
       :extra_vars      => extra_vars,
@@ -7,7 +7,8 @@ class ManageIQ::Providers::AnsibleRoleWorkflow < ManageIQ::Providers::AnsibleRun
       :roles_path      => role_options[:roles_path],
       :role_skip_facts => role_options[:role_skip_facts],
       :timeout         => timeout,
-      :poll_interval   => poll_interval
+      :poll_interval   => poll_interval,
+      :hook_object     => hook_object
     }
   end
 
@@ -17,9 +18,9 @@ class ManageIQ::Providers::AnsibleRoleWorkflow < ManageIQ::Providers::AnsibleRun
   end
 
   def run_role
-    env_vars, extra_vars, role_name, roles_path, role_skip_facts = options.values_at(:env_vars, :extra_vars, :role_name, :roles_path, :role_skip_facts)
+    env_vars, extra_vars, role_name, roles_path, role_skip_facts, hook_object = options.values_at(:env_vars, :extra_vars, :role_name, :roles_path, :role_skip_facts, :hook_object)
     role_skip_facts = true if role_skip_facts.nil?
-    response = Ansible::Runner.run_role_async(env_vars, extra_vars, role_name, :roles_path => roles_path, :role_skip_facts => role_skip_facts)
+    response = Ansible::Runner.run_role_async(env_vars, extra_vars, role_name, :roles_path => roles_path, :role_skip_facts => role_skip_facts, :hook_object => hook_object)
     if response.nil?
       queue_signal(:abort, "Failed to run ansible role", "error")
     else

--- a/app/models/manageiq/providers/ansible_runner_workflow.rb
+++ b/app/models/manageiq/providers/ansible_runner_workflow.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::AnsibleRunnerWorkflow < Job
-  def self.create_job(env_vars, extra_vars, role_or_playbook_options, timeout: 1.hour, poll_interval: 1.second)
-    super(name, job_options(env_vars, extra_vars, role_or_playbook_options, timeout, poll_interval))
+  def self.create_job(env_vars, extra_vars, role_or_playbook_options, timeout: 1.hour, poll_interval: 1.second, hook_object: nil)
+    super(name, job_options(env_vars, extra_vars, role_or_playbook_options, timeout, poll_interval, hook_object))
   end
 
   def current_job_timeout(_timeout_adjustment = 1)

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -138,10 +138,13 @@ module Ansible
       #        "run", which is sync call, or "start" which is async call.  Default is "run"
       # @param playbook_or_role_args [Hash] Hash that includes the :playbook key or :role keys
       # @return [Ansible::Runner::Response] Response object with all details about the ansible run
-      def run_via_cli(env_vars, extra_vars, tags: nil, ansible_runner_method: "run", **playbook_or_role_args)
+      def run_via_cli(env_vars, extra_vars, tags: nil, ansible_runner_method: "run", hook_object: nil, **playbook_or_role_args)
         validate_params!(env_vars, extra_vars, tags, ansible_runner_method, playbook_or_role_args)
 
         base_dir = Dir.mktmpdir("ansible-runner")
+        if hook_object&.responds_to?(:after_dir_create)
+          hook_object.after_dir_create(base_dir, env_vars, extra_vars, ansible_runner_method, playbook_or_role_args)
+        end
         params = runner_params(base_dir, ansible_runner_method, extra_vars, tags, playbook_or_role_args)
 
         begin

--- a/spec/factories/ems_cluster.rb
+++ b/spec/factories/ems_cluster.rb
@@ -10,4 +10,5 @@ FactoryGirl.define do
   end
 
   factory :ems_cluster_openstack, :class => "ManageIQ::Providers::Openstack::InfraManager::EmsCluster", :parent => :ems_cluster
+  factory :ems_cluster_redhat, :class    => "ManageIQ::Providers::Redhat::InfraManager::EmsCluster", :parent => :ems_cluster
 end

--- a/spec/models/manageiq/providers/ansible_role_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ansible_role_workflow_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::AnsibleRoleWorkflow do
   let(:job)          { described_class.create_job(*options).tap { |job| job.state = state } }
-  let(:role_options) { {:role_name => 'role_name', :roles_path => 'path/role', :role_skip_facts => true } }
+  let(:role_options) { {:role_name => 'role_name', :roles_path => 'path/role', :role_skip_facts => true, :hook_object => nil } }
   let(:options)      { [{"ENV" => "VAR"}, %w(arg1 arg2), role_options] }
   let(:state)        { "waiting_to_start" }
 
@@ -93,7 +93,7 @@ describe ManageIQ::Providers::AnsibleRoleWorkflow do
       response_async = Ansible::Runner::ResponseAsync.new(:base_dir => "/path/to/results")
 
       expect(Ansible::Runner).to receive(:run_role_async)
-        .with({"ENV"=>"VAR"}, %w(arg1 arg2), "role_name", :roles_path => "path/role", :role_skip_facts => true).and_return(response_async)
+        .with({"ENV"=>"VAR"}, %w(arg1 arg2), "role_name", :roles_path => "path/role", :role_skip_facts => true, :hook_object => nil).and_return(response_async)
       expect(job).to receive(:queue_signal).with(:poll_runner)
 
       job.signal(:run_role)


### PR DESCRIPTION
Support passing a hook object when running a role, currently it will be
called after the temporary directory is created.
The current use case is to create a temporary cert_file for an Ansible
task.

This is part of implementing: https://bugzilla.redhat.com/show_bug.cgi?id=1644605