### PR TITLE
Tag associated resource for conversion hosts

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -193,6 +193,8 @@ class ConversionHost < ApplicationRecord
   end
 
   # Wrapper method for the various tag_resource_as_xxx methods.
+  #--
+  # TODO: Do we need this?
   #
   def tag_resource_as(status)
     send("tag_resource_as_#{status}")

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -198,26 +198,30 @@ class ConversionHost < ApplicationRecord
     send("tag_resource_as_#{status}")
   end
 
-  # Tag the associated resource as enabled. The following tags are set:
+  # Tag the associated resource as enabled. The following tags are set or removed:
   #
-  # - 'v2v_transformation_host/true'
-  # - 'v2v_transformation_host/vddk' (if vddk supported)
-  # - 'v2v_transformation_host/ssh'  (if ssh supported)
+  # - 'v2v_transformation_host/true'  (added)
+  # - 'v2v_transformation_host/vddk'  (added if vddk supported)
+  # - 'v2v_transformation_host/ssh'   (added if ssh supported)
+  # - 'v2v_transformation_host/false' (removed if present)
   #
   def tag_resource_as_enabled
     resource.tag_add('v2v_transformation_host/true')
     resource.tag_add('v2v_transformation_method/vddk') if vddk_transport_supported?
     resource.tag_add('v2v_transformation_method/ssh') if ssh_transport_supported?
+    resource.tag_remove('v2v_transformation_host/false')
   end
 
   # Tag the associated resource as disabled. The following tags are set or removed:
   #
-  # - 'v2v_transformation_host/true' (added)
-  # - 'v2v_transformation_host/vddk' (removed if present)
-  # - 'v2v_transformation_host/ssh'  (removed if present)
+  # - 'v2v_transformation_host/false' (added)
+  # - 'v2v_transformation_host/true'  (removed if present)
+  # - 'v2v_transformation_host/vddk'  (removed if present)
+  # - 'v2v_transformation_host/ssh'   (removed if present)
   #
   def tag_resource_as_disabled
     resource.tag_add('v2v_transformation_host/false')
+    resource.tag_remove('v2v_transformation_host/true')
     resource.tag_remove('v2v_transformation_method/vddk')
     resource.tag_remove('v2v_transformation_method/ssh')
   end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -1,5 +1,5 @@
 describe ConversionHost do
-  let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+  let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }
   let(:params) do
     {
       :name          => 'transformer',
@@ -11,9 +11,11 @@ describe ConversionHost do
 
   context "processing configuration requests" do
     let(:vm) { FactoryBot.create(:vm_openstack) }
+
     before(:each) do
       allow(ConversionHost).to receive(:new).and_return(conversion_host)
     end
+
     context ".enable" do
       let(:expected_notify) do
         {
@@ -24,6 +26,7 @@ describe ConversionHost do
           }
         }
       end
+
       it "to succeed and send notification" do
         allow(conversion_host).to receive(:enable_conversion_host_role)
         expect(Notification).to receive(:create).with(expected_notify)
@@ -35,6 +38,17 @@ describe ConversionHost do
         allow(conversion_host).to receive(:enable_conversion_host_role).and_raise
         expect(Notification).to receive(:create).with(expected_notify)
         expect { described_class.enable(params) }.to raise_error(StandardError)
+      end
+
+      it "tags the associated resource as expected" do
+        allow(conversion_host).to receive(:enable_conversion_host_role)
+        taggings = conversion_host.resource.taggings
+        tag_names = taggings.map{ |tagging| tagging.tag.name }
+
+        expect(tag_names).to contain_exactly(
+          '/user/v2v_transformation_host/true',
+          '/user/v2v_transformation_method/ssh'
+        )
       end
     end
 

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -43,7 +43,7 @@ describe ConversionHost do
       it "tags the associated resource as expected" do
         allow(conversion_host).to receive(:enable_conversion_host_role)
         taggings = conversion_host.resource.taggings
-        tag_names = taggings.map{ |tagging| tagging.tag.name }
+        tag_names = taggings.map { |tagging| tagging.tag.name }
 
         expect(tag_names).to contain_exactly(
           '/user/v2v_transformation_host/true',
@@ -81,7 +81,7 @@ describe ConversionHost do
         expect(Notification).to receive(:create).with(expected_notify)
         conversion_host.disable
         taggings = conversion_host.resource.taggings
-        tag_names = taggings.map{ |tagging| tagging.tag.name }
+        tag_names = taggings.map { |tagging| tagging.tag.name }
 
         expect(tag_names).to contain_exactly('/user/v2v_transformation_host/false')
       end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -75,6 +75,16 @@ describe ConversionHost do
         expect(Notification).to receive(:create).with(expected_notify)
         expect { conversion_host.disable }.to raise_error(StandardError)
       end
+
+      it "tags the associated resource as expected" do
+        allow(conversion_host).to receive(:disable_conversion_host_role)
+        expect(Notification).to receive(:create).with(expected_notify)
+        conversion_host.disable
+        taggings = conversion_host.resource.taggings
+        tag_names = taggings.map{ |tagging| tagging.tag.name }
+
+        expect(tag_names).to contain_exactly('/user/v2v_transformation_host/false')
+      end
     end
   end
 


### PR DESCRIPTION
A resource that's been designated as a conversion host should be tagged and identifiable as such. This PR modifies the ConversionHost model so that on `create` or `delete` it is tagged appropriately. I also added some comments and specs.

Note that I modified the existing tagging methods slightly so that it can only be `v2v_transformation_host/true`or `v2v_transformation_host/false`. Previously it could end up with both tags.

In addition, it only sets `v2v_transformation_method/vddk` or `v2v_transformation_method/ssh` if they're actually supported. Those are deleted if the conversion host is deleted.

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1622728