### PR TITLE
Remove unnecessary code from MiqRequest#update_request_status

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -376,8 +376,6 @@ class MiqRequest < ApplicationRecord
       status[p.status] += 1
       total += 1
     end
-    unknown_state = task_count - total
-    states["unknown"] = unknown_state unless unknown_state.zero?
     msg = states.sort.collect { |s| "#{s[0].capitalize} = #{s[1]}" }.join("; ")
 
     req_state = (states.length == 1) ? states.keys.first : "active"

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -368,13 +368,11 @@ class MiqRequest < ApplicationRecord
   def update_request_status
     states = Hash.new { |h, k| h[k] = 0 }
     status = Hash.new { |h, k| h[k] = 0 }
-    total  = 0
 
     task_count = miq_request_tasks.count
     miq_request_tasks.each do |p|
       states[p.state] += 1
       status[p.status] += 1
-      total += 1
     end
     msg = states.sort.collect { |s| "#{s[0].capitalize} = #{s[1]}" }.join("; ")
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -368,14 +368,14 @@ class MiqRequest < ApplicationRecord
   def update_request_status
     states = Hash.new { |h, k| h[k] = 0 }
     status = Hash.new { |h, k| h[k] = 0 }
+    total  = 0
 
     task_count = miq_request_tasks.count
     miq_request_tasks.each do |p|
       states[p.state] += 1
-      states[:total] += 1
       status[p.status] += 1
+      total += 1
     end
-    total = states.delete(:total).to_i
     unknown_state = task_count - total
     states["unknown"] = unknown_state unless unknown_state.zero?
     msg = states.sort.collect { |s| "#{s[0].capitalize} = #{s[1]}" }.join("; ")


### PR DESCRIPTION
While reviewing a PR, this `total` code caught my eye and didn't seem to be necessary