### PR TITLE
Don't JSON.parse(nil)

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -90,6 +90,7 @@ class DialogFieldDropDownList < DialogFieldSortedItem
   end
 
   def coerce_default_value_into_proper_format
+    return unless default_value
     unless JSON.parse(default_value).kind_of?(Array)
       self.default_value = Array.wrap(default_value).to_json
     end

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -146,9 +146,25 @@ describe DialogFieldDropDownList do
         allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).with(dialog_field).and_return(values)
       end
 
-      it "uses the given value as the default" do
-        dialog_field.initialize_with_given_value("test")
-        expect(dialog_field.default_value).to eq(["test"].to_json)
+      context "given value is a string" do
+        it "uses the given value as the default" do
+          dialog_field.initialize_with_given_value("test")
+          expect(dialog_field.default_value).to eq(["test"].to_json)
+        end
+      end
+
+      context "given value is an array" do
+        it "uses the given value as the default" do
+          dialog_field.initialize_with_given_value(["test"])
+          expect(dialog_field.default_value).to eq(["test"].to_json)
+        end
+      end
+
+      context "given value is nil" do
+        it "uses the given value as the default" do
+          dialog_field.initialize_with_given_value(nil)
+          expect(dialog_field.default_value).to eq(nil)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1645555

If the default_value is nil in a multiselect dynamic dropdown, we run into a TypeError (no implicit conversion of nil into String). 
