### PR TITLE
[V2V] Add validation on VM name based on destination EMS

### DIFF
--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -142,11 +142,13 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def validate_vm_name_rhevm(vm)
-    vm.name =~ /^[\\p{L}0-9._-]*$/
+    # Regexp from oVirt code: frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/validation/BaseI18NValidation.java
+    vm.name =~ /^[\p{L}0-9._-]*$/
   end
 
   def validate_vm_name_openstack(vm)
-    true
+    # Regexp decided after discussion with Bernard Cafarelli
+    vm.name =~ /^[[:graph:]\s]*$/
   end
 
   class VmMigrateStruct < MiqHashStruct

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -148,7 +148,7 @@ class TransformationMapping::VmMigrationValidator
 
   def validate_vm_name_openstack(vm)
     # Regexp decided after discussion with Bernard Cafarelli
-    vm.name =~ /^[[:graph:]\s]*$/
+    vm.name =~ /^[[:graph:]\s]+$/
   end
 
   class VmMigrateStruct < MiqHashStruct

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -138,7 +138,7 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def validate_vm_name(vm)
-    send("validate_vm_name_#{destination_cluster(vm).emstype}", vm) ? VM_VALID : VM_UNSUPPORTED_NAME
+    send("validate_vm_name_#{destination_cluster(vm).ext_management_system.emstype}", vm) ? VM_VALID : VM_UNSUPPORTED_NAME
   end
 
   def validate_vm_name_rhevm(vm)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -134,7 +134,7 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def destination_cluster(vm)
-    @mapping.transformation_mapping_items.find(:source_type => 'EmsCluster', :source_id => vm.ems_cluster.id).destination
+    @mapping.transformation_mapping_items.find_by(:source_type => 'EmsCluster', :source_id => vm.ems_cluster.id).destination
   end
 
   def validate_vm_name(vm)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -133,9 +133,8 @@ class TransformationMapping::VmMigrationValidator
     @mapped_lans ||= Lan.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Lan').select(:source_id))
   end
 
-  # rubocop: disable Naming/UncommunicativeMethodParamName
   def destination_cluster(vm)
-    @mapping.transformation_mapping_items.find_by(:source_type => 'EmsCluster', :source_id => vm.ems_cluster.id).destination
+    @mapping.transformation_mapping_items.find_by(:source => vm.ems_cluster)&.destination
   end
 
   def validate_vm_name(vm)
@@ -151,7 +150,6 @@ class TransformationMapping::VmMigrationValidator
     # Regexp decided after discussion with Bernard Cafarelli
     vm.name =~ /^[[:graph:]\s]+$/
   end
-  # rubocop: enable Naming/UncommunicativeMethodParamName
 
   class VmMigrateStruct < MiqHashStruct
     def initialize(vm_name, vm, status, reason)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -151,6 +151,7 @@ class TransformationMapping::VmMigrationValidator
     # Regexp decided after discussion with Bernard Cafarelli
     vm.name =~ /^[[:graph:]\s]+$/
   end
+  # rubocop: enable Naming/UncommunicativeMethodParamName
 
   class VmMigrateStruct < MiqHashStruct
     def initialize(vm_name, vm, status, reason)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -133,6 +133,7 @@ class TransformationMapping::VmMigrationValidator
     @mapped_lans ||= Lan.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Lan').select(:source_id))
   end
 
+  # rubocop: disable Naming/UncommunicativeMethodParamName
   def destination_cluster(vm)
     @mapping.transformation_mapping_items.find_by(:source_type => 'EmsCluster', :source_id => vm.ems_cluster.id).destination
   end

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TransformationMapping, :v2v do
   let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
   let(:dst_cluster_redhat) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems_redhat) }
   let(:dst_cloud_tenant_openstack) { FactoryBot.create(:cloud_tenant, :ext_management_system => dst_ems_openstack) }
-  let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src_cluster) }
+  let(:vm) { FactoryBot.create(:vm_vmware, :ems_cluster => src_cluster) }
 
   let(:mapping_redhat) do
     FactoryBot.create(

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,61 +1,84 @@
 RSpec.describe TransformationMapping, :v2v do
   let(:src_ems) { FactoryBot.create(:ems_vmware) }
-  let(:dst_ems) { FactoryBot.create(:ems_redhat) }
-  let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
-  let(:dst) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
-  let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src) }
+  let(:dst_ems_redhat) { FactoryBot.create(:ems_redhat) }
+  let(:dst_ems_openstack) { FactoryBot.create(:ems_openstack) }
+  let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
+  let(:dst_cluster_redhat) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems_redhat) }
+  let(:dst_cloud_tenant_openstack) { FactoryBot.create(:cloud_tenant, :ext_management_system => dst_ems_openstack) }
+  let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src_cluster) }
 
-  let(:mapping) do
+  let(:mapping_redhat) do
     FactoryBot.create(
       :transformation_mapping,
-      :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster_redhat)]
+    )
+  end
+
+  let(:mapping_openstack) do
+    FactoryBot.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cloud_tenant_openstack)]
     )
   end
 
   describe '#destination' do
     it "finds the destination" do
-      expect(mapping.destination(src)).to eq(dst)
+      expect(mapping_redhat.destination(src_cluster)).to eq(dst_cluster_redhat)
     end
 
     it "returns nil for unmapped source" do
-      expect(mapping.destination(FactoryBot.create(:ems_cluster))).to be_nil
+      expect(mapping_redhat.destination(FactoryBot.create(:ems_cluster))).to be_nil
     end
   end
 
   describe '#service_templates' do
     let(:plan) { FactoryBot.create(:service_template_transformation_plan) }
-    before { FactoryBot.create(:service_resource, :resource => mapping, :service_template => plan) }
+    before { FactoryBot.create(:service_resource, :resource => mapping_redhat, :service_template => plan) }
 
     it 'finds the transformation plans' do
-      expect(mapping.service_templates).to match([plan])
+      expect(mapping_redhat.service_templates).to match([plan])
     end
   end
 
   describe '#search_vms_and_validate' do
-    let(:vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
-    let(:vm2) { FactoryBot.create(:vm_vmware, :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
-    let(:inactive_vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src, :ext_management_system => nil) }
+    let(:vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src_cluster, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :ems_cluster => src_cluster, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:inactive_vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src_cluster, :ext_management_system => nil) }
     let(:storage) { FactoryBot.create(:storage) }
     let(:lan) { FactoryBot.create(:lan) }
     let(:nic) { FactoryBot.create(:guest_device_nic, :lan => lan) }
 
     before do
-      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => storage, :destination => storage)
-      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => lan, :destination => lan)
+      mapping_redhat.transformation_mapping_items << TransformationMappingItem.new(:source => storage, :destination => storage)
+      mapping_redhat.transformation_mapping_items << TransformationMappingItem.new(:source => lan, :destination => lan)
       vm.storages << storage
       vm.hardware = FactoryBot.create(:hardware, :guest_devices => [nic])
     end
 
     context 'with VM list' do
       context 'returns invalid vms' do
+        it 'if VM has an invalid name in rhevm' do
+          name = ' not allowed'
+          FactoryBot.create(:vm_vmware, :name => name, :ems_cluster => src_cluster, :ext_management_system => src_ems)
+          result = mapping_redhat.search_vms_and_validate(['name' => name])
+          expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_UNSUPPORTED_NAME)
+        end
+
+        it 'if VM has an invalid name in rhevm' do
+          name = 7.chr # beep, non-printable
+          FactoryBot.create(:vm_vmware, :name => name, :ems_cluster => src_cluster, :ext_management_system => src_ems)
+          result = mapping_openstack.search_vms_and_validate(['name' => name])
+          expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_UNSUPPORTED_NAME)
+        end
+
         it 'if VM does not exist' do
-          result = mapping.search_vms_and_validate(['name' => 'vm1'])
+          result = mapping_redhat.search_vms_and_validate(['name' => 'vm1'])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_NOT_EXIST)
         end
 
         it 'if VM is inactive' do
           inactive_vm.storages << FactoryBot.create(:storage, :name => 'storage_for_inactive_vm')
-          result = mapping.search_vms_and_validate(['name' => 'test_vm_inactive'])
+          result = mapping_redhat.search_vms_and_validate(['name' => 'test_vm_inactive'])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_INACTIVE)
         end
 
@@ -66,26 +89,26 @@ RSpec.describe TransformationMapping, :v2v do
             :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
             :ext_management_system => FactoryBot.create(:ext_management_system)
           )
-          result = mapping.search_vms_and_validate(['name' => 'vm2'])
+          result = mapping_redhat.search_vms_and_validate(['name' => 'vm2'])
           expect(result['invalid'].first.reason).to match(/not_exist/)
         end
 
         it "if VM's storages are not all in the mapping" do
           vm.storages << FactoryBot.create(:storage, :name => 'storage2')
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2/)
         end
 
         it "if VM's lans are not all in the mapping" do
           vm.hardware.guest_devices << FactoryBot.create(:guest_device_nic, :lan =>FactoryBot.create(:lan, :name => 'lan2'))
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - lans: lan2/)
         end
 
         it "if any source is invalid" do
           vm.storages << FactoryBot.create(:storage, :name => 'storage2')
           vm.hardware.guest_devices << FactoryBot.create(:guest_device_nic, :lan =>FactoryBot.create(:lan, :name => 'lan2'))
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2. lans: lan2/)
         end
 
@@ -98,7 +121,7 @@ RSpec.describe TransformationMapping, :v2v do
               :status           => status
             )
 
-            result = mapping.search_vms_and_validate(['name' => vm.name])
+            result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
             expect(result['invalid'].first.reason).to match(/in_other_plan/)
           end
         end
@@ -111,20 +134,20 @@ RSpec.describe TransformationMapping, :v2v do
             :status           => 'Completed'
           )
 
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/migrated/)
         end
       end
 
       it 'returns valid vms' do
-        result = mapping.search_vms_and_validate(['name' => vm.name])
+        result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
         expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
         expect(result['valid'].first.ems_cluster_id).to eq(vm.ems_cluster_id.to_s)
       end
 
       it 'returns conflict vms' do
-        FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system))
-        result = mapping.search_vms_and_validate(['name' => vm.name])
+        FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src_cluster, :ext_management_system => FactoryBot.create(:ext_management_system))
+        result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
         expect(result['conflicted'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_CONFLICT)
       end
     end
@@ -139,7 +162,7 @@ RSpec.describe TransformationMapping, :v2v do
           :service_template => service_template,
           :status           => "Active"
         )
-        result = mapping.search_vms_and_validate(['name' => vm2.name], service_template.id.to_s)
+        result = mapping_redhat.search_vms_and_validate(['name' => vm2.name], service_template.id.to_s)
         expect(result['valid'].first.reason).to match(/ok/)
       end
 
@@ -153,14 +176,14 @@ RSpec.describe TransformationMapping, :v2v do
           :service_template => service_template,
           :status           => "Active"
         )
-        result = mapping.search_vms_and_validate(['name' => vm2.name], service_template2.id.to_s)
+        result = mapping_redhat.search_vms_and_validate(['name' => vm2.name], service_template2.id.to_s)
         expect(result['invalid'].first.reason).to match(/in_other_plan/)
       end
     end
 
     context 'without VM list' do
       it 'returns valid vms' do
-        result = mapping.search_vms_and_validate
+        result = mapping_redhat.search_vms_and_validate
         expect(result['valid'].count).to eq(1)
       end
 
@@ -171,7 +194,7 @@ RSpec.describe TransformationMapping, :v2v do
           :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
           :ext_management_system => FactoryBot.create(:ext_management_system)
         )
-        result = mapping.search_vms_and_validate
+        result = mapping_redhat.search_vms_and_validate
         expect(result['valid'].count).to eq(1)
       end
     end


### PR DESCRIPTION
We know that some VM names are invalid in RHV and OpenStack. For example, RHV doesn't allow space and punctuation, and OpenStack doesn't allow special characters. The goal is to identify VMs in source provider whose name will not be allowed by the destination provider and make them unselectable in the UI.

This pull request adds a validation on the VM name to make VMs with invalid name unselectable.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1685948#c2