### PR TITLE
Make evm:status common columns more obvious

### DIFF
--- a/lib/tasks/evm_application.rb
+++ b/lib/tasks/evm_application.rb
@@ -75,7 +75,7 @@ class EvmApplication
     # dont give headsup for empty values
     heads_up = duplicate_columns.select { |n, v| n == "Region" || (v != 0 && v.present?) }
     if heads_up.present?
-      puts "", "For all rows: #{heads_up.map { |n, v| "#{n}=#{v}" }.join(", ")}"
+      puts "", "All rows have the values: #{heads_up.map { |n, v| "#{n}=#{v}" }.join(", ")}"
       puts footnote if footnote
     elsif footnote
       puts "", footnote

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -182,7 +182,7 @@ describe EvmApplication do
            #{pad(local.zone.name, :Zone, :ljust) } | #{      local.name     }  | started |       1 | #{local_started_on          } | #{local_heartbeat}
            #{pad(remote.zone.name, :Zone, :ljust)} | #{     remote.name     }* | started |       2 | #{remote_started_on         } |
 
-          For all rows: Region=#{rgn}, Version=9.9.9.9
+          All rows have the values: Region=#{rgn}, Version=9.9.9.9
           * marks a master appliance
 
            #{header(:Zone, :ljust)               } | Type          | Status | #{header(:PID)          } | Server
@@ -191,7 +191,7 @@ describe EvmApplication do
            #{pad(remote.zone.name, :Zone, :ljust)} | Base::Refresh | ready  | #{pad(refresh.pid, :PID)} | #{     remote.name     }
            #{pad(remote.zone.name, :Zone, :ljust)} | Generic       | ready  | #{pad(generic.pid, :PID)} | #{     remote.name     }
 
-          For all rows: Region=#{rgn}
+          All rows have the values: Region=#{rgn}
         SERVER_INFO
 
         expect { EvmApplication.status(true) }.to output(expected_output).to_stdout


### PR DESCRIPTION
Followup to #18259 

Make the text more clear when all the columns for `rake evm:status`
have the same value

https://bugzilla.redhat.com/show_bug.cgi?id=1659576

This is in response to

>Maybe we can change the footer text a little bit to make it more clear why a column is hidden?
> -- https://bugzilla.redhat.com/show_bug.cgi?id=1651256 