### PR TITLE
Lock dry-logic to ~>0.4.2 as 0.5.0 is failing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "config",                         "~>1.6.0",       :require => false
 gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
+gem "dry-logic",                      "~>0.4.2",       :require => false # Lock down temporarily as 0.5.0 is breaking
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"


### PR DESCRIPTION
Starting with dry-logic 0.5.0 `rake environment` is failing on an
ArgumentError.  Temporarily lock down dry-logic until it is fixed.

```
ArgumentError: wrong number of arguments (given 0, expected 1)
/home/agrare/.gem/gems/dry-logic-0.5.0/lib/dry/logic/predicates.rb:17:in `nil?'
/home/agrare/.gem/gems/dry-configurable-0.7.0/lib/dry/configurable.rb:110:in `setting'
/home/agrare/.gem/gems/dry-validation-0.12.2/lib/dry/validation/schema/class_interface.rb:15:in `<class:Schema>'
/home/agrare/.gem/gems/dry-validation-0.12.2/lib/dry/validation/schema/class_interface.rb:7:in `<module:Validation>'
/home/agrare/.gem/gems/dry-validation-0.12.2/lib/dry/validation/schema/class_interface.rb:6:in `<module:Dry>'
/home/agrare/.gem/gems/dry-validation-0.12.2/lib/dry/validation/schema/class_interface.rb:5:in `<top (required)>'
/home/agrare/.gem/gems/activesupport-5.0.7.1/lib/active_support/dependencies.rb:293:in `require'
```