### PR TITLE
Redo presence check after possible reset of user to nil

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -266,10 +266,10 @@ module RetirementMixin
   end
 
   def q_user_info(q_options, requester)
-    if requester.present?
-      if requester.kind_of?(String)
-        requester = User.find_by(:userid => requester)
-      end
+    if requester && requester.kind_of?(String)
+      requester = User.find_by(:userid => requester)
+    end
+    if requester
       q_options[:user_id] = requester.id
       if requester.current_group.present? && requester.current_tenant.present?
         q_options[:group_id] = requester.current_group.id

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -130,7 +130,7 @@ describe "Service Retirement Management" do
       expect(@stack.retirement_due?).to be_truthy
     end
 
-    it "#raise_retirement_event" do
+    it "#raise_retirement_event without user" do
       event_name = 'foo'
       event_hash = {
         :userid              => nil,
@@ -140,6 +140,18 @@ describe "Service Retirement Management" do
 
       expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, :zone => @zone.name)
       @stack.raise_retirement_event(event_name)
+    end
+
+    it "#raise_retirement_event with user" do
+      event_name = 'foo'
+      event_hash = {
+        :userid              => user.userid,
+        :orchestration_stack => @stack,
+        :type                => "OrchestrationStack",
+      }
+
+      expect(MiqEvent).to receive(:raise_evm_event).with(@stack, event_name, event_hash, :zone => @zone.name, :user_id => user.id, :group_id => user.current_group.id, :tenant_id => user.current_tenant.id)
+      @stack.raise_retirement_event(event_name, user.userid)
     end
 
     it "#raise_audit_event" do

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -209,11 +209,27 @@ describe "Service Retirement Management" do
     expect(@service.retirement_due?).to be_truthy
   end
 
-  it "#raise_retirement_event" do
-    event_name = 'foo'
-    event_hash = {:userid => nil, :service => @service, :type => "Service"}
-    expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {})
-    @service.raise_retirement_event(event_name)
+  describe "#raise_retirement_event " do
+    it "without user" do
+      event_name = 'foo'
+      event_hash = {:userid => nil, :service => @service, :type => "Service"}
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {})
+      @service.raise_retirement_event(event_name)
+    end
+
+    it "with user" do
+      event_name = 'foo'
+      event_hash = {:userid => "admin", :service => @service, :type => "Service"}
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, :user_id => user.id, :group_id => user.current_group.id, :tenant_id => user.current_tenant.id)
+      @service.raise_retirement_event(event_name, "admin")
+    end
+
+    it "with user that isn't found" do
+      event_name = 'foo'
+      event_hash = {:userid => "nonexistent_username", :service => @service, :type => "Service"}
+      expect(MiqEvent).to receive(:raise_evm_event).with(@service, event_name, event_hash, {})
+      @service.raise_retirement_event(event_name, "nonexistent_username")
+    end
   end
 
   it "#raise_audit_event" do


### PR DESCRIPTION
Yeah, it's my bug. If the retirement requester was a string and then the lookup for the userid based on that string returned nil, ``` q_options[:user_id] = requester.id``` will fail cause no id for nil. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1677569.