### PR TITLE
[WIP] evm:status displays all columns by default

### DIFF
--- a/lib/tasks/evm.rake
+++ b/lib/tasks/evm.rake
@@ -42,12 +42,22 @@ namespace :evm do
 
   desc "Report Status of the ManageIQ EVM Application"
   task :status => :environment do
-    EvmApplication.status
+    require 'trollop'
+    opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+      opt :collapse, "Collapse columns with the same value", :type => :boolean
+    end
+
+    EvmApplication.status(false, :collapse => opts[:collapse])
   end
 
   desc "Report Status of the ManageIQ EVM Application"
   task :status_full => :environment do
-    EvmApplication.status(true)
+    require 'trollop'
+    opts = Trollop.options(EvmRakeHelper.extract_command_options) do
+      opt :collapse, "Collapse columns with the same value", :type => :boolean
+    end
+
+    EvmApplication.status(true, :collapse => opts[:collapse])
   end
 
   desc "Describe inventory of the ManageIQ EVM Application"


### PR DESCRIPTION
## Overview

`rake evm:status` has a lot of data to display.
Too much data causes the output to wrap, making the output hard to read.
The columns with duplicate values were collapsed and displayed as a summary below.

This feature was added in #17087

But some users are not expecting those columns to be displayed below, they want them all inline.

### Options

1. remove the collapse (most deletes) #18260 
2. make it configurable (most code changes) #18248 (this PR)
3. never collapse status (least code change) #18259

# THIS PR

Make it configurable

### before:

Columns with duplicate values were collapsed and displayed below in a summary section

### after:

All columns (with a value) are displayed in the table by default.

The condensed view is still available, but with a flag:

```
rake evm:status_full -- --collapse
```

https://bugzilla.redhat.com/show_bug.cgi?id=1651256

## full output reference

```text
rake evm:status_full

Checking EVM status...
 Region | Zone          | Server   | Status  |   PID |  SPID | Workers | Version | Started    | Heartbeat  | MB Usage | Roles
--------+---------------+----------+---------+-------+-------+---------+---------+------------+------------+----------+------------------------------------------------------------------------------
     10 | staging-01 wk | srvr-01* | started |  1503 |  1912 |      24 | 5.8.5.1 | 2018-11-14 | 2018-11-19 |      349 | automate:database_operations:smartstate:user_interface:web_services:websocket
     10 | staging-02    | srvr-02  | started |  1640 |  5030 |      13 | 5.8.5.1 | 2018-11-14 | 2018-11-19 |      348 | automate:ems_inventory:ems_operations:event:user_interface:web_services:websocket

* marks a master appliance

 Region | Zone          | Type                                      | Status  |   PID | SPID  | Server  | Queue                                           | Started    | Heartbeat  | MB Usage
--------+---------------+-------------------------------------------+---------+-------+-------+---------+-------------------------------------------------+------------+------------+----------
     10 | staging-01 wk | EmbeddedAnsible                           | started |       | 2195  | srvr-01 |                                                 | 2018-11-14 | 2018-11-19 |
     10 | staging-01 wk | EmbeddedAnsible::Automation::EventCatcher | started |  3538 | 3553  | srvr-01 | ems_10000000000004                              | 2018-11-14 | 2018-11-19 | 237/2048
     10 | staging-01 wk | EmbeddedAnsible::Automation::Refresh      | started | 31950 | 31982 | srvr-01 | ems_10000000000004                              | 2018-11-19 | 2018-11-19 | 216/2048
     10 | staging-01 wk | EmsMetricsProcessor                       | started |  2081 | 2115  | srvr-01 | ems_metrics_processor                           | 2018-11-14 | 2018-11-19 | 151/600
     10 | staging-01 wk | EmsMetricsProcessor                       | started |  2089 | 2114  | srvr-01 | ems_metrics_processor                           | 2018-11-14 | 2018-11-19 | 151/600
     10 | staging-01 wk | EmsRefreshCore                            | started |  2099 | 2139  | srvr-01 | ems_10000000000001                              | 2018-11-14 | 2018-11-19 | 225/400
     10 | staging-01 wk | EventHandler                              | started |  2205 | 2256  | srvr-01 | ems                                             | 2018-11-14 | 2018-11-19 | 203/500
     10 | staging-01 wk | Generic                                   | started |  1996 | 2042  | srvr-01 | generic                                         | 2018-11-14 | 2018-11-19 | 431/500
     10 | staging-01 wk | Generic                                   | started |  2003 | 2044  | srvr-01 | generic                                         | 2018-11-14 | 2018-11-19 | 422/500
     10 | staging-01 wk | Priority                                  | started |  2014 | 2048  | srvr-01 | generic                                         | 2018-11-14 | 2018-11-19 | 264/600
     10 | staging-01 wk | Priority                                  | started |  2022 | 2049  | srvr-01 | generic                                         | 2018-11-14 | 2018-11-19 | 247/600
     10 | staging-01 wk | Reporting                                 | started |  2250 | 2493  | srvr-01 | reporting                                       | 2018-11-14 | 2018-11-19 | 336/500
     10 | staging-01 wk | Reporting                                 | started |  2272 | 2516  | srvr-01 | reporting                                       | 2018-11-14 | 2018-11-19 | 339/500
     10 | staging-01 wk | Schedule                                  | started |  2032 | 2052  | srvr-01 |                                                 | 2018-11-14 | 2018-11-19 | 204/500
     10 | staging-01 wk | SmartProxy                                | started | 49979 | 49998 | srvr-01 | smartproxy                                      | 2018-11-19 | 2018-11-19 | 150/1024
     10 | staging-01 wk | SmartProxy                                | started | 49988 | 50002 | srvr-01 | smartproxy                                      | 2018-11-19 | 2018-11-19 | 150/1024
     10 | staging-01 wk | Ui                                        | started |  2539 |       | srvr-01 | http:3000                                       | 2018-11-14 | 2018-11-19 | 379/1024
     10 | staging-01 wk | VimBroker                                 | started |  2548 | 2844  | srvr-01 | drbunix:///tmp/MiqVimBroker20181114-2548-1566ii | 2018-11-14 | 2018-11-19 | 242/2048
     10 | staging-01 wk | Vmware::Infra::EventCatcher               | started |  2183 | 2204  | srvr-01 | ems_10000000000001                              | 2018-11-14 | 2018-11-19 | 168/2048
     10 | staging-01 wk | Vmware::Infra::MetricsCollector           | started |  2063 | 2104  | srvr-01 | vmware                                          | 2018-11-14 | 2018-11-19 | 150/400
     10 | staging-01 wk | Vmware::Infra::MetricsCollector           | started |  2071 | 2110  | srvr-01 | vmware                                          | 2018-11-14 | 2018-11-19 | 149/400
     10 | staging-01 wk | Vmware::Infra::Refresh                    | started | 31744 | 31765 | srvr-01 | ems_10000000000001                              | 2018-11-19 | 2018-11-19 | 190/2048
     10 | staging-01 wk | WebService                                | started |  2558 |       | srvr-01 | http:4000                                       | 2018-11-14 | 2018-11-19 | 312/1024
     10 | staging-01 wk | Websocket                                 | started | 11817 |       | srvr-01 | http:5000                                       | 2018-11-15 | 2018-11-19 | 189/1024
     10 | staging-02    | EmsRefreshCore                            | started |  1995 | 5378  | srvr-02 | ems_10000000000002                              | 2018-11-14 | 2018-11-19 | 240/400
     10 | staging-02    | EventHandler                              | started |  2034 | 5383  | srvr-02 | ems                                             | 2018-11-14 | 2018-11-19 | 269/500
     10 | staging-02    | Generic                                   | started |  1877 | 5090  | srvr-02 | generic                                         | 2018-11-14 | 2018-11-19 | 321/500
     10 | staging-02    | Generic                                   | started |  1884 | 5091  | srvr-02 | generic                                         | 2018-11-14 | 2018-11-19 | 325/500
     10 | staging-02    | Priority                                  | started |  1893 | 5088  | srvr-02 | generic                                         | 2018-11-14 | 2018-11-19 | 332/600
     10 | staging-02    | Priority                                  | started |  1901 | 5089  | srvr-02 | generic                                         | 2018-11-14 | 2018-11-19 | 346/600
     10 | staging-02    | Schedule                                  | started |  1909 | 5094  | srvr-02 |                                                 | 2018-11-14 | 2018-11-19 | 203/500
     10 | staging-02    | Ui                                        | started |  2078 |       | srvr-02 | http:3000                                       | 2018-11-14 | 2018-11-19 | 152/1024
     10 | staging-02    | VimBroker                                 | started |  2089 | 5450  | srvr-02 | drbunix:///tmp/MiqVimBroker20181114-2089-1jjs4o | 2018-11-14 | 2018-11-19 | 338/2048
     10 | staging-02    | Vmware::Infra::EventCatcher               | started |  2021 | 5387  | srvr-02 | ems_10000000000002                              | 2018-11-14 | 2018-11-19 | 222/2048
     10 | staging-02    | Vmware::Infra::Refresh                    | started | 16215 | 35469 | srvr-02 | ems_10000000000002                              | 2018-11-19 | 2018-11-19 | 288/2048
     10 | staging-02    | WebService                                | started |  2101 |       | srvr-02 | http:4000                                       | 2018-11-14 | 2018-11-19 | 154/1024
     10 | staging-02    | Websocket                                 | started |  2066 |       | srvr-02 | http:5000                                       | 2018-11-14 | 2018-11-19 | 152/1024
```

## Condensed output reference

```text
rake evm:status_full --collapse # also the default before this PR

Checking EVM status...
 Zone          | Server   |   PID |  SPID | Workers | MB Usage | Roles
---------------+----------+-------+-------+---------+----------+----------------------------------------------------------------------------------
 staging-01 wk | srvr-01* |  1503 |  1912 |      24 |      349 | automate:database_operations:smartstate:user_interface:web_services:websocket
 staging-02    | srvr-02  |  1640 |  5030 |      13 |      348 | automate:ems_inventory:ems_operations:event:user_interface:web_services:websocket

For all rows: Region=10, Status=started, Version=5.8.5.1, Started=2018-11-14, Heartbeat=2018-11-19
* marks a master appliance

 Zone          | Type                                      |   PID | SPID  | Server  | Queue                                           | Started    | MB Usage
---------------+-------------------------------------------+-------+-------+---------+-------------------------------------------------+------------+----------
 staging-01 wk | EmbeddedAnsible                           |       | 2195  | srvr-01 |                                                 | 2018-11-14 |
 staging-01 wk | EmbeddedAnsible::Automation::EventCatcher |  3538 | 3553  | srvr-01 | ems_10000000000004                              | 2018-11-14 | 237/2048
 staging-01 wk | EmbeddedAnsible::Automation::Refresh      | 31950 | 31982 | srvr-01 | ems_10000000000004                              | 2018-11-19 | 216/2048
 staging-01 wk | EmsMetricsProcessor                       |  2081 | 2115  | srvr-01 | ems_metrics_processor                           | 2018-11-14 | 151/600
 staging-01 wk | EmsMetricsProcessor                       |  2089 | 2114  | srvr-01 | ems_metrics_processor                           | 2018-11-14 | 151/600
 staging-01 wk | EmsRefreshCore                            |  2099 | 2139  | srvr-01 | ems_10000000000001                              | 2018-11-14 | 225/400
 staging-01 wk | EventHandler                              |  2205 | 2256  | srvr-01 | ems                                             | 2018-11-14 | 203/500
 staging-01 wk | Generic                                   |  1996 | 2042  | srvr-01 | generic                                         | 2018-11-14 | 431/500
 staging-01 wk | Generic                                   |  2003 | 2044  | srvr-01 | generic                                         | 2018-11-14 | 422/500
 staging-01 wk | Priority                                  |  2014 | 2048  | srvr-01 | generic                                         | 2018-11-14 | 264/600
 staging-01 wk | Priority                                  |  2022 | 2049  | srvr-01 | generic                                         | 2018-11-14 | 247/600
 staging-01 wk | Reporting                                 |  2250 | 2493  | srvr-01 | reporting                                       | 2018-11-14 | 336/500
 staging-01 wk | Reporting                                 |  2272 | 2516  | srvr-01 | reporting                                       | 2018-11-14 | 339/500
 staging-01 wk | Schedule                                  |  2032 | 2052  | srvr-01 |                                                 | 2018-11-14 | 204/500
 staging-01 wk | SmartProxy                                | 49979 | 49998 | srvr-01 | smartproxy                                      | 2018-11-19 | 150/1024
 staging-01 wk | SmartProxy                                | 49988 | 50002 | srvr-01 | smartproxy                                      | 2018-11-19 | 150/1024
 staging-01 wk | Ui                                        |  2539 |       | srvr-01 | http:3000                                       | 2018-11-14 | 379/1024
 staging-01 wk | VimBroker                                 |  2548 | 2844  | srvr-01 | drbunix:///tmp/MiqVimBroker20181114-2548-1566ii | 2018-11-14 | 242/2048
 staging-01 wk | Vmware::Infra::EventCatcher               |  2183 | 2204  | srvr-01 | ems_10000000000001                              | 2018-11-14 | 168/2048
 staging-01 wk | Vmware::Infra::MetricsCollector           |  2063 | 2104  | srvr-01 | vmware                                          | 2018-11-14 | 150/400
 staging-01 wk | Vmware::Infra::MetricsCollector           |  2071 | 2110  | srvr-01 | vmware                                          | 2018-11-14 | 149/400
 staging-01 wk | Vmware::Infra::Refresh                    | 31744 | 31765 | srvr-01 | ems_10000000000001                              | 2018-11-19 | 190/2048
 staging-01 wk | WebService                                |  2558 |       | srvr-01 | http:4000                                       | 2018-11-14 | 312/1024
 staging-01 wk | Websocket                                 | 11817 |       | srvr-01 | http:5000                                       | 2018-11-15 | 189/1024
 staging-02    | EmsRefreshCore                            |  1995 | 5378  | srvr-02 | ems_10000000000002                              | 2018-11-14 | 240/400
 staging-02    | EventHandler                              |  2034 | 5383  | srvr-02 | ems                                             | 2018-11-14 | 269/500
 staging-02    | Generic                                   |  1877 | 5090  | srvr-02 | generic                                         | 2018-11-14 | 321/500
 staging-02    | Generic                                   |  1884 | 5091  | srvr-02 | generic                                         | 2018-11-14 | 325/500
 staging-02    | Priority                                  |  1893 | 5088  | srvr-02 | generic                                         | 2018-11-14 | 332/600
 staging-02    | Priority                                  |  1901 | 5089  | srvr-02 | generic                                         | 2018-11-14 | 346/600
 staging-02    | Schedule                                  |  1909 | 5094  | srvr-02 |                                                 | 2018-11-14 | 203/500
 staging-02    | Ui                                        |  2078 |       | srvr-02 | http:3000                                       | 2018-11-14 | 152/1024
 staging-02    | VimBroker                                 |  2089 | 5450  | srvr-02 | drbunix:///tmp/MiqVimBroker20181114-2089-1jjs4o | 2018-11-14 | 338/2048
 staging-02    | Vmware::Infra::EventCatcher               |  2021 | 5387  | srvr-02 | ems_10000000000002                              | 2018-11-14 | 222/2048
 staging-02    | Vmware::Infra::Refresh                    | 16215 | 35469 | srvr-02 | ems_10000000000002                              | 2018-11-19 | 288/2048
 staging-02    | WebService                                |  2101 |       | srvr-02 | http:4000                                       | 2018-11-14 | 154/1024
 staging-02    | Websocket                                 |  2066 |       | srvr-02 | http:5000                                       | 2018-11-14 | 152/1024

For all rows: Region=10, Status=started, Heartbeat=2018-11-19
```