### PR TITLE
Add Conversion Host features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6305,6 +6305,34 @@
       :identifier: transformation_mapping_delete
       :feature_type: admin
 
+- :name: Conversion Hosts
+  :description: Conversion Hosts
+  :feature_type: node
+  :identifier: conversion_host
+  :children:
+  - :name: View
+    :description: View Conversion Hosts
+    :feature_type: view
+    :identifier: conversion_host_view
+    :children:
+    - :name: List
+      :description: Display Lists of Conversion Hosts
+      :feature_type: view
+      :identifier: conversion_host_show_list
+    - :name: Show
+      :description: Display Individual Conversion Hosts
+      :feature_type: view
+      :identifier: conversion_host_show
+  - :name: Operate
+    :description: Perform Operations on Conversion Hosts
+    :feature_type: control
+    :identifier: conversion_host_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Conversion Hosts
+      :feature_type: control
+:identifier: conversion_host_tag
+
 # API
 - :name: API
   :description: Features Exclusive to the API

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1117,6 +1117,34 @@
   :description: Everything under Migration
   :feature_type: node
   :identifier: migration
+  :children:
+  - :name: Conversion Hosts
+    :description: Conversion Hosts
+    :feature_type: node
+    :identifier: conversion_host
+    :children:
+    - :name: View
+      :description: View Conversion Hosts
+      :feature_type: view
+      :identifier: conversion_host_view
+      :children:
+      - :name: List
+        :description: Display Lists of Conversion Hosts
+        :feature_type: view
+        :identifier: conversion_host_show_list
+      - :name: Show
+        :description: Display Individual Conversion Hosts
+        :feature_type: view
+        :identifier: conversion_host_show
+    - :name: Operate
+      :description: Perform Operations on Conversion Hosts
+      :feature_type: control
+      :identifier: conversion_host_control
+      :children:
+      - :name: Edit Tags
+        :description: Edit Tags of Conversion Hosts
+        :feature_type: control
+        :identifier: conversion_host_tag
 
 # Datacenters
 - :name: Datacenters
@@ -6304,34 +6332,6 @@
       :description: Delete Transformation Mapping
       :identifier: transformation_mapping_delete
       :feature_type: admin
-
-- :name: Conversion Hosts
-  :description: Conversion Hosts
-  :feature_type: node
-  :identifier: conversion_host
-  :children:
-  - :name: View
-    :description: View Conversion Hosts
-    :feature_type: view
-    :identifier: conversion_host_view
-    :children:
-    - :name: List
-      :description: Display Lists of Conversion Hosts
-      :feature_type: view
-      :identifier: conversion_host_show_list
-    - :name: Show
-      :description: Display Individual Conversion Hosts
-      :feature_type: view
-      :identifier: conversion_host_show
-  - :name: Operate
-    :description: Perform Operations on Conversion Hosts
-    :feature_type: control
-    :identifier: conversion_host_control
-    :children:
-    - :name: Edit Tags
-      :description: Edit Tags of Conversion Hosts
-      :feature_type: control
-      :identifier: conversion_host_tag
 
 # API
 - :name: API

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6331,7 +6331,7 @@
     - :name: Edit Tags
       :description: Edit Tags of Conversion Hosts
       :feature_type: control
-:identifier: conversion_host_tag
+      :identifier: conversion_host_tag
 
 # API
 - :name: API


### PR DESCRIPTION
Adds features for ConversionHosts in order to satisfy ManageIQ/manageiq-api#507 as part of the v2v effort.

Marked as a WIP for now until my fellow v2v compatriots can confirm this is correct.