### PR TITLE
[GAPRINDASHVILI] Add mark_retired method to not reset retirement_requester

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -150,11 +150,16 @@ module RetirementMixin
     raise _("%{name} already retired") % {:name => name} if retired?
     $log.info("Finishing Retirement for [#{name}]")
     requester = retirement_requester
-    update_attributes(:retires_on => Time.zone.now, :retired => true, :retirement_state => "retired")
+    mark_retired
     message = "#{self.class.base_model.name}: [#{name}], Retires On: [#{retires_on.strftime("%x %R %Z")}], has been retired"
     $log.info("Calling audit event for: #{message} ")
     raise_audit_event(retired_event_name, message, requester)
     $log.info("Called audit event for: #{message} ")
+  end
+
+  def mark_retired
+    self[:retires_on] = Time.zone.now
+    update_attributes(:retired => true, :retirement_state => "retired")
   end
 
   def start_retirement

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -143,8 +143,17 @@ describe "Service Retirement Management" do
   end
 
   it "#finish_retirement" do
-    expect(@service.retirement_state).to be_nil
+    message = "Service: [#{@service.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+    expect(@service).to receive(:raise_audit_event).with("service_retired", message, nil)
+
     @service.finish_retirement
+
+    expect(@service.retirement_state).to eq("retired")
+  end
+
+  it "#mark_retired" do
+    expect(@service.retirement_state).to be_nil
+    @service.mark_retired
     @service.reload
     expect(@service.retired).to be_truthy
     expect(@service.retires_on).to be_between(Time.zone.now - 1.hour, Time.zone.now + 1.second)

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -1,5 +1,6 @@
 describe "VM Retirement Management" do
   let(:user) { FactoryGirl.create(:user) }
+  let(:vm) { FactoryGirl.create(:vm) }
   before(:each) do
     miq_server = EvmSpecHelper.local_miq_server
     @zone = miq_server.zone
@@ -90,8 +91,17 @@ describe "VM Retirement Management" do
   end
 
   it "#finish_retirement" do
+    message = "Vm: [#{vm.name}], Retires On: [#{Time.zone.now.strftime("%x %R %Z")}], has been retired"
+    expect(vm).to receive(:raise_audit_event).with("vm_retired", message, nil)
+
+    vm.finish_retirement
+
+    expect(vm.retirement_state).to eq("retired")
+  end
+
+  it "#mark_retired" do
     expect(@vm.retirement_state).to be_nil
-    @vm.finish_retirement
+    @vm.mark_retired
     @vm.reload
 
     expect(@vm.retired).to eq(true)


### PR DESCRIPTION
Because we have a column name and a method name that are equivalent, finish_retirement used to reset the retirement_requester to nil. Changing the method to call a different method that only sets the field name prevents this from being reset to nil at the end.

Backport of https://github.com/ManageIQ/manageiq/pull/18325

Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1641812

@miq-bot add_label bug, blocker
@miq-bot assign @gmcculloug