### PR TITLE
[MiqWorker::worker_settings] Handle number strings

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -209,7 +209,13 @@ class MiqWorker < ApplicationRecord
         # Clean up the configuration values in a format like "30.seconds"
         unless raw
           settings.keys.each do |k|
-            settings[k] = settings[k].to_i_with_method if settings[k].respond_to?(:to_i_with_method) && settings[k].number_with_method?
+            if settings[k].kind_of?(String)
+              if settings[k].number_with_method?
+                settings[k] = settings[k].to_i_with_method
+              elsif settings[k] =~ /\A\d+(.\d+)?\z/ # case where int/float saved as string
+                settings[k] = settings[k].to_i
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Due to some UI specific issues, settings in the config can be set as "integer strings", or a string that is just a integer (floats are also possible).  This doesn't work booting workers as it initializes them with incorrect values.

This does some extra checking to avoid that.


Links
-----

* Partially addressing https://bugzilla.redhat.com/show_bug.cgi?id=1672437
* Discussion in gitter:
  - https://gitter.im/ManageIQ/manageiq/core?at=5c619c3680df6804a188acf5
  - https://gitter.im/ManageIQ/manageiq/core?at=5c631b614003460b2d3ce0db