### PR TITLE
Drop the MiqEnterprise#is_enterprise? method

### DIFF
--- a/app/models/miq_enterprise.rb
+++ b/app/models/miq_enterprise.rb
@@ -30,14 +30,6 @@ class MiqEnterprise < ApplicationRecord
 
   cache_with_timeout(:my_enterprise) { in_my_region.first }
 
-  def self.is_enterprise?
-    # TODO: Need to implement a way to determine whether we're running on an "enterprise" server or a "regional" server.
-    #       This will do for now...
-    MiqRegion.count > 1
-  end
-
-  delegate :is_enterprise?, :to => :class
-
   def my_zone
     MiqServer.my_zone
   end


### PR DESCRIPTION
The method has been used by the UI only, on a single place. After [discussing](https://github.com/ManageIQ/manageiq-ui-classic/pull/5318#pullrequestreview-215559811) this with @gtanzillo we decided to drop this to reduce the complexity of the related `TreeBuilder`. As this was the only call to this method, now its definition became unnecessary.

@miq-bot add_label cleanup
@miq-bot add_reviewer @gtanzillo 