### PR TITLE
Change fix_auth database.yml status display

### DIFF
--- a/tools/fix_auth/models.rb
+++ b/tools/fix_auth/models.rb
@@ -87,13 +87,16 @@ module FixAuth
 
   class FixDatabaseYml
     attr_accessor :id
-    attr_accessor :yaml
+    attr_accessor :yml
     include FixAuth::AuthConfigModel
 
     class << self
       attr_accessor :available_columns
       attr_accessor :file_name
-      alias_method  :table_name, :file_name
+
+      def table_name
+        file_name.gsub(".yml", "")
+      end
     end
 
     def initialize(options = {})
@@ -101,7 +104,7 @@ module FixAuth
     end
 
     def load
-      @yaml = File.read(id)
+      @yml = File.read(id)
       self
     end
 
@@ -110,11 +113,11 @@ module FixAuth
     end
 
     def save!
-      File.write(id, @yaml)
+      File.write(id, @yml)
     end
 
     self.password_fields = %w(password)
-    self.available_columns = %w(yaml)
+    self.available_columns = %w(yml)
 
     def self.contenders
       [new(:id => file_name).load]


### PR DESCRIPTION
`fix_auth` fixes the `v2.key` encryption of a number of authorization keys stored in the database.

For most models, the status message makes sense: fixing `[table_name].[column]`.
For the `database.yml` file (that was shoehorned into a database table looking thing) it is a little confusing.

### Before

In the case of database.yml, it fixes `table_name` `"database.yml"`, `column` `"yaml"` contents:

```
fixing /var/www/miq/vmdb/config/database.yml.yaml
```

This is a little confusing.

### After

The fix is to change the `table_name` to `"database"`
and the `column` to `"yml"` so it displays the way the customers wants:

```
fixing /var/www/miq/vmdb/config/database.yml
```

This seems easier than to add conditional logic to the status messages

https://bugzilla.redhat.com/show_bug.cgi?id=1656838
