### PR TITLE
Add uri_attributes as virtual_attribute to CustomButton

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -15,6 +15,8 @@ class CustomButton < ApplicationRecord
   validates :name, :description, :uniqueness => {:scope => [:applies_to_class, :applies_to_id]}, :presence => true
   validates :guid, :uniqueness => true, :presence => true
 
+  virtual_attribute :uri_attributes, :string
+
   include UuidMixin
   acts_as_miq_set_member
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/5166 that fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650559

I need API to give me `uri_attributes` to get relevant data for `CustomButton` with `button_type = "ansible_playbook"`. So this PR adds it to `virtual_attribute`.

@lpichler please have a look :)

@miq-bot add_label bug, gaprindashvili/yes, hammer/yes, api, automate