### PR TITLE
Clarify the 'towhat' inclusion validation message on policy creation.

### DIFF
--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -39,7 +39,8 @@ class MiqPolicy < ApplicationRecord
   validates_presence_of     :name, :description, :guid
   validates_uniqueness_of   :name, :description, :guid
   validates :mode, :inclusion => { :in => %w(compliance control) }
-  validates :towhat, :inclusion => { :in => TOWHAT_APPLIES_TO_CLASSES }
+  validates :towhat, :inclusion => { :in      => TOWHAT_APPLIES_TO_CLASSES,
+                                     :message => "should be one of #{TOWHAT_APPLIES_TO_CLASSES.join(", ")}" }
 
   scope :with_mode,   ->(mode)   { where(:mode => mode) }
   scope :with_towhat, ->(towhat) { where(:towhat => towhat) }

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -314,7 +314,13 @@ describe MiqPolicy do
     end
 
     it 'reports invalid towhat' do
-      expect(FactoryBot.build(:miq_policy, :towhat => "BobsYourUncle")).not_to be_valid
+      policy = FactoryBot.build(:miq_policy, :towhat => "BobsYourUncle")
+      towhat_error = "should be one of ContainerGroup, ContainerImage, "\
+                     "ContainerNode, ContainerProject, ContainerReplicator, "\
+                     "ExtManagementSystem, Host, PhysicalServer, Vm"
+
+      expect(policy).not_to be_valid
+      expect(policy.errors.messages).to include(:towhat => [towhat_error])
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1663562

In [this resolved bug](https://bugzilla.redhat.com/show_bug.cgi?id=1659899) / #18032, it was found that providing an invalid `towhat` value in the payload while creating a `Policy` record via the API would result in an unclear error message. The received message is the default error message for a failed [Rails inclusion validation](https://guides.rubyonrails.org/active_record_validations.html#inclusion): "Towhat is not included in the list".

This message can be (and was) mistakenly interpreted to mean `towhat` was not included in the payload structure, when it's actually referring to the [inclusion list](https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_policy.rb#L4-L12) it's being validated against. 

This helps clarify the messaging to specify the list of valid "towhat" values, following established patterns throughout other model validations, such as: https://github.com/ManageIQ/manageiq/blob/1db6992b5076a99e13623c3de8df5030077ab341/app/models/miq_widget.rb#L24 by explicitly setting the inclusion whitelist as part of the error message. This will be particularly helpful when making requests against the API.

This also updates a supportive spec which tests the validity of the policy record.

Links
----------------

* [Rails AR Inclusion Validation](https://guides.rubyonrails.org/active_record_validations.html#inclusion)
* [Original PR for 'towhat' field validation on `Policy`](#18032)

Steps for Testing/QA
-------------------------------
Send a `POST` API request to create a `Policy` by running:

```bash
$ tools/rest_api.rb post /api/policies
```
and entering the following payload (invalid `towhat`):
```json
{
  "action": "create",  
  "resources": [{
    "name": "Invalid Towhat Policy",
    "description": "Invalid Towhat Policy",
    "mode": "control",
    "towhat": "invalidToWhat",      
    "conditions_ids": [ 2000, 3000 ],
    "policy_contents": [{             
      "event_id": 2,
      "actions": [ {"action_id": 1, "opts": { "qualifier": "failure" } } ]
    }]
  }]
}
```
**Response Before:**
```json
{
  "error": {
    "kind": "bad_request",
    "message": "Could not create the new policy - Validation failed: MiqPolicy: Towhat is not included in the list",
    "klass": "Api::BadRequestError"
  }
}
```
_**Note the error message:** "Towhat is not included in the list"_  

**Response After:**
```json
{
  "error": {
    "kind": "bad_request",
    "message": "Could not create the new policy - Validation failed: MiqPolicy: Towhat should be one of ContainerGroup, ContainerImage, ContainerNode, ContainerProject, ContainerReplicator, ExtManagementSystem, Host, PhysicalServer, Vm",
    "klass": "Api::BadRequestError"
  }
}
```
_**Note the error message:** "Towhat should be one of ContainerGroup, ContainerImage, ContainerNode, ContainerProject, ContainerReplicator, ExtManagementSystem, Host, PhysicalServer, Vm"_  