### PR TITLE
default merged_uri should return the parameter not the attribute

### DIFF
--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -33,7 +33,7 @@ class FileDepot < ApplicationRecord
     @file = file
   end
 
-  def merged_uri(_uri, _api_port)
+  def merged_uri(uri, _api_port)
     uri
   end
 end

--- a/spec/factories/file_depot.rb
+++ b/spec/factories/file_depot.rb
@@ -5,7 +5,11 @@ FactoryBot.define do
   end
 
   factory(:file_depot_ftp, :class => "FileDepotFtp", :parent => :file_depot) { uri { "ftp://somehost/export" } }
+  factory(:file_depot_swift, :class => "FileDepotSwift", :parent => :file_depot) { uri { "swift://swifthost/swiftbucket" } }
   factory :file_depot_ftp_with_authentication, :parent => :file_depot_ftp do
+    after(:create) { |x| x.authentications << FactoryBot.create(:authentication) }
+  end
+  factory :file_depot_swift_with_authentication, :parent => :file_depot_swift do
     after(:create) { |x| x.authentications << FactoryBot.create(:authentication) }
   end
 end

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -122,8 +122,8 @@ describe FileDepotFtp do
       file_depot_ftp.uri = uri
     end
 
-    it "should return the uri attribute from the file depot object and ignore the parameter" do
-      expect(file_depot_ftp.merged_uri(nil, nil)).to eq uri
+    it "should ignore the uri attribute from the file depot object and return the parameter" do
+      expect(file_depot_ftp.merged_uri(nil, nil)).to eq nil
     end
   end
 end

--- a/spec/models/file_depot_nfs_spec.rb
+++ b/spec/models/file_depot_nfs_spec.rb
@@ -1,6 +1,6 @@
 describe FileDepotNfs do
-  let(:uri)            { "nfs://foo.com/directory" }
-  let(:swift_uri)      { "swift://foo_bucket/doo_directory" }
+  let(:ignore_uri)     { "nfs://ignore.com/directory" }
+  let(:actual_uri)     { "nfs://actual_bucket/doo_directory" }
   let(:file_depot_nfs) { FileDepotNfs.new(:uri => uri) }
 
   it "should return a valid prefix" do
@@ -9,11 +9,11 @@ describe FileDepotNfs do
 
   describe "#merged_uri" do
     before do
-      file_depot_nfs.uri = uri
+      file_depot_nfs.uri = ignore_uri
     end
 
     it "should ignore the uri set on the depot object and return the uri parameter" do
-      expect(file_depot_nfs.merged_uri(swift_uri, nil)).to eq swift_uri
+      expect(file_depot_nfs.merged_uri(actual_uri, nil)).to eq actual_uri
     end
   end
 end

--- a/spec/models/file_depot_nfs_spec.rb
+++ b/spec/models/file_depot_nfs_spec.rb
@@ -12,12 +12,8 @@ describe FileDepotNfs do
       file_depot_nfs.uri = uri
     end
 
-    it "should return the uri set on the depot object and ignore the uri parameter" do
-      expect(file_depot_nfs.merged_uri(swift_uri, nil)).to eq uri
-    end
-
-    it "should return the uri set on the depot object and ignore an empty uri parameter" do
-      expect(file_depot_nfs.merged_uri(nil, nil)).to eq uri
+    it "should ignore the uri set on the depot object and return the uri parameter" do
+      expect(file_depot_nfs.merged_uri(swift_uri, nil)).to eq swift_uri
     end
   end
 end

--- a/spec/models/file_depot_nfs_spec.rb
+++ b/spec/models/file_depot_nfs_spec.rb
@@ -1,5 +1,5 @@
 describe FileDepotNfs do
-  let(:ignore_uri)     { "nfs://ignore.com/directory" }
+  let(:uri)            { "nfs://ignore.com/directory" }
   let(:actual_uri)     { "nfs://actual_bucket/doo_directory" }
   let(:file_depot_nfs) { FileDepotNfs.new(:uri => uri) }
 
@@ -9,7 +9,7 @@ describe FileDepotNfs do
 
   describe "#merged_uri" do
     before do
-      file_depot_nfs.uri = ignore_uri
+      file_depot_nfs.uri = uri
     end
 
     it "should ignore the uri set on the depot object and return the uri parameter" do


### PR DESCRIPTION
A previous PR changed merged_uri to return the attribute on the object
rather than the passed in parameter.  This is incorrect and is changed
herein.  Only Swift handles this differently.

Thie method gets called by MiqSchedule.verify_file_depot() which in turn gets called by the UI controller in two different situations - for an AdHoc DB backup, and for a Scheduled DB Backup.  We had apparently only tested AdHoc backups previously, which is why this worked.  However Scheduled backups were failing because the FileDepot object had not been created in the DB and therefore the URI attribute was nil, which is invalid when the object is subsequently created.
If we return the passed in uri parameter instead of the attribute, both Adhoc and Scheduled DB backups will work correctly.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1678223

@roliveri @h-kataria @NickLaMuro please review.  Thanks.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1678223
