### PR TITLE
Update host switch association

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -52,6 +52,8 @@ class ExtManagementSystem < ApplicationRecord
   has_many :disks,             :through => :hardwares
   has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
+  has_many :host_virtual_switches, -> { distinct }, :through => :hosts
+
   has_many :storages,       -> { distinct },          :through => :hosts
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",
                                                       :inverse_of => :ext_management_system

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -53,6 +53,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
   has_many :host_virtual_switches, -> { distinct }, :through => :hosts
+  has_many :host_virtual_lans,     -> { distinct }, :through => :host_virtual_switches, :source => :lans
 
   has_many :storages,       -> { distinct },          :through => :hosts
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -52,9 +52,6 @@ class ExtManagementSystem < ApplicationRecord
   has_many :disks,             :through => :hardwares
   has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
-  has_many :host_virtual_switches, -> { distinct }, :through => :hosts
-  has_many :host_virtual_lans,     -> { distinct }, :through => :host_virtual_switches, :source => :lans
-
   has_many :storages,       -> { distinct },          :through => :hosts
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",
                                                       :inverse_of => :ext_management_system

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -49,6 +49,7 @@ class Host < ApplicationRecord
   has_many                  :storages, :through => :host_storages
   has_many                  :writable_accessible_host_storages, -> { writable_accessible }, :class_name => "HostStorage"
   has_many                  :writable_accessible_storages, :through => :writable_accessible_host_storages, :source => :storage
+  has_many                  :host_virtual_switches, :class_name => "Switch", :dependent => :destroy, :inverse_of => :host
   has_many                  :host_switches, :dependent => :destroy
   has_many                  :switches, :through => :host_switches
   has_many                  :lans,     :through => :switches

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -7,6 +7,9 @@ module ManageIQ::Providers
 
     include AvailabilityMixin
 
+    has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
+    has_many :host_virtual_switches, -> { distinct }, :through => :hosts
+
     has_many :host_hardwares,             :through => :hosts, :source => :hardware
     has_many :host_operating_systems,     :through => :hosts, :source => :operating_system
     has_many :host_storages,              :through => :hosts

--- a/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::InfraManager::DistributedVirtualSwitch < ::Switch
-  belongs_to :ext_management_system, :foreign_key => :ems_id
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :distributed_virtual_switch
 end

--- a/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::InfraManager::DistributedVirtualSwitch < ::Switch
+  belongs_to :ext_management_system, :foreign_key => :ems_id
+end

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -208,6 +208,7 @@ module ManageIQ::Providers
         def host_virtual_switches
           add_properties(
             :manager_ref                  => %i(host uid_ems),
+            :model_class                  => Switch,
             :parent_inventory_collections => %i(hosts)
           )
         end

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -205,9 +205,16 @@ module ManageIQ::Providers
           )
         end
 
-        def switches
+        def host_virtual_switches
           add_properties(
-            :manager_ref => %i(uid_ems), # TODO looks like switches are using a bad association, this one is defined as through hosts
+            :manager_ref                  => %i(host uid_ems),
+            :parent_inventory_collections => %i(hosts)
+          )
+        end
+
+        def distributed_virtual_switches
+          add_properties(
+            :manager_ref => %i(uid_ems)
           )
           add_common_default_values
         end

--- a/app/models/switch.rb
+++ b/app/models/switch.rb
@@ -2,6 +2,8 @@ class Switch < ApplicationRecord
   include NewWithTypeStiMixin
   include CustomActionsMixin
 
+  belongs_to :host, :inverse_of => :host_virtual_switches
+
   has_many :host_switches, :dependent => :destroy
   has_many :hosts, :through => :host_switches
 


### PR DESCRIPTION
Fix issues with how switches are associated to hosts and EMSs that required really hacky ways of handling switch deletion ([here](https://github.com/ManageIQ/manageiq/pull/18427/files#diff-50f9feed046a3410ac5531492059a6fbL308)).

Depends on: ~~https://github.com/ManageIQ/manageiq-schema/pull/232~~

Dependents:
1. https://github.com/ManageIQ/manageiq-providers-scvmm/pull/104
2. https://github.com/ManageIQ/manageiq-providers-vmware/pull/364
3. https://github.com/ManageIQ/manageiq-providers-ovirt/pull/338