### PR TITLE
CustomButtonSet - make sure children follow button_order

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -3,9 +3,15 @@ class CustomButtonSet < ApplicationRecord
 
   before_save :update_children
   def update_children
-    replace_children Rbac.filtered(CustomButton.where(:id => set_data[:button_order]))
+    if set_data.try(:[], :button_order).nil?
+      remove_all_children
+      return
+    end
 
+    children = Rbac.filtered(CustomButton.where(:id => set_data[:button_order]))
     throw(:abort) if children.pluck(:id).sort != set_data[:button_order].sort
+
+    replace_children Rbac.filtered(CustomButton.where(:id => set_data[:button_order]))
   end
 
   def self.find_all_by_class_name(class_name, class_id = nil)

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -4,6 +4,8 @@ class CustomButtonSet < ApplicationRecord
   before_save :update_children
   def update_children
     replace_children Rbac.filtered(CustomButton.where(:id => set_data[:button_order]))
+
+    throw(:abort) if children.pluck(:id).sort != set_data[:button_order].sort
   end
 
   def self.find_all_by_class_name(class_name, class_id = nil)

--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -1,6 +1,11 @@
 class CustomButtonSet < ApplicationRecord
   acts_as_miq_set
 
+  before_save :update_children
+  def update_children
+    replace_children Rbac.filtered(CustomButton.where(:id => set_data[:button_order]))
+  end
+
   def self.find_all_by_class_name(class_name, class_id = nil)
     ordering = ->(o) { [o.set_data[:group_index].to_s, o.name] }
 

--- a/lib/task_helpers/imports/custom_buttons.rb
+++ b/lib/task_helpers/imports/custom_buttons.rb
@@ -30,14 +30,15 @@ module TaskHelpers
           klass = class_name.camelize.constantize
 
           obj_array.collect do |obj|
-            begin
-              klass.create!(obj['attributes']&.except('guid')).tap do |new_obj|
-                add_children(obj, new_obj)
-                add_associations(obj, new_obj)
-                try("#{class_name}_post", new_obj)
-              end
-            rescue StandardError
-              raise
+            if klass.name == "CustomButtonSet"
+              order = obj.fetch_path('attributes', 'set_data', :button_order)
+              obj['attributes']['set_data'][:button_order] = nil if order.present?
+            end
+
+            klass.create!(obj['attributes']&.except('guid')).tap do |new_obj|
+              add_children(obj, new_obj)
+              add_associations(obj, new_obj)
+              try("#{class_name}_post", new_obj)
             end
           end
         end

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -79,4 +79,28 @@ describe CustomButtonSet do
     expect(CustomButton.count).to eq(2)
     expect(CustomButtonSet.count).to eq(2)
   end
+
+  context '#update_children' do
+    let(:vm)                { FactoryBot.create(:vm_vmware, :name => 'vm') }
+    let(:custom_button_1)   { FactoryBot.create(:custom_button, :applies_to => vm) }
+    let(:custom_button_2)   { FactoryBot.create(:custom_button, :applies_to => vm) }
+    let(:custom_button_3)   { FactoryBot.create(:custom_button, :applies_to => vm) }
+    let(:set_data)          { {:applies_to_class => "Vm", :button_order => [custom_button_1.id, custom_button_2.id]} }
+    let(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "set_1", :set_data => set_data) }
+
+    it "updates children after setting button_order" do
+      expect(custom_button_set.children.count).to eq(2)
+
+      custom_button_set.set_data[:button_order] = [
+        custom_button_2.id,
+        custom_button_3.id,
+      ]
+      custom_button_set.save!
+
+      expect(custom_button_set.children.count).to eq(2)
+      expect(custom_button_set.children).not_to include(custom_button_1)
+      expect(custom_button_set.children).to include(custom_button_2)
+      expect(custom_button_set.children).to include(custom_button_3)
+    end
+  end
 end

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -297,8 +297,7 @@ describe GenericObjectDefinition do
     it "returns the custom actions in a hash grouped by buttons and button groups" do
       FactoryBot.create(:custom_button, :name => "generic_no_group", :applies_to_class => "GenericObject")
       generic_group = FactoryBot.create(:custom_button, :name => "generic_group", :applies_to_class => "GenericObject")
-      generic_group_set = FactoryBot.create(:custom_button_set, :name => "generic_group_set")
-      generic_group_set.add_member(generic_group)
+      generic_group_set = FactoryBot.create(:custom_button_set, :name => "generic_group_set", :set_data => {:button_order => [generic_group.id]})
 
       FactoryBot.create(
         :custom_button,
@@ -312,8 +311,7 @@ describe GenericObjectDefinition do
         :applies_to_class => "GenericObjectDefinition",
         :applies_to_id    => definition.id
       )
-      assigned_group_set = FactoryBot.create(:custom_button_set, :name => "assigned_group_set")
-      assigned_group_set.add_member(assigned_group)
+      assigned_group_set = FactoryBot.create(:custom_button_set, :name => "assigned_group_set", :set_data => {:button_order => [assigned_group.id]})
       definition.update(:custom_button_sets => [assigned_group_set])
 
       expected = {

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -8,7 +8,8 @@ describe ServiceTemplate do
       FactoryBot.create(:custom_button, :name => "generic_no_group", :applies_to_class => "Service")
       generic_group = FactoryBot.create(:custom_button, :name => "generic_group", :applies_to_class => "Service")
       generic_group_set = FactoryBot.create(:custom_button_set, :name => "generic_group_set")
-      generic_group_set.add_member(generic_group)
+      generic_group_set.set_data = {:button_order => [generic_group.id]}
+      generic_group_set.save!
 
       service_template = FactoryBot.create(:service_template)
       FactoryBot.create(
@@ -24,7 +25,9 @@ describe ServiceTemplate do
         :applies_to_id    => service_template.id
       )
       assigned_group_set = FactoryBot.create(:custom_button_set, :name => "assigned_group_set")
-      assigned_group_set.add_member(assigned_group)
+      assigned_group_set.set_data = {:button_order => [assigned_group.id]}
+      assigned_group_set.save!
+
       service_template.update(:custom_button_sets => [assigned_group_set])
 
       expected = {


### PR DESCRIPTION
CustomButtonSet has currently 2 independent lists of children:

- `set_data[:button_order]` is an array of ids with the right order,
- `children` (or `members`) is a collection of custom buttons, in no order

Currently, in the UI, the tree is reading button_order, the GTL is reading `members`,
the SUI toolbar is using button_order, the OPS UI toolbar is using both.

It's essential to keep the 2 lists the same, and there are 2 ways of achieving it:

* adding methods to add items to specific position, that will handle both button_order and children, and expose those via the API
* deciding `button_order` is the canonical collection, and we can always replace children based on the ids in button order.

The first option would mean doing N+1 API requests when creating a button group with N assigned buttons,
the second option means we only have to edit the custom button set, without any per-button requests.

(We never create a new custom button as part of editing/creating a set.)

---

Fixes https://github.com/ManageIQ/manageiq-api/issues/539
(together with https://github.com/ManageIQ/manageiq-api/pull/541 exposing the collection so that we can query it via the API)