### PR TITLE
[V2V] Remove fatal nil IP check in preflight check

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -274,7 +274,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :destination => destination_network_ref(destination_network),
         :mac_address => nic.address,
         :ip_address  => nic.network.try(:ipaddress)
-      }.delete_if { |_, v| v.nil? }
+      }.compact
     end
   end
 

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -269,7 +269,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       source_network = nic.lan
       destination_network = transformation_destination(source_network)
       raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping." if destination_network.nil?
-      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil? and destination_ems.emstype == 'openstack'
+      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil? && destination_ems.emstype == 'openstack'
       {
         :source      => source_network.name,
         :destination => destination_network_ref(destination_network),

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -274,7 +274,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :destination => destination_network_ref(destination_network),
         :mac_address => nic.address,
         :ip_address  => nic.network.try(:ipaddress)
-      }.delete_if { |k, v| v.nil? }
+      }.delete_if { |_, v| v.nil? }
     end
   end
 

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -269,12 +269,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       source_network = nic.lan
       destination_network = transformation_destination(source_network)
       raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping." if destination_network.nil?
-      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil?
+      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil? and destination_ems.emstype == 'openstack'
       {
         :source      => source_network.name,
         :destination => destination_network_ref(destination_network),
         :mac_address => nic.address,
-        :ip_address  => nic.network.ipaddress
+        :ip_address  => nic.network.try(:ipaddress)
       }
     end
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -269,13 +269,13 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       source_network = nic.lan
       destination_network = transformation_destination(source_network)
       raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping." if destination_network.nil?
-      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil? && destination_ems.emstype == 'openstack'
+#      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil?
       {
         :source      => source_network.name,
         :destination => destination_network_ref(destination_network),
         :mac_address => nic.address,
-        :ip_address  => nic.network.try(:ipaddress)
-      }
+        :ip_address  => nic.network.ipaddress
+      }.delete_if { |k, v| v.nil? }
     end
   end
 

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -269,12 +269,11 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       source_network = nic.lan
       destination_network = transformation_destination(source_network)
       raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has no mapping." if destination_network.nil?
-#      raise "[#{source.name}] NIC #{nic.device_name} [#{source_network.name}] has an empty IP address." if nic.network.try(:ipaddress).nil?
       {
         :source      => source_network.name,
         :destination => destination_network_ref(destination_network),
         :mac_address => nic.address,
-        :ip_address  => nic.network.ipaddress
+        :ip_address  => nic.network.try(:ipaddress)
       }.delete_if { |k, v| v.nil? }
     end
   end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -501,11 +501,6 @@ describe ServiceTemplateTransformationPlanTask do
           expect { task_1.preflight_check }.not_to raise_error
         end
 
-        it "passes preflight check regardless of power_state" do
-          src_vm_1.send(:power_state=, 'anything')
-          expect { task_1.preflight_check }.not_to raise_error
-        end
-
         context "transport method is vddk" do
           before do
             conversion_host.vddk_transport_supported = true
@@ -561,8 +556,6 @@ describe ServiceTemplateTransformationPlanTask do
         let(:dst_cloud_volume_type) { FactoryBot.create(:cloud_volume_type) }
         let(:dst_cloud_network_1) { FactoryBot.create(:cloud_network) }
         let(:dst_cloud_network_2) { FactoryBot.create(:cloud_network) }
-        let(:dst_net_1) { dst_cloud_network_1 }
-        let(:dst_net_2) { dst_cloud_network_2 }
         let(:dst_flavor) { FactoryBot.create(:flavor) }
         let(:dst_security_group) { FactoryBot.create(:security_group) }
         let(:conversion_host_vm) { FactoryBot.create(:vm_openstack, :ext_management_system => dst_ems, :cloud_tenant => dst_cloud_tenant) }
@@ -597,11 +590,6 @@ describe ServiceTemplateTransformationPlanTask do
               ]
             )
           end
-        end
-
-        it "fails preflight check if src is power off" do
-          src_vm_1.send(:power_state=, 'off')
-          expect { task_1.preflight_check }.to raise_error('OSP destination and source power_state is off')
         end
 
         it "fails preflight check if src is power off" do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -343,8 +343,8 @@ describe ServiceTemplateTransformationPlanTask do
       let(:src_vm_2) { FactoryBot.create(:vm_openstack, :ext_management_system => src_ems, :ems_cluster => src_cluster, :host => src_host) }
 
       let(:src_network_1) { FactoryBot.create(:network, :ipaddress => '10.0.1.1') }
-      let(:src_network_2a) { FactoryBot.create(:network, :ipaddress => '10.0.1.2') }
-      let(:src_network_2b) { FactoryBot.create(:network, :ipaddress => nil) }
+      let(:src_network_2) { FactoryBot.create(:network, :ipaddress => '10.0.1.2') }
+      let(:src_network_nil_ip) { FactoryBot.create(:network, :ipaddress => nil) }
 
       # Disks have to be stubbed because there's no factory for Disk class
       before do
@@ -479,7 +479,7 @@ describe ServiceTemplateTransformationPlanTask do
 
         before do
           task_1.conversion_host = conversion_host
-          allow(src_nic_2).to receive(:network).and_return(src_network_2a)
+          allow(src_nic_2).to receive(:network).and_return(src_network_2)
         end
 
         it { expect(task_1.destination_cluster).to eq(dst_cluster) }
@@ -496,8 +496,8 @@ describe ServiceTemplateTransformationPlanTask do
             )
           end
 
-          it "fails if network IP address is nil" do
-            allow(src_nic_2).to receive(:network).and_return(src_network_2b)
+          it "generates network_mappings has even if one IP is nil" do
+            allow(src_nic_2).to receive(:network).and_return(src_network_nil_ip)
             expect(task_1.network_mappings).to eq(
               [
                 { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
@@ -588,7 +588,7 @@ describe ServiceTemplateTransformationPlanTask do
 
         before do
           task_1.conversion_host = conversion_host
-          allow(src_nic_2).to receive(:network).and_return(src_network_2a)
+          allow(src_nic_2).to receive(:network).and_return(src_network_2)
         end
 
         it { expect(task_1.destination_cluster).to eq(dst_cloud_tenant) }
@@ -606,7 +606,7 @@ describe ServiceTemplateTransformationPlanTask do
           end
 
           it "fails if network IP address is nil" do
-            allow(src_nic_2).to receive(:network).and_return(src_network_2b)
+            allow(src_nic_2).to receive(:network).and_return(src_network_nil_ip)
             expect { task_1.network_mappings }.to raise_error("[#{src_vm_1.name}] NIC #{src_nic_2.device_name} [#{src_lan_2.name}] has an empty IP address.")
           end
         end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -498,7 +498,12 @@ describe ServiceTemplateTransformationPlanTask do
 
           it "fails if network IP address is nil" do
             allow(src_nic_2).to receive(:network).and_return(src_network_2b)
-            expect { task_1.network_mappings }.to raise_error("[#{src_vm_1.name}] NIC #{src_nic_2.device_name} [#{src_lan_2.name}] has an empty IP address.")
+            expect(task_1.network_mappings).to eq(
+              [
+                { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address, :ip_address => nil }
+              ]
+            )
           end
         end
 


### PR DESCRIPTION
~We introduced a check on empty IP address for NICs. However, this should only apply to migrations to OpenStack as it only breaks network port creation. This PR relaxes the check to limit it to migrations toward OpenStack.~

We introduced a check on empty IP address for NICs, because it made virt-v2v-wrapper fail when migrating to OpenStack. However, this was not limited to OpenStack and blocked migrations to RHV, so was too strict. Also, virt-v2v-wapper is able to handle NICs without IP address as long as the `ip_address` field is not part of the mapping we send to it. This PR removes the check on the IP address and removes the `ip_address` field if it's `nil`.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1680487