### PR TITLE
[GAPRINDASHVILI] Retire the direct_service_children of a bundled service

### DIFF
--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -7,6 +7,8 @@ module Service::RetirementManagement
   end
 
   def retire_service_resources
+    direct_service_children.each(&:retire_service_resources)
+
     service_resources.each do |sr|
       if sr.resource.respond_to?(:retire_now)
         $log.info("Retiring service resource for service: #{name} resource ID: #{sr.id}")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653648

We removed the call to retire direct service children here: https://github.com/ManageIQ/manageiq/pull/17881/files#diff-610ed908579256e82c76ec0910169142L10, thinking erroneously that the call was superfluous. 
