### PR TITLE
[GAPRINDASHVILI] Replace server config stub with settings stub

### DIFF
--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -285,8 +285,8 @@ describe MiqScheduleWorker::Runner do
                                       MiqWorker MiqServer MiqSearch MiqScsiLun MiqScsiTarget StorageFile
                                       Tagging VimPerformanceState)
             }
-            database_config = {:metrics_collection => @metrics_collection, :metrics_history => @metrics_history}
-            stub_server_configuration(:database => database_config)
+            database_config = {:metrics_collection => @metrics_collection, :metrics_history => @metrics_history, :maintenance => @database_maintenance}
+            stub_settings(:database => database_config)
           end
 
           context "with database_owner in region" do


### PR DESCRIPTION
The methods under test here use ::Settings which isn't affected
by stub_server_configuration

This fixes the spec failure caused by backporting https://github.com/ManageIQ/manageiq/pull/18402

This was also fixed when VMDB::Config was removed from the master branch in 2afde84cd67, but we can't backport that so this PR will have to do the job.