### PR TITLE
Properly generate report yml include with virtual attributes

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -81,16 +81,11 @@ module MiqReport::Generator
   end
 
   def get_include_for_find
-    (include_as_hash.presence || invent_includes).deep_merge(include_for_find || {}).presence
+    include_as_hash(include.presence || invent_report_includes).deep_merge(include_for_find || {}).presence
   end
 
   def invent_includes
-    return {} unless col_order
-    col_order.each_with_object({}) do |col, ret|
-      next unless col.include?(".")
-      *rels, _col = col.split(".")
-      rels.inject(ret) { |h, rel| h[rel.to_sym] ||= {} } unless col =~ /managed\./
-    end
+    include_as_hash(invent_report_includes)
   end
 
   # would like this format to go away


### PR DESCRIPTION
## Problem

### Before

If a `report.yml` file had virtual attributes in the `:cols` but did not have an `:include` entry,
it was not properly generating the `includes().references()` hash.

**REMINDER:** `report.yml` files are used to represent every data view in our product.

### After

It is now generating the correct `:includes` from `:col_order` when `:include` is not defined,
regardless of whether `:col` contains virtual attributes or not.

## Impact

We are constantly tuning the `app/model` classes. Sometimes the relations change (e.g.: `pictures` no longer points to `binary_blobs`) and other times the virtual attributes are embeddable in sql. So this means the correct `includes()`/`references()` values change.

Since the `report.yml` files are in a different git repo, they are often not updated. This means extra data gets downloaded, or in some cases, just plain break. Which happened with `ServiceTemplate.yml`.

The frustrating part is the `includes` entries can just be derived from the `app/model` class relationships, and shouldn't even need to be declared in the `report.yml` files in the first place.

## Conclusion

Properly generating the `includes()` allows us to remove more of the `:include` entries from the reports, and that means we have fewer incorrect reports / views. And it means faster views.

/cc @jrafanie @martinpovolny 