### PR TITLE
Shift Nuage's qpid_proton dependency to 0.26.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ group :redfish, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.22.0",      :require => false
+  gem "qpid_proton",                    "~>0.26.0",      :require => false
 end
 
 group :openshift, :manageiq_default do


### PR DESCRIPTION
There was nothing wrong with 0.22.0 other than complexity of installment caused by a lack of official RPM (because gem is just a binding to qpid-proton system library).

Apache guys have now prepared official RPM with version 0.26.0 and everything seems to just work for Nuage provider without any coding changes. So we shift.

@miq-bot add_label dependencies
@miq-bot assign @agrare

/cc @simaishi 