### PR TITLE
[HAMMER] Add check for evm_owner being nil when id is still set

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -254,11 +254,15 @@ module RetirementMixin
 
   def system_context_requester
     if try(:evm_owner_id).present?
-      User.find(evm_owner_id)
-    else
-      $log.info("System context defaulting to admin user because owner of #{name} not set.")
-      User.super_admin
+      if User.find_by(:id => evm_owner_id).present?
+        return evm_owner
+      else
+        $log.info("#{name} has evm_owner_id present but no user with that id found so defaulting to admin.")
+        return User.super_admin
+      end
     end
+    $log.info("System context defaulting to admin user because owner of #{name} not set.")
+    User.super_admin
   end
 
   def current_user


### PR DESCRIPTION
```system_context_requester``` fails **only on hammer** at the moment because it checks only for the userid, not the actual presence of that associated user, and for cases where the user was deleted we sometimes have the ids still set. 

The orchestration_stacks on hammer don't have owners, the schema PR (https://github.com/ManageIQ/manageiq-schema/pull/288) didn't go back to hammer, so the mixin line 256 has to have the conditions of both having the id present and also being able to find the user that is associated to that id. (On master we just did ```evm_owner``` since everything on master that gets retired has that association.)  

This is a hammer only PR since https://github.com/ManageIQ/manageiq/pull/18443 and https://github.com/ManageIQ/manageiq/pull/18437 couldn't be backported. 

It fixes https://bugzilla.redhat.com/show_bug.cgi?id=1678476. 