### PR TITLE
Classification parent

### DIFF
--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory(:category) do
     sequence(:name)        { |n| "category_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "category #{seq_padded_for_sorting(n)}" }
-    parent_id { 0 }
   end
 end

--- a/spec/factories/classification.rb
+++ b/spec/factories/classification.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :classification do
     sequence(:name)        { |n| "category_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "category #{seq_padded_for_sorting(n)}" }
-    parent_id { 0 }
   end
 
   factory :classification_tag, :class => :Classification do

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -549,8 +549,8 @@ describe Classification do
     end
 
     it "creates tag with name and ns" do
-      expect(Classification.name2tag("test_entry", 0, parent_ns)).to eq(entry_ns)
-      expect(Classification.name2tag("test_category", 0, root_ns)).to eq(parent_ns)
+      expect(Classification.name2tag("test_entry", nil, parent_ns)).to eq(entry_ns)
+      expect(Classification.name2tag("test_category", nil, root_ns)).to eq(parent_ns)
     end
 
     it "creates tag with name, ns, and parent_id" do


### PR DESCRIPTION
blocked:

- [x] https://github.com/ManageIQ/manageiq/pull/18304
- [x] https://github.com/ManageIQ/manageiq/pull/18305
- [x] update this PR to not be 0 and nil compatible (just stick with nil)
- [x] #18361 
- [x] #18418 don't use parent_id=0 in classification files (and ignore it if it is in there)
- [x] ManageIQ/manageiq-schema#309 (need to be merged simultaneously)

Extracted from #17210
Thanks for pinging me on this one @Fryguy 

## Before:

Currently we use `Classification#parent_id == 0` to mean there is a `Category` and it has no `parent`.

## After

`ActiveRecord` has the convention of having `parent_id == nil` to mean there is no `parent`.
So we follow that convention: `Classification#parent_id == nil` when this is a `Category` and it has no `parent`.
We now pass around `nil` when there is no parent (we were passing `0`). But we still handle passing a `0` in case some code is not properly updated across the various repos.

This PR:

- cleans up our use of `name2tag`.
- cleans up our interface for `Tag.find_by_classification_name`.
- relies less upon `parent_id` value, using more scopes.
- more lenient code handling `parent_id` of `0` or `nil`.
