### PR TITLE
Virtual attribute reports

### DIFF
--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -15,6 +15,8 @@ class MiqAeClass < ApplicationRecord
   validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ . - characters")
 
+  virtual_attribute :fqname, :string
+
   def self.find_by_fqname(fqname, args = {})
     ns, name = parse_fqname(fqname)
     find_by_namespace_and_name(ns, name, args)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,6 +18,7 @@ class Provider < ApplicationRecord
            :url,
            :to => :default_endpoint
 
+  virtual_column :url,               :type => :string, :uses => :endpoints
   virtual_column :verify_ssl,        :type => :integer
   virtual_column :security_protocol, :type => :string
 

--- a/spec/models/container_image_spec.rb
+++ b/spec/models/container_image_spec.rb
@@ -14,13 +14,26 @@ describe ContainerImage do
     expect(image.full_name).to eq("registry/repo/name@id")
   end
 
-  it "#display_registry" do
-    image = ContainerImage.new(:name => "fedora")
-    expect(image.display_registry).to eq("Unknown image source")
+  context "#display_registry" do
+    it "finds unknown with unknown name" do
+      image = ContainerImage.new(:name => "fedora")
+      expect(image.display_registry).to eq("Unknown image source")
+    end
 
-    reg = ContainerImageRegistry.new(:name => "docker.io", :host => "docker.io", :port => "1234")
-    image.container_image_registry = reg
-    expect(image.display_registry).to eq("docker.io:1234")
+    it "localizes for unknown" do
+      I18n.with_locale(:es) do
+        image = ContainerImage.new(:name => "fedora")
+        reg = image.display_registry
+        expect(reg).to eq("Fuente de imagen desconocida")
+      end
+    end
+
+    it "finds name with valid name" do
+      image = ContainerImage.new(:name => "fedora")
+      reg = ContainerImageRegistry.new(:name => "docker.io", :host => "docker.io", :port => "1234")
+      image.container_image_registry = reg
+      expect(image.display_registry).to eq("docker.io:1234")
+    end
   end
 
   it "#docker_id" do

--- a/spec/models/manageiq/providers/base_manager_spec.rb
+++ b/spec/models/manageiq/providers/base_manager_spec.rb
@@ -16,4 +16,11 @@ describe ManageIQ::Providers::BaseManager do
       expect(described_class.default_blacklisted_event_names).to eq(%w(ev1 ev2))
     end
   end
+
+  context ".url" do
+    it 'delegates to the provider' do
+      mgr = FactoryGirl.create(:configuration_manager_foreman, :provider => FactoryGirl.create(:provider_foreman, :url => 'example.com'))
+      expect(mgr.url).to eq('example.com')
+    end
+  end
 end


### PR DESCRIPTION
Add virtual attributes for columns showing up in reports

This is in my effort to use the metadata in the models to create report includes rather than coding it into the report yml files.

/cc @gmcculloug think these are from your side of the world