### PR TITLE
Remove unused system_automate_domains cause it's not called anymore

### DIFF
--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -66,10 +66,6 @@ module Vmdb
       end
     end
 
-    def system_automate_domains
-      @system_automate_domains ||= automate_domains.select(&:system?)
-    end
-
     def provider_plugins
       @provider_plugins ||= select { |engine| engine.name.start_with?("ManageIQ::Providers::") }
     end

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -31,16 +31,6 @@ describe Vmdb::Plugins do
     expect(domain).to_not be
   end
 
-  it ".system_automate_domains" do
-    automate_domains = described_class.system_automate_domains
-
-    domain = automate_domains.detect { |ac| ac.name == "ManageIQ" }
-    expect(domain.system?).to be_truthy
-
-    domain = automate_domains.detect { |ac| ac.path.to_s.include?("manageiq-ui-classic") }
-    expect(domain).to_not be
-  end
-
   describe ".asset_paths" do
     it "with normal engines" do
       asset_paths = described_class.asset_paths


### PR DESCRIPTION
Per https://github.com/ManageIQ/manageiq-automation_engine/pull/274#discussion_r248483387, we are no longer using this and it can be expunged. 
