### PR TITLE
Tag#find_by_classification_name

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -122,15 +122,8 @@ class Tag < ApplicationRecord
     where(:name => fq_tag_names)
   end
 
-  def self.find_by_classification_name(name, region_id = Classification.my_region_number,
-                                       ns = Classification::DEFAULT_NAMESPACE, parent_id = 0)
-    in_region(region_id).find_by(:name => Classification.name2tag(name, parent_id, ns))
-  end
-
-  def self.find_or_create_by_classification_name(name, region_id = Classification.my_region_number,
-                                                 ns = Classification::DEFAULT_NAMESPACE, parent_id = 0)
-    tag_name = Classification.name2tag(name, parent_id, ns)
-    in_region(region_id).find_by(:name => tag_name) || create(:name => tag_name)
+  def self.find_by_classification_name(name)
+    in_region(my_region_number).find_by(:name => Classification.name2tag(name))
   end
 
   def ==(comparison_object)

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -539,6 +539,29 @@ describe Classification do
     end
   end
 
+  describe "name2tag" do
+    let(:root_ns)   { "/managed" }
+    let(:parent_ns) { "/managed/test_category" }
+    let(:entry_ns)  { "/managed/test_category/test_entry" }
+    let(:parent) { FactoryBot.create(:classification, :name => "test_category") }
+
+    it "creates parent tag" do
+      expect(Classification.name2tag("test_category")).to eq(parent_ns)
+    end
+
+    it "creates tag with name and ns" do
+      expect(Classification.name2tag("test_entry", 0, parent_ns)).to eq(entry_ns)
+    end
+
+    it "creates tag with name, ns, and parent_id" do
+      expect(Classification.name2tag("test_entry", parent.id, root_ns)).to eq(entry_ns)
+    end
+
+    it "creates tag with name, ns and parent" do
+      expect(Classification.name2tag("test_entry", parent, root_ns)).to eq(entry_ns)
+    end
+  end
+
   def all_tagged_with(target, all, category = nil)
     tagged_with(target, :all => all, :cat => category)
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -118,8 +118,6 @@ describe Tag do
   describe ".find_by_classification_name" do
     let(:root_ns)   { "/managed" }
     let(:parent_ns) { "/managed/test_category" }
-    let(:entry_ns)  { "/managed/test_category/test_entry" }
-    let(:my_region_number) { Tag.my_region_number }
     let(:parent) { FactoryBot.create(:classification, :name => "test_category") }
 
     before do
@@ -134,33 +132,6 @@ describe Tag do
 
     it "doesn't find non tag" do
       expect(Tag.find_by_classification_name("test_entry")).to be_nil
-    end
-
-    it "finds tag by name and ns" do
-      expect(Tag.find_by_classification_name("test_entry", nil, parent_ns)).not_to be_nil
-      expect(Tag.find_by_classification_name("test_entry", nil, parent_ns).name).to eq(entry_ns)
-    end
-
-    it "finds tag by name, ns, and parent_id" do
-      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent.id)).not_to be_nil
-      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent.id).name).to eq(entry_ns)
-    end
-
-    it "finds tag by name, ns and parent" do
-      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent)).not_to be_nil
-      expect(Tag.find_by_classification_name("test_entry", nil, root_ns, parent).name).to eq(entry_ns)
-    end
-
-    it "finds tag in region" do
-      expect(Tag.find_by_classification_name("test_category", my_region_number)).not_to be_nil
-    end
-
-    it "filters tag in wrong region" do
-      expect(Tag.find_by_classification_name("test_category", my_region_number + 1)).to be_nil
-    end
-
-    it "find tag in any region" do
-      expect(Tag.find_by_classification_name("test_category", nil)).not_to be_nil
     end
   end
 


### PR DESCRIPTION
paret of #17210 
This method was called by Classification.
No reason to have Tag call back into Classification to format
a tag_name that should already have been sent to tag in the first place

`find_by_classification_name` is used in 1 place.
Keeping it but simplifying it greatly

@Fryguy This again reduces knowledge of the internals of classification from other classes.