### PR TITLE
Don't print the release codename in production mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -161,7 +161,7 @@ module Vmdb
     config.after_initialize do
       Vmdb::Initializer.init
       ActiveRecord::Base.connection_pool.release_connection
-      puts "** #{Vmdb::Appliance.BANNER}"
+      puts "** #{Vmdb::Appliance.BANNER}" unless Rails.env.production?
     end
 
     console do


### PR DESCRIPTION
This is breaking production scripts that parse the output
of `rails runner`. The codename is nice, but because there
is not a reliable way to determine if we're using the server
or runner, gating this on the env seems like the best option

Alternative to ManageIQ/manageiq-appliance_console#80
Fixes ManageIQ/manageiq-appliance_console#79