### PR TITLE
Rails 5.1 upgrade change uniq to distinct

### DIFF
--- a/app/models/authenticator.rb
+++ b/app/models/authenticator.rb
@@ -19,7 +19,7 @@ module Authenticator
   end
 
   private_class_method def self.valid_modes
-    Base.subclasses.flat_map(&:authenticates_for).uniq << "none"
+    Base.subclasses.flat_map(&:authenticates_for).distinct << "none"
   end
 
   private_class_method def self.authenticator_class(name)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -112,7 +112,7 @@ module Authenticator
         end
       end
 
-      groups.uniq
+      groups.distinct
     end
 
     def update_user_attributes(user, _username, lobj)

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -93,7 +93,7 @@ class ChargeableField < ApplicationRecord
   end
 
   def self.cols_on_metric_rollup
-    (%w(id tag_names resource_id) + chargeable_cols_on_metric_rollup).uniq
+    (%w(id tag_names resource_id) + chargeable_cols_on_metric_rollup).distinct
   end
 
   def self.col_index(column)

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -46,7 +46,7 @@ class Chargeback < ActsAsArModel
         data[key] ||= new(options, consumption, region.region)
 
         chargeback_rates = data[key]["chargeback_rates"].split(', ') + rates_to_apply.collect(&:description)
-        data[key]["chargeback_rates"] = chargeback_rates.uniq.join(', ')
+        data[key]["chargeback_rates"] = chargeback_rates.distinct.join(', ')
 
         # we are getting hash with metrics and costs for metrics defined for chargeback
         if Settings[:new_chargeback]

--- a/app/models/chargeback/consumption_with_rollups.rb
+++ b/app/models/chargeback/consumption_with_rollups.rb
@@ -63,11 +63,11 @@ class Chargeback
     end
 
     def tag_list_with_prefix_for(rollup)
-      (all_tag_names(rollup) + container_tag_list_with_prefix).uniq.reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + chargeback_container_labels
+      (all_tag_names(rollup) + container_tag_list_with_prefix).distinct.reject(&:empty?).map { |x| "#{tag_prefix}#{x}" } + chargeback_container_labels
     end
 
     def tag_list_with_prefix
-      @tag_list_with_prefix ||= @rollup_array.map { |rollup| tag_list_with_prefix_for(rollup) }.flatten.uniq
+      @tag_list_with_prefix ||= @rollup_array.map { |rollup| tag_list_with_prefix_for(rollup) }.flatten.distinct
     end
 
     def sum(metric, sub_metric = nil)

--- a/app/models/container_deployment.rb
+++ b/app/models/container_deployment.rb
@@ -103,7 +103,7 @@ EOS
       "variant_version"        => kind.include?("origin") ? '1.2' : '3.2',
       "variant"                => kind
     }
-    if container_deployment_nodes.collect(&:roles).flatten.uniq.include?("master_lb")
+    if container_deployment_nodes.collect(&:roles).flatten.distinct.include?("master_lb")
       config["deployment"].merge!(
         "openshift_master_cluster_method"          => "native",
         "openshift_master_cluster_hostname"        => roles_addresses("master_lb").first,
@@ -249,7 +249,7 @@ EOS
 
   def generate_roles
     result = {}
-    roles = container_deployment_nodes.collect(&:roles).flatten.uniq
+    roles = container_deployment_nodes.collect(&:roles).flatten.distinct
     result["master"] = {"osm_use_cockpit"                     => "false",
                         "openshift_master_identity_providers" => [identity_ansible_config_format]} if roles.include?("master")
     unless identity_provider_auth.first.htpassd_users.empty?

--- a/app/models/container_deployment_node.rb
+++ b/app/models/container_deployment_node.rb
@@ -15,7 +15,7 @@ class ContainerDeploymentNode < ApplicationRecord
 
   def roles
     tags.reset
-    tags.collect { |tag| tag.name.gsub("/user/", "").gsub("deployment_master", "master") }.uniq
+    tags.collect { |tag| tag.name.gsub("/user/", "").gsub("deployment_master", "master") }.distinct
   end
 
   def to_ansible_config_format

--- a/app/models/container_label_tag_mapping.rb
+++ b/app/models/container_label_tag_mapping.rb
@@ -38,7 +38,7 @@ class ContainerLabelTagMapping < ApplicationRecord
   # TODO: expensive.
   def self.controls_tag?(tag)
     return false unless tag.classification.try(:read_only) # never touch user-assignable tags.
-    tag_ids = [tag.id, tag.category.tag_id].uniq
+    tag_ids = [tag.id, tag.category.tag_id].distinct
     where(:tag_id => tag_ids).any?
   end
 

--- a/app/models/container_label_tag_mapping/mapper.rb
+++ b/app/models/container_label_tag_mapping/mapper.rb
@@ -45,7 +45,7 @@ class ContainerLabelTagMapping
     # @param labels [Array] array of {:name, :value} hashes.
     # @return [Array<InventoryObject>] representing desired tags.
     def map_labels(type, labels)
-      labels.collect_concat { |label| map_label(type, label) }.uniq
+      labels.collect_concat { |label| map_label(type, label) }.distinct
     end
 
     # Convert "tag references" to actual Tag objects.  Must have been resolved to known id first.

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -106,7 +106,7 @@ class ContainerNode < ApplicationRecord
   def external_logging_path
     node_hostnames = [kubernetes_hostname || name] # node name cannot be empty, it's an ID
     node_hostnames.push(node_hostnames.first.split('.').first).compact!
-    node_hostnames_query = node_hostnames.uniq.map { |x| "(term:(hostname:'#{x}'))" }.join(",")
+    node_hostnames_query = node_hostnames.distinct.map { |x| "(term:(hostname:'#{x}'))" }.join(",")
     query = "bool:(filter:(or:!(#{node_hostnames_query})))"
     index = ".operations.*"
     EXTERNAL_LOGGING_PATH % {:index => index, :query => query}

--- a/app/models/disk.rb
+++ b/app/models/disk.rb
@@ -47,7 +47,7 @@ class Disk < ApplicationRecord
   end
 
   def volumes
-    partitions.collect(&:volumes).flatten.uniq
+    partitions.collect(&:volumes).flatten.distinct
   end
 
   def used_percent_of_provisioned

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -256,7 +256,7 @@ class EmsCluster < ApplicationRecord
       h[c.id] = {:cl_rec => c, :ho_ids => c.host_ids}
     end
 
-    hids = cl_hash.values.flat_map { |v| v[:ho_ids] }.compact.uniq
+    hids = cl_hash.values.flat_map { |v| v[:ho_ids] }.compact.distinct
     hosts_by_id = Host.where(:id => hids).includes(:tags, :taggings).select(:id, :name).index_by(&:id)
 
     cl_hash.each do |_k, v|

--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -14,7 +14,7 @@ class EmsEvent
       targets = targets.flatten
       return if targets.blank?
 
-      refresh_targets = targets.collect { |t| get_target("#{t}_refresh_target") unless t.blank? }.compact.uniq
+      refresh_targets = targets.collect { |t| get_target("#{t}_refresh_target") unless t.blank? }.compact.distinct
       return if refresh_targets.empty?
 
       EmsRefresh.queue_refresh(refresh_targets, nil, :create_task => sync)

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -56,7 +56,7 @@ module EmsRefresh
 
     # Queue the refreshes
     task_ids = targets_by_ems.collect do |ems, ts|
-      ts = ts.collect { |t| [t.class.to_s, t.id] }.uniq
+      ts = ts.collect { |t| [t.class.to_s, t.id] }.distinct
       queue_merge(ts, ems, opts[:create_task])
     end
 
@@ -82,7 +82,7 @@ module EmsRefresh
     EmsRefresh.init_console if defined?(Rails::Console)
 
     # Handle targets passed as a single class/id pair, an array of class/id pairs, or an array of references
-    targets = get_target_objects(target, id).uniq
+    targets = get_target_objects(target, id).distinct
 
     # Store manager records to avoid n+1 queries
     manager_by_manager_id = {}
@@ -143,7 +143,7 @@ module EmsRefresh
 
     # Do lookups to get ActiveRecord objects or initialize InventoryRefresh::Target for ids that are Hash
     targets_by_type.each_with_object([]) do |(target_class, ids), target_objects|
-      ids.uniq!
+      ids.distinct!
 
       recs = if target_class <= InventoryRefresh::Target
                ids.map { |x| InventoryRefresh::Target.load(x) }
@@ -229,8 +229,8 @@ module EmsRefresh
   def self.uniq_targets(targets)
     if targets.size > 1_000
       manager_refresh_targets, application_record_targets = targets.partition { |key, _| key == "InventoryRefresh::Target" }
-      application_record_targets.uniq!
-      manager_refresh_targets.uniq! { |_, value| value.values_at(:manager_id, :association, :manager_ref) }
+      application_record_targets.distinct!
+      manager_refresh_targets.distinct! { |_, value| value.values_at(:manager_id, :association, :manager_ref) }
 
       application_record_targets + manager_refresh_targets
     else

--- a/app/models/ems_refresh/metadata_relats.rb
+++ b/app/models/ems_refresh/metadata_relats.rb
@@ -51,7 +51,7 @@ module EmsRefresh::MetadataRelats
 
               next unless x.respond_to?(c_meth)
 
-              ids = x.send(c_meth).collect(&:id).uniq
+              ids = x.send(c_meth).collect(&:id).distinct
               relats["#{p_type}_to_#{c_type}".to_sym][x.id] |= ids unless ids.empty?
             end
           end
@@ -130,7 +130,7 @@ module EmsRefresh::MetadataRelats
           next if p_type == :clusters && c_type == :vms
           next if p_type == :hosts && c_type == :vms
 
-          ids = children.collect { |c| c[:id] }.compact.uniq
+          ids = children.collect { |c| c[:id] }.compact.distinct
           relats["#{p_type}_to_#{c_type}".to_sym][p_id] |= ids unless ids.empty?
         end
       end

--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -64,7 +64,7 @@ module EmsRefresh::SaveInventory
     vms = VmOrTemplate.where(:uid_ems => vms_uids).to_a
     disconnects_index = disconnects.index_by { |vm| vm }
     vms_by_uid_ems = vms.group_by(&:uid_ems)
-    dup_vms_uids = (vms_uids.duplicates + vms.collect(&:uid_ems).duplicates).uniq.sort
+    dup_vms_uids = (vms_uids.duplicates + vms.collect(&:uid_ems).duplicates).distinct.sort
     _log.info("#{log_header} Duplicate unique values found: #{dup_vms_uids.inspect}") unless dup_vms_uids.empty?
 
     invalids_found = false
@@ -161,7 +161,7 @@ module EmsRefresh::SaveInventory
 
     # Handle genealogy link ups
     # TODO: can we use _object
-    vm_ids = hashes.flat_map { |h| !h[:invalid] && h.has_key_path?(:parent_vm, :id) ? [h[:id], h.fetch_path(:parent_vm, :id)] : [] }.uniq
+    vm_ids = hashes.flat_map { |h| !h[:invalid] && h.has_key_path?(:parent_vm, :id) ? [h[:id], h.fetch_path(:parent_vm, :id)] : [] }.distinct
     unless vm_ids.empty?
       _log.info("#{log_header} Updating genealogy connections.")
       vms = VmOrTemplate.where(:id => vm_ids).index_by(&:id)

--- a/app/models/ems_refresh/save_inventory_cloud.rb
+++ b/app/models/ems_refresh/save_inventory_cloud.rb
@@ -90,7 +90,7 @@ module EmsRefresh::SaveInventoryCloud
     deletes = determine_deletes_using_association(ems, target, disconnect)
 
     hashes.each do |h|
-      h[:cloud_tenant_ids] = (h.delete(:cloud_tenants) || []).compact.map { |x| x[:id] }.uniq
+      h[:cloud_tenant_ids] = (h.delete(:cloud_tenants) || []).compact.map { |x| x[:id] }.distinct
     end
 
     save_inventory_multi(ems.flavors, hashes, deletes, [:ems_ref])

--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -249,7 +249,7 @@ module EmsRefresh::SaveInventoryNetwork
         h[:device_type] = device[:type].constantize.base_class.name
       end
 
-      h[:security_group_ids] = (h.delete(:security_groups) || []).map { |x| x.try(:[], :id) }.compact.uniq
+      h[:security_group_ids] = (h.delete(:security_groups) || []).map { |x| x.try(:[], :id) }.compact.distinct
       h[:source] = mode
     end
 

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -328,7 +328,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def delete_unused_connection_configurations(options)
-    chosen_endpoints = options.map { |x| x.deep_symbolize_keys.fetch_path(:endpoint, :role).try(:to_sym) }.compact.uniq
+    chosen_endpoints = options.map { |x| x.deep_symbolize_keys.fetch_path(:endpoint, :role).try(:to_sym) }.compact.distinct
     existing_endpoints = endpoints.pluck(:role).map(&:to_sym)
     # Delete endpoint that were not picked
     roles_for_deletion = existing_endpoints - chosen_endpoints
@@ -693,7 +693,7 @@ class ExtManagementSystem < ApplicationRecord
     (
       self.class.blacklisted_events.where(:enabled => true).pluck(:event_name) +
       blacklisted_events.where(:enabled => true).pluck(:event_name)
-    ).uniq.sort
+    ).distinct.sort
   end
 
   def self.blacklisted_events

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -77,7 +77,7 @@ class GenericObject < ApplicationRecord
 
     klass = generic_object_definition.property_associations[name].constantize
     selected = objs.select { |obj| obj.kind_of?(klass) }
-    properties[name] = (properties[name] + selected.pluck(:id)).uniq if selected
+    properties[name] = (properties[name] + selected.pluck(:id)).distinct if selected
     save!
   end
 
@@ -168,7 +168,7 @@ class GenericObject < ApplicationRecord
         type_cast(name, value)
       elsif property_association_defined?(name)
         # property association is of multiple values
-        value.select { |v| v.kind_of?(generic_object_definition.property_associations[name].constantize) }.uniq.map(&:id)
+        value.select { |v| v.kind_of?(generic_object_definition.property_associations[name].constantize) }.distinct.map(&:id)
       end
 
     self.properties = properties.merge(name => val)

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -33,18 +33,18 @@ class Hardware < ApplicationRecord
 
   def ipaddresses
     @ipaddresses ||= if networks.loaded?
-                       networks.collect(&:ipaddress).compact.uniq + networks.collect(&:ipv6address).compact.uniq
+                       networks.collect(&:ipaddress).compact.distinct + networks.collect(&:ipv6address).compact.distinct
                      else
-                       networks.pluck(:ipaddress, :ipv6address).flatten.tap(&:compact!).tap(&:uniq!)
+                       networks.pluck(:ipaddress, :ipv6address).flatten.tap(&:compact!).tap(&:distinct!)
                      end
   end
 
   def hostnames
-    @hostnames ||= networks.collect(&:hostname).compact.uniq
+    @hostnames ||= networks.collect(&:hostname).compact.distinct
   end
 
   def mac_addresses
-    @mac_addresses ||= nics.collect(&:address).compact.uniq
+    @mac_addresses ||= nics.collect(&:address).compact.distinct
   end
 
   def ram_size_in_bytes

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1486,11 +1486,11 @@ class Host < ApplicationRecord
 
     operating_system.firewall_rules.where(conditions)
       .flat_map { |rule| rule.port_range.to_a }
-      .uniq.sort
+      .distinct.sort
   end
 
   def service_names
-    system_services.collect(&:name).uniq.sort
+    system_services.collect(&:name).distinct.sort
   end
 
   def enabled_run_level_0_services
@@ -1527,7 +1527,7 @@ class Host < ApplicationRecord
     elsif args.length == 1
       services = host_services.where("enable_run_levels LIKE ?", "%#{args.first}%")
     end
-    services.order(:name).uniq.pluck(:name)
+    services.order(:name).distinct.pluck(:name)
   end
 
   def control_supported?

--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -287,7 +287,7 @@ class JobProxyDispatcher
       Job.where(:dispatch_status => "active")
       .where(:target_class     => "VmOrTemplate")
       .where("state != ?", "finished")
-      .pluck(:target_id).compact.uniq
+      .pluck(:target_id).compact.distinct
     return @busy_resources_for_embedded_scanning_hash if vms_in_embedded_scanning.blank?
 
     embedded_scans_by_resource = Hash.new { |h, k| h[k] = 0 }

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -65,15 +65,15 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   end
 
   def ipaddresses
-    @ipaddresses ||= network_ports.collect(&:ipaddresses).flatten.compact.uniq
+    @ipaddresses ||= network_ports.collect(&:ipaddresses).flatten.compact.distinct
   end
 
   def floating_ip_addresses
-    @floating_ip_addresses ||= network_ports.collect(&:floating_ip_addresses).flatten.compact.uniq
+    @floating_ip_addresses ||= network_ports.collect(&:floating_ip_addresses).flatten.compact.distinct
   end
 
   def fixed_ip_addresses
-    @fixed_ip_addresses ||= network_ports.collect(&:fixed_ip_addresses).flatten.compact.uniq
+    @fixed_ip_addresses ||= network_ports.collect(&:fixed_ip_addresses).flatten.compact.distinct
   end
 
   def cloud_network
@@ -87,7 +87,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   end
 
   def mac_addresses
-    @mac_addresses ||= network_ports.collect(&:mac_address).compact.uniq
+    @mac_addresses ||= network_ports.collect(&:mac_address).compact.distinct
   end
 
   def perf_rollup_parents(interval_name = nil)

--- a/app/models/metric/processing.rb
+++ b/app/models/metric/processing.rb
@@ -162,8 +162,8 @@ module Metric::Processing
         next if new_perf.assoc_ids.nil? || new_perf.assoc_ids[assoc].blank? || perf.assoc_ids[assoc].blank?
         new_perf.assoc_ids[assoc][:on] ||= []
         new_perf.assoc_ids[assoc][:off] ||= []
-        new_perf.assoc_ids[assoc][:on]  = (new_perf.assoc_ids[assoc][:on] + perf.assoc_ids[assoc][:on]).uniq!
-        new_perf.assoc_ids[assoc][:off] = (new_perf.assoc_ids[assoc][:off] + perf.assoc_ids[assoc][:off]).uniq!
+        new_perf.assoc_ids[assoc][:on]  = (new_perf.assoc_ids[assoc][:on] + perf.assoc_ids[assoc][:on]).distinct!
+        new_perf.assoc_ids[assoc][:off] = (new_perf.assoc_ids[assoc][:off] + perf.assoc_ids[assoc][:off]).distinct!
       end
     end
     new_perf

--- a/app/models/metric/rollup.rb
+++ b/app/models/metric/rollup.rb
@@ -346,7 +346,7 @@ module Metric::Rollup
       [:on, :off].each do |mode|
         next if value[assoc][mode].nil?
         result[c][assoc][mode] ||= []
-        result[c][assoc][mode].concat(value[assoc][mode]).uniq!
+        result[c][assoc][mode].concat(value[assoc][mode]).distinct!
       end
     end
   end
@@ -354,7 +354,7 @@ module Metric::Rollup
   def self.rollup_tags(c, result, value)
     return if value.blank?
     result[c] ||= ""
-    result[c] = result[c].split(TAG_SEP).concat(value.split(TAG_SEP)).uniq.join(TAG_SEP)
+    result[c] = result[c].split(TAG_SEP).concat(value.split(TAG_SEP)).distinct.join(TAG_SEP)
   end
 
   #
@@ -384,7 +384,7 @@ module Metric::Rollup
     metric_rollups = MetricRollup.in_my_region.select("DISTINCT resource_type, resource_id")
 
     recs = (metrics + metric_rollups).group_by(&:resource_type)
-    recs.keys.each { |k| recs[k] = recs[k].collect(&:resource_id).uniq }
+    recs.keys.each { |k| recs[k] = recs[k].collect(&:resource_id).distinct }
 
     recs.each_with_object([]) do |(klass, ids), ret|
       ret.concat(klass.constantize.where(:id => ids))

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -104,7 +104,7 @@ module Metric::Targets
         end
       end
       host_ids = ems.hosts.index_by(&:id)
-      clusters = ems.hosts.flat_map(&:ems_cluster).uniq.compact.index_by(&:id)
+      clusters = ems.hosts.flat_map(&:ems_cluster).distinct.compact.index_by(&:id)
       ems.vms.each do |vm|
         vm.association(:ext_management_system).target = ems if vm.ems_id
         vm.association(:ems_cluster).target = clusters[vm.ems_cluster_id] if vm.ems_cluster_id
@@ -124,7 +124,7 @@ module Metric::Targets
   # @return [Array<Storage>] supported storages
   # hosts preloaded storages and tags
   def self.capture_storage_targets(hosts)
-    hosts.flat_map(&:storages).uniq.select { |s| Storage.supports?(s.store_type) & s.perf_capture_enabled? }
+    hosts.flat_map(&:storages).distinct.select { |s| Storage.supports?(s.store_type) & s.perf_capture_enabled? }
   end
 
   # @param [Array<ExtManagementSystem>] emses Typically 1 ems for this zone

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -98,7 +98,7 @@ class MiqAction < ApplicationRecord
   end
 
   def miq_policies
-    miq_policy_contents.collect(&:miq_policy).uniq
+    miq_policy_contents.collect(&:miq_policy).distinct
   end
 
   def self.invoke_actions(apply_policies_to, inputs, succeeded, failed)
@@ -108,7 +108,7 @@ class MiqAction < ApplicationRecord
     begin
       succeeded.each do |p|
         actions = case p
-                  when MiqPolicy then p.actions_for_event(inputs[:event], :success).uniq
+                  when MiqPolicy then p.actions_for_event(inputs[:event], :success).distinct
                   else            p.actions_for_event
                   end
 
@@ -129,7 +129,7 @@ class MiqAction < ApplicationRecord
 
       failed.each do |p|
         next unless p.kind_of?(MiqPolicy) # built-in policies are OpenStructs whose actions will be invoked only on success
-        actions = p.actions_for_event(inputs[:event], :failure).uniq
+        actions = p.actions_for_event(inputs[:event], :failure).distinct
 
         actions.each do |a|
           # merge in the synchronous flag and possibly the sequence if not already sorted by this

--- a/app/models/miq_alert.rb
+++ b/app/models/miq_alert.rb
@@ -125,7 +125,7 @@ class MiqAlert < ApplicationRecord
 
     alert_assignments[key] ||= begin
       profiles  = MiqAlertSet.assigned_to_target(target)
-      alert_ids = profiles.flat_map { |p| p.members.pluck(:id) }.uniq
+      alert_ids = profiles.flat_map { |p| p.members.pluck(:id) }.distinct
 
       if alert_ids.empty?
         none
@@ -177,7 +177,7 @@ class MiqAlert < ApplicationRecord
 
     # Get list of targets from assigned profiles
     targets = []
-    assignments.values.flatten.uniq.each do |prof|
+    assignments.values.flatten.distinct.each do |prof|
       prof.miq_alerts.each do |a|
         next unless a.enabled? && a.responds_to_events && a.responds_to_events.include?(HOURLY_TIMER_EVENT)
 
@@ -190,7 +190,7 @@ class MiqAlert < ApplicationRecord
     end
 
     # Call evaluate_queue for each alert/target
-    targets.uniq.each { |t| evaluate_alerts(t, HOURLY_TIMER_EVENT) }
+    targets.distinct.each { |t| evaluate_alerts(t, HOURLY_TIMER_EVENT) }
 
     _log.info("Complete")
   end

--- a/app/models/miq_compare.rb
+++ b/app/models/miq_compare.rb
@@ -246,7 +246,7 @@ class MiqCompare
       if self.class.tag_section?(section)
         # Get just the tag names from the results
         @results.each_value { |result| columns.concat(result[section].collect { |k, v| k if k.to_s[0, 1] != '_' && v[:_value_] }.compact) }
-        columns.uniq!
+        columns.distinct!
 
         # Remove unused tags from the results
         @results.each_value { |result| result[section].delete_if { |k, _v| !columns.include?(k) && k.to_s[0, 1] != '_' } }
@@ -258,7 +258,7 @@ class MiqCompare
         columns.sort! { |x, y| x[:header].to_s.downcase <=> y[:header].to_s.downcase }
       elsif !sub_sections.nil?
         @results.each_value { |result| sub_sections.concat(result[section].keys.reject { |k| k.to_s[0, 1] == '_' }) }
-        sub_sections.uniq! # uniq! returns nil if no action taken, so can't chain with sort
+        sub_sections.distinct! # uniq! returns nil if no action taken, so can't chain with sort
         sub_sections.sort! { |x, y| x.to_s.downcase <=> y.to_s.downcase }
       end
     end

--- a/app/models/miq_event_definition.rb
+++ b/app/models/miq_event_definition.rb
@@ -26,7 +26,7 @@ class MiqEventDefinition < ApplicationRecord
   end
 
   def miq_policies
-    p_ids = MiqPolicyContent.where(:miq_event_definition_id => id).uniq.pluck(:miq_policy_id)
+    p_ids = MiqPolicyContent.where(:miq_event_definition_id => id).distinct.pluck(:miq_policy_id)
     MiqPolicy.where(:id => p_ids).to_a
   end
 

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -283,7 +283,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   end
 
   def selected_tags_by_cat_and_name
-    tag_ids = (@values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags].to_miq_a).uniq
+    tag_ids = (@values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags].to_miq_a).distinct
     return {} if tag_ids.blank?
 
     # Collect the filter tags by category
@@ -316,7 +316,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
 
     unless options[:tag_filters].blank?
       tag_filters = options[:tag_filters].collect(&:to_s)
-      selected_tags = (@values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags].to_miq_a).uniq
+      selected_tags = (@values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags].to_miq_a).distinct
       tag_conditions = []
 
       # Collect the filter tags by category

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -579,7 +579,7 @@ class MiqQueue < ApplicationRecord
   def self.optional_values(options, keys = [:zone])
     options = options.dup
     Array(keys).each do |key|
-      options[key] = [nil, options[key]].uniq if options.key?(key)
+      options[key] = [nil, options[key]].distinct if options.key?(key)
     end
     options
   end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -202,7 +202,7 @@ class MiqRegion < ApplicationRecord
   end
 
   def assigned_roles
-    miq_servers.eager_load(:server_roles).collect(&:assigned_roles).flatten.uniq.compact
+    miq_servers.eager_load(:server_roles).collect(&:assigned_roles).flatten.distinct.compact
   end
 
   def role_active?(role_name)

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -208,7 +208,7 @@ class MiqReport < ApplicationRecord
   def load_custom_attributes
     return unless db_klass < CustomAttributeMixin || Chargeback.db_is_chargeback?(db)
 
-    db_klass.load_custom_attributes_for(cols.uniq)
+    db_klass.load_custom_attributes_for(cols.distinct)
   end
 
   # this method adds :custom_attributes => {} to MiqReport#include

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -392,9 +392,9 @@ module MiqReport::Generator
     # Add resource columns to performance reports cols and col_order arrays for widget click thru support
     if db_klass.to_s.ends_with?("Performance")
       res_cols = ['resource_name', 'resource_type', 'resource_id']
-      self.cols = (cols + res_cols).uniq
+      self.cols = (cols + res_cols).distinct
       orig_col_order = col_order.dup
-      self.col_order = (col_order + res_cols).uniq
+      self.col_order = (col_order + res_cols).distinct
     end
 
     only_cols = options[:only] || cols_for_report(['id'])
@@ -617,7 +617,7 @@ module MiqReport::Generator
     return data if data.blank?
 
     # Build a tempory table so that ruport sorting can be used to sort data before summarizing pivot data
-    column_names = (data.first.keys.collect(&:to_s) + col_order).uniq
+    column_names = (data.first.keys.collect(&:to_s) + col_order).distinct
     data = Ruport::Data::Table.new(:data => data, :column_names => column_names)
     data = sort_table(data, rpt_options[:pivot][:group_cols].collect(&:to_s), :order => :ascending)
 
@@ -653,7 +653,7 @@ module MiqReport::Generator
   # there may be some columns that are used to derive columns,
   # so we currently include '*'
   def cols_for_report(extra_cols = [])
-    ((cols || []) + (col_order || []) + (extra_cols || []) + build_cols_from_include(include)).uniq
+    ((cols || []) + (col_order || []) + (extra_cols || []) + build_cols_from_include(include)).distinct
   end
 
   def build_cols_from_include(hash, parent_association = nil)

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -31,7 +31,7 @@ class MiqRequestWorkflow
   end
 
   def self.all_encrypted_options_fields
-    descendants.flat_map(&:encrypted_options_fields).uniq
+    descendants.flat_map(&:encrypted_options_fields).distinct
   end
 
   def self.update_requester_from_parameters(data, user)
@@ -84,7 +84,7 @@ class MiqRequestWorkflow
     return false unless validate(values)
     password_helper(values, true)
     # Ensure that tags selected in the pre-dialog get applied to the request
-    values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).uniq if @values.try(:[], :pre_dialog_vm_tags).present?
+    values[:vm_tags] = (values[:vm_tags].to_miq_a + @values[:pre_dialog_vm_tags]).distinct if @values.try(:[], :pre_dialog_vm_tags).present?
 
     set_request_values(values)
     if request
@@ -1136,7 +1136,7 @@ class MiqRequestWorkflow
 
   def ci_to_datacenter(src, ci, ci_type)
     sources = src[ci].nil? ? find_all_ems_of_type(ci_type) : [src[ci]]
-    sources.collect { |c| find_datacenter_for_ci(c) }.compact.uniq.each_with_object({}) { |c, r| r[c.id] = c.name }
+    sources.collect { |c| find_datacenter_for_ci(c) }.compact.distinct.each_with_object({}) { |c, r| r[c.id] = c.name }
   end
 
   def respool_to_cluster(src)
@@ -1206,7 +1206,7 @@ class MiqRequestWorkflow
       result = find_datacenter_for_ci(h)
       rails_logger("host_to_folder for host #{h.name}", 1)
       result
-    end.compact.uniq
+    end.compact.distinct
     datacenters.each_with_object({}) do |dc, folders|
       rails_logger("host_to_folder for dc #{dc.name}", 0)
       folders.merge!(get_ems_folders(dc))

--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -224,7 +224,7 @@ module MiqServer::RoleManagement
       end
     end
 
-    assigned_roles = servers.collect(&:assigned_roles).flatten.uniq.compact
+    assigned_roles = servers.collect(&:assigned_roles).flatten.distinct.compact
     assigned_roles.each do |r|
       next unless roles_to_sync.include?(r)
       role_name = r.name

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -21,7 +21,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
     return true unless worker_get_monitor_status(w.pid).nil?
 
     # Unique set size is only implemented on linux
-    usage = w.unique_set_size || w.memory_usage
+    usage = w.distinctue_set_size || w.memory_usage
     if MiqWorker::STATUSES_CURRENT.include?(w.status) && usage_exceeds_threshold?(usage, memory_threshold)
       msg = "#{w.format_full_log_msg} process memory usage [#{usage}] exceeded limit [#{memory_threshold}], requesting worker to exit"
       _log.warn(msg)

--- a/app/models/miq_user_scope.rb
+++ b/app/models/miq_user_scope.rb
@@ -48,7 +48,7 @@ class MiqUserScope
 
   def merge_belongsto(*args)
     # TODO: Optimize to remove items that are descendants of others in the list.
-    args.flatten.compact.uniq
+    args.flatten.compact.distinct
   end
 
   def merge_expression(*args)

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -387,7 +387,7 @@ class MiqWidget < ApplicationRecord
   def grouped_subscribers
     grouped_users   = grouped_users_by_id
     groups_by_id    = MiqGroup.in_my_region.where(:id => grouped_users.keys).index_by(&:id)
-    users_by_userid = User.in_my_region.where(:userid => grouped_users.values.flatten.uniq).index_by(&:userid)
+    users_by_userid = User.in_my_region.where(:userid => grouped_users.values.flatten.distinct).index_by(&:userid)
     grouped_users.each_with_object({}) do |(k, v), h|
       user_objs = users_by_userid.values_at(*v).reject(&:blank?)
       h[groups_by_id[k]] = user_objs unless user_objs.blank?

--- a/app/models/miq_widget/content_option_generator.rb
+++ b/app/models/miq_widget/content_option_generator.rb
@@ -10,7 +10,7 @@ class MiqWidget::ContentOptionGenerator
   private
 
   def timezones_for_users(users)
-    users.collect { |user| user.try(:get_timezone) }.compact.uniq.sort
+    users.collect { |user| user.try(:get_timezone) }.compact.distinct.sort
   end
 
   def userids_for_users(users)

--- a/app/models/mixins/aggregation_mixin/methods.rb
+++ b/app/models/mixins/aggregation_mixin/methods.rb
@@ -35,7 +35,7 @@ module AggregationMixin
     def all_storages
       hosts = all_hosts
       MiqPreloader.preload(hosts, :storages)
-      hosts.collect(&:storages).flatten.compact.uniq
+      hosts.collect(&:storages).flatten.compact.distinct
     end
 
     def aggregate_hardware(from, field, targets = nil)
@@ -51,7 +51,7 @@ module AggregationMixin
     def lans
       hosts = all_hosts
       MiqPreloader.preload(hosts, :lans)
-      hosts.flat_map(&:lans).compact.uniq
+      hosts.flat_map(&:lans).compact.distinct
     end
   end
 end

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -204,7 +204,7 @@ module AssignmentMixin
 
       _log.debug("Directly assigned to parents: #{tlist.join(', ')}")
 
-      individually_assigned_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
+      individually_assigned_resources = tlist.flat_map { |t| assignments_cached[t] }.distinct
 
       _log.debug("Individually assigned resources: #{individually_assigned_resources.map { |x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
 
@@ -217,10 +217,10 @@ module AssignmentMixin
       end
 
       _log.debug("Tags assigned to parents: #{tlist.join(', ')}")
-      tagged_resources = tlist.flat_map { |t| assignments_cached[t] }.uniq
+      tagged_resources = tlist.flat_map { |t| assignments_cached[t] }.distinct
 
       _log.debug("Tagged resources: #{individually_assigned_resources.map { |x| "id:#{x.id} class:#{x.class}" }.join(', ')}")
-      (individually_assigned_resources + tagged_resources).uniq
+      (individually_assigned_resources + tagged_resources).distinct
     end
 
     def namespace

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -433,7 +433,7 @@ module AuthenticationMixin
   end
 
   def authentication_types
-    available_authentications.collect(&:authentication_type).uniq
+    available_authentications.collect(&:authentication_type).distinct
   end
 
   def authentication_delete(type)

--- a/app/models/mixins/custom_actions_mixin.rb
+++ b/app/models/mixins/custom_actions_mixin.rb
@@ -29,7 +29,7 @@ module CustomActionsMixin
   end
 
   def custom_button_sets_with_generics
-    custom_button_sets + generic_button_group.map(&:parent).uniq.flatten
+    custom_button_sets + generic_button_group.map(&:parent).distinct.flatten
   end
 
   def custom_buttons

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -60,7 +60,7 @@ module MiqPolicyMixin
         end
       end
 
-      result_list = presults.collect { |r| r["result"] }.uniq
+      result_list = presults.collect { |r| r["result"] }.distinct
       prof_result = result_list.first if result_list.length == 1 && result_list.first == "N/A"
       result.push(prof.attributes.merge("result" => prof_result, "policies" => presults))
     end
@@ -73,7 +73,7 @@ module MiqPolicyMixin
     plist.each do |policy|
       result = false if policy["result"] == "deny"
     end
-    result_list = plist.collect { |r| r["result"] }.uniq
+    result_list = plist.collect { |r| r["result"] }.distinct
     result = result_list.first if result_list.length == 1 && result_list.first == "N/A"
     result
   end
@@ -84,7 +84,7 @@ module MiqPolicyMixin
     plist.each do |prof|
       result = false if prof["result"] == "deny"
     end
-    result_list = plist.collect { |r| r["result"] }.uniq
+    result_list = plist.collect { |r| r["result"] }.distinct
     result = result_list.first if result_list.length == 1 && result_list.first == "N/A"
     result
   end
@@ -127,14 +127,14 @@ module MiqPolicyMixin
         profiles = (t.get_policies + MiqPolicy.associations_to_get_policies.collect do |assoc|
           next unless t.respond_to?(assoc)
           t.send(assoc).get_policies unless t.send(assoc).nil?
-        end).compact.flatten.uniq
+        end).compact.flatten.distinct
         presults = t.resolve_profiles(profiles.collect(&:id), eventobj)
         target_result = presults.inject("allow") do |s, r|
           break "deny" if r["result"] == "deny"
           s
         end
 
-        result_list = presults.collect { |r| r["result"] }.uniq
+        result_list = presults.collect { |r| r["result"] }.distinct
         target_result = result_list.first if result_list.length == 1 && result_list.first == "N/A"
         result.push("id" => t.id, "name" => t.name, "result" => target_result, "profiles" => presults)
       end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -41,7 +41,7 @@ module PerEmsWorkerMixin
       unless compare_queues(current, desired)
         _log.info("Workers are being synchronized: Current: #{current.inspect}, Desired: #{desired.inspect}")
 
-        dups = current.uniq.find_all { |u| current.find_all { |c| c == u }.length > 1 }
+        dups = current.distinct.find_all { |u| current.find_all { |c| c == u }.length > 1 }
         _log.info("Duplicate workers found: Current: #{current.inspect}, Desired: #{desired.inspect}, Dups: #{dups.inspect}") unless dups.empty?
         current -= dups
 

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -253,7 +253,7 @@ module RelationshipMixin
   # Returns a list of child relationships
   def child_rels(*args)
     options = args.extract_options!
-    rels = relationships.flat_map(&:children).uniq
+    rels = relationships.flat_map(&:children).distinct
     Relationship.filter_by_resource_type(rels, options)
   end
 
@@ -285,7 +285,7 @@ module RelationshipMixin
   # Returns a list of sibling relationships
   def sibling_rels(*args)
     options = args.extract_options!
-    rels = relationships.flat_map(&:siblings).uniq
+    rels = relationships.flat_map(&:siblings).distinct
     Relationship.filter_by_resource_type(rels, options)
   end
 
@@ -317,7 +317,7 @@ module RelationshipMixin
   # Returns a list of descendant relationships
   def descendant_rels(*args)
     options = args.extract_options!
-    rels = relationships.flat_map(&:descendants).uniq
+    rels = relationships.flat_map(&:descendants).distinct
     Relationship.filter_by_resource_type(rels, options)
   end
 
@@ -359,7 +359,7 @@ module RelationshipMixin
     options = args.extract_options!
     # TODO: make this a single query (vs 3)
     # thus making filter_by_resource_type into a query
-    rels = relationships.flat_map(&:subtree).uniq
+    rels = relationships.flat_map(&:subtree).distinct
     rels = [relationship_for_isolated_root] if rels.empty?
     Relationship.filter_by_resource_type(rels, options)
   end
@@ -480,7 +480,7 @@ module RelationshipMixin
   def fulltree_rels(*args)
     options = args.extract_options!
     root_id = relationship.try(:root_id)
-    rels = root_id ? Relationship.subtree_of(root_id).uniq : [relationship_for_isolated_root]
+    rels = root_id ? Relationship.subtree_of(root_id).distinct : [relationship_for_isolated_root]
     Relationship.filter_by_resource_type(rels, options)
   end
 

--- a/app/models/mixins/scanning_mixin.rb
+++ b/app/models/mixins/scanning_mixin.rb
@@ -189,7 +189,7 @@ module ScanningMixin
 
     # If we get through the profile check and do not have anything pass the default list
 
-    cat_scan_list.uniq!
+    cat_scan_list.distinct!
     cat_scan_list = self.class.default_scan_categories_no_profile if cat_scan_list.empty?
     cat_scan_list
   end

--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -52,7 +52,7 @@ module ServiceMixin
   end
 
   def combined_group_delay(action)
-    group_idxs = service_resources.map(&:group_idx).uniq
+    group_idxs = service_resources.map(&:group_idx).distinct
     [].tap do |results|
       group_idxs.each { |idx| results << max_group_delay(idx, delay_type(action)) }
     end.sum

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -34,11 +34,11 @@ class NetworkPort < ApplicationRecord
   virtual_column :cloud_subnets_names, :type => :string_set, :uses => :cloud_subnets
 
   def floating_ip_addresses
-    @floating_ip_addresses ||= floating_ips.collect(&:address).compact.uniq
+    @floating_ip_addresses ||= floating_ips.collect(&:address).compact.distinct
   end
 
   def fixed_ip_addresses
-    @fixed_ip_addresses ||= cloud_subnet_network_ports.collect(&:address).compact.uniq
+    @fixed_ip_addresses ||= cloud_subnet_network_ports.collect(&:address).compact.distinct
   end
 
   def ipaddresses
@@ -46,7 +46,7 @@ class NetworkPort < ApplicationRecord
   end
 
   def cloud_subnets_names
-    @cloud_subnets_names ||= cloud_subnets.collect(&:name).compact.uniq
+    @cloud_subnets_names ||= cloud_subnets.collect(&:name).compact.distinct
   end
 
   # Define all getters and setters for extra_attributes related virtual columns

--- a/app/models/physical_server_provision_workflow.rb
+++ b/app/models/physical_server_provision_workflow.rb
@@ -39,7 +39,7 @@ class PhysicalServerProvisionWorkflow < MiqProvisionConfiguredSystemWorkflow
   private
 
   def get_customization_scripts
-    ems_ids = PhysicalServer.where(:id => @values[:src_configured_system_ids]).pluck(:ems_id).uniq
+    ems_ids = PhysicalServer.where(:id => @values[:src_configured_system_ids]).pluck(:ems_id).distinct
     CustomizationScript.where(:manager_id => ems_ids)
   end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -61,7 +61,7 @@ class Relationship < ApplicationRecord
   end
 
   def self.resource_types(relationships)
-    relationships.collect(&:resource_type).uniq
+    relationships.collect(&:resource_type).distinct
   end
 
   def self.resource_pairs_to_ids(resource_pairs)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -209,7 +209,7 @@ class Service < ApplicationRecord
   end
 
   def all_states_match?(action)
-    return true if composite? && (power_states.uniq == map_power_states(action))
+    return true if composite? && (power_states.distinct == map_power_states(action))
     return true if atomic? && (power_states[0] == POWER_STATE_MAP[action])
     false
   end
@@ -239,7 +239,7 @@ class Service < ApplicationRecord
       each_group_resource do |svc_rsc|
         sa << svc_rsc
       end
-    end.map(&action_name).uniq
+    end.map(&action_name).distinct
   end
 
   def map_power_states(action)

--- a/app/models/service/resource_linking.rb
+++ b/app/models/service/resource_linking.rb
@@ -2,7 +2,7 @@ module Service::ResourceLinking
   extend ActiveSupport::Concern
 
   def add_provider_vms(provider, uid_ems_array)
-    vm_uid_array = Array(uid_ems_array).compact.uniq
+    vm_uid_array = Array(uid_ems_array).compact.distinct
     raise _("no uid_ems_array defined for linking to service") if vm_uid_array.blank?
 
     options = {

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -593,7 +593,7 @@ class Storage < ApplicationRecord
       obj = s.hosts.order(:id).first if obj.nil?
       obj
     end
-    objs.compact.uniq
+    objs.compact.distinct
   end
 
   def used_space

--- a/app/models/system_console.rb
+++ b/app/models/system_console.rb
@@ -27,7 +27,7 @@ class SystemConsole < ApplicationRecord
     port_range_start = ::Settings.server.console_proxy_port.start
     port_range_end   = ::Settings.server.console_proxy_port.end
 
-    used_ports = SystemConsole.where.not(:proxy_pid => nil).where(:host_name => local_address).order(:port).pluck(:port).uniq
+    used_ports = SystemConsole.where.not(:proxy_pid => nil).where(:host_name => local_address).order(:port).pluck(:port).distinct
 
     (port_range_start..port_range_end).each do |port_number|
       return port_number if used_ports[0].nil? || used_ports[0] > port_number

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -86,7 +86,7 @@ class Tag < ApplicationRecord
       # delete any blank tag names
       tag_names = tag_names.delete_if(&:empty?)
 
-      return tag_names.uniq
+      return tag_names.distinct
     end
   end
 

--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -20,7 +20,7 @@ class TimeProfile < ApplicationRecord
   end
 
   def self.all_timezones
-    select(%w(id profile)).collect(&:tz).uniq
+    select(%w(id profile)).collect(&:tz).distinct
   end
 
   def self.seed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,7 +237,7 @@ class User < ApplicationRecord
     if limited_self_service?
       vms
     elsif self_service?
-      (vms + miq_groups.includes(:vms).collect(&:vms).flatten).uniq
+      (vms + miq_groups.includes(:vms).collect(&:vms).flatten).distinct
     else
       Vm.all
     end

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -82,7 +82,7 @@ module VimPerformanceAnalysis
         @compute = Rbac.filtered(nil, search_options)
 
         MiqPreloader.preload(@compute, :storages)
-        stores = @compute.collect { |c| storages_for_compute_target(c) }.flatten.uniq
+        stores = @compute.collect { |c| storages_for_compute_target(c) }.flatten.distinct
 
         filter_options = {:class => Storage, :userid => @options[:userid], :miq_group_id => @options[:miq_group_id]}
         if topts[:storage_filter]

--- a/app/models/vim_performance_daily.rb
+++ b/app/models/vim_performance_daily.rb
@@ -145,6 +145,6 @@ class VimPerformanceDaily < MetricRollup
     end
     only_cols += [:derived_storage_total, :derived_storage_free] if only_cols.include?(:v_derived_storage_used)
     only_cols += Metric::BASE_COLS.collect(&:to_sym)
-    only_cols.uniq
+    only_cols.distinct
   end
 end # class VimPerformanceDaily

--- a/app/models/vim_performance_state.rb
+++ b/app/models/vim_performance_state.rb
@@ -145,7 +145,7 @@ class VimPerformanceState < ApplicationRecord
     return [] if assoc.nil?
 
     ids = mode.nil? ? (assoc[:on] || []) + (assoc[:off] || []) : assoc[mode.to_sym]
-    ids.nil? ? [] : ids.uniq.sort
+    ids.nil? ? [] : ids.distinct.sort
   end
 
   private
@@ -200,9 +200,9 @@ class VimPerformanceState < ApplicationRecord
         end
       end
 
-      r_on.uniq!
+      r_on.distinct!
       r_on.sort!
-      r_off.uniq!
+      r_off.distinct!
       r_off.sort!
     end
     self.assoc_ids = result.presence

--- a/app/models/vim_performance_tag.rb
+++ b/app/models/vim_performance_tag.rb
@@ -35,8 +35,8 @@ class VimPerformanceTag < MetricRollup
         c = [tv.column_name, tv.tag_name].join("_").to_sym
         rec.class.class_eval("attr_accessor #{c.inspect}")
         rec.send(c.to_s + "=", tv.column_name == "assoc_ids" ? tv.assoc_ids : tv.value)
-        h[:tags].push(tv.tag_name).uniq!
-        h[:tcols].push(c.to_s).uniq!
+        h[:tags].push(tv.tag_name).distinct!
+        h[:tcols].push(c.to_s).distinct!
       end
 
       h[:res].push(rec)

--- a/app/models/vim_performance_tag_value.rb
+++ b/app/models/vim_performance_tag_value.rb
@@ -69,7 +69,7 @@ class VimPerformanceTagValue
     perf_data[:perf_recs] = recs
     perf_data[:categories] = perf_data[:perf_recs].collect do |perf|
       perf.tag_names.split(TAG_SEP).collect { |t| t.split("/").first } unless perf.tag_names.nil?
-    end.flatten.compact.uniq
+    end.flatten.compact.distinct
 
     cats_to_process = (eligible_cats & perf_data[:categories]) # Process subset of perf_data[:categories] that are eligible for tag grouping
     return [] if cats_to_process.empty?

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -66,8 +66,8 @@ class Vm < VmOrTemplate
     end
     conds[0] = "(#{conds[0].join(" AND ")})"
 
-    Hardware.includes(include.uniq)
-      .references(references.uniq)
+    Hardware.includes(include.distinct)
+      .references(references.distinct)
       .where(conds)
       .collect { |h|  h.vm_or_template.kind_of?(Vm) ? h.vm_or_template : nil }.compact
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -732,7 +732,7 @@ class VmOrTemplate < ApplicationRecord
 
   def disconnect_storage(s = nil)
     if s.nil? || storage == s || storages.include?(s)
-      stores = s.nil? ? ([storage] + storages).compact.uniq : [s]
+      stores = s.nil? ? ([storage] + storages).compact.distinct : [s]
       log_text = stores.collect { |x| "Datastore [#{x.name}] id [#{x.id}]" }.join(", ")
       _log.info("Disconnecting Vm [#{name}] id [#{id}] from #{log_text}")
 
@@ -1144,7 +1144,7 @@ class VmOrTemplate < ApplicationRecord
 
     updated_vms  = VmOrTemplate.where(:id => updated_vm_rels.collect(&:resource_id))
     updated_vms += updated_folders.flat_map(&:all_vms_and_templates)
-    updated_vms  = updated_vms.uniq - added_vms
+    updated_vms  = updated_vms.distinct - added_vms
     updated_vms.each(&:classify_with_parent_folder_path_queue)
   end
   private_class_method :post_refresh_ems_folder_updates

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -76,7 +76,7 @@ module VmOrTemplate::Operations::Configuration
     if options[:datastore]
       datastore = ext_management_system.hosts.collect do |h|
         h.writable_storages.find_by(:name => options[:datastore])
-      end.uniq.compact.first
+      end.distinct.compact.first
       raise _("Datastore does not exist or cannot be accessed, unable to add disk") unless datastore
     end
 

--- a/app/models/vmdb_database/metric_collection.rb
+++ b/app/models/vmdb_database/metric_collection.rb
@@ -24,7 +24,7 @@ module VmdbDatabase::MetricCollection
 
     def collect_number_pg_processes
       require 'miq-process'
-      (MiqProcess.get_active_process_by_name('postmaster') + MiqProcess.get_active_process_by_name('postgres')).uniq.length
+      (MiqProcess.get_active_process_by_name('postmaster') + MiqProcess.get_active_process_by_name('postgres')).distinct.length
     end
 
     def collect_number_connections

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -59,7 +59,7 @@ class Zone < ApplicationRecord
   end
 
   def assigned_roles
-    miq_servers.flat_map(&:assigned_roles).uniq.compact
+    miq_servers.flat_map(&:assigned_roles).distinct.compact
   end
 
   def role_active?(role_name)
@@ -71,7 +71,7 @@ class Zone < ApplicationRecord
   end
 
   def active_role_names
-    miq_servers.flat_map(&:active_role_names).uniq
+    miq_servers.flat_map(&:active_role_names).distinct
   end
 
   def self.default_zone
@@ -176,12 +176,12 @@ class Zone < ApplicationRecord
 
   def storages
     MiqPreloader.preload(self, :ext_management_systems => {:hosts => :storages})
-    ext_management_systems.flat_map(&:storages).uniq
+    ext_management_systems.flat_map(&:storages).distinct
   end
 
   def self.storages_without_a_zone
     storage_without_hosts = Storage.includes(:hosts).where(:host_storages => {:storage_id => nil}).to_a
-    storage_without_ems = Host.where(:ems_id => nil).includes(:storages).flat_map(&:storages).uniq
+    storage_without_ems = Host.where(:ems_id => nil).includes(:storages).flat_map(&:storages).distinct
     storage_without_hosts + storage_without_ems
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Vmdb::Application.configure do
   config.eager_load = false
 
   # Print deprecation notices to the stderr
-  #ActiveSupport::Deprecation.behavior = :stderr
+  # ActiveSupport::Deprecation.behavior = :stderr
   ActiveSupport::Deprecation.behavior = :silence
 
   # Configure static asset server for tests with Cache-Control for performance

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -22,7 +22,7 @@ module ActsAsTaggable
       tags.split(separator)
     else
       []
-    end.map(&:strip).uniq
+    end.map(&:strip).distinct
   end
 
   def writable_classification_tags

--- a/lib/extensions/ar_to_model_hash.rb
+++ b/lib/extensions/ar_to_model_hash.rb
@@ -23,7 +23,7 @@ module ToModelHash
 
       cols  = (options["cols"] || options["columns"] || [])
       cols += (options["key"] || []).compact
-      ret[:columns] = cols.uniq.sort.collect(&:to_sym) unless cols.blank?
+      ret[:columns] = cols.distinct.sort.collect(&:to_sym) unless cols.blank?
 
       includes = options["include"]
       if includes

--- a/lib/extensions/descendant_loader.rb
+++ b/lib/extensions/descendant_loader.rb
@@ -153,7 +153,7 @@ class DescendantLoader
           combo[0] = combo[0].sub(/^::/, '')
         end
       end
-      combos.map { |c| c.join('::') }.uniq.reverse
+      combos.map { |c| c.join('::') }.distinct.reverse
     end
   end
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -688,11 +688,11 @@ class MiqExpression
               end
         end
         v.kind_of?(Range) ? v.to_a : v
-      end.compact.uniq.sort
+      end.compact.distinct.sort
       "[#{v_arr.join(",")}]"
     when "string_set"
       val = val.split(",") if val.kind_of?(String)
-      v_arr = val.to_miq_a.flat_map { |v| "'#{v.to_s.strip}'" }.uniq.sort
+      v_arr = val.to_miq_a.flat_map { |v| "'#{v.to_s.strip}'" }.distinct.sort
       "[#{v_arr.join(",")}]"
     else
       val

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -417,8 +417,8 @@ class MiqLdap
         result.concat(get_memberships(gobj, max_depth, attr, followed, current_depth)) unless max_depth > 0 && current_depth >= max_depth
       end
     end
-    _log.debug("Exit get_memberships: #{obj.dn}, result: #{result.uniq.inspect}")
-    result.uniq
+    _log.debug("Exit get_memberships: #{obj.dn}, result: #{result.distinct.inspect}")
+    result.distinct
   end
 
   def get_organizationalunits(basedn = nil, filter = nil)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -616,7 +616,7 @@ module Rbac
           klass.where(klass_id => descendants.select(descendant_id)).distinct
         else
           MiqPreloader.preload(descendants, method_name)
-          descendants.flat_map { |object| object.send(method_name) }.grep(klass).uniq
+          descendants.flat_map { |object| object.send(method_name) }.grep(klass).distinct
         end
       end
     end
@@ -675,7 +675,7 @@ module Rbac
         else
           vcmeta_list.grep(klass) + vcmeta.descendants.grep(klass)
         end
-      end.uniq
+      end.distinct
     end
 
     def get_belongsto_matches_for_host(blist)

--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -85,7 +85,7 @@ class EvmApplication
     return dups if data.size <= 1
     column_names ||= data.first.keys
     column_names.each do |col_header|
-      values = data.collect { |row| row[col_header] }.uniq
+      values = data.collect { |row| row[col_header] }.distinct
       dups[col_header] = values.first if values.size < 2
     end
     dups
@@ -126,7 +126,7 @@ class EvmApplication
         "Version"   => s.version,
         "Started"   => compact_date(s.started_on),
         "Heartbeat" => compact_date(s.last_heartbeat),
-        "MB Usage"  => (mem = (s.unique_set_size || s.memory_usage)).nil? ? "" : mem / 1.megabyte,
+        "MB Usage"  => (mem = (s.distinctue_set_size || s.memory_usage)).nil? ? "" : mem / 1.megabyte,
         "Roles"     => s.active_role_names.join(':'),
       }
     end

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -89,7 +89,7 @@ namespace :locale do
       f.puts "# This is automatically generated file (rake locale:extract_yaml_strings)."
       f.puts "# The file contains strings extracted from various yaml files for gettext to find."
       output.each_key do |key|
-        output[key].sort.uniq.each do |file|
+        output[key].sort.distinct.each do |file|
           f.puts "# TRANSLATORS: file: #{file}"
         end
         f.puts '_("%s")' % key

--- a/lib/tasks/model_attribute_override.rb
+++ b/lib/tasks/model_attribute_override.rb
@@ -5,7 +5,7 @@ module GettextI18nRails
 
       if model.abstract_class?
         model.direct_descendants.reject {|m| ignored?(m.table_name, ignored_tables)}.inject([]) do |attrs, m|
-          attrs.push(model_attributes(m, ignored_tables, ignored_cols)).flatten.uniq
+          attrs.push(model_attributes(m, ignored_tables, ignored_cols)).flatten.distinct
         end
       elsif !ignored?(model.table_name, ignored_tables) && @existing_tables.include?(model.table_name)
         list = model.virtual_attribute_names +

--- a/lib/vmdb/settings/hash_differ.rb
+++ b/lib/vmdb/settings/hash_differ.rb
@@ -10,7 +10,7 @@ module Vmdb
       end
 
       def self.diff(h1, h2)
-        keys = (h1.keys + h2.keys).uniq
+        keys = (h1.keys + h2.keys).distinct
         keys.each_with_object({}) do |k, result|
           v1 = h1.key?(k) ? h1[k] : MissingKey
           v2 = h2.key?(k) ? h2[k] : MissingKey

--- a/product/compare/hosts.yaml
+++ b/product/compare/hosts.yaml
@@ -208,7 +208,7 @@ col_order:
 - filesystems.owner
 - filesystems.group
 - filesystems.mtime
-- filesystems_custom_attributes.unique_name
+- filesystems_custom_attributes.distinctue_name
 - filesystems_custom_attributes.name
 - filesystems_custom_attributes.section
 - filesystems_custom_attributes.value

--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -23,7 +23,7 @@ describe "ar_dba extension" do
     it "returns the correct primary key" do
       index_def = connection.primary_key_index("miq_databases")
       expect(index_def.table).to eq("miq_databases")
-      expect(index_def.unique).to be true
+      expect(index_def.distinctue).to be true
       expect(index_def.columns).to eq(["id"])
     end
 
@@ -34,7 +34,7 @@ describe "ar_dba extension" do
 
       index_def = connection.primary_key_index(table_name)
       expect(index_def.table).to eq(table_name)
-      expect(index_def.unique).to be true
+      expect(index_def.distinctue).to be true
       expect(index_def.columns).to match_array(%w(id1 id2))
     end
   end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2188,7 +2188,7 @@ describe MiqExpression do
                                          :include_model   => true,
                                          :include_my_tags => false,
                                          :userid          => 'admin')
-      expect(tags.uniq.length).to eq(tags.length)
+      expect(tags.distinct.length).to eq(tags.length)
     end
   end
 

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -243,7 +243,7 @@ describe AutomationRequest do
 
     def check_zone(zone_name)
       expect(MiqQueue.count).to eq(4)
-      expect(MiqQueue.pluck(:zone).uniq).to eq([zone_name])
+      expect(MiqQueue.pluck(:zone).distinct).to eq([zone_name])
     end
 
     it "zone specified" do

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -52,7 +52,7 @@ describe ChargebackRateDetail do
 
       it 'loads chargeback rates with sub metric from CloudVolumes' do
         rates = ChargebackRateDetail.default_rate_details_for('Storage')
-        expect(rates.map(&:sub_metric).compact).to match_array(cloud_volumes.map(&:volume_type) + ['unclassified'].uniq.compact)
+        expect(rates.map(&:sub_metric).compact).to match_array(cloud_volumes.map(&:volume_type) + ['unclassified'].distinct.compact)
       end
     end
 

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -10,7 +10,7 @@ describe "JobProxyDispatcherEmbeddedScanSpec" do
 
     def assert_at_most_x_scan_jobs_per_y_resource(x_scans, y_resource)
       vms_in_embedded_scanning = Job.where(["dispatch_status = ? AND state != ? AND target_class = ?", "active", "finished", "VmOrTemplate"])
-                                    .pluck(:target_id).compact.uniq
+                                    .pluck(:target_id).compact.distinct
       expect(vms_in_embedded_scanning.length).to be > 0
 
       method = case y_resource

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -295,7 +295,7 @@ describe Metric do
         it "queues service rollups" do
           @vm.perf_rollup_to_parents("hourly", "2010-04-14T21:51:10Z", "2010-04-14T22:50:50Z")
 
-          expect(MiqQueue.all.pluck(:class_name).uniq).to eq(%w(Service))
+          expect(MiqQueue.all.pluck(:class_name).distinct).to eq(%w(Service))
         end
       end
     end
@@ -407,7 +407,7 @@ describe Metric do
                                                       :resource  => @host1,
                                                       :timestamp => "2010-04-14T22:00:00Z")
           metrics = Metric::Finders.find_all_by_day([@vm1, @host1], "2010-04-14T00:00:00Z", 'hourly', @time_profile)
-          expect(metrics.collect(&:resource_type).uniq).to match_array(%w(VmOrTemplate Host))
+          expect(metrics.collect(&:resource_type).distinct).to match_array(%w(VmOrTemplate Host))
         end
 
         context "calling perf_rollup to daily on the Vm" do

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -47,7 +47,7 @@ describe MiqAlert do
       end
 
       it "should queue up the correct alert for each event" do
-        guids = @events_to_alerts.collect(&:last).uniq
+        guids = @events_to_alerts.collect(&:last).distinct
         messages = MiqQueue.order("id")
         expect(messages.length).to eq(@events_to_alerts.length)
 

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -46,7 +46,7 @@ describe MiqProductFeature do
     it "creates feature identifiers once on first seed, changes nothing on second seed" do
       status_seed1 = nil
       expect { status_seed1 = MiqProductFeature.seed }.to change(MiqProductFeature, :count)
-      expect(status_seed1[:created]).to match_array status_seed1[:created].uniq
+      expect(status_seed1[:created]).to match_array status_seed1[:created].distinct
       expect(status_seed1[:updated]).to match_array []
       expect(status_seed1[:unchanged]).to match_array []
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -347,7 +347,7 @@ describe ServiceTemplate do
       expect(sub_svc).to include(@svc_c)
       expect(sub_svc).to include(@svc_d)
 
-      sub_svc.uniq!
+      sub_svc.distinct!
       expect(sub_svc.size).to eq(3)
       expect(sub_svc).not_to include(@svc_a)
       expect(sub_svc).to include(@svc_b)

--- a/spec/shared/i18n/placeholders.rb
+++ b/spec/shared/i18n/placeholders.rb
@@ -15,7 +15,7 @@ shared_examples :placeholders do |dir|
         next if placeholders.empty?
         translated_placeholders = translation.scan(/%{\w+}/)
         translated_placeholders.sort!
-        if placeholders.uniq != translated_placeholders.uniq
+        if placeholders.distinct != translated_placeholders.distinct
           errors.store_path(po_file.to_s, original, translation)
         end
       end

--- a/tools/create_evm_snapshot.rb
+++ b/tools/create_evm_snapshot.rb
@@ -16,7 +16,7 @@ type = $1
 ids  = $2.split(',').collect do |id|
   id.strip!
   id.blank? ? nil : id.to_i
-end.compact.uniq
+end.compact.distinct
 
 case type
 when 'vm'

--- a/tools/kill_provision.rb
+++ b/tools/kill_provision.rb
@@ -14,7 +14,7 @@ def kill_provision_task(prov_id, queue)
   @processed << prov_id unless @processed.include?(prov_id)
 end
 
-args = $ARGV.join(',').gsub(',,', ',').split(',').uniq
+args = $ARGV.join(',').gsub(',,', ',').split(',').distinct
 provisions = args.collect { |a| a =~ /miq_provision_(\d*)/ ? $1.to_i : a.to_i }
 
 puts "Checking for provisions IDs:<#{provisions.inspect}>"

--- a/tools/log_processing/broker_registry_counts.rb
+++ b/tools/log_processing/broker_registry_counts.rb
@@ -22,7 +22,7 @@ puts "Object Counts:"
 counts.keys.sort.each do |type|
   object_ids = counts[type]
 
-  incorrect = object_ids.reject { |_object_id, modes| modes.length == 3 && modes.uniq.sort == %w(registerBrokerObj release unregisterBrokerObj) }
+  incorrect = object_ids.reject { |_object_id, modes| modes.length == 3 && modes.distinct.sort == %w(registerBrokerObj release unregisterBrokerObj) }
   incorrect = incorrect.reject { |_object_id, modes| (c = modes.count('registerBrokerObj')) == modes.count('release') && c == modes.count('unregisterBrokerObj') }
   unreleased, overreleased = incorrect.partition { |_object_id, modes| modes.count('registerBrokerObj') > modes.count('unregisterBrokerObj') }
 

--- a/tools/metrics_populate_retro_tags.rb
+++ b/tools/metrics_populate_retro_tags.rb
@@ -17,7 +17,7 @@ else
     vm_ids += obj.send(meth).collect(&:id)
   end
 end
-vm_ids.uniq!
+vm_ids.distinct!
 
 time_cond = {:timestamp => (start_ts.to_time.utc.beginning_of_day..end_ts.to_time.utc.end_of_day)}
 puts "Processing VM IDs: #{vm_ids.sort.inspect} for time range: #{time_cond.inspect}"

--- a/tools/miqssh/miqhosts.rb
+++ b/tools/miqssh/miqhosts.rb
@@ -29,7 +29,7 @@ def load_file(file)
   end
   # Sort and uniq the arrays of hosts.
   data.each_key do |k|
-    data[k].uniq!
+    data[k].distinct!
     data[k].sort!
   end
 end
@@ -46,7 +46,7 @@ def list_servers(data, group)
   groups = group.split(',')
   servers = []
   groups.each { |g| servers.push(data[g.to_sym]) }
-  puts servers.uniq.sort.join(" ")
+  puts servers.distinct.sort.join(" ")
 end
 
 file = ARGV[0]

--- a/tools/pg_inspector/connection_locks.rb
+++ b/tools/pg_inspector/connection_locks.rb
@@ -87,7 +87,7 @@ module PgInspector
         lock["spid"] != l["spid"] &&
           l["granted"] == "t"
       end
-      blocking_locks.collect { |l| l["spid"] }.uniq
+      blocking_locks.collect { |l| l["spid"] }.distinct
     end
 
     def blocking_lock_relation(lock)
@@ -114,7 +114,7 @@ module PgInspector
     end
 
     def find_lock_blocking_spid(spid)
-      locks_owned_by_spid(spid).collect { |lock| lock["blocked_by"] }.compact.flatten.uniq
+      locks_owned_by_spid(spid).collect { |lock| lock["blocked_by"] }.compact.flatten.distinct
     end
   end
 end

--- a/tools/vim_collect_perf_history.rb
+++ b/tools/vim_collect_perf_history.rb
@@ -54,7 +54,7 @@ targets.each do |t|
            exit 1
          end
 end
-mors = targets.collect { |t| t[0] }.uniq
+mors = targets.collect { |t| t[0] }.distinct
 
 def process(accessor, dir)
   puts "Reading #{accessor}..."


### PR DESCRIPTION
DEPRECATION WARNING: uniq is deprecated and will be removed from Rails 5.1 (use distinct instead) 