### PR TITLE
Fix tag classification test

### DIFF
--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -104,15 +104,9 @@ describe Tag do
     end
 
     it "tag with nil classification" do
-      @tag.classification = nil
-      categorization = @tag.categorization
-
-      expected_categorization = {"name"         => nil,
-                                 "description"  => nil,
-                                 "category"     => {"name" => @category.name, "description" => @category.description},
-                                 "display_name" => "#{@category.description}: "}
-      expect(@tag.show).to eq(true)
-      expect(categorization).to eq(expected_categorization)
+      @tag.classification.delete
+      expect(@tag.show).to be_falsey
+      expect(@tag.categorization).to eq({})
     end
 
     it "category tags have no category" do


### PR DESCRIPTION
Per #18177 - we wanted a tag to not throw an exception when it had no classification.

As @jrafanie pointed out, setting `tag.classification = nil` doesn't really delete the record from the database. So the `classification` record will still exist in the database and `tag.category` will still return a value.

Using a `delete` or `destroy` will remove the `classification` record from the database and better represent what happens at runtime.

```diff
-  tag.classification = nil
+  tag.classification.delete
```

As you can see from this diagram (taken from another PR), it shows that a missing `classification` results in a missing `category`.

![graph 2](https://user-images.githubusercontent.com/1930/40375536-e1b5cccc-5db9-11e8-9113-4faa828f6e8e.png)


But how can a tag exist without a `classification` you ask? I've included some examples from the local MBU database to illustrate:

- `/chargeback_rate/assigned_to/ext_management_system/id/12`
- `/managed/roles/change_managers`
- `/managed/roles/operators`
- `/miq_alert_set/assigned_to/ext_management_system/id/51`
- `/miq_alert_set/assigned_to/miq_enterprise/id/1`
- `/miq_alert_set/assigned_to/vm/tag/managed/cc/001`
- `/miq_policy/assignment/miq_policy_set/15`
- `/performance/capture_enabled`
- `/performance/host_and_cluster/capture_enabled`
- `/performance/storage/capture_enabled`
