### PR TITLE
Adding data integrity constrains for some associations to User model

### DIFF
--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -514,7 +514,7 @@ describe MiqRequest do
 
     it "returns superadmin if user was deleted" do
       request = FactoryBot.create(:miq_provision_request, :requester => user)
-      user.destroy
+      user.delete
       expect(request.get_user).to eq(User.super_admin)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -622,4 +622,18 @@ describe User do
       expect(user.regional_users).to match_array([user, regional_user])
     end
   end
+
+  describe "#check_reference" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "invoked from 'before_destroy' callback" do
+      expect(user).to receive(:check_reference)
+      user.destroy
+    end
+
+    it "throws 'abort' if reference to this user present in miq_requests table" do
+      FactoryBot.create(:vm_migrate_request, :requester => user)
+      expect { user.check_reference }.to throw_symbol(:abort)
+    end
+  end
 end


### PR DESCRIPTION
**Issue:** It is currently possible to destroy user which still referred to  from other models

**Fix:** `before_destroy` callback canceling `destroy` if user refer to in other models

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1677744

@miq-bot add-label bug, core