### PR TITLE
Use throw :abort in MiqGroup#before_destroy

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -297,10 +297,11 @@ class MiqGroup < ApplicationRecord
   end
 
   def ensure_can_be_destroyed
-    raise _("The login group cannot be deleted") if current_user_group?
-    raise _("The group has users assigned that do not belong to any other group") if single_group_users?
-    raise _("A tenant default group can not be deleted") if tenant_group? && referenced_by_tenant?
-    raise _("A read only group cannot be deleted.") if system_group?
+    errors.add(:base, _("The login group cannot be deleted")) if current_user_group?
+    errors.add(:base, _("The group has users assigned that do not belong to any other group")) if single_group_users?
+    errors.add(:base, _("A tenant default group can not be deleted")) if tenant_group? && referenced_by_tenant?
+    errors.add(:base, _("A read only group cannot be deleted.")) if system_group?
+    throw :abort unless errors[:base].empty?
   end
 
   def reset_current_group_for_users

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -30,8 +30,8 @@ describe MiqWidgetSet do
     end
 
     it "the belong to group is being deleted" do
-      expect { group.destroy }.to raise_error(RuntimeError, /The group has users assigned that do not belong to any other group/)
-      expect(MiqWidgetSet.count).to eq(2)
+      expect { expect { group.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed) }.to_not(change { MiqWidgetSet.count })
+      expect(group.errors[:base][0]).to eq("The group has users assigned that do not belong to any other group")
     end
 
     it "being deleted" do


### PR DESCRIPTION
Use throw :abort instead of raising error

@miq-bot add-label  technical debt,  core, hammer/no,  changelog/no
