### PR TITLE
[WIP] Add owner to orch stack model

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -7,6 +7,7 @@ class OrchestrationStack < ApplicationRecord
   include NewWithTypeStiMixin
   include AsyncDeleteMixin
   include ProcessTasksMixin
+  include OwnershipMixin
   include RetirementMixin
   include TenantIdentityMixin
   include CustomActionsMixin
@@ -47,6 +48,8 @@ class OrchestrationStack < ApplicationRecord
   virtual_total :total_cloud_networks, :cloud_networks
 
   virtual_column :stdout, :type => :string
+
+  before_validation :set_tenant_from_group
 
   scope :without_type, ->(type) { where.not(:type => type) }
 
@@ -91,6 +94,10 @@ class OrchestrationStack < ApplicationRecord
 
   def stdout(format = nil)
     format.nil? ? try(:raw_stdout) : try(:raw_stdout, format)
+  end
+
+  def set_tenant_from_group
+    self.tenant_id = miq_group.tenant_id if miq_group
   end
 
   private :directs_and_indirects

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
@@ -15,6 +15,32 @@ describe ManageIQ::Providers::CloudManager::OrchestrationStack do
     end
   end
 
+  describe 'set_tenant_from_group' do
+    before { Tenant.seed }
+    let(:tenant1) { FactoryGirl.create(:tenant) }
+    let(:tenant2) { FactoryGirl.create(:tenant) }
+    let(:group1) { FactoryGirl.create(:miq_group, :tenant => tenant1) }
+    let(:group2) { FactoryGirl.create(:miq_group, :tenant => tenant2) }
+
+    it "assigns the tenant from the group" do
+      expect(FactoryGirl.create(:orchestration_stack, :miq_group => group1).tenant_id).to eq(tenant1.id)
+    end
+
+    it "assigns the tenant from the group_id" do
+      expect(FactoryGirl.create(:orchestration_stack, :miq_group_id => group1.id).tenant_id).to eq(tenant1.id)
+    end
+
+    it "assigns the tenant from the group over the tenant" do
+      expect(FactoryGirl.create(:orchestration_stack, :miq_group => group1, :tenant_id => tenant2.id).tenant_id).to eq(tenant1.id)
+    end
+
+    it "changes the tenant after changing the group" do
+      vm = FactoryGirl.create(:orchestration_stack, :miq_group => group1)
+      vm.update_attributes(:miq_group_id => group2.id)
+      expect(vm.tenant_id).to eq(tenant2.id)
+    end
+  end
+
   describe 'direct_<resource> methods' do
     it 'defines a set of methods for vms' do
       expect(root_stack.direct_vms.size).to eq(1)


### PR DESCRIPTION
Add owners to orch stacks provision'd by MIQ. 

I think this needs the same thing that services have: the ```belongs_to :tenant``` so I can fix these specs to look exactly like how services act. 