### PR TITLE
V2V - Force insecure connection to OpenStack for wrapper

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -319,7 +319,8 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       :osp_destination_project_id => cluster.ems_ref,
       :osp_volume_type_id         => storage.ems_ref,
       :osp_flavor_id              => destination_flavor.ems_ref,
-      :osp_security_groups_ids    => [destination_security_group.ems_ref]
+      :osp_security_groups_ids    => [destination_security_group.ems_ref],
+      :insecure_connection        => true
     }
   end
 end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -578,7 +578,8 @@ describe ServiceTemplateTransformationPlanTask do
               :osp_flavor_id              => dst_flavor.ems_ref,
               :osp_security_groups_ids    => [dst_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings           => task_1.network_mappings
+              :network_mappings           => task_1.network_mappings,
+              :insecure_connection        => true
             )
           end
         end
@@ -612,7 +613,8 @@ describe ServiceTemplateTransformationPlanTask do
               :osp_flavor_id              => dst_flavor.ems_ref,
               :osp_security_groups_ids    => [dst_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings           => task_1.network_mappings
+              :network_mappings           => task_1.network_mappings,
+              :insecure_connection        => true
             )
           end
         end


### PR DESCRIPTION
When migrating virtual machines to RHV, we force insecure connection to RHV-M. This PR implements the same for OpenStack, so that we stay consistent.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1651689