### PR TITLE
Let stack_parameters support symbol hash keys, for now

### DIFF
--- a/app/models/service_orchestration/option_converter.rb
+++ b/app/models/service_orchestration/option_converter.rb
@@ -27,7 +27,7 @@ class ServiceOrchestration
 
     def stack_parameters
       params = {}
-      @dialog_options.each do |attr, val|
+      @dialog_options.with_indifferent_access.each do |attr, val|
         if attr.start_with?('dialog_param_')
           params[attr['dialog_param_'.size..-1]] = val
         elsif attr.start_with?('password::dialog_param_')

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -21,7 +21,8 @@ describe ServiceOrchestration do
       'dialog_stack_onfailure'                => 'ROLLBACK',
       'dialog_stack_timeout'                  => '30',
       'dialog_param_InstanceType'             => 'cg1.4xlarge',
-      'password::dialog_param_DBRootPassword' => 'v2:{c2XR8/Yl1CS0phoOVMNU9w==}'
+      'password::dialog_param_DBRootPassword' => 'v2:{c2XR8/Yl1CS0phoOVMNU9w==}',
+      :dialog_param_key_in_symbol             => 'not_expected'
     }
   end
 
@@ -104,6 +105,14 @@ describe ServiceOrchestration do
 
     it "gets stack options set by dialog" do
       expect(service_with_dialog_options.stack_options).to eq(dialog_options)
+    end
+
+    it "can access options key as string" do
+      expect(service_with_dialog_options.stack_options["dialog_stack_name"]).to eq('test123')
+    end
+
+    it "can access options key as symbol" do
+      expect(service_with_dialog_options.stack_options[:dialog_param_key_in_symbol]).to eq('not_expected')
     end
 
     context "cloud tenant option" do
@@ -206,7 +215,8 @@ describe ServiceOrchestration do
       allow_any_instance_of(OrchestrationStack).to receive(:raw_update_stack) do |_instance, new_template, opts|
         expect(opts[:parameters]).to include(
           'InstanceType'   => 'cg1.4xlarge',
-          'DBRootPassword' => 'admin'
+          'DBRootPassword' => 'admin',
+          'key_in_symbol'  => 'not_expected'
         )
         expect(new_template).to eq(template_by_setter)
       end


### PR DESCRIPTION
Service dialog options keys are supposed to be in String. But for some reason, API sends those keys in symbol when ordering a Service from global region.
Before we find out where those keys are duplicated in symbol via API, we have to work around it.

https://bugzilla.redhat.com/show_bug.cgi?id=1654999

@miq-bot assign @gmcculloug 
@miq-bot add_label bug, gaprindashvili/yes, hammer/yes, services, orchestration
cc @jrafanie 