### PR TITLE
Add check for existence of user for system_context

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -253,12 +253,12 @@ module RetirementMixin
   end
 
   def system_context_requester
-    if try(:evm_owner_id).present?
-      User.find(evm_owner_id)
-    else
-      $log.info("System context defaulting to admin user because owner of #{name} not set.")
-      User.super_admin
+    if evm_owner.blank?
+      $log.info("System context defaulting to admin user because owner of #{name} (#{self.class}) not set or owner no longer found in database.")
+      return User.super_admin
     end
+    $log.info("Setting retirement requester of #{name} to #{evm_owner_id}.")
+    evm_owner
   end
 
   def current_user


### PR DESCRIPTION
system_context retirement only checks to see if the ```evm_owner_id``` is present on the object, it doesn't check that that id is that of a valid user. 

This cleans up the tests to have both cases, for when the user exists, and when it doesn't. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1672338.

## Depends on 
~~https://github.com/ManageIQ/manageiq/pull/18443~~