### PR TITLE
Add the resource name to the task action for conversion hosts

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -13,7 +13,7 @@ module ConversionHost::Configurations
 
     def queue_configuration(op, instance_id, resource, params, auth_user = nil)
       task_opts = {
-        :action => "Configuring a conversion_host: operation=#{op} resource=(name: #{resource.name} type: #{resource.class.name} id:#{resource.id})",
+        :action => "Configuring a conversion_host: operation=#{op} resource=(name: #{resource.name} type: #{resource.class.name} id: #{resource.id})",
         :userid => auth_user
       }
       queue_opts = {

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -13,7 +13,7 @@ module ConversionHost::Configurations
 
     def queue_configuration(op, instance_id, resource, params, auth_user = nil)
       task_opts = {
-        :action => "Configuring a conversion_host: operation=#{op} resource=(type: #{resource.class.name} id:#{resource.id})",
+        :action => "Configuring a conversion_host: operation=#{op} resource=(name: #{resource.name} type: #{resource.class.name} id:#{resource.id})",
         :userid => auth_user
       }
       queue_opts = {

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -91,7 +91,7 @@ describe ConversionHost do
   context "queuing configuration requests" do
     let(:ext_management_system) { FactoryBot.create(:ext_management_system) }
     let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ext_management_system) }
-    let(:expected_task_action) { "Configuring a conversion_host: operation=#{op} resource=(type: #{vm.class.name} id:#{vm.id})" }
+    let(:expected_task_action) { "Configuring a conversion_host: operation=#{op} resource=(name: #{vm.name} type: #{vm.class.name} id:#{vm.id})" }
 
     context ".enable_queue" do
       let(:op) { 'enable' }

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -91,7 +91,7 @@ describe ConversionHost do
   context "queuing configuration requests" do
     let(:ext_management_system) { FactoryBot.create(:ext_management_system) }
     let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ext_management_system) }
-    let(:expected_task_action) { "Configuring a conversion_host: operation=#{op} resource=(name: #{vm.name} type: #{vm.class.name} id:#{vm.id})" }
+    let(:expected_task_action) { "Configuring a conversion_host: operation=#{op} resource=(name: #{vm.name} type: #{vm.class.name} id: #{vm.id})" }
 
     context ".enable_queue" do
       let(:op) { 'enable' }


### PR DESCRIPTION
Because there's no direct association between conversion hosts and tasks we're relying on the task description to suss them out. This PR merely modifies the task description so that it includes the resource name as well.

This would save the UI team from having to query `/api/vms` and `/api/hosts` with the IDs from the tasks just to display a name on those list items.