### PR TITLE
Add retired to service active states

### DIFF
--- a/app/models/service_retire_request.rb
+++ b/app/models/service_retire_request.rb
@@ -1,6 +1,7 @@
 class ServiceRetireRequest < MiqRetireRequest
   TASK_DESCRIPTION  = 'Service Retire'.freeze
   SOURCE_CLASS_NAME = 'Service'.freeze
+  ACTIVE_STATES     = %w(retired) + base_class::ACTIVE_STATES
 
   delegate :service_template, :to => :source, :allow_nil => true
 end


### PR DESCRIPTION
We validate the request state in https://github.com/ManageIQ/manageiq/blob/33d994ae207105a508d9e214d39d9ec66ac066dd/app/models/miq_retire_request.rb#L3 but vms can be provisioned, so the list should include that, and services can be retired, so it should include that too.

Should've been a part of https://github.com/ManageIQ/manageiq/pull/18283. 