### PR TITLE
Add method for restricting to accessible storages

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -47,6 +47,8 @@ class Host < ApplicationRecord
   has_many                  :miq_templates, :inverse_of => :host
   has_many                  :host_storages, :dependent => :destroy
   has_many                  :storages, :through => :host_storages
+  has_many                  :writable_accessible_host_storages, -> { writable_accessible }, :class_name => "HostStorage"
+  has_many                  :writable_accessible_storages, :through => :writable_accessible_host_storages, :source => :storage
   has_many                  :host_switches, :dependent => :destroy
   has_many                  :switches, :through => :host_switches
   has_many                  :lans,     :through => :switches

--- a/app/models/host_storage.rb
+++ b/app/models/host_storage.rb
@@ -1,4 +1,16 @@
 class HostStorage < ApplicationRecord
   belongs_to :host
   belongs_to :storage
+
+  scope :writable, -> { where(:read_only => [nil, false]) }
+  scope :read_only, -> { where(:read_only => true) }
+
+  scope :accessible, -> { where(:accessible => [true, nil]) }
+  scope :inaccessible, -> { where(:accessible => false) }
+
+  class << self
+    def writable_accessible
+      writable.accessible
+    end
+  end
 end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -1069,7 +1069,7 @@ class MiqRequestWorkflow
     MiqPreloader.preload(hosts, :storages => {}, :host_storages => :storage)
 
     storages = hosts.each_with_object({}) do |host, hash|
-      host.writable_storages.each { |s| hash[s.id] = s }
+      host.writable_accessible_storages.each { |s| hash[s.id] = s }
     end.values
     selected_storage_profile_id = get_value(@values[:placement_storage_profile])
     if selected_storage_profile_id

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -75,7 +75,7 @@ module VmOrTemplate::Operations::Configuration
     raise _("VM has no EMS, unable to add disk") unless ext_management_system
     if options[:datastore]
       datastore = ext_management_system.hosts.collect do |h|
-        h.writable_storages.find_by(:name => options[:datastore])
+        h.writable_accessible_storages.find_by(:name => options[:datastore])
       end.uniq.compact.first
       raise _("Datastore does not exist or cannot be accessed, unable to add disk") unless datastore
     end


### PR DESCRIPTION
Use the host_storage.accessible property to filter storages that cannot
be accessed by the provider due to being disconnected or otherwise
inaccessible.

Depends on:

- [x] https://github.com/ManageIQ/manageiq-schema/pull/329
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/356

https://bugzilla.redhat.com/show_bug.cgi?id=1668020