### PR TITLE
Restore an event for the main app logs' disk usage

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -101,15 +101,16 @@ module MiqServer::EnvironmentManagement
     disks.each do |disk|
       next unless disk[:used_bytes_percent].to_i > threshold
       disk_usage_event = case disk[:mount_point].chomp
-                         when '/'                then 'evm_server_system_disk_high_usage'
-                         when '/boot'            then 'evm_server_boot_disk_high_usage'
-                         when '/home'            then 'evm_server_home_disk_high_usage'
-                         when '/var'             then 'evm_server_var_disk_high_usage'
-                         when '/var/log'         then 'evm_server_var_log_disk_high_usage'
-                         when '/var/log/audit'   then 'evm_server_var_log_audit_disk_high_usage'
-                         when '/var/www/miq_tmp' then 'evm_server_miq_tmp_disk_high_usage'
-                         when '/tmp'             then 'evm_server_tmp_disk_high_usage'
-                         when %r{lib/pgsql}      then 'evm_server_db_disk_high_usage'
+                         when '/'                     then 'evm_server_system_disk_high_usage'
+                         when '/boot'                 then 'evm_server_boot_disk_high_usage'
+                         when '/home'                 then 'evm_server_home_disk_high_usage'
+                         when '/var'                  then 'evm_server_var_disk_high_usage'
+                         when '/var/log'              then 'evm_server_var_log_disk_high_usage'
+                         when '/var/log/audit'        then 'evm_server_var_log_audit_disk_high_usage'
+                         when '/var/www/miq/vmdb/log' then 'evm_server_log_disk_high_usage'
+                         when '/var/www/miq_tmp'      then 'evm_server_miq_tmp_disk_high_usage'
+                         when '/tmp'                  then 'evm_server_tmp_disk_high_usage'
+                         when %r{lib/pgsql}           then 'evm_server_db_disk_high_usage'
                          end
 
       next unless disk_usage_event

--- a/db/fixtures/miq_event_definitions.csv
+++ b/db/fixtures/miq_event_definitions.csv
@@ -21,6 +21,7 @@ evm_server_home_disk_high_usage,Server High /home Disk Usage,Default,evm_operati
 evm_server_var_disk_high_usage,Server High /var Disk Usage,Default,evm_operations
 evm_server_var_log_disk_high_usage,Server High /var/log Disk Usage,Default,evm_operations
 evm_server_var_log_audit_disk_high_usage,Server High /var/log/audit Disk Usage,Default,evm_operations
+evm_server_log_disk_high_usage,Server High /var/www/miq/vmdb/log Disk Usage,Default,evm_operations
 evm_server_miq_tmp_disk_high_usage,Server High Temp Storage Disk Usage,Default,evm_operations
 evm_server_tmp_disk_high_usage,Server High /tmp Disk Usage,Default,evm_operations
 evm_server_db_disk_high_usage,Server High DB Disk Usage,Default,evm_operations


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1658670

Although removed in https://github.com/ManageIQ/manageiq/pull/5551 and
related appliance PRs, it's quite possible that users could mount their own
disk at this moint point and would want to monitor for this event.  It's
trivial processing to skip it if they don't have a disk mounted at this
location.

The description of the event needed to be changed to include the full
log path to make it less ambiguous with the other "log" disk usage events.