### PR TITLE
De-dup git fetches for override_gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -253,7 +253,13 @@ end
 def override_gem(name, *args)
   if dependencies.any?
     raise "Trying to override unknown gem #{name}" unless (dependency = dependencies.find { |d| d.name == name })
-    dependencies.delete(dependency)
+
+    removed_dependency = dependencies.delete(dependency)
+    if removed_dependency.source.kind_of?(Bundler::Source::Git)
+      @sources.send(:source_list_for, removed_dependency.source).delete_if do |other_source|
+        removed_dependency.source == other_source
+      end
+    end
 
     calling_file = caller_locations.detect { |loc| !loc.path.include?("lib/bundler") }.path
     calling_dir  = File.dirname(calling_file)


### PR DESCRIPTION
When overriding a gem via `bundler.d` for local dev (or otherwise), the git sources of those gems that are overwritten would still be fetched since removing the spec from `dependencies` does not remove the source from `@sources`.

This can be illustrated by doing having a simple `bundler.d/Gem.dev.rb` with the following:

```ruby
kbrock = "https://github.com/kbrock/manageiq-api"
override_gem "manageiq-api", :git => kbrock, :branch => "master"

bdunne = "https://github.com/bdunne/manageiq-api"
override_gem "manageiq-api", :git => bdunne, :branch => "master"

nickla = "https://github.com/NickLaMuro/manageiq-api"
override_gem "manageiq-api", :git => nickla, :branch => "master"
```

The resulting `bin/bundle update` output will be:

    $ bin/bundle update
    ** override_gem: manageiq-api, [{:git=>"https://github.com/NickLaMuro/manageiq-api", :branch=>"master"}], caller: /Users/nicklamuro/code/redhat/manageiq/bundler.d/Gem.dev.rb
    ** override_gem: manageiq-api, [{:git=>"https://github.com/NickLaMuro/manageiq-api", :branch=>"master"}], caller: /Users/nicklamuro/code/redhat/manageiq/bundler.d/Gem.dev.rb
    ** override_gem: manageiq-api, [{:git=>"https://github.com/NickLaMuro/manageiq-api", :branch=>"master"}], caller: /Users/nicklamuro/code/redhat/manageiq/bundler.d/Gem.dev.rb
    Fetching https://github.com/ManageIQ/manageiq-gems-pending.git
    Fetching https://github.com/ManageIQ/handsoap.git

    # truncated...

    Fetching https://github.com/ManageIQ/jquery-rjs.git
    Fetching https://github.com/ManageIQ/manageiq-v2v
    Fetching https://github.com/NickLaMuro/manageiq-api  <----
    Fetching https://github.com/bdunne/manageiq-api      <----
    Fetching https://github.com/kbrock/manageiq-api      <----
    Fetching https://github.com/ManageIQ/manageiq-api    <----
    Fetching gem metadata from https://rubygems.org/......
    Fetching gem metadata from https://rubygems.org/.
    Resolving dependencies.....................................
    Using rake 11.3.0
    ...

As illustrated in the above "fetches", not only are the three different repos provided in the `bundler.d/Gem.dev.rb` file fetched (redundant in all but the laziest of dev's files), the original repo from the gem to be overwritten is also fetched, even though it is not used.

This simply removes the unneeded source from the `@sources` list if it matches the dependency that was removed via `override_gem`.