### PR TITLE
ems_infra_pause/resume features to miq_product_feature_identifiers

### DIFF
--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -382,7 +382,9 @@
   - ems_infra_delete
   - ems_infra_discover
   - ems_infra_edit
+  - ems_infra_pause
   - ems_infra_refresh
+  - ems_infra_resume
   - ems_infra_scale
   - ems_infra_show
   - ems_infra_show_list


### PR DESCRIPTION
Default roles extension for Suspend provider RFE
According to https://github.com/ManageIQ/manageiq/issues/17489#issuecomment-465953908
"any Role that can create and delete a provider should be able to Pause/Resume."

Default roles have almost all time either admin or read, so no action required for these roles. Except `miq_product_feature_identifiers`, which has extra list of infra roles defined. 

Links
----------------
Issue: https://github.com/ManageIQ/manageiq/issues/17489
Features definitions:
- https://github.com/ManageIQ/manageiq/pull/17500
- https://github.com/ManageIQ/manageiq/pull/18375
