### PR TITLE
Add job_timeout parameter for upgrade_cluster

### DIFF
--- a/app/models/ems_cluster/cluster_upgrade.rb
+++ b/app/models/ems_cluster/cluster_upgrade.rb
@@ -10,9 +10,9 @@ module EmsCluster::ClusterUpgrade
     end
   end
 
-  def upgrade_cluster(options = {})
+  def upgrade_cluster(ansible_extra_vars = {}, job_timeout = 1.year)
     role_options = {:role_name => "oVirt.cluster-upgrade"}
-    job = ManageIQ::Providers::Redhat::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(options), role_options)
+    job = ManageIQ::Providers::Redhat::AnsibleRoleWorkflow.create_job({}, extra_vars_for_upgrade(ansible_extra_vars), role_options, :timeout => job_timeout)
     job.signal(:start)
     job.miq_task
   end

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -261,8 +261,9 @@ describe EmsCluster do
                     :cluster_name    => @cluster.name,
                     :hostname        => "localhost",
                     :ca_string       => @ems.default_endpoint.certificate_authority}
-      role_arg = {:role_name=>"oVirt.cluster-upgrade"}
-      expect(ManageIQ::Providers::AnsibleRoleWorkflow).to receive(:create_job).with(env_vars, extra_args, role_arg).and_call_original
+      role_arg = { :role_name => "oVirt.cluster-upgrade" }
+      timeout = { :timeout => 1.year }
+      expect(ManageIQ::Providers::AnsibleRoleWorkflow).to receive(:create_job).with(env_vars, extra_args, role_arg, timeout).and_call_original
       @cluster.upgrade_cluster
     end
 


### PR DESCRIPTION
The motivation here is that we need the job to have one timeout, and the
Ansible role to have another - the job will end if the timeout from the
time it was created will pass, while Ansible playbook will only timeout if it is
stack for too long on one phase. So we will want to set the job timeout
to something huge - 1 year, and set a real timeout through the playbook
extra_vars.

This is part of implementing: https://bugzilla.redhat.com/show_bug.cgi?id=1644605