### PR TITLE
[POC][WIP] Make use of platform column to further increase the speed of #allowed_templates

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -300,7 +300,13 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     :vm_tags
   end
 
-  VM_OR_TEMPLATE_EXTRA_COLS = %i[mem_cpu cpu_total_cores v_total_snapshots allocated_disk_storage].freeze
+  VM_OR_TEMPLATE_EXTRA_COLS = %i[
+    platform
+    mem_cpu
+    cpu_total_cores
+    v_total_snapshots
+    allocated_disk_storage
+  ].freeze
   def allowed_templates(options = {})
     # Return pre-selected VM if we are called for cloning
     if [:clone_to_vm, :clone_to_template].include?(request_type)
@@ -348,7 +354,6 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     rails_logger('allowed_templates', 1)
     log_allowed_template_list(allowed_templates_list)
 
-    MiqPreloader.preload(allowed_templates_list, [:operating_system])
     @_ems_allowed_templates_cache = {}
     @allowed_templates_cache = allowed_templates_list.collect do |template|
       create_hash_struct_from_vm_or_template(template, options)
@@ -1048,7 +1053,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
                  :evm_object_class       => :Vm}
     data_hash[:cloud_tenant] = vm_or_template.cloud_tenant if vm_or_template.cloud_tenant_id
     if vm_or_template.operating_system
-      data_hash[:operating_system] = MiqHashStruct.new(:product_name => vm_or_template.operating_system.product_name)
+      data_hash[:operating_system] = MiqHashStruct.new(:product_name => vm_or_template.operating_system_product_name)
     end
     if options[:include_datacenter] == true
       data_hash[:datacenter_name] = vm_or_template.owning_blue_folder.try(:parent_datacenter).try(:name)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -169,6 +169,8 @@ class VmOrTemplate < ApplicationRecord
   virtual_delegate :name, :to => :host, :prefix => true, :allow_nil => true, :type => :string
   virtual_delegate :name, :to => :storage, :prefix => true, :allow_nil => true, :type => :string
   virtual_delegate :name, :to => :ems_cluster, :prefix => true, :allow_nil => true, :type => :string
+  virtual_delegate :platform, :to => :operating_system, :allow_nil => true
+  virtual_delegate :product_name, :to => :operating_system, :prefix => true, :allow_nil => true
   virtual_delegate :vmm_product, :to => :host, :prefix => :v_host, :allow_nil => true, :type => :string
   virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true, :type => :float
   virtual_delegate :num_cpu, :to => "hardware.cpu_sockets", :allow_nil => true, :default => 0, :type => :integer
@@ -532,7 +534,8 @@ class VmOrTemplate < ApplicationRecord
   end
 
   def platform
-    name = OperatingSystem.platform(self)
+    name   = self[:platform] if has_attribute?(:platform)
+    name ||= OperatingSystem.platform(self)
     if name == 'unknown'
       parent = genealogy_parent
       name = OperatingSystem.platform(parent) unless parent.nil?


### PR DESCRIPTION
**REQUIRES https://github.com/ManageIQ/manageiq-schema/pull/322 TO FUNCTION PROPERLY**

(Will also require a pre-requisite PR to properly add before save hooks to models)

By adding a few key `virtual_attributes`, we are able to process over 100k records for `MiqProvisionVirtWorkflow#allowed_templates` in under 5 seconds, and use very limited memory.  There are still a few things required to make this work in all cases, but the main changes required after the update include:

* Make use of `virtual_delegate :platform` to avoid preloading of `OperatingSystem` records for `VmOrTemplate` records.
* Since models are not used, switch to pulling back records as hashes, and make use of those results for creating `MiqHashStruct` results


Benchmarks
----------

Note, metrics are taken only around the `#allowed_templates` method, so extra memory and time to process the rest of the request is not currently being shown.

**PR https://github.com/ManageIQ/manageiq/pull/18353 Improvements**


Memory: ~1.2Gigs

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
|  27107 |      33 |     1958.5 | 243133 |
|  26803 |      33 |     1944.2 | 243133 |
|  27642 |      33 |     1965.5 | 243133 |

**After switching to `virtual_delegate :platform` in `SELECT`**

Memory: ~900MB

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
|  14344 |      33 |     1759.6 | 243133 |
|  14631 |      33 |     1729.0 | 243133 |
|  13405 |      33 |     1752.3 | 243133 |

**After skipping `ActiveRecord` objects**

Memory: ~400MB

|     ms | queries | query (ms) |   rows |
|   ---: |    ---: |       ---: |   ---: |
|   4102 |      33 |     1751.3 | 243133 |
|   4124 |      33 |     1787.1 | 243133 |
|   4133 |      33 |     1746.9 | 243133 |


TODO
----

* [ ] There are still a few spots that don't fully support pure hashes that need to be addressed


Links
-----

* Additional Fixes for:  https://bugzilla.redhat.com/show_bug.cgi?id=1662972
* Requires Schema migration:  https://github.com/ManageIQ/manageiq-schema/pull/322
* Built on top of:  https://github.com/ManageIQ/manageiq/pull/18353


Steps for Testing/QA
--------------------

Just like https://github.com/ManageIQ/manageiq/pull/18353 I was using a combination of this script for testing the full routes:

```console
$ cat script_1
ActiveRecord::Base.logger = Logger.new(STDOUT).tap {|l| l.level = Logger::INFO }

Rails.application.load_console
Rails.env = ENV["RAILS_ENV"]
include Rails::ConsoleMethods
MiqUiWorker.preload_for_console # required


app.post "/dashboard/authenticate", :params => { :user_name => "admin", :user_password => "smartvm" }
app.get  "/vm_cloud/explorer"
csrf_token = app.response.body.match(/.*csrf-token.*content="(?<CSRF_TOKEN>[^"]*)"/)[:CSRF_TOKEN]

headers = { :"X-CSRF-Token" => csrf_token }
app.post "/vm_cloud/x_button?pressed=instance_miq_request_new", :headers => headers
app.post "/miq_request/pre_prov/?sel_id=3192",                  :headers => headers
app.post "/vm_cloud/pre_prov?button=continue",                  :headers => headers
$ bin/rails r script_1
```

And this one, which tested `MiqProvisionVirtWorkflow#allowed_templates` on it's own:

```console
$ cat script_2
user     = User.find(1)
wf_klass = ManageIQ::Providers::Amazon::CloudManager::ProvisionWorkflow
workflow = wf_klass.new({}, user, { :initial_pass => true, :src_vm_id => [1] })

dialog_options =  {
  :initial_pass            => true,
  :src_vm_id               => [ 1, "[SOME AWS PUBLIC IMAGE NAME HERE]" ],
  :miq_request_dialog_name => "miq_provision_amazon_dialogs_template",
  :customize_enabled       => [ "enabled" ],
  :current_tab_key         => :requester
}

profile do # use whatever profiler you want here
  workflow.init_from_dialog dialog_options
end
$ bin/rails r script_2
```