### PR TITLE
[V2V] Fix placeholder name for conversion hosts

### DIFF
--- a/db/fixtures/notification_types.yml
+++ b/db/fixtures/notification_types.yml
@@ -191,12 +191,12 @@
   :level: :error
   :audience: global
 - :name: conversion_host_config_success
-  :message: 'Conversion Host %{op_name} of resource %{resource} completed successfully.'
+  :message: 'Conversion Host %{op_name} of resource %{op_arg} completed successfully.'
   :expires_in: 24.hours
   :level: :success
   :audience: global
 - :name: conversion_host_config_failure
-  :message: 'Conversion Host %{op_name} of resource %{resource} failed. Please check the logs for further details.'
+  :message: 'Conversion Host %{op_name} of resource %{op_arg} failed. Please check the logs for further details.'
   :expires_in: 24.hours
   :level: :error
   :audience: global


### PR DESCRIPTION
The placeholder for notification messages in the `notification_types.yml` needs to match what we use internally within `ConversionHost::Configurations`, which is `op_arg`. You can see that used here:

https://github.com/ManageIQ/manageiq/blob/master/app/models/conversion_host/configurations.rb#L9