### PR TITLE
Call .reload on associations in save_inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -231,7 +231,7 @@ module EmsRefresh::SaveInventoryInfra
       h[:storage_id] = h.fetch_path(:storage, :id)
     end
 
-    host.host_storages(true)
+    host.host_storages.reload
     deletes = if disconnect && target == host
                 host.host_storages.dup
               else

--- a/app/models/ems_refresh/save_inventory_network.rb
+++ b/app/models/ems_refresh/save_inventory_network.rb
@@ -84,7 +84,7 @@ module EmsRefresh::SaveInventoryNetwork
   def save_network_groups_inventory(ems, hashes, target = nil)
     target = ems if target.nil?
 
-    ems.network_groups(true)
+    ems.network_groups.reload
     deletes = if target == ems
                 ems.network_groups.dup
               else


### PR DESCRIPTION
Instead of passing true to the association to reload it just call
.reload.

Fixes "DEPRECATION WARNING: Passing an argument to force an
association to reload is now deprecated and will be removed in
Rails 5.1. Please call `reload` on the result collection proxy instead."

https://travis-ci.org/ManageIQ/manageiq-providers-vmware/jobs/499076345#L2849