### PR TITLE
Mark rbac_tenant_manage_quotas as  MY TENANT FEATURE

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -33,7 +33,8 @@ class MiqProductFeature < ApplicationRecord
   REQUIRED_ATTRIBUTES = [:identifier].freeze
   OPTIONAL_ATTRIBUTES = %i(name feature_type description children hidden protected).freeze
   ALLOWED_ATTRIBUTES = (REQUIRED_ATTRIBUTES + OPTIONAL_ATTRIBUTES).freeze
-  TENANT_FEATURE_ROOT_IDENTIFIERS = %w(dialog_new_editor dialog_edit_editor dialog_copy_editor dialog_delete rbac_tenant_manage_quotas).freeze
+  MY_TENANT_FEATURE_ROOT_IDENTIFIERS = %w(rbac_tenant_manage_quotas).freeze
+  TENANT_FEATURE_ROOT_IDENTIFIERS = (%w(dialog_new_editor dialog_edit_editor dialog_copy_editor dialog_delete) + MY_TENANT_FEATURE_ROOT_IDENTIFIERS).freeze
 
   def name
     value = self[:name]
@@ -47,6 +48,10 @@ class MiqProductFeature < ApplicationRecord
 
   def self.tenant_identifier(identifier, tenant_id)
     "#{identifier}_tenant_#{tenant_id}"
+  end
+
+  def self.my_root_tenant_identifier?(identifier)
+    MY_TENANT_FEATURE_ROOT_IDENTIFIERS.include?(identifier)
   end
 
   def self.root_tenant_identifier?(identifier)


### PR DESCRIPTION
Extending: https://github.com/ManageIQ/manageiq/pull/18151

will be used for
- [ ]  [UI PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/5123)
- [ ] [API PR](https://github.com/ManageIQ/manageiq-api/pull/536)

This PR is based recent feature called [ Dynamic product features according to tenants](https://github.com/ManageIQ/manageiq/issues/18100):

**Scenario:**
Let's have tenant structure:

```
My Company
|--->  Alpha (user alpha)
       |---> Omega (user omega)
````  

According to the BZ **user alpha**  needs to have forbidden access to **managing quotas** for tenant Alpha (user alpha) and allowed to **managing quotas**.

We can use for this recent feature called [ Dynamic product features according to tenants](https://github.com/ManageIQ/manageiq/issues/18100)
that we will authorise dynamic tenant product features (`rbac_tenant_manage_quotas_tenant_<TENANT ID where we want/don't want to manage tenant quotas >`) to access managing quotas of <tenants>.

To accomplish this we need to change places where we are authorising `rbac_tenant_manage_quotas_tenant` to `rbac_tenant_manage_quotas_tenant_<TENANT ID where we want/don't want to manage tenant quotas >`

**This places are in UI and API in the PRs above**

**User alpha** has this setting in role (rbac_tenant_manage_quotas_tenant is checked just for Omega Tenant)
![screenshot 2019-01-03 at 16 37 36](https://user-images.githubusercontent.com/14937244/50646978-c14bb580-0f77-11e9-983e-0d9c263fff09.png)
which will forbid managing for **tenant alpha**

![screenshot 2019-01-03 at 16 49 49](https://user-images.githubusercontent.com/14937244/50647080-fce67f80-0f77-11e9-9543-7d3f986e2453.png)
and allow **manage quotas for omega tenant**

![screenshot 2019-01-03 at 16 50 00](https://user-images.githubusercontent.com/14937244/50647117-15ef3080-0f78-11e9-806d-b9df1910a783.png)

This is done in UI PR ^.



Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1468795

@miq-bot add_label enhancement, blocker
@miq-bot assign @gtanzillo 