### PR TITLE
Performance improvements to MiqProvisionVirtWorkflow#allowed_templates

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -339,6 +339,9 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
       end
     end
 
+    # Only select the colums we need
+    vms = vms.select(:id, :name, :guid, :uid_ems, :ems_id)
+
     allowed_templates_list = source_vm_rbac_filter(vms, condition, VM_OR_TEMPLATE_EXTRA_COLS).to_a
     @allowed_templates_filter = filter_id
     @allowed_templates_tag_filters = @values[:vm_tags]

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -340,7 +340,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
 
     # Only select the colums we need
-    vms = vms.select(:id, :name, :guid, :uid_ems, :ems_id)
+    vms = vms.select(:id, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
 
     allowed_templates_list = source_vm_rbac_filter(vms, condition, VM_OR_TEMPLATE_EXTRA_COLS).to_a
     @allowed_templates_filter = filter_id
@@ -1046,7 +1046,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
                  :allocated_disk_storage => vm_or_template.allocated_disk_storage,
                  :v_total_snapshots      => vm_or_template.v_total_snapshots,
                  :evm_object_class       => :Vm}
-    data_hash[:cloud_tenant] = vm_or_template.cloud_tenant if vm_or_template.respond_to?(:cloud_tenant)
+    data_hash[:cloud_tenant] = vm_or_template.cloud_tenant if vm_or_template.cloud_tenant_id
     if vm_or_template.operating_system
       data_hash[:operating_system] = MiqHashStruct.new(:product_name => vm_or_template.operating_system.product_name)
     end

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -342,14 +342,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     @allowed_templates_filter = filter_id
     @allowed_templates_tag_filters = @values[:vm_tags]
     rails_logger('allowed_templates', 1)
-    if allowed_templates_list.blank?
-      _log.warn("Allowed Templates is returning an empty list")
-    else
-      _log.warn("Allowed Templates is returning <#{allowed_templates_list.length}> template(s)")
-      allowed_templates_list.each do |vm|
-        _log.debug("Allowed Template <#{vm.id}:#{vm.name}>  GUID: <#{vm.guid}>  UID_EMS: <#{vm.uid_ems}>")
-      end
-    end
+    log_allowed_template_list(allowed_templates_list)
 
     MiqPreloader.preload(allowed_templates_list, [:snapshots, :operating_system, :ext_management_system, {:hardware => :disks}])
     @allowed_templates_cache = allowed_templates_list.collect do |template|
@@ -1093,5 +1086,18 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   def selected_host(src)
     raise _("Unable to find Host with Id: [%{id}]") % {:id => src[:host_id]} if src[:host].nil?
     [load_ar_obj(src[:host])]
+  end
+
+  def log_allowed_template_list(template_list)
+    if template_list.blank?
+      _log.warn("Allowed Templates is returning an empty list")
+    else
+      _log.warn("Allowed Templates is returning <#{template_list.length}> template(s)")
+      if _log.level == Logger::DEBUG # skip .each if not in DEBUG
+        template_list.each do |vm|
+          _log.debug("Allowed Template <#{vm.id}:#{vm.name}>  GUID: <#{vm.guid}>  UID_EMS: <#{vm.uid_ems}>")
+        end
+      end
+    end
   end
 end

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -1042,18 +1042,17 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
                  :v_total_snapshots      => vm_or_template.v_total_snapshots,
                  :evm_object_class       => :Vm}
     data_hash[:cloud_tenant] = vm_or_template.cloud_tenant if vm_or_template.respond_to?(:cloud_tenant)
-    hash_struct = MiqHashStruct.new(data_hash)
-    hash_struct.operating_system = MiqHashStruct.new(
-      :product_name => vm_or_template.operating_system.product_name
-    ) if vm_or_template.operating_system
-    hash_struct.ext_management_system = MiqHashStruct.new(
-      :name => vm_or_template.ext_management_system.name
-    ) if vm_or_template.ext_management_system
+    if vm_or_template.operating_system
+      data_hash[:operating_system] = MiqHashStruct.new(:product_name => vm_or_template.operating_system.product_name)
+    end
+    if vm_or_template.ems_id
+      data_hash[:ext_management_system] = MiqHashStruct.new(:name => vm_or_template.ext_management_system.name)
+    end
     if options[:include_datacenter] == true
-      hash_struct.datacenter_name = vm_or_template.owning_blue_folder.try(:parent_datacenter).try(:name)
+      data_hash[:datacenter_name] = vm_or_template.owning_blue_folder.try(:parent_datacenter).try(:name)
     end
 
-    hash_struct
+    MiqHashStruct.new(data_hash)
   end
 
   def exit_pre_dialog


### PR DESCRIPTION
This PR introduces a number of improvements to the `MiqProvisionVirtWorkflow#allowed_templates`, and specifically is beneficial to environments that have EMS's with lots of templates (Amazon in particular when public images are included).

These changes specifically do as much as possible without trying to change anything in the database, but a follow up PR (will be posted shortly) will take these changes further with a few database modifications.


Notable Changes
---------------

* Limit preloading and prefer virtual attributes (60% drop in processing, 1Gig drop in MEM usage)
* Use hash cache for EMS relations instead of preload (Additional 5% drop in processing time)
* Limit VM columns pulled back (Additional 10% drop in processing time, 500MB drop in MEM usage)

More specific numbers in the commit messages.


Links
-----

* Partially Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1662972
* Related:
  - https://github.com/ManageIQ/manageiq/pull/18354
  - https://github.com/ManageIQ/manageiq-schema/pull/322


Steps for Testing/QA
--------------------

The main pain points with this can be recreated with a single AWS EMS that has public images enabled, and has had it's initial refresh.

I was using a combination of this script for testing the full routes:

```console
$ cat script_1
ActiveRecord::Base.logger = Logger.new(STDOUT).tap {|l| l.level = Logger::INFO }

Rails.application.load_console
Rails.env = ENV["RAILS_ENV"]
include Rails::ConsoleMethods
MiqUiWorker.preload_for_console # required


app.post "/dashboard/authenticate", :params => { :user_name => "admin", :user_password => "smartvm" }
app.get  "/vm_cloud/explorer"
csrf_token = app.response.body.match(/.*csrf-token.*content="(?<CSRF_TOKEN>[^"]*)"/)[:CSRF_TOKEN]

headers = { :"X-CSRF-Token" => csrf_token }
app.post "/vm_cloud/x_button?pressed=instance_miq_request_new", :headers => headers
app.post "/miq_request/pre_prov/?sel_id=3192",                  :headers => headers
app.post "/vm_cloud/pre_prov?button=continue",                  :headers => headers
$ bin/rails r script_1
```

And this one, which tested `MiqProvisionVirtWorkflow#allowed_templates` on it's own:

```console
$ cat script_2
user     = User.find(1)
wf_klass = ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow
workflow = wf_klass.new({}, user, { :initial_pass => true, :src_vm_id => [1] })

dialog_options =  {
  :initial_pass            => true,
  :src_vm_id               => [ 1, "[SOME AWS PUBLIC IMAGE NAME HERE]" ],
  :miq_request_dialog_name => "miq_provision_amazon_dialogs_template",
  :customize_enabled       => [ "enabled" ],
  :current_tab_key         => :requester
}

profile do # use whatever profiler you want here
  workflow.init_from_dialog dialog_options
end
$ bin/rails r script_2
```