### PR TITLE
Re-raise the LoadError if it is not for the file we are trying to load

### DIFF
--- a/lib/extensions/as_include_concern.rb
+++ b/lib/extensions/as_include_concern.rb
@@ -49,7 +49,8 @@ module ActiveSupport
         begin
           to_include = "#{name}::#{mod}"
           require_dependency to_include.underscore
-        rescue LoadError
+        rescue LoadError => err
+          raise unless err.message.include?(to_include.underscore)
           to_include = mod
           require_dependency to_include.underscore
         end


### PR DESCRIPTION
Previously this could mask LoadErrors when the file we are trying to load is found and loaded, but it requires another file which is not found, raises LoadError and incorrectly runs the code in the rescue block.