### PR TITLE
[Service#power_state] Avoid update if values match

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -262,7 +262,9 @@ class Service < ApplicationRecord
   end
 
   def update_power_status(action)
-    options[:power_status] = "#{action}_complete"
+    expected_status = "#{action}_complete"
+    return true if options[:power_status] == expected_status
+    options[:power_status] = expected_status
     update_attributes(:options => options)
   end
 


### PR DESCRIPTION
As part of the getter for `Service#power_state`, avoid calling an `update_attributes` if the value is already what we are going to update it to.

This avoids not only some SQL queries, but some YAML serialization that slows down API requests and reports that use this `virtual_attribute`.

**Note**:  The changes that introduced the `update_attributes` in `power_state` can be found here:

https://github.com/ManageIQ/manageiq/pull/12963

And provides some context as to why I kept it instead of removing that `update_attributes`.


Benchmarks:
-----------

These benchmarks are done against the API doing the following request:

```
url: /api/services
attributes:
  expand: resources
  attributes:
    -picture
    - picture.image_href
    - chargeback_report
    - evm_owner.userid
    - v_total_vms
    - power_state
    - all_service_children
    - tags
  filter[]:      ancestry=null
  sort_by:       created_at
  sort_options:  nil
  sort_order:    desc
  limit:         20
  offset:        0
```

And about half of the attributes need to trigger an update.  Because of the way the code is configured and that the metrics were taken against a database that is detached from the provider (the `power_states_match?` call is consistent every time as a result), this happens consistently across runs.


**Before**

```
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 2060 |     322 |        152 | 1627 |
|  799 |     321 |      132.5 |  196 |
|  839 |     321 |      134.2 |  196 |
```


**After**

```
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 1976 |     290 |        164 | 1625 |
|  675 |     289 |      128.4 |  194 |
|  686 |     289 |      128.4 |  194 |
```


Also, if you combine this change with the changes is https://github.com/ManageIQ/manageiq-api/pull/557 you will get the following improvements

```
|   ms | queries | query (ms) | rows |
| ---: |    ---: |       ---: | ---: |
| 1819 |     230 |      143.5 | 1590 |
|  637 |     229 |      131.7 |  159 |
|  624 |     229 |      132.7 |  159 |
```


Links
-----

* Related PR:  https://github.com/ManageIQ/manageiq-api/pull/557
* Updating as part of a getter introduced in:  https://github.com/ManageIQ/manageiq/pull/12963
* Partially addresses BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=1656371