### PR TITLE
Support EmsCuster#total_direct_miq_templates in sql

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -134,7 +134,7 @@ class EmsCluster < ApplicationRecord
   end
 
   virtual_total :total_direct_vms, :direct_vm_rels
-  virtual_total :total_direct_miq_templates, :direct_miq_templates
+  virtual_total :total_direct_miq_templates, :miq_templates
 
   def total_direct_vms_and_templates
     total_direct_vms + total_direct_miq_templates


### PR DESCRIPTION
given:

```ruby
  alias_method :direct_miq_templates, :miq_templates
```

implies: a total of one is the same as the total of the other.

The difference being that `miq_templates` are actually an association
So it is sql friendly, so this can now be in subqueries, sorts, and the like.

The individual count is no better, it is just the ability to be in a query for a report/view that we get the biggest win.

### Before

```ruby
EmsCluster.attribute_supported_by_sql?(:total_direct_miq_templates)
# => false  
```

### After

```ruby
EmsCluster.attribute_supported_by_sql?(:total_direct_miq_templates)
# => true  
```

I saw this while working an another relationship.

```
EmsCluster.select(:id, :name, :total_direct_miq_templates).map { |ec| "#{ec.name}: #{ec.total_direct_miq_templates}" }
```


|       ms |   bytes | objects |query |  qry ms |     rows |comments
|      ---:|     ---:|     ---:|  ---:|     ---:|      ---:| ---
|     69.7 | 1,006,322* |  13,434 |   11 |    10.8 |       10 |before
|     33.7 | 81,215* |   1,003 |    1 |     4.6 |       10 |after
| 51.6% | 92% | 93% | 91% | 57.4% | - | diff

of note, the 10 extra queries were `count(*)` - which does not reflect in the `rows` column (but in essence the rows was more like 20 before - 10 ems records and 10 individual integer counts

