### PR TITLE
Do not report an error in websocket_log when closing a VNC connection

### DIFF
--- a/lib/websocket_server.rb
+++ b/lib/websocket_server.rb
@@ -39,7 +39,7 @@ class WebsocketServer
         @proxy.each_ready do |left, right|
           begin
             @adapters[left].fetch(64.kilobytes) { |data| @adapters[right].issue(data) } # left -> right
-          rescue IOError
+          rescue IOError, IO::WaitReadable, IO::WaitWritable
             cleanup(:info, "Closing websocket proxy for VM %{vm_id}", left, right)
           rescue StandardError => ex
             cleanup(:error, "Websocket proxy for VM %{vm_id} errored with #{ex} #{ex.backtrace.join("\n")}", left, right)


### PR DESCRIPTION
When closing a VNC console, the transmission block (1) can throw an `IO::WaitWritable` or with an even higher probability an `IO::WaitReadable` exception. These are not inherited from the `IOError`, so the cleanup will not treat this a closed exception (2) but as an error (3).

```ruby
begin
  # transmission (1)
rescue IOError
  # clean up closed connection (2)
rescue StandardError => ex
  # clean up error (3)
end
```
The cleanup function is the same for both (2) and (3), the only difference is the way how we report them into the websocket log, That's the problem I'm trying to fix here by adding the 2 exception classes into (2).

@miq-bot add_label bug, providers/console, hammer/no
@miq-bot add_reviewer @djberg96, @kbrock @jrafanie 