### PR TITLE
Update ancestry to latest 3.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ manageiq_plugin "manageiq-schema"
 gem "activerecord-id_regions",        "~>0.2.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
-gem "ancestry",                       "~>2.2.1",       :require => false
+gem "ancestry",                       "~>3.0.4",       :require => false
 gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.11.1",      :require => false
 gem "color",                          "~>1.8"

--- a/lib/patches/ancestry_patch.rb
+++ b/lib/patches/ancestry_patch.rb
@@ -24,11 +24,7 @@ module Ancestry
   module InstanceMethods
     prepend AncestryInstanceMethodsPatch
 
-    ANCESTRY_DELIMITER = '/'.freeze
-
-    def parse_ancestry_column(obj)
-      obj.to_s.split(ANCESTRY_DELIMITER).map! { |id| cast_primary_key(id) }
-    end
+    ANCESTRY_DELIMITER = '/'.freeze unless defined?(ANCESTRY_DELIMITER)
 
     def ancestor_ids
       @_ancestor_ids ||= parse_ancestry_column(read_attribute(ancestry_base_class.ancestry_column))
@@ -60,13 +56,8 @@ module Ancestry
                   end
     end
 
-    STRING_BASED_KEYS = %i[string uuid text].freeze
     def cast_primary_key(key)
-      if STRING_BASED_KEYS.include?(primary_key_type)
-        key
-      else
-        key.to_i
-      end
+      self.class.primary_key_is_an_integer? ? key.to_i : key
     end
 
     def clear_memoized_instance_variables


### PR DESCRIPTION
Point ancestry to the latest version

This fixes an issue in our patch that prevented us from upgrading to the latest version of ancestry.

A number of rails 5.1 and 5.2 bugs have been (and are being) fixed.
This isolates us from running into problems that have already been fixed.

This version of ancestry is backwards compatible to rails 4.x

I deleted `parse_ancestry_column` as the stock version uses less memory and a tad faster.

### ips

 label               | 3.0.5         | ancestry_patch
---------------------|---------------|-----------------------
 `obj.ancestor_ids`  | 212,396.9 i/s | 141,636.4 i/s - 1.50x
 `root.ancestor_ids` | 333,376.6 i/s | 319,555.8 i/s

### memsize

 label               | 3.0.5       | ancestry_patch
---------------------|-------------|---------------------
 `obj.ancestor_ids`  | 480.0 bytes | 480.0 bytes
 `root.ancestor_ids` | 120.0 bytes | 160.0 bytes - 1.33x

### objects

 label               | 3.0.5    | ancestry_patch
---------------------|----------|------------------
 `obj.ancestor_ids`  | 8.0 objs | 8.0 objs
 `root.ancestor_ids` | 3.0 objs | 4.0 objs - 1.33x
