### PR TITLE
Send 'which prince' failures to /dev/null

### DIFF
--- a/lib/pdf_generator/prince_pdf_generator.rb
+++ b/lib/pdf_generator/prince_pdf_generator.rb
@@ -2,7 +2,7 @@ class PrincePdfGenerator < PdfGenerator
   include Vmdb::Logging
   def self.executable
     return @executable if defined?(@executable)
-    @executable = `which prince`.chomp
+    @executable = `which prince 2> /dev/null`.chomp
   end
 
   def self.available?


### PR DESCRIPTION
Just a minor bit of cleanup that will eliminate some warning output while running specs if the `prince` command isn't found.