### PR TITLE
MiqExpression column info include

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -451,7 +451,7 @@ class MiqExpression
       return result
     end
 
-    f.collect_reflections.map(&:name).inject(result[:include]) { |a, p| a[p] ||= {} }
+    result[:include] = f.includes
 
     if f.column
       result[:data_type] = f.column_type

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -457,22 +457,12 @@ class MiqExpression
       result[:data_type] = f.column_type
       result[:format_sub_type] = f.sub_type
       result[:sql_support] = f.attribute_supported_by_sql?
-      result[:excluded_by_preprocess_options] = exclude_col_by_preprocess_options?(f, options)
+      result[:excluded_by_preprocess_options] = f.exclude_col_by_preprocess_options?(options)
     end
     result
   rescue ArgumentError
     result[:sql_support] = false
     result
-  end
-
-  def self.exclude_col_by_preprocess_options?(field, options)
-    if options.kind_of?(Hash) && options[:vim_performance_daily_adhoc]
-      Metric::Rollup.excluded_col_for_expression?(field.column.to_sym)
-    elsif field.target == Service
-      Service::AGGREGATE_ALL_VM_ATTRS.include?(field.column.to_sym)
-    else
-      false
-    end
   end
 
   def lenient_evaluate(obj, tz = nil)

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -54,7 +54,7 @@ class MiqExpression::Target
   end
 
   def reflection_supported_by_sql?
-    model.follow_associations(associations).present?
+    model&.follow_associations(associations).present?
   end
 
   # AR or virtual reflections
@@ -67,6 +67,12 @@ class MiqExpression::Target
   def collect_reflections
     model.collect_reflections(associations) ||
       raise(ArgumentError, "One or more associations are invalid: #{associations.join(", ")}")
+  end
+
+  def includes
+    ret = {}
+    model && collect_reflections.map(&:name).inject(ret) { |a, p| a[p] ||= {} }
+    ret
   end
 
   def target

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -88,6 +88,16 @@ class MiqExpression::Target
     "#{tag_path}#{value.nil? ? '' : '/' + value.to_s.gsub(/\//, "%2f")}"
   end
 
+  def exclude_col_by_preprocess_options?(options)
+    if options.kind_of?(Hash) && options[:vim_performance_daily_adhoc]
+      Metric::Rollup.excluded_col_for_expression?(column.to_sym)
+    elsif target == Service
+      Service::AGGREGATE_ALL_VM_ATTRS.include?(column.to_sym)
+    else
+      false
+    end
+  end
+
   private
 
   def tag_path


### PR DESCRIPTION
Part of #13446 

The high level goal is to remove all the sql meta-data methods from `MiqExpression` and have `Field` support all these meta-data requests.

This PR moves the `include` and `excluded_by_preprocess_options` logic and put into `Field`