### PR TITLE
Fix address validation for ConversionHost model

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -17,8 +17,8 @@ class ConversionHost < ApplicationRecord
   validates :address,
     :uniqueness => true,
     :format     => { :with => Resolv::AddressRegex },
-    :inclusion  => { :in => -> (conversion_host) { conversion_host.resource.ipaddresses } },
-    :unless     => -> (conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? }
+    :inclusion  => { :in => ->(conversion_host) { conversion_host.resource.ipaddresses } },
+    :unless     => ->(conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? }
 
   include_concern 'Configurations'
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -17,8 +17,8 @@ class ConversionHost < ApplicationRecord
   validates :address,
     :uniqueness => true,
     :format     => { :with => Resolv::AddressRegex },
-    :inclusion  => { :in => -> { resource.ipaddresses } },
-    :unless     => -> { resource.blank? || resource.ipaddresses.blank? }
+    :inclusion  => { :in => -> (conversion_host) { conversion_host.resource.ipaddresses } },
+    :unless     => -> (conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? }
 
   include_concern 'Configurations'
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -204,6 +204,12 @@ describe ConversionHost do
       expect(conversion_host.errors[:address]).to include("is not included in the list")
     end
 
+    it "is valid if the address is included within the list of available resource addresses" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.1")
+      expect(conversion_host.valid?).to be(true)
+    end
+
     it "is ignored if the resource does not have any ipaddresses" do
       conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
       expect(conversion_host.valid?).to be(true)

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -186,4 +186,27 @@ describe ConversionHost do
       it_behaves_like "#check_ssh_connection"
     end
   end
+
+  context "address validation" do
+    let(:vm) { FactoryBot.create(:host) }
+
+    it "is invalid if the address is not a valid IP address" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "xxx")
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:address]).to include("is invalid")
+    end
+
+    it "is invalid if the address is present but not included in the resource addresses" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:address]).to include("is not included in the list")
+    end
+
+    it "is ignored if the resource does not have any ipaddresses" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
+      expect(conversion_host.valid?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
The address validation for the `ConversionHost` model is busted. It mistakenly does not pass in a parameter, which causes it to blow up with an ArgumentError when called.

Inadvertently introduced in https://github.com/ManageIQ/manageiq/pull/18277