### PR TITLE
use like (vs ilike) for service query

### DIFF
--- a/app/models/service/aggregation.rb
+++ b/app/models/service/aggregation.rb
@@ -149,7 +149,7 @@ module Service::Aggregation
     def aggregation_where_clause(arel, subtree_services)
       arel.grouping(
         subtree_services[:id].eq(arel[:id])
-         .or(subtree_services[:ancestry].matches(ancestry_ilike))
+         .or(subtree_services[:ancestry].matches(ancestry_ilike, nil, true))
       ).or(subtree_services[:ancestry].eq(service_id_cast))
     end
 


### PR DESCRIPTION
The services query uses a potentially ugly subquery for looking up vm totals and stuff.

For ancestry, using `LIKE` is better than `ILIKE` - the case sensitivity doesn't provide much when searching numbers and symbols and it prevents us from using text indexes.

After this I'll still need to tweak our indexes, but this ilike is preventing us from using anything


