### PR TITLE
Use resource_type for MiqReport#add_schedule

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -150,8 +150,8 @@ class MiqReport < ApplicationRecord
 
     params['filter'] = MiqExpression.new("=" => {"field" => "MiqReport-id",
                                                  "value" => id})
-    params['towhat'] = "MiqReport"
-    params['prod_default'] = "system"
+    params['resource_type'] = "MiqReport"
+    params['prod_default']  = "system"
 
     MiqSchedule.create!(params)
   end


### PR DESCRIPTION
Instead of `towhat`, which is now deprecated.  This is causing warnings in the `manageiq-api` repo, most of which are fixed via https://github.com/ManageIQ/manageiq-api/pull/516 now.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/17545
* https://github.com/ManageIQ/manageiq-api/pull/516