### PR TITLE
Report accurate status on inactive VM

### DIFF
--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -37,7 +37,7 @@ class TransformationMapping::VmMigrationValidator
     conflict_list = []
 
     vm_names = @vm_list.collect { |row| row['name'] }
-    vm_objects = Vm.where(:name => vm_names, :ems_cluster => mapped_clusters).includes(:lans, :storages, :host, :ext_management_system)
+    vm_objects = Vm.where(:name => vm_names).includes(:ems_cluster, :lans, :storages, :host, :ext_management_system)
 
     @vm_list.each do |row|
       vm_name = row['name']
@@ -47,7 +47,8 @@ class TransformationMapping::VmMigrationValidator
         next
       end
 
-      vms = vm_objects.select { |vm| vm.name == vm_name }
+      vms = vm_objects.includes(:lans, :storages, :host, :ext_management_system).select { |vm| mapped_clusters.include?(vm.ems_cluster) }
+      vms = vms.select { |vm| vm.name == vm_name }
       vms = vms.select { |vm| vm.uid_ems == row['uid_ems'] } if row['uid_ems'].present?
       vms = vms.select { |vm| vm.host.name == row['host'] } if row['host'].present?
       vms = vms.select { |vm| vm.ext_management_system.name == row['provider'] } if row['provider'].present?

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -47,7 +47,12 @@ class TransformationMapping::VmMigrationValidator
         next
       end
 
-      vms = vm_objects.includes(:lans, :storages, :host, :ext_management_system).select { |vm| mapped_clusters.include?(vm.ems_cluster) }
+      if vm_objects.select { |vm| vm.name == vm_name && !vm.active? }.any?
+        invalid_list << VmMigrateStruct.new(vm_name, nil, VM_INVALID, VM_INACTIVE)
+        next
+      end
+
+      vms = vm_objects.select { |vm| mapped_clusters.include?(vm.ems_cluster) }
       vms = vms.select { |vm| vm.name == vm_name }
       vms = vms.select { |vm| vm.uid_ems == row['uid_ems'] } if row['uid_ems'].present?
       vms = vms.select { |vm| vm.host.name == row['host'] } if row['host'].present?
@@ -90,8 +95,6 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def vm_migration_status(vm)
-    return VM_INACTIVE unless vm.active?
-
     vm_as_resources = ServiceResource.joins(:service_template).where(:resource => vm, :service_templates => {:type => 'ServiceTemplateTransformationPlan'})
 
     # VM has not been migrated before


### PR DESCRIPTION
Currently in v2v, the VM Validator method in the CSV mode, provides incorrect status on an inactive VM -- the status reported is `not_exist` (as in, the VM does not exist)

This used to work prior to the refactor done in https://github.com/ManageIQ/manageiq/pull/17364

In this PR, the VM Validator method was fixed to get the accurate `inactive` status of the VM

https://bugzilla.redhat.com/show_bug.cgi?id=1639239

<img width="904" alt="screen shot 2018-11-08 at 2 46 59 pm" src="https://user-images.githubusercontent.com/1538216/48233303-8ce9bd80-e369-11e8-9f82-4de52d12ae3b.png">
