### PR TITLE
Add ResultSetOperations module for MiqReportResult

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -274,14 +274,16 @@ class MiqReport < ApplicationRecord
     @col_format_hash ||= col_order.zip(col_formats).to_h
   end
 
-  def format_result_set(result_set)
-    tz = get_time_zone(Time.zone)
+  def format_row(row)
+    @tz ||= get_time_zone(Time.zone)
 
-    result_set.map! do |row|
-      row.map do |key, _|
-        [key, format_column(key, row, tz, col_format_hash[key])]
-      end.to_h
-    end
+    row.map do |key, _|
+      [key, format_column(key, row, @tz, col_format_hash[key])]
+    end.to_h
+  end
+
+  def format_result_set(result_set)
+    result_set.map { |row| format_row(row) }
   end
 
   def filter_result_set(result_set, options)

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -267,7 +267,7 @@ class MiqReport < ApplicationRecord
       if col_order&.include?(attr)
         attr
       else
-        raise ArgumentError, "#{attr} is not a valid attribute for #{name}"
+        raise ArgumentError, N_("#{attr} is not a valid attribute for #{name}")
       end
     end.compact
   end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -270,6 +270,10 @@ class MiqReport < ApplicationRecord
     end.compact
   end
 
+  def col_format_hash
+    @col_format_hash ||= col_order.zip(col_formats).to_h
+  end
+
   private
 
   def va_sql_cols

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -252,6 +252,24 @@ class MiqReport < ApplicationRecord
     # which does not exist in the MiqReport class
   end
 
+  def columns_for_sorting(columns)
+    columns || sortby || col_order
+  end
+
+  def validate_sorting_columns(columns)
+    validate_columns(columns_for_sorting(columns))
+  end
+
+  def validate_columns(sorting_columns)
+    sorting_columns.split(",").collect do |attr|
+      if col_order&.include?(attr)
+        attr
+      else
+        raise ArgumentError, "#{attr} is not a valid attribute for #{name}"
+      end
+    end.compact
+  end
+
   private
 
   def va_sql_cols

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -289,9 +289,9 @@ class MiqReport < ApplicationRecord
   def filter_result_set(result_set, options)
     filter_columns = validate_columns(options[:filter_column])
     formatted_result_set = format_result_set(result_set, filter_columns)
-    result_set_filtered_ids = formatted_result_set.map { |x| x[options[:filter_column]].include?(options[:filter_string]) ? x['id'].to_i : nil }.compact
+    result_set_filtered = formatted_result_set.select { |x| x[options[:filter_column]].include?(options[:filter_string]) }
 
-    [result_set.select! { |x| result_set_filtered_ids.include?(x['id']) }, result_set_filtered_ids.count]
+    [result_set_filtered, result_set_filtered.count]
   end
 
   private

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -253,6 +253,8 @@ class MiqReport < ApplicationRecord
   end
 
   def columns_for_sorting(columns)
+    columns = columns.split(",") if columns && columns.kind_of?(String)
+
     columns || sortby || col_order
   end
 
@@ -261,7 +263,7 @@ class MiqReport < ApplicationRecord
   end
 
   def validate_columns(sorting_columns)
-    sorting_columns.split(",").collect do |attr|
+    Array(sorting_columns).collect do |attr|
       if col_order&.include?(attr)
         attr
       else

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -274,22 +274,23 @@ class MiqReport < ApplicationRecord
     @col_format_hash ||= col_order.zip(col_formats).to_h
   end
 
-  def format_row(row)
+  def format_row(row, allowed_columns = nil)
     @tz ||= get_time_zone(Time.zone)
 
     row.map do |key, _|
-      [key, format_column(key, row, @tz, col_format_hash[key])]
+      [key, allowed_columns.nil? || allowed_columns&.include?(key) ? format_column(key, row, @tz, col_format_hash[key]) : row[key]]
     end.to_h
   end
 
-  def format_result_set(result_set)
-    result_set.map { |row| format_row(row) }
+  def format_result_set(result_set, skip_columns = nil)
+    result_set.map { |row| format_row(row, skip_columns) }
   end
 
   def filter_result_set(result_set, options)
-    filter_columns = validate_columns(options[:filter_column]) + ['id']
-    formatted_result_set = format_result_set(result_set.map { |x| x.slice(*filter_columns) })
+    filter_columns = validate_columns(options[:filter_column])
+    formatted_result_set = format_result_set(result_set, filter_columns)
     result_set_filtered_ids = formatted_result_set.map { |x| x[options[:filter_column]].include?(options[:filter_string]) ? x['id'].to_i : nil }.compact
+
     [result_set.select! { |x| result_set_filtered_ids.include?(x['id']) }, result_set_filtered_ids.count]
   end
 

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -1,5 +1,6 @@
 class MiqReportResult < ApplicationRecord
   include_concern 'Purging'
+  include_concern 'ResultSetOperations'
 
   belongs_to :miq_report
   belongs_to :miq_group
@@ -51,6 +52,14 @@ class MiqReportResult < ApplicationRecord
   after_commit { report.extras[:grouping] = @_extra_groupings if report.kind_of?(MiqReport) && report.extras }
 
   delegate :table, :to => :report_results, :allow_nil => true
+
+  def result_set_for_reporting(options)
+    self.class.result_set_for_reporting(self, options)
+  end
+
+  def report_or_miq_report
+    report || miq_report
+  end
 
   def friendly_title
     report_source == MiqWidget::WIDGET_REPORT_SOURCE && miq_widget_content ? miq_widget_content.miq_widget.title : report.title

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -32,8 +32,8 @@ module MiqReportResult::ResultSetOperations
       count_of_full_result_set = result_set.count
       if result_set.present? && report
         result_set, count_of_full_result_set = filter_result_set(report, result_set, options) if options.key?(:filter_column) && options.key?(:filter_string)
-        result_set = result_set.stable_sort_by(sorting_columns, options[:sort_order])
         result_set.map! { |x| x.slice(*report.col_order) }
+        result_set = result_set.stable_sort_by(sorting_columns, options[:sort_order])
         result_set = apply_limit_and_offset(result_set, options)
       end
 

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -1,0 +1,36 @@
+module MiqReportResult::ResultSetOperations
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def apply_limit_and_offset(results, options)
+      results.slice(options['offset'].to_i, options['limit'].to_i) || []
+    end
+
+    def format_result_set(miq_report, result_set)
+      tz = miq_report.get_time_zone(Time.zone)
+
+      col_format_hash = miq_report.col_order.zip(miq_report.col_formats).to_h
+
+      result_set.map! do |row|
+        row.map do |key, _|
+          [key, miq_report.format_column(key, row, tz, col_format_hash[key])]
+        end.to_h
+      end
+    end
+
+    def result_set_for_reporting(report_result, options)
+      report = report_result.report_or_miq_report
+      sorting_columns = report.validate_sorting_columns(options[:sort_by])
+      result_set = report_result.result_set
+      count_of_full_result_set = result_set.count
+
+      if result_set.present? && report
+        result_set = result_set.stable_sort_by(sorting_columns, options[:sort_order])
+        result_set.map! { |x| x.slice(*report.col_order) }
+        result_set = apply_limit_and_offset(result_set, options)
+      end
+
+      {:result_set => format_result_set(report, result_set), :count_of_full_result_set => count_of_full_result_set}
+    end
+  end
+end

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -12,13 +12,17 @@ module MiqReportResult::ResultSetOperations
       result_set = report_result.result_set
       count_of_full_result_set = result_set.count
       if result_set.present? && report
-        result_set, count_of_full_result_set = report.filter_result_set(result_set, options) if options.key?(:filter_column) && options.key?(:filter_string)
+        if options.key?(:filter_column) && options.key?(:filter_string)
+          result_set, count_of_full_result_set = report.filter_result_set(result_set, options)
+          allowed_columns_to_format = report.col_order - [options[:filter_column]]
+        end
+
         result_set.map! { |x| x.slice(*report.col_order) }
         result_set = result_set.stable_sort_by(sorting_columns, options[:sort_order])
         result_set = apply_limit_and_offset(result_set, options)
       end
 
-      {:result_set => report.format_result_set(result_set), :count_of_full_result_set => count_of_full_result_set}
+      {:result_set => report.format_result_set(result_set, allowed_columns_to_format), :count_of_full_result_set => count_of_full_result_set}
     end
   end
 end

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -6,36 +6,19 @@ module MiqReportResult::ResultSetOperations
       results.slice(options['offset'].to_i, options['limit'].to_i) || []
     end
 
-    def format_result_set(miq_report, result_set)
-      tz = miq_report.get_time_zone(Time.zone)
-
-      result_set.map! do |row|
-        row.map do |key, _|
-          [key, miq_report.format_column(key, row, tz, miq_report.col_format_hash[key])]
-        end.to_h
-      end
-    end
-
-    def filter_result_set(report, result_set, options)
-      filter_columns = report.validate_columns(options[:filter_column]) + ['id']
-      formatted_result_set = format_result_set(report, result_set.map { |x| x.slice(*filter_columns) })
-      result_set_filtered_ids = formatted_result_set.map { |x| x[options[:filter_column]].include?(options[:filter_string]) ? x['id'].to_i : nil }.compact
-      [result_set.select! { |x| result_set_filtered_ids.include?(x['id']) }, result_set_filtered_ids.count]
-    end
-
     def result_set_for_reporting(report_result, options)
       report = report_result.report_or_miq_report
       sorting_columns = report.validate_sorting_columns(options[:sort_by])
       result_set = report_result.result_set
       count_of_full_result_set = result_set.count
       if result_set.present? && report
-        result_set, count_of_full_result_set = filter_result_set(report, result_set, options) if options.key?(:filter_column) && options.key?(:filter_string)
+        result_set, count_of_full_result_set = report.filter_result_set(result_set, options) if options.key?(:filter_column) && options.key?(:filter_string)
         result_set.map! { |x| x.slice(*report.col_order) }
         result_set = result_set.stable_sort_by(sorting_columns, options[:sort_order])
         result_set = apply_limit_and_offset(result_set, options)
       end
 
-      {:result_set => format_result_set(report, result_set), :count_of_full_result_set => count_of_full_result_set}
+      {:result_set => report.format_result_set(result_set), :count_of_full_result_set => count_of_full_result_set}
     end
   end
 end

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -9,11 +9,9 @@ module MiqReportResult::ResultSetOperations
     def format_result_set(miq_report, result_set)
       tz = miq_report.get_time_zone(Time.zone)
 
-      col_format_hash = miq_report.col_order.zip(miq_report.col_formats).to_h
-
       result_set.map! do |row|
         row.map do |key, _|
-          [key, miq_report.format_column(key, row, tz, col_format_hash[key])]
+          [key, miq_report.format_column(key, row, tz, miq_report.col_format_hash[key])]
         end.to_h
       end
     end


### PR DESCRIPTION
pulled from https://github.com/ManageIQ/manageiq-api/pull/547 ([commit](https://github.com/ManageIQ/manageiq-api/pull/547/commits/d1c2a88a7e3611067fb77902a08dfc96776367d6))

those methods are used for **sorting, ordering and filtering report resul**t stored in `MiqReportResult#result_set`
and it probably make more sense to have this in core.

Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1678150 (part)
* https://github.com/ManageIQ/manageiq-api/pull/547


@miq-bot assign @kbrock 


