### PR TITLE
Fixed saving edited tag name

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -529,7 +529,11 @@ class Classification < ApplicationRecord
 
   def save_tag
     tag_name = Classification.name2tag(name, parent_id, ns)
-    self.tag = Tag.in_region(region_id).find_or_create_by(:name => tag_name)
+    if tag.present?
+      tag.update_attributes(:name => tag_name)
+    else
+      self.tag = Tag.in_region(region_id).find_or_create_by(:name => tag_name)
+    end
   end
 
   def delete_all_entries

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -571,6 +571,31 @@ describe Classification do
     end
   end
 
+  describe '#save' do
+    let(:new_name) { "new_tag_name" }
+
+    context "editing existing tag" do
+      it "updates record in Tag table which linked to this classification" do
+        classification = FactoryBot.create(:classification_tag, :name => "some_tag_name")
+        tag = classification.tag
+        classification.name = new_name
+        classification.save
+        expect(tag.id).to eq classification.tag.id
+        expect(classification.tag.name).to eq(Classification.name2tag(new_name))
+      end
+    end
+
+    context "saving new tag" do
+      it "creates new record in Tag table and links it to this classification" do
+        classification = Classification.new
+        classification.description = "some description"
+        classification.name = new_name
+        classification.save
+        expect(classification.tag).to eq(Tag.last)
+      end
+    end
+  end
+
   def all_tagged_with(target, all, category = nil)
     tagged_with(target, :all => all, :cat => category)
   end


### PR DESCRIPTION
**Issue:** Editing tag name on existing record creates new record in `Tag` table

**Fix:**  Do not create new record in Tag table when editing existing tag

https://bugzilla.redhat.com/show_bug.cgi?id=1666887

@miq-bot add-label core, bug