### PR TITLE
Don't format chargeback rate column in MiqReport::Formatting

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -268,6 +268,10 @@ class Chargeback < ActsAsArModel
     end
   end
 
+  def self.rate_column?(col)
+    col.ends_with?("_rate")
+  end
+
   private
 
   def relevant_fields

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -37,6 +37,8 @@ module MiqReport::Formatting
       end
     end
 
+    # TODO: remove this and update storing column format to instance of report in UI (this requires migration)
+    options[:format] = :_none_ if Chargeback.db_is_chargeback?(db) && Chargeback.rate_column?(col.to_s)
     col = Chargeback.default_column_for_format(col.to_s) if Chargeback.db_is_chargeback?(db)
 
     format = options.delete(:format)


### PR DESCRIPTION

This is not best fix but usable for backport

**Issue:**
Some of "float" format was taken for chargeback rate columns which are strings.
Solution is to don't format such columns

```
[----] E, [2018-11-01T11:25:45.469900 #11829:93af80] ERROR -- : /opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75b755f67a94/app/helpers/number_helper.rb:53:in `Float'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75b755f67a94/app/helpers/number_helper.rb:53:in `handling_negatives'
/opt/rh/cfme-gemset/bundler/gems/cfme-ui-classic-75b755f67a94/app/helpers/number_helper.rb:4:in `number_to_human_size'
/var/www/miq/vmdb/app/models/miq_report/formatting.rb:122:in `format_bytes_to_human_size'
/var/www/miq/vmdb/app/models/miq_report/formatting.rb:90:in `apply_format_function'
/var/www/miq/vmdb/app/models/miq_report/formatting.rb:75:in `format'
```

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1645193

@miq-bot assign @gtanzillo 
@miq-bot add_label hammer/yes, bug, chargeback

