### PR TITLE
Consume surro-gate from github as this way the gemspec gets evaluated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,7 +206,7 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
-  gem "surro-gate",                     "~>1.0.2"
+  gem "surro-gate", :git => "https://github.com/skateman/surro-gate"
   gem "websocket-driver",               "~>0.6.3"
 end
 


### PR DESCRIPTION
Credit goes to @lpichler for having a MAC :rofl:  fixes `bundle update` on OSX.

This is a temporary fix until I can get my hands on a MAC and fix the issue in the gem's `extconf.rb`.