### PR TITLE
Fixed: started_on column is empty in task which power-on VM

### DIFF
--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -168,6 +168,7 @@ module ProcessTasksMixin
         :instance_id  => instance.id,
         :method_name  => options[:task],
         :args         => args,
+        :miq_task_id  => task&.id,
         :miq_callback => cb
       }
       user = User.current_user

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -464,6 +464,7 @@ class VmOrTemplate < ApplicationRecord
           :instance_id  => vm.id,
           :method_name  => options[:task],
           :args         => args,
+          :miq_task_id  => task&.id,
           :miq_callback => cb,
         }
       else
@@ -474,6 +475,7 @@ class VmOrTemplate < ApplicationRecord
           :instance_id  => vm.id,
           :method_name  => options[:task],
           :args         => args,
+          :miq_task_id  => task&.id,
           :miq_callback => cb,
         }
       end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -127,6 +127,7 @@ describe Vm do
       expect(MiqQueue.count).to eq(1)
       msg = MiqQueue.first
       expect(msg.miq_callback).to eq({:class_name => "MiqTask", :method_name => :queue_callback, :instance_id => task.id, :args => ["Finished"]})
+      expect(msg.miq_task_id).to eq(task.id)
     end
 
     it "sets up powerops callback for Power Operations" do
@@ -137,6 +138,7 @@ describe Vm do
       expect(MiqQueue.count).to eq(1)
       msg = MiqQueue.first
       expect(msg.miq_callback).to eq({:class_name => @vm.class.base_class.name, :method_name => :powerops_callback, :instance_id => @vm.id, :args => [task.id]})
+      expect(msg.miq_task_id).to eq(task.id)
 
       allow(Vm).to receive(:start).and_raise(MiqException::MiqVimBrokerUnavailable)
       msg.deliver


### PR DESCRIPTION
Adding miq_task_id to list of parameters when adding to `MiqQueue` will allow automatically update `MiqTask#started_on` when queued item delivered

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1516838

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/53572002-3da5e380-3b38-11e9-9704-90e7efa953e9.png)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/53571229-5dd4a300-3b36-11e9-8982-7892c18bcd82.png)


@miq-bot add-label bug