### PR TITLE
Remove spec with false premise

### DIFF
--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -23,9 +23,5 @@ describe "ar_dba extension" do
     it "returns true for a table with a primary key" do
       expect(connection.primary_key?("miq_databases")).to be true
     end
-
-    it "returns true for composite primary keys" do
-      expect(connection.primary_key?("storages_vms_and_templates")).to be true
-    end
   end
 end


### PR DESCRIPTION
We don't use composite primary keys any more.
So although this spec passes it doesn't really indicate
anything of value

Just saw this when rooting around the extensions for PG 10 compatibility.