### PR TITLE
Update surro-gate to 1.0.4 to fix compilation issues on OSX

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,7 +206,7 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
-  gem "surro-gate", :git => "https://github.com/skateman/surro-gate"
+  gem "surro-gate",                     "~>1.0.4"
   gem "websocket-driver",               "~>0.6.3"
 end
 


### PR DESCRIPTION
There was an issue with my proxy on OSX, the native extension compilation was triggered even if it was not necessary. As a [temporary fix](https://github.com/ManageIQ/manageiq/pull/18273) on Friday evening I switched the gem to install from git. Thanks to @kbrock now the issues is [fixed](https://github.com/skateman/surro-gate/pull/22) and available in the next version.

@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @djberg96 
@miq-bot add_reviewer @lpichler 