### PR TITLE
rspec fix: reload Tag and Classification after update

### DIFF
--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -580,6 +580,8 @@ describe Classification do
         tag = classification.tag
         classification.name = new_name
         classification.save
+        tag.reload
+        classification.reload
         expect(tag.id).to eq classification.tag.id
         expect(classification.tag.name).to eq(Classification.name2tag(new_name))
       end


### PR DESCRIPTION
reload Tag and Classification after update

@miq-bot add-label bug, test, hammer/yes
