### PR TITLE
Include  /etc/manageiq/postgresql.conf.d/ directory to log collection

### DIFF
--- a/app/models/miq_server/log_management.rb
+++ b/app/models/miq_server/log_management.rb
@@ -80,7 +80,7 @@ module MiqServer::LogManagement
     return [] unless pg_data
 
     pg_data = Pathname.new(pg_data)
-    [pg_data.join("*.conf"), pg_data.join("pg_log/*")]
+    [pg_data.join("*.conf"), pg_data.join("pg_log/*"), Pathname.new("/etc/manageiq/postgresql.conf.d/*")]
   end
 
   def log_start_and_end_for_pattern(pattern)

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -95,7 +95,7 @@ describe MiqServer do
 
       it "pg_data_dir set" do
         allow(@miq_server).to receive_messages(:pg_data_dir => '/var/lib/pgsql/data')
-        expected = %w(/var/lib/pgsql/data/*.conf /var/lib/pgsql/data/pg_log/*)
+        expected = %w(/var/lib/pgsql/data/*.conf /var/lib/pgsql/data/pg_log/* /etc/manageiq/postgresql.conf.d/*)
         expect(@miq_server.pg_log_patterns.collect(&:to_s)).to match_array expected
       end
     end


### PR DESCRIPTION
Include  ```/etc/manageiq/postgresql.conf.d/*``` to log collection

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1652116

@miq-bot add-label bug, hammer/yes