### PR TITLE
Add an inventory_collection for the EMS

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -37,6 +37,16 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
       'unknown'
     end
 
+    def ext_management_system
+      add_properties(
+        :manager_ref       => %i(guid),
+        :custom_save_block => lambda do |ems, inventory_collection|
+          ems_attrs = inventory_collection.data.first&.attributes
+          ems.update_attributes!(ems_attrs) if ems_attrs
+        end
+      )
+    end
+
     def vms
       vm_template_shared
     end


### PR DESCRIPTION
There are some attributes that need to be updated on the EMS record by
the parser.  For graph refresh this is currently done by directly doing
an ems.update_attributes! in the parser which breaks our "parser
shouldn't connect to the DB" rule.

This adds an inventory collection which allows the parser to set
properties to be saved on the ext_management_system record.

Example: https://github.com/ManageIQ/manageiq-providers-vmware/pull/376