### PR TITLE
[WIP] Classification optimization

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -553,10 +553,7 @@ class Classification < ApplicationRecord
   end
 
   def delete_tag_and_taggings
-    tag = find_tag
-    return if tag.nil?
-
-    tag.destroy
+    tag&.destroy
   end
 
   def delete_tags_and_entries

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -524,17 +524,20 @@ class Classification < ApplicationRecord
     File.split(tag).last unless tag.nil?
   end
 
+  def derive_tag_name
+    Classification.name2tag(name, category? ? parent_id : parent, ns)
+  end
+
   def find_tag
-    tag_name = Classification.name2tag(name, parent, ns)
-    Tag.in_region(region_id).find_by(:name => tag_name)
+    Tag.in_region(region_id).find_by(:name => derive_tag_name)
   end
 
   def save_tag
-    tag_name = Classification.name2tag(name, parent, ns)
     if tag_id.present? || tag.present?
+      tag_name = derive_tag_name
       tag.update(:name => tag_name) unless tag.name == tag_name
     else
-      self.tag = Tag.in_region(region_id).find_or_create_by(:name => tag_name)
+      self.tag = Tag.in_region(region_id).find_or_create_by(:name => derive_tag_name)
     end
   end
 

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -214,9 +214,9 @@ class Classification < ApplicationRecord
 
   def self.category_names_for_perf_by_tag(region_id = my_region_number, ns = DEFAULT_NAMESPACE)
     in_region(region_id).is_category.where(:perf_by_tag => true)
-      .includes(:tag)
-      .collect { |c| c.name if c.tag2ns(c.tag_name) == ns }
-      .compact
+                        .includes(:tag)
+                        .collect { |c| c.name if c.tag2ns(c.tag_name) == ns }
+                        .compact
   end
 
   def self.find_assigned_entries(obj, ns = DEFAULT_NAMESPACE)

--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -18,8 +18,6 @@ class Classification < ApplicationRecord
   validates :name, :presence => true, :length => {:maximum => NAME_MAX_LENGTH}
   validate :validate_format_of_name
 
-  validate :validate_uniqueness_on_tag_name
-
   validates :syntax, :inclusion => {:in      => %w[string integer boolean],
                                     :message => "should be one of 'string', 'integer' or 'boolean'"}
 
@@ -505,17 +503,6 @@ class Classification < ApplicationRecord
   end
 
   private_class_method :add_entries_from_hash
-
-  def validate_uniqueness_on_tag_name
-    tag_name = Classification.name2tag(name, parent, ns)
-    exist_scope = Classification.default_scoped
-                                .includes(:tag)
-                                .where(:tags => {:name => tag_name})
-                                .merge(Tag.in_region(region_id))
-    exist_scope = exist_scope.where.not(:id => id) unless new_record?
-
-    errors.add("name", "has already been taken") if exist_scope.exists?
-  end
 
   def self.name2tag(name, parent_id = nil, ns = DEFAULT_NAMESPACE)
     if parent_id.nil?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,6 +15,8 @@ class Tag < ApplicationRecord
   scope :is_category, -> { joins(:classification).merge(Classification.is_category) }
   scope :is_entry,    -> { joins(:classification).merge(Classification.is_entry) }
 
+  validates :name, :unique_within_region => true
+
   def self.list(object, options = {})
     ns = get_namespace(options)
     if ns[0..7] == "/virtual"


### PR DESCRIPTION
Dependencies:

- [x] #18409
- [ ] #19523
- [x] https://travis-ci.org/kbrock/manageiq-cross_repo/builds/612422470 - failures unrelated:
  - azure: #19522 https://github.com/ManageIQ/manageiq-providers-azure/pull/369
  - api sporadic: https://github.com/ManageIQ/manageiq-api/pull/711

Reduce the number of queries for classification updates:

```ruby
c = Classification.last
c.update_attributes(:name => "managed")          # name  
```

|    ms |      bytes | objects|query |qry ms|     rows |`comments`
|   ---:|        ---:|    ---:|  ---:|  ---:|      ---:| ---
|  84.1 | 1,504,436* | 19,330 |   14 | 14.7 |        7 | before-name-1
|  63.8 | 1,178,814* | 15,670 |    7 | 11.9 |        3 | after-name-2
|   24% | 22%        | 19%    | 50%  |  19% |  57%     | diff

\* Memory usage does not reflect 113 freed objects. 
\* Memory usage does not reflect 100 freed objects. 

```ruby
c = Classification.last
c.update_attributes(:description => "Migrated")  # desc
```

|    ms |      bytes | objects|query |qry ms|     rows |`comments`
|   ---:|        ---:|    ---:|  ---:|  ---:|      ---:| ---
|  85.4 | 1,496,034* | 19,243 |   14 | 15.8 |        9 | before-desc-1
|  46.8 |   159,206* |  1,924 |    4 |  7.7 |          | after-desc-1
|   45% |       89%  |   90%  |  71% |  51% |  100%    | diff

\* Memory usage does not reflect 112 freed objects. 
\* Memory usage does not reflect 5 freed objects. 

```ruby
c = Classification.last
c.save                                           # nop
```

|    ms |      bytes | objects|query |qry ms|     rows | comments
|   ---:|        ---:|    ---:|  ---:|  ---:|      ---:| ---
|  72.6 | 1,436,927* | 18,756 |   13 |  8.9 |        9 | before-nop-1
|  37.2 |    65,917* |    837 |    2 |  0.7 |          | after-nop-2
|   49% |        95% |   96%  |  85% | 92.1%|     100% | diff

\* Memory usage does not reflect 112 freed objects. 
\* Memory usage does not reflect 2 freed objects. 

of note, the 2 "queries" for the no-op save is `"BEGIN" ; "END"`