### PR TITLE
StringIO#write accepts multiple args in ruby 2.5

### DIFF
--- a/lib/vmdb/loggers/io_logger.rb
+++ b/lib/vmdb/loggers/io_logger.rb
@@ -7,10 +7,12 @@ module Vmdb::Loggers
       super()
     end
 
-    def write(string)
-      @buffer ||= ""
-      @buffer << string
-      dump_buffer if string.include?("\n")
+    def write(*args)
+      args.each do |arg|
+        @buffer ||= ""
+        @buffer << arg
+        dump_buffer if arg.include?("\n")
+      end
     end
 
     def <<(string)


### PR DESCRIPTION
As of this commit, which landed in ruby 2.5.0, both IO and StringIO
write now accept multiple arguments:
https://github.com/ruby/ruby/commit/aeaeb4b0686b01a4a56998a4b7d87da470a57209

Somehow this was causing the automation engine spec, specifically, the
"writes to the logger synchronously" example to spin at 100% cpu,
perhaps because write was failing with argument errors.

Seen originally in:
https://github.com/ManageIQ/manageiq-automation_engine/pull/296

cc @djberg96 @gmcculloug (I am pretty confident this is the fix for the hang you were seeing in the automation specs in the PR above)