### PR TITLE
Support for automate ansible job/workflow template method.

### DIFF
--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -17,7 +17,7 @@ class MiqAeMethod < ApplicationRecord
 
   AVAILABLE_LANGUAGES  = ["ruby", "perl"]  # someday, add sh, perl, python, tcl and any other scripting language
   validates_inclusion_of  :language,  :in => AVAILABLE_LANGUAGES
-  AVAILABLE_LOCATIONS = %w(builtin inline expression playbook).freeze
+  AVAILABLE_LOCATIONS = %w(builtin inline expression playbook ansible_job_template ansible_workflow_template).freeze
   validates_inclusion_of  :location,  :in => AVAILABLE_LOCATIONS
   AVAILABLE_SCOPES     = ["class", "instance"]
   validates_inclusion_of  :scope,     :in => AVAILABLE_SCOPES


### PR DESCRIPTION
Add new locations ```ansible_job_template``` and ```ansible_workflow_template``` for new automate method types for external Ansible Tower job/workflow template.

Part of https://github.com/ManageIQ/manageiq-automation_engine/pull/265.
Related to https://github.com/ManageIQ/manageiq-automation_engine/pull/284.
Related to https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/136.

https://bugzilla.redhat.com/show_bug.cgi?id=1591797

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement

The class of Ansible Tower job template is `ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript`.

The class of Ansible Tower workflow template is `ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow`.

Their common parent class is `ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript`.