### PR TITLE
Link service resources of bundled service correctly

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -199,7 +199,7 @@ class ServiceTemplate < ApplicationRecord
 
     nh['initiator'] = service_task.options[:initiator] if service_task.options[:initiator]
 
-    Service.create(nh) do |svc|
+    service = Service.create(nh) do |svc|
       svc.service_template = self
       set_ownership(svc, service_task.get_user)
 
@@ -208,7 +208,9 @@ class ServiceTemplate < ApplicationRecord
         %w(id created_at updated_at service_template_id).each { |key| nh.delete(key) }
         svc.add_resource(sr.resource, nh) unless sr.resource.nil?
       end
+    end
 
+    service.tap do |svc|
       if parent_svc
         service_resource = ServiceResource.find_by(:id => service_task.options[:service_resource_id])
         parent_svc.add_resource!(svc, service_resource)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -355,19 +355,41 @@ describe ServiceTemplate do
       expect(sub_svc).to include(@svc_d)
     end
 
-    it "should add_resource! only if a parent_svc exists" do
-      sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
-      parent_svc = instance_double("service_task", :options => {:dialog => {}})
-      expect(parent_svc).to receive(:add_resource!).once
+    describe "#create_service" do
+      let(:service_task) do
+        FactoryGirl.create(:service_template_provision_task,
+                           :miq_request => service_template_request,
+                           :options     => {:service_resource_id => service_resource.id})
+      end
+      let(:service_template_request) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+      let(:service_resource) do
+        FactoryGirl.create(:service_resource,
+                           :resource_type => 'MiqRequest',
+                           :resource_id   => service_template_request.id)
+      end
+      let(:user) { FactoryGirl.create(:user) }
+      let(:parent_service) { FactoryGirl.create(:service) }
 
-      @svc_a.create_service(sub_svc, parent_svc)
-    end
+      it "create service sets parent service resource resource id" do
+        @svc_a.create_service(service_task, parent_service)
+        parent_service.reload
+        expect(parent_service.service_resources.first.resource).to eq(parent_service.children.first)
+      end
 
-    it "should not call add_resource! if no parent_svc exists" do
-      sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
-      expect(sub_svc).to receive(:add_resource!).never
+      it "should add_resource! only if a parent_svc exists" do
+        sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
+        parent_svc = instance_double("service_task", :options => {:dialog => {}}, :service_resources => instance_double('service_resource'))
+        expect(parent_svc).to receive(:add_resource!).once
 
-      @svc_a.create_service(sub_svc)
+        @svc_a.create_service(sub_svc, parent_svc)
+      end
+
+      it "should not call add_resource! if no parent_svc exists" do
+        sub_svc = instance_double("service_task", :options => {:dialog => {}}, :get_user => service_user)
+        expect(sub_svc).to receive(:add_resource!).never
+
+        @svc_a.create_service(sub_svc)
+      end
     end
 
     it "should pass display attribute to created top level service" do


### PR DESCRIPTION
This fixes an issue with the provisioning of bundled services that was introduced in https://github.com/ManageIQ/manageiq/pull/16799/files#diff-9257fff45a7d1258305c9a6b7d15e322R198, a pr which changed service_template.rb to use the block form of create. The issue with this is that when we get to the "add_resource" call the child service isn't saved yet and does not have an ID which causes the service resource to be saved with a resource_type but without a resource_id.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653648

It was originally https://github.com/ManageIQ/manageiq/pull/18250 but that got closed because master and hammer both have the service retire task logic implemented as part of retirement as a request. 