### PR TITLE
Add method to copy service templates

### DIFF
--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -21,6 +21,10 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
     MiqProvision
   end
 
+  def service_template_resource_copy
+    dup.tap(&:save!)
+  end
+
   def execute
     # Should not be called.
     raise _("Provision Request Templates do not support the execute method.")

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -43,7 +43,9 @@ class ServiceTemplate < ApplicationRecord
   include ArchivedMixin
   include CiFeatureMixin
   include_concern 'Filter'
+  include_concern 'Copy'
 
+  validates :name, :presence => true
   belongs_to :tenant
   # # These relationships are used to specify children spawned from a parent service
   # has_many   :child_services, :class_name => "ServiceTemplate", :foreign_key => :service_template_id
@@ -433,6 +435,10 @@ class ServiceTemplate < ApplicationRecord
     ResourceActionWorkflow.new(dialog_options, user, provision_action, ra_options).tap do |wf|
       wf.request_options = request_options
     end
+  end
+
+  def dup
+    super.tap { |obj| obj.update_attributes(:guid => nil) }
   end
 
   def add_resource(rsc, options = {})

--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -1,0 +1,17 @@
+module ServiceTemplate::Copy
+  extend ActiveSupport::Concern
+
+  def template_copy(new_name = "Copy of " + name + Time.zone.now.to_s)
+    if template_valid? && type != 'ServiceTemplateAnsiblePlaybook'
+      ActiveRecord::Base.transaction do
+        dup.tap do |template|
+          template.update_attributes(:name => new_name, :display => false)
+          service_resources.each do |sr|
+            resource = sr.resource.respond_to?(:service_template_resource_copy) ? sr.resource.service_template_resource_copy : sr.resource
+            template.add_resource(resource, sr)
+          end
+        end.save!
+      end
+    end
+  end
+end

--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -24,7 +24,10 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
 
   def remove_invalid_resource
     # remove the resource from both memory and table
-    service_resources.to_a.delete_if { |r| r.destroy unless r.reload.resource.present? }
+    service_resources.to_a.delete_if do |r|
+      r.reload if r.persisted?
+      r.destroy if r.resource.blank?
+    end
   end
 
   def create_subtasks(_parent_service_task, _parent_service)


### PR DESCRIPTION
Copying service templates is an RFE that I wound up with. We determined (see linked issue) that only some of the parts and pieces need to be copied, so only resources that are miq_provision_request_templates get new guids, everything else gets linked back to the existing resource. 

The next part of this is determining what to do with custom buttons, ansible things, and custom button sets, as well as how this works for service bundles as GM pointed out in comments here. 


Issue is here: https://github.com/ManageIQ/manageiq/issues/18450 

## Depends on
~~https://github.com/ManageIQ/manageiq/pull/18474~~
