### PR TITLE
Fixing subservice task creation for service bundles

### DIFF
--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -77,7 +77,7 @@ class MiqRequestTask < ApplicationRecord
     req_status = status.slice('Error', 'Timeout', 'Warn').keys.first || 'Ok'
 
     if req_state == "finished" && state != "finished"
-      req_state = (req_status == 'Ok') ? 'provisioned' : "finished"
+      req_state = req_status == 'Ok' ? completed_state : "finished"
       $log.info("Child tasks finished but current task still processing. Setting state to: [#{req_state}]...")
     end
 
@@ -92,6 +92,10 @@ class MiqRequestTask < ApplicationRecord
     end
 
     update_and_notify_parent(:state => req_state, :status => req_status, :message => display_message(msg))
+  end
+
+  def completed_state
+    "provisioned"
   end
 
   def execute_callback(state, message, _result)

--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -86,6 +86,10 @@ class MiqRetireTask < MiqRequestTask
     end
   end
 
+  def completed_state
+    "retired"
+  end
+
   def self.display_name(number = 1)
     n_('Retire Task', 'Retire Tasks', number)
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -152,6 +152,10 @@ class Service < ApplicationRecord
     'service_reconfigure'
   end
 
+  def retireable?
+    parent.present? ? true : type.present?
+  end
+
   alias root_service root
   alias services children
   alias direct_service_children children
@@ -216,10 +220,6 @@ class Service < ApplicationRecord
 
   def composite?
     children.present?
-  end
-
-  def retireable?
-    type.present?
   end
 
   def atomic?

--- a/spec/models/mixins/ci_feature_mixin_spec.rb
+++ b/spec/models/mixins/ci_feature_mixin_spec.rb
@@ -19,23 +19,10 @@ describe CiFeatureMixin do
       expect(service.service_resources.first.resource.retireable?).to eq(false)
     end
 
-    context "service" do
-      context "with type" do
-        let(:service1) { FactoryBot.create(:service_ansible_tower, :type => ServiceAnsibleTower) }
-        it "is retireable" do
-          FactoryBot.create(:service_resource, :service => service, :resource => service1)
+    it "service is retireable" do
+      FactoryBot.create(:service_resource, :service => service, :resource => FactoryBot.create(:service_ansible_tower, :type => ServiceAnsibleTower))
 
-          expect(service.service_resources.first.resource.retireable?).to eq(true)
-        end
-      end
-
-      context "without type" do
-        it "is not retireable" do
-          FactoryBot.create(:service_resource, :service => service, :resource => FactoryBot.create(:service))
-
-          expect(service.service_resources.first.resource.retireable?).to eq(false)
-        end
-      end
+      expect(service.service_resources.first.resource.retireable?).to eq(true)
     end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -675,6 +675,31 @@ describe Service do
     end
   end
 
+  describe "#retireable?" do
+    let(:service_with_type) { FactoryBot.create(:service, :type => "thing") }
+    let(:service_without_type) { FactoryBot.create(:service, :type => nil) }
+    let(:service_with_parent) { FactoryBot.create(:service, :service => FactoryBot.create(:service)) }
+    context "with no parent" do
+      context "with type" do
+        it "true" do
+          expect(service_with_type.retireable?).to be(true)
+        end
+      end
+
+      context "without type" do
+        it "checks type presence" do
+          expect(service_without_type.retireable?).to be(false)
+        end
+      end
+    end
+
+    context "with parent" do
+      it "true" do
+        expect(service_with_parent.retireable?).to be(true)
+      end
+    end
+  end
+
   describe "#retired" do
     it "defaults to false" do
       service = described_class.new

--- a/spec/models/vm_retire_task_spec.rb
+++ b/spec/models/vm_retire_task_spec.rb
@@ -9,6 +9,13 @@ describe VmRetireTask do
     expect(vm_retire_task).to have_attributes(:state => 'pending', :status => 'Ok')
   end
 
+  describe "#after_request_task_create" do
+    it "should set the task description" do
+      vm_retire_task.after_request_task_create
+      expect(vm_retire_task.description).to eq("VM Retire for: #{vm.name} - ")
+    end
+  end
+
   describe "deliver_to_automate" do
     before do
       MiqRegion.seed


### PR DESCRIPTION
Subservices aren't being correctly retired. The task creation should be using src_id**s**, and the recursive call to create tasks for subservices is wrong. Also, the service retireable check should handle subservices for bundles, and the request and task should be able to mark themselves as finished after the status update to "retired", just like we do for provisioning. 

```req_state = (states.length == 1) ? states.keys.first : "active"```, the check we're currently using at https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request.rb#L383 is being overriden here to set the request to finished to work for bundles. We should be checking state and status for all the child tasks and if they're all ok and finished, then the parent can be updated. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1608958
Also fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653648

They're related. 
