### PR TITLE
Detach actioncable from the WebsocketServer and run it with the UI

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -84,8 +84,10 @@ module Vmdb
 
     # Disable ActionCable's request forgery protection
     # This is basically matching a set of allowed origins which is not good for us
-    # Our own origin-host forgery protection is implemented in lib/websocket_server.rb
-    Rails.application.config.action_cable.disable_request_forgery_protection = true
+    config.action_cable.disable_request_forgery_protection = false
+    # Matching the origin against the HOST header is much more convenient
+    config.action_cable.allow_same_origin_as_host = true
+    config.action_cable.mount_path = '/ws/notifications'
 
     # Customize any additional options below...
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Vmdb::Application.routes.draw do
   if Rails.env.development? && defined?(Rails::Server)
     logger = Logger.new(STDOUT)
     logger.level = Logger.const_get(::Settings.log.level_websocket.upcase)
-    mount WebsocketServer.new(:logger => logger) => '/ws'
+    mount WebsocketServer.new(:logger => logger) => '/ws/console'
   end
 end

--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -52,9 +52,6 @@ class WebsocketServer
   end
 
   def call(env)
-    # Pass the request to ActionCable if it is for notifications
-    return ActionCable.server.call(env) if env['REQUEST_URI'].start_with?('/ws/notifications') && ::Settings.server.asynchronous_notifications
-
     exp = %r{^/ws/console/([a-zA-Z0-9]+)/?$}.match(env['REQUEST_URI'])
     if WebSocket::Driver.websocket?(env) && same_origin_as_host?(env) && exp.present?
       @logger.info("Remote console connection initiated with secret #{exp[1]}")

--- a/spec/lib/websocket_server_spec.rb
+++ b/spec/lib/websocket_server_spec.rb
@@ -17,15 +17,6 @@ describe WebsocketServer do
   let(:env) { {'REQUEST_URI' => "/ws/#{url}", 'rack.hijack' => hijack} }
 
   describe '#call' do
-    context 'notifications' do
-      let(:url) { 'notifications' }
-
-      it 'calls actioncable' do
-        expect(ActionCable.server).to receive(:call).with(env)
-        subject.call(env)
-      end
-    end
-
     context 'remote console' do
       let(:url) { 'console/12345' }
 


### PR DESCRIPTION
As the remote console implementation is growing, I think it is the right time to start using the worker for the remote consoles only. I looked up the documentation of ActionCable and realized that we were already running it under the default `/cable` endpoint. The reverse proxy configuration on the appliances masked this, so it is not really exposed in production. However, it consumes up to 5 worker threads just because.

So I was thinking why don't we use this embedded solution only? This way I can reduce the complexity of the `WebsocketServer` a little and maybe even rename it in the future. 

* @djberg96 this will solve your issue with websockets when running your development setup with `evm:start`.
* @kbrock maybe we will have to adjust the number of threads for the workers.
* ~~@skateman you have to test this on an appliance~~

Merge with https://github.com/ManageIQ/manageiq-appliance/pull/219
Parent issue: https://github.com/ManageIQ/manageiq/issues/18300