### PR TITLE
Add fullscreen title to MiqReportResult

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -5,6 +5,7 @@ class MiqReportResult < ApplicationRecord
   belongs_to :miq_group
   belongs_to :miq_task
   has_one    :binary_blob, :as => :resource, :dependent => :destroy
+  has_one    :miq_widget_content, :dependent => :nullify
   has_many   :miq_report_result_details, :dependent => :delete_all
   has_many   :html_details, -> { where("data_type = 'html'") }, :class_name => "MiqReportResultDetail", :foreign_key => "miq_report_result_id"
 
@@ -50,6 +51,10 @@ class MiqReportResult < ApplicationRecord
   after_commit { report.extras[:grouping] = @_extra_groupings if report.kind_of?(MiqReport) && report.extras }
 
   delegate :table, :to => :report_results, :allow_nil => true
+
+  def friendly_title
+    report_source == MiqWidget::WIDGET_REPORT_SOURCE && miq_widget_content ? miq_widget_content.miq_widget.title : report.title
+  end
 
   def result_set
     (table || []).map(&:to_hash)

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -34,6 +34,7 @@ class MiqWidget < ApplicationRecord
   acts_as_miq_set_member
 
   WIDGET_DIR =  File.expand_path(File.join(Rails.root, "product/dashboard/widgets"))
+  WIDGET_REPORT_SOURCE = "Generated for widget".freeze
 
   before_destroy :destroy_schedule
 
@@ -318,7 +319,7 @@ class MiqWidget < ApplicationRecord
     userid_for_result = "widget_id_#{id}|#{name}|schedule"
     MiqReportResult.purge_for_user(:userid => userid_for_result)
 
-    rpt.build_create_results(:userid => userid_for_result, :report_source => "Generated for widget", :timezone => timezone, :miq_group_id => group.id)
+    rpt.build_create_results(:userid => userid_for_result, :report_source => WIDGET_REPORT_SOURCE, :timezone => timezone, :miq_group_id => group.id)
   end
 
   def find_or_build_contents_for_user(group, user, timezone = nil)

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -27,6 +27,25 @@ describe MiqReportResult do
     expect(task.state).to eq MiqTask::STATE_FINISHED
   end
 
+  describe "#friendly_title" do
+    let(:report_title) { "VMs using thin provisioned disks" }
+    let(:report) { FactoryBot.create(:miq_report, :title => report_title) }
+    let(:report_result_for_report) { FactoryBot.create(:miq_report_result, :miq_report_id => report.id, :report => report) }
+    let(:widget_title) { "Widget: VMs using thin provisioned disks" }
+    let(:widget) { FactoryBot.create(:miq_widget, :widget => widget_title) }
+    let(:widget_content) { FactoryBot.create(:miq_widget_content, :miq_widget => widget) }
+    let(:report_for_widget) { FactoryBot.create(:miq_report, :title => widget_title) }
+    let(:report_result_for_widget) { FactoryBot.create(:miq_report_result, :miq_report => report_for_widget, :report => report_for_widget, :report_source => MiqWidget::WIDGET_REPORT_SOURCE) }
+
+    it "display title for widget" do
+      expect(report_result_for_report.friendly_title).to eq(report_title)
+    end
+
+    it "display title for widget" do
+      expect(report_result_for_widget.friendly_title).to eq(widget_title)
+    end
+  end
+
   context "report result created by User 1 with current group 1" do
     before do
       @report_1 = FactoryBot.create(:miq_report)


### PR DESCRIPTION
`MiqReportResult` is used for Report and for Widgets
but when we are displaying report result in full screen
for widget we need to display name of widget and
this method is used for this reason.


Links
------
* https://bugzilla.redhat.com/show_bug.cgi?id=1650418

@miq-bot assign @gtanzillo 
@miq-bot add_label report, bug
