### PR TITLE
remove towhat reference

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -150,7 +150,7 @@ class MiqReport < ApplicationRecord
 
     params['filter'] = MiqExpression.new("=" => {"field" => "MiqReport-id",
                                                  "value" => id})
-    params['towhat'] = "MiqReport"
+    params['resource_type'] = "MiqReport"
     params['prod_default'] = "system"
 
     MiqSchedule.create!(params)


### PR DESCRIPTION
This removes a deprecation warning (it was being triggered in manageiq-api repo

```
DEPRECATION WARNING:
towhat= is deprecated and will be removed from Ivanchuk release
(resource_type=)
called from add_schedule at spec/manageiq/app/models/miq_report.rb:156
```

I do admit, this makes me a little nervous.

There is no doubt that this call is creating an `MiqSchedule`, but there are other valid references of `towhat` for things like `MiqPolicy` so we need to be extra vigilant around these.