### PR TITLE
Change ConversionHost resource_type validation

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -116,8 +116,8 @@ class ConversionHost < ApplicationRecord
   # using the SupportsFeature mixin.
   #
   def resource_supports_conversion_host
-    unless resource.class.supports_conversion_host?
-      errors.add(:resource_type, "#{resource.class} does not support conversion hosts")
+    unless resource.supports_conversion_host?
+      errors.add(:resource_type, resource.unsupported_reason(:conversion_host))
     end
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -9,8 +9,7 @@ class ConversionHost < ApplicationRecord
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   validates :name, :presence => true
-  validates :resource_id, :presence => true
-  validates :resource_type, :presence => true
+  validates :resource, :presence => true
 
   validates :address,
     :uniqueness => true,
@@ -116,8 +115,8 @@ class ConversionHost < ApplicationRecord
   # using the SupportsFeature mixin.
   #
   def resource_supports_conversion_host
-    unless resource.supports_conversion_host?
-      errors.add(:resource_type, resource.unsupported_reason(:conversion_host))
+    if resource && !resource.supports_conversion_host?
+      errors.add(:resource, resource.unsupported_reason(:conversion_host))
     end
   end
 

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -10,7 +10,7 @@ describe ConversionHost do
   end
 
   context "processing configuration requests" do
-    let(:vm) { FactoryBot.create(:vm) }
+    let(:vm) { FactoryBot.create(:vm_openstack) }
     before(:each) do
       allow(ConversionHost).to receive(:new).and_return(conversion_host)
     end
@@ -66,7 +66,7 @@ describe ConversionHost do
 
   context "queuing configuration requests" do
     let(:ext_management_system) { FactoryBot.create(:ext_management_system) }
-    let(:vm) { FactoryBot.create(:vm, :ext_management_system => ext_management_system) }
+    let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ext_management_system) }
     let(:expected_task_action) { "Configuring a conversion_host: operation=#{op} resource=(type: #{vm.class.name} id:#{vm.id})" }
 
     context ".enable_queue" do

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -5,7 +5,7 @@ describe ConversionHost do
 
   context "provider independent methods" do
     let(:host) { FactoryBot.create(:host) }
-    let(:vm) { FactoryBot.create(:vm) }
+    let(:vm) { FactoryBot.create(:vm_or_template) }
     let(:conversion_host_1) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
     let(:conversion_host_2) { FactoryBot.create(:conversion_host, :skip_validate, :resource => vm) }
     let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -4,10 +4,10 @@ describe ConversionHost do
   let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
 
   context "provider independent methods" do
-    let(:host) { FactoryBot.create(:host_redhat) }
-    let(:vm) { FactoryBot.create(:vm_openstack) }
-    let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
-    let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:host) { FactoryBot.create(:host) }
+    let(:vm) { FactoryBot.create(:vm) }
+    let(:conversion_host_1) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
+    let(:conversion_host_2) { FactoryBot.create(:conversion_host, :skip_validate, :resource => vm) }
     let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
     let(:task_3) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_2) }

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -140,7 +140,7 @@ describe ConversionHost do
   end
 
   context "resource provider is rhevm" do
-    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone)) }
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
     let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => host, :vddk_transport_supported => true) }
 
@@ -188,7 +188,7 @@ describe ConversionHost do
   end
 
   context "address validation" do
-    let(:vm) { FactoryBot.create(:host_redhat) }
+    let(:vm) { FactoryBot.create(:vm_openstack) }
 
     it "is invalid if the address is not a valid IP address" do
       allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
@@ -217,7 +217,8 @@ describe ConversionHost do
   end
 
   context "resource validation" do
-    let(:redhat_host) { FactoryBot.create(:host_redhat) }
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:redhat_host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
     let(:azure_vm) { FactoryBot.create(:vm_azure) }
 
     it "is valid if the associated resource supports conversion hosts" do
@@ -228,6 +229,7 @@ describe ConversionHost do
     it "is invalid if the associated resource does not support conversion hosts" do
       conversion_host = ConversionHost.new(:name => "test", :resource => azure_vm)
       expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors.messages[:resource_type].first).to eql("Feature not available/supported")
     end
   end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -215,4 +215,19 @@ describe ConversionHost do
       expect(conversion_host.valid?).to be(true)
     end
   end
+
+  context "resource validation" do
+    let(:redhat_host) { FactoryBot.create(:host_redhat) }
+    let(:azure_vm) { FactoryBot.create(:vm_azure) }
+
+    it "is valid if the associated resource supports conversion hosts" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => redhat_host)
+      expect(conversion_host.valid?).to be(true)
+    end
+
+    it "is invalid if the associated resource does not support conversion hosts" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => azure_vm)
+      expect(conversion_host.valid?).to be(false)
+    end
+  end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -229,7 +229,13 @@ describe ConversionHost do
     it "is invalid if the associated resource does not support conversion hosts" do
       conversion_host = ConversionHost.new(:name => "test", :resource => azure_vm)
       expect(conversion_host.valid?).to be(false)
-      expect(conversion_host.errors.messages[:resource_type].first).to eql("Feature not available/supported")
+      expect(conversion_host.errors.messages[:resource].first).to eql("Feature not available/supported")
+    end
+
+    it "is invalid if there is no associated resource" do
+      conversion_host = ConversionHost.new(:name => "test2")
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:resource].first).to eql("can't be blank")
     end
   end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -4,10 +4,11 @@ describe ConversionHost do
   let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
 
   context "provider independent methods" do
-    let(:host) { FactoryBot.create(:host) }
-    let(:vm) { FactoryBot.create(:vm_or_template) }
-    let(:conversion_host_1) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
-    let(:conversion_host_2) { FactoryBot.create(:conversion_host, :skip_validate, :resource => vm) }
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
+    let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
     let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
     let(:task_3) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_2) }

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -4,8 +4,8 @@ describe ConversionHost do
   let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
 
   context "provider independent methods" do
-    let(:host) { FactoryBot.create(:host) }
-    let(:vm) { FactoryBot.create(:vm_or_template) }
+    let(:host) { FactoryBot.create(:host_redhat) }
+    let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
     let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
     let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
@@ -188,7 +188,7 @@ describe ConversionHost do
   end
 
   context "address validation" do
-    let(:vm) { FactoryBot.create(:host) }
+    let(:vm) { FactoryBot.create(:host_redhat) }
 
     it "is invalid if the address is not a valid IP address" do
       allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -60,7 +60,7 @@ describe ServiceTemplateTransformationPlanRequest do
       let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
 
       it 'returns false' do
-        host = FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)))
+        host = FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)))
         conversion_host = FactoryBot.create(:conversion_host, :resource => host)
         expect(request.validate_conversion_hosts).to be false
       end
@@ -96,7 +96,7 @@ describe ServiceTemplateTransformationPlanRequest do
       let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
 
       it 'returns true' do
-        host = FactoryBot.create(:host, :ext_management_system => dst_ems, :ems_cluster => dst_cluster)
+        host = FactoryBot.create(:host_redhat, :ext_management_system => dst_ems, :ems_cluster => dst_cluster)
         conversion_host = FactoryBot.create(:conversion_host, :resource => host)
         expect(request.validate_conversion_hosts).to be true
       end

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -60,14 +60,14 @@ describe ServiceTemplateTransformationPlanRequest do
       let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
 
       it 'returns false' do
-        host = FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)))
+        host = FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone), :api_version => '4.2.4'))
         conversion_host = FactoryBot.create(:conversion_host, :resource => host)
         expect(request.validate_conversion_hosts).to be false
       end
     end
 
     context 'conversion host exists in EMS and resource is a Host' do
-      let(:dst_ems) { FactoryBot.create(:ems_redhat) }
+      let(:dst_ems) { FactoryBot.create(:ems_redhat, :api_version => '4.2.4') }
       let(:src_cluster) { FactoryBot.create(:ems_cluster) }
       let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
 

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -16,10 +16,10 @@ describe ServiceTemplateTransformationPlanTask do
     let(:src) { FactoryBot.create(:ems_cluster) }
     let(:dst) { FactoryBot.create(:ems_cluster) }
     let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
-    let(:vm)  { FactoryBot.create(:vm_openstack) }
-    let(:vm2)  { FactoryBot.create(:vm_openstack) }
+    let(:vm)  { FactoryBot.create(:vm_or_template) }
+    let(:vm2)  { FactoryBot.create(:vm_or_template) }
     let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
-    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => host) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
 
     let(:mapping) do
       FactoryBot.create(

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -15,9 +15,9 @@ describe ServiceTemplateTransformationPlanTask do
   context 'independent of provider' do
     let(:src) { FactoryBot.create(:ems_cluster) }
     let(:dst) { FactoryBot.create(:ems_cluster) }
-    let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
-    let(:vm)  { FactoryBot.create(:vm_or_template) }
-    let(:vm2)  { FactoryBot.create(:vm_or_template) }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
+    let(:vm)  { FactoryBot.create(:vm_openstack) }
+    let(:vm2)  { FactoryBot.create(:vm_openstack) }
     let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => host) }
 
@@ -301,8 +301,8 @@ describe ServiceTemplateTransformationPlanTask do
 
       let(:src_hardware) { FactoryBot.create(:hardware, :nics => [src_nic_1, src_nic_2]) }
 
-      let(:src_vm_1) { FactoryBot.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
-      let(:src_vm_2) { FactoryBot.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
+      let(:src_vm_1) { FactoryBot.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
+      let(:src_vm_2) { FactoryBot.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
 
       let(:src_network) { FactoryBot.create(:network, :ipaddress => '10.0.0.1') }
 
@@ -422,7 +422,7 @@ describe ServiceTemplateTransformationPlanTask do
         let(:dst_storage) { FactoryBot.create(:storage) }
         let(:dst_lan_1) { FactoryBot.create(:lan) }
         let(:dst_lan_2) { FactoryBot.create(:lan) }
-        let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:host, :ext_management_system => dst_ems)) }
+        let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:host_redhat, :ext_management_system => dst_ems)) }
 
         let(:mapping) do
           FactoryBot.create(

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -418,7 +418,7 @@ describe ServiceTemplateTransformationPlanTask do
       end
 
       context 'destination is rhevm' do
-        let(:dst_ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone)) }
+        let(:dst_ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
         let(:dst_storage) { FactoryBot.create(:storage) }
         let(:dst_lan_1) { FactoryBot.create(:lan) }
         let(:dst_lan_2) { FactoryBot.create(:lan) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -15,7 +15,7 @@ describe ServiceTemplateTransformationPlanTask do
   context 'independent of provider' do
     let(:src) { FactoryBot.create(:ems_cluster) }
     let(:dst) { FactoryBot.create(:ems_cluster) }
-    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
+    let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
     let(:vm)  { FactoryBot.create(:vm_or_template) }
     let(:vm2)  { FactoryBot.create(:vm_or_template) }
     let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }


### PR DESCRIPTION
This is something of a followup to https://github.com/ManageIQ/manageiq/pull/18277 where I think I got confused about how `resource_type` should be validated, thinking that STI would automatically kick in. But no, that's not how it works. Instead, since we're dealing with strings, it will fail in practice because the `resource_type` will be e.g. 'ManageIQ::Providers::Openstack::CloudManager::Vm' rather than just 'Vm'.

This PR removes hard coded string checks and instead relies on the individual providers to tell us if the resource supports conversion hosts or not. With both https://github.com/ManageIQ/manageiq-providers-ovirt/pull/315 and https://github.com/ManageIQ/manageiq-providers-openstack/pull/407 now merged, which implemented `supports :conversion_host` using the `SupportsFeature` mixin, we can now use this in practice for validations intead.



