### PR TITLE
Separate queue put from publish event so we don't queue put twice

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -100,7 +100,8 @@ class CustomButton < ApplicationRecord
     MiqQueue.put(queue_opts(target, args))
   end
 
-  def publish_event(source, target, args)
+  def publish_event(source, target, args = nil)
+    args ||= resource_action.automate_queue_hash(target, {}, User.current_user)
     Array(target).each { |t| create_event(source, t, args) }
   end
 

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -384,5 +384,23 @@ describe CustomButton do
         end
       end
     end
+
+    describe "publish event" do
+      context "with blank args" do
+        it "resource action calls automate_queue_hash" do
+          expect(resource_action).to receive(:automate_queue_hash).with(vm, {}, user).and_return(:username => "foo")
+
+          User.with_user(user) { custom_button.publish_event('UI', vm) }
+        end
+      end
+
+      context "with args" do
+        it "resource action doesn't call automate_queue_hash" do
+          expect(resource_action).not_to receive(:automate_queue_hash)
+
+          User.with_user(user) { custom_button.publish_event('UI', vm, :username => "foo") }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The main repo part of https://github.com/ManageIQ/manageiq-api/pull/506/files. We're currently not creating custom button events for custom buttons with dialogs, because invoke never gets called. But invoke also does a queue put, which both custom buttons with and without dialogs handle, so the line to create custom button events needed to be later than the queue put as to not do the queue twice. 



## related 
https://github.com/ManageIQ/manageiq-api/pull/506