### PR TITLE
Updating Rails patch version to 5.0.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "openscap",                       "~>0.4.8",       :require => false
 gem "pg",                             "~>0.18.2",      :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.0.6"
+gem "rails",                          "~>5.0.7.1"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false


### PR DESCRIPTION
Fixes CVE-2018-16476

https://groups.google.com/forum/#!msg/rubyonrails-security/FL4dSdzr2zw/zjKVhF4qBAAJ

Rails Changelog https://weblog.rubyonrails.org/2018/3/29/Rails-5-0-7-and-5-1-6-have-been-released/