### PR TITLE
EmsCluster#direct_vm_rels use sql to filter

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -110,7 +110,7 @@ class EmsCluster < ApplicationRecord
   # Direct Vm relationship methods
   def direct_vm_rels
     # Look for only the Vms at the second depth (default RP + 1)
-    descendant_rels(:of_type => 'VmOrTemplate').select { |r| (r.depth - depth) == 2 }
+    grandchild_rels(:of_type => 'VmOrTemplate')
   end
 
   def direct_vms

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -667,7 +667,7 @@ class Host < ApplicationRecord
   # Vm relationship methods
   def direct_vms
     # Look for only the Vms at the second depth (default RP + 1)
-    rels = descendant_rels(:of_type => 'Vm').select { |r| (r.depth - depth) == 2 }
+    rels = grandchild_rels(:of_type => 'Vm')
     Relationship.resources(rels).sort_by { |r| r.name.downcase }
   end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -667,8 +667,7 @@ class Host < ApplicationRecord
   # Vm relationship methods
   def direct_vms
     # Look for only the Vms at the second depth (default RP + 1)
-    rels = grandchild_rels(:of_type => 'Vm')
-    Relationship.resources(rels).sort_by { |r| r.name.downcase }
+    grandchildren(:of_type => 'Vm').sort_by { |r| r.name.downcase }
   end
 
   # Resource Pool relationship methods

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -405,6 +405,10 @@ module RelationshipMixin
     Relationship.filter_by_resource_type(rels, options)
   end
 
+  def grandchildren(*args)
+    Relationship.resources(grandchild_rels(*args))
+  end
+
   def child_and_grandchild_rels(*args)
     options = args.extract_options!
     rels = relationships.inject(Relationship.none) do |stmt, r|

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -848,6 +848,14 @@ describe RelationshipMixin do
     end
   end
 
+  describe "#grandchildren" do
+    it "works with relationships" do
+      vms[0].with_relationship_type(test_rel_type) do
+        expect(vms[0].grandchildren).to match_array([vms[3], vms[4], vms[5], vms[6], vms[7]])
+      end
+    end
+  end
+
   describe "#child_and_grandchild_rels" do
     it "works with relationships" do
       vms[0].with_relationship_type(test_rel_type) do


### PR DESCRIPTION
blocked:

- [x] #18239 fix grand children relationships

This is part of improving the performance for ems_clusters page. [[BZ 1648412]](
(https://bugzilla.redhat.com/show_bug.cgi?id=1648412) - but it is a minor improvement.

The vms in a cluster are stored in the relationships page.

### Before
When counting the number of vms in a cluster it was bringing back all descendant relationship records, filtering to 2 levels down (aka grand children), and then counts those.

### After
Now, it issues a `COUNT(*)` for the relationship records that are 2 levels down.

This removes an N+1 and changes a `SELECT.to_a.count` to a `COUNT(*)`
A larger database brings back even more records for this page.

|       ms |query |  qry ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  1,528.8 |   22 |    21.7 |       32 |`/ems_cluster/show/10000000000001#before`
|  1,231.0 |   21 |    22.7 |        9 |`/ems_cluster/show/10000000000001#after`
| 19% | 5% | n/a | 72% | improvement

There is one fewer query run. And one query is converted from a `select *` to a `count(*)`.
Fewer objects are brought back.

The query times (`qry ms`) are averaging a little faster. Fluctuation of these 2 times show it to be a little bit slower for this run