### PR TITLE
Cloud instances cannot have disconnected state

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -94,6 +94,14 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     [availability_zone, host_aggregates, service].compact.flatten unless interval_name == 'realtime'
   end
 
+  def disconnected
+    false
+  end
+
+  def disconnected?
+    false
+  end
+
   #
   # UI Button Validation Methods
   #

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -44,4 +44,12 @@ describe VmCloud do
       end
     end
   end
+
+  it '.disconnected' do
+    expect(subject.disconnected).to be_falsey
+  end
+
+  it '.disconnected?' do
+    expect(subject.disconnected?).to be_falsey
+  end
 end


### PR DESCRIPTION
With this commit we hard-code `disconnected?` methods to `false` for cloud VMs. A VM can only get disconnected when its host suddenly shuts down. But for cloud provider this cannot happen: if host goes down, VM is gone for good from user perspective.

Problem is that VM's `disconnected?` status is calculated based on `connection_status` DB value. For cloud VMs this value is left as NULL which is interpreted as disconnected. There are two kinds of workarounds that cloud providers were currently using to overcome this issue:

a) override `disconnected?` on corresponding Vm class (AWS, Azure)    [link](https://github.com/ManageIQ/manageiq-providers-amazon/blob/master/app/models/manageiq/providers/amazon/cloud_manager/vm.rb#L36-L42)
b) forcibly set `vm.connection_state = 'connected'` upon inventoring (OpenStack)    [link](https://github.com/ManageIQ/manageiq-providers-openstack/blob/master/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb#L324)

Option (b) is a dirty workaround because there is no such thing as `vm.connection_state` for cloud VMs. Option (a) is impractical because every future cloud provider needs to override like this. With this commit we therefore override the functions in base cloud Vm class so it works for all cloud providers.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649403

@miq-bot assign @agrare
@miq-bot add_label enhancement,hammer/yes

/cc @Fryguy @skateman 