### PR TITLE
Fix Relationship#grandchildren

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -196,8 +196,8 @@ class Relationship < ApplicationRecord
   #
   def grandchild_conditions
     t = self.class.arel_table
-    t.grouping(t[:ancestry].matches("#{child_ancestry}/%", nil, true).and(
-                 t[:ancestry].does_not_match("#{child_ancestry}/%", nil, true)))
+    t.grouping(t[:ancestry].matches("#{child_ancestry}/%", nil, true)
+                           .and(t[:ancestry].does_not_match("#{child_ancestry}/%/%", nil, true)))
   end
 
   def child_and_grandchild_conditions

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -813,7 +813,7 @@ describe RelationshipMixin do
     end
   end
 
-  describe "#parent_rel_ids" do
+  describe "#parent_rels" do
     it "works with relationships" do
       pars = vms[8].with_relationship_type(test_rel_type, &:parent_rels)
       pars_vms = pars.map(&:resource)
@@ -836,6 +836,24 @@ describe RelationshipMixin do
       end
       parent_vms = Relationship.where(:id => ids).map(&:resource)
       expect(parent_vms).to eq([vms[7]])
+    end
+  end
+
+  describe "#grandchild_rels" do
+    it "works with relationships" do
+      vms[0].with_relationship_type(test_rel_type) do
+        rels = vms[0].grandchild_rels
+        expect(rels.map(&:resource)).to match_array([vms[3], vms[4], vms[5], vms[6], vms[7]])
+      end
+    end
+  end
+
+  describe "#child_and_grandchild_rels" do
+    it "works with relationships" do
+      vms[0].with_relationship_type(test_rel_type) do
+        rels = vms[0].child_and_grandchild_rels
+        expect(rels.map(&:resource)).to match_array([vms[1], vms[2], vms[3], vms[4], vms[5], vms[6], vms[7]])
+      end
     end
   end
 


### PR DESCRIPTION
pulled out of #18235

`grandchild_conditions` did not properly building sql.
The sql would never return any rows

### before

```sql
(
          relationship LIKE "child_ancestry/%"    -- grand child or lower
  AND NOT relationship LIKE "child_ancestry/%"    -- NOT grand child or lower (BUG)
)
```

### after
```sql
(
          relationship LIKE "child_ancestry/%"    -- grand child or lower
  AND NOT relationship LIKE "child_ancestry/%/%"  -- NOT great grand child or lower
)
```   

Now it returns the correct nodes.
Also of note, this now generates the same sql declared in this method's comment.