### PR TITLE
[V2V] Fix ConversionHost active_tasks method to use state == 'migrate'

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -5,7 +5,7 @@ class ConversionHost < ApplicationRecord
 
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
-  has_many :active_tasks, -> { where(:state => 'migrate') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
+  has_many :active_tasks, -> { where(:state => ['active', 'migrate']) }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   validates :name, :presence => true

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -5,7 +5,7 @@ class ConversionHost < ApplicationRecord
 
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
-  has_many :active_tasks, -> { where(:state => 'active') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
+  has_many :active_tasks, -> { where(:state => 'migrate') }, :class_name => ServiceTemplateTransformationPlanTask, :inverse_of => :conversion_host
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   validates :name, :presence => true

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -9,9 +9,9 @@ describe ConversionHost do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
     let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
-    let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
+    let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'migrate', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
-    let(:task_3) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_2) }
+    let(:task_3) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'migrate', :conversion_host => conversion_host_2) }
 
     before do
       allow(conversion_host_1).to receive(:active_tasks).and_return([task_1])

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -9,7 +9,7 @@ describe ConversionHost do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
     let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
-    let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'migrate', :conversion_host => conversion_host_1) }
+    let(:task_1) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'active', :conversion_host => conversion_host_1) }
     let(:task_2) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
     let(:task_3) { FactoryBot.create(:service_template_transformation_plan_task, :state => 'migrate', :conversion_host => conversion_host_2) }
 


### PR DESCRIPTION
When the throttling feature has been moved to the backend, the state for an active task has become `migrate`, instead of `active`. This has not been updated in the `ConversionHost.active_tasks` relationship, which leads to have always zero active tasks reported.

This PR fixes that by changing the state lookup to `migrate`.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1686877