### PR TITLE
Miq expression remove unused attributes

### DIFF
--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2792,6 +2792,18 @@ describe MiqExpression do
   end
 
   describe ".get_col_info" do
+    it "return column info for missing model" do
+      field = "hostname"
+      col_info = described_class.get_col_info(field)
+      expect(col_info).to match(
+        :data_type                      => nil,
+        :excluded_by_preprocess_options => false,
+        :include                        => {},
+        :tag                            => false,
+        :sql_support                    => false,
+      )
+    end
+
     it "return column info for model-virtual field" do
       field = "VmInfra-uncommitted_storage"
       col_info = described_class.get_col_info(field)
@@ -2831,6 +2843,7 @@ describe MiqExpression do
       )
     end
 
+    # TODO: think this should return same results as missing model?
     it "return column info for managed-field" do
       tag = "managed-location"
       col_info = described_class.get_col_info(tag)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2801,9 +2801,7 @@ describe MiqExpression do
         :format_sub_type                => :bytes,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => true,
         :sql_support                    => false,
-        :virtual_reflection             => false
       )
     end
 
@@ -2816,9 +2814,7 @@ describe MiqExpression do
         :format_sub_type                => :boolean,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => true,
         :sql_support                    => true,
-        :virtual_reflection             => false
       )
     end
 
@@ -2831,9 +2827,7 @@ describe MiqExpression do
         :format_sub_type                => nil,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => false,
         :sql_support                    => false,
-        :virtual_reflection             => false
       )
     end
 
@@ -2845,9 +2839,7 @@ describe MiqExpression do
         :excluded_by_preprocess_options => false,
         :include                        => {},
         :tag                            => true,
-        :virtual_column                 => false,
         :sql_support                    => true,
-        :virtual_reflection             => false
       )
     end
 
@@ -2859,9 +2851,7 @@ describe MiqExpression do
         :excluded_by_preprocess_options => false,
         :include                        => {},
         :tag                            => true,
-        :virtual_column                 => false,
         :sql_support                    => true,
-        :virtual_reflection             => false
       )
     end
 
@@ -2873,9 +2863,7 @@ describe MiqExpression do
         :excluded_by_preprocess_options => false,
         :include                        => {},
         :tag                            => true,
-        :virtual_column                 => false,
         :sql_support                    => true,
-        :virtual_reflection             => false
       )
     end
 
@@ -2888,9 +2876,7 @@ describe MiqExpression do
         :format_sub_type                => :integer,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => false,
         :sql_support                    => true,
-        :virtual_reflection             => false
       )
     end
 
@@ -2903,9 +2889,7 @@ describe MiqExpression do
         :format_sub_type                => :string,
         :include                        => {:guest_applications => {}},
         :tag                            => false,
-        :virtual_column                 => false,
         :sql_support                    => true,
-        :virtual_reflection             => false
       )
     end
 
@@ -2918,9 +2902,7 @@ describe MiqExpression do
         :format_sub_type                => :bytes,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => true,
         :sql_support                    => false,
-        :virtual_reflection             => true
       )
     end
 
@@ -2933,9 +2915,7 @@ describe MiqExpression do
         :format_sub_type                => nil,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => false,
         :sql_support                    => false,
-        :virtual_reflection             => true
       )
     end
 
@@ -2947,9 +2927,7 @@ describe MiqExpression do
         :excluded_by_preprocess_options => false,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => true,
         :sql_support                    => false,
-        :virtual_reflection             => true
       )
     end
 
@@ -2962,9 +2940,7 @@ describe MiqExpression do
         :format_sub_type                => :boolean,
         :include                        => {},
         :tag                            => false,
-        :virtual_column                 => true,
         :sql_support                    => false,
-        :virtual_reflection             => true
       )
     end
   end


### PR DESCRIPTION
extracted #13446

`get_col_info(field)` tells us if a field is a `:virtual_column` (aka `virtual_attribute`) or accessed through a `:virtual_relation`. This lets us know if the report sql can contain the field.

A few years ago, the code has been simplified to directly ask the question at hand "is this field supported by sql?" (aka `:sql_support`). There is no need to keep these old attributes around. Especially since the logic behind `:sql_support` has been getting more and more complicated over the years.

This PR removes the unused attributes.
The `api/reports` does share the attributes from a report. so this will trim that down.

Do note, that `MiqExpression.get_col_info` has a ton of tests (as you can see by all the removed lines in the spec)