### PR TITLE
simplify MiqWorker.server_scope

### DIFF
--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -242,17 +242,6 @@ describe MiqWorker do
       expect(described_class.server_scope).to eq([@worker])
     end
 
-    it ".server_scope with a different server" do
-      expect(described_class.server_scope(@server2.id)).to eq([@worker2])
-    end
-
-    it ".server_scope after already scoping on a different server" do
-      described_class.where(:miq_server_id => @server2.id).scoping do
-        expect(described_class.server_scope).to eq([@worker2])
-        expect(described_class.server_scope(@server.id)).to eq([@worker2])
-      end
-    end
-
     describe "#worker_settings" do
       let(:config1) do
         {


### PR DESCRIPTION
I was attempting to add `cache_with_timeout` to `MiqWorker.server_scope`.
I'm still not sure if that is a good idea, but removing the `server_id` from this scope sure simplifies the worker's api.

This was hanging out in my local branches for over a year.
If you are hesitant here, just say so and we can delete this PR.

thnx

/cc @carbonin Think you are the one who would feel the most strongly about this one way or another. (or @jrafanie I guess)