### PR TITLE
Override add resource to no-op in service orchestration subclass

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -28,7 +28,8 @@ class ServiceOrchestration < Service
   def deploy_orchestration_stack
     creation_options = stack_options
     @orchestration_stack = ManageIQ::Providers::CloudManager::OrchestrationStack.create_stack(
-      orchestration_manager, stack_name, orchestration_template, creation_options)
+      orchestration_manager, stack_name, orchestration_template, creation_options
+    )
   ensure
     # create options may never be saved before unless they were overridden
     save_create_options
@@ -145,9 +146,11 @@ class ServiceOrchestration < Service
   end
 
   def save_create_options
-    stack_attributes = @orchestration_stack ?
-                       @orchestration_stack.attributes.compact :
-                       {:name => stack_name}
+    stack_attributes = if @orchestration_stack
+                         @orchestration_stack.attributes.compact
+                       else
+                         {:name => stack_name}
+                       end
     stack_attributes.delete('id')
     options.merge!(:orchestration_stack => stack_attributes,
                    :create_options      => dup_and_process_password(stack_options))

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -77,6 +77,11 @@ class ServiceOrchestration < Service
     orchestration_stack.vms
   end
 
+  def add_resource(rsc, _options = {})
+    raise "Service Orchestration subclass does not support add_resource for #{rsc.class.name}" unless rsc.kind_of?(OrchestrationStack)
+    super
+  end
+
   # This is called when provision is completed and stack is added to VMDB through a refresh
   def post_provision_configure
     add_stack_to_resource

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -9,8 +9,8 @@ describe ServiceOrchestration do
 
   let(:service_template) do
     FactoryBot.create(:service_template_orchestration,
-                       :orchestration_manager  => manager_in_st,
-                       :orchestration_template => template_in_st)
+                      :orchestration_manager  => manager_in_st,
+                      :orchestration_template => template_in_st)
   end
 
   let(:dialog_options) do
@@ -27,11 +27,11 @@ describe ServiceOrchestration do
 
   let(:service) do
     FactoryBot.create(:service_orchestration,
-                       :service_template       => service_template,
-                       :orchestration_manager  => manager_in_st,
-                       :orchestration_template => template_in_st,
-                       :evm_owner              => FactoryBot.create(:user),
-                       :miq_group              => FactoryBot.create(:miq_group))
+                      :service_template       => service_template,
+                      :orchestration_manager  => manager_in_st,
+                      :orchestration_template => template_in_st,
+                      :evm_owner              => FactoryBot.create(:user),
+                      :miq_group              => FactoryBot.create(:miq_group))
   end
 
   let(:service_with_dialog_options) do
@@ -98,7 +98,8 @@ describe ServiceOrchestration do
   describe "#stack_options" do
     before do
       allow_any_instance_of(ManageIQ::Providers::Amazon::CloudManager::OrchestrationServiceOptionConverter).to(
-        receive(:stack_create_options).and_return(dialog_options))
+        receive(:stack_create_options).and_return(dialog_options)
+      )
     end
 
     it "gets stack options set by dialog" do
@@ -266,8 +267,8 @@ describe ServiceOrchestration do
 
   describe '#post_provision_configure' do
     before do
-      allow(ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack).to receive(
-        :raw_create_stack).and_return("ems_ref")
+      allow(ManageIQ::Providers::Amazon::CloudManager::OrchestrationStack)
+        .to receive(:raw_create_stack).and_return("ems_ref")
       @resulting_stack = service.deploy_orchestration_stack
 
       service.miq_request_task = FactoryBot.create(:service_template_provision_task)

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -55,6 +55,17 @@ describe ServiceOrchestration do
     end
   end
 
+  describe "#add_resource" do
+    it "doesn't allow service to be added" do
+      expect { service_with_dialog_options.add_resource(FactoryBot.create(:service), {}) }.to raise_error(/Service Orchestration subclass does not support add_resource for/)
+    end
+
+    it "allows stack to be added" do
+      service_with_dialog_options.add_resource(FactoryBot.create(:orchestration_stack))
+      expect(service_with_dialog_options.service_resources.pluck(:resource_type)).to include("OrchestrationStack", "OrchestrationTemplate")
+    end
+  end
+
   describe "#my_zone" do
     it "deployed stack, takes the zone from ext_management_system" do
       deployed_stack.ext_management_system = manager_by_setter


### PR DESCRIPTION
The service orchestration shouldn't be doing ```add_resource``` except for stacks and we should be telling people that they shouldn't try it for things except for stacks. 

It ~~fixes~~ attempts to prevent someone from reopening https://bugzilla.redhat.com/show_bug.cgi?id=1664121