### PR TITLE
Save mappings to options hash when calculated

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -84,15 +84,21 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def virtv2v_disks
-    options[:virtv2v_disks] ||= calculate_virtv2v_disks.tap do |disks|
-      update_attributes(:options => options.merge(:virtv2v_disks => disks))
-    end
+    return options[:virtv2v_disks] if options[:virtv2v_disks].present?
+
+    options[:virtv2v_disks] = calculate_virtv2v_disks
+    save!
+
+    options[:virtv2v_disks]
   end
 
   def network_mappings
-    options[:network_mappings] ||= calculate_network_mappings.tap do |mappings|
-      update_attributes(:options => options.merge(:network_mappings => mappings))
-    end
+    return options[:network_mappings] if options[:network_mappings].present?
+
+    options[:network_mappings] = calculate_network_mappings
+    save!
+
+    options[:network_mappings]
   end
 
   def destination_network_ref(network)


### PR DESCRIPTION
When calculating the network mappings and virtv2v disks, we add them to the task options hash for future consumption, such as when building the virt-v2v-wrapper options. This PR effectively save the options hash, when previous code only changed the in-memory value.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1649020