### PR TITLE
Fix miq request ownership

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -224,6 +224,14 @@ class MiqGroup < ApplicationRecord
     end
   end
 
+  def regional_groups
+    self.class.regional_groups(self)
+  end
+
+  def self.regional_groups(group)
+    where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:description)]).eq(group.description.downcase)))
+  end
+
   def self.create_tenant_group(tenant)
     tenant_full_name = (tenant.ancestors.map(&:name) + [tenant.name]).join("/")
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -148,11 +148,11 @@ class MiqRequest < ApplicationRecord
   end
 
   def self.user_owned(user)
-    where(:requester_id => user.id)
+    where(:requester_id => user.regional_users.select(:id))
   end
 
   def self.group_owned(miq_group)
-    where(:requester_id => miq_group.user_ids)
+    where(:requester_id => miq_group.regional_groups.joins(:users).select("users.id"))
   end
 
   # Supports old-style requests where specific request was a seperate table connected as a resource

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -243,6 +243,14 @@ class User < ApplicationRecord
     end
   end
 
+  def regional_users
+    self.class.regional_users(self)
+  end
+
+  def self.regional_users(user)
+    where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:userid)]).eq(user.userid.downcase)))
+  end
+
   def self.super_admin
     in_my_region.find_by_userid("admin")
   end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -584,6 +584,19 @@ describe MiqGroup do
     end
   end
 
+  describe "#regional_groups" do
+    let(:other_id) { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
+    let(:group) { FactoryGirl.create(:miq_group) }
+    let!(:regional_group) { FactoryGirl.create(:miq_group, :description => group.description.upcase, :id => other_id) }
+
+    it "finds regional groups" do
+      FactoryGirl.create(:miq_group) # ensure these doen't come back
+      FactoryGirl.create(:miq_group, :id => other_id + 1)
+
+      expect(group.regional_groups).to match_array([group, regional_group])
+    end
+  end
+
   describe ".with_roles_excluding" do
     it "handles multiple columns" do
       a = FactoryGirl.create(:miq_group, :features => "good")

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -563,4 +563,32 @@ describe MiqRequest do
       expect(orch_stack_request.class::SOURCE_CLASS_NAME).to eq('OrchestrationStack')
     end
   end
+
+  describe ".user_owned" do
+    let(:regional_id) { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
+    let(:user) { FactoryGirl.create(:user) }
+    let!(:regional_user) { FactoryGirl.create(:user, :userid => user.userid.upcase, :id => regional_id) }
+    let!(:request) { FactoryGirl.create(:vm_migrate_request, :requester => user) }
+    let!(:regional_request) { FactoryGirl.create(:vm_migrate_request, :requester => regional_user) }
+    it "finds request for cross region users" do
+      FactoryGirl.create(:vm_migrate_request, :requester => FactoryGirl.create(:user))
+      FactoryGirl.create(:vm_migrate_request, :requester => FactoryGirl.create(:user), :id => regional_id + 1)
+      expect(MiqRequest.user_owned(regional_user)).to match_array([request, regional_request])
+    end
+  end
+
+  describe ".group_owned" do
+    let(:regional_id) { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
+    let(:group) { FactoryGirl.create(:miq_group) }
+    let(:regional_group) { FactoryGirl.create(:miq_group, :id => regional_id) }
+    let(:user) { FactoryGirl.create(:user, :miq_groups => [group]) }
+    let!(:regional_user) { FactoryGirl.create(:user, :userid => user.userid.upcase, :id => regional_id, :miq_groups => [regional_group]) }
+    let!(:request) { FactoryGirl.create(:vm_migrate_request, :requester => user) }
+    let!(:regional_request) { FactoryGirl.create(:vm_migrate_request, :requester => regional_user) }
+    it "finds request for cross region groups" do
+      FactoryGirl.create(:vm_migrate_request, :requester => FactoryGirl.create(:user))
+      FactoryGirl.create(:vm_migrate_request, :requester => FactoryGirl.create(:user), :id => regional_id + 1)
+      expect(MiqRequest.user_owned(regional_user)).to match_array([request, regional_request])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -609,4 +609,17 @@ describe User do
       expect(User.with_roles_excluding("everything").select(:id, :name)).to match_array([u1, u2])
     end
   end
+
+  describe "#regional_users" do
+    let(:other_id) { ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1) }
+    let(:user) { FactoryGirl.create(:user) }
+    let!(:regional_user) { FactoryGirl.create(:user, :userid => user.userid.upcase, :id => other_id) }
+
+    it "finds regional users" do
+      FactoryGirl.create(:user) # ensure these doen't come back
+      FactoryGirl.create(:user, :id => other_id + 1)
+
+      expect(user.regional_users).to match_array([user, regional_user])
+    end
+  end
 end


### PR DESCRIPTION
## Overview
Currently, MiqRequests only show requests created in the same region.
This works most of the time except for a rollup (aka reporting) region.

You see, we have different user records for each region. They have the same `userid` (aka the string login name), but the `id` is different.
Requests created in this region are associated with the user from this region, and requests created in another region are associated with the user from the other region.

Followup to #18245 (added specs)
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1647169

## Before

For the request screen, we only showed requests associated with the currently logged in user.
Requests from other regions were not associated with this user and did not show.

## After

For the request screen, we now only show requests associated with the currently logged in `userid` (the string you use to login).
Requests from other regions are associated with a different user, but the `userid` match, so they are now shown.

The `OwnershipMixin` uses `userid` to store object ownership.
The MiqRequest needed to overrides these methods since ownership is stored in `requester_id`.
The new methods have been changed to still be based upon `requester_id`, but the code is now more similar to the `OwnershipMixin` version.