### PR TITLE
Loosen the Postgres version initializer check

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -2,13 +2,13 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   def initialize(*args)
     super
 
+    msg = "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (10 required)"
+
     if postgresql_version < 90500
-      raise "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (9.5 required)"
+      raise msg
     end
 
-    if postgresql_version >= 90600
-      msg = "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (9.6+ is not supported yet)"
-
+    if postgresql_version < 100000 || postgresql_version >= 110000
       raise msg if Rails.env.production? && !ENV["UNSAFE_PG_VERSION"]
       $stderr.puts msg
     end


### PR DESCRIPTION
We want to give developers some more time to upgrade, but also
want production to be able to use 10 now.