### PR TITLE
Update surro-gate to v1.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,7 +209,7 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
-  gem "surro-gate",                     "~>1.0.4"
+  gem "surro-gate",                     "~>1.0.5"
   gem "websocket-driver",               "~>0.6.3"
 end
 


### PR DESCRIPTION
Fixes a bug in socket closing with SPICE consoles.

@miq-bot add_label bug, consoles, hammer/no