### PR TITLE
[GAPRINDASHVILI] Retire direct service children and don't duplicate sr retirement

### DIFF
--- a/app/models/service/retirement_management.rb
+++ b/app/models/service/retirement_management.rb
@@ -7,8 +7,10 @@ module Service::RetirementManagement
   end
 
   def retire_service_resources
+    direct_service_children.each(&:retire_service_resources)
+
     service_resources.each do |sr|
-      if sr.resource.respond_to?(:retire_now)
+      if sr.resource.respond_to?(:retire_now) && sr.resource_type != "Service"
         $log.info("Retiring service resource for service: #{name} resource ID: #{sr.id}")
         sr.resource.retire_now(retirement_requester)
       end


### PR DESCRIPTION
Puts back the original direct_service_retirement call taken out here: https://github.com/ManageIQ/manageiq/pull/17881/files#diff-610ed908579256e82c76ec0910169142L10. The fact that things were being provisioned without the link in the first commit meant that the children of a bundle weren't being retired. This fixes that and adds an additional check to make sure that we're not doubly retiring anything.

## Related to:
~~https://github.com/ManageIQ/manageiq/pull/18251~~ (merged)
~~https://github.com/ManageIQ/manageiq/pull/18250~~ (orig PR, closed cause I goofed up versions)

https://bugzilla.redhat.com/show_bug.cgi?id=1655081