### PR TITLE
Fix graph refresh overwriting smartstate OS info

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -55,13 +55,6 @@ module ManageIQ::Providers
           )
         end
 
-        def operating_systems
-          add_properties(
-            :manager_ref                  => %i(vm_or_template),
-            :parent_inventory_collections => %i(vms miq_templates),
-          )
-        end
-
         def host_operating_systems
           add_properties(
             :model_class                  => ::OperatingSystem,

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -86,13 +86,16 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
         vms_and_templates_ids   = inventory_collection.data.map { |os| os.vm_or_template&.id }.compact
         vms_and_templates_index = VmOrTemplate.includes(:operating_system).where(:id => vms_and_templates_ids).index_by(&:id)
 
+        drift_states = DriftState.where(:resource_type => "VmOrTemplate", :resource_id => vms_and_templates_ids)
+                                 .select(:resource_id).distinct.index_by(&:resource_id)
+
         inventory_collection.each do |inventory_object|
           vm_or_template = vms_and_templates_index[inventory_object.vm_or_template.id]
 
           # If a VM has had smartstate run on it (drift_states are present) then don't overwrite the
           # operating system record with one from the provider.  This is because typically far more
           # details and correct information can be found from smartstate.
-          next unless vm_or_template.drift_states.blank? || vm_or_template.operating_system.nil? ||
+          next unless drift_states[vm_or_template.id].nil? || vm_or_template.operating_system.nil? ||
                       vm_or_template.operating_system.product_name.blank?
 
           operating_system = vm_or_template.operating_system || inventory_object.model_class.new

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -82,9 +82,31 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     end
 
     def operating_systems
+      custom_save_block = lambda do |_ems, inventory_collection|
+        vms_and_templates_ids = inventory_collection.data.map { |os| os.vm_or_template&.id }.compact
+
+        vms_and_templates_index = VmOrTemplate.where(:id => vms_and_templates_ids).index_by(&:id)
+        operating_systems_index = OperatingSystem.where(:vm_or_template_id => vms_and_templates_ids).index_by(&:vm_or_template_id)
+
+        inventory_collection.each do |inventory_object|
+          vm_or_template = vms_and_templates_index[inventory_object.vm_or_template.id]
+
+          # If a VM has had smartstate run on it (drift_states are present) then don't overwrite the
+          # operating system record with one from the provider.  This is because typically far more
+          # details and correct information can be found from smartstate.
+          next unless vm_or_template.drift_states.blank? || vm_or_template.operating_system.nil? ||
+                      vm_or_template.operating_system.product_name.blank?
+
+          operating_system = operating_systems_index[inventory_object.vm_or_template.id] ||
+                             inventory_object.model_class.new
+          operating_system.update_attributes!(inventory_object.attributes)
+        end
+      end
+
       add_properties(
         :manager_ref                  => %i(vm_or_template),
-        :parent_inventory_collections => %i(vms miq_templates)
+        :parent_inventory_collections => %i(vms miq_templates),
+        :custom_save_block            => custom_save_block
       )
     end
 


### PR DESCRIPTION
Fix an issue where graph refresh was overwriting VM operating system
information retrieved from smartstate analysis.

This adds a custom save block which checks if smartstate has been run
before overwriting the OS record.

Alternate solution to https://github.com/ManageIQ/manageiq-providers-openstack/pull/410