### PR TITLE
[V2V] Add conversion_host.id to task options

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -48,15 +48,15 @@ module ConversionHost::Configurations
       vddk_url = params.delete(:param_v2v_vddk_package_url)
 
       conversion_host = new(params)
+      conversion_host.enable_conversion_host_role(vddk_url)
+      conversion_host.save!
 
-      unless task_id.nil?
+      if task_id.present?
         task = MiqTask.find(task_id)
         task.options[:conversion_host_id] = conversion_host.id
         task.save!
       end
 
-      conversion_host.enable_conversion_host_role(vddk_url)
-      conversion_host.save!
       conversion_host
     rescue StandardError => error
       raise


### PR DESCRIPTION
The conversion host configuration is asynchronous and we need to associate the async task with the conversion host, so that we can manipulate the tasks in the UI. For example, we only show the last configuration task for a given conversion host in the UI. This PR add the conversion host id to the enablement task options. The disable task is not required as it destroys the conversion host.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1622728