### PR TITLE
Allow tag names to be updated

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -529,7 +529,11 @@ class Classification < ApplicationRecord
 
   def save_tag
     tag_name = Classification.name2tag(name, parent_id, ns)
-    self.tag = Tag.in_region(region_id).find_or_create_by(:name => tag_name)
+    if tag_id.present? || tag.present?
+      tag.update_attributes(:name => tag_name) unless tag.name == tag_name
+    else
+      self.tag = Tag.in_region(region_id).find_or_create_by(:name => tag_name)
+    end
   end
 
   def delete_all_entries

--- a/spec/factories/classification.rb
+++ b/spec/factories/classification.rb
@@ -29,20 +29,16 @@ FactoryBot.define do
   #
 
   factory :classification_cost_center_with_tags, :parent => :classification_cost_center do
-    children do
-      [
-        FactoryBot.create(:classification_tag, :name => "001", :description => "Cost Center 001"),
-      ]
+    after(:create) do |c|
+      FactoryBot.create(:classification_tag, :name => "001", :description => "Cost Center 001", :parent => c)
     end
   end
 
   factory :classification_department_with_tags, :parent => :classification_department do
-    children do
-      [
-        FactoryBot.create(:classification_tag, :name => "accounting", :description => "Accounting"),
-        FactoryBot.create(:classification_tag, :name => "finance",    :description => "Financial Services"),
-        FactoryBot.create(:classification_tag, :name => "hr",         :description => "Human Resources"),
-      ]
+    after(:create) do |c|
+      FactoryBot.create(:classification_tag, :parent => c, :name => "accounting", :description => "Accounting")
+      FactoryBot.create(:classification_tag, :parent => c, :name => "finance",    :description => "Financial Services")
+      FactoryBot.create(:classification_tag, :parent => c, :name => "hr",         :description => "Human Resources")
     end
   end
 end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -571,6 +571,15 @@ describe Classification do
     end
   end
 
+  describe '.create' do
+    it "assigns proper tags" do
+      FactoryBot.create(:classification_department_with_tags)
+      Tag.all.each do |tag|
+        expect(tag.name).to eq(Classification.name2tag(tag.classification.name, tag.classification.parent_id))
+      end
+    end
+  end
+
   def all_tagged_with(target, all, category = nil)
     tagged_with(target, :all => all, :cat => category)
   end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -571,6 +571,32 @@ describe Classification do
     end
   end
 
+  describe '#save' do
+    let(:new_name) { "new_tag_name" }
+    let(:category) { FactoryBot.create(:classification, :name => "category") }
+
+    context "editing existing classification" do
+      let(:classification) { FactoryBot.create(:classification_tag, :parent => category, :name => "some_tag_name") }
+      it "doesn't assign new tag " do
+        tag = classification.tag
+        classification.update_attributes!(:name => new_name)
+        classification.reload
+        expect(tag.id).to eq classification.tag.id
+        expect(classification.name).to eq(new_name)
+        expect(classification.tag.name).to eq(Classification.name2tag(new_name, category))
+      end
+    end
+
+    context "saving new classification" do
+      it "creates new tag" do
+        classification = Classification.create(:description => new_name, :parent => category, :name => new_name)
+        expect(classification.tag).to be_present
+        expect(classification.name).to eq(new_name)
+        expect(classification.tag.name).to eq(Classification.name2tag(new_name, category))
+      end
+    end
+  end
+
   describe '.create' do
     it "assigns proper tags" do
       FactoryBot.create(:classification_department_with_tags)


### PR DESCRIPTION
This is a follow up to #18378 

### Before

When a `classification#name` was changed, a new tag was assigned.
The existing tag was linked to records in the database. Those records were linked to a tag with an incorrect classification.

### After

When a `classification#name` is changed, the corresponding tag is updated.
Now records linked to the tag are still linked and the classifications are valid.

### Didn't we just undo this change?

2 Bad entries in classification factory were causing tests in many repos to fail when classifications were changed. Changing this factory to properly create classification/tags now means that the proper changes to classifications does not break other repo tests.

