### PR TITLE
Add the graph integrity flag to the base persister

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.8.5"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
-gem "inventory_refresh",              "~>0.1.1",       :require => false
+gem "inventory_refresh",              "~>0.1.2",       :require => false
 gem "kubeclient",                     "~>4.0",         :require => false # For scaling pods at runtime
 gem "linux_admin",                    "~>1.2.1",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -93,17 +93,31 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
     nil
   end
 
+  def saver_strategy
+    :default
+  end
+
   # Persisters for targeted refresh can override to true
   def targeted?
     false
   end
 
+  def parent
+    manager.presence
+  end
+
+  def assert_graph_integrity?
+    !Rails.env.production?
+  end
+
   # @return [Hash] kwargs shared for all InventoryCollection objects
   def shared_options
     {
-      :strategy => strategy,
-      :targeted => targeted?,
-      :parent   => manager.presence
+      :strategy               => strategy,
+      :saver_strategy         => saver_strategy,
+      :targeted               => targeted?,
+      :parent                 => parent,
+      :assert_graph_integrity => assert_graph_integrity?,
     }
   end
 

--- a/spec/models/manageiq/providers/inventory/persister/test_persister.rb
+++ b/spec/models/manageiq/providers/inventory/persister/test_persister.rb
@@ -128,16 +128,4 @@ class TestPersister < ManageIQ::Providers::Inventory::Persister
   def strategy
     :local_db_find_missing_references
   end
-
-  def parent
-    manager.presence
-  end
-
-  def shared_options
-    {
-      :strategy => strategy,
-      :targeted => targeted?,
-      :parent   => parent
-    }
-  end
 end


### PR DESCRIPTION
Add the flag for graph integrity checking to the base persister and
default to true when not in production mode.

Depends on:
- [x] https://github.com/ManageIQ/inventory_refresh/pull/62