### PR TITLE
Don't rely on false return from callbacks to halt execution

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -93,6 +93,8 @@ module Vmdb
 
     config.autoload_paths += config.eager_load_paths
 
+    config.active_support.halt_callback_chains_on_return_false = false
+
     # NOTE:  If you are going to make changes to autoload_paths, please make
     # sure they are all strings.  Rails will push these paths into the
     # $LOAD_PATH.


### PR DESCRIPTION
We're already using throw :abort, so there's no code for us to change.

This setting is removed in rails 5.1 but will temporarily get rid of this
annoying warning:

```
DEPRECATION WARNING: Returning `false` in Active Record and Active Model
callbacks will not implicitly halt a callback chain in Rails 5.1. To
explicitly halt the callback chain, please use `throw :abort` instead.
(called from block (3 levels) in <top (required)> at
/home/travis/build/ManageIQ/manageiq/spec/models/miq_task_spec.rb:297)
```