### PR TITLE
Add more robust error handling to ConversionHost#get_conversion_state

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -153,9 +153,9 @@ class ConversionHost < ApplicationRecord
     JSON.parse(json_state)
   rescue Net::SSH::Exception => err
     raise "Failed to connect and retrieve conversion state data from file '#{path}' with [#{err.class}: #{err}"
-  rescue JSON::ParserError => err
+  rescue JSON::ParserError
     raise "Could not parse conversion state data from file '#{path}': #{json_state}"
-  rescue => err
+  rescue StandardError => err
     raise "Error retrieving and parsing conversion state file '#{path}' from '#{resource.name}' with [#{err.class}: #{err}"
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -151,10 +151,10 @@ class ConversionHost < ApplicationRecord
   def get_conversion_state(path)
     json_state = connect_ssh { |ssu| ssu.get_file(path, nil) }
     JSON.parse(json_state)
-  rescue JSON::ParserError => err
-    raise "Could not parse conversion state data from file '#{path}': #{json_state}"
   rescue Net::SSH::Exception => err
     raise "Failed to connect and retrieve conversion state data from file '#{path}' with [#{err.class}: #{err}"
+  rescue JSON::ParserError => err
+    raise "Could not parse conversion state data from file '#{path}': #{json_state}"
   rescue => err
     raise "Error retrieving and parsing conversion state file '#{path}' from '#{resource.name}' with [#{err.class}: #{err}"
   end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -254,7 +254,8 @@ class ConversionHost < ApplicationRecord
   # TODO: Move this to ManageIQ::Providers::Redhat::InfraManager::ConversionHost
   #
   def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
-    [hostname || ipaddress, resource.authentication_userid, resource.authentication_password, nil, nil]
+    authentication = find_credentials
+    [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
   end
 
   # For the OpenStack provider, use the first authentication containing an ssh keypair that has

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -151,7 +151,7 @@ class ConversionHost < ApplicationRecord
   def get_conversion_state(path)
     json_state = connect_ssh { |ssu| ssu.get_file(path, nil) }
     JSON.parse(json_state)
-  rescue Net::SSH::Exception => err
+  rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
     raise "Failed to connect and retrieve conversion state data from file '#{path}' with [#{err.class}: #{err}"
   rescue JSON::ParserError
     raise "Could not parse conversion state data from file '#{path}': #{json_state}"

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -317,7 +317,7 @@ describe ConversionHost do
 
     it "works as expected if the connection is successful and the JSON is valid" do
       allow(conversion_host).to receive(:connect_ssh).and_return({:alpha => {:beta => 'hello'}}.to_json)
-      expect(conversion_host.get_conversion_state(path)).to eql({'alpha' => {'beta' => 'hello'}})
+      expect(conversion_host.get_conversion_state(path)).to eql('alpha' => {'beta' => 'hello'})
     end
 
     it "works as expected if the connection is successful but the JSON is invalid" do


### PR DESCRIPTION
Based on a conversation with Kedar Kulkarni, this PR attempts to add some more robust error handling to the `get_conversion_state` method. At the moment the SFTP download is sometimes failing somehow, so the data stream ends up being blank, which then results in a JSON parser error. This doesn't tell us the "real" error, which I'm hoping to figure out.

Original BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1653407

~~(The other micro changes you see were already-existent blank spaces that were auto-stripped by my editor, I'm surprised rubocop didn't catch those before).~~

~~WIP for now as I'm not sure that this will be enough, or if MiqSshUtil (from gems-pending) needs some TLC.~~