### PR TITLE
Add product features for pausing/resuming ansible/foreman providers

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4785,6 +4785,14 @@
         :description: Edit a Provider
         :feature_type: admin
         :identifier: provider_foreman_edit_provider
+      - :name: Pause
+        :description: Pause a Provider
+        :feature_type: admin
+        :identifier: provider_foreman_pause
+      - :name: Resume
+        :description: Resume a Provider
+        :feature_type: admin
+        :identifier: provider_foreman_resume
       - :name: Add Provider
         :description: Add a Provider
         :feature_type: admin
@@ -4981,6 +4989,14 @@
         :description: Edit a Provider
         :feature_type: admin
         :identifier: automation_manager_edit_provider
+      - :name: Pause
+        :description: Pause a Provider
+        :feature_type: admin
+        :identifier: automation_manager_pause
+      - :name: Resume
+        :description: Resume a Provider
+        :feature_type: admin
+        :identifier: automation_manager_resume
       - :name: Add Provider
         :description: Add a Provider
         :feature_type: admin


### PR DESCRIPTION
These are necessary for adding the pause/resume ability for foreman and ansible tower providers.

@miq-bot add_label hammer/no, providers/foreman, providers/ansible_tower
@miq-bot add_reviewer @slemrmartin 

Parent issue: https://github.com/ManageIQ/manageiq/issues/17489