### PR TITLE
[WIP] Switch to manageiq-password instead of gems-pending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "linux_admin",                    "~>1.2.1",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.3.2",       :require => false
 gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
+gem "manageiq-password",              "~>0.1.0",       :require => false
 gem "manageiq-postgres_ha_admin",     "~>3.0",         :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)

--- a/config/application.rb
+++ b/config/application.rb
@@ -130,8 +130,8 @@ module Vmdb
       require_relative 'environments/patches/database_configuration'
 
       # To evaluate settings or database.yml with encrypted passwords
-      require 'miq-password'
-      MiqPassword.key_root = Rails.root.join("certs")
+      require 'manageiq/password'
+      ManageIQ::Password.key_root = Rails.root.join("certs")
 
       require 'vmdb_helper'
     end

--- a/tools/fix_auth/auth_model.rb
+++ b/tools/fix_auth/auth_model.rb
@@ -1,4 +1,4 @@
-require 'util/miq-password'
+require 'manageiq/password'
 
 module FixAuth
   module AuthModel

--- a/tools/fix_auth/fix_auth.rb
+++ b/tools/fix_auth/fix_auth.rb
@@ -1,4 +1,4 @@
-require 'util/miq-password'
+require 'manageiq/password'
 
 module FixAuth
   class FixAuth

--- a/tools/pg_inspector/inspect_pg.rb
+++ b/tools/pg_inspector/inspect_pg.rb
@@ -8,7 +8,7 @@ end
 
 require 'yaml'
 require 'manageiq-gems-pending'
-require 'util/miq-password'
+require 'manageiq/password'
 
 BASE_DIR = __dir__
 LOG_DIR = '/var/www/miq/vmdb/log'.freeze

--- a/tools/pg_inspector/inspect_pg_server.rb
+++ b/tools/pg_inspector/inspect_pg_server.rb
@@ -9,7 +9,7 @@ end
 
 require 'yaml'
 require 'manageiq-gems-pending'
-require 'util/miq-password'
+require 'manageiq/password'
 
 BASE_DIR = __dir__
 LOG_DIR = '/var/www/miq/vmdb/log'.freeze


### PR DESCRIPTION
Use the extracted manageiq-password gem instead of gems-pending

Depends on:
https://github.com/ManageIQ/manageiq-gems-pending/pull/407
https://github.com/ManageIQ/manageiq-schema/pull/303
https://github.com/agrare/manageiq-postgres_ha_admin/pull/1