### PR TITLE
Use Optimist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly 
 gem "net-ldap",                       "~>0.16.1",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false
 gem "openscap",                       "~>0.4.8",       :require => false
+gem "optimist",                       "~>3.0",         :require => false
 gem "pg",                             "~>0.18.2",      :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
 gem "query_relation",                 "~>0.1.0",       :require => false
@@ -67,7 +68,6 @@ gem "rugged",                         "~>0.27.0",      :require => false
 gem "simple-rss",                     "~>1.3.1",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sqlite3",                                         :require => false
-gem "trollop",                        "~>2.1.3",       :require => false
 
 # Modified gems (forked on Github)
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"

--- a/lib/task_helpers/exports.rb
+++ b/lib/task_helpers/exports.rb
@@ -6,15 +6,15 @@ module TaskHelpers
     end
 
     def self.parse_options
-      require 'trollop'
-      options = Trollop.options(EvmRakeHelper.extract_command_options) do
+      require 'optimist'
+      options = Optimist.options(EvmRakeHelper.extract_command_options) do
         opt :keep_spaces, 'Keep spaces in filenames', :type => :boolean, :short => 's', :default => false
         opt :directory, 'Directory to place exported files in', :type => :string, :required => true
         opt :all, 'Export read-only objects', :type => :boolean, :default => false
       end
 
       error = validate_directory(options[:directory])
-      Trollop.die :directory, error if error
+      Optimist.die :directory, error if error
 
       options
     end

--- a/lib/task_helpers/imports.rb
+++ b/lib/task_helpers/imports.rb
@@ -1,13 +1,13 @@
 module TaskHelpers
   class Imports
     def self.parse_options
-      require 'trollop'
-      options = Trollop.options(EvmRakeHelper.extract_command_options) do
+      require 'optimist'
+      options = Optimist.options(EvmRakeHelper.extract_command_options) do
         opt :source, 'Directory or file to import from', :type => :string, :required => true
       end
 
       error = validate_source(options[:source])
-      Trollop.die :source, error if error
+      Optimist.die :source, error if error
 
       options
     end

--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -124,8 +124,8 @@ namespace :evm do
   #  bin/rake evm:raise_server_event -- --event db_failover_executed
   desc 'Raise evm event'
   task :raise_server_event => :environment do
-    require 'trollop'
-    opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+    require 'optimist'
+    opts = Optimist.options(EvmRakeHelper.extract_command_options) do
       opt :event, "Server Event", :type => :string, :required => true
     end
     EvmDatabase.raise_server_event(opts[:event])

--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -20,9 +20,9 @@ module EvmDba
   end
 
   def self.with_options(*option_types, &block)
-    require 'trollop'
+    require 'optimist'
 
-    Trollop.options(EvmRakeHelper.extract_command_options) do
+    Optimist.options(EvmRakeHelper.extract_command_options) do
       option_types.each do |type|
         case type
         when :db_credentials

--- a/spec/tools/perf_generate.rb
+++ b/spec/tools/perf_generate.rb
@@ -1,6 +1,6 @@
-require 'trollop'
+require 'optimist'
 ARGV.shift if ARGV[0] == '--'
-opts = Trollop.options do
+opts = Optimist.options do
   banner "Generate metrics records.\n\nUsage: rails runner #{$0} [-- options]\n\nOptions:\n\t"
   opt :realtime,    "Realtime range",      :default => "4.hours"
   opt :hourly,      "Hourly range",        :default => "6.months"
@@ -14,9 +14,9 @@ opts = Trollop.options do
   opt :no_delete,   "Skips deleting of the generated files"
   opt :dry_run,     "Same as --no-generate --no-import --no-delete"
 end
-Trollop.die "script must be run with rails runner" unless Object.const_defined?(:Rails)
-Trollop.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
-Trollop.die :hourly,   "must be a number with method (e.g. 6.months)" unless opts[:hourly].number_with_method?
+Optimist.die "script must be run with rails runner" unless Object.const_defined?(:Rails)
+Optimist.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
+Optimist.die :hourly,   "must be a number with method (e.g. 6.months)" unless opts[:hourly].number_with_method?
 opts[:no_generate] = opts[:no_import] = opts[:no_delete] = true if opts[:dry_run]
 
 require 'ruby-progressbar'

--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 require 'bundler/setup'
-require 'trollop'
+require 'optimist'
 
 TYPES = %w(string integer boolean symbol float array).freeze
 
-opts = Trollop.options(ARGV) do
+opts = Optimist.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <settings path separated by a /> -v <new value>\n" \
          "Example (String):  #{__FILE__} -s 1 -p reporting/history/keep_reports -v 3.months\n" \
          "Example (Integer): #{__FILE__} -s 1 -p workers/worker_base/queue_worker_base/ems_metrics_collector_worker/defaults/count -v 1 -t integer\n" \
@@ -23,10 +23,10 @@ end
 
 puts opts.inspect
 
-Trollop.die :serverid, "is required" unless opts[:serverid_given]
-Trollop.die :path,     "is required" unless opts[:path_given]
-Trollop.die :value,    "is required" unless opts[:value_given]
-Trollop.die :type,     "must be one of #{TYPES.inspect}" unless TYPES.include?(opts[:type])
+Optimist.die :serverid, "is required" unless opts[:serverid_given]
+Optimist.die :path,     "is required" unless opts[:path_given]
+Optimist.die :value,    "is required" unless opts[:value_given]
+Optimist.die :type,     "must be one of #{TYPES.inspect}" unless TYPES.include?(opts[:type])
 
 # Grab the value that we have set and translate to appropriate var class
 newval =

--- a/tools/convert_mapped_tags.rb
+++ b/tools/convert_mapped_tags.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 
-require 'trollop'
+require 'optimist'
 
-options = Trollop.options(ARGV) do
+options = Optimist.options(ARGV) do
   banner "USAGE:  #{__FILE__} -c|--commit\n" \
          "Example (Commit):  #{__FILE__} --commit\n" \
          "Example (Dry Run): #{__FILE__}         \n" \
@@ -70,4 +70,4 @@ end
 
 puts
 
-Trollop.educate if !options[:help] && !options[:commit] # display help message only in Dry Run
+Optimist.educate if !options[:help] && !options[:commit] # display help message only in Dry Run

--- a/tools/copy_reports_structure.rb
+++ b/tools/copy_reports_structure.rb
@@ -5,10 +5,10 @@ if __FILE__ == $PROGRAM_NAME
   $LOAD_PATH.push(File.expand_path(__dir__))
 end
 
-require 'trollop'
+require 'optimist'
 require 'copy_reports_structure/report_structure'
 
-opts = Trollop.options(ARGV) do
+opts = Optimist.options(ARGV) do
   banner "Utility to: \n" \
          "  - make report structure configured for a group available to another group\n" \
          "  - make report structure configured for a group available to role\n" \

--- a/tools/fix_auth/cli.rb
+++ b/tools/fix_auth/cli.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 
 module FixAuth
   class Cli
@@ -6,7 +6,7 @@ module FixAuth
 
     def parse(args, env = {})
       args.shift if args.first == "--" # Handle when called through script/runner
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         banner "Usage: ruby #{$PROGRAM_NAME} [options] database [...]\n" \
                "       ruby #{$PROGRAM_NAME} [options] -P new_password database [...] to replace all passwords"
 

--- a/tools/log_processing/ems_refresh_timings.rb
+++ b/tools/log_processing/ems_refresh_timings.rb
@@ -5,13 +5,13 @@ require 'manageiq-gems-pending'
 require 'miq_logger_processor'
 require 'active_support/core_ext/enumerable' # Pull in Enumerable sum method
 require 'more_core_extensions/core_ext/array'
-require 'trollop'
+require 'optimist'
 require 'time'
 
 def parse_args(argv)
   logfiles = []
 
-  opts = Trollop.options do
+  opts = Optimist.options do
     banner <<-EOS
 Parse EMS Refreshes from a set of evm.log files and filter on a set of
 provided conditions.

--- a/tools/miqldap_to_sssd/cli.rb
+++ b/tools/miqldap_to_sssd/cli.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 
 module MiqLdapToSssd
   class Cli
@@ -9,7 +9,7 @@ module MiqLdapToSssd
 
       LOGGER.debug("Invoked #{self.class}\##{__method__}")
 
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         banner "Usage: ruby #{$PROGRAM_NAME} [options]\n"
 
         opt :domain,

--- a/tools/pg_inspector/active_connections_to_human.rb
+++ b/tools/pg_inspector/active_connections_to_human.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 require 'yaml'
 require 'time'
 begin
@@ -18,7 +18,7 @@ module PgInspector
 
     HELP_MSG_SHORT = "Dump active connections to human readable YAML file".freeze
     def parse_options(args)
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         opt(:connections, "Active connections file",
             :type => :string, :short => "c", :default => DEFAULT_OUTPUT_PATH.join("#{PREFIX}active_connections.yml").to_s)
         opt(:servers, "Servers information file",

--- a/tools/pg_inspector/active_connections_to_yaml.rb
+++ b/tools/pg_inspector/active_connections_to_yaml.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 require 'pg'
 require 'pg_inspector/error'
 require 'pg_inspector/pg_inspector_operation'
@@ -8,7 +8,7 @@ module PgInspector
   class ActiveConnectionsYAML < PgInspectorOperation
     HELP_MSG_SHORT = "Dump active connections to YAML file".freeze
     def parse_options(args)
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         banner <<-BANNER
 
 #{HELP_MSG_SHORT}

--- a/tools/pg_inspector/cli.rb
+++ b/tools/pg_inspector/cli.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 require 'pg_inspector/util'
 require 'pg_inspector/active_connections_to_yaml'
 require 'pg_inspector/servers_to_yaml'
@@ -22,7 +22,7 @@ module PgInspector
     def parse(args)
       args.shift if args.first == "--" # Handle when called through script/runner
       op_help = operation_help
-      Trollop.options(args) do
+      Optimist.options(args) do
         banner <<-BANNER
 pg_inspector is a tool to inspect ManageIQ process caused deadlock in PostgreSQL.
 
@@ -42,7 +42,7 @@ BANNER
       if current_operation && SUB_COMMANDS[current_operation.to_sym]
         self.cmd = SUB_COMMANDS[current_operation.to_sym].new
       else
-        Trollop.educate
+        Optimist.educate
       end
       cmd.parse_options(args)
       self

--- a/tools/pg_inspector/connection_locks.rb
+++ b/tools/pg_inspector/connection_locks.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 require 'yaml'
 require 'pg_inspector/error'
 require 'pg_inspector/pg_inspector_operation'
@@ -10,7 +10,7 @@ module PgInspector
     attr_accessor :locks, :connections, :blocked_connections
 
     def parse_options(args)
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         opt(:locks, "Lock file",
             :type => :string, :short => "l", :default => DEFAULT_OUTPUT_PATH.join("#{PREFIX}locks.yml").to_s)
         opt(:connections, "Human readable active connections file",

--- a/tools/pg_inspector/servers_to_yaml.rb
+++ b/tools/pg_inspector/servers_to_yaml.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'trollop'
+require 'optimist'
 require 'pg'
 require 'pg_inspector/error'
 require 'pg_inspector/pg_inspector_operation'
@@ -10,7 +10,7 @@ module PgInspector
     HELP_MSG_SHORT = "Dump ManageIQ server information to YAML file".freeze
 
     def parse_options(args)
-      self.options = Trollop.options(args) do
+      self.options = Optimist.options(args) do
         banner <<-BANNER
 
 #{HELP_MSG_SHORT}

--- a/tools/purge_metrics.rb
+++ b/tools/purge_metrics.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
-require 'trollop'
+require 'optimist'
 
 MODES = %w(count purge)
 
 ARGV.shift if ARGV[0] == '--' # if invoked with rails runner
-opts = Trollop.options do
+opts = Optimist.options do
   banner "Purge metrics records.\n\nUsage: ruby #{$0} [options]\n\nOptions:\n\t"
   opt :mode,     "Mode (#{MODES.join(", ")})", :default => "count"
   opt :realtime, "Realtime range", :default => "4.hours"
@@ -14,11 +14,11 @@ opts = Trollop.options do
   opt :window,   "Window of records to delete at once", :default => 10000
   opt :limit,    "Total number of records to delete per method"
 end
-Trollop.die :mode,     "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
-Trollop.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
-Trollop.die :hourly,   "must be a number with method (e.g. 6.months)" unless opts[:hourly].number_with_method?
-Trollop.die :daily,    "must be a number with method (e.g. 6.months)" unless opts[:daily].number_with_method?
-Trollop.die :window,   "must be a number greater than 0" if opts[:window] <= 0
+Optimist.die :mode,     "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
+Optimist.die :realtime, "must be a number with method (e.g. 4.hours)"  unless opts[:realtime].number_with_method?
+Optimist.die :hourly,   "must be a number with method (e.g. 6.months)" unless opts[:hourly].number_with_method?
+Optimist.die :daily,    "must be a number with method (e.g. 6.months)" unless opts[:daily].number_with_method?
+Optimist.die :window,   "must be a number greater than 0" if opts[:window] <= 0
 
 def log(msg)
   $log.info("MIQ(#{__FILE__}) #{msg}")

--- a/tools/purge_miq_report_results.rb
+++ b/tools/purge_miq_report_results.rb
@@ -1,25 +1,25 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
-require 'trollop'
+require 'optimist'
 
 MODES = %w(count purge)
 
 ARGV.shift if ARGV[0] == '--' # if invoked with rails runner
-opts = Trollop.options do
+opts = Optimist.options do
   banner "Purge miq_report_results records.\n\nUsage: ruby #{$0} [options]\n\nOptions:\n\t"
   opt :mode,      "Mode (#{MODES.join(", ")})",          :default => "count"
   opt :window,    "Window of records to delete at once", :default => 100
   opt :date,      "Range of reports to keep by date (default: VMDB configuration)",     :type => :string
   opt :remaining, "Number of results to keep per report (default: VMDB configuration)", :type => :int
 end
-Trollop.die :mode,   "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
-Trollop.die :window, "must be a number greater than 0"    if opts[:window] <= 0
+Optimist.die :mode,   "must be one of #{MODES.join(", ")}" unless MODES.include?(opts[:mode])
+Optimist.die :window, "must be a number greater than 0"    if opts[:window] <= 0
 if opts[:remaining_given]
-  Trollop.die :remaining, "must be a number greater than 0" if opts[:remaining] <= 0
+  Optimist.die :remaining, "must be a number greater than 0" if opts[:remaining] <= 0
   purge_mode  = :remaining
   purge_value = opts[:remaining]
 elsif opts[:date_given]
-  Trollop.die :date, "must be a number with method (e.g. 6.months)" unless opts[:date].number_with_method?
+  Optimist.die :date, "must be a number with method (e.g. 6.months)" unless opts[:date].number_with_method?
   purge_mode  = :date
   purge_value = opts[:date].to_i_with_method.seconds.ago.utc
 else

--- a/tools/radar/capture_radar.rb
+++ b/tools/radar/capture_radar.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 require File.expand_path("../../config/environment", __dir__)
-require 'trollop'
+require 'optimist'
 require './tools/radar/rollup_radar_mixin'
 include RollupRadarMixin
 
-opts = Trollop.options(ARGV) do
+opts = Optimist.options(ARGV) do
   banner "USAGE:   #{__FILE__} -h <number of hours back to query metrics>\n" \
          "Example: #{__FILE__} -d <number of days back to query metrics>"
 
@@ -12,7 +12,7 @@ opts = Trollop.options(ARGV) do
   opt :days,  "Days",  :short => "d", :type => :int
   opt :label, "Label", :short => "l", :type => :string, :default => "com.redhat.component"
 end
-Trollop.die :hours, "is required" unless opts[:hours] || opts[:days_given]
+Optimist.die :hours, "is required" unless opts[:hours] || opts[:days_given]
 
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 

--- a/tools/radar/report_radar.rb
+++ b/tools/radar/report_radar.rb
@@ -5,11 +5,11 @@ HEADERS_AND_COLUMNS = ['Hour', 'Date', 'Label of image (key : value)', 'Project'
 
 require File.expand_path("../../config/environment", __dir__)
 require './tools/radar/rollup_radar_mixin'
-require 'trollop'
+require 'optimist'
 
 include RollupRadarMixin
 
-opts = Trollop.options(ARGV) do
+opts = Optimist.options(ARGV) do
   banner "USAGE:  #{__FILE__} -d <number of days back to query metrics, default is 1 day>\n" \
          "        or                                                                     \n" \
          "        #{__FILE__} -s <start date to query metrics, required>                 \n" \
@@ -21,7 +21,7 @@ opts = Trollop.options(ARGV) do
 end
 
 def absolute_time_range(start_date, end_date)
-  Trollop.die "Start date is missing" if end_date && !start_date
+  Optimist.die "Start date is missing" if end_date && !start_date
 
   begin
     end_date = if end_date
@@ -32,11 +32,11 @@ def absolute_time_range(start_date, end_date)
 
     start_date = Date.strptime(start_date.to_s, "%Y%m%d").beginning_of_day.utc
   rescue ArgumentError
-    Trollop.die "Cannot parse any of input date"
+    Optimist.die "Cannot parse any of input date"
   end
 
   if start_date > end_date
-    Trollop.die "Start date cannot be greater then end date"
+    Optimist.die "Start date cannot be greater then end date"
   end
 
   [start_date..end_date]

--- a/tools/rebuild_provision_request.rb
+++ b/tools/rebuild_provision_request.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
-require 'trollop'
+require 'optimist'
 require 'rest-client'
 #
 # Helper Script to show the json / hash output of an
@@ -20,7 +20,7 @@ end
 
 ARGV.shift if ARGV[0] == '--'
 
-opts = Trollop.options do
+opts = Optimist.options do
   banner <<-EOS
 
 Reconstruct provision request parameters based on an existing request
@@ -62,12 +62,12 @@ Usage: #{PROGRAM_STRING} [--options]\n\nOptions:\n\t
 end
 
 if opts[:request_id].nil? && opts[:last_requests].nil?
-  Trollop.die :request_id, "must exist as an option"
+  Optimist.die :request_id, "must exist as an option"
 elsif opts[:last_requests_given] && opts[:count]
-  Trollop.die :count, "must be greater than 0" if opts[:count] <= 0
+  Optimist.die :count, "must be greater than 0" if opts[:count] <= 0
 else
-  Trollop.die :request_id, "must be a number greater than 0" if opts[:request_id] <= 0
-  Trollop.die :output, "must be either hash or json" unless %w(hash json).include?(opts[:output])
+  Optimist.die :request_id, "must be a number greater than 0" if opts[:request_id] <= 0
+  Optimist.die :output, "must be either hash or json" unless %w(hash json).include?(opts[:output])
 end
 
 class Tab

--- a/tools/remove_grouping_from_report_results.rb
+++ b/tools/remove_grouping_from_report_results.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
-require 'trollop'
+require 'optimist'
 
-opts = Trollop.options do
+opts = Optimist.options do
   banner "Remove extras[:grouping] from MiqReportResult#report column.\n\nUsage: ruby #{$PROGRAM_NAME} [options]\n\nOptions:\n\t"
   opt :dry_run,    "For testing, rollback any changes when the script exits.", :short => :none, :default => false
   opt :batch_size, "Limit memory usage by process this number of report results at a time.",    :default => 50
@@ -12,10 +12,10 @@ puts "Using options: #{opts.inspect}\n\n"
 
 if defined?(Rails)
   puts "Warning: Rails is already loaded!  Please do not invoke using rails runner. Exiting with help text.\n\n"
-  Trollop.educate
+  Optimist.educate
 end
 
-# Load rails after trollop options are set.  No one wants to wait for -h.
+# Load rails after optimist options are set.  No one wants to wait for -h.
 require File.expand_path('../config/environment', __dir__)
 
 # Wrap all changes in a transaction and roll them back if dry-run or an error occurs.

--- a/tools/replicate_server_settings.rb
+++ b/tools/replicate_server_settings.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 require File.expand_path("../config/environment", __dir__)
 $LOAD_PATH << Rails.root.join("tools").to_s
-require 'trollop'
+require 'optimist'
 require 'server_settings_replicator/server_settings_replicator'
 
-opts = Trollop.options(ARGV) do
+opts = Optimist.options(ARGV) do
   banner "USAGE:   #{__FILE__} -s <server id> -p <path/to/the/settings> \n" \
          "Example: #{__FILE__} -d -s 1 -p ems/ems_amazon/additional_instance_types"
 
@@ -14,7 +14,7 @@ opts = Trollop.options(ARGV) do
 end
 
 puts opts.inspect
-Trollop.die :path, "is required" unless opts[:path_given]
+Optimist.die :path, "is required" unless opts[:path_given]
 
 server = opts[:serverid] ? MiqServer.find(opts[:serverid]) : MiqServer.my_server
 ServerSettingsReplicator.replicate(server, opts[:path], opts[:dry_run])

--- a/tools/vim_collect_inventory.rb
+++ b/tools/vim_collect_inventory.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 
-require 'trollop'
+require 'optimist'
 ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-opts = Trollop.options do
+opts = Optimist.options do
   opt :ip,     "IP address", :type => :string, :required => true
   opt :user,   "User Name",  :type => :string, :required => true
   opt :pass,   "Password",   :type => :string, :required => true
@@ -11,7 +11,7 @@ opts = Trollop.options do
   opt :bypass, "Bypass broker usage", :type => :boolean
   opt :dir,    "Output directory",    :default => "."
 end
-Trollop.die :ip, "is an invalid format" unless opts[:ip] =~ /^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$/
+Optimist.die :ip, "is an invalid format" unless opts[:ip] =~ /^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$/
 
 def process(accessor, dir)
   puts "Reading #{accessor}..."

--- a/tools/vim_collect_perf_history.rb
+++ b/tools/vim_collect_perf_history.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 
-require 'trollop'
+require 'optimist'
 ARGV.shift if ARGV.first == "--" # Handle when called through script/runner
-opts = Trollop.options do
+opts = Optimist.options do
   opt :ip,     "IP address", :type => :string, :required => true
   opt :user,   "User Name",  :type => :string, :required => true
   opt :pass,   "Password",   :type => :string, :required => true
@@ -11,7 +11,7 @@ opts = Trollop.options do
   opt :bypass, "Bypass broker usage", :type => :boolean
   opt :dir,    "Output directory",    :default => "."
 end
-Trollop.die :ip, "is an invalid format" unless opts[:ip] =~ /^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$/
+Optimist.die :ip, "is an invalid format" unless opts[:ip] =~ /^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$/
 
 targets = eval(ARGV.first) rescue nil
 if targets.nil? || !targets.kind_of?(Array) || targets.empty?


### PR DESCRIPTION
`Trollop` is a deprecated gem, and has been renamed/replaced by [`Optimist`](https://github.com/ManageIQ/optimist).

This will probably also need to happen in conjunction with `manageiq-providers-vmware`, since that also has a script that uses this.

That said, this is not intended to be backported, and should just be used to remove the deprecation warnings the "proper" way.


Links
-----

* Org search of current usage of old gem (hides some irrelevant repos):  [search](https://github.com/search?l=&q=Trollop+repo%3AManageIQ%2Fmanageiq+repo%3AManageIQ%2Fmanageiq-release+repo%3AManageIQ%2Fmanageiq-appliance_console+repo%3AManageIQ%2Fmanageiq-appliance-build+repo%3AManageIQ%2Fmanageiq-api+repo%3AManageIQ%2Fmanageiq-providers-vmware+repo%3AManageIQ%2Fhttpd_configmap_generator+repo%3AManageIQ%2Fguides&type=Code)