### PR TITLE
GenericObjectDefinition model: validation in before_destroy should be executed before :dependent => destroy

### DIFF
--- a/app/models/generic_object_definition.rb
+++ b/app/models/generic_object_definition.rb
@@ -41,7 +41,7 @@ class GenericObjectDefinition < ApplicationRecord
                     :normalize_property_associations,
                     :normalize_property_methods
 
-  before_destroy    :check_not_in_use
+  before_destroy    :check_not_in_use, :prepend => true
 
   delegate :count, :to => :generic_objects, :prefix => true, :allow_nil => false
   virtual_column :generic_objects_count, :type => :integer


### PR DESCRIPTION
Validation in `before_destroy` should be executed before `:dependent => :destroy` 

@miq-bot add-label technical debt