### PR TITLE
Give dialogs/models/archive logs unique names

### DIFF
--- a/app/models/log_file.rb
+++ b/app/models/log_file.rb
@@ -18,7 +18,7 @@ class LogFile < ApplicationRecord
     zone        = server.zone
     path        = "#{zone.name}_#{zone.id}", "#{server.name}_#{server.id}"
     date_string = "#{format_log_time(logging_started_on)}_#{format_log_time(logging_ended_on)}"
-    fname       = historical ? "Archive_" : "Current_"
+    fname       = "#{File.basename(loc_file, ".*").capitalize}_"
     fname += "region_#{MiqRegion.my_region.region rescue "unknown"}_#{zone.name}_#{zone.id}_#{server.name}_#{server.id}_#{date_string}#{File.extname(loc_file)}"
     dest        = File.join("/", path, fname)
     _log.info("Built relative path: [#{dest}] from source: [#{loc_file}]")

--- a/spec/models/log_collection_spec.rb
+++ b/spec/models/log_collection_spec.rb
@@ -70,41 +70,25 @@ describe "LogCollection" do
       end
     end
 
-    context "using a historical log file" do
-      before do
-        allow(MiqRegion).to receive(:my_region).and_return(@region)
-        @log_file.update_attributes(:historical => true)
-      end
+    %w(models dialogs current archive).each do |log_type|
+      context "using a #{log_type} log file" do
+        before do
+          @fname = "#{log_type}.zip"
+          allow(MiqRegion).to receive(:my_region).and_return(@region)
+          @log_file.update_attributes(:historical => log_type != "current")
+        end
 
-      it "should build a historical destination directory path based on zone and server" do
-        res      = @log_file.relative_path_for_upload(@fname)
-        expected = "/#{@zone.name}_#{@zone.id}/#{@miq_server.name}_#{@miq_server.id}"
-        expect(File.dirname(res)).to eq(expected)
-      end
+        it "should build a destination directory path based on zone and server" do
+          res      = @log_file.relative_path_for_upload(@fname)
+          expected = "/#{@zone.name}_#{@zone.id}/#{@miq_server.name}_#{@miq_server.id}"
+          expect(File.dirname(res)).to eq(expected)
+        end
 
-      it "should build a historical destination filename based on archive, region, zone, server and date" do
-        res      = @log_file.relative_path_for_upload("/test.zip")
-        expected = "Archive_region_#{@region.region}_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}_#{@timestamp}_#{@timestamp}#{File.extname(@fname)}"
-        expect(File.basename(res)).to eq(expected)
-      end
-    end
-
-    context "using a current log file" do
-      before do
-        allow(MiqRegion).to receive(:my_region).and_return(@region)
-        @log_file.update_attributes(:historical => false)
-      end
-
-      it "should build a current destination directory path based on zone and server" do
-        res      = @log_file.relative_path_for_upload(@fname)
-        expected = "/#{@zone.name}_#{@zone.id}/#{@miq_server.name}_#{@miq_server.id}"
-        expect(File.dirname(res)).to eq(expected)
-      end
-
-      it "should build a current destination filename based on current, region, zone, server and date" do
-        res      = @log_file.relative_path_for_upload("/test.zip")
-        expected = "Current_region_#{@region.region}_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}_#{@timestamp}_#{@timestamp}#{File.extname(@fname)}"
-        expect(File.basename(res)).to eq(expected)
+        it "should build a destination filename based on archive, region, zone, server and date" do
+          res      = @log_file.relative_path_for_upload(@fname)
+          expected = "#{log_type.capitalize}_region_#{@region.region}_#{@zone.name}_#{@zone.id}_#{@miq_server.name}_#{@miq_server.id}_#{@timestamp}_#{@timestamp}#{File.extname(@fname)}"
+          expect(File.basename(res)).to eq(expected)
+        end
       end
     end
   end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1656318

Previously, if you tried to collect logs from servers using an nfs
or smb depot, only the Archive***.zip and Current***.zip would be
uploaded.  Behind, the scenes, we were uploading the automate models and
dialogs as the same Archive***.zip so they'd overwrite each other.

In MiqServer#post_logs, it calls:
post_automate_models  => was using Archive***.zip
post_automate_dialogs => was using Archive***.zip
post_historical_logs  => was using Archive***.zip
post_current_logs     => uses Current***.zip

Therefore, the last Archive***.zip would "win", so the historical logs
would be in the Archive***.zip.

The nfs/smb code relies upon relative_path_for_upload to
determine a remote filename for upload. This method only knew about
archive and current logs and was giving everything but "Current" logs the
"Archive" filename prefix which meant dialogs/models and archived logs
would often have the same filename.

This method now uses the already known local file's name to determine this
prefix, allowing the input dialogs.zip, models.zip, current.zip, and
archive.zip to create unique names for this set of logs regardless of the
 zone, server, or log timestamps.