### PR TITLE
Don't reset retirement_requester after end of retirement

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -167,11 +167,16 @@ module RetirementMixin
     raise _("%{name} already retired") % {:name => name} if retired?
     $log.info("Finishing Retirement for [#{name}]")
     requester = retirement_requester
-    update_attributes(:retires_on => Time.zone.now, :retired => true, :retirement_state => "retired")
+    mark_retired
     message = "#{self.class.base_model.name}: [#{name}], Retires On: [#{retires_on.strftime("%x %R %Z")}], has been retired"
     $log.info("Calling audit event for: #{message} ")
     raise_audit_event(retired_event_name, message, requester)
     $log.info("Called audit event for: #{message} ")
+  end
+
+  def mark_retired
+    self[:retires_on] = Time.zone.now
+    update_attributes(:retired => true, :retirement_state => "retired")
   end
 
   def start_retirement

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -1,5 +1,6 @@
 describe "Service Retirement Management" do
   let!(:user) { FactoryBot.create(:user_miq_request_approver, :userid => "admin") }
+  let(:orchestration_stack) { FactoryBot.create(:orchestration_stack) }
   context "with zone/ems" do
     before do
       @miq_server = EvmSpecHelper.local_miq_server
@@ -67,8 +68,17 @@ describe "Service Retirement Management" do
     end
 
     it "#finish_retirement" do
+      message = "OrchestrationStack: [#{orchestration_stack.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+      expect(orchestration_stack).to receive(:raise_audit_event).with("orchestration_stack_retired", message, nil)
+
+      orchestration_stack.finish_retirement
+
+      expect(orchestration_stack.retirement_state).to eq("retired")
+    end
+
+    it "#mark_retired" do
       expect(@stack.retirement_state).to be_nil
-      @stack.finish_retirement
+      @stack.mark_retired
       @stack.reload
       expect(@stack.retired).to be_truthy
       expect(@stack.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -147,8 +147,17 @@ describe "Service Retirement Management" do
   end
 
   it "#finish_retirement" do
+    message = "Service: [#{service3.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+    expect(service3).to receive(:raise_audit_event).with("service_retired", message, nil)
+
+    service3.finish_retirement
+
+    expect(service3.retirement_state).to eq("retired")
+  end
+
+  it "#mark_retired" do
     expect(@service.retirement_state).to be_nil
-    @service.finish_retirement
+    @service.mark_retired
     @service.reload
     expect(@service.retired).to be_truthy
     expect(@service.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -102,8 +102,17 @@ describe "VM Retirement Management" do
   end
 
   it "#finish_retirement" do
+    message = "Vm: [#{vm2.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+    expect(vm2).to receive(:raise_audit_event).with("vm_retired", message, nil)
+
+    vm2.finish_retirement
+
+    expect(vm2.retirement_state).to eq("retired")
+  end
+
+  it "#mark_retired" do
     expect(@vm.retirement_state).to be_nil
-    @vm.finish_retirement
+    @vm.mark_retired
     @vm.reload
 
     expect(@vm.retired).to eq(true)


### PR DESCRIPTION
Because we have a column name and a method name that are equivalent, finish_retirement used to reset the retirement_requester to nil. Changing the method to call a different method that only sets the field name prevents this from being reset to nil at the end. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1638502