### PR TITLE
[HAMMER] Fixed tag name saving

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -529,7 +529,11 @@ class Classification < ApplicationRecord
   end
 
   def save_tag
-    self.tag = Tag.find_or_create_by_classification_name(name, region_id, ns, parent_id)
+    if tag.present?
+      tag.update_attributes(:name => Classification.name2tag(name, parent_id, ns))
+    else
+      self.tag = Tag.find_or_create_by_classification_name(name, region_id, ns, parent_id)
+    end
   end
 
   def delete_all_entries

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -539,6 +539,31 @@ describe Classification do
     end
   end
 
+  describe '#save' do
+    let(:new_name) { "new_tag_name" }
+
+    context "editing existing tag" do
+      it "updates record in Tag table which linked to this classification" do
+        classification = FactoryBot.create(:classification_tag, :name => "some_tag_name")
+        tag = classification.tag
+        classification.name = new_name
+        classification.save
+        expect(tag.id).to eq classification.tag.id
+        expect(classification.tag.name).to eq(Classification.name2tag(new_name))
+      end
+    end
+
+    context "saving new tag" do
+      it "creates new record in Tag table and links it to this classification" do
+        classification = Classification.new
+        classification.description = "some description"
+        classification.name = new_name
+        classification.save
+        expect(classification.tag).to eq(Tag.last)
+      end
+    end
+  end
+
   def all_tagged_with(target, all, category = nil)
     tagged_with(target, :all => all, :cat => category)
   end


### PR DESCRIPTION
**Issue:** Editing tag name on existing record creates new record in Tag table

**Fix:** Do not create new record in Tag table when editing existing tag

Backport of https://github.com/ManageIQ/manageiq/pull/18378
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1669269

@miq-bot add-label core, bug,  gaprindashvili/yes,  hammer/yes  