### PR TITLE
[V2V] Use default queue priority for log download

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -149,7 +149,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     queue_options = {:class_name  => self.class,
                      :method_name => 'transformation_log',
                      :instance_id => id,
-                     :priority    => MiqQueue::HIGH_PRIORITY,
                      :args        => [log_type],
                      :zone        => conversion_host.resource.my_zone}
     MiqTask.generic_action_with_callback(task_options, queue_options)


### PR DESCRIPTION
When downloading the transformation log, we queue an async task, with high priority. There's no reason to do so, so this PR reverts to normal priority, which is the default priority.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1655124