### PR TITLE
[WIP] Test all settings values round-trip cleanly to_json and back

### DIFF
--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -582,4 +582,15 @@ describe Vmdb::Settings do
 
     expect(::Settings.api.token_ttl).to eq("2.minutes")
   end
+
+  describe "Full settings values" do
+    # Important for being able to safely modify settings through the REST API.
+    it "can be round-tripped through JSON" do
+      orig = Settings.to_hash
+      tripped = JSON.parse(orig.to_json, :symbolize_names => true)
+
+      expect(tripped.pretty_inspect).to eq(orig.pretty_inspect)
+      expect(tripped).to eq(orig)
+    end
+  end
 end


### PR DESCRIPTION
Important for being able to safely modify settings through the REST API.

https://github.com/ManageIQ/manageiq/issues/17201
https://bugzilla.redhat.com/show_bug.cgi?id=1558031

Currently fails on several regexps and symbols.  Diff listed here: https://github.com/ManageIQ/manageiq/issues/17201#issuecomment-385925194

@miq-bot add-label test
cc @Fryguy 