### PR TITLE
Dup should just dup and not save...

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -438,7 +438,7 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def dup
-    super.tap { |obj| obj.update_attributes(:guid => nil) }
+    super.tap { |obj| obj.guid = nil }
   end
 
   def add_resource(rsc, options = {})


### PR DESCRIPTION
Per post-merge review https://github.com/ManageIQ/manageiq/pull/18464#discussion_r260373968, overriding dup shouldn't save the object, only dup it, so this shouldn't be an update_attrs. 

