### PR TITLE
Revert "MiqServer.seed should not call Zone.seed"

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -154,6 +154,7 @@ class MiqServer < ApplicationRecord
 
   def self.seed
     unless exists?(:guid => my_guid)
+      Zone.seed
       _log.info("Creating Default MiqServer with guid=[#{my_guid}], zone=[#{Zone.default_zone.name}]")
       create!(:guid => my_guid, :zone => Zone.default_zone)
       my_server_clear_cache

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,8 +1,5 @@
 describe MiqServer do
-  context ".seed" do
-    before { Zone.seed }
-    include_examples ".seed called multiple times"
-  end
+  include_examples ".seed called multiple times"
 
   context "#hostname" do
     it("with a valid hostname")    { expect(MiqServer.new(:hostname => "test").hostname).to eq("test") }


### PR DESCRIPTION
Reverts ManageIQ/manageiq#18173

This broke travis for manageiq-ui-classic in multiple spec files (and probably more):

```
  1) ApplicationHelper::ToolbarBuilder update_url_parms when the request query string has a few specific params to be excluded excludes specific parameters and adds the new one
     Failure/Error: MiqServer.seed
     
     NoMethodError:
       undefined method `name' for nil:NilClass
     # /home/mmarosi/manageiq/app/models/miq_server.rb:158:in `seed'
     # ./spec/helpers/application_helper/toolbar_builder_spec.rb:335:in `block (3 levels) in <top (required)>'

```

It is related to Zone in manageiq/app/models/miq_server.rb
```
157:        _log.info("Creating Default MiqServer with guid=[#{my_guid}], zone=[#{Zone.default_zone.name}]")
```
Deleting this line fixes it, but its not the right fix imo.