### PR TITLE
Add a configuration parameter for custom favicon, by default false

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1009,6 +1009,7 @@
   :custom_brand: false
   :custom_login_logo: false
   :custom_logo: false
+  :custom_favicon: false
   :events:
     :disk_usage_gt_percent: 80
   :heartbeat_timeout: 2.minutes


### PR DESCRIPTION
This parameter is being used in https://github.com/ManageIQ/manageiq-ui-classic/pull/5202

@miq-bot assign @martinpovolny 
@miq-bot add_label graphics