### PR TITLE
bug 1641011: Upgrade manageiq-smartstate to 0.2.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.2.14",       :require => false
+  gem "manageiq-smartstate",            "~>0.2.18",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1641011

Upgrade manageiq-smartstate to 0.2.18 which contains the fix
for bug 1641011.

