### PR TITLE
[WIP]Seed vmdb table

### DIFF
--- a/app/models/vmdb_table.rb
+++ b/app/models/vmdb_table.rb
@@ -6,6 +6,35 @@ class VmdbTable < ApplicationRecord
 
   has_one  :latest_hourly_metric,  -> { VmdbMetric.where(:capture_interval_name => 'hourly', :resource_type => 'VmdbTable', :timestamp => VmdbMetric.maximum(:timestamp)) }, :as => :resource, :class_name => 'VmdbMetric'
 
+  # index_name1,unique1,col11,col12|index_name2,unique2,col21,col22
+  virtual_attribute :all_indexes, :string, :arel => (lambda do |t|
+    t.grouping(
+      Arel::Nodes::SqlLiteral.new(
+        "SELECT
+           string_agg(
+           distinct ix.relname || ',' || indisunique || ',' ||
+          regexp_replace(pg_get_indexdef(indexrelid), '^[^\\)]*\\(([^\\)]*)\\).*$', '\\1'), '|')
+        FROM pg_class t
+        INNER JOIN pg_index i ON t.oid = i.indrelid
+        INNER JOIN pg_class ix ON ix.oid = i.indexrelid
+        WHERE t.relname = #{t.name}.name"
+      )
+    )
+    # if we want only the primary index, add "AND i.indisprimary"
+  end)
+
+  # viable for vmdb_table_evm - defined in vmdb_table to make query from base class work
+  virtual_attribute :actual_text_tables, :string, :arel => (lambda do |t|
+    t.grouping(
+      Arel::Nodes::SqlLiteral.new(
+        "SELECT string_agg(pg_class.relname, ',')
+        FROM pg_class JOIN pg_class pg_class2 ON pg_class.oid = pg_class2.reltoastrelid
+        WHERE pg_class2.relname = #{t.name}.name
+        GROUP BY pg_class2.relname"
+      )
+    )
+  end)
+
   include VmdbDatabaseMetricsMixin
 
   include_concern 'Seeding'
@@ -18,5 +47,22 @@ class VmdbTable < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Table', 'Tables', number)
+  end
+
+  def sql_indexes
+    if has_attribute?(:all_indexes)
+      self["all_indexes"].split("|").map do |indx|
+        index_name, unique, *columns = indx.split(",")
+        ActiveRecord::ConnectionAdapters::IndexDefinition.new(name, index_name, unique == 't', columns.map(&:strip))
+      end
+    else
+      self.class.connection.indexes(name) << self.class.connection.primary_key_index(name)
+      # ALT: self.class.connection.all_indexes(name)
+    end
+  end
+
+  def actual_text_tables
+    return self["actual_text_tables"]&.split(",") || [] if has_attribute?(:actual_text_tables)
+    self.class.connection.respond_to?(:text_tables) ? self.class.connection.text_tables(name) : []
   end
 end

--- a/app/models/vmdb_table_evm.rb
+++ b/app/models/vmdb_table_evm.rb
@@ -3,11 +3,4 @@ class VmdbTableEvm < VmdbTable
 
   include_concern 'VmdbTableEvm::MetricCapture'
   include_concern 'Seeding'
-
-  def sql_indexes
-    actual  = self.class.connection.indexes(name)
-    pk = self.class.connection.primary_key_index(name)
-    actual << pk if pk
-    actual
-  end
 end

--- a/app/models/vmdb_table_evm/seeding.rb
+++ b/app/models/vmdb_table_evm/seeding.rb
@@ -19,7 +19,7 @@ module VmdbTableEvm::Seeding
 
   def seed_texts
     mine   = text_tables.index_by(&:name)
-    actual = self.class.connection.respond_to?(:text_tables) ? self.class.connection.text_tables(name) : []
+    actual = actual_text_tables
 
     actual.sort.each do |table_name|
       table = mine.delete(table_name)

--- a/app/models/vmdb_table_text.rb
+++ b/app/models/vmdb_table_text.rb
@@ -3,9 +3,6 @@ class VmdbTableText < VmdbTable
 
   include_concern 'Seeding'
 
-  def sql_indexes
-    self.class.connection.respond_to?(:text_table_indexes) ? self.class.connection.text_table_indexes(name) : []
-  end
 
   def capture_metrics
     # TODO:

--- a/lib/extensions/ar_adapter/ar_dba.rb
+++ b/lib/extensions/ar_adapter/ar_dba.rb
@@ -511,7 +511,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
     result.map do |row|
       index_name = row[0]
       unique     = row[1] == 't'
-      indkey     = row[2].split(" ")
+      indkey     = row[2].split(" ").map(&:to_i)
       oid        = row[3]
 
       columns = Hash[query(<<-SQL, "Columns for index #{index_name} on #{table_name}")]
@@ -522,7 +522,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
       SQL
 
       column_names = columns.values_at(*indkey).compact
-      column_names.empty? ? nil : IndexDefinition.new(table_name, index_name, unique, column_names)
+      column_names.empty? ? nil : ActiveRecord::ConnectionAdapters::IndexDefinition.new(table_name, index_name, unique, column_names)
     end.compact
   end
 

--- a/spec/models/vmdb_table_evm_spec.rb
+++ b/spec/models/vmdb_table_evm_spec.rb
@@ -63,8 +63,9 @@ describe VmdbTableEvm do
     end
 
     it "adds new tables" do
-      table_names = ['flintstones']
-      allow(described_class.connection).to receive(:text_tables).and_return(table_names)
+      table_names = ['pg_toast_foo']
+      expect_any_instance_of(VmdbTable).to receive(:actual_text_tables).and_return(table_names)
+      expect_any_instance_of(VmdbTable).to receive(:sql_indexes).and_return([])
       @evm_table.seed_texts
       expect(@evm_table.text_tables.collect(&:name)).to eq(table_names)
       @evm_table.text_tables.each { |t| expect(t.vmdb_database).to eq(@db) }
@@ -76,7 +77,7 @@ describe VmdbTableEvm do
       @evm_table.reload
       expect(@evm_table.text_tables.collect(&:name)).to eq(table_names)
 
-      allow(described_class.connection).to receive(:text_tables).and_return([])
+      allow_any_instance_of(VmdbTable).to receive(:actual_text_tables).and_return([])
       @evm_table.seed_texts
       @evm_table.reload
       expect(@evm_table.text_tables.collect(&:name)).to eq([])
@@ -85,7 +86,8 @@ describe VmdbTableEvm do
     it "finds existing tables" do
       table_names = ['flintstones']
       table_names.each { |t| FactoryGirl.create(:vmdb_table_text, :vmdb_database => @db, :evm_table => @evm_table, :name => t) }
-      allow(described_class.connection).to receive(:text_tables).and_return(table_names)
+      allow_any_instance_of(VmdbTable).to receive(:actual_text_tables).and_return(table_names)
+      allow_any_instance_of(VmdbTableText).to receive(:sql_indexes).and_return([])
       @evm_table.seed_texts
       @evm_table.reload
       expect(@evm_table.text_tables.collect(&:name)).to eq(table_names)


### PR DESCRIPTION
@jrafanie  pointed me to a primordial seed (run on every boot) that was taking too long for a customer.

The main changes:
1. Fixed a bug where the indexes for toast tables were not loading. (+299 rows coming back)
2. I encoded indexes and toast table name into virtual attributes that were included in the primary query.
3. To get the virtual attributes working correctly, we now perform a single query to bring back text and evm tables. Then we manually setup the associations. (reduces down to 1 query)

I also removed a number of N+1 queries

|       ms |   bytes | objects |query |  qry ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  2,615.0 | 20,561,192* | 1,663,622 |2,475 | 1,485.7 |    1,525 |`before`
|  2,688.2 | 23,546,833* | 1,720,303 |2,475 | 1,526.4 |    1,525 |`before`
|  2,719.9 | 25,512,377* | 1,847,085 |2,475 | 1,522.8 |    1,824 |`bugfix`
|  2,745.9 | 17,254,882* | 1,842,885 |2,475 | 1,542.3 |    1,824 |`bugfix`
|    589.6 | 3,584,760* | 822,205 |   27 |   199.8 |    1,824 |`after`
|  **78.3%**   | **86%**         | **55%**    | **99%**  | **87%** | **same** | **change**

## Full Numbers

|       ms |   bytes | objects |query |  qry ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|  2,745.9 | 17,254,882* | 1,842,885 |2,475 | 1,542.3 |    1,824 |`after bugfix`
|     17.1 |         |         |    2 |     2.9 |      299 |`.SELECT "vmdb_tables".* `
|    200.3 |         |         |  300 |   139.7 |      299 |`.SELECT "vmdb_indexes".* `
|    168.0 |         |         |  330 |   168.0 |          |`.SELECT relname AS table_name `
|    236.3 |         |         |  299 |   236.3 |          |`.SELECT distinct i.relname, d.indisunique, d.indkey, i.oid `
|    264.4 |         |         |  859 |   264.4 |          |`.SELECT a.attnum, a.attname `
|    336.0 |         |         |  330 |   336.0 |          |`.SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid,`
|    219.6 |         |         |  330 |   219.6 |          |`.SELECT c.relname, array_agg(a.attname) `
* Memory usage does not reflect 1,005,398 freed objects. 

|       ms |   bytes | objects |query |  qry ms |     rows |`comments`
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|    589.6 | 3,584,760* | 822,205 |   27 |   199.8 |    1,824 |`after`
|     50.1 |         |         |    1 |    50.1 |          |`.SELECT "vmdb_tables"."id", "vmdb_tables"."name", "vmdb_tables"."type", "vmdb_tables"."vmdb_database_i`
|      5.8 |         |         |    1 |     5.8 |          |`.SELECT "vmdb_indexes".* `
* Memory usage does not reflect 412,341 freed objects. 
