### PR TITLE
[WIP] remove duplication for seeding from yaml

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -28,4 +28,22 @@ class ApplicationRecord < ActiveRecord::Base
     return super if options.delete(:ui) == true
     "#{name}: #{super}"
   end
+
+  def self.find_or_create_with_index(index, value, options, &block)
+    return unless value
+    index.delete(value) || create!(options, &block)
+  end
+
+  def self.create_or_update_with_index(index, key, attributes, &block)
+    return unless key
+    if (rec = index.delete(key))
+      rec.attributes = attributes
+      if rec.changed?
+        yield rec if block_given?
+        rec.save!
+      end
+    else
+      create!(attributes, &block)
+    end
+  end
 end

--- a/app/models/chargeable_field.rb
+++ b/app/models/chargeable_field.rb
@@ -120,13 +120,7 @@ class ChargeableField < ApplicationRecord
       if measure
         f[:chargeback_rate_detail_measure_id] = measures[measure].id
       end
-      rec = existing[f[:metric]]
-      if rec.nil?
-        create(f)
-      else
-        rec.attributes = f
-        rec.save! if rec.changed?
-      end
+      create_or_update_with_index(existing, f[:metric], f)
     end
   end
 

--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -29,17 +29,8 @@ class CustomizationTemplate < ApplicationRecord
 
     seed_data.each do |s|
       log_attrs = s.slice(:name, :type, :description)
-
-      rec = current.delete(s[:name])
-      if rec.nil?
-        _log.info("Creating #{log_attrs.inspect}")
-        create!(s)
-      else
-        rec.attributes = s.except(:type)
-        if rec.changed?
-          _log.info("Updating #{log_attrs.inspect}")
-          rec.save!
-        end
+      create_with(:type => s[:type]).create_or_update_with_index(current, s[:name], s.except(:type)) do |rec|
+        _log.info("#{rec.new_record? ? "Creating" : "Updating"} #{log_attrs.inspect}")
       end
     end
 

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -13,16 +13,8 @@ class ServerRole < ApplicationRecord
     CSV.foreach(fixture_path, :headers => true, :skip_lines => /^#/).each do |csv_row|
       action = csv_row.to_hash
 
-      rec = server_roles[action['name']]
-      if rec.nil?
-        _log.info("Creating Server Role [#{action['name']}]")
-        create(action)
-      else
-        rec.attributes = action
-        if rec.changed?
-          _log.info("Updating Server Role [#{action['name']}]")
-          rec.save
-        end
+      create_or_update_with_index(server_roles, action['name'], action) do |rec|
+        _log.info("#{rec.new_record? ? "Creating" : "Updating"} Server Role [#{action['name']}]")
       end
     end
     @zone_scoped_roles = @region_scoped_roles = nil


### PR DESCRIPTION
Current code is complaining about duplication and making most travis runs fail.

While I don't think we typically need to go this far, I want PRs to be green

The error is with complexity and duplicate code in `VmdbDatabase::Seeding` (even though the PRs do not modify that file)

```ruby
        if text_table.new_record? || text_table.changed?
```

https://codeclimate.com/github/ManageIQ/manageiq/pull/18359