### PR TITLE
Add empty IP address check to preflight check

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -54,7 +54,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   def preflight_check
     destination_cluster
     virtv2v_disks
-    network_mappings
+    network_mappings.each { |m| raise if m.ip_address.nil? }
     raise if destination_ems.emstype == 'openstack' && source.power_state == 'off'
     true
   rescue

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -54,7 +54,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   def preflight_check
     destination_cluster
     virtv2v_disks
-    network_mappings.each { |m| raise if m.ip_address.nil? }
+    network_mappings
     raise if destination_ems.emstype == 'openstack' && source.power_state == 'off'
     true
   rescue
@@ -256,11 +256,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       source_network = nic.lan
       destination_network = transformation_destination(source_network)
       raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping." if destination_network.nil?
+      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil?
       {
         :source      => source_network.name,
         :destination => destination_network_ref(destination_network),
         :mac_address => nic.address,
-        :ip_address  => nic.network.try(:ipaddress)
+        :ip_address  => nic.network.ipaddress
       }
     end
   end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -453,6 +453,8 @@ describe ServiceTemplateTransformationPlanTask do
           )
         end
 
+        it { expect(task_1.preflight_check). to be false }
+
         context "transport method is vddk" do
           before do
             conversion_host.vddk_transport_supported = true
@@ -541,6 +543,8 @@ describe ServiceTemplateTransformationPlanTask do
             ]
           )
         end
+
+        it { expect(task_1.preflight_check). to be false }
 
         context "transport method is vddk" do
           before do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -304,7 +304,9 @@ describe ServiceTemplateTransformationPlanTask do
       let(:src_vm_1) { FactoryBot.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
       let(:src_vm_2) { FactoryBot.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
 
-      let(:src_network) { FactoryBot.create(:network, :ipaddress => '10.0.0.1') }
+      let(:src_network_1) { FactoryBot.create(:network, :ipaddress => '10.0.1.1') }
+      let(:src_network_2a) { FactoryBot.create(:network, :ipaddress => '10.0.1.2') }
+      let(:src_network_2b) { FactoryBot.create(:network, :ipaddress => nil) }
 
       # Disks have to be stubbed because there's no factory for Disk class
       before do
@@ -312,7 +314,7 @@ describe ServiceTemplateTransformationPlanTask do
         allow(src_disk_1).to receive(:storage).and_return(src_storage)
         allow(src_disk_2).to receive(:storage).and_return(src_storage)
         allow(src_vm_1).to receive(:allocated_disk_storage).and_return(34_359_738_368)
-        allow(src_nic_1).to receive(:network).and_return(src_network)
+        allow(src_nic_1).to receive(:network).and_return(src_network_1)
         allow(src_host).to receive(:thumbprint_sha1).and_return('01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67')
         allow(src_host).to receive(:authentication_userid).and_return('esx_user')
         allow(src_host).to receive(:authentication_password).and_return('esx_passwd')
@@ -438,22 +440,28 @@ describe ServiceTemplateTransformationPlanTask do
 
         before do
           task_1.conversion_host = conversion_host
+          allow(src_nic_2).to receive(:network).and_return(src_network_2a)
         end
 
         it { expect(task_1.destination_cluster).to eq(dst_cluster) }
 
         it_behaves_like "#virtv2v_disks"
 
-        it "checks network mappings and generates network_mappings hash" do
-          expect(task_1.network_mappings).to eq(
-            [
-              { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.0.1' },
-              { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address, :ip_address => nil }
-            ]
-          )
-        end
+        context "#network_mappings" do
+          it "generates network_mappings hash" do
+            expect(task_1.network_mappings).to eq(
+              [
+                { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address, :ip_address => '10.0.1.2' }
+              ]
+            )
+          end
 
-        it { expect(task_1.preflight_check). to be false }
+          it "fails if network IP address is nil" do
+            allow(src_nic_2).to receive(:network).and_return(src_network_2b)
+            expect { task_1.network_mappings }.to raise_error("[#{src_vm_1.name}] NIC #{src_nic_2.device_name} [#{src_lan_2.name}] has an empty IP address.")
+          end
+        end
 
         context "transport method is vddk" do
           before do
@@ -510,6 +518,8 @@ describe ServiceTemplateTransformationPlanTask do
         let(:dst_cloud_volume_type) { FactoryBot.create(:cloud_volume_type) }
         let(:dst_cloud_network_1) { FactoryBot.create(:cloud_network) }
         let(:dst_cloud_network_2) { FactoryBot.create(:cloud_network) }
+        let(:dst_net_1) { dst_cloud_network_1 }
+        let(:dst_net_2) { dst_cloud_network_2 }
         let(:dst_flavor) { FactoryBot.create(:flavor) }
         let(:dst_security_group) { FactoryBot.create(:security_group) }
         let(:conversion_host_vm) { FactoryBot.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant) }
@@ -529,22 +539,28 @@ describe ServiceTemplateTransformationPlanTask do
 
         before do
           task_1.conversion_host = conversion_host
+          allow(src_nic_2).to receive(:network).and_return(src_network_2a)
         end
 
         it { expect(task_1.destination_cluster).to eq(dst_cloud_tenant) }
 
         it_behaves_like "#virtv2v_disks"
 
-        it "checks network mappings and generates network_mappings hash" do
-          expect(task_1.network_mappings).to eq(
-            [
-              { :source => src_lan_1.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.0.1' },
-              { :source => src_lan_2.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address, :ip_address => nil }
-            ]
-          )
-        end
+        context "#network_mappings" do
+          it "generates network_mappings hash" do
+            expect(task_1.network_mappings).to eq(
+              [
+                { :source => src_lan_1.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lan_2.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address, :ip_address => '10.0.1.2' }
+              ]
+            )
+          end
 
-        it { expect(task_1.preflight_check). to be false }
+          it "fails if network IP address is nil" do
+            allow(src_nic_2).to receive(:network).and_return(src_network_2b)
+            expect { task_1.network_mappings }.to raise_error("[#{src_vm_1.name}] NIC #{src_nic_2.device_name} [#{src_lan_2.name}] has an empty IP address.")
+          end
+        end
 
         context "transport method is vddk" do
           before do


### PR DESCRIPTION
With Linux virtual machines, we have at least two known cases where the IP address for an NIC is empty: 1. _ghost_ config files(ifcfg-*) ; 2. the NIC has more than one IPv4 or one IPv6 address on the NIC. This leads to generating network mappings for conversion with _nil_ addresses, which in turn causes the conversion to fail, as virt-v2v-wrapper can't handle _nil_ addresses.

This PR adds a preflight check on the transformation task to verify that no interface in the mapping has a _nil_ address. The goal is to fail early in the transformation process and not even stop the source VM, preserving the source environment.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1671719