### PR TITLE
Add more ConversionHost validations

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -13,7 +13,9 @@ class ConversionHost < ApplicationRecord
   validates :name, :presence => true
   validates :resource_type, :presence => true, :inclusion => { :in => VALID_RESOURCE_TYPES }
   validates :resource_id, :presence => true
-  validates :address, :presence => true, :uniqueness => true, :format => { :with => Resolv::AddressRegex }
+
+  validates :address, :presence => true, :uniqueness => true, :format => { :with => Resolv::AddressRegex },
+    :inclusion => { :in => proc{ |record| record.resource.ipaddresses } }
 
   include_concern 'Configurations'
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -3,7 +3,7 @@ class ConversionHost < ApplicationRecord
 
   acts_as_miq_taggable
 
-  VALID_RESOURCE_TYPES = %w[Vm Host]
+  VALID_RESOURCE_TYPES = %w(Vm Host).freeze
 
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -14,8 +14,13 @@ class ConversionHost < ApplicationRecord
   validates :resource_type, :presence => true, :inclusion => { :in => VALID_RESOURCE_TYPES }
   validates :resource_id, :presence => true
 
-  validates :address, :presence => true, :uniqueness => true, :format => { :with => Resolv::AddressRegex },
-    :inclusion => { :in => proc { |record| record.resource.ipaddresses } }
+  validates :address, :uniqueness => true,
+    :if        => proc { |record| record.address.present? },
+    :format    => { :with => Resolv::AddressRegex },
+    :inclusion => {
+      :in => proc { |record| record.resource.ipaddresses },
+      :if => proc { |record| record.resource.ipaddresses.present? }
+    }
 
   include_concern 'Configurations'
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -13,7 +13,7 @@ class ConversionHost < ApplicationRecord
   validates :name, :presence => true
   validates :resource_type, :presence => true, :inclusion => { :in => VALID_RESOURCE_TYPES }
   validates :resource_id, :presence => true
-  validates :address, :presence => true, :uniqueness => true
+  validates :address, :presence => true, :uniqueness => true, :format => { :with => Resolv::AddressRegex }
 
   include_concern 'Configurations'
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -15,7 +15,7 @@ class ConversionHost < ApplicationRecord
   validates :resource_id, :presence => true
 
   validates :address, :presence => true, :uniqueness => true, :format => { :with => Resolv::AddressRegex },
-    :inclusion => { :in => proc{ |record| record.resource.ipaddresses } }
+    :inclusion => { :in => proc { |record| record.resource.ipaddresses } }
 
   include_concern 'Configurations'
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -3,10 +3,17 @@ class ConversionHost < ApplicationRecord
 
   acts_as_miq_taggable
 
+  VALID_RESOURCE_TYPES = %w[Vm Host]
+
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
+
+  validates :name, :presence => true
+  validates :resource_type, :presence => true, :inclusion => { :in => VALID_RESOURCE_TYPES }
+  validates :resource_id, :presence => true
+  validates :address, :presence => true, :uniqueness => true
 
   include_concern 'Configurations'
 
@@ -38,7 +45,7 @@ class ConversionHost < ApplicationRecord
   def ipaddress(family = 'ipv4')
     return address if address && IPAddr.new(address).send("#{family}?")
     resource.ipaddresses.detect { |ip| IPAddr.new(ip).send("#{family}?") }
-  end 
+  end
 
   def run_conversion(conversion_options)
     result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', nil, nil, conversion_options.to_json) }
@@ -65,7 +72,7 @@ class ConversionHost < ApplicationRecord
     connect_ssh { |ssu| ssu.get_file(path, nil) }
   rescue => e
     raise "Could not get conversion log '#{path}' from '#{resource.name}' with [#{e.class}: #{e}"
-  end 
+  end
 
   def check_conversion_host_role
     install_conversion_host_module
@@ -127,7 +134,7 @@ class ConversionHost < ApplicationRecord
     require 'MiqSshUtil'
     MiqSshUtil.shell_with_su(*miq_ssh_util_args) do |ssu, _shell|
       yield(ssu)
-    end  
+    end
   rescue Exception => e
     _log.error("SSH connection failed for [#{ipaddress}] with [#{e.class}: #{e}]")
     raise e
@@ -139,7 +146,7 @@ class ConversionHost < ApplicationRecord
 
   def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
     [hostname || ipaddress, resource.authentication_userid, resource.authentication_password, nil, nil]
-  end 
+  end
 
   def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
     authentication = resource.ext_management_system.authentications

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -61,8 +61,7 @@ describe ServiceTemplateTransformationPlanRequest do
 
       it 'returns false' do
         host = FactoryGirl.create(:host, :ext_management_system => FactoryGirl.create(:ext_management_system, :zone => FactoryGirl.create(:zone)))
-        allow(host).to receive(:ipaddresses).and_return(['127.0.0.1'])
-        conversion_host = FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host', :address => host.ipaddresses.first)
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host')
         expect(request.validate_conversion_hosts).to be false
       end
     end
@@ -98,8 +97,7 @@ describe ServiceTemplateTransformationPlanRequest do
 
       it 'returns true' do
         host = FactoryGirl.create(:host, :ext_management_system => dst_ems, :ems_cluster => dst_cluster)
-        allow(host).to receive(:ipaddresses).and_return(['127.0.0.1'])
-        conversion_host = FactoryGirl.create(:conversion_host, :resource => host, :address => host.ipaddresses.first)
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host')
         expect(request.validate_conversion_hosts).to be true
       end
     end
@@ -135,8 +133,7 @@ describe ServiceTemplateTransformationPlanRequest do
 
       it 'returns true' do
         vm = FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant)
-        allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
-        conversion_host = FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm', :address => vm.ipaddresses.first)
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm')
         expect(request.validate_conversion_hosts).to be true
       end
     end

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -61,7 +61,8 @@ describe ServiceTemplateTransformationPlanRequest do
 
       it 'returns false' do
         host = FactoryGirl.create(:host, :ext_management_system => FactoryGirl.create(:ext_management_system, :zone => FactoryGirl.create(:zone)))
-        conversion_host = FactoryGirl.create(:conversion_host, :resource => host)
+        allow(host).to receive(:ipaddresses).and_return(['127.0.0.1'])
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host', :address => host.ipaddresses.first)
         expect(request.validate_conversion_hosts).to be false
       end
     end
@@ -97,7 +98,8 @@ describe ServiceTemplateTransformationPlanRequest do
 
       it 'returns true' do
         host = FactoryGirl.create(:host, :ext_management_system => dst_ems, :ems_cluster => dst_cluster)
-        conversion_host = FactoryGirl.create(:conversion_host, :resource => host)
+        allow(host).to receive(:ipaddresses).and_return(['127.0.0.1'])
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => host, :address => host.ipaddresses.first)
         expect(request.validate_conversion_hosts).to be true
       end
     end
@@ -133,7 +135,8 @@ describe ServiceTemplateTransformationPlanRequest do
 
       it 'returns true' do
         vm = FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant)
-        conversion_host = FactoryGirl.create(:conversion_host, :resource => vm)
+        allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+        conversion_host = FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm', :address => vm.ipaddresses.first)
         expect(request.validate_conversion_hosts).to be true
       end
     end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -19,7 +19,7 @@ describe ServiceTemplateTransformationPlanTask do
     let(:vm)  { FactoryGirl.create(:vm_or_template) }
     let(:vm2)  { FactoryGirl.create(:vm_or_template) }
     let(:apst) { FactoryGirl.create(:service_template_ansible_playbook) }
-    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => host) }
+    let(:conversion_host){ FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host') }
 
     let(:mapping) do
       FactoryGirl.create(
@@ -247,8 +247,7 @@ describe ServiceTemplateTransformationPlanTask do
     let(:request) { FactoryGirl.create(:service_template_transformation_plan_request, :source => plan) }
     let(:task_1) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_1) }
     let(:task_2) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_2) }
-
-    let(:conversion_host) { FactoryGirl.create(:conversion_host) }
+    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => src_vm_1, :resource_type => 'Vm') }
 
     describe '#transformation_destination' do
       it { expect(task_1.transformation_destination(src_cluster)).to eq(dst_cluster) }
@@ -516,7 +515,7 @@ describe ServiceTemplateTransformationPlanTask do
         let(:dst_flavor) { FactoryGirl.create(:flavor) }
         let(:dst_security_group) { FactoryGirl.create(:security_group) }
         let(:conversion_host_vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant) }
-        let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => conversion_host_vm) }
+        let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => conversion_host_vm, :resource_type => 'Vm') }
 
         let(:mapping) do
           FactoryGirl.create(


### PR DESCRIPTION
As I was doing some general testing with various POST operations with the REST API for conversion hosts, I realized there were almost no validations on the model. This PR adds some validations to a few columns, specifically the following:

* `name` - must be present
* `resource_type` - must be present and "Vm" or "Host"
* `resource_id` - must be present
* `address` - must be present, unique, and be a valid IP address

I'm not sure about the uniqueness constraint on the `address` field and/or if there are any other validations that we would like to see added, so a WIP for now.