### PR TITLE
Add Ruby 2.5.x to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+- 2.5.3
 - 2.4.5
 - 2.3.8
 sudo: false
@@ -15,6 +16,8 @@ env:
   - TEST_SUITE=vmdb PARALLEL=true
   - TEST_SUITE=brakeman
 matrix:
+  allow_failures:
+  - rvm: 2.5.3
   allow_failures:
   - rvm: 2.4.2
   exclude:


### PR DESCRIPTION
The Rails team recently revealed that Rails 6 will require Ruby 2.5.x or later. With that in mind, I think it would be prudent to add Ruby 2.5.x to our test matrix. Initially, make it an allowed failure, and adjust later as needed.

https://weblog.rubyonrails.org/2018/12/20/timeline-for-the-release-of-Rails-6-0/