### PR TITLE
Only run preprocess_targets_manager_refresh when doing graph refresh and add specs

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -231,11 +231,6 @@ module ManageIQ
           ems = @ems_by_ems_id[ems_id]
           next unless ems.inventory_object_refresh?
 
-          if targets.any? { |t| t.kind_of?(ExtManagementSystem) }
-            targets_for_log = targets.map { |t| "#{t.class} [#{t.name}] id [#{t.id}] " }
-            _log.info("Defaulting to full refresh for EMS: [#{ems.name}], id: [#{ems.id}], from targets: #{targets_for_log}") if targets.length > 1
-          end
-
           # We want all targets of class EmsEvent to be merged into one target, so they can be refreshed together, otherwise
           # we could be missing some crosslinks in the refreshed data
           all_targets, sub_ems_targets = targets.partition { |x| x.kind_of?(ExtManagementSystem) }

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -229,6 +229,7 @@ module ManageIQ
       def preprocess_targets_manager_refresh
         @targets_by_ems_id.each do |ems_id, targets|
           ems = @ems_by_ems_id[ems_id]
+          next unless ems.inventory_object_refresh?
 
           if targets.any? { |t| t.kind_of?(ExtManagementSystem) }
             targets_for_log = targets.map { |t| "#{t.class} [#{t.name}] id [#{t.id}] " }

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -17,7 +17,7 @@ describe ManageIQ::Providers::BaseManager::Refresher do
       let(:vm)  { FactoryBot.create(:vm, :ext_management_system => ems) }
       let(:lots_of_vms) do
         num_targets = Settings.ems_refresh.full_refresh_threshold + 1
-        num_targets.times.map { FactoryBot.create(:vm, :ext_management_system => ems) }
+        Array.new(num_targets) { FactoryBot.create(:vm, :ext_management_system => ems) }
       end
 
       it "keeps a single vm target" do

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -1,0 +1,45 @@
+describe ManageIQ::Providers::BaseManager::Refresher do
+  context "#initialize" do
+    let(:ems1) { FactoryBot.create(:ext_management_system) }
+    let(:ems2) { FactoryBot.create(:ext_management_system) }
+    let(:vm1)  { FactoryBot.create(:vm, :ext_management_system => ems1) }
+    let(:vm2)  { FactoryBot.create(:vm, :ext_management_system => ems2) }
+
+    it "groups targets by ems" do
+      refresher = described_class.new([vm1, vm2])
+      expect(refresher.targets_by_ems_id.keys).to include(ems1.id, ems2.id)
+    end
+  end
+
+  context "#refresh" do
+    context "#preprocess_targets" do
+      let(:ems) { FactoryBot.create(:ext_management_system) }
+      let(:vm)  { FactoryBot.create(:vm, :ext_management_system => ems) }
+      let(:lots_of_vms) do
+        num_targets = Settings.ems_refresh.full_refresh_threshold + 1
+        num_targets.times.map { FactoryBot.create(:vm, :ext_management_system => ems) }
+      end
+
+      it "keeps a single vm target" do
+        refresher = described_class.new([vm])
+        refresher.preprocess_targets
+
+        expect(refresher.targets_by_ems_id[vm.ext_management_system.id]).to eq([vm])
+      end
+
+      it "does a full refresh with an EMS and a VM" do
+        refresher = described_class.new([vm, ems])
+        refresher.preprocess_targets
+
+        expect(refresher.targets_by_ems_id[vm.ext_management_system.id]).to eq([ems])
+      end
+
+      it "does a full refresh with a lot of targets" do
+        refresher = described_class.new(lots_of_vms)
+        refresher.preprocess_targets
+
+        expect(refresher.targets_by_ems_id[ems.id]).to eq([ems])
+      end
+    end
+  end
+end


### PR DESCRIPTION
If we run preprocess_targets_manager_refresh on an EMS that isn't using graph refresh then we accidentally disable targeted refresh due to the ems.allow_targeted_refresh? check which was a setting that was never added to classic refresh.

Introduced by refactoring in https://github.com/ManageIQ/manageiq/pull/18312.  This would have been a bug if we had turned off graph refresh for any provider inheriting from that class also, but now it used by everyone.