### PR TITLE
Modify the enable ConversionHost::Configurations#enable method to handle arguments more robustly

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -28,9 +28,11 @@ module ConversionHost::Configurations
     end
 
     def enable_queue(params, auth_user = nil)
+      params = params.symbolize_keys
       resource_type = params[:resource_type]
       resource_id = params[:resource_id]
-      resource = resource_type.constantize.find(resource_id)
+
+      resource = resource_type.to_s.downcase.classify.constantize.find(resource_id)
 
       queue_configuration('enable', nil, resource, [params], auth_user)
     end

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -36,14 +36,18 @@ module ConversionHost::Configurations
     end
 
     def enable(params)
+      params = params.symbolize_keys
       _log.info("Enabling a conversion_host with parameters: #{params}")
-      params.delete(:task_id) # in case this is being called through *_queue which will stick in a :task_id
-      params.delete(:miq_task_id) # miq_queue.activate_miq_task will stick in a :miq_task_id
 
-      vddk_url = params.delete("param_v2v_vddk_package_url")
+      params.delete(:task_id)     # In case this is being called through *_queue which will stick in a :task_id
+      params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
+
+      vddk_url = params.delete(:param_v2v_vddk_package_url)
       resource_id = params[:resource_id]
       resource_type = params[:resource_type]
-      resource = resource_type.constantize.find(resource_id)
+
+      # Effectively ignore case since we cannot guarantee it from the REST API
+      resource = resource_type.to_s.downcase.classify.constantize.find(resource_id)
 
       conversion_host = new(params.merge(:resource => resource))
       conversion_host.enable_conversion_host_role(vddk_url)

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -75,7 +75,7 @@ describe ConversionHost do
         task_id = described_class.enable_queue(params)
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [params],
+          :args        => [params.merge(:task_id => task_id)],
           :class_name  => described_class.name,
           :method_name => "enable",
           :priority    => MiqQueue::NORMAL_PRIORITY,


### PR DESCRIPTION
In the course of working on the REST API interface for the `enable` method, I realized there were two issues. First, we cannot guarantee that the keys to the `params` argument will be symbols or strings. Second, the `constantize` method will fail if the case of the argument isn't set properly, which IMO is an implementation detail that a consumer of the REST API should not have to worry about.

For the first case, I felt the best thing to do was to simply symbolize all of the arguments so we know we're always dealing with symbols.

For the second case, I modified the call first `downcase` then `classify` the resource_type argument so that `constantize` won't fail. Thus, someone using the REST API can pass "vm", "VM", or "Vm" and it will Just Work.

Update: Made some similar changes to the `enable_queue` method as well.