### PR TITLE
Remove tenant selection from base deployment options

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -103,20 +103,6 @@ class OrchestrationTemplate < ApplicationRecord
   # Basic options for all templates, each subclass should add more type/provider specific deployment options
   # Return array of OrchestrationParameters. (Deployment options are different from parameters, but they use same class)
   def deployment_options(_manager_class = nil)
-    tenant_opt = OrchestrationTemplate::OrchestrationParameter.new(
-      :name           => "tenant_name",
-      :label          => "Tenant",
-      :data_type      => "string",
-      :description    => "Tenant where the stack will be deployed",
-      :required       => true,
-      :reconfigurable => false,
-      :constraints => [
-        OrchestrationTemplate::OrchestrationParameterAllowedDynamic.new(
-          :fqname => "/Cloud/Orchestration/Operations/Methods/Available_Tenants"
-        )
-      ]
-    )
-
     stack_name_opt = OrchestrationTemplate::OrchestrationParameter.new(
       :name           => "stack_name",
       :label          => "Stack Name",
@@ -130,7 +116,7 @@ class OrchestrationTemplate < ApplicationRecord
         )
       ]
     )
-    [tenant_opt, stack_name_opt]
+    [stack_name_opt]
   end
 
   # List managers that may be able to deploy this template

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -304,8 +304,7 @@ describe OrchestrationTemplate do
   describe "#deployment_options" do
     it do
       options = subject.deployment_options
-      assert_deployment_option(options[0], "tenant_name", :OrchestrationParameterAllowedDynamic, true)
-      assert_deployment_option(options[1], "stack_name", :OrchestrationParameterPattern, true)
+      assert_deployment_option(options[0], "stack_name", :OrchestrationParameterPattern, true)
     end
   end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1642594

The only provider that needs tenant is openstack. The options will be added in manageiq-providers-openstack repo.

Newly generated service dialog from orchestration template by default will no longer contain a dynamic dropdown for tenant selection.

@miq-bot assign @tinaafitz 
@miq-bot label bug
cc @d-m-u 

This PR will temporarily break the CI build for manageiq-providers-openstack, manageiq-providers-azure, and manageiq-providers-amazon.
