### PR TITLE
Adding event_streams to autovacuum list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,6 +96,7 @@
     - BinaryBlobPart
     - CustomizationSpec
     - EventLog
+    - EventStream
     - FirewallRule
     - Host
     - Job


### PR DESCRIPTION
It was included in the original maintenance but was lost when the table was renamed from `ems_events` to `event_streams`. This PR adds it back.

https://bugzilla.redhat.com/show_bug.cgi?id=1669541

/cc @carbonin 