### PR TITLE
When user changing display timezone than some widgets show no data

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -327,7 +327,7 @@ class MiqWidget < ApplicationRecord
     settings_for_build = {:miq_group_id => group.id}
     settings_for_build[:user_id]  = user.id  if user
     settings_for_build[:timezone] = timezone if timezone
-    contents = contents_for_owner(group, user, timezone) || miq_widget_contents.build(settings_for_build)
+    contents = miq_widget_contents.find_by(settings_for_build) || miq_widget_contents.build(settings_for_build)
     contents.updated_at = Time.now.utc # Force updated timestamp to change when saved even if the new contents are the same
 
     contents
@@ -355,20 +355,22 @@ class MiqWidget < ApplicationRecord
     end
   end
 
-  def contents_for_owner(group, user, timezone = nil)
-    return unless group
-    timezone = "UTC" if timezone && !timezone_matters?
-    conditions = {:miq_group_id => group.id}
-    conditions[:user_id]   = user.id if user
-    conditions[:timezone] = timezone if timezone
-    miq_widget_contents.find_by(conditions)
-  end
-
   def contents_for_user(user)
     user = self.class.get_user(user)
     timezone = timezone_matters? ? user.get_timezone : "UTC"
-    contents = contents_for_owner(user.current_group, user, timezone)
-    contents ||= contents_for_owner(user.current_group, nil, timezone)
+    conditions = {:miq_group_id => user.current_group.id}
+    conditions[:user_id] = user.id
+    conditions[:timezone] = timezone
+    contents = miq_widget_contents.find_by(conditions)
+
+    conditions.delete(:user_id)
+    contents ||= miq_widget_contents.find_by(conditions)
+
+    if contents.nil?
+      _log.warn("No contents found for Widget: '#{title}' Group: #{user.current_group.description} in Timezone '#{timezone}'. Attempting to get widget's contents from any Timezone ...")
+      conditions.delete(:timezone)
+      contents = miq_widget_contents.find_by(conditions)
+    end
     contents
   end
 

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -165,7 +165,7 @@ describe MiqWidget do
     end
 
     context "#contents_for_user" do
-      it "user owned" do
+      it "returns user owned widget contents in UTC timezone if user's timezone not specified" do
         content = FactoryBot.create(:miq_widget_content,
                                      :miq_widget   => @widget_report_vendor_and_guest_os,
                                      :user_id      => @user1.id,
@@ -175,24 +175,26 @@ describe MiqWidget do
         expect(@widget_report_vendor_and_guest_os.contents_for_user(@user1)).to eq(content)
       end
 
-      it "owned by miq_group and in user's timezone" do
-        @user1.settings.store_path(:display, :timezone, "Eastern Time (US & Canada)")
-        content = FactoryBot.create(:miq_widget_content,
-                                     :miq_widget   => @widget_report_vendor_and_guest_os,
-                                     :miq_group_id => @group1.id,
-                                     :timezone     => "Eastern Time (US & Canada)"
-                                    )
-        expect(@widget_report_vendor_and_guest_os.contents_for_user(@user1)).to eq(content)
-      end
-
-      it "owned by miq_group and not in user's timezone" do
+      it "returns widget contents in user's timezone when content from different timezone also available" do
         @user1.settings.store_path(:display, :timezone, "Eastern Time (US & Canada)")
         FactoryBot.create(:miq_widget_content,
-                                     :miq_widget   => @widget_report_vendor_and_guest_os,
-                                     :miq_group_id => @group1.id,
-                                     :timezone     => "UTC"
-                                    )
-        expect(@widget_report_vendor_and_guest_os.contents_for_user(@user1)).to be_nil
+                          :miq_widget   => @widget_report_vendor_and_guest_os,
+                          :miq_group_id => @group1.id,
+                          :timezone     => "UTC")
+        content_user_timezone = FactoryBot.create(:miq_widget_content,
+                                                  :miq_widget   => @widget_report_vendor_and_guest_os,
+                                                  :miq_group_id => @group1.id,
+                                                  :timezone     => "Eastern Time (US & Canada)")
+        expect(@widget_report_vendor_and_guest_os.contents_for_user(@user1)).to eq(content_user_timezone)
+      end
+
+      it "returns widget contents if only content available is not in user's timezone" do
+        @user1.settings.store_path(:display, :timezone, "Eastern Time (US & Canada)")
+        content_utc = FactoryBot.create(:miq_widget_content,
+                                        :miq_widget   => @widget_report_vendor_and_guest_os,
+                                        :miq_group_id => @group1.id,
+                                        :timezone     => "UTC")
+        expect(@widget_report_vendor_and_guest_os.contents_for_user(@user1)).to eq(content_utc)
       end
 
       it "both user and miq_group owned" do


### PR DESCRIPTION
**Issue**: user's timezone is part of filter when searching for widget's content. So, when use changing display timezone than data disappears from widgets. 

**Fix**: if widget's content for specific timezone not found than try to find content without specifying timezone

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1676584

@miq-bot add-label bug, reporting

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/52651124-a004b000-2eb9-11e9-8c3e-09698f596dca.png)

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/52651142-a6932780-2eb9-11e9-8ad0-04a19af8d650.png)


