### PR TITLE
Add Volume Resizing capability to SupportsFeatureMixin

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -196,6 +196,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_total  :total_subnets,           :cloud_subnets
   virtual_column :supports_block_storage,  :type => :boolean
   virtual_column :supports_volume_multiattachment, :type => :boolean
+  virtual_column :supports_volume_resizing, :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
   virtual_column :supports_cinder_volume_types, :type => :boolean
 
@@ -634,6 +635,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_volume_multiattachment
     supports_volume_multiattachment?
+  end
+
+  def supports_volume_resizing
+    supports_volume_resizing?
   end
 
   def supports_cloud_object_store_container_create

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -146,6 +146,7 @@ module SupportsFeatureMixin
     :object_storage                      => 'Object Storage',
     :vm_import                           => 'VM Import',
     :volume_multiattachment              => 'Volume Multiattachment',
+    :volume_resizing                     => 'Volume Resizing',
     :change_password                     => 'Change Password'
   }.freeze
 


### PR DESCRIPTION
The Openstack and Amazon providers both theoretically support resizing volumes, but currently detection of this feature is done in the UI via a conditional on the class name of the provider. Adding this as a capability to SupportsFeatureMixin and as a virtual column on ExtManagementSystem would allow this to be handled in a cleaner way in the UI.

See also https://github.com/ManageIQ/manageiq-providers-openstack/pull/448