### PR TITLE
Rbac virtual attributes

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -319,6 +319,7 @@ module MiqReport::Generator
 
     ## add in virtual attributes that can be calculated from sql
     rbac_opts[:extra_cols] = va_sql_cols unless va_sql_cols.blank?
+    rbac_opts[:use_sql_view] = true if db_options && db_options[:use_sql_view]
 
     results, attrs = Rbac.search(rbac_opts)
     results = Metric::Helper.remove_duplicate_timestamps(results)

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -97,6 +97,7 @@ module MiqReport::Search
                                   )
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
     search_options[:extra_cols] = va_sql_cols if va_sql_cols.present?
+    search_options[:use_sql_view] = true if db_options && db_options[:use_sql_view]
 
     if options[:parent]
       targets = get_parent_targets(options[:parent], options[:association] || options[:parent_method])


### PR DESCRIPTION
### Overview

When running queries, we are putting more and more virtual attributes into the main query. This transitions us from running N+1 queries from ruby to only running 1. Just running them as subqueries.

Running them as sub queries still runs each of the queries, but it lets us avoid downloading a ton of data to then do a `COUNT`, `SUM`, or `FIRST`. So if you look at the `EXPLAIN` plans, the queries are still happening, but in a much more controlled manner.

addresses

- https://bugzilla.redhat.com/show_bug.cgi?id=1686433

### Problem

This is a PR/BZ after all. There is a problem.

We are running these sub queries once for every row in the database (6k), not for every row returned (20). Typically, this is a lot faster and still less work than downloading all that data to ruby.

Well it is faster until the number of rows in the base table is sufficiently large, and the virtual attribute subquery is sufficiently slow.

And yes, we found that edge case for the `Service` explorer page.

### Solution

The solution is to run the subquery once for every row on the screen rather than every row in the base table. To get this, we run the query with the `WHERE` and `LIMIT` as an inline view (subquery in the `FROM` clause). So the database is running for "every row in the base table", we just pretended like the 20 rows in the result set were "every row in the table."

Active record has the `from()` method to allow us to do this pretty easily.

```sql
-- before
SELECT "base".*,
       virtual_attribute /* 6k times */
FROM   "base"
WHERE  "base"."name" LIKE '%good stuff%'
LIMIT  20

-- after
SELECT *,
       virtual_attribute /* 20 times */
FROM (
    SELECT "base".*
    FROM   "base"
    WHERE  "base"."name" LIKE '%good stuff%'
    LIMIT  20
) AS "base"
```

----

## Numbers

I was not able to compare the timing of the original query. I needed to pair back to only 1 virtual attribute.

|         ms |     bytes |   objects |query |    qry ms |     rows |`comments`
|        ---:|       ---:|       ---:|  ---:|       ---:|      ---:| ---
|  445,306.4 | 1,694,049* |    10,177 |    6 | 445,251.6 |       25 |`before-7 attrs`
|    1,252.4 | 1,754,293* |    10,984 |    6 |   1,197.6 |       25 |`after-7 attrs`

|         ms |     bytes |   objects |query |    qry ms |     rows |`comments`
|        ---:|       ---:|       ---:|  ---:|       ---:|      ---:| ---
|   48,988.7 | 1,615,740 |     8,581 |    6 |  48,935.9 |       25 |`before-1 attr`
|      240.9 | 1,632,170 |     8,836 |    6 |     187.7 |       25 |`after-1 attr`
|      99.5% |       -1% |       -3% |    - |     99.6% |        - | delta

----
## Code

for those following at home, this is how I reproduced it.
```ruby
ENV["PATCH"]="orig" # "view"
Rbac.filtered(Service, :userid => "admin", :use_sql_view => (ENV["PATCH"].to_s =~ /view/), :targets_hash => true, :named_scope => [["retired", false], "displayed"], :targets => Service, :include_for_find => {:service_template=>{:picture=>{}}}, :limit => 20, :offset => 0, :order => "LOWER(services.name)", :extra_cols => %w(v_total_vms)).to_a.size

# Service.yaml screen uses:
# :extra_cols => %w(v_total_vms aggregate_all_vm_cpus aggregate_all_vm_memory aggregate_all_vm_disk_count aggregate_all_vm_disk_space_allocated aggregate_all_vm_disk_space_used aggregate_all_vm_memory_on_disk)
```
