### PR TITLE
Bump vmware_web_service to 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ end
 
 group :vmware, :manageiq_default do
   manageiq_plugin "manageiq-providers-vmware"
-  gem "vmware_web_service",             "~>0.3.0"
+  gem "vmware_web_service",             "~>0.4.0"
 end
 
 ### shared dependencies
@@ -181,7 +181,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.2.18",       :require => false
+  gem "manageiq-smartstate",            "~>0.2.19",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Also bump manageiq-smartstate to 0.2.19

In the never-ending quest for truth, justice, and the American way, we attempt to deal with
issue revolving around vmware_web_service caused by a switch from trollop to optimist.
This is the upstream PR - not for backporting.

@agrare @NickLaMuro @roliveri @simaishi 

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1669626
* https://github.com/ManageIQ/manageiq/pull/18395
* https://github.com/ManageIQ/ffi-vix_disk_lib/pull/13
* https://github.com/ManageIQ/vmware_web_service/pull/46

Steps for Testing/QA [Optional]
-------------------------------

If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.
