### PR TITLE
Add conversion option to the SupportsFeatureMixin module

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -73,6 +73,7 @@ module SupportsFeatureMixin
     :backup_restore                      => 'CloudVolume backup restore',
     :cinder_service                      => 'Cinder storage service',
     :cinder_volume_types                 => 'Cinder volume types',
+    :conversion                          => 'Conversion host support',
     :create_floating_ip                  => 'Floating IP Creation',
     :create_host_aggregate               => 'Host Aggregate Creation',
     :create_security_group               => 'Security Group Creation',


### PR DESCRIPTION
This PR adds the `conversion` option to the `SupportsFeature` mixin for conversion host support (or not).

The idea here is that we can then use this for V2V, where individual resources (VM or possibly Host) within each provider repo can put this within their respective vm.rb or host.rb file(s). This will help us govern behavior elsewhere within the codebase via `supports :conversion` or `supports_not :conversion`.

With this in place, the ManageIQ REST API can also take advantage of it in order to check for support. See here for an example of where this is already used:

https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/subcollections/security_groups.rb#L12