### PR TITLE
Don't seed tenant product features for tenant from remote region

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -143,7 +143,7 @@ class MiqProductFeature < ApplicationRecord
 
   def self.seed_tenant_miq_product_features
     result = with_tenant_feature_root_features.map.each do |tenant_miq_product_feature|
-      Tenant.all.map { |tenant| tenant.build_miq_product_feature(tenant_miq_product_feature) }
+      Tenant.in_my_region.all.map { |tenant| tenant.build_miq_product_feature(tenant_miq_product_feature) }
     end.flatten
 
     MiqProductFeature.create(result).map(&:identifier)


### PR DESCRIPTION
let's assume we replicated remote region to a global region, 
then tenant records(from remote region) replicated to global region.

then `MiqProductFeaure.seed` is run on the global region - and it is causing creation of tenant product features also for tenants from remote region.

Note: Highlighted features are created on remote tenants which are hidden in tenant tree.
![screenshot 2018-12-12 at 16 03 08](https://user-images.githubusercontent.com/14937244/49878442-dd03e600-fe27-11e8-87b1-ea7d4333436d.png)


**This PR stops creation of such product tenant features for remote tenants.**

### Links 
https://bugzilla.redhat.com/show_bug.cgi?id=1468795 (this PR is not last for the BZ, there is other bug)
https://github.com/ManageIQ/manageiq/issues/18100 - learn more about tenant product features
@miq-bot assign @gtanzillo 

@miq-bot add_label hammer/yes, gaprindashvili/yes,blocker
