### PR TITLE
Add decimal type for MiqExpression::Target

### DIFF
--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -49,7 +49,7 @@ class MiqExpression::Target
   end
 
   def numeric?
-    [:fixnum, :integer, :decimal, :float].include?(column_type)
+    %i(fixnum integer decimal float).include?(column_type)
   end
 
   def plural?

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -44,8 +44,12 @@ class MiqExpression::Target
     column_type == :string
   end
 
+  def decimal?
+    column_type == :decimal
+  end
+
   def numeric?
-    [:fixnum, :integer, :float].include?(column_type)
+    [:fixnum, :integer, :decimal, :float].include?(column_type)
   end
 
   def plural?

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -325,6 +325,14 @@ RSpec.describe MiqExpression::Field do
       expect(MiqExpression::Field.parse("Vm-id")).to be_numeric
     end
 
+    it "detects decimal as numeric" do
+      expect(MiqExpression::Field.parse("MiqServer-memory_size")).to be_numeric
+    end
+
+    it "detects float as numeric" do
+      expect(MiqExpression::Field.parse("MiqServer-percent_memory")).to be_numeric
+    end
+
     it "detects string as non-numeric" do
       expect(MiqExpression::Field.parse("Vm-name")).not_to be_numeric
     end


### PR DESCRIPTION
we are not counting with decimal type in  `MiqExpression::Target`
then we had:

before:
```
 MiqExpression.parse_field_or_tag("MiqServer-memory_size").numeric?
=> false
```

after:
```
 MiqExpression.parse_field_or_tag("MiqServer-memory_size").numeric?
=> true
```

@miq-bot add_label bug

@miq-bot assign @kbrock 

# usage 
in order to remove get_col_info:
https://github.com/ManageIQ/manageiq/blob/444f9f8c19c851f02f9a7024f8680612ab442fa9/app/models/miq_report.rb#L136
