### PR TITLE
[V2V] Refactor ConversionHost to use AuthenticationMixin

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -57,14 +57,14 @@ class ConversionHost < ApplicationRecord
       ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
 
       case auth
-        when AuthUseridPassword
-          ssh_options[:auth_methods] = %w[password]
-          ssh_options[:password] = auth.password
-        when AuthPrivateKey
-          ssh_options[:auth_methods] = %w[publickey hostbased]
-          ssh_options[:key_data] = auth.auth_key
-        else
-          raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
+      when AuthUseridPassword
+        ssh_options[:auth_methods] = %w[password]
+        ssh_options[:password] = auth.password
+      when AuthPrivateKey
+        ssh_options[:auth_methods] = %w[publickey hostbased]
+        ssh_options[:key_data] = auth.auth_key
+      else
+        raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
       end
 
       # Options from STI subclasses will override the defaults we've set above.

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -37,19 +37,19 @@ class ConversionHost < ApplicationRecord
     authentications.each do |auth|
       user = auth.userid || ENV['USER']
 
-      options = { :timeout => 3 }
+      ssh_options = { :timeout => 3 }
 
       if auth.password
-        options[:password] = auth.password
-        options[:auth_methods] = ['password']
+        ssh_options[:password] = auth.password
+        ssh_options[:auth_methods] = ['password']
       end
 
       if auth.auth_key
-        options[:keys] = [auth.auth_key]
-        options[:auth_methods] = ['public_key', 'host_based']
+        ssh_options[:keys] = [auth.auth_key]
+        ssh_options[:auth_methods] = ['public_key', 'host_based']
       end
 
-      Net::SSH.start(host, user, options) { |ssh| ssh.exec!('uname -a') }
+      Net::SSH.start(host, user, ssh_options) { |ssh| ssh.exec!('uname -a') }
     end
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -253,7 +253,7 @@ class ConversionHost < ApplicationRecord
   # TODO: Move this to ManageIQ::Providers::Redhat::InfraManager::ConversionHost
   #
   def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
-    authentication = find_credentials_redhat
+    authentication = find_credentials
     [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
   end
 
@@ -263,7 +263,7 @@ class ConversionHost < ApplicationRecord
   # TODO: Move this to ManageIQ::Providers::OpenStack::CloudManager::ConversionHost
   #
   def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
-    authentication = find_credentials_openstack
+    authentication = find_credentials
     [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -49,9 +49,7 @@ class ConversionHost < ApplicationRecord
         options[:auth_methods] = ['public_key', 'host_based']
       end
 
-      Net::SSH.start(host, user, options) do |ssh|
-        ssh.exec!('uname -a')
-      end
+      Net::SSH.start(host, user, options) { |ssh| ssh.exec!('uname -a') }
     end
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -229,8 +229,8 @@ class ConversionHost < ApplicationRecord
   end
 
   # Find the credentials for the associated Redhat resource. If an AuthUseridPassword
-  # object is not found, but the associated userid and password are found, automatically
-  # create a new AuthUseridPassword record associated with that resource.
+  # object is not found, but the associated userid and password are found, return
+  # a (temporary, unsaved) AuthUseridPassword object using those values.
   #--
   # TODO: Move this into the provider specific subclass.
   #
@@ -243,7 +243,7 @@ class ConversionHost < ApplicationRecord
         :resource => resource,
         :userid   => resource.authentication_userid,
         :password => resource.authentication.password
-      ).save
+      )
     end
 
     authentication

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -37,7 +37,7 @@ class ConversionHost < ApplicationRecord
     authentications.each do |auth|
       user = auth.userid || ENV['USER']
 
-      options = {}
+      options = { :timeout => 3 }
 
       if auth.password
         options[:password] = auth.password
@@ -60,7 +60,7 @@ class ConversionHost < ApplicationRecord
   #  - Credentials are set on the resource and SSH connection works
   #  - The number of concurrent tasks has not reached the limit
   def eligible?
-    source_transport_method.present? && check_ssh_connection && check_concurrent_tasks
+    source_transport_method.present? && verify_credentials && check_concurrent_tasks
   end
 
   def check_concurrent_tasks

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -31,9 +31,11 @@ class ConversionHost < ApplicationRecord
   after_create :tag_resource_as_enabled
   after_destroy :tag_resource_as_disabled
 
-  # Check using all associated authentications if any are directly associated
-  # with the conversion host. Otherwise, use the default check which uses the
-  # associated resource's authentications.
+  # Use the +auth_type+ if present, or check the first associated authentication
+  # if any are directly associated with the conversion host. Otherwise, use the
+  # default check which uses the associated resource's authentications.
+  #
+  # In practice there should only be one associated authentication.
   #
   # Subclasses should pass provider-specific +options+, such as proxy information.
   #
@@ -49,9 +51,6 @@ class ConversionHost < ApplicationRecord
       require 'net/ssh'
       host = hostname || ipaddress
 
-      # Default to the authentication type from the +auth_type+ argument if
-      # present. Otherwise, default to the first associated authentication. In
-      # practice there should not be more than one.
       auth = authentication_type(auth_type) || authentications.first
       user = auth.userid || ENV['USER']
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -54,14 +54,15 @@ class ConversionHost < ApplicationRecord
 
         ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
 
-        if auth.password
-          ssh_options[:password] = auth.password
-          ssh_options[:auth_methods] = %w[password]
-        end
-
-        if auth.auth_key
-          ssh_options[:keys] = [auth.auth_key]
-          ssh_options[:auth_methods] = %w[public_key host_based]
+        case auth
+          when AuthUseridPassword
+            ssh_options[:password] = auth.password
+            ssh_options[:auth_methods] = %w[password]
+          when AuthPrivateKey
+            ssh_options[:keys] = [auth.auth_key]
+            ssh_options[:auth_methods] = %w[public_key host_based]
+          else
+            next # Skip anything we don't recognize and aren't sure how to handle
         end
 
         # Options from STI subclasses will override the defaults we've set above.

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -56,8 +56,10 @@ class ConversionHost < ApplicationRecord
 
         case auth
           when AuthUseridPassword
+            ssh_options[:auth_methods] = %w[password]
             ssh_options[:password] = auth.password
           when AuthPrivateKey
+            ssh_options[:auth_methods] = %w[publickey hostbased]
             ssh_options[:key_data] = auth.auth_key
           else
             next # Skip anything we don't recognize and aren't sure how to handle

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -75,7 +75,7 @@ class ConversionHost < ApplicationRecord
     raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - %{error_message}") % {:error_message => err.message}
   rescue Net::SSH::HostKeyMismatch => err
     raise MiqException::MiqSshUtilHostKeyMismatch, _("Host key mismatch - %{error_message}") % {:error_message => err.message}
-  rescue StandardError => err
+  rescue Exception => err
     raise _("Unknown error - %{error_message}") % {:error_message => err.message}
   else
     true

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -52,7 +52,6 @@ class ConversionHost < ApplicationRecord
       host = hostname || ipaddress
 
       auth = authentication_type(auth_type) || authentications.first
-      user = auth.userid || ENV['USER']
 
       ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
 
@@ -70,7 +69,7 @@ class ConversionHost < ApplicationRecord
       # Options from STI subclasses will override the defaults we've set above.
       ssh_options.merge!(options)
 
-      Net::SSH.start(host, user, ssh_options) { |ssh| ssh.exec!('uname -a') }
+      Net::SSH.start(host, auth.userid, ssh_options) { |ssh| ssh.exec!('uname -a') }
     end
   rescue Net::SSH::AuthenticationFailed => err
     raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - %{error_message}") % {:error_message => err.message}

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -106,7 +106,7 @@ class ConversionHost < ApplicationRecord
   def check_ssh_connection
     connect_ssh { |ssu| ssu.shell_exec('uname -a') }
     true
-  rescue
+  rescue StandardError
     false
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -219,7 +219,7 @@ class ConversionHost < ApplicationRecord
     authentication = send("find_resource_credentials_#{resource.ext_management_system.emstype}")
 
     unless authentication
-      msg = "Credential not found for #{resource.name}"
+      msg = "Credentials not found for conversion host #{name} or resource #{resource.name}"
       msg << " #{msg}" if msg
       _log.error(msg)
       raise MiqException::Error, msg

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -57,10 +57,8 @@ class ConversionHost < ApplicationRecord
         case auth
           when AuthUseridPassword
             ssh_options[:password] = auth.password
-            ssh_options[:auth_methods] = %w[password]
           when AuthPrivateKey
-            ssh_options[:keys] = [auth.auth_key]
-            ssh_options[:auth_methods] = %w[public_key host_based]
+            ssh_options[:key_data] = auth.auth_key
           else
             next # Skip anything we don't recognize and aren't sure how to handle
         end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -50,7 +50,7 @@ class ConversionHost < ApplicationRecord
       host = hostname || ipaddress
 
       authentications.each do |auth|
-        user = auth.userid || ENV['USER'] || Etc.getlogin
+        user = auth.userid || ENV['USER']
 
         ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -47,12 +47,12 @@ class ConversionHost < ApplicationRecord
 
         if auth.password
           ssh_options[:password] = auth.password
-          ssh_options[:auth_methods] = ['password']
+          ssh_options[:auth_methods] = %w[password]
         end
 
         if auth.auth_key
           ssh_options[:keys] = [auth.auth_key]
-          ssh_options[:auth_methods] = ['public_key', 'host_based']
+          ssh_options[:auth_methods] = %w[public_key host_based]
         end
 
         Net::SSH.start(host, user, ssh_options) { |ssh| ssh.exec!('uname -a') }

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -230,14 +230,13 @@ class ConversionHost < ApplicationRecord
 
   # Find the credentials for the associated Redhat resource. By default it will
   # look for a v2v auth type. If that is not found, it will look for the
-  # authentication associated with the resource using ipmi, ssh_keypair or default,
+  # authentication associated with the resource using ssh_keypair or default,
   # in that order, as the authtype.
   #--
   # TODO: Move this into the provider specific subclass.
   #
   def find_credentials_redhat
     authentication_type('v2v') ||
-      resource.authentication_type('ipmi') ||
       resource.authentication_type('ssh_keypair') ||
       resource.authentication_type('default')
   end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -239,6 +239,7 @@ class ConversionHost < ApplicationRecord
 
     if authentication.nil? && resource.authentication_userid && resource.authentication_password
       authentication = AuthUseridPassword.new(
+        :name     => resource.name,
         :resource => resource,
         :userid   => resource.authentication_userid,
         :password => resource.authentication.password

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -6,7 +6,11 @@ class ConversionHost < ApplicationRecord
 
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
-  has_many :active_tasks, -> { where(:state => ['active', 'migrate']) }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
+
+  has_many :active_tasks, -> { where(:state => ['active', 'migrate']) },
+    :class_name => ServiceTemplateTransformationPlanTask,
+    :inverse_of => :conversion_host
+
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   validates :name, :presence => true

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -76,7 +76,7 @@ module ConversionHost::Configurations
   end
 
   def disable_queue(auth_user = nil)
-    self.class.queue_configuration('disable', id, resource, [], auth_user)
+    self.class.queue_configuration('disable', id, resource, {}, auth_user)
   end
 
   def disable

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -16,14 +16,16 @@ module ConversionHost::Configurations
         :action => "Configuring a conversion_host: operation=#{op} resource=(name: #{resource.name} type: #{resource.class.name} id: #{resource.id})",
         :userid => auth_user
       }
+
       queue_opts = {
         :class_name  => name,
         :method_name => op,
         :instance_id => instance_id,
         :role        => 'ems_operations',
         :zone        => resource.ext_management_system.my_zone,
-        :args        => params
+        :args        => [params, auth_user]
       }
+
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
 
@@ -34,10 +36,10 @@ module ConversionHost::Configurations
       params[:resource_id] = resource.id
       params[:resource_type] = resource.class.name
 
-      queue_configuration('enable', nil, resource, [params], auth_user)
+      queue_configuration('enable', nil, resource, params, auth_user)
     end
 
-    def enable(params)
+    def enable(params, auth_user = nil)
       params = params.symbolize_keys
       _log.info("Enabling a conversion_host with parameters: #{params}")
 
@@ -50,16 +52,15 @@ module ConversionHost::Configurations
       params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
 
       ssh_key = params.delete(:ssh_key)
-      params = params.merge(:ssh_transport_supported => true) if ssh_key
 
       new(params).tap do |conversion_host|
         conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
 
         if ssh_key
-          conversion_host.authentications << AuthPrivateKey.new(
+          conversion_host.authentications << AuthPrivateKey.create!(
             :name     => conversion_host.name,
             :auth_key => ssh_key,
-            :userid   => params[:auth_user],
+            :userid   => auth_user,
             :authtype => 'v2v'
           )
         end

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -50,16 +50,16 @@ module ConversionHost::Configurations
       params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
 
       ssh_key = params.delete(:ssh_key)
+      params = params.merge(:ssh_transport_supported => true) if ssh_key
 
       new(params).tap do |conversion_host|
         conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
 
         if ssh_key
-          conversion_host.authentications << Authentication.new(
+          conversion_host.authentications << AuthPrivateKey.new(
             :name     => conversion_host.name,
-            :type     => 'ConversionHost',
-            :authtype => 'ssh_keypair',
             :auth_key => ssh_key,
+            :userid   => params[:auth_user]
           )
         end
 

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -51,7 +51,7 @@ module ConversionHost::Configurations
       vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
       params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
 
-      ssh_key = params.delete(:ssh_key)
+      ssh_key = params.delete(:conversion_host_ssh_private_key)
 
       new(params).tap do |conversion_host|
         conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -54,8 +54,6 @@ module ConversionHost::Configurations
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
       new(params).tap do |conversion_host|
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
-
         if ssh_key
           conversion_host.authentications << AuthPrivateKey.create!(
             :name     => conversion_host.name,
@@ -65,6 +63,7 @@ module ConversionHost::Configurations
           )
         end
 
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
         conversion_host.save!
       end
     rescue StandardError => error

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -59,7 +59,8 @@ module ConversionHost::Configurations
           conversion_host.authentications << AuthPrivateKey.new(
             :name     => conversion_host.name,
             :auth_key => ssh_key,
-            :userid   => params[:auth_user]
+            :userid   => params[:auth_user],
+            :authtype => 'v2v'
           )
         end
 

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -67,10 +67,6 @@ module AuthenticationMixin
   end
 
   def authentication_key_pairs
-    authentications.select { |a| a.kind_of?(ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair) }
-  end
-
-  def authentication_private_keys
     authentications.select { |a| a.kind_of?(AuthPrivateKey) }
   end
 
@@ -437,7 +433,7 @@ module AuthenticationMixin
   end
 
   def available_authentications
-    authentication_userid_passwords + authentication_tokens + authentication_private_keys
+    authentication_userid_passwords + authentication_key_pairs + authentication_tokens
   end
 
   def authentication_types

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -70,6 +70,10 @@ module AuthenticationMixin
     authentications.select { |a| a.kind_of?(ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair) }
   end
 
+  def authentication_private_keys
+    authentications.select { |a| a.kind_of?(AuthPrivateKey) }
+  end
+
   def authentication_for_providers
     authentications.where.not(:authtype => nil)
   end
@@ -433,7 +437,7 @@ module AuthenticationMixin
   end
 
   def available_authentications
-    authentication_userid_passwords + authentication_key_pairs + authentication_tokens
+    authentication_userid_passwords + authentication_key_pairs + authentication_tokens + authentication_private_keys
   end
 
   def authentication_types

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -437,7 +437,7 @@ module AuthenticationMixin
   end
 
   def available_authentications
-    authentication_userid_passwords + authentication_key_pairs + authentication_tokens + authentication_private_keys
+    authentication_userid_passwords + authentication_tokens + authentication_private_keys
   end
 
   def authentication_types

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -121,7 +121,7 @@ describe ConversionHost do
         task_id = described_class.enable_queue(params)
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [params.merge(:task_id => task_id).except(:resource)],
+          :args        => [params.merge(:task_id => task_id).except(:resource), nil],
           :class_name  => described_class.name,
           :method_name => "enable",
           :priority    => MiqQueue::NORMAL_PRIORITY,
@@ -138,7 +138,7 @@ describe ConversionHost do
         task_id = conversion_host.disable_queue
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [],
+          :args        => [{:task_id => task_id}, nil],
           :class_name  => described_class.name,
           :instance_id => conversion_host.id,
           :method_name => "disable",

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -25,28 +25,28 @@ describe ConversionHost do
     context "#eligible?" do
       it "fails when no source transport method is enabled" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return(nil)
-        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(true)
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
         allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
       it "fails when no source transport method is enabled" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
-        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(false)
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(false)
         allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
       it "fails when no source transport method is enabled" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
-        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(true)
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
         allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(false)
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
       it "succeeds when all criteria are met" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
-        allow(conversion_host_1).to receive(:check_ssh_connection).and_return(true)
+        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
         allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
         expect(conversion_host_1.eligible?).to eq(true)
       end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -278,7 +278,7 @@ describe ConversionHost do
 
     it "works as expected with no associated authentications if the connect_ssh method fails" do
       allow(conversion_host_vm).to receive(:connect_ssh).and_raise(Exception.new)
-      expect{ conversion_host_vm.verify_credentials }.to raise_error{ RuntimeError }
+      expect { conversion_host_vm.verify_credentials }.to raise_error(RuntimeError)
     end
 
     it "works if there is an associated validation" do
@@ -292,7 +292,7 @@ describe ConversionHost do
       authentication = FactoryBot.create(:authentication_ssh_keypair)
       conversion_host_vm.authentications << authentication
       allow(Net::SSH).to receive(:start).and_raise(Net::SSH::AuthenticationFailed.new)
-      expect{ conversion_host_vm.verify_credentials }.to raise_error{ MiqException::MiqInvalidCredentialsError }
+      expect { conversion_host_vm.verify_credentials }.to raise_error(MiqException::MiqInvalidCredentialsError)
     end
 
     it "works if there are multiple associated validations" do

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -276,11 +276,23 @@ describe ConversionHost do
       expect(conversion_host_vm.verify_credentials).to be_truthy
     end
 
+    it "works as expected with no associated authentications if the connect_ssh method fails" do
+      allow(conversion_host_vm).to receive(:connect_ssh).and_raise(Exception.new)
+      expect{ conversion_host_vm.verify_credentials }.to raise_error{ RuntimeError }
+    end
+
     it "works if there is an associated validation" do
       authentication = FactoryBot.create(:authentication_ssh_keypair)
       conversion_host_vm.authentications << authentication
       allow(Net::SSH).to receive(:start).and_return(true)
       expect(conversion_host_vm.verify_credentials).to be_truthy
+    end
+
+    it "works as expected if there is an associated validation that is invalid" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair)
+      conversion_host_vm.authentications << authentication
+      allow(Net::SSH).to receive(:start).and_raise(Net::SSH::AuthenticationFailed.new)
+      expect{ conversion_host_vm.verify_credentials }.to raise_error{ MiqException::MiqInvalidCredentialsError }
     end
 
     it "works if there are multiple associated validations" do

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -289,5 +289,12 @@ describe ConversionHost do
       allow(Net::SSH).to receive(:start).and_return(true)
       expect(conversion_host_vm.verify_credentials).to be_truthy
     end
+
+    it "works if an auth_type is explicitly specified" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair)
+      conversion_host_vm.authentications << authentication
+      allow(Net::SSH).to receive(:start).and_return(true)
+      expect(conversion_host_vm.verify_credentials('v2v')).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
Currently there's a lot of hand-crafted ssh handling using the MiqSshUtil library baked into the ConversionHost model that is tied to specific providers. I thought we should leverage the AuthenticationMixin to take advantage of its features.

Specifically, this would give use a direct association between conversion hosts and authentications. This would be beneficial for certain providers, e.g. openstack, where we are currently using credentials set at the provider level. This way, we can set it on a per-resource level for all provider types by setting the authentication on the conversion host instance itself.

This will also be necessary for the UI where users are allowed to upload their own ssh keys.