### PR TITLE
Allow virtual_delegate type to be passed in

### DIFF
--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -111,6 +111,9 @@ module VirtualDelegates
     #
     # this is called at schema load time (and not at class definition time)
     #
+    # Of note, klass.type_for_attribute() loads the schema of the target type.
+    # In rare cases, this can cause race conditions
+    #
     # @param  method_name [Symbol] name of the attribute on the source class to be defined
     # @param  col [Symbol] name of the attribute on the associated class to be referenced
     # @option options :to [Symbol] name of the association from the source class to be referenced
@@ -122,7 +125,7 @@ module VirtualDelegates
       end
 
       col = col.to_s
-      type = to_ref.klass.type_for_attribute(col)
+      type = options[:type] || to_ref.klass.type_for_attribute(col)
       raise "unknown attribute #{to}##{col} referenced in #{name}" unless type
       arel = virtual_delegate_arel(col, to_ref)
       define_virtual_attribute(method_name, type, :uses => (options[:uses] || to), :arel => arel)


### PR DESCRIPTION
Related to:

- https://github.com/ManageIQ/manageiq-api/pull/550
- https://github.com/ManageIQ/manageiq-api/pull/554
- https://bugzilla.redhat.com/show_bug.cgi?id=1671458

`klass.type_for_attribute()` loads the schema of the target type.
In rare cases, this can cause race conditions.

A delegate is an attribute that is based upon an attribute on another
model. So in order to define the attribute on this model it
needs to reference the definition of the attribute on another model.

Making loading depend upon the loading of another resource can
possibly create circular dependencies and/or race conditions
while loading attributes.

The quick solution is to just manually define the type (Which is how we
do it for all other virtual attributes)