### PR TITLE
Tenancy for central admin

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -90,8 +90,16 @@ class Tenant < ApplicationRecord
     self.class.descendants_of(self).where(:divisible => false)
   end
 
+  def regional_tenants
+    self.class.regional_tenants(self)
+  end
+
+  def self.regional_tenants(tenant)
+    where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:name)]).eq(tenant.name.downcase)))
+  end
+
   def accessible_tenant_ids(strategy = nil)
-    (strategy ? send(strategy) : []).append(id)
+    (strategy ? regional_tenants.map(&strategy.to_sym).flatten : []) + regional_tenants.ids
   end
 
   def name

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2501,6 +2501,61 @@ describe Rbac::Filterer do
     end
   end
 
+  context "multi regional environment(global region)" do
+    # 3 regions - default - 2 remotes
+    # create service template in one region
+    # user in remote region - tenant - in other region
+
+    let(:common_t2_name) { "Tenant 2" }
+    # global(default) region
+    # T1 -> T2 -> T3
+    let(:t1) { FactoryGirl.create(:tenant) }
+    let(:t2) { FactoryGirl.create(:tenant, :parent => t1, :name => common_t2_name.upcase) }
+    let(:t3) { FactoryGirl.create(:tenant, :parent => t2) }
+
+    # user with T2
+    #
+    let(:group_t2) { FactoryGirl.create(:miq_group, :tenant => t2) }
+    let(:user_t2)  { FactoryGirl.create(:user, :miq_groups => [group_t2]) }
+
+    # in other region
+    #
+    #
+    let(:other_region) { FactoryGirl.create(:miq_region) }
+
+    def id_for_model_in_region(model, other_region)
+      model.id_in_region(model.count + 1_000_000, other_region.region)
+    end
+
+    #
+    # T1 -> T2 -> T3
+    let(:t1_other_region) { FactoryGirl.create(:tenant, :id => id_for_model_in_region(Tenant, other_region)) }
+    let(:t2_other_region) { FactoryGirl.create(:tenant, :parent => t1_other_region, :id => id_for_model_in_region(Tenant, other_region), :name => common_t2_name) }
+    let(:t3_other_region) { FactoryGirl.create(:tenant, :parent => t2_other_region, :id => id_for_model_in_region(Tenant, other_region)) }
+
+    #
+    # user with T2
+    #
+    let(:group_t2_other_region) { FactoryGirl.create(:miq_group, :tenant => t2_other_region, :id => id_for_model_in_region(MiqGroup, other_region)) }
+    let(:user_t2_other_region)  { FactoryGirl.create(:user, :miq_groups => [group_t2_other_region], :id => id_for_model_in_region(User, other_region)) }
+    let!(:service_template_other_region) { FactoryGirl.create(:service_template, :tenant => t2_other_region, :id => id_for_model_in_region(ServiceTemplate, other_region)) }
+
+    let!(:vm_other_region) { FactoryGirl.create(:vm, :tenant => t2_other_region, :id => id_for_model_in_region(Vm, other_region)) }
+
+    it "finds also service templates from other region" do
+      expect(ServiceTemplate.count).to eq(1)
+      result = described_class.filtered(ServiceTemplate, :user => user_t2_other_region)
+      expect(result).to eq([service_template_other_region])
+
+      # on global region
+      result = described_class.filtered(ServiceTemplate, :user => user_t2)
+      expect(result).to eq([service_template_other_region])
+
+      result = described_class.filtered(Vm, :user => user_t2)
+      expect(result).to eq([vm_other_region])
+    end
+  end
+
   private
 
   # separate them to match easier for failures


### PR DESCRIPTION
This PR is adding a way how to use tenancy from remote region in central admin.

This change would require the user to manually create the tenant structure that exists in the remote regions in the global region.

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1465158


@miq-bot assign @gtanzillo 
@miq-bot add_label enhancement, rbac
