### PR TITLE
Fix the dynamic service task naming generation for subclasses

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -51,18 +51,24 @@ class ServiceRetireTask < MiqRetireTask
   end
 
   def create_task(svc_rsc, parent_service, nh, parent_task)
-    resource_type = svc_rsc.resource.type.presence || "Service"
-    (resource_type.demodulize + "RetireTask").constantize.new(nh).tap do |task|
+    task_type = retire_task_type(svc_rsc.resource.class)
+    task_type.new(nh).tap do |task|
       task.options.merge!(
         :src_ids             => [svc_rsc.resource.id],
         :service_resource_id => svc_rsc.id,
         :parent_service_id   => parent_service.id,
         :parent_task_id      => parent_task.id,
       )
-      task.request_type = resource_type.demodulize.underscore.downcase + "_retire"
+      task.request_type = task_type.name.underscore[0..-6]
       task.source = svc_rsc.resource
       parent_task.miq_request_tasks << task
       task.save!
     end
+  end
+
+  private
+
+  def retire_task_type(resource_type)
+    (resource_type.base_class.name + "RetireTask").safe_constantize || (resource_type.name.demodulize + "RetireTask").safe_constantize
   end
 end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1684092

The service task magic generation should've used safe_constantize. 

for subclasses like ServiceOrchestration we need the base class name; for Vms we just need the class name

This fixes the tests, too, cause they should've used ```add_resource```. 