### PR TITLE
Load decorators from the manageiq-decorators plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,6 +190,7 @@ group :consumption, :manageiq_default do
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb
+  manageiq_plugin "manageiq-decorators"
   manageiq_plugin "manageiq-ui-classic"
   # Modified gems (forked on Github)
   gem "jquery-rjs",                   "=0.1.1",                       :git => "https://github.com/ManageIQ/jquery-rjs.git", :tag => "v0.1.1-1"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -15,7 +15,7 @@ class ApplicationRecord < ActiveRecord::Base
   extend ArTableLock
 
   # FIXME: UI code - decorator support
-  if defined?(ManageIQ::UI::Classic::Engine)
+  if defined?(ManageIQ::Decorators::Engine)
     extend MiqDecorator::Klass
     include MiqDecorator::Instance
   end


### PR DESCRIPTION
This will allow us to use decorators independently from the classic UI.

Related issue: #17675

@miq-bot add_label hammer/no
@miq-bot add_reviewer @martinpovolny