### PR TITLE
[V2V] Set context data for the task associated with conversion host creation

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -28,11 +28,14 @@ module ConversionHost::Configurations
 
       task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
 
-      # Set the context_data after the fact because the above call only accepts certain
-      # options while ignoring the rest. Useful for a retry option in the UI.
+      # Set the context_data after the fact because the above call only accepts
+      # certain options while ignoring the rest. We also don't want to store
+      # any ssh key information. Useful for a retry option in the UI, and
+      # informational purposes in general.
       #
       MiqTask.find(task_id).tap do |task|
-        task.context_data = params.first&.except(:task_id, :miq_task_id)
+        params = params.first&.except(:task_id, :miq_task_id)
+        task.context_data = params&.reject { |key, value| key.to_s.end_with?('_key') }
         task.save
       end
 

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -34,8 +34,9 @@ module ConversionHost::Configurations
       # informational purposes in general.
       #
       MiqTask.find(task_id).tap do |task|
-        params = params.first&.except(:task_id, :miq_task_id)
-        task.context_data = params&.reject { |key, value| key.to_s.end_with?('_key') }
+        params = params&.except(:task_id, :miq_task_id)
+        hash = {:request_params => params&.reject { |key, value| key.to_s.end_with?('private_key') }}
+        task.context_data = hash
         task.save
       end
 
@@ -56,13 +57,14 @@ module ConversionHost::Configurations
       params = params.symbolize_keys
       _log.info("Enabling a conversion_host with parameters: #{params}")
 
-      params.delete(:task_id)     # In case this is being called through *_queue which will stick in a :task_id
-      params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
+      params.delete(:task_id) # In case this is being called through *_queue which will stick in a :task_id
+      miq_task_id = params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
 
       vmware_vddk_package_url = params.delete(:vmware_vddk_package_url)
-      params[:vddk_transport_supported] = !vmware_vddk_package_url.nil?
+      params[:vddk_transport_supported] = vmware_vddk_package_url.present?
+
       vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
-      params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
+      params[:ssh_transport_supported] = vmware_ssh_private_key.present?
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
@@ -78,6 +80,13 @@ module ConversionHost::Configurations
 
         conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
         conversion_host.save!
+
+        if miq_task_id
+          MiqTask.find(miq_task_id).tap do |task|
+            task.context_data.to_h[:conversion_host_id] = conversion_host.id
+            task.save
+          end
+        end
       end
     rescue StandardError => error
       raise

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -35,7 +35,7 @@ module ConversionHost::Configurations
       #
       MiqTask.find(task_id).tap do |task|
         params = params&.except(:task_id, :miq_task_id)
-        hash = {:request_params => params&.reject { |key, value| key.to_s.end_with?('private_key') }}
+        hash = {:request_params => params&.reject { |key, _value| key.to_s.end_with?('private_key') }}
         task.context_data = hash
         task.save
       end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -119,7 +119,7 @@ describe ConversionHost do
 
       it "to queue with a task" do
         task_id = described_class.enable_queue(params)
-        expected_context_data = params.except(:resource)
+        expected_context_data = {:request_params => params.except(:resource)}
 
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
         expect(MiqQueue.first).to have_attributes(
@@ -133,8 +133,8 @@ describe ConversionHost do
       end
 
       it "rejects ssh key information as context data" do
-        task_id = described_class.enable_queue(params.merge(:ssh_key => 'xxx', :vmware_ssh_private_key => 'yyy'))
-        expected_context_data = params.except(:resource)
+        task_id = described_class.enable_queue(params.merge(:conversion_host_ssh_private_key => 'xxx', :vmware_ssh_private_key => 'yyy'))
+        expected_context_data = {:request_params => params.except(:resource)}
 
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
       end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -131,6 +131,13 @@ describe ConversionHost do
           :zone        => vm.ext_management_system.my_zone
         )
       end
+
+      it "rejects ssh key information as context data" do
+        task_id = described_class.enable_queue(params.merge(:ssh_key => 'xxx', :vmware_ssh_private_key => 'yyy'))
+        expected_context_data = params.except(:resource)
+
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
+      end
     end
 
     context "#disable_queue" do

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -119,7 +119,9 @@ describe ConversionHost do
 
       it "to queue with a task" do
         task_id = described_class.enable_queue(params)
-        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
+        expected_context_data = params.except(:resource)
+
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
         expect(MiqQueue.first).to have_attributes(
           :args        => [params.merge(:task_id => task_id).except(:resource), nil],
           :class_name  => described_class.name,


### PR DESCRIPTION
This PR modifies the `ConversionHost::Configurations#enable_queue` method so that the original params are stored in the `context_data` of the associated task. This is a serialized field, so it would be accessible as a hash of options.

A few things to head off potential questions about why this PR is written the way it is:

Q: What is this going to be used for?
A: The UI team would like it for a "retry" option. To do that they need the original parameters, which they can retrieve from the associated task.

Q: Why not just add `context_data` to the `task_opts` hash above?
A: Because `MiqTask.generic_action_with_callback` only recognizes certain options. The rest are dropped.

Q: Why use `MiqTask.find` on a task that you just created?
A: Because `MiqTask.generic_action_with_callback` returns a `task_id` instead of the full task object.

Q: Where are `task_id` and `miq_task_id` coming from, and why explicitly `.except` them?
A: They're injected at some point in the queue lifecycle, so I have to manually reject them because they aren't actually part of the params. The specs revealed that. Without that, the specs will fail.

https://bugzilla.redhat.com/show_bug.cgi?id=1622728