### PR TITLE
RHV requires disconnect_storage before ems

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -654,6 +654,7 @@ class VmOrTemplate < ApplicationRecord
   #
 
   def disconnect_inv
+    disconnect_storage
     disconnect_ems
 
     classify_with_parent_folder_path(false)
@@ -663,7 +664,6 @@ class VmOrTemplate < ApplicationRecord
     end
 
     disconnect_host
-    disconnect_storage
     disconnect_stack if respond_to?(:orchestration_stack)
   end
 


### PR DESCRIPTION
RHV disconnect_storage has to perform an API call to the provider to
check if the underlying disks are still on the datastore.  In order to
do this it must still have its ext_management_system link to be able to
connect.  This means that disconnect_storage must be called prior to
disconnect_ems.

Introduced by cleanup done in https://github.com/ManageIQ/manageiq-providers-ovirt/pull/310

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1659340