### PR TITLE
Fix issues with OpenSCAP policy

### DIFF
--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -183,6 +183,7 @@ request_orchestration_stack_retire,Orchestration Stack Retire Request,Default,or
 # Container Operations
 #
 request_containerimage_scan,Container Image Analysis Request,Default,container_operations
+containerimage_scan_abort,Container Image Analysis Failure,Default,container_operations
 containerimage_scan_complete,Container Image Analysis Complete,Default,container_operations
 containerimage_created,Container Image Discovered,Default,container_operations
 containerimage_compliance_check,Container Image Compliance Check,Default,compliance

--- a/db/fixtures/miq_policy_sets.yml
+++ b/db/fixtures/miq_policy_sets.yml
@@ -70,8 +70,8 @@
           action_type: default
           options: {}
       Condition:
-      - name: if container image has high severity openscap rule results
-        description: Has high severity OpenSCAP rule results
+      - name: if container image has no high severity failure in openscap rule results
+        description: No high severity failure in OpenSCAP rule results
         expression: !ruby/object:MiqExpression
           exp:
             not:


### PR DESCRIPTION
Fix the name and description of OpenSCAP policy.
Add containerimage_scan_abort event.

Blocks https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/303.

https://bugzilla.redhat.com/show_bug.cgi?id=1499161

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, hammer/yes