### PR TITLE
[V2V] Generate extra vars for conversion host playbooks

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -99,7 +99,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh',
       :v2v_vddk_package_url => vddk_package_url,
       :v2v_ssh_private_key  => ssh_private_key,
-      :v2v_ca_bundle            => resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars)
   ensure

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -91,9 +91,9 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vddk_package_url = nil, ssh_private_key = nil)
-    raise "vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && v2v_vddk_package_url.nil?
-    raise "ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_support && ssh_private_key.nil?
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil)
+    raise "vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
+    raise "ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_support && vmware_ssh_private_key.nil?
     playbook = "/usr/share/ovirt-ansible-v2v-conversion-host/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh',

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -93,7 +93,7 @@ class ConversionHost < ApplicationRecord
 
   def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil)
     raise "vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
-    raise "ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_support && vmware_ssh_private_key.nil?
+    raise "ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/ovirt-ansible-v2v-conversion-host/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh',

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -92,8 +92,8 @@ class ConversionHost < ApplicationRecord
   end
 
   def enable_conversion_host_role(vddk_package_url = nil, ssh_private_key = nil)
-    raise "vddk_package_url is mandatory if transformation method is vddk") if vddk_transport_supported && v2v_vddk_package_url.nil?
-    raise "ssh_private_key is mandatory if transformation_method is ssh") if ssh_transport_support && ssh_private_key.nil?
+    raise "vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && v2v_vddk_package_url.nil?
+    raise "ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_support && ssh_private_key.nil?
     playbook = "/usr/share/ovirt-ansible-v2v-conversion-host/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh',

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -97,8 +97,8 @@ class ConversionHost < ApplicationRecord
     playbook = "/usr/share/ovirt-ansible-v2v-conversion-host/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh',
-      :v2v_vddk_package_url => vddk_package_url,
-      :v2v_ssh_private_key  => ssh_private_key,
+      :v2v_vddk_package_url => vmware_vddk_package_url,
+      :v2v_ssh_private_key  => vmware_ssh_private_key,
       :v2v_ca_bundle        => resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars)

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -44,11 +44,13 @@ module ConversionHost::Configurations
       params.delete(:task_id)     # In case this is being called through *_queue which will stick in a :task_id
       params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
 
-      vddk_package_url = params.delete(:vddk_package_url)
+      vmware_vddk_package_url = params.delete(:vmware_vddk_package_url)
+      params[:vddk_transport_supported] = !vmware_vddk_package_url.nil?
       vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
-
+      params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
+      
       conversion_host = new(params)
-      conversion_host.enable_conversion_host_role(vddk_package_url, vmware_ssh_private_key)
+      conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
       conversion_host.save!
       conversion_host
     rescue StandardError => error

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -44,10 +44,11 @@ module ConversionHost::Configurations
       params.delete(:task_id)     # In case this is being called through *_queue which will stick in a :task_id
       params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
 
-      vddk_url = params.delete(:param_v2v_vddk_package_url)
+      vddk_package_url = params.delete(:vddk_package_url)
+      vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
 
       conversion_host = new(params)
-      conversion_host.enable_conversion_host_role(vddk_url)
+      conversion_host.enable_conversion_host_role(vddk_package_url, vmware_ssh_private_key)
       conversion_host.save!
       conversion_host
     rescue StandardError => error

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -48,7 +48,7 @@ module ConversionHost::Configurations
       params[:vddk_transport_supported] = !vmware_vddk_package_url.nil?
       vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
       params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
-      
+
       conversion_host = new(params)
       conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
       conversion_host.save!

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 describe ConversionHost do
   let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
   let(:conversion_host_ssh) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -1,5 +1,9 @@
+require 'byebug'
+
 describe ConversionHost do
-  let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }
+  let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+  let(:conversion_host_ssh) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }
+  let(:conversion_host_vddk) { FactoryBot.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }
   let(:params) do
     {
       :name          => 'transformer',
@@ -40,15 +44,34 @@ describe ConversionHost do
         expect { described_class.enable(params) }.to raise_error(StandardError)
       end
 
-      it "tags the associated resource as expected" do
-        allow(conversion_host).to receive(:enable_conversion_host_role)
-        taggings = conversion_host.resource.taggings
-        tag_names = taggings.map { |tagging| tagging.tag.name }
+      context "transport method is SSH" do
+        let(:conversion_host) { conversion_host_ssh }
 
-        expect(tag_names).to contain_exactly(
-          '/user/v2v_transformation_host/true',
-          '/user/v2v_transformation_method/ssh'
-        )
+        it "tags the associated resource as expected" do
+          allow(conversion_host).to receive(:enable_conversion_host_role)
+          taggings = conversion_host.resource.taggings
+          tag_names = taggings.map { |tagging| tagging.tag.name }
+
+          expect(tag_names).to contain_exactly(
+            '/user/v2v_transformation_host/true',
+            '/user/v2v_transformation_method/ssh'
+          )
+        end
+      end
+
+      context "transport method is VDDK" do
+        let(:conversion_host) { conversion_host_vddk }
+
+        it "tags the associated resource as expected" do
+          allow(conversion_host).to receive(:enable_conversion_host_role)
+          taggings = conversion_host.resource.taggings
+          tag_names = taggings.map { |tagging| tagging.tag.name }
+
+          expect(tag_names).to contain_exactly(
+            '/user/v2v_transformation_host/true',
+            '/user/v2v_transformation_method/vddk'
+          )
+        end
       end
     end
 


### PR DESCRIPTION
The conversion host playbooks will be called from ManageIQ appliance. The variables for the oVirt.v2v-conversion-host role are documented in https://github.com/oVirt/v2v-conversion-host/blob/master/docs/Ansible.md (refactor in progress at time of PR filing). A lot of these variables are not relevant when the playbook is run by ManageIQ, so we don't have to implement them. The minimal set of variables comes either from user dialogs or from the VMDB. This PR implement this minimal set.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1622728