### PR TITLE
Fix saving network manager in belongsto filter

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -339,6 +339,15 @@ class ExtManagementSystem < ApplicationRecord
     self::ProvisionWorkflow
   end
 
+  BELONGS_TO_DESCENDANTS_CLASSES_BY_NAME = {
+    'Network Manager' => 'ManageIQ::Providers::NetworkManager'
+  }.freeze
+
+  def self.belongsto_descendant_class(name)
+    return unless (descendant = BELONGS_TO_DESCENDANTS_CLASSES_BY_NAME.keys.detect { |x| name.end_with?(x) })
+    BELONGS_TO_DESCENDANTS_CLASSES_BY_NAME[descendant]
+  end
+
   # UI methods for determining availability of fields
   def supports_port?
     false

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -1,6 +1,9 @@
 module ManageIQ::Providers
   class NetworkManager < BaseManager
     include SupportsFeatureMixin
+
+    PROVIDER_NAME = "Network Manager".freeze
+
     class << model_name
       define_method(:route_key) { "ems_networks" }
       define_method(:singular_route_key) { "ems_network" }
@@ -88,7 +91,7 @@ module ManageIQ::Providers
     end
 
     def name
-      "#{parent_manager.try(:name)} Network Manager"
+      "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
     end
   end
 

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -93,6 +93,11 @@ module ManageIQ::Providers
     def name
       "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
     end
+
+    def self.find_object_for_belongs_to_filter(name)
+      name.gsub!(" #{self::PROVIDER_NAME}", "")
+      includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
+    end
   end
 
   def self.display_name(number = 1)

--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -3,6 +3,11 @@ module MiqFilter
     belongsto2object_list(tag).last
   end
 
+  def self.find_object_by_name(klass, name)
+    klass = klass.constantize
+    klass.find_by(:name => name)
+  end
+
   def self.belongsto2object_list(tag)
     # /belongsto/ExtManagementSystem|<name>/EmsCluster|<name>/EmsFolder|<name>
     raise _("invalid tag: %{tag}") % {:tag => tag} unless tag.starts_with?("/belongsto/ExtManagementSystem")
@@ -10,8 +15,7 @@ module MiqFilter
 
     # root object
     klass, name = parts.shift.split("|")
-    klass = klass.constantize
-    obj = klass.find_by(:name => name)
+    obj = find_object_by_name(klass, name)
 
     if obj.nil?
       _log.warn("lookup for klass=#{klass.to_s.inspect} with name=#{name.inspect} failed in tag=#{tag.inspect}")

--- a/spec/models/miq_filter_spec.rb
+++ b/spec/models/miq_filter_spec.rb
@@ -48,5 +48,15 @@ describe MiqFilter do
       host_object_path = [ems, datacenter, mtc, host_folder, host_1]
       expect(belongsto2object_list(mtc_folder_path_with_host_1)).to match_array(host_object_path)
     end
+
+    context "with network manager" do
+      let(:ems_openstack) { FactoryBot.create(:ems_openstack) }
+      let(:network_manager_folder_path) { "/belongsto/ExtManagementSystem|#{ems_openstack.name} Network Manager" }
+
+      it "converts path with network manager" do
+        ems_openstack.update_attributes(:name => "XXX")
+        expect(belongsto2object_list(network_manager_folder_path)).to match_array([ems_openstack.network_manager])
+      end
+    end
   end
 end


### PR DESCRIPTION
**belongsto filters** are set in group in **Host & Cluster tab**:

<img width="551" alt="screenshot 2019-03-01 at 14 08 14" src="https://user-images.githubusercontent.com/14937244/53640170-c6ea1280-3c2b-11e9-9ddb-496cc7982e21.png">

In this filter are listed Providers, Hosts,  Storage managers and also **Network Providers**.

But when you checked any network provider then **it was stored to the group** but it was not reflected in UI because the method [MiqFilter#belongsto2object_list](https://github.com/ManageIQ/manageiq/blob/cb357b8f9b0a5db72a1a6bd8c73919fd8a6d148c/app/models/miq_filter.rb#L25) did not work properly with network providers.

This PR fixes method [MiqFilter#belongsto2object_list](https://github.com/ManageIQ/manageiq/blob/cb357b8f9b0a5db72a1a6bd8c73919fd8a6d148c/app/models/miq_filter.rb#L25) to count also with network providers. 

Links
-----

* https://bugzilla.redhat.com/show_bug.cgi



@miq-bot assign @gtanzillo 
@miq-bot add_label bug

