### PR TITLE
Use throw :abort in Tenant#before_destroy

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -359,8 +359,9 @@ class Tenant < ApplicationRecord
   end
 
   def ensure_can_be_destroyed
-    raise _("A tenant with groups associated cannot be deleted.") if miq_groups.non_tenant_groups.exists?
-    raise _("A tenant created by tenant mapping cannot be deleted") if source
+    errors.add(:base, _("A tenant with groups associated cannot be deleted.")) if miq_groups.non_tenant_groups.exists?
+    errors.add(:base, _("A tenant created by tenant mapping cannot be deleted.")) if source
+    throw :abort unless errors[:base].empty?
   end
 
   def validate_default_tenant

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -242,12 +242,14 @@ describe Tenant do
 
     it "wouldn't delete tenant with groups associated" do
       FactoryBot.create(:miq_group, :tenant => tenant)
-      expect { tenant.destroy! }.to raise_error(RuntimeError, /A tenant with groups.*cannot be deleted/)
+      expect { tenant.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      expect(tenant.errors.full_messages[0]).to eq("A tenant with groups associated cannot be deleted.")
     end
 
     it "does not delete tenant created by tenant mapping process" do
       tenant.source = cloud_tenant
-      expect { tenant.destroy! }.to raise_error(RuntimeError, /A tenant created by tenant mapping cannot be deleted/)
+      expect { tenant.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      expect(tenant.errors.full_messages[0]).to eq("A tenant created by tenant mapping cannot be deleted.")
     end
   end
 


### PR DESCRIPTION
Use `throw :abort` instead of raising error

@miq-bot add-label technical debt, core, hammer/no, changelog/no