### PR TITLE
Fix supports_capture assuming MetricsCapture class

### DIFF
--- a/app/models/metric/ci_mixin.rb
+++ b/app/models/metric/ci_mixin.rb
@@ -21,8 +21,9 @@ module Metric::CiMixin
     end
 
     supports :capture do
-      unless self.class.parent::MetricsCapture.instance_methods.include?(:perf_collect_metrics)
-        unsupported_reason_add(:metrics, _('This provider does not support metrics collection'))
+      metrics_capture_klass = "#{self.class.parent.name}::MetricsCapture".safe_constantize
+      unless metrics_capture_klass&.method_defined?(:perf_collect_metrics)
+        unsupported_reason_add(:capture, _('This provider does not support metrics collection'))
       end
     end
   end

--- a/spec/models/metric/ci_mixin_spec.rb
+++ b/spec/models/metric/ci_mixin_spec.rb
@@ -63,4 +63,26 @@ describe Metric::CiMixin do
       end
     end
   end
+
+  context "#supports_capture?" do
+    context "with a VM" do
+      let(:unsupported_vm) { FactoryGirl.create(:vm_microsoft) }
+      let(:supported_vm)   { FactoryGirl.create(:vm_vmware) }
+
+      it "correctly checks capture support" do
+        expect(unsupported_vm.supports_capture?).to be_falsy
+        expect(supported_vm.supports_capture?).to be_truthy
+      end
+    end
+
+    context "with a Host" do
+      let(:unsupported_host) { FactoryGirl.create(:host_microsoft) }
+      let(:supported_host)   { FactoryGirl.create(:vm_vmware) }
+
+      it "correctly checks capture support" do
+        expect(unsupported_host.supports_capture?).to be_falsy
+        expect(supported_host.supports_capture?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
The supports :capture block assumes that the MetricsCapture class always
exists even if metrics capture is unsupported which is not the case.

Modify the block to check for the existence of the metrics capture class
before checking its instance methods.

Also fix the unsupported_reason_add setting the reason to the wrong
feature key (:metrics when should have been :capture).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1638045