### PR TITLE
Use currencies from money gem in Chargeback

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -85,7 +85,7 @@ class ChargebackRate < ApplicationRecord
         rates = cbr.delete(:rates)
 
         rates.each do |rate_detail|
-          currency = ChargebackRateDetailCurrency.find_by(:name => rate_detail.delete(:type_currency))
+          currency = ChargebackRateDetailCurrency.find_by(:code => rate_detail.delete(:type_currency))
           field = ChargeableField.find_by(:metric => rate_detail.delete(:metric))
           rate_detail[:chargeable_field_id] = field.id
           if currency

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -278,7 +278,7 @@ class ChargebackRateDetail < ApplicationRecord
 
       chargeback_rate[:rates].each do |detail|
         detail_new = ChargebackRateDetail.new(detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES))
-        detail_new.detail_currency = ChargebackRateDetailCurrency.find_by(:name => detail[:type_currency])
+        detail_new.detail_currency = ChargebackRateDetailCurrency.find_by(:code => detail[:type_currency])
         detail_new.metric = detail[:metric]
         detail_new.chargeable_field = ChargeableField.find_by(:metric => detail.delete(:metric))
 

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -39,15 +39,13 @@ class ChargebackRateDetailCurrency < ApplicationRecord
     if File.exist?(currency_file_source)
       fixture_mtime_currency = File.mtime(currency_file_source).utc
       currencies.each do |currency|
-        rec = ChargebackRateDetailCurrency.find_by(:name => currency[:name])
+        rec = ChargebackRateDetailCurrency.find_by(:code => currency[:code])
         if rec.nil?
-          _log.info("Creating [#{currency[:name]}] with symbols=[#{currency[:symbol]}]")
+          _log.info("Creating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
           ChargebackRateDetailCurrency.create(currency)
         elsif fixture_mtime_currency > rec.created_at
-          _log.info("Updating [#{currency[:name]}] with symbols=[#{currency[:symbol]}]")
-          rec.update_attributes(currency)
-          rec.created_at = fixture_mtime_currency
-          rec.save
+          _log.info("Updating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
+          rec.update_attributes(currency.merge(:created_at => fixture_mtime_currency))
         end
       end
     end

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -22,11 +22,14 @@ class ChargebackRateDetailCurrency < ApplicationRecord
     File.join(FIXTURE_DIR, CURRENCY_FILE)
   end
 
+  def self.currencies
+    YAML.load_file(currency_file_source)
+  end
+
   def self.seed
     if File.exist?(currency_file_source)
-      fixture = YAML.load_file(currency_file_source)
       fixture_mtime_currency = File.mtime(currency_file_source).utc
-      fixture.each do |cbr|
+      currencies.each do |cbr|
         rec = ChargebackRateDetailCurrency.find_by(:name => cbr[:name])
         if rec.nil?
           _log.info("Creating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -8,7 +8,8 @@ class ChargebackRateDetailCurrency < ApplicationRecord
 
   has_many :chargeback_rate_detail, :foreign_key => "chargeback_rate_detail_currency_id"
 
-  CURRENCY_FILE = "chargeback_rate_detail_currencies.yml".freeze
+  CURRENCY_FILE = "/currency_iso.json".freeze
+  FIXTURE_DIR = Money::Currency::Loader::DATA_PATH.freeze
 
   def self.currencies_for_select
     # Return a hash where the keys are the possible currencies and the values are their ids
@@ -23,7 +24,15 @@ class ChargebackRateDetailCurrency < ApplicationRecord
   end
 
   def self.currencies
-    YAML.load_file(currency_file_source)
+    parse_currency_file.transform_values.map do |x|
+      {:code => x[:iso_code], :name => x[:name], :full_name => x[:name], :symbol => x[:symbol]}
+    end
+  end
+
+  def self.parse_currency_file
+    json = File.read(currency_file_source)
+    json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
+    JSON.parse(json, :symbolize_names => true)
   end
 
   def self.seed

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -8,6 +8,8 @@ class ChargebackRateDetailCurrency < ApplicationRecord
 
   has_many :chargeback_rate_detail, :foreign_key => "chargeback_rate_detail_currency_id"
 
+  CURRENCY_FILE = "chargeback_rate_detail_currencies.yml".freeze
+
   def self.currencies_for_select
     # Return a hash where the keys are the possible currencies and the values are their ids
     ChargebackRateDetailCurrency.all.each_with_object({}) do |currency, hsh|
@@ -16,11 +18,14 @@ class ChargebackRateDetailCurrency < ApplicationRecord
     end
   end
 
+  def self.currency_file_source
+    File.join(FIXTURE_DIR, CURRENCY_FILE)
+  end
+
   def self.seed
-    fixture_file_currency = File.join(FIXTURE_DIR, 'chargeback_rate_detail_currencies.yml')
-    if File.exist?(fixture_file_currency)
-      fixture = YAML.load_file(fixture_file_currency)
-      fixture_mtime_currency = File.mtime(fixture_file_currency).utc
+    if File.exist?(currency_file_source)
+      fixture = YAML.load_file(currency_file_source)
+      fixture_mtime_currency = File.mtime(currency_file_source).utc
       fixture.each do |cbr|
         rec = ChargebackRateDetailCurrency.find_by(:name => cbr[:name])
         if rec.nil?

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -38,14 +38,14 @@ class ChargebackRateDetailCurrency < ApplicationRecord
   def self.seed
     if File.exist?(currency_file_source)
       fixture_mtime_currency = File.mtime(currency_file_source).utc
-      currencies.each do |cbr|
-        rec = ChargebackRateDetailCurrency.find_by(:name => cbr[:name])
+      currencies.each do |currency|
+        rec = ChargebackRateDetailCurrency.find_by(:name => currency[:name])
         if rec.nil?
-          _log.info("Creating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")
-          ChargebackRateDetailCurrency.create(cbr)
+          _log.info("Creating [#{currency[:name]}] with symbols=[#{currency[:symbol]}]")
+          ChargebackRateDetailCurrency.create(currency)
         elsif fixture_mtime_currency > rec.created_at
-          _log.info("Updating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")
-          rec.update_attributes(cbr)
+          _log.info("Updating [#{currency[:name]}] with symbols=[#{currency[:symbol]}]")
+          rec.update_attributes(currency)
           rec.created_at = fixture_mtime_currency
           rec.save
         end

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -42,7 +42,7 @@ class ChargebackRateDetailCurrency < ApplicationRecord
         rec = ChargebackRateDetailCurrency.find_by(:name => cbr[:name])
         if rec.nil?
           _log.info("Creating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")
-          rec = ChargebackRateDetailCurrency.create(cbr)
+          ChargebackRateDetailCurrency.create(cbr)
         elsif fixture_mtime_currency > rec.created_at
           _log.info("Updating [#{cbr[:name]}] with symbols=[#{cbr[:symbol]}]")
           rec.update_attributes(cbr)

--- a/db/fixtures/chargeback_rates.yml
+++ b/db/fixtures/chargeback_rates.yml
@@ -8,7 +8,7 @@
     :metric: cpu_usagemhz_rate_average
     :per_time: hourly
     :per_unit: megahertz
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -18,7 +18,7 @@
     :metric: v_derived_cpu_total_cores_used
     :per_time: hourly
     :per_unit: cpu core
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -28,7 +28,7 @@
     :metric: derived_vm_numvcpus
     :per_time: hourly
     :per_unit: cpu
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -38,7 +38,7 @@
     :metric: derived_vm_numvcpu_cores
     :per_time: hourly
     :per_unit: cpu core
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -48,7 +48,7 @@
     :metric: derived_memory_used
     :per_time: hourly
     :per_unit: megabytes
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -58,7 +58,7 @@
     :metric: derived_memory_available
     :per_time: hourly
     :per_unit: megabytes
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -68,7 +68,7 @@
     :metric: net_usage_rate_average
     :per_time: hourly
     :per_unit: kbps
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: 100
@@ -82,7 +82,7 @@
     :metric: disk_usage_rate_average
     :per_time: hourly
     :per_unit: kbps
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -91,7 +91,7 @@
   - :description: Fixed Compute Cost 1
     :metric: fixed_compute_1
     :per_time: hourly
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -100,7 +100,7 @@
   - :description: Fixed Compute Cost 2
     :metric: fixed_compute_2
     :per_time: hourly
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -115,7 +115,7 @@
     :metric: derived_vm_allocated_disk_storage
     :per_time: hourly
     :per_unit: gigabytes
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -125,7 +125,7 @@
     :metric: derived_vm_used_disk_storage
     :per_time: hourly
     :per_unit: gigabytes
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -134,7 +134,7 @@
   - :description: Fixed Storage Cost 1
     :metric: fixed_storage_1
     :per_time: hourly
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -143,7 +143,7 @@
   - :description: Fixed Storage Cost 2
     :metric: fixed_storage_2
     :per_time: hourly
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -158,7 +158,7 @@
     :metric: cpu_usagemhz_rate_average
     :per_time: hourly
     :per_unit: megahertz
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -168,7 +168,7 @@
     :metric: v_derived_cpu_total_cores_used
     :per_time: hourly
     :per_unit: cpu core
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -178,7 +178,7 @@
     :metric: derived_vm_numvcpus
     :per_time: hourly
     :per_unit: cpu
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -188,7 +188,7 @@
     :metric: derived_vm_numvcpu_cores
     :per_time: hourly
     :per_unit: cpu core
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -198,7 +198,7 @@
     :metric: derived_memory_used
     :per_time: hourly
     :per_unit: megabytes
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -208,7 +208,7 @@
     :metric: derived_memory_available
     :per_time: hourly
     :per_unit: megabytes
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -218,7 +218,7 @@
     :metric: net_usage_rate_average
     :per_time: hourly
     :per_unit: kbps
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: 100
@@ -232,7 +232,7 @@
     :metric: disk_usage_rate_average
     :per_time: hourly
     :per_unit: kbps
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -241,7 +241,7 @@
   - :description: Fixed Compute Cost 1
     :metric: fixed_compute_1
     :per_time: hourly
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity
@@ -250,7 +250,7 @@
   - :description: Fixed Compute Cost 2
     :metric: fixed_compute_2
     :per_time: hourly
-    :type_currency: Dollars
+    :type_currency: USD
     :tiers:
     - :start: 0
       :finish: Infinity

--- a/spec/models/chargeback_rate_detail_currency_spec.rb
+++ b/spec/models/chargeback_rate_detail_currency_spec.rb
@@ -1,4 +1,19 @@
 describe ChargebackRateDetailCurrency do
+  describe '.seed' do
+    before do
+      ChargebackRateDetailCurrency.seed
+    end
+
+    let(:expected_currencies) do
+      %w(AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BRL BSD BTN BWP BYN BYR BZD CAD CDF CHF CLF CLP CNY COP CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HRK HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRO MUR MVR MWK MXN MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SKK SLL SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD UYU VES VND VUV WST XAF XAG XAU XCD XDR XOF XPD XPF XPT YER ZAR ZMK ZMW)
+    end
+
+    it "returns supported currencies" do
+      expect(ChargebackRateDetailCurrency.count).to eq(164)
+      expect(ChargebackRateDetailCurrency.all.map(&:code)).to eq(expected_currencies)
+    end
+  end
+
   it "has a valid factory" do
     expect(FactoryBot.create(:chargeback_rate_detail_currency)).to be_valid
   end


### PR DESCRIPTION
This PR adds new **146** currencies. (before **18**, after **164**)

- currencies are taken from [json file from Money gem](https://github.com/RubyMoney/money/blob/master/config/currency_iso.json) (already included in the project).
- existing currencies (assigned to rates) are untouched
- seed processes are using attribute [code as reference](https://github.com/ManageIQ/manageiq/pull/18486/commits/8c79f27f56e205730f4926624a8661e91f256e6c) to find if currency already exists instead of using attribute `name`



## Next

- remove `chargeback_currencies.yml`
- add other cost formaters for left alignment (e.g. 333 CZK)- (now we are using just with right alignment `$1111` )
 

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1517026
https://bugzilla.redhat.com/show_bug.cgi?id=1447170
https://bugzilla.redhat.com/show_bug.cgi?id=1668561

