### PR TITLE
Pass CA when upgrading cluster through Ansible

### DIFF
--- a/app/models/ems_cluster/cluster_upgrade.rb
+++ b/app/models/ems_cluster/cluster_upgrade.rb
@@ -12,7 +12,7 @@ module EmsCluster::ClusterUpgrade
 
   def upgrade_cluster(options = {})
     role_options = {:role_name => "oVirt.cluster-upgrade"}
-    job = ManageIQ::Providers::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(options), role_options)
+    job = ManageIQ::Providers::Redhat::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(options), role_options)
     job.signal(:start)
     job.miq_task
   end
@@ -32,7 +32,8 @@ module EmsCluster::ClusterUpgrade
       :engine_user     => connect_options[:username],
       :engine_password => connect_options[:password],
       :cluster_name    => name,
-      :hostname        => "localhost"
-    }
+      :hostname        => "localhost",
+      :ca_string       => connect_options[:ca_certs]
+    }.compact
   end
 end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -170,6 +170,18 @@ FactoryGirl.define do
     end
   end
 
+  trait :skip_validate do
+    to_create { |instance| instance.save(:validate => false) }
+  end
+
+  factory :ems_redhat_with_authentication_with_ca,
+          :parent => :ems_redhat do
+    certificate_authority "cert108"
+    after(:create) do |x|
+      x.authentications << FactoryGirl.create(:authentication)
+    end
+  end
+
   factory :ems_redhat_with_metrics_authentication,
           :parent => :ems_redhat do
     after(:create) do |x|

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -247,7 +247,7 @@ describe EmsCluster do
 
   context "#upgrade_cluster" do
     before do
-      @ems = FactoryGirl.create(:ems_redhat_with_authentication)
+      @ems = FactoryGirl.create(:ems_redhat_with_authentication_with_ca, :skip_validate)
       @cluster = FactoryGirl.create(:ems_cluster, :ems_id => @ems.id)
       my_server = double("my_server", :guid => "guid1")
       allow(MiqServer).to receive(:my_server).and_return(my_server)
@@ -259,7 +259,8 @@ describe EmsCluster do
                     :engine_user     => @ems.authentication_userid,
                     :engine_password => @ems.authentication_password,
                     :cluster_name    => @cluster.name,
-                    :hostname        => "localhost"}
+                    :hostname        => "localhost",
+                    :ca_string       => @ems.default_endpoint.certificate_authority}
       role_arg = {:role_name=>"oVirt.cluster-upgrade"}
       expect(ManageIQ::Providers::AnsibleRoleWorkflow).to receive(:create_job).with(env_vars, extra_args, role_arg).and_call_original
       @cluster.upgrade_cluster


### PR DESCRIPTION
When CA is available for provider, use it for the upgrade_cluster role.

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/313
This is part of implementing: https://bugzilla.redhat.com/show_bug.cgi?id=1644605