### PR TITLE
Remove old ManagerRefresher class

### DIFF
--- a/app/models/manageiq/providers/base_manager/manager_refresher.rb
+++ b/app/models/manageiq/providers/base_manager/manager_refresher.rb
@@ -1,6 +1,0 @@
-module ManageIQ
-  module Providers
-    class BaseManager::ManagerRefresher < ManageIQ::Providers::BaseManager::Refresher
-    end
-  end
-end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/refresher.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/refresher.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Refresher < ManageIQ::Providers::BaseManager::ManagerRefresher
+class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
   include ManageIQ::Providers::AnsibleTower::Shared::AutomationManager::Refresher
 
   def self.display_name(number = 1)


### PR DESCRIPTION
All functionality of ManageIQ::Providers::BaseManager::ManagerRefresher
has been moved into the base Refresher class in https://github.com/ManageIQ/manageiq/pull/18312 so this can finally be removed.

Depends on:

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/373

- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/442

- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/165

- [x] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/259

- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/50

- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/90

- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/323

- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/516

- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/161