### PR TITLE
Accept Hash object as result of inter region api invocation

### DIFF
--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -80,6 +80,11 @@ module InterRegionApiMethodRelay
       result.attributes
     when ManageIQ::API::Client::Resource
       instance_for_resource(result)
+    when Hash
+      # Some of API invocation returning Hash object
+      # Example: retire_resource for Service
+      _log.warn("remote API invocation returned Hash object")
+      result
     else
       raise InterRegionApiMethodRelayError, "Got unexpected API result object #{result.class}"
     end

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -228,6 +228,11 @@ describe InterRegionApiMethodRelay do
         }.to raise_error(described_class::InterRegionApiMethodRelayError)
       end
 
+      it "accepts Hash object as api result" do
+        expect(api_collection).to receive(action).and_return({})
+        expect { described_class.exec_api_call(region, collection_name, action) }.not_to raise_error
+      end
+
       it "calls the given action with the given args" do
         args = {:my => "args", :here => 123}
         expect(api_collection).to receive(action).with(args).and_return(api_success_result)


### PR DESCRIPTION
**Issue**:
Setting retirement date on Service via Centralized Administration generates error in log:
```
ERROR -- : [InterRegionApiMethodRelay::InterRegionApiMethodRelayError]: Got unexpected API result object Hash  Method:[block in method_missing]
ERROR -- : /var/www/miq/vmdb/app/models/mixins/inter_region_api_method_relay.rb:84:in `exec_api_call'
/var/www/miq/vmdb/app/models/mixins/inter_region_api_method_relay.rb:32:in `block (2 levels) in api_relay_method'
/var/www/miq/vmdb/app/models/mixins/retirement_mixin.rb:16:in `block in retire'
```

Blocking: https://github.com/ManageIQ/manageiq/pull/18195 and https://github.com/ManageIQ/manageiq-ui-classic/pull/4874

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650335 

@miq-bot add-label bug, blocker. hammer/yes, gaprindashvili/yes, core