### PR TITLE
dynamic DatePicker value isn't being set correctly

### DIFF
--- a/app/models/dialog_field_date_control.rb
+++ b/app/models/dialog_field_date_control.rb
@@ -28,7 +28,7 @@ class DialogFieldDateControl < DialogField
 
     return default_time if automate_hash["value"].blank?
     begin
-      return DateTime.parse(automate_hash["value"]).iso8601
+      return DateTime.parse(automate_hash["value"].to_s).iso8601
     rescue
       return default_time
     end

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -85,8 +85,18 @@ describe DialogFieldDateControl do
     end
 
     context "when the automate hash has a value" do
-      context "when the value is a date format" do
+      context "when the value is a string" do
         let(:value) { "01/02/2015" }
+
+        it_behaves_like "DialogFieldDateControl#normalize_automate_values"
+
+        it "returns the value in iso format" do
+          expect(dialog_field.normalize_automate_values(automate_hash)).to eq("2015-01-02T00:00:00+00:00")
+        end
+      end
+
+      context "when the value is a date object" do
+        let(:value) { Time.utc(2015, 1, 2) }
 
         it_behaves_like "DialogFieldDateControl#normalize_automate_values"
 


### PR DESCRIPTION
Dynamic date pickers and datetime pickers are sometimes called with time objects, not strings, and so we need to ensure they're strings before we try and feed them into DateTime.parse in the model. 

normalize_automate_vals gets called with ActiveSupport::TimeWithZone.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685266
