### PR TITLE
Jobs aren't retireable

### DIFF
--- a/app/models/manageiq/providers/automation_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/automation_manager/orchestration_stack.rb
@@ -1,2 +1,7 @@
 class ManageIQ::Providers::AutomationManager::OrchestrationStack < ::OrchestrationStack
+  include CiFeatureMixin
+
+  def retireable?
+    false
+  end
 end


### PR DESCRIPTION
Jobs aren't retireable so this prevents the creation of JobRetireTasks which are invalid. 

The check is at this level because neither jobs nor workflow jobs are retireable. 

Fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=1650437.

@tinaafitz is working on the Automate changes necessary to finish this bug because at the moment, even if JobRetireTask creation is prevented by this change, anything that's retiring will still be stuck in retry until failure because retireable isn't exposed thru Automate. 