### PR TITLE
Warn devs if their current branch is out of date

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -37,4 +37,6 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.compile_assets if ENV['RAILS_ENV'] == 'production'
 
   ManageIQ::Environment.clear_logs_and_temp
+
+  ManageIQ::Environment.warn_if_branch_out_of_date
 end


### PR DESCRIPTION
It's easy to pull in provider or other repo updates via `bin/update`
but forget to git pull or git fetch + merge your current branch, leading
to "constant" errors or just inconsistency.

Now, at the end of `bin/update`, it will check your current branch vs.
it's upstream remote tracking branch if it has one and tries
upstream/master if you don't.  This should cover the cases for both
release branches such as master and also feature branches which may not
track anything but probably originated from upstream/master.  We can
externalize the "master" branch name at some point so this can be used
on hammer, gaprindashvili, etc.

If you don't use upstream as your remote name, you're on your own.

It looks like this at the end of `bin/update`.

```
...
JS plugins:
  ManageIQ::GraphQL::Engine:
    namespace: manageiq-graphql
    path: /Users/joerafaniello/.gem/ruby/2.4.5/bundler/gems/manageiq-graphql-82fdd9385bdd
  ManageIQ::Providers::Lenovo::Engine:
    namespace: manageiq-providers-lenovo
    path: /Users/joerafaniello/.gem/ruby/2.4.5/bundler/gems/manageiq-providers-lenovo-5eea49854a3a
  ManageIQ::Providers::Nuage::Engine:
    namespace: manageiq-providers-nuage
    path: /Users/joerafaniello/.gem/ruby/2.4.5/bundler/gems/manageiq-providers-nuage-2f8d63586d9b
  ManageIQ::UI::Classic::Engine:
    namespace: manageiq-ui-classic
    path: /Users/joerafaniello/.gem/ruby/2.4.5/bundler/gems/manageiq-ui-classic-2721cb43d860
  ManageIQ::V2V::Engine:
    namespace: manageiq-v2v
    path: /Users/joerafaniello/.gem/ruby/2.4.5/bundler/gems/manageiq-v2v-c097fb87593a

== Updating UI assets complete ==

== Removing old logs and tempfiles ==

== Your branch is 15 commits out of date, please pull or fetch + merge.
```