### PR TITLE
[specs] remove TODO, warn, and $log hacking

### DIFF
--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -11,16 +11,8 @@ describe Metric::CiMixin::Capture do
   let(:ems_openstack) { FactoryGirl.create(:ems_openstack, :zone => zone) }
   let(:vm) { FactoryGirl.create(:vm_perf_openstack, :ext_management_system => ems_openstack) }
 
-  # TODO: Don't hack this log stuff. This is difficult right now as some assertions
-  # below are actually emitted by the provider. Not worth fixing right now.
   before do
     allow(ems_openstack).to receive(:connect).with(:service => "Metering").and_return(metering)
-    @orig_log = $log
-    $log = double.as_null_object
-  end
-
-  after do
-    $log = @orig_log
   end
 
   describe "#perf_capture_realtime integration tests" do


### PR DESCRIPTION
From what I can tell, this doesn't seem to be valid any more, so removing.  Tests for this file seem to pass just fine, and it removes the following warning that gets fired as a result:

```
MIQ(MiqEvent.raise_evm_event) Event containerproject_created for class [ContainerProject] id [XXX] was not raised: containerproject_created is not defined in MiqEventDefinition
```

Which has been showing up in the `rspec` output.


Background
----------
Since `$log` is now a `double`, and `_log`/`Vmdb::LogProxy` calls `.send(:warn)` to the associated logger (`$log` 99% of the time), that means it will safely call `Kernel#warn`, which is a part of all objects (unless explicitly removed).

Normally all `RSpec::Mocks::Double` classes will call `#method_missing` with their stubs, but since `#warn` is already defined (as mentioned above), it just call that method normally and not do the assumed `double` functionality.

That all said, would really appreciate some double checking of this to confirm that it is in fact fine to remove this by someone who actually understands what the implications doing so are.


Links
-----

* TODO introduced in https://github.com/ManageIQ/manageiq/pull/15219
* Warning observed here:  https://gitter.im/ManageIQ/manageiq?at=5c10404628907a3c7b05c87e