### PR TITLE
Add ConversionHost validations

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,12 +1,18 @@
 class ConversionHost < ApplicationRecord
   include NewWithTypeStiMixin
 
+  VALID_RESOURCE_TYPES = %w(Vm Host).freeze
+
   acts_as_miq_taggable
 
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
+
+  validates :name, :presence => true
+  validates :resource_id, :presence => true
+  validates :resource_type, :presence => true, :inclusion => { :in => VALID_RESOURCE_TYPES }
 
   include_concern 'Configurations'
 
@@ -36,9 +42,9 @@ class ConversionHost < ApplicationRecord
   end
 
   def ipaddress(family = 'ipv4')
-    return address if address && IPAddr.new(address).send("#{family}?")
+    return address if address.present? && IPAddr.new(address).send("#{family}?")
     resource.ipaddresses.detect { |ip| IPAddr.new(ip).send("#{family}?") }
-  end 
+  end
 
   def run_conversion(conversion_options)
     result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', nil, nil, conversion_options.to_json) }
@@ -65,7 +71,7 @@ class ConversionHost < ApplicationRecord
     connect_ssh { |ssu| ssu.get_file(path, nil) }
   rescue => e
     raise "Could not get conversion log '#{path}' from '#{resource.name}' with [#{e.class}: #{e}"
-  end 
+  end
 
   def check_conversion_host_role
     install_conversion_host_module
@@ -127,7 +133,7 @@ class ConversionHost < ApplicationRecord
     require 'MiqSshUtil'
     MiqSshUtil.shell_with_su(*miq_ssh_util_args) do |ssu, _shell|
       yield(ssu)
-    end  
+    end
   rescue Exception => e
     _log.error("SSH connection failed for [#{ipaddress}] with [#{e.class}: #{e}]")
     raise e
@@ -139,7 +145,7 @@ class ConversionHost < ApplicationRecord
 
   def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
     [hostname || ipaddress, resource.authentication_userid, resource.authentication_password, nil, nil]
-  end 
+  end
 
   def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
     authentication = resource.ext_management_system.authentications

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -14,6 +14,12 @@ class ConversionHost < ApplicationRecord
   validates :resource_id, :presence => true
   validates :resource_type, :presence => true, :inclusion => { :in => VALID_RESOURCE_TYPES }
 
+  validates :address,
+    :uniqueness => true,
+    :format     => { :with => Resolv::AddressRegex },
+    :inclusion  => { :in => -> { resource.ipaddresses } },
+    :unless     => -> { resource.ipaddresses.blank? }
+
   include_concern 'Configurations'
 
   # To be eligible, a conversion host must have the following properties

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,7 +1,7 @@
 class ConversionHost < ApplicationRecord
   include NewWithTypeStiMixin
 
-  VALID_RESOURCE_TYPES = %w(VmOrTemplate Vm Host).freeze
+  VALID_RESOURCE_TYPES = %w(VmOrTemplate Host).freeze
 
   acts_as_miq_taggable
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,7 +1,7 @@
 class ConversionHost < ApplicationRecord
   include NewWithTypeStiMixin
 
-  VALID_RESOURCE_TYPES = %w(Vm Host).freeze
+  VALID_RESOURCE_TYPES = %w(VmOrTemplate Vm Host).freeze
 
   acts_as_miq_taggable
 
@@ -18,7 +18,7 @@ class ConversionHost < ApplicationRecord
     :uniqueness => true,
     :format     => { :with => Resolv::AddressRegex },
     :inclusion  => { :in => -> { resource.ipaddresses } },
-    :unless     => -> { resource.ipaddresses.blank? }
+    :unless     => -> { resource.blank? || resource.ipaddresses.blank? }
 
   include_concern 'Configurations'
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -5,9 +5,9 @@ describe ConversionHost do
 
   context "provider independent methods" do
     let(:host) { FactoryGirl.create(:host) }
-    let(:vm) { FactoryGirl.create(:vm_or_template) }
-    let(:conversion_host_1) { FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host') }
-    let(:conversion_host_2) { FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm') }
+    let(:vm) { FactoryGirl.create(:vm) }
+    let(:conversion_host_1) { FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host', :address => '10.0.0.1') }
+    let(:conversion_host_2) { FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm', :address => '10.0.1.1') }
     let(:task_1) { FactoryGirl.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryGirl.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
     let(:task_3) { FactoryGirl.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_2) }
@@ -15,6 +15,7 @@ describe ConversionHost do
     before do
       allow(conversion_host_1).to receive(:active_tasks).and_return([task_1])
       allow(conversion_host_2).to receive(:active_tasks).and_return([task_3])
+      allow(conversion_host_2).to receive(:resource).and_return(vm)
 
       allow(host).to receive(:ipaddresses).and_return(['10.0.0.1', 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329', '192.168.0.1'])
       allow(host).to receive(:ipaddress).and_return(nil)

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -15,7 +15,6 @@ describe ConversionHost do
     before do
       allow(conversion_host_1).to receive(:active_tasks).and_return([task_1])
       allow(conversion_host_2).to receive(:active_tasks).and_return([task_3])
-      allow(conversion_host_2).to receive(:resource).and_return(vm)
 
       allow(host).to receive(:ipaddresses).and_return(['10.0.0.1', 'FE80:0000:0000:0000:0202:B3FF:FE1E:8329', '192.168.0.1'])
       allow(host).to receive(:ipaddress).and_return(nil)

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -6,8 +6,8 @@ describe ConversionHost do
   context "provider independent methods" do
     let(:host) { FactoryGirl.create(:host) }
     let(:vm) { FactoryGirl.create(:vm_or_template) }
-    let(:conversion_host_1) { FactoryGirl.create(:conversion_host, :resource => host) }
-    let(:conversion_host_2) { FactoryGirl.create(:conversion_host, :resource => vm) }
+    let(:conversion_host_1) { FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host') }
+    let(:conversion_host_2) { FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm') }
     let(:task_1) { FactoryGirl.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryGirl.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
     let(:task_3) { FactoryGirl.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_2) }
@@ -118,12 +118,12 @@ describe ConversionHost do
       it "returns false if if kill command failed" do
         allow(conversion_host_1).to receive(:connect_ssh).and_raise('Unexpected failure')
         expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(false)
-      end 
+      end
 
       it "returns true if if kill command succeeded" do
         allow(conversion_host_1).to receive(:connect_ssh)
         expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(true)
-      end 
+      end
     end
   end
 
@@ -167,7 +167,7 @@ describe ConversionHost do
   context "resource provider is openstack" do
     let(:ems) { FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.create(:zone)) }
     let(:vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
-    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
+    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true, :resource_type => 'Vm') }
 
     context "ems authentications is empty" do
       it { expect(conversion_host.check_ssh_connection).to be(false) }

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -6,8 +6,8 @@ describe ConversionHost do
   context "provider independent methods" do
     let(:host) { FactoryGirl.create(:host) }
     let(:vm) { FactoryGirl.create(:vm) }
-    let(:conversion_host_1) { FactoryGirl.create(:conversion_host, :resource => host, :resource_type => 'Host', :address => '10.0.0.1') }
-    let(:conversion_host_2) { FactoryGirl.create(:conversion_host, :resource => vm, :resource_type => 'Vm', :address => '10.0.1.1') }
+    let(:conversion_host_1) { FactoryGirl.create(:conversion_host, :resource => host, :address => '10.0.0.1') }
+    let(:conversion_host_2) { FactoryGirl.create(:conversion_host, :resource => vm, :address => '10.0.1.1') }
     let(:task_1) { FactoryGirl.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryGirl.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
     let(:task_3) { FactoryGirl.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_2) }
@@ -168,7 +168,7 @@ describe ConversionHost do
   context "resource provider is openstack" do
     let(:ems) { FactoryGirl.create(:ems_openstack, :zone => FactoryGirl.create(:zone)) }
     let(:vm) { FactoryGirl.create(:vm_openstack, :ext_management_system => ems) }
-    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true, :resource_type => 'Vm') }
+    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
 
     context "ems authentications is empty" do
       it { expect(conversion_host.check_ssh_connection).to be(false) }

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -134,6 +134,7 @@ describe ServiceTemplateTransformationPlanRequest do
       it 'returns true' do
         vm = FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant)
         conversion_host = FactoryGirl.create(:conversion_host, :resource => vm)
+        p conversion_host.errors
         expect(request.validate_conversion_hosts).to be true
       end
     end

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -134,7 +134,6 @@ describe ServiceTemplateTransformationPlanRequest do
       it 'returns true' do
         vm = FactoryGirl.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant)
         conversion_host = FactoryGirl.create(:conversion_host, :resource => vm)
-        p conversion_host.errors
         expect(request.validate_conversion_hosts).to be true
       end
     end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -248,7 +248,7 @@ describe ServiceTemplateTransformationPlanTask do
     let(:task_1) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_1) }
     let(:task_2) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_2) }
 
-    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => src_vm_1, :resource_type => 'Vm') }
+    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => src_vm_1) }
 
     describe '#transformation_destination' do
       it { expect(task_1.transformation_destination(src_cluster)).to eq(dst_cluster) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -248,7 +248,7 @@ describe ServiceTemplateTransformationPlanTask do
     let(:task_1) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_1) }
     let(:task_2) { FactoryGirl.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => src_vm_2) }
 
-    let(:conversion_host) { FactoryGirl.create(:conversion_host) }
+    let(:conversion_host) { FactoryGirl.create(:conversion_host, :resource => src_vm_1, :resource_type => 'Vm') }
 
     describe '#transformation_destination' do
       it { expect(task_1.transformation_destination(src_cluster)).to eq(dst_cluster) }


### PR DESCRIPTION
As I was doing some general testing with various POST operations with the REST API for conversion hosts, I realized there were almost no validations on the model. This PR adds some validations to a few columns, specifically the following:

    name - must be present
    resource_type - must be present and "Vm" or "Host" or "VmOrTemplate"
    resource_id - must be present
    address - must be unique, and be a valid IP address, if present

Replaces https://github.com/ManageIQ/manageiq/pull/18264

~~The "VmOrTemplate" was required for the service template request/plan models and specs~~, as was the check for the presence of an IP address before validating.

Ignore that first part, we only need `VmOrTemplate` and not `Vm`, since it's a subclass.