### PR TITLE
Explicitly specify the primary key for the metrics tables

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -33,6 +33,9 @@
 # [PostgreSQL table inheritance]: https://www.postgresql.org/docs/9.6/static/tutorial-inheritance.html
 # [PostgreSQL table partioning]: https://www.postgresql.org/docs/9.6/static/ddl-partitioning.html
 class Metric < ApplicationRecord
+  # Specify the primary key for a model backed by a view
+  self.primary_key = "id"
+
   BASE_COLS = ["id", "timestamp", "capture_interval_name", "resource_type", "resource_id", "resource_name", "tag_names", "parent_host_id", "parent_ems_cluster_id", "parent_ems_id", "parent_storage_id"]
 
   include Metric::Common

--- a/app/models/metric_rollup.rb
+++ b/app/models/metric_rollup.rb
@@ -1,5 +1,8 @@
 # @see Metric
 class MetricRollup < ApplicationRecord
+  # Specify the primary key for a model backed by a view
+  self.primary_key = "id"
+
   include Metric::Common
   include_concern 'Metric::ChargebackHelper'
 

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -1,4 +1,25 @@
 describe MetricRollup do
+  describe "metric_rollups view" do
+    it "creates an object with an id" do
+      metric = described_class.create!(:timestamp => Time.now.utc)
+      expect(metric.id).to be > 0
+    end
+
+    it "initializes an object's id after save" do
+      metric = described_class.new
+      metric.timestamp = Time.now.utc
+      metric.save!
+      expect(metric.id).to be > 0
+    end
+
+    it "updates an existing object correctly" do
+      metric = described_class.create!(:timestamp => Time.now.utc)
+      old_id = metric.id
+      metric.update_attributes!(:timestamp => Time.now.utc - 1.day)
+      expect(metric.id).to eq(old_id)
+    end
+  end
+
   context "test" do
     it "should not raise an error when a polymorphic reflection is included and references are specified in a query" do
       skip "until ActiveRecord is fixed"

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -5,6 +5,27 @@ describe Metric do
     _guid, _server, @zone = EvmSpecHelper.create_guid_miq_server_zone
   end
 
+  describe "metrics view" do
+    it "creates an object with an id" do
+      metric = described_class.create!(:timestamp => Time.now.utc)
+      expect(metric.id).to be > 0
+    end
+
+    it "initializes an object's id after save" do
+      metric = described_class.new
+      metric.timestamp = Time.now.utc
+      metric.save!
+      expect(metric.id).to be > 0
+    end
+
+    it "updates an existing object correctly" do
+      metric = described_class.create!(:timestamp => Time.now.utc)
+      old_id = metric.id
+      metric.update_attributes!(:timestamp => Time.now.utc - 1.day)
+      expect(metric.id).to eq(old_id)
+    end
+  end
+
   context "as vmware" do
     before do
       @ems_vmware = FactoryBot.create(:ems_vmware, :zone => @zone)


### PR DESCRIPTION
This is required as a view doesn't have a primary key, so
active record can't fetch the value by default.