### PR TITLE
Print deprecations in test mode

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Vmdb::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance
   config.public_file_server.enabled = true
-  config.static_cache_control = "public, max-age=3600"
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Avoid potential warnings and race conditions
   config.assets.configure do |env|

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,7 +12,6 @@ Vmdb::Application.configure do
 
   # Print deprecation notices to the stderr
   #ActiveSupport::Deprecation.behavior = :stderr
-  ActiveSupport::Deprecation.behavior = :silence
 
   # Configure static asset server for tests with Cache-Control for performance
   config.public_file_server.enabled = true

--- a/spec/factories/account.rb
+++ b/spec/factories/account.rb
@@ -2,15 +2,15 @@ FactoryBot.define do
   factory :account
 
   factory :account_user, :parent => :account do
-    name 'bob'
-    acctid 10
-    homedir '/dev/null'
-    accttype 'user'
+    name { 'bob' }
+    acctid { 10 }
+    homedir { '/dev/null' }
+    accttype { 'user' }
   end
 
   factory :account_group, :parent => :account do
-    name 'monsters'
-    acctid 175
-    accttype 'group'
+    name { 'monsters' }
+    acctid { 175 }
+    accttype { 'group' }
   end
 end

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -1,94 +1,94 @@
 FactoryBot.define do
   factory :authentication do
-    userid      "testuser"
-    password    "secret"
-    authtype    "default"
-    status      "Valid"
+    userid      { "testuser" }
+    password    { "secret" }
+    authtype    { "default" }
+    status      { "Valid" }
   end
 
   factory :authentication_status_error, :parent => :authentication do
-    status      "Error"
-    authtype    "bearer"
+    status      { "Error" }
+    authtype    { "bearer" }
   end
 
   factory :authentication_ipmi, :parent => :authentication do
-    authtype    "ipmi"
+    authtype    { "ipmi" }
   end
 
   factory :authentication_ws, :parent => :authentication do
-    authtype    "ws"
+    authtype    { "ws" }
   end
 
   factory :authentication_ssh_keypair, :parent => :authentication, :class => 'ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair' do
-    authtype    "ssh_keypair"
-    userid      "testuser"
-    password    nil
-    auth_key    'private_key_content'
+    authtype    { "ssh_keypair" }
+    userid      { "testuser" }
+    password    { nil }
+    auth_key    { 'private_key_content' }
   end
 
   factory :authentication_ssh_keypair_root, :parent => :authentication_ssh_keypair do
-    userid      "root"
+    userid      { "root" }
   end
 
   factory :authentication_ssh_keypair_without_key, :parent => :authentication_ssh_keypair do
-    auth_key    nil
-    status      "SomeMockedStatus"
+    auth_key    { nil }
+    status      { "SomeMockedStatus" }
   end
 
   factory :authentication_allow_all, :parent => :authentication, :class => "AuthenticationAllowAll" do
-    authtype "AllowAllPasswordIdentityProvider"
+    authtype { "AllowAllPasswordIdentityProvider" }
   end
 
   factory :authentication_github, :parent => :authentication, :class => "AuthenticationGithub" do
-    authtype "GitHubIdentityProvider"
-    github_organizations ["github_organizations"]
+    authtype { "GitHubIdentityProvider" }
+    github_organizations { ["github_organizations"] }
   end
 
   factory :authentication_google, :parent => :authentication, :class => "AuthenticationGoogle" do
-    authtype "GoogleIdentityProvider"
-    google_hosted_domain "google_hosted_domain"
+    authtype { "GoogleIdentityProvider" }
+    google_hosted_domain { "google_hosted_domain" }
   end
 
   factory :authentication_htpasswd, :parent => :authentication, :class => "AuthenticationHtpasswd" do
-    authtype "HTPasswdPasswordIdentityProvider"
-    htpassd_users [{"htpassuser1" => "htpassword"}, {"htpassuser2" => "htpassword"}]
+    authtype { "HTPasswdPasswordIdentityProvider" }
+    htpassd_users { [{"htpassuser1" => "htpassword"}, {"htpassuser2" => "htpassword"}] }
   end
 
   factory :authentication_ldap, :parent => :authentication, :class => "AuthenticationLdap" do
-    authtype "LDAPPasswordIdentityProvider"
-    ldap_id ["ldap_id"]
-    ldap_email ["ldap_email"]
-    ldap_name ["ldap_name"]
-    ldap_preferred_user_name ["ldap_preferred_user_name"]
-    ldap_bind_dn "ldap_bind_dn"
-    ldap_insecure true
-    ldap_url "ldap_url"
-    certificate_authority "certificate_authority"
+    authtype { "LDAPPasswordIdentityProvider" }
+    ldap_id { ["ldap_id"] }
+    ldap_email { ["ldap_email"] }
+    ldap_name { ["ldap_name"] }
+    ldap_preferred_user_name { ["ldap_preferred_user_name"] }
+    ldap_bind_dn { "ldap_bind_dn" }
+    ldap_insecure { true }
+    ldap_url { "ldap_url" }
+    certificate_authority { "certificate_authority" }
   end
 
   factory :authentication_open_id, :parent => :authentication, :class => "AuthenticationOpenId" do
-    authtype "OpenIDIdentityProvider"
-    open_id_sub_claim "open_id_sub_claim"
-    open_id_user_info "open_id_user_info"
-    open_id_authorization_endpoint "open_id_authorization_endpoint"
-    open_id_token_endpoint "open_id_token_endpoint"
-    open_id_extra_scopes ["open_id_extra_scopes"]
-    open_id_extra_authorize_parameters "open_id_extra_authorize_parameters"
+    authtype { "OpenIDIdentityProvider" }
+    open_id_sub_claim { "open_id_sub_claim" }
+    open_id_user_info { "open_id_user_info" }
+    open_id_authorization_endpoint { "open_id_authorization_endpoint" }
+    open_id_token_endpoint { "open_id_token_endpoint" }
+    open_id_extra_scopes { ["open_id_extra_scopes"] }
+    open_id_extra_authorize_parameters { "open_id_extra_authorize_parameters" }
   end
 
   factory :authentication_request_header, :parent => :authentication, :class => "AuthenticationRequestHeader" do
-    authtype "RequestHeaderIdentityProvider"
-    request_header_challenge_url "request_header_challenge_url"
-    request_header_login_url "request_header_login_url"
-    request_header_headers ["request_header_headers"]
-    request_header_preferred_username_headers ["request_header_preferred_username_headers"]
-    request_header_name_headers ["request_header_name_headers"]
-    request_header_email_headers ["request_header_email_headers"]
-    certificate_authority "certificate_authority"
+    authtype { "RequestHeaderIdentityProvider" }
+    request_header_challenge_url { "request_header_challenge_url" }
+    request_header_login_url { "request_header_login_url" }
+    request_header_headers { ["request_header_headers"] }
+    request_header_preferred_username_headers { ["request_header_preferred_username_headers"] }
+    request_header_name_headers { ["request_header_name_headers"] }
+    request_header_email_headers { ["request_header_email_headers"] }
+    certificate_authority { "certificate_authority" }
   end
 
   factory :authentication_redhat_metric, :parent => :authentication do
-    authtype "metrics"
+    authtype { "metrics" }
   end
 
   factory :automation_manager_authentication,

--- a/spec/factories/blacklisted_event.rb
+++ b/spec/factories/blacklisted_event.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :blacklisted_event do
-    enabled true
+    enabled { true }
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory(:category) do
     sequence(:name)        { |n| "category_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "category #{seq_padded_for_sorting(n)}" }
-    parent_id 0
+    parent_id { 0 }
   end
 end

--- a/spec/factories/chargeable_field.rb
+++ b/spec/factories/chargeable_field.rb
@@ -1,99 +1,99 @@
 FactoryBot.define do
   factory :chargeable_field do
-    metric 'unknown'
-    group  'unknown'
-    source 'unknown'
+    metric { 'unknown' }
+    group  { 'unknown' }
+    source { 'unknown' }
     initialize_with { ChargeableField.find_or_create_by!(:metric => metric, :group => group, :source => source) }
   end
 
   factory :chargeable_field_fixed_compute_1, :parent => :chargeable_field do
-    description 'Fixed Compute Cost 1'
-    source      'compute_1'
-    group       'fixed'
-    metric      'fixed_compute_1'
+    description { 'Fixed Compute Cost 1' }
+    source      { 'compute_1' }
+    group       { 'fixed' }
+    metric      { 'fixed_compute_1' }
   end
 
   factory :chargeable_field_cpu_used, :parent => :chargeable_field do
-    description 'Used CPU in MHz'
-    metric      'cpu_usagemhz_rate_average'
-    group       'cpu'
-    source      'used'
+    description { 'Used CPU in MHz' }
+    metric      { 'cpu_usagemhz_rate_average' }
+    group       { 'cpu' }
+    source      { 'used' }
     detail_measure { FactoryBot.build(:chargeback_measure_hz) }
   end
 
   factory :chargeable_field_cpu_allocated, :parent => :chargeable_field do
-    description 'Allocated CPU Count'
-    metric      'derived_vm_numvcpus'
-    group       'cpu'
-    source      'allocated'
+    description { 'Allocated CPU Count' }
+    metric      { 'derived_vm_numvcpus' }
+    group       { 'cpu' }
+    source      { 'allocated' }
   end
 
   factory :chargeable_field_memory_allocated, :parent => :chargeable_field do
-    description 'Allocated Memory in MB'
-    metric      'derived_memory_available'
-    group       'memory'
-    source      'allocated'
+    description { 'Allocated Memory in MB' }
+    metric      { 'derived_memory_available' }
+    group       { 'memory' }
+    source      { 'allocated' }
     detail_measure { FactoryBot.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_storage_allocated, :parent => :chargeable_field do
-    description 'Allocated Disk Storage in Bytes'
-    metric      'derived_vm_allocated_disk_storage'
-    group       'storage'
-    source      'allocated'
+    description { 'Allocated Disk Storage in Bytes' }
+    metric      { 'derived_vm_allocated_disk_storage' }
+    group       { 'storage' }
+    source      { 'allocated' }
     detail_measure { FactoryBot.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_cpu_cores_used, :parent => :chargeable_field do
-    description 'Used CPU in Cores'
-    metric      'v_derived_cpu_total_cores_used'
-    group       'cpu_cores'
-    source      'used'
+    description { 'Used CPU in Cores' }
+    metric      { 'v_derived_cpu_total_cores_used' }
+    group       { 'cpu_cores' }
+    source      { 'used' }
   end
 
   factory :chargeable_field_cpu_cores_allocated, :parent => :chargeable_field do
-    description 'Allocated CPU in Cores'
-    metric      'derived_vm_numvcpu_cores'
-    group       'cpu_cores'
-    source      'allocated'
+    description { 'Allocated CPU in Cores' }
+    metric      { 'derived_vm_numvcpu_cores' }
+    group       { 'cpu_cores' }
+    source      { 'allocated' }
   end
 
   factory :chargeable_field_memory_used, :parent => :chargeable_field do
-    description 'Used Memory in MB'
-    metric      'derived_memory_used'
-    group       'memory'
-    source      'used'
+    description { 'Used Memory in MB' }
+    metric      { 'derived_memory_used' }
+    group       { 'memory' }
+    source      { 'used' }
     detail_measure { FactoryBot.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_net_io_used, :parent => :chargeable_field do
-    description 'Used Network I/O in KBps'
-    metric      'net_usage_rate_average'
-    group       'net_io'
-    source      'used'
+    description { 'Used Network I/O in KBps' }
+    metric      { 'net_usage_rate_average' }
+    group       { 'net_io' }
+    source      { 'used' }
     detail_measure { FactoryBot.build(:chargeback_measure_bps) }
   end
 
   factory :chargeable_field_disk_io_used, :parent => :chargeable_field do
-    description 'Used disk I/O in KBps'
-    metric      'disk_usage_rate_average'
-    group       'disk_io'
-    source      'used'
+    description { 'Used disk I/O in KBps' }
+    metric      { 'disk_usage_rate_average' }
+    group       { 'disk_io' }
+    source      { 'used' }
     detail_measure { FactoryBot.build(:chargeback_measure_bps) }
   end
 
   factory :chargeable_field_storage_used, :parent => :chargeable_field do
-    description 'Used Disk Storage in Bytes'
-    metric      'derived_vm_used_disk_storage'
-    group       'storage'
-    source      'used'
+    description { 'Used Disk Storage in Bytes' }
+    metric      { 'derived_vm_used_disk_storage' }
+    group       { 'storage' }
+    source      { 'used' }
     detail_measure { FactoryBot.build(:chargeback_measure_bytes) }
   end
 
   factory :chargeable_field_metering_used, :parent => :chargeable_field do
-    description 'Metering Used Hours'
-    metric      'metering_used_hours'
-    group       'metering'
-    source      'used'
+    description { 'Metering Used Hours' }
+    metric      { 'metering_used_hours' }
+    group       { 'metering' }
+    source      { 'used' }
   end
 end

--- a/spec/factories/chargeback_rate.rb
+++ b/spec/factories/chargeback_rate.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :chargeback_rate do
     guid                   { SecureRandom.uuid }
     sequence(:description) { |n| "Chargeback Rate ##{n}" }
-    rate_type 'Compute'
+    rate_type { 'Compute' }
 
     transient do
-      per_time      'hourly'
-      detail_params nil
+      per_time      { 'hourly' }
+      detail_params { nil }
     end
 
     after(:create) do |chargeback_rate, evaluator|
@@ -51,7 +51,7 @@ FactoryBot.define do
     end
 
     trait :with_storage_details do
-      rate_type 'Storage'
+      rate_type { 'Storage' }
 
       after(:create) do |chargeback_rate, evaluator|
         %i(

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     detail_currency { FactoryBot.create(:chargeback_rate_detail_currency) }
 
     transient do
-      tiers_params nil
+      tiers_params { nil }
     end
 
     trait :tiers do
@@ -31,43 +31,43 @@ FactoryBot.define do
   end
 
   trait :megabytes do
-    per_unit "megabytes"
+    per_unit { "megabytes" }
   end
 
   trait :kbps do
-    per_unit "kbps"
+    per_unit { "kbps" }
   end
 
   trait :gigabytes do
-    per_unit "gigabytes"
+    per_unit { "gigabytes" }
   end
 
   trait :daily do
-    per_time "daily"
+    per_time { "daily" }
   end
 
   trait :hourly do
-    per_time "hourly"
+    per_time { "hourly" }
   end
 
   factory :chargeback_rate_detail_cpu_used, :parent => :chargeback_rate_detail do
-    per_unit    "megahertz"
+    per_unit    { "megahertz" }
     chargeable_field { FactoryBot.build(:chargeable_field_cpu_used) }
   end
 
   factory :chargeback_rate_detail_cpu_cores_used, :parent => :chargeback_rate_detail do
-    per_unit    "cores"
+    per_unit    { "cores" }
     chargeable_field { FactoryBot.build(:chargeable_field_cpu_cores_used) }
   end
 
   factory :chargeback_rate_detail_cpu_cores_allocated, :parent => :chargeback_rate_detail do
-    per_unit    "cores"
+    per_unit    { "cores" }
     chargeable_field { FactoryBot.build(:chargeable_field_cpu_cores_allocated) }
   end
 
   factory :chargeback_rate_detail_cpu_allocated, :traits => [:daily],
                                                  :parent => :chargeback_rate_detail do
-    per_unit    "cpu"
+    per_unit    { "cpu" }
     chargeable_field { FactoryBot.build(:chargeable_field_cpu_allocated) }
   end
 

--- a/spec/factories/chargeback_rate_detail_currency.rb
+++ b/spec/factories/chargeback_rate_detail_currency.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :chargeback_rate_detail_currency do
-    code  "EUR"
-    name "Euro"
-    full_name "Euro"
-    symbol "€"
-    unicode_hex "8364"
+    code  { "EUR" }
+    name { "Euro" }
+    full_name { "Euro" }
+    symbol { "€" }
+    unicode_hex { "8364" }
   end
 end

--- a/spec/factories/chargeback_rate_detail_measure.rb
+++ b/spec/factories/chargeback_rate_detail_measure.rb
@@ -1,24 +1,24 @@
 FactoryBot.define do
   factory :chargeback_rate_detail_measure do
-    step  "1024"
-    name "Bytes Units"
-    units_display %w(B KB MB GB TB)
-    units %w(bytes kilobytes megabytes gigabytes terabytes)
+    step  { "1024" }
+    name { "Bytes Units" }
+    units_display { %w(B KB MB GB TB) }
+    units { %w(bytes kilobytes megabytes gigabytes terabytes) }
   end
 
   factory :chargeback_measure_bytes, :parent => :chargeback_rate_detail_measure
 
   factory :chargeback_measure_hz, :parent => :chargeback_rate_detail_measure do
-    name 'Hz Units'
-    step '1000'
-    units_display %w(Hz KHz MHz GHz THz)
-    units %w(hertz kilohertz megahertz gigahertz teraherts)
+    name { 'Hz Units' }
+    step { '1000' }
+    units_display { %w(Hz KHz MHz GHz THz) }
+    units { %w(hertz kilohertz megahertz gigahertz teraherts) }
   end
 
   factory :chargeback_measure_bps, :parent => :chargeback_rate_detail_measure do
-    name 'Bytes per Second Units'
-    step '1000'
-    units_display %w(Bps KBps MBps GBps)
-    units %w(bps kbps mbps gbps)
+    name { 'Bytes per Second Units' }
+    step { '1000' }
+    units_display { %w(Bps KBps MBps GBps) }
+    units { %w(bps kbps mbps gbps) }
   end
 end

--- a/spec/factories/chargeback_tier.rb
+++ b/spec/factories/chargeback_tier.rb
@@ -1,29 +1,29 @@
 FactoryBot.define do
   factory :chargeback_tier do
-    start 0
-    finish Float::INFINITY
-    fixed_rate 0.0
-    variable_rate 0.0
+    start { 0 }
+    finish { Float::INFINITY }
+    fixed_rate { 0.0 }
+    variable_rate { 0.0 }
 
     trait :first_of_three do
-      start 0.0
-      finish 20.0
-      fixed_rate 0.1
-      variable_rate 0.2
+      start { 0.0 }
+      finish { 20.0 }
+      fixed_rate { 0.1 }
+      variable_rate { 0.2 }
     end
 
     trait :second_of_three do
-      start 20.0
-      finish 40.0
-      fixed_rate 0.3
-      variable_rate 0.4
+      start { 20.0 }
+      finish { 40.0 }
+      fixed_rate { 0.3 }
+      variable_rate { 0.4 }
     end
 
     trait :third_of_three do
-      start 40.0
-      finish Float::INFINITY
-      fixed_rate 0.5
-      variable_rate 0.6
+      start { 40.0 }
+      finish { Float::INFINITY }
+      fixed_rate { 0.5 }
+      variable_rate { 0.6 }
     end
   end
 

--- a/spec/factories/classification.rb
+++ b/spec/factories/classification.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :classification do
     sequence(:name)        { |n| "category_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "category #{seq_padded_for_sorting(n)}" }
-    parent_id 0
+    parent_id { 0 }
   end
 
   factory :classification_tag, :class => :Classification do
@@ -15,13 +15,13 @@ FactoryBot.define do
   #
 
   factory :classification_cost_center, :parent => :classification do
-    name        "cc"
-    description "Cost Center"
+    name        { "cc" }
+    description { "Cost Center" }
   end
 
   factory :classification_department, :parent => :classification do
-    name        "department"
-    description "Department"
+    name        { "department" }
+    description { "Department" }
   end
 
   #

--- a/spec/factories/cloud_service.rb
+++ b/spec/factories/cloud_service.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :cloud_service do
     sequence(:executable_name) { |n| "cloud_service_#{seq_padded_for_sorting(n)}" }
-    scheduling_disabled false
+    scheduling_disabled { false }
   end
 end

--- a/spec/factories/cloud_volume.rb
+++ b/spec/factories/cloud_volume.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   end
 
   factory :cloud_volume_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::CloudVolume", :parent => :cloud_volume do
-    status "available"
+    status { "available" }
   end
 end

--- a/spec/factories/cloud_volume_snapshot.rb
+++ b/spec/factories/cloud_volume_snapshot.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
   factory :cloud_volume_snapshot_openstack,
           :class  => "ManageIQ::Providers::Openstack::CloudManager::CloudVolumeSnapshot",
           :parent => :cloud_volume_snapshot do
-    status "available"
+    status { "available" }
   end
 end

--- a/spec/factories/compliance.rb
+++ b/spec/factories/compliance.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :compliance do
     sequence(:id)          { |n| 10_000_000 + n }
     sequence(:resource_id) { |n| 10_000_010 + n }
-    resource_type          'Host'
-    compliant              true
-    timestamp              DateTime.current
-    updated_on             DateTime.current
-    event_type             'string'
-    compliance_details     []
+    resource_type          { 'Host' }
+    compliant              { true }
+    timestamp              { DateTime.current }
+    updated_on             { DateTime.current }
+    event_type             { 'string' }
+    compliance_details     { [] }
   end
 end

--- a/spec/factories/compliance_detail.rb
+++ b/spec/factories/compliance_detail.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :compliance_detail do
     sequence(:id) { |n| 10_000_000 + n }
-    created_on DateTime .current
-    updated_on DateTime.current
-    miq_policy_desc 'Policy description'
-    miq_policy_result true
-    condition_desc 'Condition description'
-    condition_result true
+    created_on { DateTime .current }
+    updated_on { DateTime.current }
+    miq_policy_desc { 'Policy description' }
+    miq_policy_result { true }
+    condition_desc { 'Condition description' }
+    condition_result { true }
   end
 end

--- a/spec/factories/condition.rb
+++ b/spec/factories/condition.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :condition do
     sequence(:name)        { |num| "condition_#{seq_padded_for_sorting(num)}" }
     sequence(:description) { |num| "Condition #{seq_padded_for_sorting(num)}" }
-    towhat                 "Vm"
+    towhat                 { "Vm" }
     expression             { MiqExpression.new(">=" => {"field" => "Vm-num_cpu", "value" => "2"}) }
   end
 end

--- a/spec/factories/configuration_profile.rb
+++ b/spec/factories/configuration_profile.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/foreman/configuration_manager/configuration_profile"],
           :class   => "ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile",
           :parent  => :configuration_profile do
-    name "foreman config profile"
+    name { "foreman config profile" }
   end
 end

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :configuration_script_base do
     sequence(:name) { |n| "Configuration_script_base_#{seq_padded_for_sorting(n)}" }
     sequence(:manager_ref) { SecureRandom.random_number(100) }
-    variables :instance_ids => ['i-3434']
+    variables { { :instance_ids => ['i-3434'] } }
   end
 
   factory :configuration_script_payload, :class => "ConfigurationScriptPayload", :parent => :configuration_script_base

--- a/spec/factories/container_label_tag_mapping.rb
+++ b/spec/factories/container_label_tag_mapping.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :container_label_tag_mapping do
-    label_name 'name'
+    label_name { 'name' }
 
     trait :only_nodes do
-      labeled_resource_type 'ContainerNode'
+      labeled_resource_type { 'ContainerNode' }
     end
   end
 

--- a/spec/factories/container_quota_scope.rb
+++ b/spec/factories/container_quota_scope.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :container_quota_scope do
-    scope "NotTerminating"
+    scope { "NotTerminating" }
   end
 end

--- a/spec/factories/custom_attribute.rb
+++ b/spec/factories/custom_attribute.rb
@@ -2,10 +2,10 @@ FactoryBot.define do
   factory :custom_attribute
 
   factory :miq_custom_attribute, :parent => :custom_attribute do
-    source   'EVM'
+    source   { 'EVM' }
   end
 
   factory :ems_custom_attribute, :parent => :custom_attribute do
-    source   'VC'
+    source   { 'VC' }
   end
 end

--- a/spec/factories/custom_button_set.rb
+++ b/spec/factories/custom_button_set.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     sequence(:description) { |n| "custom_button_set_#{seq_padded_for_sorting(n)}" }
 
     transient do
-      members []
+      members { [] }
     end
 
     after(:create) do |custom_button_set, evaluator|

--- a/spec/factories/dialog_field.rb
+++ b/spec/factories/dialog_field.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :dialog_field do
-    name "Dialog Field"
+    name { "Dialog Field" }
   end
 
   factory :dialog_field_button,      :parent => :dialog_field, :class => "DialogFieldButton"

--- a/spec/factories/ems_folder.rb
+++ b/spec/factories/ems_folder.rb
@@ -45,28 +45,28 @@ FactoryBot.define do
   end
 
   factory :vmware_folder_root, :parent => :vmware_folder do
-    name   "Datacenters"
-    hidden true
+    name   { "Datacenters" }
+    hidden { true }
   end
 
   factory :vmware_folder_vm_root, :parent => :vmware_folder_vm do
-    name   "vm"
-    hidden true
+    name   { "vm" }
+    hidden { true }
   end
 
   factory :vmware_folder_host_root, :parent => :vmware_folder_host do
-    name   "host"
-    hidden true
+    name   { "host" }
+    hidden { true }
   end
 
   factory :vmware_folder_datastore_root, :parent => :vmware_folder_datastore do
-    name   "datastore"
-    hidden true
+    name   { "datastore" }
+    hidden { true }
   end
 
   factory :vmware_folder_network_root, :parent => :vmware_folder_network do
-    name   "network"
-    hidden true
+    name   { "network" }
+    hidden { true }
   end
 
   factory :vmware_datacenter, :parent => :vmware_folder, :class => "Datacenter" do

--- a/spec/factories/endpoint.rb
+++ b/spec/factories/endpoint.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :endpoint do
-    port 443
-    hostname "example.com"
+    port { 443 }
+    hostname { "example.com" }
   end
 end

--- a/spec/factories/entitlement.rb
+++ b/spec/factories/entitlement.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :entitlement do
     transient do
-      features nil
-      role nil
+      features { nil }
+      role { nil }
     end
 
     after :build do |entitlement, e|

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     # authorizations
 
     transient do
-      authtype nil
+      authtype { nil }
     end
 
     after(:create) do |ems, ev|
@@ -21,7 +21,7 @@ FactoryBot.define do
 
     trait :with_clusters do
       transient do
-        cluster_count 3
+        cluster_count { 3 }
       end
 
       after :create do |ems, evaluator|
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     trait :with_storages do
       transient do
-        storage_count 3
+        storage_count { 3 }
       end
 
       after :create do |ems, evaluator|
@@ -40,7 +40,7 @@ FactoryBot.define do
     end
 
     trait :with_authentication do
-      authtype "default"
+      authtype { "default" }
     end
 
     trait :with_unvalidated_authentication do
@@ -144,7 +144,7 @@ FactoryBot.define do
 
   factory :ems_vmware_with_authentication,
           :parent => :ems_vmware do
-    authtype "default"
+    authtype { "default" }
   end
 
   factory :ems_microsoft,
@@ -154,7 +154,7 @@ FactoryBot.define do
 
   factory :ems_microsoft_with_authentication,
           :parent => :ems_microsoft do
-    authtype "default"
+    authtype { "default" }
   end
 
   factory :ems_redhat,
@@ -164,17 +164,17 @@ FactoryBot.define do
 
   factory :ems_redhat_v3,
           :parent => :ems_redhat do
-    api_version '3.5'
+    api_version { '3.5' }
   end
 
   factory :ems_redhat_v4,
           :parent => :ems_redhat do
-    api_version '4.0'
+    api_version { '4.0' }
   end
 
   factory :ems_redhat_with_authentication,
           :parent => :ems_redhat do
-    authtype "default"
+    authtype { "default" }
   end
 
   trait :skip_validate do
@@ -183,8 +183,8 @@ FactoryBot.define do
 
   factory :ems_redhat_with_authentication_with_ca,
           :parent => :ems_redhat do
-    certificate_authority "cert108"
-    authtype "default"
+    certificate_authority { "cert108" }
+    authtype { "default" }
   end
 
   factory :ems_redhat_with_metrics_authentication,
@@ -218,7 +218,7 @@ FactoryBot.define do
 
   factory :ems_openstack_infra_with_authentication,
           :parent => :ems_openstack_infra do
-    authtype %w(default amqp)
+    authtype { %w(default amqp) }
   end
 
   factory :ems_vmware_cloud,
@@ -237,19 +237,19 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/amazon/cloud_manager"],
           :class   => "ManageIQ::Providers::Amazon::CloudManager",
           :parent  => :ems_cloud do
-    provider_region "us-east-1"
+    provider_region { "us-east-1" }
   end
 
   factory :ems_amazon_network,
           :aliases => ["manageiq/providers/amazon/network_manager"],
           :class   => "ManageIQ::Providers::Amazon::NetworkManager",
           :parent  => :ems_network do
-    provider_region "us-east-1"
+    provider_region { "us-east-1" }
   end
 
   factory :ems_amazon_with_authentication,
           :parent => :ems_amazon do
-    authtype "default"
+    authtype { "default" }
   end
 
   factory :ems_amazon_with_cloud_networks,
@@ -271,9 +271,9 @@ FactoryBot.define do
 
   factory :ems_azure_with_authentication,
           :parent => :ems_azure do
-    azure_tenant_id "ABCDEFGHIJABCDEFGHIJ0123456789AB"
-    subscription "0123456789ABCDEFGHIJABCDEFGHIJKL"
-    authtype "default"
+    azure_tenant_id { "ABCDEFGHIJABCDEFGHIJ0123456789AB" }
+    subscription { "0123456789ABCDEFGHIJABCDEFGHIJKL" }
+    authtype { "default" }
   end
 
   factory :ems_openstack,
@@ -283,7 +283,7 @@ FactoryBot.define do
 
   factory :ems_openstack_with_authentication,
           :parent => :ems_openstack do
-    authtype %w(default amqp)
+    authtype { %w(default amqp) }
   end
 
   factory :ems_openstack_network,
@@ -303,7 +303,7 @@ FactoryBot.define do
 
   factory :ems_google_with_authentication,
           :parent => :ems_google do
-    authtype "default"
+    authtype { "default" }
   end
 
   factory :ems_google_network,

--- a/spec/factories/file_depot.rb
+++ b/spec/factories/file_depot.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :file_depot do
-    name "File Depot"
-    uri  "nfs://somehost/export"
+    name { "File Depot" }
+    uri  { "nfs://somehost/export" }
   end
 
-  factory(:file_depot_ftp, :class => "FileDepotFtp", :parent => :file_depot) { uri "ftp://somehost/export" }
+  factory(:file_depot_ftp, :class => "FileDepotFtp", :parent => :file_depot) { uri { "ftp://somehost/export" } }
   factory :file_depot_ftp_with_authentication, :parent => :file_depot_ftp do
     after(:create) { |x| x.authentications << FactoryBot.create(:authentication) }
   end

--- a/spec/factories/filesystem.rb
+++ b/spec/factories/filesystem.rb
@@ -1,18 +1,18 @@
 FactoryBot.define do
   factory :filesystem do
     sequence(:name)     { |n| "filesystem_#{seq_padded_for_sorting(n)}" }
-    size 200
+    size { 200 }
   end
 
   factory :filesystem_openstack_conf, :parent => :filesystem do
-    name "etc/nova/nova.conf"
+    name { "etc/nova/nova.conf" }
   end
 
   factory :filesystem_binary_file, :parent => :filesystem do
-    name "periodical/utilities/blue_screen.exe"
+    name { "periodical/utilities/blue_screen.exe" }
   end
 
   factory :filesystem_txt_file, :parent => :filesystem do
-    name "periodical/utilities/blue_screen_description.txt"
+    name { "periodical/utilities/blue_screen_description.txt" }
   end
 end

--- a/spec/factories/flavor.rb
+++ b/spec/factories/flavor.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   end
 
   factory :flavor_openstack, :parent => :flavor, :class => "ManageIQ::Providers::Openstack::CloudManager::Flavor" do
-    root_disk_size 1_073_741_824
+    root_disk_size { 1_073_741_824 }
   end
 
   factory :flavor_amazon,    :parent => :flavor, :class => "ManageIQ::Providers::Amazon::CloudManager::Flavor"

--- a/spec/factories/guest_device.rb
+++ b/spec/factories/guest_device.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
 
   factory :guest_device_nic, :parent => :guest_device do
     sequence(:device_name) { |n| "Network Adapter #{seq_padded_for_sorting(n)}" }
-    device_type            "ethernet"
-    controller_type        "ethernet"
+    device_type            { "ethernet" }
+    controller_type        { "ethernet" }
     sequence(:address)     { |n| mac_from_seq(n) }
   end
 

--- a/spec/factories/hardware.rb
+++ b/spec/factories/hardware.rb
@@ -1,29 +1,29 @@
 FactoryBot.define do
   factory :hardware do
     trait(:cpu1x1) do
-      cpu_sockets          1
-      cpu_cores_per_socket 1
-      cpu_total_cores      1
+      cpu_sockets          { 1 }
+      cpu_cores_per_socket { 1 }
+      cpu_total_cores      { 1 }
     end
 
     trait(:cpu2x2) do
-      cpu_sockets          2
-      cpu_cores_per_socket 2
-      cpu_total_cores      4
+      cpu_sockets          { 2 }
+      cpu_cores_per_socket { 2 }
+      cpu_total_cores      { 4 }
     end
 
     trait(:cpu1x2) do
-      cpu_sockets          1
-      cpu_cores_per_socket 2
-      cpu_total_cores      2
+      cpu_sockets          { 1 }
+      cpu_cores_per_socket { 2 }
+      cpu_total_cores      { 2 }
     end
 
     trait(:cpu4x2) do
-      cpu_sockets          4
-      cpu_cores_per_socket 2
-      cpu_total_cores      8
+      cpu_sockets          { 4 }
+      cpu_cores_per_socket { 2 }
+      cpu_total_cores      { 8 }
     end
 
-    trait(:ram1GB) { memory_mb 1024 }
+    trait(:ram1GB) { memory_mb { 1024 } }
   end
 end

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -2,10 +2,10 @@ FactoryBot.define do
   factory :host do
     sequence(:name)     { |n| "host_#{seq_padded_for_sorting(n)}" }
     sequence(:hostname) { |n| "host-#{seq_padded_for_sorting(n)}" }
-    vmm_vendor          "vmware"
-    ipaddress           "127.0.0.1"
-    user_assigned_os    "linux_generic"
-    power_state         "on"
+    vmm_vendor          { "vmware" }
+    ipaddress           { "127.0.0.1" }
+    user_assigned_os    { "linux_generic" }
+    power_state         { "on" }
   end
 
   factory :host_with_ref, :parent => :host do
@@ -34,8 +34,8 @@ FactoryBot.define do
   end
 
   factory :host_with_ipmi, :parent => :host do
-    ipmi_address "127.0.0.1"
-    mac_address  "aa:bb:cc:dd:ee:ff"
+    ipmi_address { "127.0.0.1" }
+    mac_address  { "aa:bb:cc:dd:ee:ff" }
     after(:create) do |x|
       x.authentications = [FactoryBot.build(:authentication_ipmi, :resource => x)]
     end
@@ -43,39 +43,39 @@ FactoryBot.define do
 
   # Type specific subclasses
   factory(:host_vmware,     :parent => :host,        :class => "ManageIQ::Providers::Vmware::InfraManager::Host")
-  factory(:host_vmware_esx, :parent => :host_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::HostEsx") { vmm_product "ESX" }
+  factory(:host_vmware_esx, :parent => :host_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::HostEsx") { vmm_product { "ESX" } }
 
   factory :host_redhat, :parent => :host, :class => "ManageIQ::Providers::Redhat::InfraManager::Host" do
     sequence(:ems_ref) { |n| "host-#{seq_padded_for_sorting(n)}" }
-    vmm_vendor "redhat"
+    vmm_vendor { "redhat" }
   end
 
   factory :host_openstack_infra, :parent => :host, :class => "ManageIQ::Providers::Openstack::InfraManager::Host" do
-    vmm_vendor  "unknown"
-    ems_ref     "openstack-perf-host"
-    ems_ref_obj "openstack-perf-host-nova-instance"
+    vmm_vendor  { "unknown" }
+    ems_ref     { "openstack-perf-host" }
+    ems_ref_obj { "openstack-perf-host-nova-instance" }
     association :ems_cluster, factory: :ems_cluster_openstack
   end
 
   factory :host_openstack_infra_compute, :parent => :host_openstack_infra,
                                          :class  => "ManageIQ::Providers::Openstack::InfraManager::Host" do
-    name "host0 (NovaCompute)"
+    name { "host0 (NovaCompute)" }
   end
 
   factory :host_openstack_infra_compute_maintenance, :parent => :host_openstack_infra,
                                                      :class  => "ManageIQ::Providers::Openstack::InfraManager::Host" do
-    name        "host1 (NovaCompute)"
-    maintenance true
+    name        { "host1 (NovaCompute)" }
+    maintenance { true }
   end
 
   factory :host_microsoft, :parent => :host, :class => "ManageIQ::Providers::Microsoft::InfraManager::Host" do
-    vmm_vendor  "microsoft"
-    vmm_product "Hyper-V"
+    vmm_vendor  { "microsoft" }
+    vmm_product { "Hyper-V" }
   end
 
   trait :storage do
     transient do
-      storage_count 1
+      storage_count { 1 }
     end
 
     after :create do |h, evaluator|
@@ -85,7 +85,7 @@ FactoryBot.define do
 
   trait :storage_redhat do
     transient do
-      storage_count 1
+      storage_count { 1 }
     end
 
     after :create do |h, evaluator|

--- a/spec/factories/log_file.rb
+++ b/spec/factories/log_file.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :log_file do
-    state       "collecting"
-    historical  true
-    description "Default logfile"
+    state       { "collecting" }
+    historical  { true }
+    description { "Default logfile" }
   end
 end

--- a/spec/factories/metric.rb
+++ b/spec/factories/metric.rb
@@ -4,17 +4,17 @@ FactoryBot.define do
   end
 
   factory :metric_vm_rt, :parent => :metric, :class => :Metric do
-    capture_interval_name "realtime"
-    resource_type         "VmOrTemplate"
+    capture_interval_name { "realtime" }
+    resource_type         { "VmOrTemplate" }
   end
 
   factory :metric_host_rt, :parent => :metric, :class => :Metric do
-    capture_interval_name "realtime"
-    resource_type         "Host"
+    capture_interval_name { "realtime" }
+    resource_type         { "Host" }
   end
 
   factory :metric_container_node_rt, :parent => :metric, :class => :Metric do
-    capture_interval_name "realtime"
-    resource_type         "ContainerNode"
+    capture_interval_name { "realtime" }
+    resource_type         { "ContainerNode" }
   end
 end

--- a/spec/factories/metric_rollup.rb
+++ b/spec/factories/metric_rollup.rb
@@ -2,15 +2,15 @@ FactoryBot.define do
   factory :metric_rollup do
     timestamp { Time.now.utc }
     trait :with_data do
-      cpu_usage_rate_average            50.0
-      cpu_usagemhz_rate_average         50.0
-      derived_vm_numvcpus               1.0
-      derived_memory_available          1000.0
-      derived_memory_used               100.0
-      disk_usage_rate_average           100.0
-      net_usage_rate_average            25.0
-      derived_vm_used_disk_storage      1.0.gigabytes
-      derived_vm_allocated_disk_storage 4.0.gigabytes
+      cpu_usage_rate_average            { 50.0 }
+      cpu_usagemhz_rate_average         { 50.0 }
+      derived_vm_numvcpus               { 1.0 }
+      derived_memory_available          { 1000.0 }
+      derived_memory_used               { 100.0 }
+      disk_usage_rate_average           { 100.0 }
+      net_usage_rate_average            { 25.0 }
+      derived_vm_used_disk_storage      { 1.0.gigabytes }
+      derived_vm_allocated_disk_storage { 4.0.gigabytes }
     end
 
     trait :in_other_region do
@@ -19,37 +19,37 @@ FactoryBot.define do
   end
 
   factory :metric_rollup_vm_hr, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "hourly"
-    resource_type         "VmOrTemplate"
+    capture_interval_name { "hourly" }
+    resource_type         { "VmOrTemplate" }
   end
 
   factory :metric_rollup_vm_daily, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "daily"
-    resource_type         "VmOrTemplate"
+    capture_interval_name { "daily" }
+    resource_type         { "VmOrTemplate" }
   end
 
   factory :metric_rollup_host_hr, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "hourly"
-    resource_type         "Host"
+    capture_interval_name { "hourly" }
+    resource_type         { "Host" }
   end
 
   factory :metric_rollup_host_daily, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "daily"
-    resource_type         "Host"
+    capture_interval_name { "daily" }
+    resource_type         { "Host" }
   end
 
   factory :metric_rollup_cm_hr, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "hourly"
-    resource_type         "ExtManagementSystem"
+    capture_interval_name { "hourly" }
+    resource_type         { "ExtManagementSystem" }
   end
 
   factory :metric_rollup_cm_daily, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "daily"
-    resource_type         "ExtManagementSystem"
+    capture_interval_name { "daily" }
+    resource_type         { "ExtManagementSystem" }
   end
 
   factory :metric_rollup_storage_hr, :parent => :metric_rollup, :class => :MetricRollup do
-    capture_interval_name "hourly"
-    resource_type         "Storage"
+    capture_interval_name { "hourly" }
+    resource_type         { "Storage" }
   end
 end

--- a/spec/factories/middleware_datasource.rb
+++ b/spec/factories/middleware_datasource.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
 
   factory :hawkular_middleware_datasource_initialized,
           :parent => :hawkular_middleware_datasource do
-    name 'ExampleDS'
-    nativeid 'Local~/subsystem=datasources/data-source=ExampleDS'
+    name { 'ExampleDS' }
+    nativeid { 'Local~/subsystem=datasources/data-source=ExampleDS' }
     middleware_server { FactoryBot.create(:middleware_server) }
   end
 end

--- a/spec/factories/middleware_deployment.rb
+++ b/spec/factories/middleware_deployment.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :middleware_deployment do
     ext_management_system
-    name "A Middleware Deployment"
+    name { "A Middleware Deployment" }
   end
 end

--- a/spec/factories/middleware_messaging.rb
+++ b/spec/factories/middleware_messaging.rb
@@ -8,19 +8,19 @@ FactoryBot.define do
 
   factory :hawkular_middleware_messaging_initialized,
           :parent => :hawkular_middleware_messaging do
-    name 'JMS Queue [DLQ]'
-    nativeid 'Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ'
+    name { 'JMS Queue [DLQ]' }
+    nativeid { 'Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ' }
   end
 
   factory :hawkular_middleware_messaging_initialized_queue,
           :parent => :hawkular_middleware_messaging do
-    name 'JMS Queue [DLQ]'
-    nativeid 'Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ'
+    name { 'JMS Queue [DLQ]' }
+    nativeid { 'Local~/subsystem=messaging-activemq/server=default/jms-queue=DLQ' }
   end
 
   factory :hawkular_middleware_messaging_initialized_topic,
           :parent => :hawkular_middleware_messaging do
-    name 'JMS Topic [HawkularAlertData]'
-    nativeid 'Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertData'
+    name { 'JMS Topic [HawkularAlertData]' }
+    nativeid { 'Local~/subsystem=messaging-activemq/server=default/jms-topic=HawkularAlertData' }
   end
 end

--- a/spec/factories/miq_action.rb
+++ b/spec/factories/miq_action.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :miq_action do
     sequence(:name)        { |num| "action_#{seq_padded_for_sorting(num)}" }
     sequence(:description) { |num| "Test Action_#{seq_padded_for_sorting(num)}" }
-    action_type            "Test"
+    action_type            { "Test" }
   end
 end

--- a/spec/factories/miq_ae_class.rb
+++ b/spec/factories/miq_ae_class.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     trait :of_domain do
       transient do
-        domain nil
+        domain { nil }
       end
 
       before(:create) do |ae_class, evaluator|

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -4,21 +4,21 @@ FactoryBot.define do
   end
 
   factory :miq_ae_domain_enabled, :parent => :miq_ae_domain do
-    enabled true
+    enabled { true }
   end
 
   factory :miq_ae_domain_disabled, :parent => :miq_ae_domain do
-    enabled false
+    enabled { false }
   end
 
   factory :miq_ae_system_domain, :parent => :miq_ae_domain do
-    enabled false
+    enabled { false }
     source { MiqAeDomain::SYSTEM_SOURCE }
   end
 
   factory :miq_ae_system_domain_enabled, :parent => :miq_ae_domain do
     source { MiqAeDomain::SYSTEM_SOURCE }
-    enabled true
+    enabled { true }
   end
 
   factory :miq_ae_git_domain, :parent => :miq_ae_domain do
@@ -29,7 +29,7 @@ FactoryBot.define do
   factory :miq_ae_domain, :parent => :miq_ae_namespace, :class => "MiqAeDomain" do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
     tenant { Tenant.seed }
-    enabled true
+    enabled { true }
     source { MiqAeDomain::USER_SOURCE }
     trait :with_methods do
       transient do
@@ -71,8 +71,8 @@ FactoryBot.define do
 
     trait :with_small_model do
       transient do
-        ae_class 'CLASS1'
-        ae_namespace 'NS1/NS2'
+        ae_class { 'CLASS1' }
+        ae_namespace { 'NS1/NS2' }
       end
 
       after :create do |aedomain, evaluator|

--- a/spec/factories/miq_alert.rb
+++ b/spec/factories/miq_alert.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
   factory :miq_alert do
     sequence(:description) { |n| "Test Alert #{n}" }
-    enabled         true
+    enabled         { true }
   end
 
   factory :miq_alert_vm, :parent => :miq_alert do
-    options         :notifications => {}
-    db              "Vm"
+    options         { { :notifications => {} } }
+    db              { "Vm" }
   end
 
   factory :miq_alert_host, :parent => :miq_alert do
-    options         :notifications => {}
-    db              "Host"
+    options         { { :notifications => {} } }
+    db              { "Host" }
   end
 end

--- a/spec/factories/miq_alert_set.rb
+++ b/spec/factories/miq_alert_set.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :miq_alert_set do
-    transient { alerts nil }
+    transient { alerts { nil } }
     sequence(:name)         { |n| "alert_profile_#{seq_padded_for_sorting(n)}" }
     sequence(:description)  { |n| "alert_profile_#{seq_padded_for_sorting(n)}" }
 
@@ -14,10 +14,10 @@ FactoryBot.define do
   end
 
   factory :miq_alert_set_vm, :parent => :miq_alert_set do
-    mode "VmOrTemplate" # VmOrTemplate.base_model.name
+    mode { "VmOrTemplate" } # VmOrTemplate.base_model.name
   end
 
   factory :miq_alert_set_host, :parent => :miq_alert_set do
-    mode "Host" # Host.base_model.name
+    mode { "Host" } # Host.base_model.name
   end
 end

--- a/spec/factories/miq_alert_status_action.rb
+++ b/spec/factories/miq_alert_status_action.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :miq_alert_status_action do
-    action_type 'comment'
-    comment     'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    action_type { 'comment' }
+    comment     { 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' }
   end
 end

--- a/spec/factories/miq_compare.rb
+++ b/spec/factories/miq_compare.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :miq_compare do
-    report nil
-    options nil
+    report { nil }
+    options { nil }
     initialize_with { new(options, report) }
   end
 end

--- a/spec/factories/miq_dialog.rb
+++ b/spec/factories/miq_dialog.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
   end
 
   factory :miq_dialog_provision, :parent => :miq_dialog do
-    name        "miq_provision_dialogs"
-    dialog_type "MiqProvisionWorkflow"
+    name        { "miq_provision_dialogs" }
+    dialog_type { "MiqProvisionWorkflow" }
 
     content do
       {
@@ -29,7 +29,7 @@ FactoryBot.define do
   end
 
   factory :miq_provision_configured_system_foreman_dialog, :parent => :miq_dialog do
-    name        "miq_provision_configured_system_foreman_dialogs"
-    dialog_type "MiqProvisionConfiguredSystemWorkflow"
+    name        { "miq_provision_configured_system_foreman_dialogs" }
+    dialog_type { "MiqProvisionConfiguredSystemWorkflow" }
   end
 end

--- a/spec/factories/miq_event_definition.rb
+++ b/spec/factories/miq_event_definition.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :miq_event_definition do
     sequence(:name)  { |num| "event_definition_#{num}" }
-    description      "Test event_definition"
+    description      { "Test event_definition" }
   end
 end

--- a/spec/factories/miq_group.rb
+++ b/spec/factories/miq_group.rb
@@ -3,13 +3,13 @@ FactoryBot.define do
 
   factory :miq_group do
     transient do
-      features nil
-      role nil
+      features { nil }
+      role { nil }
 
       # Temporary: Allows entitlements, a new table, to be invisible to current spec setup code
       # Do NOT use these if possible.
-      miq_user_role_id nil
-      miq_user_role nil
+      miq_user_role_id { nil }
+      miq_user_role { nil }
     end
 
     sequence(:sequence)  # don't want to spend time looking these up
@@ -34,7 +34,7 @@ FactoryBot.define do
     end
 
     transient do
-      default_tenant nil
+      default_tenant { nil }
     end
 
     trait :in_other_region do

--- a/spec/factories/miq_policy.rb
+++ b/spec/factories/miq_policy.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :miq_policy do
     sequence(:name)        { |num| "policy_#{seq_padded_for_sorting(num)}" }
     sequence(:description) { |num| "Test Policy_#{seq_padded_for_sorting(num)}" }
-    mode                   'control'
-    towhat                 "Vm"
+    mode                   { 'control' }
+    towhat                 { "Vm" }
   end
 
   factory :miq_policy_read_only, :parent => :miq_policy do
-    read_only true
+    read_only { true }
   end
 end

--- a/spec/factories/miq_policy_set.rb
+++ b/spec/factories/miq_policy_set.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :miq_policy_set do
-    description "Test Policy Set"
+    description { "Test Policy Set" }
   end
 
   factory :miq_policy_set_read_only, :parent => :miq_policy_set do
-    read_only true
+    read_only { true }
   end
 end

--- a/spec/factories/miq_product_feature.rb
+++ b/spec/factories/miq_product_feature.rb
@@ -2,10 +2,10 @@ FactoryBot.define do
   factory :miq_product_feature
 
   factory :miq_product_feature_everything, :parent => :miq_product_feature do
-    identifier   "everything"
-    name         "Everything"
-    description  "Access to Everything"
-    protected    false
-    feature_type "node"
+    identifier   { "everything" }
+    name         { "Everything" }
+    description  { "Access to Everything" }
+    protected    { false }
+    feature_type { "node" }
   end
 end

--- a/spec/factories/miq_queue.rb
+++ b/spec/factories/miq_queue.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :miq_queue do
-    state  'ready'
-    args   []
+    state  { 'ready' }
+    args   { [] }
   end
 end

--- a/spec/factories/miq_report.rb
+++ b/spec/factories/miq_report.rb
@@ -1,23 +1,23 @@
 FactoryBot.define do
   factory :miq_report do
     sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
-    db              'Vm'
-    title           'some title'
-    rpt_type        'Default'
-    template_type   'report'
-    rpt_group       'Custom'
+    db              { 'Vm' }
+    title           { 'some title' }
+    rpt_type        { 'Default' }
+    template_type   { 'report' }
+    rpt_group       { 'Custom' }
     association     :miq_group
   end
 
   factory :miq_report_filesystem, :parent => :miq_report do
     sequence(:name) { |n| "Files #{seq_padded_for_sorting(n)}" }
-    db              'Filesystem'
-    title           'Files'
-    cols            %w(name base_name file_version size contents_available permissions updated_on mtime)
-    col_order       %w(name base_name file_version size contents_available permissions updated_on mtime)
-    headers         %w(Name File\ Name File\ Version Size Contents\ Available Permissions Collected\ On Last\ Modified)
-    sortby          ["name"]
-    order           "Ascending"
+    db              { 'Filesystem' }
+    title           { 'Files' }
+    cols            { %w(name base_name file_version size contents_available permissions updated_on mtime) }
+    col_order       { %w(name base_name file_version size contents_available permissions updated_on mtime) }
+    headers         { %w(Name File\ Name File\ Version Size Contents\ Available Permissions Collected\ On Last\ Modified) }
+    sortby          { ["name"] }
+    order           { "Ascending" }
   end
 
   factory :miq_report_with_results, :parent => :miq_report do
@@ -26,22 +26,22 @@ FactoryBot.define do
 
   factory :miq_report_chargeback, :parent => :miq_report do
     sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
-    db              'ChargebackVm'
-    title           'some title'
-    rpt_type        'Default'
-    template_type   'report'
-    rpt_group       'Custom'
+    db              { 'ChargebackVm' }
+    title           { 'some title' }
+    rpt_type        { 'Default' }
+    template_type   { 'report' }
+    rpt_group       { 'Custom' }
     association     :miq_group
   end
 
   factory :miq_report_chargeback_with_results, :parent => :miq_report do
     miq_report_results { [FactoryBot.create(:miq_chargeback_report_result)] }
     sequence(:name) { |n| "Test Report #{seq_padded_for_sorting(n)}" }
-    db              'ChargebackVm'
-    title           'some title'
-    rpt_type        'Default'
-    template_type   'report'
-    rpt_group       'Custom'
+    db              { 'ChargebackVm' }
+    title           { 'some title' }
+    rpt_type        { 'Default' }
+    template_type   { 'report' }
+    rpt_group       { 'Custom' }
     association     :miq_group
   end
 end

--- a/spec/factories/miq_report_result.rb
+++ b/spec/factories/miq_report_result.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :miq_chargeback_report_result, :parent => :miq_report_result do
     sequence(:name) { |n| "Test Chargeback Report Result #{seq_padded_for_sorting(n)}" }
-    db "ChargebackVm"
-    report_source "Requested by user"
+    db { "ChargebackVm" }
+    report_source { "Requested by user" }
   end
 end

--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     requester { create(:user) }
 
     factory :automation_request, :class => "AutomationRequest" do
-      request_type "automation"
+      request_type { "automation" }
     end
 
     factory :service_reconfigure_request,        :class => "ServiceReconfigureRequest"
@@ -22,7 +22,7 @@ FactoryBot.define do
 
     trait :with_approval do
       transient do
-        reason ""
+        reason { "" }
       end
 
       after(:create) do |request, evaluator|

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :miq_request_task do
-    status "Ok"
+    status { "Ok" }
   end
 
   factory :miq_retire_task,    :parent => :miq_request_task,   :class => "MiqRetireTask"
@@ -14,12 +14,12 @@ FactoryBot.define do
   factory :miq_provision_redhat_via_pxe, :parent => :miq_provision_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe"
   factory :miq_provision_vmware,         :parent => :miq_provision,        :class => "ManageIQ::Providers::Vmware::InfraManager::Provision" do
     trait :clone_to_vm do
-      request_type "clone_to_vm"
+      request_type { "clone_to_vm" }
     end
   end
   factory :miq_provision_vmware_via_pxe, :parent => :miq_provision_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe"
   factory :vm_migrate_task,              :parent => :miq_request_task,     :class => "VmMigrateTask" do
-    request_type "vm_migrate"
+    request_type { "vm_migrate" }
   end
 
   # Cloud
@@ -35,22 +35,22 @@ FactoryBot.define do
   # Services
   factory :service_reconfigure_task,        :parent => :miq_request_task, :class => "ServiceReconfigureTask"
   factory :service_template_provision_task, :parent => :miq_request_task, :class => "ServiceTemplateProvisionTask" do
-    state        'pending'
-    request_type 'clone_to_service'
+    state        { 'pending' }
+    request_type { 'clone_to_service' }
   end
 
   factory :service_template_transformation_plan_task, :parent => :service_template_provision_task, :class => 'ServiceTemplateTransformationPlanTask' do
-    request_type 'transformation_plan'
+    request_type { 'transformation_plan' }
   end
 
   # Retire Tasks
   factory :service_retire_task,             :parent => :miq_retire_task, :class => "ServiceRetireTask" do
-    state        'pending'
+    state        { 'pending' }
   end
   factory :vm_retire_task,                  :parent => :miq_retire_task, :class => "VmRetireTask" do
-    state        'pending'
+    state        { 'pending' }
   end
   factory :orchestration_stack_retire_task, :parent => :miq_retire_task, :class => "OrchestrationStackRetireTask" do
-    state        'pending'
+    state        { 'pending' }
   end
 end

--- a/spec/factories/miq_schedule.rb
+++ b/spec/factories/miq_schedule.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :miq_schedule_validation, :class => :MiqSchedule do
     sequence(:name)     { |n| "schedule_#{seq_padded_for_sorting(n)}" }
-    description         "test"
-    resource_type       "MiqReport"
+    description         { "test" }
+    resource_type       { "MiqReport" }
     run_at              {}
     sched_action        {}
   end
@@ -11,10 +11,10 @@ FactoryBot.define do
     run_at = {:start_time   => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}}
     sched_action = {:method => "test"}
     sequence(:name)     { |n| "schedule_#{seq_padded_for_sorting(n)}" }
-    description         "test"
-    resource_type       "MiqReport"
-    run_at              run_at
-    sched_action        sched_action
+    description         { "test" }
+    resource_type       { "MiqReport" }
+    run_at              { run_at }
+    sched_action        { sched_action }
   end
 
   factory :miq_automate_schedule, :class => :MiqSchedule do
@@ -22,10 +22,10 @@ FactoryBot.define do
     sched_action = {:method => "automation_request"}
     filter = {:uri_parts => {:instance => 'test', :message => 'create'}, :ui => { :ui_attrs => [], :ui_object => {} }, :parameters => {'request' => 'test_request', 'key1' => 'value1'}}
     sequence(:name)     { |n| "automate_schedule_#{seq_padded_for_sorting(n)}" }
-    description         "test_automation"
-    resource_type       "AutomationRequest"
-    run_at              run_at
-    sched_action        sched_action
-    filter              filter
+    description         { "test_automation" }
+    resource_type       { "AutomationRequest" }
+    run_at              { run_at }
+    sched_action        { sched_action }
+    filter              { filter }
   end
 end

--- a/spec/factories/miq_search.rb
+++ b/spec/factories/miq_search.rb
@@ -2,18 +2,18 @@ FactoryBot.define do
   factory :miq_search do
     sequence(:name)        { |n| "miq_search_#{seq_padded_for_sorting(n)}" }
     sequence(:description) { |n| "MiqSearch #{seq_padded_for_sorting(n)}" }
-    db          "Vm"
-    search_type "default"
+    db          { "Vm" }
+    search_type { "default" }
 
     filter { MiqExpression.new("CONTAINS" => {"tag" => "Vm.managed-environment", "value" => "prod"}) }
   end
 
   factory :miq_search_global, :parent => :miq_search do
-    search_type "global"
+    search_type { "global" }
   end
 
   factory :miq_search_user, :parent => :miq_search do
-    search_type "user"
+    search_type { "user" }
     search_key  { FactoryBot.create(:user).id }
   end
 end

--- a/spec/factories/miq_server.rb
+++ b/spec/factories/miq_server.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
     zone            { FactoryBot.build(:zone) }
     sequence(:name) { |n| "miq_server_#{seq_padded_for_sorting(n)}" }
     last_heartbeat  { Time.now.utc }
-    status          "started"
+    status          { "started" }
     started_on      { Time.now.utc }
-    stopped_on      ""
-    version         '9.9.9.9'
+    stopped_on      { "" }
+    version         { '9.9.9.9' }
   end
 end

--- a/spec/factories/miq_task.rb
+++ b/spec/factories/miq_task.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :miq_task do
-    status          "Ok"
-    state           "Active"
+    status          { "Ok" }
+    state           { "Active" }
     sequence(:name) { |n| "task_#{seq_padded_for_sorting(n)}" }
   end
 

--- a/spec/factories/miq_user_role.rb
+++ b/spec/factories/miq_user_role.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   factory :miq_user_role do
     transient do
       # e.g.: miq_request_approval
-      features nil
+      features { nil }
       # e.g.: super_administrator
-      role nil
+      role { nil }
     end
 
     name { |ur| ur.role ? "EvmRole-#{ur.role}" : generate(:miq_user_role_name) }

--- a/spec/factories/miq_widget.rb
+++ b/spec/factories/miq_widget.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :miq_widget do
     sequence(:title)        { |n| "widget_#{seq_padded_for_sorting(n)}" }
     sequence(:description)  { |n| "widget_#{seq_padded_for_sorting(n)}" }
-    content_type            "report"
+    content_type            { "report" }
   end
 end

--- a/spec/factories/miq_worker.rb
+++ b/spec/factories/miq_worker.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :miq_worker do
     pid    { rand(99999) }
-    status "ready"
+    status { "ready" }
   end
 
   factory :miq_generic_worker, :class => "MiqGenericWorker", :parent => :miq_worker

--- a/spec/factories/notification_type.rb
+++ b/spec/factories/notification_type.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :notification_type do
     sequence(:name) { |n| "notification_type_#{seq_padded_for_sorting(n)}" }
     sequence(:message) { |n| "message_#{seq_padded_for_sorting(n)}" }
-    audience 'user'
-    level "info"
+    audience { 'user' }
+    level { "info" }
   end
 end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :orchestration_stack do
-    ems_ref "1"
+    ems_ref { "1" }
   end
 
   factory :orchestration_stack_cloud, :parent => :orchestration_stack, :class => "ManageIQ::Providers::CloudManager::OrchestrationStack"

--- a/spec/factories/physical_server.rb
+++ b/spec/factories/physical_server.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :physical_server do
-    vendor "lenovo"
+    vendor { "lenovo" }
   end
 end

--- a/spec/factories/picture.rb
+++ b/spec/factories/picture.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :picture do
-    content   'foo'
-    extension 'png'
+    content   { 'foo' }
+    extension { 'png' }
   end
 end

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   end
 
   factory :provider_foreman, :class => "ManageIQ::Providers::Foreman::Provider", :parent => :provider do
-    url "example.com"
+    url { "example.com" }
 
     after(:build) do |provider|
       provider.authentications << FactoryBot.build(:authentication,
@@ -17,7 +17,7 @@ FactoryBot.define do
 
   factory :provider_openstack, :class => "ManageIQ::Providers::Openstack::Provider", :parent => :provider
   factory(:provider_ansible_tower, :class => "ManageIQ::Providers::AnsibleTower::Provider", :parent => :provider) do
-    url "example.com"
+    url { "example.com" }
     trait(:with_authentication) do
       after(:create) do |x|
         x.authentications << FactoryBot.create(:authentication)

--- a/spec/factories/pxe_image.rb
+++ b/spec/factories/pxe_image.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :pxe_image, :class => 'PxeImage' do
     sequence(:name)         { |n| "pxe_image_#{seq_padded_for_sorting(n)}" }
     sequence(:description)  { |n| "pxe_desc_#{seq_padded_for_sorting(n)}"  }
-    kernel                  'ubuntu-10.10-desktop-i386/vmlinuz'
-    kernel_options          "vga=788 -- quiet"
+    kernel                  { 'ubuntu-10.10-desktop-i386/vmlinuz' }
+    kernel_options          { "vga=788 -- quiet" }
   end
 
   factory :pxe_image_ipxe, :parent => :pxe_image, :class => 'PxeImageIpxe'

--- a/spec/factories/relationship.rb
+++ b/spec/factories/relationship.rb
@@ -1,28 +1,28 @@
 FactoryBot.define do
   factory :relationship do
     trait :membership do
-      relationship 'membership'
+      relationship { 'membership' }
     end
   end
 
   factory :relationship_vm_vmware, :parent => :relationship do
-    resource_type  "VmOrTemplate"
+    resource_type  { "VmOrTemplate" }
   end
 
   factory :relationship_host_vmware, :parent => :relationship do
-    resource_type  "Host"
+    resource_type  { "Host" }
   end
 
   factory :relationship_storage_vmware, :parent => :relationship do
-    resource_type  "Storage"
+    resource_type  { "Storage" }
   end
 
   factory :relationship_miq_widget_set, :parent => :relationship do
-    resource_type 'MiqWidgetSet'
+    resource_type { 'MiqWidgetSet' }
   end
 
   factory :relationship_miq_widget, :parent => :relationship do
-    resource_type 'MiqWidget'
+    resource_type { 'MiqWidget' }
   end
 
   factory :relationship_miq_widget_set_with_membership, :parent => :relationship_miq_widget_set,

--- a/spec/factories/scan_item_set.rb
+++ b/spec/factories/scan_item_set.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :scan_item_set do
     sequence(:name) { |i| "scan_item_set#{i}" }
-    description 'ScanItemSet description'
+    description { 'ScanItemSet description' }
   end
 end

--- a/spec/factories/service_order.rb
+++ b/spec/factories/service_order.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory(:service_order) do
-    name "service order"
-    state "ordered"
+    name { "service order" }
+    state { "ordered" }
 
     factory(:shopping_cart) do
-      name "shopping cart"
-      state "cart"
+      name { "shopping cart" }
+      state { "cart" }
     end
   end
 end

--- a/spec/factories/service_template.rb
+++ b/spec/factories/service_template.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
   end
 
   trait :orderable do
-    display true
+    display { true }
     service_template_catalog
   end
 end

--- a/spec/factories/small_environment.rb
+++ b/spec/factories/small_environment.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
   end
 
   factory :host_small_environment, :parent => :host_with_ref do
-    vmm_product  "Workstation"
+    vmm_product  { "Workstation" }
     vms          { [FactoryBot.create(:vm_with_ref, :name => "vmtest1"), FactoryBot.create(:vm_with_ref, :name => "vmtest2")] }
   end
 end

--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -4,11 +4,11 @@ FactoryBot.define do
   end
 
   factory :storage_vmware, :parent => :storage do
-    store_type "VMFS"
+    store_type { "VMFS" }
   end
 
   factory :storage_nfs, :parent => :storage do
-    store_type "NFS"
+    store_type { "NFS" }
   end
 
   factory :storage_redhat, :parent => :storage_nfs do
@@ -17,11 +17,11 @@ FactoryBot.define do
   end
 
   factory :storage_block, :parent => :storage do
-    store_type "FCP"
+    store_type { "FCP" }
   end
 
   factory :storage_unknown, :parent => :storage do
-    store_type "UNKNOWN"
+    store_type { "UNKNOWN" }
   end
 
   # Factories for perf_capture_timer and perf_capture_gap testing

--- a/spec/factories/storage_file.rb
+++ b/spec/factories/storage_file.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :storage_file do
     sequence(:name)  { |n| "path/to/file#{seq_padded_for_sorting(n)}/file#{n}.log" }
-    vm_or_template_id    1000
+    vm_or_template_id    { 1000 }
   end
 end

--- a/spec/factories/system_console.rb
+++ b/spec/factories/system_console.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory(:system_console) do
-    host_name 'manageiq.org'
-    port '80'
-    ssl false
-    protocol :vnc
-    secret SecureRandom.base64[0, 8]
-    vm nil
-    user nil
+    host_name { 'manageiq.org' }
+    port { '80' }
+    ssl { false }
+    protocol { :vnc }
+    secret { SecureRandom.base64[0, 8] }
+    vm { nil }
+    user { nil }
   end
 end

--- a/spec/factories/tenant.rb
+++ b/spec/factories/tenant.rb
@@ -18,6 +18,6 @@ FactoryBot.define do
   end
 
   factory :tenant_project, :parent => :tenant do
-    divisible false
+    divisible { false }
   end
 end

--- a/spec/factories/tenant_quota.rb
+++ b/spec/factories/tenant_quota.rb
@@ -1,34 +1,34 @@
 FactoryBot.define do
   factory :tenant_quota do
     factory :tenant_quota_cpu do
-      name :cpu_allocated
-      unit "fixnum"
-      value 16
-      warn_value 12
+      name { :cpu_allocated }
+      unit { "fixnum" }
+      value { 16 }
+      warn_value { 12 }
     end
 
     factory :tenant_quota_mem do
-      name :mem_allocated
-      unit "bytes"
-      value 2_147_483_648 # 2 GB
+      name { :mem_allocated }
+      unit { "bytes" }
+      value { 2_147_483_648 } # 2 GB
     end
 
     factory :tenant_quota_storage do
-      name :storage_allocated
-      unit "bytes"
-      value 2_147_483_648 # 2 GB
+      name { :storage_allocated }
+      unit { "bytes" }
+      value { 2_147_483_648 } # 2 GB
     end
 
     factory :tenant_quota_vms do
-      name :vms_allocated
-      unit "FIXNUM"
-      value 2
+      name { :vms_allocated }
+      unit { "FIXNUM" }
+      value { 2 }
     end
 
     factory :tenant_quota_templates do
-      name :templates_allocated
-      unit "FIXNUM"
-      value 2
+      name { :templates_allocated }
+      unit { "FIXNUM" }
+      value { 2 }
     end
   end
 end

--- a/spec/factories/time_profile.rb
+++ b/spec/factories/time_profile.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
   end
 
   factory :time_profile_with_rollup, :parent => :time_profile do
-    rollup_daily_metrics true
+    rollup_daily_metrics { true }
   end
 
   factory :time_profile_utc, :parent => :time_profile_with_rollup do
-    tz "UTC"
+    tz { "UTC" }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :user do
     transient do
       # e.g. "super_administrtor"
-      role nil
+      role { nil }
       # e.g.: "miq_request_approval"
-      features nil
+      features { nil }
       tenant { Tenant.seed }
     end
 
@@ -12,7 +12,7 @@ FactoryBot.define do
     sequence(:name)   { |s| "Test User #{s}" }
 
     # encrypted password for "dummy"
-    password_digest "$2a$10$FTbGT/y/PQ1HvoOoc1FcyuuTtHzfop/uG/mcEAJLYpzmsUIJcGT7W"
+    password_digest { "$2a$10$FTbGT/y/PQ1HvoOoc1FcyuuTtHzfop/uG/mcEAJLYpzmsUIJcGT7W" }
 
     after :build do |u, e|
       if e.miq_groups.blank? && (e.role || e.features)
@@ -24,14 +24,14 @@ FactoryBot.define do
     end
 
     trait :with_miq_edit_features do
-      features %w(
+      features { %w(
         miq_ae_class_edit
         miq_ae_domain_edit
         miq_ae_class_copy
         miq_ae_instance_copy
         miq_ae_method_copy
         miq_ae_namespace_edit
-      )
+      ) }
     end
   end
 
@@ -48,10 +48,10 @@ FactoryBot.define do
   end
 
   factory :user_admin, :parent => :user do
-    role "super_administrator"
+    role { "super_administrator" }
   end
 
   factory :user_miq_request_approver, :parent => :user do
-    features "miq_request_approval"
+    features { "miq_request_approval" }
   end
 end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :vm_or_template do
     sequence(:name) { |n| "vm_#{seq_padded_for_sorting(n)}" }
-    location        "unknown"
+    location        { "unknown" }
     uid_ems         { SecureRandom.uuid }
-    vendor          "unknown"
-    template        false
-    raw_power_state "running"
+    vendor          { "unknown" }
+    template        { false }
+    raw_power_state { "running" }
 
     trait :in_other_region do
       other_region
@@ -14,49 +14,49 @@ FactoryBot.define do
 
   factory :template, :class => "MiqTemplate", :parent => :vm_or_template do
     sequence(:name) { |n| "template_#{seq_padded_for_sorting(n)}" }
-    template        true
-    raw_power_state "never"
+    template        { true }
+    raw_power_state { "never" }
   end
 
   factory(:vm,             :class => "Vm",            :parent => :vm_or_template)
-  factory(:vm_cloud,       :class => "VmCloud",       :parent => :vm)       { cloud true }
+  factory(:vm_cloud,       :class => "VmCloud",       :parent => :vm)       { cloud { true } }
   factory(:vm_infra,       :class => "VmInfra",       :parent => :vm)
   factory(:vm_server,      :class => "VmServer",      :parent => :vm)
   factory(:vm_xen,         :class => "VmXen",         :parent => :vm_infra)
-  factory(:template_cloud, :class => "TemplateCloud", :parent => :template) { cloud true }
+  factory(:template_cloud, :class => "TemplateCloud", :parent => :template) { cloud { true } }
   factory(:template_infra, :class => "TemplateInfra", :parent => :template)
 
   factory :template_amazon, :class => "ManageIQ::Providers::Amazon::CloudManager::Template", :parent => :template_cloud do
     location { |x| "#{x.name}/#{x.name}.img.manifest.xml" }
-    vendor   "amazon"
+    vendor   { "amazon" }
   end
 
   factory :template_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::Template", :parent => :template_cloud do
-    vendor "openstack"
+    vendor { "openstack" }
   end
 
   factory :volume_template_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::VolumeTemplate", :parent => :template_cloud do
-    vendor "openstack"
+    vendor { "openstack" }
   end
 
   factory :miq_template do
-    name "ubuntu-16.04-stable"
-    location "Minneapolis, MN"
-    vendor "openstack"
+    name { "ubuntu-16.04-stable" }
+    location { "Minneapolis, MN" }
+    vendor { "openstack" }
   end
 
   factory :template_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Template", :parent => :template_cloud do
     location { |x| "#{x.name}/#{x.name}.img.manifest.xml" }
-    vendor   "azure"
+    vendor   { "azure" }
   end
 
-  factory(:template_google, :class => "ManageIQ::Providers::Google::CloudManager::Template", :parent => :template_cloud) { vendor "google" }
-  factory(:template_microsoft, :class => "ManageIQ::Providers::Microsoft::InfraManager::Template", :parent => :template_infra) { vendor "microsoft" }
-  factory(:template_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::Template", :parent => :template_infra) { vendor "redhat" }
+  factory(:template_google, :class => "ManageIQ::Providers::Google::CloudManager::Template", :parent => :template_cloud) { vendor { "google" } }
+  factory(:template_microsoft, :class => "ManageIQ::Providers::Microsoft::InfraManager::Template", :parent => :template_infra) { vendor { "microsoft" } }
+  factory(:template_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::Template", :parent => :template_infra) { vendor { "redhat" } }
 
   factory :template_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::Template", :parent => "template_infra" do
     location { |x| "[storage] #{x.name}/#{x.name}.vmtx" }
-    vendor   "vmware"
+    vendor   { "vmware" }
   end
 
   factory :template_vmware_with_ref, :parent => :template_vmware do
@@ -67,14 +67,14 @@ FactoryBot.define do
   factory :template_vmware_cloud,
           :class  => "ManageIQ::Providers::Vmware::CloudManager::Template",
           :parent => :template_cloud do
-    vendor "vmware"
+    vendor { "vmware" }
   end
 
   factory(:template_xen, :class => "TemplateXen", :parent => :template_infra)
 
   factory :vm_amazon, :class => "ManageIQ::Providers::Amazon::CloudManager::Vm", :parent => :vm_cloud do
     location { |x| "#{x.name}.us-west-1.compute.amazonaws.com" }
-    vendor   "amazon"
+    vendor   { "amazon" }
 
     trait :with_provider do
       after(:create) do |x|
@@ -83,17 +83,17 @@ FactoryBot.define do
     end
 
     trait :powered_off do
-      raw_power_state "stopped"
+      raw_power_state { "stopped" }
     end
   end
 
   factory :vm_azure, :class => "ManageIQ::Providers::Azure::CloudManager::Vm", :parent => :vm_cloud do
-    location "westus"
-    vendor   "azure"
-    uid_ems  "01234567890/test_resource_group/microsoft.resources/vm_1"
-    ems_ref  "01234567890/test_resource_group/microsoft.resources/vm_1"
-    raw_power_state "VM running"
-    name "vm_1"
+    location { "westus" }
+    vendor   { "azure" }
+    uid_ems  { "01234567890/test_resource_group/microsoft.resources/vm_1" }
+    ems_ref  { "01234567890/test_resource_group/microsoft.resources/vm_1" }
+    raw_power_state { "VM running" }
+    name { "vm_1" }
 
     trait :with_provider do
       after(:create) do |x|
@@ -103,7 +103,7 @@ FactoryBot.define do
   end
 
   factory :vm_google, :class => "ManageIQ::Providers::Google::CloudManager::Vm", :parent => :vm_cloud do
-    vendor "google"
+    vendor { "google" }
 
     trait :with_provider do
       after(:create) do |x|
@@ -114,18 +114,18 @@ FactoryBot.define do
 
   factory :vm_microsoft, :class => "ManageIQ::Providers::Microsoft::InfraManager::Vm", :parent => :vm_infra do
     location        { |x| "#{x.name}/#{x.name}.xml" }
-    vendor          "microsoft"
-    raw_power_state "Running"
+    vendor          { "microsoft" }
+    raw_power_state { "Running" }
   end
 
   factory :vm_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::Vm", :parent => :vm_cloud do
-    vendor          "openstack"
-    raw_power_state "ACTIVE"
+    vendor          { "openstack" }
+    raw_power_state { "ACTIVE" }
     sequence(:ems_ref) { |n| "some-uuid-#{seq_padded_for_sorting(n)}" }
     cloud_tenant { FactoryBot.create(:cloud_tenant_openstack) }
 
     factory :vm_perf_openstack, :parent => :vm_openstack do
-      ems_ref "openstack-perf-vm"
+      ems_ref { "openstack-perf-vm" }
     end
 
     trait :with_provider do
@@ -136,14 +136,14 @@ FactoryBot.define do
   end
 
   factory :vm_redhat, :class => "ManageIQ::Providers::Redhat::InfraManager::Vm", :parent => :vm_infra do
-    vendor          "redhat"
-    raw_power_state "up"
+    vendor          { "redhat" }
+    raw_power_state { "up" }
   end
 
   factory :vm_vmware, :class => "ManageIQ::Providers::Vmware::InfraManager::Vm", :parent => :vm_infra do
     location        { |x| "[storage] #{x.name}/#{x.name}.vmx" }
-    vendor          "vmware"
-    raw_power_state "poweredOn"
+    vendor          { "vmware" }
+    raw_power_state { "poweredOn" }
   end
 
   factory :vm_with_ref, :parent => :vm_vmware do
@@ -153,9 +153,9 @@ FactoryBot.define do
 
   # Factories for perf_capture, perf_process testing
   factory :vm_perf, :parent => :vm_vmware do
-    name     "MIQ-WEBSVR1"
-    location "MIQ-WEBSVR1/MIQ-WEBSVR1.vmx"
-    ems_ref  "vm-578855"
+    name     { "MIQ-WEBSVR1" }
+    location { "MIQ-WEBSVR1/MIQ-WEBSVR1.vmx" }
+    ems_ref  { "vm-578855" }
     ems_ref_obj { VimString.new("vm-578855", "VirtualMachine", "ManagedObjectReference") }
   end
 
@@ -165,6 +165,6 @@ FactoryBot.define do
   end
 
   factory :vm_vmware_cloud, :class => "ManageIQ::Providers::Vmware::CloudManager::Vm", :parent => :vm_cloud do
-    vendor "vmware"
+    vendor { "vmware" }
   end
 end

--- a/spec/factories/vmdb_metric.rb
+++ b/spec/factories/vmdb_metric.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :vmdb_metric
 
   factory :vmdb_metric_hourly, :parent => :vmdb_metric do
-    capture_interval_name "hourly"
+    capture_interval_name { "hourly" }
   end
 end

--- a/spec/models/vim_performance_analysis_spec.rb
+++ b/spec/models/vim_performance_analysis_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe VimPerformanceAnalysis do
 
   describe ".get_daily_perf" do
     it "should not raise an error" do
-      range       = {:days => 7, :end_date => "2016-04-19T23:00:00Z".to_time}
+      range       = {:days => 7, :end_date => "2016-04-19T23:00:00Z".to_time(:utc)}
       ext_options = {:tz => "UTC", :time_profile => time_profile}
       perf_cols   = [:max_cpu_usagemhz_rate_average, :derived_cpu_available, :total_vcpus, :max_derived_memory_used, :derived_memory_available, :used_space, :total_space]
       expect { described_class.get_daily_perf(host1, range, ext_options, perf_cols).all.inspect }.not_to raise_error


### PR DESCRIPTION
It's time to print deprecations again in test mode.  Most of the noisiest warnings are fixed below:

https://github.com/ManageIQ/manageiq-providers-vmware/pull/372
https://github.com/ManageIQ/manageiq-providers-openstack/pull/440
https://github.com/ManageIQ/manageiq-providers-azure/pull/322
https://github.com/ManageIQ/manageiq-providers-amazon/pull/513
https://github.com/ManageIQ/manageiq-providers-redfish/pull/49
https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/136

The remaining deprecations we can handle afterwards, such as the uniq/distinct one:
https://github.com/ManageIQ/manageiq/pull/18446