### PR TITLE
set read_only value to true

### DIFF
--- a/product/dashboard/widgets/chart_pods_per_ready.yaml
+++ b/product/dashboard/widgets/chart_pods_per_ready.yaml
@@ -15,4 +15,4 @@ miq_schedule_options:
       :value: "1"
       :unit: daily
 enabled: true
-read_only: false
+read_only: true


### PR DESCRIPTION
This simple change brings this out-of-the-box widget definition inline with the other out-of-the-box widgets by setting the read_only value to true.