### PR TITLE
[WIP] Add MiqSchedule to RBAC

### DIFF
--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -43,6 +43,10 @@ class MiqSchedule < ApplicationRecord
   default_value_for :enabled, true
   default_value_for(:zone_id) { MiqServer.my_server.zone_id }
 
+  def self.rbac_scope_for_model(user)
+    user.super_admin_user? ? all : where(:userid => user.userid)
+  end
+
   def set_start_time_and_prod_default
     run_at # Internally this will correct :start_time to UTC
     self.prod_default = "system" if SYSTEM_SCHEDULE_CLASSES.include?(resource_type.to_s)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -883,6 +883,29 @@ describe Rbac::Filterer do
       end
     end
 
+    context 'searching for MiqSchedules' do
+      before { EvmSpecHelper.create_guid_miq_server_zone }
+
+      let!(:miq_schedule_1) { FactoryGirl.create(:miq_schedule, :resource_type => 'VmOrTemplate', :userid => other_user.userid) }
+      let!(:miq_schedule_2) { FactoryGirl.create(:miq_schedule, :resource_type => 'VmOrTemplate', :userid => admin_user.userid) }
+
+      it "returns all MiqSchedules for super admin user" do
+        User.with_user(admin_user) do
+          result = Rbac::Filterer.filtered(MiqSchedule.where(:resource_type => 'VmOrTemplate'))
+          expect(result).to match_array([miq_schedule_1, miq_schedule_2])
+        end
+      end
+
+      context "when user is non-super admin user" do
+        it "returns all custom button events" do
+          User.with_user(other_user) do
+            result = Rbac::Filterer.filtered(MiqSchedule.where(:resource_type => 'VmOrTemplate'))
+            expect(result).to eq([miq_schedule_1])
+          end
+        end
+      end
+    end
+
     context "searching for hosts" do
       it "can filter results by vmm_vendor" do
         host = FactoryGirl.create(:host, :vmm_vendor => "vmware")


### PR DESCRIPTION
with using only `rbac_scope_for_model` feature **(scope in model ability)**
`rbac_scope_for_model` feature has been added in https://github.com/ManageIQ/manageiq/pull/17954/files#diff-8d948055de14ced0e63abf9637a9a788R546


@miq-bot assign @gtanzillo 
@miq add_label rbac, refactoring


# Usage for UI
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/4889
