### PR TITLE
[HAMMER] Change factories from vm_vmware to vm_openstack.

### DIFF
--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -301,8 +301,8 @@ describe ServiceTemplateTransformationPlanTask do
 
       let(:src_hardware) { FactoryGirl.create(:hardware, :nics => [src_nic_1, src_nic_2]) }
 
-      let(:src_vm_1) { FactoryGirl.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
-      let(:src_vm_2) { FactoryGirl.create(:vm_vmware, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
+      let(:src_vm_1) { FactoryGirl.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host, :hardware => src_hardware) }
+      let(:src_vm_2) { FactoryGirl.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
 
       let(:src_network_1) { FactoryBot.create(:network, :ipaddress => '10.0.1.1') }
       let(:src_network_2a) { FactoryBot.create(:network, :ipaddress => '10.0.1.2') }


### PR DESCRIPTION
Followup PR to https://github.com/ManageIQ/manageiq/pull/18451, which passed on master but failed on hammer. The fundamental issue is that the `vm_vmware` factory has a location with brackets and spaces in it, which is throwing off the expectations, though the behavior is correct as far as I can tell.

In master the factory was changed to `vm_openstack`, so I just altered the specs to use that instead.