### PR TITLE
Remove deprecated MiqDialog.sync_from_file method

### DIFF
--- a/app/models/miq_dialog/seeding.rb
+++ b/app/models/miq_dialog/seeding.rb
@@ -25,11 +25,6 @@ class MiqDialog
         seed_record(path, MiqDialog.find_by(:filename => seed_filename(path)))
       end
 
-      # TODO: Remove this once we change all of the callers
-      def sync_from_file(path, _root)
-        seed_dialog(path)
-      end
-
       private
 
       def seed_record(path, dialog)


### PR DESCRIPTION
Added temporarily in https://github.com/ManageIQ/manageiq/pull/18366/files#diff-4662619cda7219ae1605ab55f1e2f2bcR28
Last caller was removed in https://github.com/ManageIQ/manageiq-ui-classic/pull/5206

@gtanzillo Please review.

