### PR TITLE
Job model: validation in before_destroy should be executed before deleting dependent records

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -10,7 +10,7 @@ class Job < ApplicationRecord
   serialize :context
   alias_attribute :jobid, :guid
 
-  before_destroy :check_active_on_destroy
+  before_destroy :check_active_on_destroy, :prepend => true
   after_update_commit :update_linked_task
 
   DEFAULT_TIMEOUT = 300


### PR DESCRIPTION
`Job` model: validation in `before_destroy` should be executed before deleting dependent records

@miq-bot add-label technical debt