### PR TITLE
Fix for inability to see dialog details passed to catalog after upgrade from 5.9.4 to 5.9.6

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -119,6 +119,8 @@ class Dialog < ApplicationRecord
   end
 
   def init_fields_with_values_for_request(values)
+    values = values.with_indifferent_access
+
     dialog_field_hash.each do |_key, field|
       field.value = values[field.automate_key_name] || values[field.name]
     end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -518,19 +518,39 @@ describe Dialog do
     let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1]) }
     let(:dialog_field1) { DialogField.new(:value => "123", :name => "field1") }
 
-    context "when the values use the automate key name" do
-      it "initializes the fields with the given values" do
-        values = {"dialog_field1" => "field 1 new value"}
-        dialog.init_fields_with_values_for_request(values)
-        expect(dialog_field1.value).to eq("field 1 new value")
+    context "when the keys are strings" do
+      context "when the values use the automate key name" do
+        it "initializes the fields with the given values" do
+          values = {"dialog_field1" => "field 1 new value"}
+          dialog.init_fields_with_values_for_request(values)
+          expect(dialog_field1.value).to eq("field 1 new value")
+        end
+      end
+
+      context "when the values use the regular name" do
+        it "initializes the fields with the given values" do
+          values = {"field1" => "field 1 new value"}
+          dialog.init_fields_with_values_for_request(values)
+          expect(dialog_field1.value).to eq("field 1 new value")
+        end
       end
     end
 
-    context "when the values use the regular name" do
-      it "initializes the fields with the given values" do
-        values = {"field1" => "field 1 new value"}
-        dialog.init_fields_with_values_for_request(values)
-        expect(dialog_field1.value).to eq("field 1 new value")
+    context "when the keys are symbols" do
+      context "when the values use the automate key name" do
+        it "initializes the fields with the given values" do
+          values = {:dialog_field1 => "field 1 new value"}
+          dialog.init_fields_with_values_for_request(values)
+          expect(dialog_field1.value).to eq("field 1 new value")
+        end
+      end
+
+      context "when the values use the regular name" do
+        it "initializes the fields with the given values" do
+          values = {:field1 => "field 1 new value"}
+          dialog.init_fields_with_values_for_request(values)
+          expect(dialog_field1.value).to eq("field 1 new value")
+        end
       end
     end
   end


### PR DESCRIPTION
I don't know the underlying cause of the issue, but when `#init_fields_with_values_for_request` is called, sometimes the keys of the `values` hash that gets passed in are symbols instead of strings. This caused an issue of initializing dialog fields with nil values and the customer unable to view the data of the request they made.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1670327

/cc @tinaafitz @d-m-u 

@miq-bot add_label bug
@miq-bot add_reviewer @d-m-u 
@miq-bot assign @tinaafitz 