### PR TITLE
Require the api client gem before using it

### DIFF
--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -1,3 +1,5 @@
+require 'manageiq-api-client'
+
 module ProcessTasksMixin
   extend ActiveSupport::Concern
   include RetirementMixin


### PR DESCRIPTION
Running spec/models/mixins/process_tasks_mixin_spec.rb by itself was
failing with:

```
LoadError:
  Unable to autoload constant ManageIQ::API, expected ../bundler/gems/manageiq-api-5f1904138cd0/lib/manageiq/api.rb to define it
```

manageiq-api gem and manageiq-api-client gem share the
ManageIQ::API namespace.  Therefore, if you try to autoload
ManageIQ::API::Client, by convention rails will look for it in the
manageiq-api gem and fail to autoload it. We have to explicitly
require the client gem to get access to it.