### PR TITLE
Add report interval date and report generation to Chargeback reports

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -5,6 +5,7 @@ class Chargeback < ActsAsArModel
     :interval_name         => :string,
     :display_range         => :string,
     :report_interval_range => :string,
+    :report_generation_date => :datetime,
     :chargeback_rates      => :string,
     :entity                => :binary,
     :tag_name              => :string,
@@ -18,6 +19,7 @@ class Chargeback < ActsAsArModel
     -owner_name
     _metric
     -report_interval_range
+    -report_generation_date
     -provider_name
     -provider_uid
     -project_uid
@@ -189,6 +191,7 @@ class Chargeback < ActsAsArModel
     calculate_fixed_compute_metric(consumption)
     self.class.try(:refresh_dynamic_metric_columns)
     self.report_interval_range = "#{consumption.report_interval_start.strftime('%m/%d/%Y')} - #{consumption.report_interval_end.strftime('%m/%d/%Y')}"
+    self.report_generation_date = Time.current
 
     _log.debug("Consumption Type: #{consumption.class}")
     rates.each do |rate|

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -1,15 +1,15 @@
 class Chargeback < ActsAsArModel
   set_columns_hash( # Fields common to any chargeback type
-    :start_date           => :datetime,
-    :end_date             => :datetime,
-    :interval_name        => :string,
-    :display_range        => :string,
+    :start_date            => :datetime,
+    :end_date              => :datetime,
+    :interval_name         => :string,
+    :display_range         => :string,
     :report_interval_range => :string,
-    :chargeback_rates     => :string,
-    :entity               => :binary,
-    :tag_name             => :string,
-    :label_name           => :string,
-    :fixed_compute_metric => :integer,
+    :chargeback_rates      => :string,
+    :entity                => :binary,
+    :tag_name              => :string,
+    :label_name            => :string,
+    :fixed_compute_metric  => :integer,
   )
 
   ALLOWED_FIELD_SUFFIXES = %w[

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -4,6 +4,7 @@ class Chargeback < ActsAsArModel
     :end_date             => :datetime,
     :interval_name        => :string,
     :display_range        => :string,
+    :report_interval_range => :string,
     :chargeback_rates     => :string,
     :entity               => :binary,
     :tag_name             => :string,
@@ -16,6 +17,7 @@ class Chargeback < ActsAsArModel
     _cost
     -owner_name
     _metric
+    -report_interval_range
     -provider_name
     -provider_uid
     -project_uid
@@ -186,6 +188,8 @@ class Chargeback < ActsAsArModel
   def calculate_costs(consumption, rates)
     calculate_fixed_compute_metric(consumption)
     self.class.try(:refresh_dynamic_metric_columns)
+    self.report_interval_range = "#{consumption.report_interval_start.strftime('%m/%d/%Y')} - #{consumption.report_interval_end.strftime('%m/%d/%Y')}"
+
     _log.debug("Consumption Type: #{consumption.class}")
     rates.each do |rate|
       _log.debug("Calculation with rate: #{rate.id} #{rate.description}(#{rate.rate_type})")

--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -1,16 +1,16 @@
 class Chargeback < ActsAsArModel
   set_columns_hash( # Fields common to any chargeback type
-    :start_date            => :datetime,
-    :end_date              => :datetime,
-    :interval_name         => :string,
-    :display_range         => :string,
-    :report_interval_range => :string,
+    :start_date             => :datetime,
+    :end_date               => :datetime,
+    :interval_name          => :string,
+    :display_range          => :string,
+    :report_interval_range  => :string,
     :report_generation_date => :datetime,
-    :chargeback_rates      => :string,
-    :entity                => :binary,
-    :tag_name              => :string,
-    :label_name            => :string,
-    :fixed_compute_metric  => :integer,
+    :chargeback_rates       => :string,
+    :entity                 => :binary,
+    :tag_name               => :string,
+    :label_name             => :string,
+    :fixed_compute_metric   => :integer,
   )
 
   ALLOWED_FIELD_SUFFIXES = %w[

--- a/app/models/chargeback/consumption.rb
+++ b/app/models/chargeback/consumption.rb
@@ -37,6 +37,14 @@ class Chargeback
       [Time.current, @end_time, resource_end_of_life].compact.min
     end
 
+    def report_interval_start
+      @start_time
+    end
+
+    def report_interval_end
+      [Time.current, @end_time].min
+    end
+
     private
 
     def hours_in_interval

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -427,6 +427,7 @@ describe ChargebackVm do
         context "current month and previous month" do
           let(:options) { base_options.merge(:interval => 'monthly') }
           let(:finish_time) { Time.current }
+          let(:finish_time_formatted) { finish_time.strftime('%m/%d/%Y') }
           let(:report_start) { month_end + 2.days }
           subject { ChargebackVm.build_results_for_report_ChargebackVm(options).first }
 
@@ -442,13 +443,17 @@ describe ChargebackVm do
           end
 
           it "reports report interval range and report generation date" do
+            skip('this feature needs to be added to new chargeback') if Settings.new_chargeback
+
             # reporting of first month
             report_range = "#{first_month_beginning_formatted} - #{second_month_beginning_formatted}"
             expect(subject.first.report_interval_range).to eq(report_range)
+            expect(subject.first.report_generation_date.strftime('%m/%d/%Y')).to eq(finish_time_formatted)
 
             # reporting of second month
             report_range = "#{second_month_beginning_formatted} - #{(second_month_beginning + 2.days).strftime('%m/%d/%Y')}"
             expect(subject.second.report_interval_range).to eq(report_range)
+            expect(subject.second.report_generation_date.strftime('%m/%d/%Y')).to eq(finish_time_formatted)
           end
         end
       end

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -222,6 +222,8 @@ describe MeteringVm do
        tenant_name
        beginning_of_resource_existence_in_report_interval
        end_of_resource_existence_in_report_interval
+       report_interval_range
+       report_generation_date
   )
   end
 

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -191,7 +191,7 @@ describe MeteringVm do
   end
 
   let(:allowed_attributes) do
-    %w(start_date
+    %w[start_date
        end_date
        interval_name
        display_range
@@ -223,8 +223,7 @@ describe MeteringVm do
        beginning_of_resource_existence_in_report_interval
        end_of_resource_existence_in_report_interval
        report_interval_range
-       report_generation_date
-  )
+       report_generation_date]
   end
 
   it 'lists proper attributes' do


### PR DESCRIPTION
To accomplish "actual date range"  from request in BZ.
We are reporting chargeback for calendar months (weeks, days) but when you report partial month you need to know range of generated data.

report generated on 18 March

<img width="1635" alt="Screenshot 2019-03-19 at 10 32 15" src="https://user-images.githubusercontent.com/14937244/54595121-47817f00-4a32-11e9-8078-2988baf47712.png">

Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1545445
* https://github.com/ManageIQ/manageiq-ui-classic/pull/5348
* https://github.com/ManageIQ/manageiq/pull/18561


@miq-bot assign @gtanzillo 

@miq-bot add_label enhancement, chargeback

