### PR TITLE
Add List Retired/Orphaned/Archived RBAC featuers

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -197,9 +197,11 @@ class VmOrTemplate < ApplicationRecord
   scope :with_type,    ->(type) { where(:type => type) }
   scope :archived,     ->       { where(:ems_id => nil, :storage_id => nil) }
   scope :orphaned,     ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
+  scope :retired,      ->       { where(:retired => true) }
   scope :with_ems,     ->       { where.not(:ems_id => nil) }
   scope :not_archived, ->       { where.not(:ems_id => nil).or(where.not(:storage_id => nil)) }
   scope :not_orphaned, ->       { where.not(:ems_id => nil).or(where(:storage_id => nil)) }
+  scope :not_retired,  ->       { where(:retired => false).or(where(:retired => nil)) }
 
   # The SQL form of `#registered?`, with it's inverse as well.
   # TODO: Vmware Specific (copied (old) TODO from #registered?)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -193,11 +193,13 @@ class VmOrTemplate < ApplicationRecord
   before_validation :set_tenant_from_group
   after_save :save_genealogy_information
 
-  scope :active,    ->       { where.not(:ems_id => nil) }
-  scope :with_type, ->(type) { where(:type => type) }
-  scope :archived,  ->       { where(:ems_id => nil, :storage_id => nil) }
-  scope :orphaned,  ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
-  scope :with_ems,  ->       { where.not(:ems_id => nil) }
+  scope :active,       ->       { where.not(:ems_id => nil) }
+  scope :with_type,    ->(type) { where(:type => type) }
+  scope :archived,     ->       { where(:ems_id => nil, :storage_id => nil) }
+  scope :orphaned,     ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
+  scope :with_ems,     ->       { where.not(:ems_id => nil) }
+  scope :not_archived, ->       { where.not(:ems_id => nil).or(where.not(:storage_id => nil)) }
+  scope :not_orphaned, ->       { where.not(:ems_id => nil).or(where(:storage_id => nil)) }
 
   # The SQL form of `#registered?`, with it's inverse as well.
   # TODO: Vmware Specific (copied (old) TODO from #registered?)

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5080,6 +5080,18 @@
         :description: Display Lists of Instances related to a CI
         :feature_type: view
         :identifier: instance_show_list
+      - :name: List Archived
+        :description: Display Lists of archived Instances related to a CI
+        :feature_type: view
+        :identifier: instance_show_list_archived
+      - :name: List Orphaned
+        :description: Display Lists of orphaned Instances related to a CI
+        :feature_type: view
+        :identifier: instance_show_list_orphaned
+      - :name: List Retired
+        :description: Display Lists of retired Instances related to a CI
+        :feature_type: view
+        :identifier: instance_show_list_retired
       - :name: Show
         :description: Display Individual Instances related to a CI
         :feature_type: view
@@ -5387,6 +5399,18 @@
         :description: Display Lists of VMs related to a CI
         :feature_type: view
         :identifier: vm_show_list
+      - :name: List Archived
+        :description: Display Lists of archived Vms related to a CI
+        :feature_type: view
+        :identifier: vm_show_list_archived
+      - :name: List Orphaned
+        :description: Display Lists of orphaned Vms related to a CI
+        :feature_type: view
+        :identifier: vm_show_list_orphaned
+      - :name: List Retired
+        :description: Display Lists of retired Vms related to a CI
+        :feature_type: view
+        :identifier: vm_show_list_retired
       - :name: Show
         :description: Display Individual VMs related to a CI
         :feature_type: view


### PR DESCRIPTION
Add RBAC features for showing Retired/Orphaned/Archived VMs. So they can be hidden per user in UI.

Links [Optional]
----------------
https://bugzilla.redhat.com/show_bug.cgi?id=1545942
https://github.com/ManageIQ/manageiq-ui-classic/pull/5357

Screenshots
----------------
#### Before
![Screenshot from 2019-07-16 15-51-46](https://user-images.githubusercontent.com/9535558/61300158-bce33d80-a7e1-11e9-8f80-f54f3744809d.png)

#### After
![Screenshot from 2019-07-16 15-50-05](https://user-images.githubusercontent.com/9535558/61300166-bf459780-a7e1-11e9-9f87-29a33fa106ec.png)


