### PR TITLE
Remove deprecation warning for AR::Connection#table_exists?

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,6 +1,6 @@
 module ArPglogicalMigrationHelper
   def self.discover_schema_migrations_ran_class
-    return unless ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
+    return unless ActiveRecord::Base.connection.data_source_exists?("schema_migrations_ran")
     Class.new(ActiveRecord::Base) do
       require 'active_record-id_regions'
       include ActiveRecord::IdRegions

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -1,7 +1,7 @@
 describe ArPglogicalMigrationHelper do
   shared_context "without the schema_migrations_ran table" do
     before do
-      allow(ActiveRecord::Base.connection).to receive(:table_exists?).with("schema_migrations_ran").and_return(false)
+      allow(ActiveRecord::Base.connection).to receive(:data_source_exists?).with("schema_migrations_ran").and_return(false)
     end
   end
 

--- a/tools/radar/rollup_radar_mixin.rb
+++ b/tools/radar/rollup_radar_mixin.rb
@@ -18,7 +18,7 @@ module RollupRadarMixin
       :database => "db/radar.sqlite3"
     )
 
-    unless connection.table_exists?(:max_by_labels)
+    unless connection.data_source_exists?(:max_by_labels)
       connection.create_table :max_by_labels do |t|
         t.datetime :timestamp
         t.string   :label_name


### PR DESCRIPTION
The warning was:

DEPRECATION WARNING: #table_exists? currently checks both tables and
views. This behavior is deprecated and will be changed with Rails 5.1 to
only check tables. Use #data_source_exists? instead. (called from
discover_schema_migrations_ran_class at
/home/travis/build/ManageIQ/manageiq/lib/extensions/ar_migration.rb:3)

@jrafanie Please review
cc @carbonin (because it's in pglogical)