### PR TITLE
Use throw :abort in before_destroy for Dialog model

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -183,7 +183,8 @@ class Dialog < ApplicationRecord
   def reject_if_has_resource_actions
     if resource_actions.length > 0
       connected_components = resource_actions.collect { |ra| ra.resource_type.constantize.find(ra.resource_id) }
-      raise _("Dialog cannot be deleted because it is connected to other components: #{connected_components.map { |cc| cc.class.name + ":" + cc.id.to_s + " - " + cc.try(:name) }}")
+      errors.add(:base, _("Dialog cannot be deleted because it is connected to other components: #{connected_components.map { |cc| cc.class.name + ":" + cc.id.to_s + " - " + cc.try(:name) }}"))
+      throw :abort
     end
   end
 

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -96,13 +96,6 @@ describe Dialog do
       expect(err_msg).to eq("Dialog cannot be deleted because it is connected to other components: [\"Dialog:#{dialog.id} - #{dialog.name}\"]")
       expect(Dialog.count).to eq(1)
     end
-
-    describe "#reject_if_has_resource_actions" do
-      it "before_destroy callback throws :abort if dialog has associatex resource" do
-        FactoryBot.create(:resource_action, :action => "Provision", :dialog => dialog, :resource_type => Dialog, :resource_id => dialog.id)
-        expect { dialog.send(:reject_if_has_resource_actions) }.to throw_symbol(:abort)
-      end
-    end
   end
 
   describe "dialog structures" do


### PR DESCRIPTION
 Use `throw :abort` in `before_destroy` for `Dialog` model

@miq-bot add-label technical debt