### PR TITLE
Default to resource name for conversion hosts

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -9,6 +9,7 @@ class ConversionHost < ApplicationRecord
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   validates :resource, :presence => true
+  validates :name, :presence => true
 
   validates :address,
     :uniqueness => true,
@@ -18,8 +19,7 @@ class ConversionHost < ApplicationRecord
 
   validate :resource_supports_conversion_host
 
-  # Default to the resource name if no name is provided
-  before_save { name ||= resource.name }
+  before_validation :name, :default_name, :on => :create
 
   include_concern 'Configurations'
 
@@ -203,5 +203,11 @@ class ConversionHost < ApplicationRecord
   def tag_resource_as_disabled
     resource.tag_add('v2v_transformation_host/false')
     resource.tag_remove('v2v_transformation_method/vddk')
+  end
+
+  # Set the default name to the name of the associated resource.
+  #
+  def default_name
+    self.name ||= self.resource&.name
   end
 end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -208,6 +208,6 @@ class ConversionHost < ApplicationRecord
   # Set the default name to the name of the associated resource.
   #
   def default_name
-    self.name ||= self.resource&.name
+    self.name ||= resource&.name
   end
 end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -8,8 +8,8 @@ class ConversionHost < ApplicationRecord
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
-  validates :resource, :presence => true
   validates :name, :presence => true
+  validates :resource, :presence => true
 
   validates :address,
     :uniqueness => true,

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -8,7 +8,6 @@ class ConversionHost < ApplicationRecord
   has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
-  validates :name, :presence => true
   validates :resource, :presence => true
 
   validates :address,
@@ -18,6 +17,9 @@ class ConversionHost < ApplicationRecord
     :unless     => ->(conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? }
 
   validate :resource_supports_conversion_host
+
+  # Default to the resource name if no name is provided
+  before_save { name ||= resource.name }
 
   include_concern 'Configurations'
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -242,13 +242,12 @@ describe ConversionHost do
 
   context "name validation" do
     let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
-    let(:redhat_host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+    let(:redhat_host) { FactoryBot.create(:host_redhat, :name => 'foo', :ext_management_system => ems) }
 
     it "defaults to the associated resource name if no name is explicitly provided" do
-      conversion_host1 = ConversionHost.new(:name => 'foo')
-      #conversion_host2 = ConversionHost.new
-      expect(conversion_host1.name).to eql('foo')
-      #expect(conversion_host2.name).to eql(redhat_host.name)
+      conversion_host = ConversionHost.new(:resource => redhat_host)
+      expect(conversion_host.valid?).to be(true)
+      expect(conversion_host.name).to eql(redhat_host.name)
     end
   end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -239,4 +239,16 @@ describe ConversionHost do
       expect(conversion_host.errors[:resource].first).to eql("can't be blank")
     end
   end
+
+  context "name validation" do
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:redhat_host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+
+    it "defaults to the associated resource name if no name is explicitly provided" do
+      conversion_host1 = ConversionHost.new(:name => 'foo')
+      #conversion_host2 = ConversionHost.new
+      expect(conversion_host1.name).to eql('foo')
+      #expect(conversion_host2.name).to eql(redhat_host.name)
+    end
+  end
 end


### PR DESCRIPTION
Based on feedback from the V2V team, a conversion host should default to the associated resource name if no name is explicitly specified. This PR modifies the `ConversionHost` model so that it does just that on creation.