### PR TITLE
Fix a sporadic failure caused by array matching

### DIFF
--- a/spec/models/chargeback_rate_detail_currency_spec.rb
+++ b/spec/models/chargeback_rate_detail_currency_spec.rb
@@ -10,7 +10,7 @@ describe ChargebackRateDetailCurrency do
 
     it "returns supported currencies" do
       expect(ChargebackRateDetailCurrency.count).to eq(164)
-      expect(ChargebackRateDetailCurrency.all.map(&:code)).to eq(expected_currencies)
+      expect(ChargebackRateDetailCurrency.all.map(&:code)).to match_array(expected_currencies)
     end
   end
 


### PR DESCRIPTION
ChargebackRateDetailCurrency was doing an array match with .eq leading
to sporadic failures if the strings weren't sorted normally.

https://travis-ci.org/ManageIQ/manageiq/jobs/508318525#L2230-L2239