### PR TITLE
Default connection_status to connected

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -316,7 +316,7 @@ class VmOrTemplate < ApplicationRecord
 
   # TODO: Vmware specific, and is this even being used anywhere?
   def connected_to_ems?
-    connection_state == 'connected'
+    connection_state == 'connected' || connection_state.nil?
   end
 
   def terminated?
@@ -1319,10 +1319,10 @@ class VmOrTemplate < ApplicationRecord
   end)
 
   def disconnected?
-    connection_state != "connected"
+    !connected_to_ems?
   end
   virtual_attribute :disconnected, :boolean, :arel => (lambda do |t|
-    t.grouping(t[:connection_state].eq(nil).or(t[:connection_state].not_eq("connected")))
+    t.grouping(t[:connection_state].not_eq(nil).and(t[:connection_state].not_eq("connected")))
   end)
   alias_method :disconnected, :disconnected?
 

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -125,7 +125,7 @@ module VmOrTemplate::Operations
               _('The VM is terminated')
             elsif !has_required_host?
               _('The VM is not connected to a Host')
-            elsif !connection_state.nil? && !connected_to_ems?
+            elsif disconnected?
               _('The VM does not have a valid connection state')
             elsif !has_active_ems?
               _("The VM is not connected to an active Provider")

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -982,24 +982,41 @@ describe VmOrTemplate do
     end
   end
 
-  describe ".disconnected" do
+  describe "connected_to_ems?" do
     let(:vm) { FactoryGirl.create(:vm_vmware, :connection_state => "connected") }
     let(:vm2) { FactoryGirl.create(:vm_vmware, :connection_state => "disconnected") }
+    let(:vm3) { FactoryGirl.create(:vm_vmware, :connection_state => nil) }
 
     it "detects nil" do
-      vm.update_attributes(:connection_state => nil)
-      expect(vm.disconnected).to be_truthy
-      expect(virtual_column_sql_value(VmOrTemplate, "disconnected")).to be_truthy
+      expect(vm3).to be_connected_to_ems
     end
 
     it "detects connected" do
-      expect(vm.disconnected).to be_falsey
+      expect(vm).to be_connected_to_ems
+    end
+
+    it "detects disconnected" do
+      expect(vm2).not_to be_connected_to_ems
+    end
+  end
+
+  describe ".disconnected?" do
+    let(:vm) { FactoryGirl.create(:vm_vmware, :connection_state => "connected") }
+    let(:vm2) { FactoryGirl.create(:vm_vmware, :connection_state => "disconnected") }
+    let(:vm3) { FactoryGirl.create(:vm_vmware, :connection_state => nil) }
+
+    it "detects nil" do
+      expect(vm3).not_to be_disconnected
+      expect(virtual_column_sql_value(VmOrTemplate, "disconnected")).to be_falsey
+    end
+
+    it "detects connected" do
+      expect(vm).not_to be_disconnected
       expect(virtual_column_sql_value(VmOrTemplate, "disconnected")).to be_falsey
     end
 
     it "detects disconnected" do
-      vm2.save
-      expect(vm2.disconnected).to be_truthy
+      expect(vm2).to be_disconnected
       expect(virtual_column_sql_value(VmOrTemplate, "disconnected")).to be_truthy
     end
   end
@@ -1300,7 +1317,7 @@ describe VmOrTemplate do
     let(:klass) { :vm_vmware }
     let(:storage) { FactoryGirl.create(:storage_vmware) }
     let(:ems) { FactoryGirl.create(:ems_vmware) }
-    let(:connection_state) { nil }
+    let(:connection_state) { 'disconnected' }
     let(:retired) { false }
 
     let!(:vm) do


### PR DESCRIPTION
For most providers, connection_status is populated
For cloud providers, it is sometimes left to be nil.
Since it doesn't make sense.

But nil for them actually mean connected.

So this changes what nil means.
We're also modifying the parsers for the providers to the nil
will not get into the database.

Related to:

- https://bugzilla.redhat.com/show_bug.cgi?id=1649403
- ManageIQ/manageiq#18213
- ManageIQ/manageiq-providers-vmware#338
- ManageIQ/manageiq-providers-google#81
- ManageIQ/manageiq-providers-azure#307
- ManageIQ/manageiq-providers-amazon#500

Fixes: ManageIQ/manageiq-ui-classic#4909

/cc @agrare @miha-plesko