### PR TITLE
Only show builds for the master branch, not PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![License](http://img.shields.io/badge/license-APACHE2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
 
-[![Build history for master branch](https://buildstats.info/travisci/chart/ManageIQ/manageiq?branch=master&buildCount=50)](https://travis-ci.org/ManageIQ/manageiq/branches)
+[![Build history for master branch](https://buildstats.info/travisci/chart/ManageIQ/manageiq?branch=master&includeBuildsFromPullRequest=false&buildCount=50)](https://travis-ci.org/ManageIQ/manageiq/branches)
 
 ## Discover, Optimize, and Control your Hybrid IT
 


### PR DESCRIPTION
The default graph mixes build results for the branch and pull requests.
That seems confusing to me.  How would you ever be able to spot trends
when master is mixed with people's PR results?

Even if all PRs were breaking and master was green, how you would be
able to spot which results on the graph were PRs and which were branch
builds?

[skip ci]