### PR TITLE
Disable asset compile in ruby tests.

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,6 +23,8 @@ Vmdb::Application.configure do
     env.cache = ActiveSupport::Cache.lookup_store(:memory_store)
   end
 
+  config.assets.compile = ENV['TEST_SUITE'] == 'spec:javascript'
+
   # Log error messages when you accidentally call methods on nil
   config.whiny_nils = true
 


### PR DESCRIPTION
The first test after 'render_view' that calls asset_path or its children
methods like image_path or stylesheet_path are called triggers asset
compilation and therefor lasts for 1.5-3m depending on CPU.
    
This delay is a minor issue in travis (3m our of 36m is not THAT much).
But is a major issue when debugging tests localty as it means extra 1.5m
or more in each run of a single spec file.
    
The idea is to disable asset precompiling to remove that delay.
    
Compiled assets are only needed for the javascript tests.

----
ATTENTION: this PR has the potential of breaking the UI test suite.