### PR TITLE
Change Stacked Area chart for Area chart for the Virtual Machine CPU States

### DIFF
--- a/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/daily_perf_charts/AvailabilityZone.yaml
@@ -84,7 +84,7 @@
     - derived_vm_count_on
 
 - :title: Instances
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/EmsCluster.yaml
+++ b/product/charts/layouts/daily_perf_charts/EmsCluster.yaml
@@ -28,7 +28,7 @@
     - derived_host_count_on
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/daily_perf_charts/EmsCluster.yaml
+++ b/product/charts/layouts/daily_perf_charts/EmsCluster.yaml
@@ -122,7 +122,7 @@
     - derived_host_count_on
 
 - :title: Hosts
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_host_count_on
   - derived_host_count_off
@@ -132,7 +132,7 @@
   - Display-Hosts-off:Hosts that were stopped
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/Host.yaml
+++ b/product/charts/layouts/daily_perf_charts/Host.yaml
@@ -25,7 +25,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/daily_perf_charts/Host.yaml
+++ b/product/charts/layouts/daily_perf_charts/Host.yaml
@@ -107,7 +107,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/HostAggregate.yaml
+++ b/product/charts/layouts/daily_perf_charts/HostAggregate.yaml
@@ -75,7 +75,7 @@
 #    - derived_vm_count_on
 
 - :title: Instances
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/ManageIQ_Providers_Openstack_InfraManager_EmsCluster.yaml
+++ b/product/charts/layouts/daily_perf_charts/ManageIQ_Providers_Openstack_InfraManager_EmsCluster.yaml
@@ -99,7 +99,7 @@
     - derived_host_count_on
 
 - :title: Hosts
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_host_count_on
   - derived_host_count_off
@@ -109,7 +109,7 @@
   - Display-Hosts-off:Hosts that were stopped
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/ManageIQ_Providers_Openstack_InfraManager_Host.yaml
+++ b/product/charts/layouts/daily_perf_charts/ManageIQ_Providers_Openstack_InfraManager_Host.yaml
@@ -87,7 +87,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/Parent-EmsCluster.yaml
+++ b/product/charts/layouts/daily_perf_charts/Parent-EmsCluster.yaml
@@ -46,7 +46,7 @@
   :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/daily_perf_charts/Parent-Host.yaml
+++ b/product/charts/layouts/daily_perf_charts/Parent-Host.yaml
@@ -43,7 +43,7 @@
   :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/daily_perf_charts/Storage.yaml
+++ b/product/charts/layouts/daily_perf_charts/Storage.yaml
@@ -72,7 +72,7 @@
   - derived_storage_total:Projected to hit total
 
 - :title: Hosts
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_host_count_on
   - derived_host_count_off
@@ -82,7 +82,7 @@
   - Display-Hosts-off:Hosts that were stopped
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/daily_perf_charts/VmOrTemplate.yaml
+++ b/product/charts/layouts/daily_perf_charts/VmOrTemplate.yaml
@@ -33,7 +33,7 @@
   :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/hourly_perf_charts/AvailabilityZone.yaml
+++ b/product/charts/layouts/hourly_perf_charts/AvailabilityZone.yaml
@@ -62,7 +62,7 @@
     - derived_vm_count_on
 
 - :title: Instances
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/hourly_perf_charts/EmsCluster.yaml
+++ b/product/charts/layouts/hourly_perf_charts/EmsCluster.yaml
@@ -21,7 +21,7 @@
     - derived_host_count_on
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/hourly_perf_charts/EmsCluster.yaml
+++ b/product/charts/layouts/hourly_perf_charts/EmsCluster.yaml
@@ -99,7 +99,7 @@
     - derived_host_count_on
 
 - :title: Hosts
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_host_count_on
   - derived_host_count_off
@@ -109,7 +109,7 @@
   - Display-Hosts-off:Hosts that were stopped
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/hourly_perf_charts/Host.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Host.yaml
@@ -18,7 +18,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/hourly_perf_charts/Host.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Host.yaml
@@ -84,7 +84,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/hourly_perf_charts/ManageIQ_Providers_Openstack_InfraManager_EmsCluster.yaml
+++ b/product/charts/layouts/hourly_perf_charts/ManageIQ_Providers_Openstack_InfraManager_EmsCluster.yaml
@@ -77,7 +77,7 @@
     - derived_host_count_on
 
 - :title: Hosts
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_host_count_on
   - derived_host_count_off
@@ -87,7 +87,7 @@
   - Display-Hosts-off:Hosts that were stopped
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/hourly_perf_charts/ManageIQ_Providers_Openstack_InfraManager_Host.yaml
+++ b/product/charts/layouts/hourly_perf_charts/ManageIQ_Providers_Openstack_InfraManager_Host.yaml
@@ -65,7 +65,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machines
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/hourly_perf_charts/Parent-EmsCluster.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Parent-EmsCluster.yaml
@@ -21,7 +21,7 @@
     - derived_host_count_on
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/hourly_perf_charts/Parent-Host.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Parent-Host.yaml
@@ -18,7 +18,7 @@
     - derived_vm_count_on
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/hourly_perf_charts/Storage.yaml
+++ b/product/charts/layouts/hourly_perf_charts/Storage.yaml
@@ -17,7 +17,7 @@
   :type: None
 
 - :title: Used Disk Space
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_derived_storage_used
   - derived_storage_free
@@ -29,7 +29,7 @@
   :units: GB
 
 - :title: Hosts
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_host_count_on
   - derived_host_count_off
@@ -39,7 +39,7 @@
   - Display-Hosts-off:Hosts that were stopped
 
 - :title: VMs
-  :type: StackedArea
+  :type: Area
   :columns:
   - derived_vm_count_on
   - derived_vm_count_off

--- a/product/charts/layouts/hourly_perf_charts/VmOrTemplate.yaml
+++ b/product/charts/layouts/hourly_perf_charts/VmOrTemplate.yaml
@@ -21,7 +21,7 @@
   :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation

--- a/product/charts/layouts/realtime_perf_charts/VmOrTemplate.yaml
+++ b/product/charts/layouts/realtime_perf_charts/VmOrTemplate.yaml
@@ -18,7 +18,7 @@
   :applies_to_method: cpu_percent_available?
 
 - :title: Virtual Machine CPU States
-  :type: StackedArea
+  :type: Area
   :columns:
   - v_pct_cpu_ready_delta_summation
   - v_pct_cpu_used_delta_summation


### PR DESCRIPTION
Change Stacked Area chart for Area chart for the Virtual Machine CPU States chart.
 Now the values should not be aggregated.

Screenshots [Optional]
----------------

Before:
![screenshot from 2019-01-07 13-54-55](https://user-images.githubusercontent.com/9535558/50769479-57d3eb80-1284-11e9-8caf-7d64d34112b8.png)

After:
![screenshot from 2019-01-07 13-57-19](https://user-images.githubusercontent.com/9535558/50769437-3a068680-1284-11e9-8ada-fca26ad6a42b.png)



Links [Optional]
----------------

https://bugzilla.redhat.com/show_bug.cgi?id=1527695

Steps for Testing/QA [Optional]
-------------------------------
1. Navigate to VM named CU data
2. Monitoring -> Utilization
3. Virtual Machine CPU States chart should be correct
