### PR TITLE
Only try to create the ServerRole if it doesn't exist

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -24,7 +24,7 @@ module EvmSpecHelper
   def self.assign_embedded_ansible_role(miq_server = nil)
     MiqRegion.seed
     miq_server ||= local_miq_server
-    FactoryGirl.create(:server_role, :name => 'embedded_ansible', :max_concurrent => 0)
+    ServerRole.find_by(:name => "embedded_ansible") || FactoryGirl.create(:server_role, :name => 'embedded_ansible', :max_concurrent => 0)
     miq_server.assign_role('embedded_ansible').update_attributes(:active => true)
   end
 


### PR DESCRIPTION
If we seed the database, the record is already there and this call blows up

Based on changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/4943