### PR TITLE
EMS.enable!/disable! removed from public

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -210,18 +210,6 @@ class ExtManagementSystem < ApplicationRecord
 
   after_save :change_maintenance_for_child_managers, :if => proc { |ems| ems.enabled_changed? }
 
-  def disable!
-    _log.info("Disabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => false)
-    _log.info("Disabling EMS [#{name}] id [#{id}] successful.")
-  end
-
-  def enable!
-    _log.info("Enabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => true)
-    _log.info("Enabling EMS [#{name}] id [#{id}] successful.")
-  end
-
   # Move ems to maintenance zone and backup current one
   # @param orig_zone [Integer] because of zone of child manager can be changed by parent manager's ensure_managers() callback
   #                            we need to specify original zone for children explicitly
@@ -805,6 +793,12 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   private
+
+  def disable!
+    _log.info("Disabling EMS [#{name}] id [#{id}].")
+    update!(:enabled => false)
+    _log.info("Disabling EMS [#{name}] id [#{id}] successful.")
+  end
 
   # Child managers went to/from maintenance mode with parent
   def change_maintenance_for_child_managers


### PR DESCRIPTION
`ExtManagementSystem.enable!` and `disable!`  are replaced by `pause!`/`resume`.

`Disable!` needs to stay there because of call in EMS.destroy. Pausing in destroy causes errors in other repositories' specs due to lack of maintenance_zone initialization, multiple after_save callback etc.

**Issue**: #17489

https://bugzilla.redhat.com/show_bug.cgi?id=1455145
