### PR TITLE
Ems factory uses valid authentications

### DIFF
--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     userid      "testuser"
     password    "secret"
     authtype    "default"
+    status      "Valid"
   end
 
   factory :authentication_status_error, :parent => :authentication do

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -7,6 +7,16 @@ FactoryBot.define do
     zone                 { FactoryBot.create(:zone) }
     storage_profiles     { [] }
 
+    # authorizations
+
+    transient do
+      authtype nil
+    end
+
+    after(:create) do |ems, ev|
+      Array(ev.authtype).each { |a| ems.authentications << FactoryBot.create(:authentication, :authtype => a) }
+    end
+
     # Traits
 
     trait :with_clusters do
@@ -30,9 +40,7 @@ FactoryBot.define do
     end
 
     trait :with_authentication do
-      after(:create) do |x|
-        x.authentications << FactoryBot.create(:authentication)
-      end
+      authtype "default"
     end
 
     trait :with_unvalidated_authentication do
@@ -136,9 +144,7 @@ FactoryBot.define do
 
   factory :ems_vmware_with_authentication,
           :parent => :ems_vmware do
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   factory :ems_microsoft,
@@ -148,9 +154,7 @@ FactoryBot.define do
 
   factory :ems_microsoft_with_authentication,
           :parent => :ems_microsoft do
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   factory :ems_redhat,
@@ -170,9 +174,7 @@ FactoryBot.define do
 
   factory :ems_redhat_with_authentication,
           :parent => :ems_redhat do
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   trait :skip_validate do
@@ -182,9 +184,7 @@ FactoryBot.define do
   factory :ems_redhat_with_authentication_with_ca,
           :parent => :ems_redhat do
     certificate_authority "cert108"
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   factory :ems_redhat_with_metrics_authentication,
@@ -218,10 +218,7 @@ FactoryBot.define do
 
   factory :ems_openstack_infra_with_authentication,
           :parent => :ems_openstack_infra do
-    after :create do |x|
-      x.authentications << FactoryBot.create(:authentication)
-      x.authentications << FactoryBot.create(:authentication, :authtype => "amqp")
-    end
+    authtype %w(default amqp)
   end
 
   factory :ems_vmware_cloud,
@@ -252,9 +249,7 @@ FactoryBot.define do
 
   factory :ems_amazon_with_authentication,
           :parent => :ems_amazon do
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   factory :ems_amazon_with_cloud_networks,
@@ -278,9 +273,7 @@ FactoryBot.define do
           :parent => :ems_azure do
     azure_tenant_id "ABCDEFGHIJABCDEFGHIJ0123456789AB"
     subscription "0123456789ABCDEFGHIJABCDEFGHIJKL"
-    after :create do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   factory :ems_openstack,
@@ -290,10 +283,7 @@ FactoryBot.define do
 
   factory :ems_openstack_with_authentication,
           :parent => :ems_openstack do
-    after :create do |x|
-      x.authentications << FactoryBot.create(:authentication)
-      x.authentications << FactoryBot.create(:authentication, :authtype => "amqp")
-    end
+    authtype %w(default amqp)
   end
 
   factory :ems_openstack_network,
@@ -313,9 +303,7 @@ FactoryBot.define do
 
   factory :ems_google_with_authentication,
           :parent => :ems_google do
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication)
-    end
+    authtype "default"
   end
 
   factory :ems_google_network,

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -29,6 +29,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_authentication do
+      after(:create) do |x|
+        x.authentications << FactoryBot.create(:authentication)
+      end
+    end
+
+    trait :with_unvalidated_authentication do
+      after(:create) do |x|
+        x.authentications << FactoryBot.create(:authentication, :status => nil)
+      end
+    end
+
     trait :with_invalid_authentication do
       after(:create) do |x|
         x.authentications << FactoryBot.create(:authentication, :status => "invalid")
@@ -126,13 +138,6 @@ FactoryBot.define do
           :parent => :ems_vmware do
     after(:create) do |x|
       x.authentications << FactoryBot.create(:authentication)
-    end
-  end
-
-  factory :ems_vmware_with_valid_authentication,
-          :parent => :ems_vmware do
-    after(:create) do |x|
-      x.authentications << FactoryBot.create(:authentication, :status => "Valid")
     end
   end
 

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     url "example.com"
     trait(:with_authentication) do
       after(:create) do |x|
-        x.authentications << FactoryBot.create(:authentication, :status => "Valid")
+        x.authentications << FactoryBot.create(:authentication)
       end
     end
   end

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -489,6 +489,7 @@ describe AuthenticationMixin do
         end
 
         it "(:save => true) updates status" do
+          @host.authentications.first.update_attributes(:status => nil) # start unauthorized
           allow(@host).to receive(:verify_credentials).and_return(true)
           @host.authentication_check(:save => true)
           expect(@host.authentication_type(:default).status).to eq("Valid")
@@ -496,6 +497,7 @@ describe AuthenticationMixin do
         end
 
         it "(:save => false) does not update status" do
+          @host.authentications.first.update_attributes(:status => nil) # start unauthorized
           allow(@host).to receive(:missing_credentials?).and_return(false)
           @host.authentication_check(:save => false)
           expect(@host.authentication_type(:default).status).to be_nil

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -1,7 +1,7 @@
 describe PerEmsWorkerMixin do
   before do
     _guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
-    @ems = FactoryBot.create(:ems_vmware_with_authentication, :zone => zone)
+    @ems = FactoryBot.create(:ems_vmware, :with_unvalidated_authentication, :zone => zone)
     @ems_queue_name = "ems_#{@ems.id}"
 
     # General stubbing for testing any worker (methods called during initialize)

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -70,8 +70,8 @@ describe Storage do
       @zone   = @server.zone
 
       @zone2     = FactoryBot.create(:zone, :name => 'Bedrock')
-      @ems1      = FactoryBot.create(:ems_vmware_with_valid_authentication, :name => "test_vcenter1",     :zone => @zone)
-      @ems2      = FactoryBot.create(:ems_vmware_with_authentication,       :name => "test_vcenter2",     :zone => @zone2)
+      @ems1      = FactoryBot.create(:ems_vmware_with_authentication,           :name => "test_vcenter1", :zone => @zone)
+      @ems2      = FactoryBot.create(:ems_vmware, :with_invalid_authentication, :name => "test_vcenter2", :zone => @zone2)
       @storage1  = FactoryBot.create(:storage,               :name => "test_storage_vmfs", :store_type => "VMFS")
       @storage2  = FactoryBot.create(:storage,               :name => "test_storage_nfs",  :store_type => "NFS")
       @storage3  = FactoryBot.create(:storage,               :name => "test_storage_foo",  :store_type => "FOO")
@@ -159,7 +159,7 @@ describe Storage do
     context "on a host with authentication status ok" do
       before do
         allow_any_instance_of(Authentication).to receive(:after_authentication_changed)
-        FactoryBot.create(:authentication, :resource => @host1, :status => "Valid")
+        FactoryBot.create(:authentication, :resource => @host1)
       end
 
       it "#active_hosts_with_authentication_status_ok" do
@@ -419,8 +419,8 @@ describe Storage do
 
     it "returns true for VMware Storage when queried whether it supports smartstate analysis" do
       FactoryBot.create(:host_vmware,
-                         :ext_management_system => FactoryBot.create(:ems_vmware_with_valid_authentication),
-                         :storages              => [@storage])
+                        :ext_management_system => FactoryBot.create(:ems_vmware_with_authentication),
+                        :storages              => [@storage])
 
       expect(@storage.supports_smartstate_analysis?).to eq(true)
     end
@@ -469,8 +469,8 @@ describe Storage do
 
     it "returns true for VMware Storage when queried whether it supports smartstate analysis" do
       FactoryBot.create(:host_vmware,
-                         :ext_management_system => FactoryBot.create(:ems_vmware_with_valid_authentication),
-                         :storages              => [@storage])
+                        :ext_management_system => FactoryBot.create(:ems_vmware_with_authentication),
+                        :storages              => [@storage])
       expect(@storage.supports_smartstate_analysis?).to eq(true)
     end
 


### PR DESCRIPTION
The current `:authentication` factory is ambiguous.
Most of the places we want to use a valid authentication.
Any time we want an invalid authentication, we state otherwise.

Unfortunately, since the default authentication is not valid for many cases, we end up stubbing out the values in our specs.

### After This PR

From here, we can remove stubbing of authentication in providers [[example]](https://github.com/ManageIQ/manageiq-providers-azure/blob/master/spec/models/manageiq/providers/azure/cloud_manager/event_catcher_spec.rb#L7)
