### PR TITLE
Deprecate invalid custom attribute names

### DIFF
--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -93,6 +93,40 @@ describe CustomAttributeMixin do
     end
   end
 
+  context ".add_custom_attribute" do
+    it "regular key" do
+      test_class.add_custom_attribute("foo")
+      expect(test_class.new).to respond_to(:foo)
+      expect(test_class.new).to respond_to(:foo=)
+    end
+
+    it "key with a letter followed by a number" do
+      test_class.add_custom_attribute("fun4all")
+      expect(test_class.new).to respond_to(:"fun4all")
+      expect(test_class.new).to respond_to(:"fun4all=")
+    end
+
+    it "key with a space(deprecated)" do
+      ActiveSupport::Deprecation.silence { test_class.add_custom_attribute("exit message") }
+      expect(test_class.new).to respond_to(:"exit message")
+      expect(test_class.new).to respond_to(:"exit message=")
+    end
+
+    it "key with leading number(deprecated)" do
+      ActiveSupport::Deprecation.silence { test_class.add_custom_attribute("4fun") }
+      expect(test_class.new).to respond_to(:"4fun")
+      expect(test_class.new).to respond_to(:"4fun=")
+    end
+  end
+
+  it "#miq_custom_set with a space(deprecated)" do
+    object = test_class.create!
+    ActiveSupport::Deprecation.silence { object.miq_custom_set("hello world", "baz") }
+    ca = CustomAttribute.find_by(:resource_type => test_class.name, :resource_id => object.id)
+    expect(ca.name).to  eq("hello world")
+    expect(ca.value).to eq("baz")
+  end
+
   it "#miq_custom_set" do
     supported_factories.each do |factory_name|
       object = FactoryBot.create(factory_name)


### PR DESCRIPTION
add_custom_attribute/miq_custom_set will now log a deprecation if we try
to define or add a custom attribute name that is an invalid column name.

https://bugzilla.redhat.com/show_bug.cgi?id=1662319

From:
https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS

SQL identifiers and key words must begin with a letter (a-z, but also
letters with diacritical marks and non-Latin letters) or an underscore
(_). Subsequent characters in an identifier or key word can be letters,
underscores, digits (0-9), or dollar signs ($). Note that dollar signs
are not allowed in identifiers according to the letter of the SQL
standard, so their use might render applications less portable. The SQL
standard will not define a key word that contains digits or starts or
ends with an underscore, so identifiers of this form are safe against
possible conflict with future extensions of the standard.

Similar to https://bugzilla.redhat.com/show_bug.cgi?id=1558618