### PR TITLE
Add service_template_ansible_tower factory, inherit naming from parent

### DIFF
--- a/spec/factories/service_template.rb
+++ b/spec/factories/service_template.rb
@@ -1,11 +1,12 @@
 FactoryBot.define do
-  factory :service_template
-  factory :service_template_orchestration, :class => 'ServiceTemplateOrchestration', :parent => :service_template
-  factory :service_template_ansible_playbook, :class => 'ServiceTemplateAnsiblePlaybook', :parent => :service_template
-  factory :service_template_container_template, :class => 'ServiceTemplateContainerTemplate', :parent => :service_template
-  factory :service_template_transformation_plan, :class => 'ServiceTemplateTransformationPlan', :parent => :service_template do
+  factory :service_template do
     sequence(:name) { |n| "service_template_#{seq_padded_for_sorting(n)}" }
   end
+  factory :service_template_orchestration, :class => 'ServiceTemplateOrchestration', :parent => :service_template
+  factory :service_template_ansible_playbook, :class => 'ServiceTemplateAnsiblePlaybook', :parent => :service_template
+  factory :service_template_ansible_tower, :class => 'ServiceTemplateAnsibleTower', :parent => :service_template
+  factory :service_template_container_template, :class => 'ServiceTemplateContainerTemplate', :parent => :service_template
+  factory :service_template_transformation_plan, :class => 'ServiceTemplateTransformationPlan', :parent => :service_template
 
   trait :with_provision_resource_action_and_dialog do
     after(:create) do |x|


### PR DESCRIPTION
This is necessary for https://github.com/ManageIQ/manageiq/pull/18464 to pass. 

We should be inheriting the naming of these from the parent because we validate that they all have names, so I've no idea why it was written to only have the naming set on a couple to start with. 

## Related to
https://github.com/ManageIQ/manageiq/pull/18464