### PR TITLE
Use scope instead of parent_id => 0

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < Classification
-  default_scope { where(:parent_id => 0) }
+  default_scope { is_category }
 
   def tags
     Tag.joins(:classification).where(:classifications => {:parent_id => id})

--- a/lib/task_helpers/imports/tags.rb
+++ b/lib/task_helpers/imports/tags.rb
@@ -58,7 +58,7 @@ module TaskHelpers
         ns = tag_category["ns"] ? tag_category["ns"] : "/managed"
         tag_category["name"] = tag_category["name"].to_s
 
-        classification = Classification.find_by_name(tag_category['name'], REGION_NUMBER, ns, 0)
+        classification = Classification.find_by_name(tag_category['name'], REGION_NUMBER, ns)
 
         entries = tag_category.delete('entries')
 

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -434,7 +434,7 @@ describe Classification do
       end
 
       it "does not re-seed deleted tags" do
-        Classification.where("parent_id != 0").destroy_all
+        Classification.is_entry.destroy_all
         expect(Classification.count).to eq(1)
 
         Classification.seed
@@ -445,7 +445,7 @@ describe Classification do
         # If categories' names are edited they auto-save a different associated tag
         # This tests that if seeding category and it's invalid (due to uniqueness constraints)
         # then seeding still doesn't fail.
-        cat = Classification.find_by!(:description => "Cost Center", :parent_id => 0)
+        cat = Classification.is_category.find_by!(:description => "Cost Center")
         allow(YAML).to receive(:load_file).and_call_original
         cat.update_attributes!(:name => "new_name")
         expect {


### PR DESCRIPTION
We are transitioning the value of `parent_id` for Classification categories from `0` to `nil`.

The easiest way to do this is to remove the references to the hardcoded value and instead use the high level concept.

### Before:

Lots of locations have a hardcoded value of `0`.

### After

Code reference the concept `category` instead of the underlying implementation.

/cc @Fryguy This pulls out this concept and simplifies the transition (since there will be less to do)
part of #17210
