### PR TITLE
Escape characters in SSH URI for virt-v2v

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -288,7 +288,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :scheme   => 'ssh',
         :userinfo => 'root',
         :host     => source.host.ipaddress,
-        :path => "/vmfs/volumes/#{URI.escape(storage.name)}/#{URI.escape(source.location)}"
+        :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
       :transport_method => 'ssh'
     }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -284,7 +284,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def conversion_options_source_provider_vmwarews_ssh(storage)
     {
-      :vm_name          => URI::Generic.build(:scheme => 'ssh', :userinfo => 'root', :host => source.host.ipaddress, :path => "/vmfs/volumes").to_s + "/#{CGI.escape(storage.name)}/#{CGI.escape(source.location)}",
+      :vm_name          => URI::Generic.build(
+        :scheme   => 'ssh',
+        :userinfo => 'root',
+        :host     => source.host.ipaddress,
+        :path => "/vmfs/volumes/#{URI.escape(storage.name)}/#{URI.escape(source.location)}"
+      ).to_s,
       :transport_method => 'ssh'
     }
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -284,7 +284,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def conversion_options_source_provider_vmwarews_ssh(storage)
     {
-      :vm_name          => URI::Generic.build(:scheme => 'ssh', :userinfo => 'root', :host => source.host.ipaddress, :path => "/vmfs/volumes").to_s + "/#{storage.name}/#{source.location}",
+      :vm_name          => URI::Generic.build(:scheme => 'ssh', :userinfo => 'root', :host => source.host.ipaddress, :path => "/vmfs/volumes").to_s + CGI.escape("/#{storage.name}/#{source.location}"),
       :transport_method => 'ssh'
     }
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -284,7 +284,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def conversion_options_source_provider_vmwarews_ssh(storage)
     {
-      :vm_name          => URI::Generic.build(:scheme => 'ssh', :userinfo => 'root', :host => source.host.ipaddress, :path => "/vmfs/volumes").to_s + CGI.escape("/#{storage.name}/#{source.location}"),
+      :vm_name          => URI::Generic.build(:scheme => 'ssh', :userinfo => 'root', :host => source.host.ipaddress, :path => "/vmfs/volumes").to_s + "/#{CGI.escape(storage.name)}/#{CGI.escape(source.location)}",
       :transport_method => 'ssh'
     }
   end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -289,7 +289,7 @@ describe ServiceTemplateTransformationPlanTask do
     context 'source is vmwarews' do
       let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
       let(:src_host) { FactoryBot.create(:host, :ext_management_system => src_ems, :ipaddress => '10.0.0.1') }
-      let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems, name: 'stockage récent') }
+      let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems, :name => 'stockage récent') }
 
       let(:src_lan_1) { FactoryBot.create(:lan) }
       let(:src_lan_2) { FactoryBot.create(:lan) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -289,7 +289,7 @@ describe ServiceTemplateTransformationPlanTask do
     context 'source is vmwarews' do
       let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
       let(:src_host) { FactoryBot.create(:host, :ext_management_system => src_ems, :ipaddress => '10.0.0.1') }
-      let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems) }
+      let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems, name: 'stockage récent') }
 
       let(:src_lan_1) { FactoryBot.create(:lan) }
       let(:src_lan_2) { FactoryBot.create(:lan) }
@@ -497,7 +497,7 @@ describe ServiceTemplateTransformationPlanTask do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/#{src_storage.name}/#{src_vm_1.location}",
+              :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :transport_method    => 'ssh',
               :rhv_url             => "https://#{dst_ems.hostname}/ovirt-engine/api",
               :rhv_cluster         => dst_cluster.name,
@@ -606,7 +606,7 @@ describe ServiceTemplateTransformationPlanTask do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/#{src_storage.name}/#{src_vm_1.location}",
+              :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :transport_method           => 'ssh',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(


### PR DESCRIPTION
Migrating to OSP over SSH transformation method with names containing international chars, such as `�Ää`,  fails with  :

```
[   3.5] Opening the source -i vmx ssh://root@10.8.58.29/vmfs/volumes/env-esxi67-ims-h01_localdisk/�Ää/�Ää.vmx
virt-v2v: error: remote vmx 
‘ssh://root@10.8.58.29/vmfs/volumes/env-esxi67-ims-h01_localdisk/�Ää/�Ää.vmx’ 
could not be parsed as a URI
```
This PR escapes the characters for the URI bits that are not yet escaped.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1669240