### PR TITLE
[GAPRINDASHVILI] retirement_requester should be userid, not object

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -106,8 +106,7 @@ module RetirementMixin
 
   def retirement_check
     return if retired? || retiring? || retirement_initialized?
-    requester = system_context_requester
-
+    requester = system_context_requester&.userid
     if !retirement_warned? && retirement_warning_due?
       begin
         self.retirement_last_warn = Time.now.utc

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -1,5 +1,5 @@
 describe "Service Retirement Management" do
-  let(:user) { FactoryGirl.create(:user) }
+  let!(:user) { FactoryGirl.create(:user_miq_request_approver) }
   before(:each) do
     @miq_server = EvmSpecHelper.local_miq_server
     @stack = FactoryGirl.create(:orchestration_stack)
@@ -35,7 +35,7 @@ describe "Service Retirement Management" do
     event_name = 'request_orchestration_stack_retire'
     event_hash = {:userid => user.userid, :orchestration_stack => @stack, :type => "OrchestrationStack"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, :user_id => user.id).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, :user_id => user.id, :tenant_id => user.current_tenant.id, :group_id => user.current_group.id).once
 
     @stack.retire_now(user.userid)
     @stack.reload

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -1,5 +1,5 @@
 describe "Service Retirement Management" do
-  let(:user) { FactoryGirl.create(:user) }
+  let!(:user) { FactoryGirl.create(:user_miq_request_approver) }
   before(:each) do
     @server = EvmSpecHelper.local_miq_server
     @service = FactoryGirl.create(:service)
@@ -54,7 +54,7 @@ describe "Service Retirement Management" do
     event_name = 'request_service_retire'
     event_hash = {:userid => user.userid, :service => @service, :type => "Service"}
 
-    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, :user_id => user.id).once
+    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, :user_id => user.id, :tenant_id => user.current_tenant.id, :group_id => user.current_group.id).once
 
     @service.retire_now(user.userid)
   end

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -1,5 +1,5 @@
 describe "VM Retirement Management" do
-  let(:user) { FactoryGirl.create(:user) }
+  let!(:user) { FactoryGirl.create(:user_miq_request_approver) }
   before(:each) do
     miq_server = EvmSpecHelper.local_miq_server
     @zone = miq_server.zone
@@ -54,7 +54,7 @@ describe "VM Retirement Management" do
   it "#retire_now with userid" do
     event_name = 'request_vm_retire'
     event_hash = {:userid => user.userid, :vm => @vm, :host => @vm.host, :type => "ManageIQ::Providers::Vmware::InfraManager::Vm"}
-    options = {:zone => @zone.name, :user_id => user.id}
+    options = {:zone => @zone.name, :user_id => user.id, :tenant_id => user.current_tenant.id, :group_id => user.current_group.id}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash, options).once
 
@@ -163,7 +163,7 @@ describe "VM Retirement Management" do
   it "#raise_retirement_event with current user" do
     event_name = 'foo'
     event_hash = {:userid => user.userid, :vm => @vm, :host => @vm.host, :type => "ManageIQ::Providers::Vmware::InfraManager::Vm"}
-    options = {:zone => @vm.my_zone, :user_id => user.id}
+    options = {:zone => @vm.my_zone, :user_id => user.id, :tenant_id => user.current_tenant.id, :group_id => user.current_group.id}
 
     expect(MiqEvent).to receive(:raise_evm_event).with(@vm, event_name, event_hash, options).once
     @vm.raise_retirement_event(event_name, user.userid)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649219.

Because [fc23f2c Merge pull request #18106 from d-m-u/fixing_retirement_user_on_gap](https://github.com/ManageIQ/manageiq/pull/18106) got in without [the changes I made on master to update the retirement_requester](https://github.com/ManageIQ/manageiq/blob/master/app/models/mixins/retirement_mixin.rb#L31), the user on 5.9.6 is an object in the retirement_requester field rather than what it should be, the userid.