### PR TITLE
Dont return different types in virtual columns

### DIFF
--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -6,11 +6,9 @@ class MiqTemplate < VmOrTemplate
   virtual_column :display_type,                         :type => :string
   virtual_column :display_operating_system,             :type => :string
   virtual_column :display_platform,                     :type => :string
-  virtual_column :display_cpu_cores,                    :type => :string
-  virtual_column :display_memory,                       :type => :string
-  virtual_column :display_snapshots,                    :type => :string
   virtual_column :display_tenant,                       :type => :string
   virtual_column :display_deprecated,                   :type => :string
+  virtual_column :display_memory,                       :type => :integer
 
   include_concern 'Operations'
 
@@ -83,28 +81,8 @@ class MiqTemplate < VmOrTemplate
     end
   end
 
-  def display_cpu_cores
-    if respond_to?(:volume_template?) || respond_to?(:volume_snapshot_template?)
-      _("N/A")
-    else
-      cpu_total_cores
-    end
-  end
-
   def display_memory
-    if respond_to?(:volume_template?) || respond_to?(:volume_snapshot_template?)
-      _("N/A")
-    else
-      mem_cpu.to_i * 1024 * 1024
-    end
-  end
-
-  def display_snapshots
-    if respond_to?(:volume_template?) || respond_to?(:volume_snapshot_template?)
-      _("N/A")
-    else
-      v_total_snapshots
-    end
+    mem_cpu.to_i * 1024 * 1024
   end
 
   def display_tenant


### PR DESCRIPTION

This PR should fix virtual columns introduced in #17884 which is needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/4509
These virtual columns returned different types (Integer/String) and that caused problems when trying to sort by these columns,

Links
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1610927
https://github.com/ManageIQ/manageiq-ui-classic/pull/4509

@himdel Could you please verify this fixes the issue?

