### PR TITLE
Remove seedable model detection in favor of a list

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -238,7 +238,7 @@ class MiqServer < ApplicationRecord
     server.ntp_reload
     server.set_database_application_name
 
-    EvmDatabase.seed_last
+    EvmDatabase.seed_rest
 
     start_memcached
     MiqApache::Control.restart if MiqEnvironment::Command.supports_apache?


### PR DESCRIPTION
Additionally, simplify the seed_classes method by moving up the
validation of the list of models earlier.

My motivation for doing this is a) less magic and b) the previous logic required a literal `self.seed` to be defined, which is incorrect.  It turns out some models have a `::Seeding` module with `def seed` inside of a `ClassMethods` module, and those weren't being detected.  However, because those models just happened to be primordial, and those are hardcoded, we lucked out in them getting in the list.  I started working on MiqDialog and moving it into a seeding module, and suddenly noticed that it stopped seeding altogether, which is how I found this.

@bdunne Please review.