### PR TITLE
Remove Open4 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,10 +152,6 @@ group :google, :openshift, :manageiq_default do
   gem "sshkey",                         "~>1.8.0",       :require => false
 end
 
-group :automate, :cockpit, :manageiq_default do
-  gem "open4",                          "~>1.3.0",       :require => false
-end
-
 ### end of provider bundler groups
 
 group :automate, :seed, :manageiq_default do

--- a/app/models/miq_cockpit_ws_worker/runner.rb
+++ b/app/models/miq_cockpit_ws_worker/runner.rb
@@ -143,16 +143,16 @@ class MiqCockpitWsWorker::Runner < MiqWorker::Runner
     cockpit_ws = MiqCockpit::WS.new(opts)
     cockpit_ws.save_config
 
-    require 'open4'
+    require "open3"
     env = {
       "XDG_CONFIG_DIRS" => cockpit_ws.config_dir,
       "DRB_URI"         => @drb_uri
     }
-    pid, stdin, stdout, stderr = Open4.popen4(env, *cockpit_ws.command(BINDING_ADDRESS))
+    stdin, stdout, stderr, wait_thr = Open3.popen3(env, *cockpit_ws.command(BINDING_ADDRESS))
     stdin.close
 
     _log.info("#{log_prefix} cockpit-ws process started - pid=#{pid}")
-    return pid, stdout, stderr
+    return wait_thr.pid, stdout, stderr
   end
 
   def check_drb_service


### PR DESCRIPTION
With the removal of `open4` from automate:

https://github.com/ManageIQ/manageiq-automation_engine/pull/251

`MiqCockpitWsWorker::Runner` is the only place that his is currently using `open4` in the `ManageIQ` organization:

https://github.com/search?l=Ruby&q=org%3AManageIQ+Open4&type=Code

`Open3` seems to be able to do everything that is asked of `Open4`, so the change should have little to no affect.


Links
-----

* For a longer description... https://github.com/ManageIQ/manageiq-automation_engine/pull/251
* https://github.com/ManageIQ/manageiq-automation_engine/pull/251