### PR TITLE
Automatically include spec helper in rails console in test mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -182,6 +182,12 @@ module Vmdb
       # since the railtie for it is loaded first and will include
       # `Rails::ConsoleMethods` before we have a chance to modify them here.
       TOPLEVEL_BINDING.eval('self').extend(Vmdb::ConsoleMethods)
+
+      # In test mode automatically load the spec helper which will, among other
+      # things, find the factory definitions and load factory related methods.
+      if Rails.env.test?
+        require_relative '../spec/spec_helper'
+      end
     end
   end
 end


### PR DESCRIPTION
In some cases I want to run the the rails console in sandbox (test) mode and tinker with the factories. At the moment, however, I have to load the spec_helper.rb flie manually every time so that it finds factory definitions and custom sequencing methods that we've added for those factories.

This PR modifies the application configuration so that in test mode (only) the spec helper is automatically loaded when firing up the Rails console in a test environment.