### PR TITLE
Support more regions in  FactoryGirl's factories

### DIFF
--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -32,5 +32,17 @@ FactoryBot.define do
     trait :tenant_type do
       group_type { MiqGroup::TENANT_GROUP }
     end
+
+    transient do
+      default_tenant nil
+    end
+
+    trait :in_other_region do
+      other_region
+
+      after(:create) do |instance, evaluator|
+        instance.tenant = evaluator.default_tenant
+      end
+    end
   end
 end

--- a/spec/factories/tenant.rb
+++ b/spec/factories/tenant.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     parent { Tenant.seed }
   end
 
+  trait :in_other_region do
+    other_region
+  end
+
   factory :tenant_with_cloud_tenant, :parent => :tenant do
     source { FactoryBot.create(:cloud_tenant) }
   end

--- a/spec/factories/tenant.rb
+++ b/spec/factories/tenant.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
 
   trait :in_other_region do
     other_region
+
+    after(:create) do |instance, evaluator|
+      instance.default_miq_group = FactoryGirl.create(:miq_group, :in_other_region, :other_region => evaluator.other_region, :default_tenant => instance)
+    end
   end
 
   factory :tenant_with_cloud_tenant, :parent => :tenant do

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -883,4 +883,36 @@ describe Tenant do
       end
     end
   end
+
+  context "using more regions with factory" do
+    context "without MiqRegion.seed" do
+      let!(:other_region) { FactoryGirl.create(:miq_region) }
+
+      it "uses other region" do
+        expect(MiqRegion.count).to eq(1)
+        exception_message = "You need to seed default MiqRegion with MiqRegion.seed"
+        expect { FactoryGirl.create(:tenant, :in_other_region,  :other_region => other_region) }.to raise_error(exception_message)
+      end
+    end
+
+    context "with MiqRegion.seed" do
+      before do
+        MiqRegion.seed
+      end
+
+      let!(:other_region) { FactoryGirl.create(:miq_region) }
+      let!(:tenant) { FactoryGirl.create(:tenant, :in_other_region, :other_region => other_region) }
+
+      it "uses other region" do
+        expect(MiqRegion.count).to eq(2)
+        expect(tenant.miq_region.region).to eq(other_region.region)
+      end
+
+      it "raises error when region is not passed" do
+        exception_message = "You need to pass specific region  with :other_region: \n"\
+                            "FactoryGirl.create(:tenant, :in_other_region, :other_region => <region>) "
+        expect { FactoryGirl.create(:tenant, :in_other_region) }.to raise_error(exception_message)
+      end
+    end
+  end
 end

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -906,6 +906,7 @@ describe Tenant do
       it "uses other region" do
         expect(MiqRegion.count).to eq(2)
         expect(tenant.miq_region.region).to eq(other_region.region)
+        expect(tenant.default_miq_group.miq_region.region).to eq(other_region.region)
       end
 
       it "raises error when region is not passed" do


### PR DESCRIPTION
We can use `FactoryGirl's` factories when we want to write specs with more regions.
This PR brings `:trait` called `other_region` - defined globally which could be added in our factories

### Usage:
**How to add to factory:**

it is enough to add to the factory this `:trait`
```ruby
  trait :in_other_region do
    other_region
  end
```
Example:
 ```ruby

FactoryGirl.define do
  factory :tenant do
    sequence(:name) { |n| "Tenant #{n}" }
    sequence(:subdomain) { |n| "tenant#{n}" }
    parent { Tenant.seed }
  end

  trait :in_other_region do
    other_region
  end

...
```

and then you can use:

 ```ruby
MiqRegion.seed # mandatory
other_region = FactoryGirl.create(:miq_region) # mandatory to create new region
FactoryGirl.create(:tenant, :in_other_region, :other_region => other_region) # create tenant in specified region  other_region
```

### Practical usage + Links
in https://github.com/ManageIQ/manageiq/blob/master/spec/models/chargeback_vm_spec.rb#L1177
in https://github.com/ManageIQ/manageiq-ui-classic/pull/4831/files
in upcoming work from https://bugzilla.redhat.com/show_bug.cgi?id=1465158


@miq-bot add_label technical_debt, spec

cc @jrafanie @bdunne 
@miq-bot assign @gtanzillo 