### PR TITLE
5.1: Fixes ambiguous source reflection for through

### DIFF
--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -20,7 +20,7 @@ class LoadBalancer < ApplicationRecord
   has_many :network_ports, :as => :device
   has_many :cloud_subnet_network_ports, :through => :network_ports
   has_many :cloud_subnets, :through => :cloud_subnet_network_ports
-  has_many :floating_ips, :through => :network_ports
+  has_many :floating_ips, :through => :network_ports, :source => :floating_ips
   has_many :security_groups, -> { distinct }, :through => :network_ports
 
   has_many :vms, -> { distinct }, :through => :load_balancer_pool_members


### PR DESCRIPTION
NetworkPort has:
  has_one :floating_ip
  has_many :floating_ips

Since the through association on LoadBalancer goes through
network_ports, it doesn't know which assocation to use for the source.

Since we were using floating_ips originally in rails 5.0, we'll specify
the same for the source.

This was deprecated in rails 5.0 and now raises an error in 5.1:

```
Error caught: [ActionView::Template::Error] Ambiguous source reflection
for through association. Please specify a :source directive on your
declaration like:

  class LoadBalancer < ActiveRecord::Base
      has_many :floating_ips, {:through=>:network_ports,
      :source=>"floating_ip"}
        end
```
Extracted from https://github.com/ManageIQ/manageiq/pull/18076