### PR TITLE
Remove value2tag for count field in MiqExpression

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -620,7 +620,9 @@ class MiqExpression
         end
       end
     elsif ops["count"]
-      [MiqExpression::CountField.parse(ops["count"]).ruby_value, quote(ops["value"], "integer")]
+      target = parse_field_or_tag(ops["count"])
+      fld = "<count ref=#{target.model.to_s.downcase}>#{target.tag_path_with}</count>"
+      [fld, quote(ops["value"], target.column_type)]
     elsif ops["regkey"]
       if operator == "key exists"
         "<registry key_exists=1, type=boolean>#{ops["regkey"].strip}</registry>  == 'true'"

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -620,9 +620,7 @@ class MiqExpression
         end
       end
     elsif ops["count"]
-      ref, count = value2tag(ops["count"])
-      field = "<count ref=#{ref}>#{count}</count>"
-      [field, quote(ops["value"], "integer")]
+      [MiqExpression::CountField.parse(ops["count"]).ruby_value, quote(ops["value"], "integer")]
     elsif ops["regkey"]
       if operator == "key exists"
         "<registry key_exists=1, type=boolean>#{ops["regkey"].strip}</registry>  == 'true'"

--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -22,8 +22,8 @@ class MiqExpression::CountField < MiqExpression::Target
     [model, *associations].join(".")
   end
 
-  def ruby_value
-    "<count ref=#{model.to_s.downcase}>#{tag_path_with}</count>"
+  def column_type
+    :integer
   end
 
   private

--- a/lib/miq_expression/count_field.rb
+++ b/lib/miq_expression/count_field.rb
@@ -22,6 +22,10 @@ class MiqExpression::CountField < MiqExpression::Target
     [model, *associations].join(".")
   end
 
+  def ruby_value
+    "<count ref=#{model.to_s.downcase}>#{tag_path_with}</count>"
+  end
+
   private
 
   def tag_values

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -967,7 +967,7 @@ describe MiqExpression do
 
   describe "#to_ruby" do
     it "generates the ruby for a = expression with count" do
-      actual = described_class.new("=" => {"count" => "Vm-snapshots", "value" => "1"}).to_ruby
+      actual = described_class.new("=" => {"count" => "Vm.snapshots", "value" => "1"}).to_ruby
       expected = "<count ref=vm>/virtual/snapshots</count> == 1"
       expect(actual).to eq(expected)
     end
@@ -985,7 +985,7 @@ describe MiqExpression do
     end
 
     it "generates the ruby for a < expression with count" do
-      actual = described_class.new("<" => {"count" => "Vm-snapshots", "value" => "2"}).to_ruby
+      actual = described_class.new("<" => {"count" => "Vm.snapshots", "value" => "2"}).to_ruby
       expected = "<count ref=vm>/virtual/snapshots</count> < 2"
       expect(actual).to eq(expected)
     end
@@ -997,7 +997,7 @@ describe MiqExpression do
     end
 
     it "generates the ruby for a > expression with count" do
-      actual = described_class.new(">" => {"count" => "Vm-snapshots", "value" => "2"}).to_ruby
+      actual = described_class.new(">" => {"count" => "Vm.snapshots", "value" => "2"}).to_ruby
       expected = "<count ref=vm>/virtual/snapshots</count> > 2"
       expect(actual).to eq(expected)
     end
@@ -1009,7 +1009,7 @@ describe MiqExpression do
     end
 
     it "generates the ruby for a >= expression with count" do
-      actual = described_class.new(">=" => {"count" => "Vm-snapshots", "value" => "2"}).to_ruby
+      actual = described_class.new(">=" => {"count" => "Vm.snapshots", "value" => "2"}).to_ruby
       expected = "<count ref=vm>/virtual/snapshots</count> >= 2"
       expect(actual).to eq(expected)
     end
@@ -1021,7 +1021,7 @@ describe MiqExpression do
     end
 
     it "generates the ruby for a <= expression with count" do
-      actual = described_class.new("<=" => {"count" => "Vm-snapshots", "value" => "2"}).to_ruby
+      actual = described_class.new("<=" => {"count" => "Vm.snapshots", "value" => "2"}).to_ruby
       expected = "<count ref=vm>/virtual/snapshots</count> <= 2"
       expect(actual).to eq(expected)
     end
@@ -1033,7 +1033,7 @@ describe MiqExpression do
     end
 
     it "generates the ruby for a != expression with count" do
-      actual = described_class.new("!=" => {"count" => "Vm-snapshots", "value" => "2"}).to_ruby
+      actual = described_class.new("!=" => {"count" => "Vm.snapshots", "value" => "2"}).to_ruby
       expected = "<count ref=vm>/virtual/snapshots</count> != 2"
       expect(actual).to eq(expected)
     end


### PR DESCRIPTION
- it is not needed to have `value2tag` here
method is only calling `MiqExpression::CountField.parse` in this situation
- updating specs: correct format is
`model.assocation` (MiqExpression::CountField::REGEX)

🥅 Sub goal : Remove `value2tag`- code inside of this method is basically calling other method on related instance of `MiqExpression::Target` and code after each calling of `value2tag` looks related to `MiqExpression::Target ` (or childs) - so it could be encapsulated

⚽️ Goal: Remove useless code, simplification of MiqExpresion and finding code/patterns which could be live by `MiqExpression::Target ` (childs) - moving responsibility to `MiqExpression::Target ` (childs)

@miq-bot add_label refactoring, reporting

@miq-bot assign @kbrock 