### PR TITLE
Remove workaround in custom calculate method

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -764,13 +764,6 @@ module ActiveRecord
 
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
-        # work around 1 until https://github.com/rails/rails/pull/25304 gets merged
-        # This allows attribute_name to be a virtual_attribute
-        if (arel = klass.arel_attribute(attribute_name)) && virtual_attribute?(attribute_name)
-          attribute_name = arel
-        end
-        # end work around 1
-
         # allow calculate to work when including a virtual attribute
         real = without_virtual_includes
         return super if real.equal?(self)


### PR DESCRIPTION
We have a custom `calcuate` method in lib/extensions that includes some code that is no longer needed. The PR referenced in the comments (by @kbrock) was merged over two years ago:

https://github.com/rails/rails/pull/25304

This PR simply removes the code that is no longer necessary.

Update: Will only work for Rails 5.1+.

