### PR TITLE
Alter ansible_playbook method so that some arguments are optional

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -164,18 +164,8 @@ class ConversionHost < ApplicationRecord
   # +extra_vars+ option should be a hash of key/value pairs which, if present,
   # will be passed to the '-e' flag.
   #
-  # If a local connection is specified the connection type is set to 'local'
-  # and the inventory host list is set to 'localhost'. Otherwise it will use
-  # the IP address of the conversion host and the default connection type.
-  #
-  def ansible_playbook(playbook, extra_vars = {}, local_connection = false)
-    command = "ansible-playbook #{playbook}"
-
-    if local_connection
-      command += " -i localhost, -c local"
-    else
-      command += " -i #{ipaddress},"
-    end
+  def ansible_playbook(playbook, extra_vars = {})
+    command = "ansible-playbook #{playbook} -i #{ipaddress}"
 
     extra_vars.each { |k, v| command += " -e '#{k}=#{v}'" }
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -105,8 +105,7 @@ class ConversionHost < ApplicationRecord
   def disable_conversion_host_role
     install_conversion_host_module
     playbook = "/usr/share/ovirt-ansible-v2v-conversion-host/playbooks/conversion_host_disable.yml"
-    extra_vars = {}
-    ansible_playbook(playbook, extra_vars)
+    ansible_playbook(playbook)
   ensure
     check_conversion_host_role
   end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -169,7 +169,7 @@ class ConversionHost < ApplicationRecord
   # and the inventory host list is set to 'localhost'. Otherwise it will use
   # the IP address of the conversion host and the default connection type.
   #
-  def ansible_playbook(playbook, extra_vars, local_connection = false)
+  def ansible_playbook(playbook, extra_vars = {}, local_connection = false)
     command = "ansible-playbook #{playbook}"
 
     if local_connection


### PR DESCRIPTION
This PR modifies the `ansible_playbook` method of the `ConversionHost` model so that the 2nd and 3rd arguments are optional. The `extra_vars` will simply default to an empty hash, while the `local_connection` argument (formerly just `connection`) is now a boolean argument that defaults to false.

I also added some comments.

This is a nicer approach, since the 3rd argument currently isn't used at all unless it's set to 'local', so it made sense to me to make it a boolean with a default value. Giving the 2nd argument a default value means we don't have to explicitly pass an empty hash when no extra vars are needed.

This PR also solves bugs with several internal methods where the 3rd argument is missing, e.g. `check_conversion_host_role`.