### PR TITLE
Disconnect storage when disconnecting the VM

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -95,10 +95,6 @@ class EmsEvent
       call("src_vm", "snapshots.destroy_all")
     end
 
-    def src_vm_disconnect_storage
-      call("src_vm", "disconnect_storage")
-    end
-
     private
 
     def parse_policy_parameters(target_str, policy_event, param)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -663,7 +663,7 @@ class VmOrTemplate < ApplicationRecord
     end
 
     disconnect_host
-
+    disconnect_storage
     disconnect_stack if respond_to?(:orchestration_stack)
   end
 


### PR DESCRIPTION
Instead of having the EventHandler call disconnect_storage from an event
handler, call it when disconnecting the VM.

Related:
- https://github.com/ManageIQ/manageiq-providers-vmware/pull/336
- https://github.com/ManageIQ/manageiq-content/pull/472
- https://github.com/ManageIQ/manageiq-providers-ovirt/pull/310

https://bugzilla.redhat.com/show_bug.cgi?id=1644770