### PR TITLE
Corrected method describing task state

### DIFF
--- a/app/models/vmdb_database_connection.rb
+++ b/app/models/vmdb_database_connection.rb
@@ -70,7 +70,7 @@ class VmdbDatabaseConnection < ApplicationRecord
   end
 
   def task_state
-    waiting
+    state
   end
 
   def wait_time
@@ -99,7 +99,7 @@ class VmdbDatabaseConnection < ApplicationRecord
       'xact_start'              => xact_start,
       'last_request_start_time' => query_start,
       'command'                 => query,
-      'task_state'              => waiting,
+      'task_state'              => state,
       'login'                   => usename,
       'application'             => application_name,
       'request_id'              => usesysid,


### PR DESCRIPTION
Going to Ops -> Database accordion -> Client Connections tab gives me an error:

```
[----] F, [2018-11-06T15:07:47.101099 #16452:2af58f771424] FATAL -- : Error caught: [NameError] undefined l
ocal variable or method `waiting' for #<VmdbDatabaseConnection:0x007f5d97938a18>
Did you mean?  wait_time
/home/rblanco/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activemodel-5.0.7/lib/active_model/attribute_m
ethods.rb:433:in `method_missing'
/home/rblanco/devel/manageiq/app/models/vmdb_database_connection.rb:73:in `task_state'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:715:in `block in build_get_attributes_with_
options'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:711:in `each'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:711:in `build_get_attributes_with_options'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:699:in `build_reportable_data'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:412:in `block in build_table'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:411:in `collect'
/home/rblanco/devel/manageiq/app/models/miq_report/generator.rb:411:in `build_table'
/home/rblanco/devel/manageiq/app/models/miq_report/search.rb:118:in `paged_view_search'
/home/rblanco/devel/manageiq-ui-classic/app/controllers/application_controller.rb:1466:in `get_view'
/home/rblanco/devel/manageiq-ui-classic/app/controllers/application_controller.rb:435:in `report_data'
```

from what's available in the `self`, I'm guessing that `state` might be the right attribute to call, but I'm not sure:

```ruby
[8] pry(#<VmdbDatabaseConnection>)> self
=> #<VmdbDatabaseConnection:0x007f5048bfbbd0
 datid: 908555,
 datname: "gaprindashvili",
 pid: 19710,
 usesysid: 16384,
 usename: "root",
 application_name: "bin/rails",
 client_addr: nil,
 client_hostname: nil,
 client_port: -1,
 backend_start: Tue, 06 Nov 2018 14:12:03 UTC +00:00,
 xact_start: Tue, 06 Nov 2018 14:13:23 UTC +00:00,
 query_start: Tue, 06 Nov 2018 14:13:23 UTC +00:00,
 state_change: Tue, 06 Nov 2018 14:13:23 UTC +00:00,
 wait_event_type: nil,
 wait_event: nil,
 state: "active",
 backend_xid: nil,
 backend_xmin: "39100843",
 query:
  "SELECT \"pg_stat_activity\".\"datid\" AS t0_r0, \"pg_stat_activity\".\"datname\" AS t0_r1, \"pg_stat_activity\".\"pid\" AS t0_r2, \"pg_stat_activity\".\"usesysid\" AS t0_r3, \"pg_stat_activity\".\"usename\" AS t0_r4, \"pg_stat_activity\".\"application_name\" AS t0_r5, \"pg_stat_activity\".\"client_addr\" AS t0_r6, \"pg_stat_activity\".\"client_hostname\" AS t0_r7, \"pg_stat_activity\".\"client_port\" AS t0_r8, \"pg_stat_activity\".\"backend_start\" AS t0_r9, \"pg_stat_activity\".\"xact_start\" AS t0_r10, \"pg_stat_activity\".\"query_start\" AS t0_r11, \"pg_stat_activity\".\"state_change\" AS t0_r12, \"pg_stat_activity\".\"wait_event_type\" AS t0_r13, \"pg_stat_activity\".\"wait_event\" AS t0_r14, \"pg_stat_activity\".\"state\" AS t0_r15, \"pg_stat_activity\".\"backend_xid\" AS t0_r16, \"pg_stat_activity\".\"backend_xmin\" AS t0_r17, \"pg_stat_activity\".\"query\" AS t0_r18, \"pg_stat_activity\".\"backend_type\" AS t0_r19, \"pg_locks\".\"locktype\" AS t1_r0, \"pg_locks\".\"database\" AS t1_r1, \"pg_locks\".\"relation\" AS t1_r2, \"pg_locks\".\"page\" AS t1_r3, \"pg_locks\".\"tuple\" AS t1_r4, \"pg_locks\".\"vi",
 backend_type: "client backend">
```


Steps for Testing/QA
-------------------------------
 Ops -> Database accordion -> Client Connections tab 
