### PR TITLE
Use throw :abort in MiqAction#before_destroy

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -940,7 +940,10 @@ class MiqAction < ApplicationRecord
   end
 
   def check_policy_contents_empty_on_destroy
-    raise _("Action is referenced in at least one policy and connot be deleted") unless miq_policy_contents.empty?
+    unless miq_policy_contents.empty?
+      errors.add(:base, _("Action is referenced in at least one policy and cannot be deleted"))
+      throw :abort
+    end
   end
 
   def round_if_memory_reconfigured

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -17,8 +17,7 @@ describe MiqAction do
       group  = FactoryBot.create(:miq_group, :tenant => tenant)
       @user = FactoryBot.create(:user, :userid => "test", :miq_groups => [group])
       @vm   = FactoryBot.create(:vm_vmware, :evm_owner => @user, :miq_group => group)
-      FactoryBot.create(:miq_action, :name => "custom_automation")
-      @action = MiqAction.find_by(:name => "custom_automation")
+      @action = FactoryBot.create(:miq_action)
       expect(@action).not_to be_nil
       @action.options = {:ae_request => "test_custom_automation"}
       @args = {
@@ -539,7 +538,7 @@ describe MiqAction do
 
   describe "#destroy" do
     it "does not destroy this action if it referenced in at least one policy" do
-      action = FactoryBot.create(:miq_action, :name => "custom_automation")
+      action = FactoryBot.create(:miq_action)
       FactoryBot.create(:miq_policy_content, :miq_action => action)
       expect { action.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
     end

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -536,4 +536,12 @@ describe MiqAction do
       it_behaves_like "#workflow check"
     end
   end
+
+  describe "#destroy" do
+    it "does not destroy this action if it referenced in at least one policy" do
+      action = FactoryBot.create(:miq_action, :name => "custom_automation")
+      FactoryBot.create(:miq_policy_content, :miq_action => action)
+      expect { action.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    end
+  end
 end


### PR DESCRIPTION
Use `throw :abort` instead of raising error

@miq-bot add-label 