### PR TITLE
Don't create retire subtasks for service templates

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -167,6 +167,10 @@ class ServiceTemplate < ApplicationRecord
     archive!
   end
 
+  def retireable?
+    false
+  end
+
   def request_class
     ServiceTemplateProvisionRequest
   end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608958

We had [taken out much of the logic in the create_retire_subtask method for filtering out things we shouldn't create tasks for](https://github.com/ManageIQ/manageiq/commit/7d01d513f9d0ac58bbb708e2a8165112d3df5bdc) as part of a refactor because it didn't belong in the service task creation. In the process, _someone_ was a complete doofus who forgot to override the service_template ```retireable?``` method in the ```ci_feature_mixin```. 