### PR TITLE
Speed up Service access 

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -213,17 +213,21 @@ class Service < ApplicationRecord
   end
 
   def all_states_match?(action)
-    return true if composite? && (power_states.uniq == map_power_states(action))
-    return true if atomic? && (power_states[0] == POWER_STATE_MAP[action])
-    false
+    if composite?
+      power_states.uniq == map_power_states(action)
+    else
+      power_states[0] == POWER_STATE_MAP[action]
+    end
   end
 
+  # @return true if this is a composite service
   def composite?
     children.present?
   end
 
+  # @return true if this is a single service (not made up of multiple services)
   def atomic?
-    children.empty?
+    !composite?
   end
 
   def orchestration_stacks


### PR DESCRIPTION
When fetching services through the api

```
api/services
  expand=resources
  attributes=picture,
             picture.image_href,
             chargeback_report,
             evm_owner.userid,
             v_total_vms,
             power_state,
             all_service_children,
             tags
  filter[]=ancestry=null

  sort_by=created_at
  sort_options=
  sort_order=desc
  limit=20
  offset=0
```

reduce calls to database

|       ms |       bytes | objects |query |  qry ms |     rows |comments
|      ---:|         ---:|     ---:|  ---:|     ---:|      ---:| ---
|    570.4 | 25,230,444* | 334,164 |  165 |    50.8 |       53 |orig
|    537.5 | 24,482,568* | 328,012 |  145 |    51.6 |       53 |atomic

\* Memory usage does not reflect 4 freed objects.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1656371