### PR TITLE
Fixed: Timezone set-up in MySettings was not honored when displaying date fields in the report

### DIFF
--- a/app/models/miq_report/generator/html.rb
+++ b/app/models/miq_report/generator/html.rb
@@ -1,6 +1,6 @@
 module MiqReport::Generator::Html
   def build_html_rows(clickable_rows = false)
-    get_time_zone(Time.zone.name) if Time.zone
+    time_zone = get_time_zone(Time.zone)
     html_rows = []
     group_counter = 0
     row = 0
@@ -47,7 +47,7 @@ module MiqReport::Generator::Html
         col_order.each_with_index do |c, c_idx|
           next if column_is_hidden?(c)
 
-          build_html_col(output, c, self.col_formats[c_idx], d.data)
+          build_html_col(output, c, self.col_formats[c_idx], d.data, time_zone)
         end
 
         output << "</tr>"
@@ -66,8 +66,8 @@ module MiqReport::Generator::Html
     html_rows
   end
 
-  def build_html_col(output, col_name, col_format, row_data)
-    style = get_style_class(col_name, row_data, tz)
+  def build_html_col(output, col_name, col_format, row_data, time_zone)
+    style = get_style_class(col_name, row_data, time_zone)
     style_class = !style.nil? ? " class='#{style}'" : nil
     if col_name == 'resource_type'
       output << "<td#{style_class}>"
@@ -87,7 +87,7 @@ module MiqReport::Generator::Html
         output << "<td#{style_class}>"
       end
       output << CGI.escapeHTML(format(col_name.split("__").first, row_data[col_name],
-                                      :format => col_format || :_default_, :tz => tz))
+                                      :format => col_format || :_default_, :tz => time_zone))
     end
     output << '</td>'
   end

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -754,16 +754,16 @@ describe MiqReport do
         @expected_html_rows.push(generate_html_row(true, @tenant.name, formatted_values))
 
         User.current_user = user_admin
+
+        EvmSpecHelper.local_miq_server
       end
 
       it "returns expected html outputs with formatted values" do
-        allow(User).to receive(:server_timezone).and_return("UTC")
         report.generate_table
         expect(report.build_html_rows).to match_array(@expected_html_rows)
       end
 
       it "returns only rows for tenant with any tenant_quotas" do
-        allow(User).to receive(:server_timezone).and_return("UTC")
         report.generate_table
         # 6th row would be for tenant_without_quotas, but skipped now because of skip_condition, so we expecting 5
         expect(report.table.data.count).to eq(5)


### PR DESCRIPTION
**Issue:**  
  Timezone for Display Settings set up in `MySettings` was not passed to column formatting when generating report.

When Timezone set-up as 
![screen shot 2019-02-06 at 1 49 32 pm](https://user-images.githubusercontent.com/6556758/52365702-0dc25f00-2a16-11e9-8c67-c462f39e78a2.png)



**BEFORE:**
<img width="1011" alt="before" src="https://user-images.githubusercontent.com/6556758/52365719-1b77e480-2a16-11e9-9c79-a7f846a7e953.png">

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/52365742-2a5e9700-2a16-11e9-8e6f-03701e2ec30e.png)



@miq-bot add-label bug, reporting