### PR TITLE
[WIP] remove sql munging

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -301,7 +301,6 @@ module MiqReport::Generator
     targets = db_class.find_entries(ext_options) if targets.respond_to?(:find_entries)
     # TODO: add once only_cols is fixed
     # targets = targets.select(only_cols)
-    where_clause = MiqExpression.merge_where_clauses(self.where_clause, options[:where_clause])
 
     # Remove custom_attributes as part of the `includes` if all of them exist
     # in the select statement
@@ -314,6 +313,7 @@ module MiqReport::Generator
       :filter           => conditions,
       :include_for_find => get_include_for_find,
       :where_clause     => where_clause,
+      :conditions       => options[:where_clause],
       :skip_counts      => true
     )
 

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -399,29 +399,6 @@ class MiqExpression
     col_details.values.each_with_object({}) { |v, result| result.deep_merge!(v[:include]) }
   end
 
-  def self.expand_conditional_clause(klass, cond)
-    return klass.send(:sanitize_sql_for_conditions, cond) unless cond.kind_of?(Hash)
-
-    cond = klass.predicate_builder.resolve_column_aliases(cond)
-    cond = klass.send(:expand_hash_conditions_for_aggregates, cond)
-
-    klass.predicate_builder.build_from_hash(cond).map { |b| klass.connection.visitor.compile(b) }.join(' AND ')
-  end
-
-  def self.merge_where_clauses(*list)
-    list = list.compact.collect do |s|
-      expand_conditional_clause(MiqReport, s)
-    end.compact
-
-    if list.empty?
-      nil
-    elsif list.size == 1
-      list.first
-    else
-      "(#{list.join(") AND (")})"
-    end
-  end
-
   def self.get_cols_from_expression(exp, options = {})
     result = {}
     if exp.kind_of?(Hash)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2431,45 +2431,6 @@ describe MiqExpression do
     end
   end
 
-  describe ".merge_where_clauses" do
-    it "returns nil for nil" do
-      expect(MiqExpression.merge_where_clauses(nil)).to be_nil
-    end
-
-    it "returns nil for blank" do
-      expect(MiqExpression.merge_where_clauses("")).to be_nil
-    end
-
-    it "returns nil for multiple empty arrays" do
-      expect(MiqExpression.merge_where_clauses([],[])).to be_nil
-    end
-
-    it "returns same string single results" do
-      expect(MiqExpression.merge_where_clauses("a=5")).to eq("a=5")
-    end
-
-    it "returns same string when concatinating blank results" do
-      expect(MiqExpression.merge_where_clauses("a=5", [])).to eq("a=5")
-    end
-
-    # would be nice if we returned a hash
-    it "returns a string if the only argument is a hash" do
-      expect(MiqExpression.merge_where_clauses({"vms.id" => 5})).to eq("\"vms\".\"id\" = 5")
-    end
-
-    it "concatinates 2 arrays" do
-      expect(MiqExpression.merge_where_clauses(["a=?",5], ["b=?",5])).to eq("(a=5) AND (b=5)")
-    end
-
-    it "concatinates 2 string" do
-      expect(MiqExpression.merge_where_clauses("a=5", "b=5")).to eq("(a=5) AND (b=5)")
-    end
-
-    it "concatinates a string and a hash" do
-      expect(MiqExpression.merge_where_clauses("a=5", {"vms.id" => 5})).to eq("(a=5) AND (\"vms\".\"id\" = 5)")
-    end
-  end
-
   describe ".get_col_type" do
     subject { described_class.get_col_type(@field) }
     let(:string_custom_attribute) do


### PR DESCRIPTION
This code was the last remnants of our sql munging.

Rbac takes a number of parameters that are placed in the where clause
so it is easy to just use another one of them in this code.

Also, this was using a number of internal active record methods.

This was introduced in a72d4fe with the caveat that it is too bad we are doing this.

Not sure when the last reference to this sql was removed in the session, but I know @himdel and @martinpovolny were hard at work. thanks.