### PR TITLE
Simplify the ConversionHost::Configurations#enable method.

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -29,7 +29,7 @@ module ConversionHost::Configurations
 
     def enable_queue(params, auth_user = nil)
       params = params.symbolize_keys
-      resource = params.delete('resource')
+      resource = params.delete(:resource)
       queue_configuration('enable', nil, resource, [params], auth_user)
     end
 

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -29,11 +29,7 @@ module ConversionHost::Configurations
 
     def enable_queue(params, auth_user = nil)
       params = params.symbolize_keys
-      resource_type = params[:resource_type]
-      resource_id = params[:resource_id]
-
-      resource = resource_type.to_s.downcase.classify.constantize.find(resource_id)
-
+      resource = params.delete('resource')
       queue_configuration('enable', nil, resource, [params], auth_user)
     end
 
@@ -45,13 +41,8 @@ module ConversionHost::Configurations
       params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
 
       vddk_url = params.delete(:param_v2v_vddk_package_url)
-      resource_id = params[:resource_id]
-      resource_type = params[:resource_type]
 
-      # Effectively ignore case since we cannot guarantee it from the REST API
-      resource = resource_type.to_s.downcase.classify.constantize.find(resource_id)
-
-      conversion_host = new(params.merge(:resource => resource))
+      conversion_host = new(params)
       conversion_host.enable_conversion_host_role(vddk_url)
       conversion_host.save!
       conversion_host

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -30,6 +30,10 @@ module ConversionHost::Configurations
     def enable_queue(params, auth_user = nil)
       params = params.symbolize_keys
       resource = params.delete(:resource)
+
+      params[:resource_id] = resource.id
+      params[:resource_type] = resource.class.name
+
       queue_configuration('enable', nil, resource, [params], auth_user)
     end
 

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -4,7 +4,8 @@ describe ConversionHost do
     {
       :name          => 'transformer',
       :resource_type => vm.class.name,
-      :resource_id   => vm.id
+      :resource_id   => vm.id,
+      :resource      => vm
     }
   end
 
@@ -75,32 +76,13 @@ describe ConversionHost do
         task_id = described_class.enable_queue(params)
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [params.merge(:task_id => task_id)],
+          :args        => [params.merge(:task_id => task_id).except(:resource)],
           :class_name  => described_class.name,
           :method_name => "enable",
           :priority    => MiqQueue::NORMAL_PRIORITY,
           :role        => "ems_operations",
           :zone        => vm.ext_management_system.my_zone
         )
-      end
-
-      it "to queue with a task even with lowercase resource type" do
-        params[:resource_type] = 'vm'
-        task_id = described_class.enable_queue(params)
-        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
-        expect(MiqQueue.first).to have_attributes(
-          :args        => [params.merge(:task_id => task_id)],
-          :class_name  => described_class.name,
-          :method_name => "enable",
-          :priority    => MiqQueue::NORMAL_PRIORITY,
-          :role        => "ems_operations",
-          :zone        => vm.ext_management_system.my_zone
-        )
-      end
-
-      it "to fail when the resource is not found" do
-        vm.destroy!
-        expect { described_class.enable_queue(params) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -84,6 +84,20 @@ describe ConversionHost do
         )
       end
 
+      it "to queue with a task even with lowercase resource type" do
+        params[:resource_type] = 'vm'
+        task_id = described_class.enable_queue(params)
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
+        expect(MiqQueue.first).to have_attributes(
+          :args        => [params.merge(:task_id => task_id)],
+          :class_name  => described_class.name,
+          :method_name => "enable",
+          :priority    => MiqQueue::NORMAL_PRIORITY,
+          :role        => "ems_operations",
+          :zone        => vm.ext_management_system.my_zone
+        )
+      end
+
       it "to fail when the resource is not found" do
         vm.destroy!
         expect { described_class.enable_queue(params) }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq/pull/18388

Upon further review the extra effort to suss out the resource_id and resource_type within the enable method are unnecessary, as the appropriate resource will be set automatically using AR's baked in features, so we can just pass the params directly as-is. So, this PR eliminates an unnecessary (and currently somewhat broken) constantize effort, as well as an unnecessary lookup.

We needn't explicitly check for the resource_id and resource_type, either, as they are already required via model validations.

I also removed the downcase call within the enable_queue method, since it broke VmOrTemplate lookups.

Per request, the enable_queue method now assumes a resource is being passed in, instead of doing a lookup.