### PR TITLE
Fix: started_on and state attributes for task linked to chargeback for service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -418,22 +418,32 @@ class Service < ApplicationRecord
   end
 
   def queue_chargeback_report_generation(options = {})
+    msg = "Generating chargeback report for `#{self.class.name}` with id #{id}"
     task = MiqTask.create(
-      :name    => "Generating chargeback report with id: #{id}",
+      :name    => msg,
       :state   => MiqTask::STATE_QUEUED,
       :status  => MiqTask::STATUS_OK,
-      :message => "Queueing Chargeback of #{self.class.name} with id: #{id}"
+      :message => "Queueing: #{msg}"
     )
+
+    cb = {
+      :class_name  => task.class.to_s,
+      :instance_id => task.id,
+      :method_name => :queue_callback,
+      :args        => ["Finished"]
+    }
 
     MiqQueue.submit_job(
       :service     => "reporting",
       :class_name  => self.class.name,
       :instance_id => id,
       :task_id     => task.id,
+      :miq_task_id  => task.id,
+      :miq_callback => cb,
       :method_name => "generate_chargeback_report",
       :args        => options
     )
-    _log.info("Added to queue: generate_chargeback_report for service #{name}")
+    _log.info("Added to queue: #{msg}")
     task
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -452,6 +452,8 @@ describe Service do
           expect(args).to include(:class_name  => described_class.name,
                                   :method_name => "generate_chargeback_report",
                                   :args        => {:report_source => "Test Run"})
+          expect(args).to have_key(:miq_task_id)
+          expect(args).to have_key(:miq_callback)
         end
         expect(@service.queue_chargeback_report_generation(:report_source => "Test Run")).to be_kind_of(MiqTask)
       end


### PR DESCRIPTION
Added `miq_task_id` amd `miq_callback` to parameters when submitting job to generate chargeback report for `Service`. It wii allow to initialize `started_on` column and will change task's status to `Finished` when queue item delivered

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1648499

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/54147540-c6f6c900-4408-11e9-9b31-b1243113f73d.png)


**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/54139825-c6563680-43f8-11e9-8167-18ef3715fe12.png)

@miq-bot add-label bug