### PR TITLE
Move ALLOWED_FIELD_SUFFIXES to core in Chargeback and MeteringReport

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -11,6 +11,20 @@ class Chargeback < ActsAsArModel
     :fixed_compute_metric => :integer,
   )
 
+  ALLOWED_FIELD_SUFFIXES = %w[
+    _rate
+    _cost
+    -owner_name
+    _metric
+    -provider_name
+    -provider_uid
+    -project_uid
+    -archived
+    -chargeback_rates
+    -vm_guid
+    -vm_uid
+  ].freeze
+
   def self.dynamic_rate_columns
     @chargeable_fields = {}
     @chargeable_fields[self.class] ||=

--- a/app/models/metering.rb
+++ b/app/models/metering.rb
@@ -2,6 +2,10 @@ module Metering
   extend ActiveSupport::Concern
   DISALLOWED_SUFFIXES = %w(_cost chargeback_rates).freeze
   METERING_ALLOCATED_FIELDS = %w(metering_allocated_cpu_cores_metric metering_allocated_cpu_metric metering_allocated_memory_metric).freeze
+  ALLOWED_FIELD_SUFFIXES = %w[
+    -beginning_of_resource_existence_in_report_interval
+    -end_of_resource_existence_in_report_interval
+  ].freeze
 
   included do
     def self.attribute_names

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -910,7 +910,7 @@ class MiqExpression
       model.constantize.try(:refresh_dynamic_metric_columns)
       md = model_details(model, :include_model => false, :include_tags => true).select do |c|
         allowed_suffixes = Chargeback::ALLOWED_FIELD_SUFFIXES
-        allowed_suffixes += ReportController::Reports::Editor::METERING_VM_ALLOWED_FIELD_SUFFIXES if model.starts_with?('Metering')
+        allowed_suffixes += Metering::ALLOWED_FIELD_SUFFIXES if model.starts_with?('Metering')
         c.last.ends_with?(*allowed_suffixes)
       end
       td = if TAG_CLASSES.include?(cb_model)

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -909,7 +909,7 @@ class MiqExpression
       cb_model = Chargeback.report_cb_model(model)
       model.constantize.try(:refresh_dynamic_metric_columns)
       md = model_details(model, :include_model => false, :include_tags => true).select do |c|
-        allowed_suffixes = ReportController::Reports::Editor::CHARGEBACK_ALLOWED_FIELD_SUFFIXES
+        allowed_suffixes = Chargeback::ALLOWED_FIELD_SUFFIXES
         allowed_suffixes += ReportController::Reports::Editor::METERING_VM_ALLOWED_FIELD_SUFFIXES if model.starts_with?('Metering')
         c.last.ends_with?(*allowed_suffixes)
       end


### PR DESCRIPTION
**why?**

- constant [ALLOWED_FIELD_SUFFIXES](https://github.com/manageiq/manageiq-ui-classic/blob/ebe04bc82f00c5ac83f25f87b80ed5055376dee8/app/controllers/report_controller/reports/editor.rb#L11) is related more to `Chargeback` class than [editor in UI ](https://github.com/manageiq/manageiq-ui-classic/blob/ebe04bc82f00c5ac83f25f87b80ed5055376dee8/app/controllers/report_controller/reports/editor.rb#L1532
)
- when we will add new column, this change will stop adding special PR in UI repo
- same for [Metering Reports](https://github.com/manageiq/manageiq-ui-classic/blob/ebe04bc82f00c5ac83f25f87b80ed5055376dee8/app/controllers/report_controller/reports/editor.rb#L25)


Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1545445 (first part)

@miq-bot assign @gtanzillo 

@miq-bot add_label refactoring

