### PR TITLE
Cloud VM should be marked as connected by default

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -28,6 +28,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   has_many   :host_aggregates,        :through => :host
 
   default_value_for :cloud, true
+  default_value_for :connection_state, 'connected'
 
   virtual_column :ipaddresses, :type => :string_set, :uses => {:network_ports => :ipaddresses}
   virtual_column :floating_ip_addresses, :type => :string_set, :uses => {:network_ports => :floating_ip_addresses}

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -44,4 +44,12 @@ describe VmCloud do
       end
     end
   end
+
+  it '.disconnected' do
+    expect(subject.disconnected).to be_falsey
+  end
+
+  it '.disconnected?' do
+    expect(subject.disconnected?).to be_falsey
+  end
 end


### PR DESCRIPTION
With this commit we set default value of connection stats for cloud instances, which is supposed to be 'connected' for all of them. That's because cloud instances can not reach disconnected state. Until now `connection_stats = nil` was the default which is interpreted as 'disconnected' by MIQ -> which is imposssible for cloud instances per se.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649403
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/4909

@miq-bot assign @agrare
@miq-bot add_label enhancement,hammer/yes

/cc @kbrock @Fryguy @skateman