### PR TITLE
 Move the backend-generated PDF report's styling from the frontend

### DIFF
--- a/lib/pdf_generator.rb
+++ b/lib/pdf_generator.rb
@@ -45,7 +45,7 @@ class PdfGenerator
   # Find stylesheet asset with short path and return filesystem path
   #
   def self.stylesheet_file_path(stylesheet)
-    Rails.application.assets.find_asset(stylesheet).try(:pathname).try(:to_s)
+    Rails.root.join('lib', 'pdf_generator', stylesheet).to_s
   end
 
   private_class_method :stylesheet_file_path

--- a/lib/pdf_generator/pdf_report.css
+++ b/lib/pdf_generator/pdf_report.css
@@ -1,0 +1,159 @@
+/*
+* This sheet is used by PDFs generated with MiqReportResult
+* It will be fully replaced with the client-side PDF generation
+*/
+
+body {
+  font: 13px/1.231 Arial, Helvetica, sans-serif;
+}
+
+table {
+  border-spacing: 0;
+  border-left: 1px solid #d1d1d1;
+  border-collapse: separate;
+  color: #4d5258;
+}
+
+table thead tr th {
+  height: 19px;
+  margin: 0;
+  padding: 4px;
+  padding-left: 10px;
+  border-right: 1px solid #d1d1d1;
+  border-left: 0 !important;
+  border-top: 1px solid #d1d1d1;
+  border-bottom: 1px #d1d1d1 solid;
+  font: normal 12px Arial, Helvetica, sans-serif !important;
+  line-height: 19px;
+}
+
+table thead tr th {
+  background: #f5f5f5;
+}
+
+table tbody tr.row1-nocursor {
+  background: #f5f5f5;
+}
+
+table tbody tr td {
+  border: 1px solid transparent;
+  border-right: 1px solid #d1d1d1;
+  border-bottom-color: #e7e7e7;
+  padding: 2px 2px 2px 10px;
+  margin: 0;
+  vertical-align: middle;
+  cursor: default;
+  color: #4d5258;
+}
+
+table tbody tr td.group {
+  border-top: 1px solid #fff;
+  background: #ececec;
+  font: normal 12px Arial, Helvetica, sans-serif;
+}
+
+table tbody tr td.miq_rpt_red_bg,
+table.adminlist tbody tr td.miq_rpt_red_bg,
+.miq_rpt_red_bg {
+  background: #fbdbdb !important;
+}
+
+table tbody tr td.miq_rpt_yellow_bg,
+table.adminlist tbody tr td.miq_rpt_yellow_bg,
+.miq_rpt_yellow_bg {
+  background-color: #ffdc99 !important;
+}
+
+table tbody tr td.miq_rpt_green_bg,
+table.adminlist tbody tr td.miq_rpt_green_bg,
+.miq_rpt_green_bg {
+  background-color: #cef7c9 !important;
+}
+
+table tbody tr td.miq_rpt_blue_bg,
+table.adminlist tbody tr td.miq_rpt_blue_bg,
+.miq_rpt_blue_bg {
+  background-color: #76badf !important;
+}
+
+table tbody tr td.miq_rpt_purple_bg,
+table.adminlist tbody tr td.miq_rpt_purple_bg,
+.miq_rpt_purple_bg {
+  background-color: #c0acdc !important;
+}
+
+table tbody tr td.miq_rpt_maroon_bg,
+table.adminlist tbody tr td.miq_rpt_maroon_bg,
+.miq_rpt_maroon_bg {
+  background-color: #d4edfa !important;
+}
+
+table tbody tr td.miq_rpt_gray_bg,
+table.adminlist tbody tr td.miq_rpt_gray_bg,
+.miq_rpt_gray_bg {
+  background-color: #d1d1d1 !important;
+}
+
+.miq_rpt_red_text {
+  color: #cc0000;
+  font-weight: bold;
+}
+
+.miq_rpt_yellow_text {
+  color: #cccc00;
+  font-weight: bold;
+}
+
+.miq_rpt_green_text {
+  color: #3f9c35;
+  font-weight: bold;
+}
+
+.miq_rpt_blue_text {
+  color: #006e9c;
+  font-weight: bold;
+}
+
+.miq_rpt_purple_text {
+  color: #925bad;
+  font-weight: bold;
+}
+
+.miq_rpt_maroon_text {
+  color: #76badf;
+  font-weight: bold;
+}
+
+.miq_rpt_gray_text {
+  color: gray;
+  font-weight: bold;
+}
+
+/* stylelint-disable property-no-unknown */
+@page {
+  prince-shrink-to-fit: auto;
+}
+/* stylelint-enable */
+
+
+/*
+* Encoded FontAwesome ttf
+*/
+
+@font-face {
+  font-family: 'FontAwesome';
+  src: asset_url("font-awesome/fonts/fontawesome-webfont.ttf");
+  font-weight: normal;
+  font-style: normal;
+}
+
+/*
+* Encoded PatternFly ttf
+*/
+
+@font-face {
+  font-family: "PatternFlyIcons-webfont";
+  src: asset_url("PatternFlyIcons-webfont.ttf");
+  font-weight: normal;
+  font-style: normal;
+}


### PR DESCRIPTION
Since there is no on-the-fly asset compilation in production, there is no access to the `Rails.application.assets` object. Also the `pdf_report.css` and the files it loads are no longer used in the UI. Eventually this styling needs to be removed and a unified PDF generation should be used, probably via a headless webdriver on the backend.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650057

@miq-bot add_label bug, gaprindashvili/no, hammer/yes
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @martinpovolny