### PR TITLE
Display deprecated as a true/false string

### DIFF
--- a/app/models/miq_template.rb
+++ b/app/models/miq_template.rb
@@ -93,7 +93,7 @@ class MiqTemplate < VmOrTemplate
     if respond_to?(:volume_template?) || respond_to?(:volume_snapshot_template?)
       _("N/A")
     elsif respond_to?(:deprecated)
-      _(deprecated.to_s)
+      deprecated ? _("true") : _("false")
     else
       _("N/A")
     end


### PR DESCRIPTION
Display deprecated as true/false or N/A. This is needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/4509

Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1610927
ManageIQ/manageiq#17884 & ManageIQ/manageiq#18217
https://github.com/ManageIQ/manageiq-ui-classic/pull/4509

ping @himdel @martinpovolny 
