### PR TITLE
[V2V] Allow downloading wrapper log file

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -113,7 +113,11 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     SecurityGroup.find_by(:id => vm_resource.options["osp_security_group_id"])
   end
 
-  def transformation_log(log_type)
+  def valid_transformation_log_types
+    %w(v2v wrapper)
+  end
+
+  def transformation_log(log_type = 'v2v')
     if conversion_host.nil?
       msg = "Conversion host was not found. Download of transformation log aborted."
       _log.error(msg)
@@ -133,7 +137,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   # Intend to be called by UI to display transformation log. The log is stored in MiqTask#task_results
   # Since the task_results may contain a large block of data, it is desired to remove the task upon receiving the data
   def transformation_log_queue(userid = nil, log_type = 'v2v')
-    raise "Transformation log type '#{log_type}' not supported" unless %w(v2v wrapper).include?(log_type)
+    raise "Transformation log type '#{log_type}' not supported" unless valid_transformation_log_types.include?(log_type)
     userid ||= User.current_userid || 'system'
     if conversion_host.nil?
       msg = "Conversion host was not found. Cannot queue the download of #{log_type} log."

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -113,16 +113,16 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     SecurityGroup.find_by(:id => vm_resource.options["osp_security_group_id"])
   end
 
-  def transformation_log
+  def transformation_log(log_type)
     if conversion_host.nil?
       msg = "Conversion host was not found. Download of transformation log aborted."
       _log.error(msg)
       raise MiqException::Error, msg
     end
 
-    logfile = options.fetch_path(:virtv2v_wrapper, "v2v_log")
+    logfile = options.fetch_path(:virtv2v_wrapper, "#{log_type}_log")
     if logfile.blank?
-      msg = "The location of transformation log was not set. Download of transformation log aborted."
+      msg = "The location of #{log_type} log was not set. Download of #{log_type} log aborted."
       _log.error(msg)
       raise MiqException::Error, msg
     end
@@ -132,20 +132,21 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   # Intend to be called by UI to display transformation log. The log is stored in MiqTask#task_results
   # Since the task_results may contain a large block of data, it is desired to remove the task upon receiving the data
-  def transformation_log_queue(userid = nil)
+  def transformation_log_queue(userid = nil, log_type = 'v2v')
+    raise "Transformation log type '#{log_type}' not supported" unless %w(v2v wrapper).include?(log_type)
     userid ||= User.current_userid || 'system'
     if conversion_host.nil?
-      msg = "Conversion host was not found. Cannot queue the download of transformation log."
+      msg = "Conversion host was not found. Cannot queue the download of #{log_type} log."
       return create_error_status_task(userid, msg).id
     end
 
-    _log.info("Queuing the download of transformation log for #{description} with ID [#{id}]")
+    _log.info("Queuing the download of #{log_type} log for #{description} with ID [#{id}]")
     task_options = {:userid => userid, :action => 'transformation_log'}
     queue_options = {:class_name  => self.class,
                      :method_name => 'transformation_log',
                      :instance_id => id,
                      :priority    => MiqQueue::HIGH_PRIORITY,
-                     :args        => [],
+                     :args        => [log_type],
                      :zone        => conversion_host.resource.my_zone}
     MiqTask.generic_action_with_callback(task_options, queue_options)
   end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -120,6 +120,11 @@ describe ServiceTemplateTransformationPlanTask do
           end
         end
 
+        it 'raises when log type is invalid' do
+          msg = "Transformation log type 'invalid' not supported"
+          expect { task.transformation_log_queue('user', 'invalid') }.to raise_error(msg)
+        end
+
         it 'gets the transformation log from conversion host' do
           expect(task).to receive(:transformation_log).and_return('transformation migration log content')
           taskid = task.transformation_log_queue('user')
@@ -144,7 +149,7 @@ describe ServiceTemplateTransformationPlanTask do
         it 'returns an error message' do
           taskid = task.transformation_log_queue('user')
           expect(MiqTask.find(taskid)).to have_attributes(
-            :message => "Conversion host was not found. Cannot queue the download of transformation log.",
+            :message => "Conversion host was not found. Cannot queue the download of v2v log.",
             :status  => 'Error'
           )
         end
@@ -160,13 +165,13 @@ describe ServiceTemplateTransformationPlanTask do
 
       it 'requires transformation log location in options' do
         task.options.store_path(:virtv2v_wrapper, "v2v_log", "")
-        expect { task.transformation_log }.to raise_error(MiqException::Error)
+        expect { task.transformation_log("v2v") }.to raise_error(MiqException::Error)
       end
 
       it 'gets the transformation log content' do
         msg = 'my transformation migration log'
         allow(conversion_host).to receive(:get_conversion_log).with(task.options[:virtv2v_wrapper]['v2v_log']).and_return(msg)
-        expect(task.transformation_log).to eq(msg)
+        expect(task.transformation_log("v2v")).to eq(msg)
       end
     end
 


### PR DESCRIPTION
In the current implementation, we provide a download button in the UI that allows downloading the virt-v2v log file. It's been reported by field that the virt-v2v-wrapper log is more relevant and provides better error messages. This PR allows downloading the wrapper log.

The `transformation_log` method becomes more generic by accepting a `log_type` argument. The default `log_type` value is `v2v` to not break code calling it. The `transformation_log_queue` method gates the log type to allow only `v2v` and `wrapper`. The migration log controller has been modified to leverage this new feature in https://github.com/ManageIQ/manageiq-v2v/pull/887.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1655124