### PR TITLE
Ensure a users own tasks are the only ones returned when the users role has View/My Tasks

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -1,8 +1,10 @@
 class MiqProductFeature < ApplicationRecord
-  SUPER_ADMIN_FEATURE = "everything".freeze
+  SUPER_ADMIN_FEATURE   = "everything".freeze
   REPORT_ADMIN_FEATURE  = "miq_report_superadmin".freeze
   REQUEST_ADMIN_FEATURE = "miq_request_approval".freeze
-  TENANT_ADMIN_FEATURE = "rbac_tenant".freeze
+  REPORT_MY_TASKS       = "miq_task_my_ui".freeze
+  REPORT_ALL_TASKS      = "miq_task_all_ui".freeze
+  TENANT_ADMIN_FEATURE  = "rbac_tenant".freeze
 
   acts_as_tree
 

--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -112,6 +112,10 @@ class MiqUserRole < ApplicationRecord
     allows?(:identifier => MiqProductFeature::TENANT_ADMIN_FEATURE)
   end
 
+  def report_only_my_user_tasks?
+    !allows?(:identifier => MiqProductFeature::REPORT_ALL_TASKS) && allows?(:identifier => MiqProductFeature::REPORT_MY_TASKS)
+  end
+
   def report_admin_user?
     allows?(:identifier => MiqProductFeature::REPORT_ADMIN_FEATURE)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
 
   delegate   :miq_user_role, :current_tenant, :get_filters, :has_filters?, :get_managed_filters, :get_belongsto_filters,
              :to => :current_group, :allow_nil => true
-  delegate   :super_admin_user?, :request_admin_user?, :self_service?, :limited_self_service?, :report_admin_user?,
+  delegate   :super_admin_user?, :request_admin_user?, :self_service?, :limited_self_service?, :report_admin_user?, :report_only_my_user_tasks?,
              :to => :miq_user_role, :allow_nil => true
 
   validates_presence_of   :name, :userid

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -222,6 +222,8 @@ describe MiqUserRole do
   let(:tenant_admin_role) { FactoryBot.create(:miq_user_role, :features => MiqProductFeature::TENANT_ADMIN_FEATURE) }
   let(:report_admin_role) { FactoryBot.create(:miq_user_role, :features => MiqProductFeature::REPORT_ADMIN_FEATURE) }
   let(:request_admin_role) { FactoryBot.create(:miq_user_role, :features => MiqProductFeature::REQUEST_ADMIN_FEATURE) }
+  let(:report_only_my_tasks) { FactoryBot.create(:miq_user_role, :features => MiqProductFeature::REPORT_MY_TASKS) }
+  let(:report_only_all_tasks) { FactoryBot.create(:miq_user_role, :features => MiqProductFeature::REPORT_ALL_TASKS) }
   let(:regular_role) { FactoryBot.create(:miq_user_role) }
 
   describe "#super_admin_user?" do
@@ -235,6 +237,20 @@ describe MiqUserRole do
 
     it "detects non-admin" do
       expect(regular_role).not_to be_super_admin_user
+    end
+  end
+
+  describe "#report_only_my_user_tasks?" do
+    it "detects access limited to only the current users tasks" do
+      expect(report_only_my_tasks).to be_report_only_my_user_tasks
+    end
+
+    it "detects access not limited to only the current users tasks" do
+      expect(report_only_all_tasks).not_to be_report_only_my_user_tasks
+    end
+
+    it "detects no access to tasks" do
+      expect(regular_role).not_to be_report_only_my_user_tasks
     end
   end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1639387

This is a companion PR for, and must be merged before, the manageiq-api repo PR:
https://github.com/ManageIQ/manageiq-api/pull/526

A role can be configured to view all tasks or only my tasks. When a user is assigned to
a role that is configured to view only "My Tasks" The API would incorrectly returning all
tasks for all users.

And when querying a single task by ID would return the task even if not owned by the
current user.

This PR corrects this erroneous condition by adding two new methods to the
base_controller/renderer.rb #find_resource and #find_collection. Each of these
two new methods is overridden in the task_controller.rb where logic is adding to
correctly handle this condition.

**To test:**

Assign a group to a user where the group has a role configured with
View / My Tasks and without View / All Tasks

Then exercise the API for this user to query the task collection ensuring only tasks
owned by the specified user are returned:

e.g.:
curl -k "https://:@/api/tasks/"
This should only return tasks owned by the specified user and should match what the UI
shows when that specified user is logged in and lists their tasks.

and queries for individual task do not return tasks owned by another user.

e.g.:
curl -k "https://:@/api/tasks/"
This should only return the task if it is owned by the specified user

