### PR TITLE
[WIP] evm:status displays all columns

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -68,29 +68,9 @@ class EvmApplication
 
   def self.output_status(data, footnote = nil)
     return if data.blank?
-    duplicate_columns = redundant_columns(data)
-    puts data.tableize(:columns => (data.first.keys - duplicate_columns.keys))
-
-    # dont give headsup for empty values
-    heads_up = duplicate_columns.select { |n, v| n == "Region" || (v != 0 && v.present?) }
-    if heads_up.present?
-      puts "", "For all rows: #{heads_up.map { |n, v| "#{n}=#{v}" }.join(", ")}"
-      puts footnote if footnote
-    elsif footnote
-      puts "", footnote
-    end
+    puts data.tableize(:columns => data.first.keys)
+    puts "", footnote if footnote
   end
-
-  def self.redundant_columns(data, column_names = nil, dups = {})
-    return dups if data.size <= 1
-    column_names ||= data.first.keys
-    column_names.each do |col_header|
-      values = data.collect { |row| row[col_header] }.uniq
-      dups[col_header] = values.first if values.size < 2
-    end
-    dups
-  end
-  private_class_method :redundant_columns
 
   def self.compact_date(date)
     return "" unless date

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -149,7 +149,6 @@ describe EvmApplication do
 
     context "for just the local server" do
       it "displays server status for the local server and it's workers" do
-
         expected_output = <<~SERVER_INFO
           Checking EVM status...
            #{header(:Region)  } | #{header(:Zone, :ljust)} | Server                   | Status  | PID | SPID | Workers | Version | #{header(:Started, :ljust)  } | #{header(:Heartbeat, :ljust)  } | MB Usage | Roles
@@ -177,21 +176,18 @@ describe EvmApplication do
       it "displays server status for the all servers and workers" do
         expected_output = <<~SERVER_INFO
           Checking EVM status...
-           #{header(:Zone, :ljust)               } | Server                    | Workers | #{header(:Started, :ljust)  } | #{header(:Heartbeat, :ljust).rstrip}
-          -#{line_for(:Zone)                     }-+---------------------------+---------+-#{line_for(:Started)        }-+-#{line_for(:Heartbeat)}-
-           #{pad(local.zone.name, :Zone, :ljust) } | #{      local.name     }  |       1 | #{local_started_on          } | #{local_heartbeat}
-           #{pad(remote.zone.name, :Zone, :ljust)} | #{     remote.name     }* |       2 | #{remote_started_on         } |
+           #{header(:Region)  } | #{header(:Zone, :ljust)               } | Server                    | Status  | PID | SPID | Workers | Version | #{header(:Started, :ljust)  } | #{header(:Heartbeat, :ljust)       } | MB Usage | Roles
+          -#{line_for(:Region)}-+-#{line_for(:Zone)                     }-+---------------------------+---------+-----+------+---------+---------+-#{line_for(:Started)        }-+-#{line_for(:Heartbeat)             }-+----------+-------
+           #{pad(rgn, :Region)} | #{pad(local.zone.name, :Zone, :ljust) } | #{      local.name     }  | started |     |      |       1 | 9.9.9.9 | #{local_started_on          } | #{pad(local_heartbeat, :Heartbeat) } |          |
+           #{pad(rgn, :Region)} | #{pad(remote.zone.name, :Zone, :ljust)} | #{     remote.name     }* | started |     |      |       2 | 9.9.9.9 | #{remote_started_on         } | #{pad("", :Heartbeat)              } |          |
 
-          For all rows: Region=#{rgn}, Status=started, Version=9.9.9.9
           * marks a master appliance
 
-           #{header(:Zone, :ljust)               } | Type          | #{header(:PID)          } | Server
-          -#{line_for(:Zone)                     }-+---------------+-#{line_for(:PID)        }-+--------------------------
-           #{pad(local.zone.name, :Zone, :ljust) } | Ui            | #{pad(ui.pid, :PID)     } | #{      local.name     }
-           #{pad(remote.zone.name, :Zone, :ljust)} | Base::Refresh | #{pad(refresh.pid, :PID)} | #{     remote.name     }
-           #{pad(remote.zone.name, :Zone, :ljust)} | Generic       | #{pad(generic.pid, :PID)} | #{     remote.name     }
-
-          For all rows: Region=#{rgn}, Status=ready
+           #{header(:Region)  } | #{header(:Zone, :ljust)               } | Type          | Status | #{header(:PID)          } | SPID | Server                   | Queue | Started | Heartbeat | MB Usage
+          -#{line_for(:Region)}-+-#{line_for(:Zone)                     }-+---------------+--------+-#{line_for(:PID)        }-+------+--------------------------+-------+---------+-----------+----------
+           #{pad(rgn, :Region)} | #{pad(local.zone.name, :Zone, :ljust) } | Ui            | ready  | #{pad(ui.pid, :PID)     } |      | #{      local.name     } |       |         |           |
+           #{pad(rgn, :Region)} | #{pad(remote.zone.name, :Zone, :ljust)} | Base::Refresh | ready  | #{pad(refresh.pid, :PID)} |      | #{     remote.name     } |       |         |           |
+           #{pad(rgn, :Region)} | #{pad(remote.zone.name, :Zone, :ljust)} | Generic       | ready  | #{pad(generic.pid, :PID)} |      | #{     remote.name     } |       |         |           |
         SERVER_INFO
 
         expect { EvmApplication.status(true) }.to output(expected_output).to_stdout


### PR DESCRIPTION
This is option 3 for fixing this BZ (base ref #18248)
There was some confusion on the best approach.
I coded up all 3

Users were confused that redundant columns were hidden
Now displaying all columns

concern:

Columns `Version`, `Heartbeat` (and probably `Status` and `Started`) are expected to be the same. Those columns were added because they are useful, but may make the screen too wide

https://bugzilla.redhat.com/show_bug.cgi?id=1651256
