### PR TITLE
make Field/Target consistent with get_col_info

### DIFF
--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -41,6 +41,9 @@ class MiqExpression::Tag < MiqExpression::Target
   end
 
   def attribute_supported_by_sql?
+    reflection_supported_by_sql?
+  rescue ArgumentError
+    # the association chain is not legal, so no, it is not supported by sql
     false
   end
 

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -128,6 +128,10 @@ class MiqExpression::Target
     target&.arel_attribute(column, arel_table)
   end
 
+  def virtual_attribute?
+    false
+  end
+
   private
 
   def tag_path

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -157,8 +157,12 @@ RSpec.describe MiqExpression::Tag do
   end
 
   describe "#attribute_supported_by_sql?" do
-    it "is always false" do
-      expect(described_class.new(Vm, [], "host")).not_to be_attribute_supported_by_sql
+    it "is supported by sql" do
+      expect(described_class.new(Vm, [], "host")).to be_attribute_supported_by_sql
+    end
+
+    it "is not supported by sql" do
+      expect(described_class.new(Vm, ['bogus'], "host")).not_to be_attribute_supported_by_sql
     end
   end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2905,15 +2905,16 @@ RSpec.describe MiqExpression do
     end
 
     # TODO: think this should return same results as missing model?
-    it "return column info for managed-field" do
+    it "return column info for managed-field (no model)" do
       tag = "managed-location"
       col_info = described_class.get_col_info(tag)
       expect(col_info).to match(
         :data_type                      => :string,
         :excluded_by_preprocess_options => false,
+        :format_sub_type                => :string,
         :include                        => {},
         :tag                            => true,
-        :sql_support                    => true,
+        :sql_support                    => false,
       )
     end
 
@@ -2923,6 +2924,7 @@ RSpec.describe MiqExpression do
       expect(col_info).to match(
         :data_type                      => :string,
         :excluded_by_preprocess_options => false,
+        :format_sub_type                => :string,
         :include                        => {},
         :tag                            => true,
         :sql_support                    => true,
@@ -2935,7 +2937,8 @@ RSpec.describe MiqExpression do
       expect(col_info).to match(
         :data_type                      => :string,
         :excluded_by_preprocess_options => false,
-        :include                        => {},
+        :format_sub_type                => :string,
+        :include                        => {:host => {}},
         :tag                            => true,
         :sql_support                    => true,
       )


### PR DESCRIPTION
## High level

`MiqExpression` has 2 different interfaces for fetching the metadata on a report column.

```ruby
MiqExpression.get_col_info("Vm.host-name")[:sql_support] # old
MiqExpression.parse_field_or_tag("Vm.host-name").attribute_supported_by_sql? # new
```

We are transitioning from the first towards the second.
For this to happen, there needs to be a template for transitioning and the values returned from both methods need to be the same.

## Issue

For some method calls, the two methods return different results. So the goal of this PR is to determine which of the two values is correct and return the proper value from both methods.

We have decided upon these correct answers:

1. For valid associations, `tags` are `supported_by_sql` (added both valid and invalid test cases here)
2. We need to `include` associated model to get managed fields from an associated table.
3. An invalid query is not `supported_by_sql`
4. Properly error when asking for a managed field but not specifying the source model.

Good news: Since this is confusing code with a lot of edge cases, the test cases around this are quite good.


## Follow up

The code provides us a good transition template:

```
  f = parse_field_or_tag(field)
    {
      :include                        => f.includes,
      :data_type                      => f.column_type,
      :format_sub_type                => f.sub_type,
      :sql_support                    => f.attribute_supported_by_sql?,
      :excluded_by_preprocess_options => f.exclude_col_by_preprocess_options?(options),
      :tag                            => f.kind_of?(MiqExpression::Tag),
    }
```

We are down to only a few dozen remaining calls into `get_col_info`, so the transition is almost complete.
We also cache the data in `MiqExpression#col_details`, so those need to be transitioned as well.

These reside in core and manageiq-ui-classic.