### PR TITLE
Improve spec for non-dynamic product feature

### DIFF
--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -80,6 +80,7 @@ describe MiqUserRole do
 
       let!(:tenant_1) { FactoryBot.create(:tenant, :parent => root_tenant) }
       let!(:tenant_2) { FactoryBot.create(:tenant, :parent => root_tenant) }
+      let!(:tenant_3) { FactoryBot.create(:tenant, :parent => root_tenant) }
 
       let(:feature)             { MiqProductFeature.find_all_by_identifier(["dialog_edit_editor_tenant_#{tenant_2.id}", "rbac_tenant_manage_quotas_tenant_#{tenant_2.id}"]) }
       let(:non_dynamic_feature) { MiqProductFeature.find_all_by_identifier(["dialog_edit_editor", "rbac_tenant_manage_quotas"]) }
@@ -87,7 +88,7 @@ describe MiqUserRole do
       let(:role_no_dynamic) { FactoryBot.create(:miq_user_role, :miq_product_features => non_dynamic_feature) }
       let(:group_tenant_1) { FactoryBot.create(:miq_group, :miq_user_role => role, :tenant => tenant_1) }
       let(:group_tenant_2) { FactoryBot.create(:miq_group, :miq_user_role => role, :tenant => tenant_2) }
-      let(:group_3)        { FactoryBot.create(:miq_group, :miq_user_role => role_no_dynamic, :tenant => tenant_2) }
+      let(:group_3)        { FactoryBot.create(:miq_group, :miq_user_role => role_no_dynamic, :tenant => tenant_3) }
       let!(:user_1) { FactoryBot.create(:user, :userid => "user_1", :miq_groups => [group_tenant_1]) }
       let!(:user_2) { FactoryBot.create(:user, :userid => "user_2", :miq_groups => [group_tenant_2]) }
       let!(:user_3) { FactoryBot.create(:user, :userid => "user_3", :miq_groups => [group_3]) }
@@ -107,6 +108,8 @@ describe MiqUserRole do
       end
 
       it "authorize user with non-dynamic product feature" do
+        MiqProductFeature.where(:identifier => ["dialog_edit_editor_tenant_#{tenant_3.id}", "rbac_tenant_manage_quotas_tenant_#{tenant_3.id}"]).destroy_all
+
         User.with_user(user_3) do
           expect(user_3.role_allows?(:identifier => "dialog_edit_editor")).to be_truthy
           expect(user_3.role_allows?(:identifier => "rbac_tenant_manage_quotas")).to be_truthy


### PR DESCRIPTION
Authorization for user with non-dynamic product feature if included in user's role was added [here](https://github.com/ManageIQ/manageiq/pull/18179)

we need to update spec to hit this [code](https://github.com/ManageIQ/manageiq/pull/18179/files#diff-59b5e7d642867a7e9775d5eca9708e44R30) 

when 
`user_role_allows?(user, :identifier => tenant_identifier)` is false
(from `[identifier, tenant_identifier].any? { |i| user_role_allows?(user, :identifier => i) }`)

Links 
-----

* https://github.com/ManageIQ/manageiq/pull/18179

@miq-bot assign @gtanzillo 
@miq-bot add_label  test, technical debt

