### PR TITLE
Fix the metric rollup spec changing the timestamp

### DIFF
--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -13,9 +13,9 @@ describe MetricRollup do
     end
 
     it "updates an existing object correctly" do
-      metric = described_class.create!(:timestamp => Time.now.utc)
+      metric = described_class.create!(:timestamp => Time.now.utc, :cpu_usage_rate_average => 50.0)
       old_id = metric.id
-      metric.update_attributes!(:timestamp => Time.now.utc - 1.day)
+      metric.update_attributes!(:cpu_usage_rate_average => 75.0)
       expect(metric.id).to eq(old_id)
     end
   end


### PR DESCRIPTION
The test for updating a metric rollup record keeps the same primary key
was changing the timestamp of the record.  On the first day of the month
this would change which table the record was in, e.g. on Mar 1st the
record would be in metric_rollups_03 and `timestamp - 1.day` would put
it in metric_rollups_02 causing an inheritance check constraint
violation.

Since we never change the timestamp of a record this test is invalid
anyway and the solution is to change some other property which we do
regularly update like a cpu metric value.