### PR TITLE
V2V - Collect virt-v2v PID from conversion host in kill_virtv2v

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -208,7 +208,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       options[:virtv2v_finished_on] = Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')
       if virtv2v_state['failed']
         options[:virtv2v_status] = 'failed'
-        raise "Disks transformation failed."
       else
         options[:virtv2v_status] = 'succeeded'
         updated_disks.each { |d| d[:percent] = 100 }
@@ -218,8 +217,8 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end 
 
   def kill_virtv2v(signal = 'TERM')
-    return false unless options[:virtv2v_wrapper]['pid']
-    conversion_host.kill_process(options[:virtv2v_wrapper]['pid'], signal)
+    virtv2v_state = conversion_host.get_conversion_state(options[:virtv2v_wrapper]['state_file'])
+    conversion_host.kill_process(virtv2v_state['pid'].to_s, signal)
   end
 
   private

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -187,7 +187,7 @@ describe ServiceTemplateTransformationPlanTask do
       before do
         task.options = { :virtv2v_wrapper => { 'state_file' => '/tmp/v2v.state' }}
         task.conversion_host = conversion_host
-        allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return({ "pid" => 1234 })
+        allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return("pid" => 1234)
       end
 
       it "returns false if if kill command failed" do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -185,22 +185,17 @@ describe ServiceTemplateTransformationPlanTask do
 
     describe '#kill_virtv2v' do
       before do
+        task.options = { :virtv2v_wrapper => { 'state_file' => '/tmp/v2v.state' }}
         task.conversion_host = conversion_host
-        task.options = { :virtv2v_wrapper => {}}
-      end
-
-      it "does nothing if pid not present in options[:virtv2v_wrapper]" do
-        expect(task.kill_virtv2v('KILL')).to eq(false)
+        allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return({ "pid" => 1234 })
       end
 
       it "returns false if if kill command failed" do
-        task.options[:virtv2v_wrapper]['pid'] = '1234'
         allow(conversion_host).to receive(:kill_process).with('1234', 'KILL').and_return(false)
         expect(task.kill_virtv2v('KILL')).to eq(false)
       end
 
       it "returns true if if kill command succeeded" do
-        task.options[:virtv2v_wrapper]['pid'] = '1234'
         allow(conversion_host).to receive(:kill_process).with('1234', 'KILL').and_return(true)
         expect(task.kill_virtv2v('KILL')).to eq(true)
       end


### PR DESCRIPTION
In the current implementation, we still use the old format of `task.options[:virtv2v_wrapper]` to identify the PID of virt-v2v. The value is always `nil` as we don't store it there anymore, which in turns makes the cancellation ineffective. This PR fixes it by calling `get_conversion_state`, that gets the state from the conversion host, and thus the PID.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1666799