### PR TITLE
Delegate vms_and_templates and miq_templates to parent_manager

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -71,6 +71,10 @@ module ManageIQ::Providers
              :resource_groups,
              :vms,
              :total_vms,
+             :vms_and_templates,
+             :total_vms_and_templates,
+             :miq_templates,
+             :total_miq_templates,
              :hosts,
              :to        => :parent_manager,
              :allow_nil => true

--- a/spec/models/manageiq/providers/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/network_manager_spec.rb
@@ -1,0 +1,16 @@
+describe ManageIQ::Providers::NetworkManager do
+  let(:vms) { FactoryBot.create(:vm) }
+  let(:template) { FactoryBot.create(:miq_template) }
+
+  let(:ems) { FactoryBot.create(:ems_openstack, :vms => [vms], :miq_templates => [template]) }
+
+  it "delegates vms and templates to parent manager (ExtManagementSystem)" do
+    expect(ems.id).not_to eq(ems.network_manager.id)
+    expect(ems.vms).to match_array([vms])
+    expect(ems.network_manager.vms).to match_array([vms])
+    expect(ems.miq_templates).to match_array([template])
+    expect(ems.network_manager.miq_templates).to match_array([template])
+    expect(ems.vms_and_templates).to match_array([vms, template])
+    expect(ems.network_manager.vms_and_templates).to match_array([vms, template])
+  end
+end


### PR DESCRIPTION
Images(templates) of Network manager(and not only instances) should be also delegated to its parent manager(provider).

it causes that filters(so called belongs to filters) with networks manager Host & Cluster filter will not work without this change:

<img width="551" alt="screenshot 2019-03-01 at 14 08 14" src="https://user-images.githubusercontent.com/14937244/53644095-03bb0700-3c36-11e9-9488-848c8037f303.png">

because it leads to call method `vms_and_templates` on instances of `ManageIQ::Providers::NetworkManager` and it is returning empty array without delegation in this PR.

## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1679027


