### PR TITLE
Don't retire load balancers

### DIFF
--- a/app/models/load_balancer.rb
+++ b/app/models/load_balancer.rb
@@ -2,7 +2,6 @@ class LoadBalancer < ApplicationRecord
   include NewWithTypeStiMixin
   include AsyncDeleteMixin
   include ProcessTasksMixin
-  include RetirementMixin
   include TenantIdentityMixin
   include CloudTenancyMixin
   include CustomActionsMixin

--- a/app/models/retirement_manager.rb
+++ b/app/models/retirement_manager.rb
@@ -1,7 +1,7 @@
 class RetirementManager
   def self.check
     ems_ids = MiqServer.my_server.zone.ext_management_system_ids
-    [LoadBalancer, OrchestrationStack, Vm, Service].flat_map do |i|
+    [OrchestrationStack, Vm, Service].flat_map do |i|
       instances = not_retired_with_ems(i, ems_ids)
       instances.each(&:retirement_check)
     end

--- a/spec/models/retirement_manager_spec.rb
+++ b/spec/models/retirement_manager_spec.rb
@@ -4,8 +4,6 @@ describe RetirementManager do
       _, _, zone = EvmSpecHelper.local_guid_miq_server_zone
       ems = FactoryBot.create(:ems_network, :zone => zone)
 
-      load_balancer = FactoryBot.create(:load_balancer, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
-      FactoryBot.create(:load_balancer, :retired => true)
       orchestration_stack = FactoryBot.create(:orchestration_stack, :retires_on => Time.zone.today + 1.day, :ext_management_system => ems)
       FactoryBot.create(:orchestration_stack, :retired => true)
       vm = FactoryBot.create(:vm, :retires_on => Time.zone.today + 1.day, :ems_id => ems.id)
@@ -13,7 +11,7 @@ describe RetirementManager do
       service = FactoryBot.create(:service, :retires_on => Time.zone.today + 1.day)
       FactoryBot.create(:service, :retired => true)
 
-      expect(RetirementManager.check).to match_array([load_balancer, orchestration_stack, vm, service])
+      expect(RetirementManager.check).to match_array([orchestration_stack, vm, service])
     end
   end
 end


### PR DESCRIPTION
Presently system_context retirement only checks to see if the `evm_owner_id` is present on the object, it doesn't check that that id is that of a valid user. In order to make the check run on ```evm_owner``` we will need to remove load balancers from the list of things to retire in the retirement manager per https://github.com/ManageIQ/manageiq/pull/18437#discussion_r254874102 since load balancers don't have owners. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1672338. (it doesn't _fix_ it but the related PR does and this is required for the related PR)

## related to

https://github.com/ManageIQ/manageiq/pull/18437