### PR TITLE
Added ability to destroy all users dashboards

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -18,6 +18,10 @@ class MiqWidgetSet < ApplicationRecord
     MiqWidgetSet.with_users.where(:name => name, :group_id => owner_id).destroy_all
   end
 
+  def self.destroy_user_versions
+    MiqWidgetSet.with_users.destroy_all
+  end
+
   def self.where_unique_on(name, user = nil)
     userid = user.try(:userid)
     group_id = user.try(:current_group_id)

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -40,6 +40,19 @@ describe MiqWidgetSet do
     end
   end
 
+  describe ".destroy_user_versions" do
+    before do
+      FactoryBot.create(:miq_widget_set, :name => 'User_Home', :userid => user.userid)
+    end
+
+    it "destroys all user's versions of dashboards (dashboards been customized by user)" do
+      expect(MiqWidgetSet.count).to eq(2)
+      MiqWidgetSet.destroy_user_versions
+      expect(MiqWidgetSet.count).to eq(1)
+      expect(MiqWidgetSet.first).to eq(@ws_group)
+    end
+  end
+
   describe "#where_unique_on" do
     let(:group2) { FactoryBot.create(:miq_group, :description => 'dev group2') }
     let(:ws_1)   { FactoryBot.create(:miq_widget_set, :name => 'Home', :userid => user.userid, :group_id => group.id) }


### PR DESCRIPTION
Added ability to destroy all users dashboards

**Usage:**
From Rails console execute ```MiqWidgetSet.destroy_user_versions``` 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1295839