### PR TITLE
[V2V] Expose virt-v2v-wrapper error message in options hash

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -209,6 +209,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     updates = {}
     virtv2v_state = conversion_host.get_conversion_state(options[:virtv2v_wrapper]['state_file'])
     updated_disks = virtv2v_disks
+    updates[:virtv2v_message] = virtv2v_state['last_message']['message'] if virtv2v_state['last_message'].present?
     if virtv2v_state['finished'].nil?
       updated_disks.each do |disk|
         matching_disks = virtv2v_state['disks'].select { |d| d['path'] == disk[:path] }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -387,21 +387,26 @@ describe ServiceTemplateTransformationPlanTask do
         it "raises when conversion is failed" do
           allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
             {
-              "failed"      => true,
-              "finished"    => true,
-              "started"     => true,
-              "disks"       => [
+              "failed"       => true,
+              "finished"     => true,
+              "started"      => true,
+              "disks"        => [
                 { "path" => src_disk_1.filename, "progress" => 23.0 },
                 { "path" => src_disk_1.filename, "progress" => 0.0 }
               ],
-              "pid"         => 5855,
-              "return_code" => 1,
-              "disk_count"  => 2
+              "pid"          => 5855,
+              "return_code"  => 1,
+              "disk_count"   => 2,
+              "last_message" => {
+                "message" => "virt-v2v failed somehow",
+                "type"    => "error"
+              }
             }
           )
           expect { task_1.get_conversion_state }.to raise_error("Disks transformation failed.")
           expect(task_1.options[:virtv2v_status]).to eq('failed')
-          epxect(task_1.options[:virtv2v_finished_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
+          expect(task_1.options[:virtv2v_finished_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
+          expect(task_1.options[:virtv2v_message]).to eq('virt-v2v failed somehow')
         end
 
         it "updates disks progress" do
@@ -449,6 +454,7 @@ describe ServiceTemplateTransformationPlanTask do
           )
           expect(task_1.options[:virtv2v_status]).to eq('finished')
           epxect(task_1.options[:virtv2v_finished_on]).to eq(time)
+          expect(task_1.options[:virtv2v_message]).to be_nil
         end
       end
 


### PR DESCRIPTION
When the disk conversion fails, the error message is really vague: _Disk Transformation failed_, so the user needs to look into the wrapper and virt-v2v logs to identify the cause. Since recently, virt-v2v-wrapper provides a human-readable error message based on virt-v2v log. An example is below

```json
    {
      "started": true,
      "disks": [
        {
          "path": "[datastore13] tg-mini2/tg-mini2_3.vmdk",
          "progress": 100
        },
        {
          "path": "[datastore13] tg-mini2/tg-mini2_4.vmdk",
          "progress": 100
        }
      ],
      "pid": 30375,
      "disk_count": 2,
      "return_code": 0,
      "failed": true,
      "finished": true,
      "last_message": {
        "message": "Failed to create port",
        "type": "error"
      }
    }
```

This PR exposes the message from virt-v2v-wrapper in the task options hash, so that it can be consumed by Automate and the UI.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1595365