### PR TITLE
[HAMMER] Add FactoryBot alias for FactoryGirl

### DIFF
--- a/spec/support/factory_girl_helper.rb
+++ b/spec/support/factory_girl_helper.rb
@@ -18,6 +18,10 @@ def seq_padded_for_sorting(n)
 end
 
 require 'factory_girl'
+
+# Alias as we switch from FactoryGirl to FactoryBot. This will aid backporting.
+FactoryBot = FactoryGirl
+
 # in case we are running as an engine, the factories are located in the dummy app
 FactoryGirl.definition_file_paths << 'spec/manageiq/spec/factories'
 # also add factories from provider gems until miq codebase does not use any provider specific factories anymore


### PR DESCRIPTION
This is a followup to https://github.com/ManageIQ/manageiq/pull/18279 where we're dealing with the name change from `FactoryGirl` to `FactoryBot`. Since that PR was not backported, we need to help make future backports easier.

So, this PR creates a simple alias so that both constants are defined.