### PR TITLE
[WIP] Remove reset of retirement_requester to nil

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -70,7 +70,6 @@ module RetirementMixin
 
     self.retirement_last_warn = nil # Reset so that a new warning can be sent out when the time is right
     self[:retires_on] = timestamp
-    self.retirement_requester = nil
   end
 
   def extend_retires_on(days, date = Time.zone.now)

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -32,6 +32,14 @@ describe "Service Retirement Management" do
       @stack.reload
     end
 
+    it "#make_retire_request" do
+      expect(@stack.retirement_state).to be_nil
+      expect(OrchestrationStackRetireRequest).to receive(:make_request).with(nil, {:src_ids=>[@stack.id], :__request_type__=>"orchestration_stack_retire"}, user, true)
+      OrchestrationStack.make_retire_request(@stack.id, user)
+      @stack.reload
+      expect(@stack.retirement_requester).to eq(user.userid)
+    end
+
     it "#retire_now with userid" do
       expect(@stack.retirement_state).to be_nil
       expect(OrchestrationStackRetireRequest).to_not receive(:make_request)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -42,6 +42,14 @@ describe "Service Retirement Management" do
     expect(@service.retirement_state).to eq("retiring")
   end
 
+  it "#make_retire_request" do
+    expect(@service.retirement_state).to be_nil
+    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids=>[@service.id], :__request_type__=>"service_retire"}, user, true)
+    Service.make_retire_request(@service.id, user)
+    @service.reload
+    expect(@service.retirement_requester).to eq(user.userid)
+  end
+
   it "#retire_now" do
     expect(@service.retirement_state).to be_nil
     expect(MiqEvent).to receive(:raise_evm_event).once

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -27,6 +27,14 @@ describe "VM Retirement Management" do
     expect(@vm.retirement_state).to eq("retiring")
   end
 
+  it "#make_retire_request" do
+    expect(@vm.retirement_state).to be_nil
+    expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids=>[@vm.id], :__request_type__=>"vm_retire"}, user, true)
+    Vm.make_retire_request(@vm.id, user)
+    @vm.reload
+    expect(@vm.retirement_requester).to eq(user.userid)
+  end
+
   it "#retire_now" do
     expect(MiqEvent).to receive(:raise_evm_event).once
     @vm.retire_now


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1638502

I added code to set the retirement_requester on the object here: https://github.com/ManageIQ/manageiq/commit/2168b96c9b227159a7f29e65ff4cd3742fc18955. 

Setting the retirement requester in ```make_retire_request``` like that, however, does no good if we're also resetting it in ```retires_on=```.