### PR TITLE
Fix save_inventory error if lan can't be found

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -305,6 +305,9 @@ module EmsRefresh::SaveInventoryInfra
   end
 
   def save_switches_inventory(host, hashes)
+    ems = host.ext_management_system
+    log_header = "EMS: [#{ems.name}], id: [#{ems.id}]"
+
     already_saved, not_yet_saved = hashes.partition { |h| h[:id] }
     save_inventory_multi(host.switches, not_yet_saved, [], [:uid_ems], :lans)
     host_switches_hash = already_saved.collect { |switch| {:host_id => host.id, :switch_id => switch[:id]} }
@@ -321,6 +324,11 @@ module EmsRefresh::SaveInventoryInfra
       next if sh[:lans].nil?
       sh[:lans].each do |lh|
         lan = switch.lans.detect { |l| l.uid_ems == lh[:uid_ems] }
+        if lan.nil?
+          _log.warn("#{log_header} Failed to find lan [#{lh[:uid_ems]}] for switch ID [#{switch.id}]")
+          next
+        end
+
         lh[:id] = lan.id
       end
     end


### PR DESCRIPTION
When loading IDs of newly saved lans skip any that can't be found by uid_ems.  This is still indicative of another issue but this should at least allow refresh to continue.

```
NoMethodError: undefined method `id' for nil:NilClass]. Skipping Host.
[----] E, [2018-11-20T03:53:53.054427 #66702:e15118] ERROR -- : [NoMethodError]: undefined method `id' for nil:NilClass  Method:[block in method_missing]
[----] E, [2018-11-20T03:53:53.054663 #66702:e15118] ERROR -- : /var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:324:in `block (2 levels) in save_switches_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:322:in `each' 
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:322:in `block in save_switches_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:317:in `each' 
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:317:in `save_switches_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_helper.rb:122:in `block in save_child_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_helper.rb:122:in `each' 
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_helper.rb:122:in `save_child_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:183:in `block in save_hosts_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:132:in `each' 
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:132:in `save_hosts_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_helper.rb:122:in `block in save_child_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_helper.rb:122:in `each' 
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_helper.rb:122:in `save_child_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory_infra.rb:69:in `save_ems_infra_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/save_inventory.rb:12:in `save_ems_inventory'
/opt/rh/cfme-gemset/bundler/gems/cfme-providers-vmware-7f32eae469a5/app/models/manageiq/providers/vmware/infra_manager/refresher.rb:62:in `block in save_inventory
```

https://bugzilla.redhat.com/show_bug.cgi?id=1657341