### PR TITLE
RequestLogSessionMiddleware - log session id with requests (disabled by default)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -114,6 +114,10 @@ module Vmdb
     require_relative '../lib/request_started_on_middleware'
     config.middleware.use RequestStartedOnMiddleware
 
+    # enable to log session id for every request
+    # require_relative '../lib/request_log_session_middleware'
+    # config.middleware.use RequestLogSessionMiddleware
+
     # config.eager_load_paths accepts an array of paths from which Rails will eager load on boot if cache classes is enabled.
     # Defaults to every folder in the app directory of the application.
 

--- a/lib/request_log_session_middleware.rb
+++ b/lib/request_log_session_middleware.rb
@@ -1,0 +1,26 @@
+# Add to config/application.rb:
+#
+#     config.middleware.use 'RequestLogSessionMiddleware'
+#
+class RequestLogSessionMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    session_id = cookies(env)['_vmdb_session']
+    Rails.logger.info("Session ID: #{session_id.inspect}")
+
+    @app.call(env)
+  end
+
+  private
+
+  def cookies(env)
+    env["HTTP_COOKIE"].split(/\s*;\s*/).map do |keyval|
+      keyval.split('=')
+    end.to_h
+  rescue StandardError
+    {}
+  end
+end


### PR DESCRIPTION
When reading the logs (`production.log`), it's currently impossible to track which requests are related (done by the same user) and which are not.

This adds a middleware that allows us to track related requests from the log, even if the appliance is being used by other users at the same time.

It does so by logging the value of the `_vmdb_session` cookie in the request.

```
[----] I, [2019-02-13T16:19:14.433083 #5086:3fe83574fa9c]  INFO -- : Started GET "/?timeout=true" for 192.168.16.105 at 2019-02-13 16:19:14 +0000
[----] I, [2019-02-13T16:19:14.452487 #5086:3fe83574fa9c]  INFO -- : Session ID: "4327ae2c86935109d0ef103836c0f2eb"
```

Cc @jrafanie 