### PR TITLE
Use throw :abort in MiqUserRole#before_destroy

### DIFF
--- a/app/models/miq_user_role.rb
+++ b/app/models/miq_user_role.rb
@@ -13,7 +13,12 @@ class MiqUserRole < ApplicationRecord
 
   default_value_for :read_only, false
 
-  before_destroy { |r| raise _("Read only roles cannot be deleted.") if r.read_only }
+  before_destroy do |r|
+    if r.read_only
+      errors.add(:base, _("Read only roles cannot be deleted."))
+      throw :abort
+    end
+  end
 
   FIXTURE_PATH = File.join(FIXTURE_DIR, table_name)
   FIXTURE_YAML = "#{FIXTURE_PATH}.yml"


### PR DESCRIPTION
Use `throw :abort` instead of raising error

@miq-bot add-label technical debt, core, hammer/no, changelog/no