### PR TITLE
Fixing service bundle resource linking

### DIFF
--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -7,12 +7,10 @@ module Service::RetirementManagement
   end
 
   def retire_service_resources
-    # TODO: delete me per https://github.com/ManageIQ/manageiq/pull/16933#discussion_r175805070
-    return
     direct_service_children.each(&:retire_service_resources)
 
     service_resources.each do |sr|
-      if sr.resource.respond_to?(:retire_now)
+      if sr.resource.respond_to?(:retire_now) && sr.resource_type != "Service"
         $log.info("Retiring service resource for service: #{name} resource ID: #{sr.id}")
         sr.resource.retire_now(retirement_requester)
       end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -199,7 +199,7 @@ class ServiceTemplate < ApplicationRecord
 
     nh['initiator'] = service_task.options[:initiator] if service_task.options[:initiator]
 
-    Service.create(nh) do |svc|
+    service = Service.create(nh) do |svc|
       svc.service_template = self
       set_ownership(svc, service_task.get_user)
 
@@ -208,7 +208,9 @@ class ServiceTemplate < ApplicationRecord
         %w(id created_at updated_at service_template_id).each { |key| nh.delete(key) }
         svc.add_resource(sr.resource, nh) unless sr.resource.nil?
       end
+    end
 
+    service.tap do |svc|
       if parent_svc
         service_resource = ServiceResource.find_by(:id => service_task.options[:service_resource_id])
         parent_svc.add_resource!(svc, service_resource)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -117,33 +117,61 @@ describe "Service Retirement Management" do
     expect(@service.retires_on).to eq(options[:date])
   end
 
-  it "#retire_service_resources" do
-    ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
-    vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
-    @service << vm
-    expect(@service.service_resources.size).to eq(1)
-    expect(@service.service_resources.first.resource).to_not receive(:retire_now)
-    @service.retire_service_resources
-  end
+  describe "#retire_service_resources" do
+    context "when service resource is not a service" do
+      it "retires the service resource" do
+        ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
+        @service << FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
+        expect(@service.service_resources.size).to eq(1)
+        expect(@service.service_resources.first.resource).to receive(:retire_now)
+        @service.retire_service_resources
+      end
+    end
 
-  it "#retire_service_resources should get service's retirement_requester" do
-    ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
-    vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
-    userid = 'freddy'
-    @service.update_attributes(:retirement_requester => userid)
-    @service << vm
-    expect(@service.service_resources.size).to eq(1)
-    expect(@service.service_resources.first.resource).to_not receive(:retire_now).with(userid)
-    @service.retire_service_resources
-  end
+    context "when service resource is a service" do
+      it "doesn't retire the service resource" do
+        service_c1 = FactoryGirl.create(:service)
+        @service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "Service", :service_id => service_c1.id, :resource_id => service_c1.id)
 
-  it "#retire_service_resources should get service's nil retirement_requester" do
-    ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
-    vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
-    @service << vm
-    expect(@service.service_resources.size).to eq(1)
-    expect(@service.service_resources.first.resource).to_not receive(:retire_now).with(nil)
-    @service.retire_service_resources
+        expect(@service.service_resources.size).to eq(1)
+        expect(@service.service_resources.first.resource).not_to receive(:retire_now)
+        @service.retire_service_resources
+      end
+    end
+
+    context "when service resources are both service and vm_or_template" do
+      it "retires only the vm resource type service resource" do
+        service_c1 = FactoryGirl.create(:service)
+        vm = FactoryGirl.create(:vm)
+        @service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "VmOrTemplate", :service_id => service_c1.id, :resource_id => vm.id)
+        @service.service_resources << FactoryGirl.create(:service_resource, :resource_type => "Service", :service_id => service_c1.id, :resource_id => service_c1.id)
+
+        expect(@service.service_resources.size).to eq(2)
+        expect(@service.service_resources.sort.first.resource).to receive(:retire_now)
+        expect(@service.service_resources.sort.second.resource).not_to receive(:retire_now)
+        @service.retire_service_resources
+      end
+    end
+
+    it "#retire_service_resources should get service's retirement_requester" do
+      ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
+      vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
+      userid = 'freddy'
+      @service.update_attributes(:retirement_requester => userid)
+      @service << vm
+      expect(@service.service_resources.size).to eq(1)
+      expect(@service.service_resources.first.resource).to receive(:retire_now).with(userid)
+      @service.retire_service_resources
+    end
+
+    it "#retire_service_resources should get service's nil retirement_requester" do
+      ems = FactoryGirl.create(:ems_vmware, :zone => @server.zone)
+      vm  = FactoryGirl.create(:vm_vmware, :ems_id => ems.id)
+      @service << vm
+      expect(@service.service_resources.size).to eq(1)
+      expect(@service.service_resources.first.resource).to receive(:retire_now).with(nil)
+      @service.retire_service_resources
+    end
   end
 
   it "#finish_retirement" do

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -355,19 +355,41 @@ describe ServiceTemplate do
       expect(sub_svc).to include(@svc_d)
     end
 
-    it "should add_resource! only if a parent_svc exists" do
-      sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
-      parent_svc = instance_double("service_task", :options => {:dialog => {}})
-      expect(parent_svc).to receive(:add_resource!).once
+    describe "#create_service" do
+      let(:service_task) do
+        FactoryGirl.create(:service_template_provision_task,
+                           :miq_request => service_template_request,
+                           :options     => {:service_resource_id => service_resource.id})
+      end
+      let(:service_template_request) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+      let(:service_resource) do
+        FactoryGirl.create(:service_resource,
+                           :resource_type => 'MiqRequest',
+                           :resource_id   => service_template_request.id)
+      end
+      let(:user) { FactoryGirl.create(:user) }
+      let(:parent_service) { FactoryGirl.create(:service) }
 
-      @svc_a.create_service(sub_svc, parent_svc)
-    end
+      it "create service sets parent service resource resource id" do
+        @svc_a.create_service(service_task, parent_service)
 
-    it "should not call add_resource! if no parent_svc exists" do
-      sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
-      expect(sub_svc).to receive(:add_resource!).never
+        expect(parent_service.service_resources.first.resource_id).to eq(parent_service.children.first.id)
+      end
 
-      @svc_a.create_service(sub_svc)
+      it "should add_resource! only if a parent_svc exists" do
+        sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
+        parent_svc = instance_double("service_task", :options => {:dialog => {}}, :service_resources => instance_double('service_resource'))
+        expect(parent_svc).to receive(:add_resource!).once
+
+        @svc_a.create_service(sub_svc, parent_svc)
+      end
+
+      it "should not call add_resource! if no parent_svc exists" do
+        sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
+        expect(sub_svc).to receive(:add_resource!).never
+
+        @svc_a.create_service(sub_svc)
+      end
     end
 
     it "should pass display attribute to created top level service" do


### PR DESCRIPTION
This fixes an issue with the provisioning of bundled services that was introduced in https://github.com/ManageIQ/manageiq/pull/16799/files#diff-9257fff45a7d1258305c9a6b7d15e322R198, a pr which changed service_template.rb to use the block form of create. The issue with this is that when we get to the "add_resource" call the child service isn't saved yet and does not have an ID which causes the service resource to be saved with a resource_type but without a resource_id. 

The second commit puts back the original direct_service_retirement call taken out here: https://github.com/ManageIQ/manageiq/pull/17881/files#diff-610ed908579256e82c76ec0910169142L10. The fact that things were being provisioned without the link in the first commit meant that the children of a bundle weren't being retired. This fixes that and adds an additional check to make sure that we're not doubly retiring anything. 

This will in some form need to go back to Fine, though the call for the double service retirement was removed entirely from gaprindashvili.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653648