### PR TITLE
Add owner to orch stack model provisioning

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -7,6 +7,7 @@ class OrchestrationStack < ApplicationRecord
   include NewWithTypeStiMixin
   include AsyncDeleteMixin
   include ProcessTasksMixin
+  include OwnershipMixin
   include RetirementMixin
   include TenantIdentityMixin
   include CustomActionsMixin
@@ -18,6 +19,7 @@ class OrchestrationStack < ApplicationRecord
   has_ancestry
 
   belongs_to :ext_management_system, :foreign_key => :ems_id
+  belongs_to :tenant
 
   has_many   :authentication_orchestration_stacks
   has_many   :authentications, :through => :authentication_orchestration_stacks
@@ -47,6 +49,8 @@ class OrchestrationStack < ApplicationRecord
   virtual_total :total_cloud_networks, :cloud_networks
 
   virtual_column :stdout, :type => :string
+
+  before_validation :set_tenant_from_group
 
   scope :without_type, ->(type) { where.not(:type => type) }
 
@@ -91,6 +95,10 @@ class OrchestrationStack < ApplicationRecord
 
   def stdout(format = nil)
     format.nil? ? try(:raw_stdout) : try(:raw_stdout, format)
+  end
+
+  def set_tenant_from_group
+    self.tenant_id = miq_group.tenant_id if miq_group
   end
 
   private :directs_and_indirects

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
@@ -15,6 +15,32 @@ describe ManageIQ::Providers::CloudManager::OrchestrationStack do
     end
   end
 
+  describe 'set_tenant_from_group' do
+    before { Tenant.seed }
+    let(:tenant1) { FactoryGirl.create(:tenant) }
+    let(:tenant2) { FactoryGirl.create(:tenant) }
+    let(:group1) { FactoryGirl.create(:miq_group, :tenant => tenant1) }
+    let(:group2) { FactoryGirl.create(:miq_group, :tenant => tenant2) }
+
+    it "assigns the tenant from the group" do
+      expect(FactoryGirl.create(:orchestration_stack, :miq_group => group1).tenant).to eq(tenant1)
+    end
+
+    it "assigns the tenant from the group_id" do
+      expect(FactoryGirl.create(:orchestration_stack, :miq_group_id => group1.id).tenant).to eq(tenant1)
+    end
+
+    it "assigns the tenant from the group over the tenant" do
+      expect(FactoryGirl.create(:orchestration_stack, :miq_group => group1, :tenant_id => tenant2).tenant).to eq(tenant1)
+    end
+
+    it "changes the tenant after changing the group" do
+      stack = FactoryGirl.create(:orchestration_stack, :miq_group => group1)
+      stack.update_attributes(:miq_group_id => group2.id)
+      expect(stack.tenant).to eq(tenant2)
+    end
+  end
+
   describe 'direct_<resource> methods' do
     it 'defines a set of methods for vms' do
       expect(root_stack.direct_vms.size).to eq(1)


### PR DESCRIPTION
Add owner to orch stacks so that when we retire them, we can have some concept of who the retiree is. This is exact the same's we do for services. 