### PR TITLE
Don't set version restriction for 'pg' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "net-ldap",                       "~>0.16.1",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false
 gem "openscap",                       "~>0.4.8",       :require => false
 gem "optimist",                       "~>3.0",         :require => false
-gem "pg",                             "~>0.18.2",      :require => false
+gem "pg",                                              :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
 gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.0.7.1"


### PR DESCRIPTION
As per discussion with @Fryguy and @carbonin, removing the `pg` gem version restriction as our code doesn't depend on a particular version.

cc @agrare 
