### PR TITLE
Fixing a spec failure

### DIFF
--- a/spec/factories/job.rb
+++ b/spec/factories/job.rb
@@ -3,5 +3,5 @@ FactoryBot.define do
     sequence(:name) { |n| "job_#{seq_padded_for_sorting(n)}" }
   end
 
-  factory :infra_conversion_job, :parent => :job
+  factory :infra_conversion_job, :class => 'InfraConversionJob', :parent => :job
 end

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
 
   factory :service_template_transformation_plan_task, :parent => :service_template_provision_task, :class => 'ServiceTemplateTransformationPlanTask' do
     request_type { 'transformation_plan' }
+    after(:build) do |task|
+      infra_conversion_job = FactoryBot.create(:infra_conversion_job)
+      task.options[:infra_conversion_job_id] = infra_conversion_job.id
+    end
   end
 
   # Retire Tasks


### PR DESCRIPTION
Spec failure here: https://travis-ci.org/ManageIQ/manageiq-api/jobs/501544480

A `ServiceTemplateTransformationPlanTask` cancel will cancel its related InfraConversionJob. 

