### PR TITLE
Physical server provisioning with internal state machine

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -33,6 +33,7 @@ class PhysicalServer < ApplicationRecord
 
   virtual_column :v_availability, :type => :string, :uses => :host
   virtual_column :v_host_os, :type => :string, :uses => :host
+  virtual_delegate :emstype, :to => "ext_management_system", :allow_nil => true
 
   has_many :physical_switches, :through => :computer_system, :source => :connected_physical_switches
 

--- a/app/models/physical_server_provision_task.rb
+++ b/app/models/physical_server_provision_task.rb
@@ -1,0 +1,23 @@
+class PhysicalServerProvisionTask < MiqProvisionTask
+  include_concern 'StateMachine'
+
+  def description
+    'Provision Physical Server'
+  end
+
+  def self.base_model
+    PhysicalServerProvisionTask
+  end
+
+  def self.request_class
+    PhysicalServerProvisionRequest
+  end
+
+  def model_class
+    PhysicalServer
+  end
+
+  def deliver_to_automate
+    super('physical_server_provision', my_zone)
+  end
+end

--- a/app/models/physical_server_provision_task/state_machine.rb
+++ b/app/models/physical_server_provision_task/state_machine.rb
@@ -1,0 +1,36 @@
+module PhysicalServerProvisionTask::StateMachine
+  def run_provision
+    raise MiqException::MiqProvisionError, "Unable to find #{model_class} with id #{source_id.inspect}" if source.blank?
+    dump_obj(options, "MIQ(#{self.class.name}##{__method__}) options: ", $log, :info)
+    signal :start_provisioning
+  end
+
+  def start_provisioning
+    update_and_notify_parent(:message => msg('start provisioning'))
+    # Implement provisioning in subclass, user-defined values are stored in options field.
+    raise NotImplementedError, 'Must be implemented in subclass and signal :done_provisioning when done'
+  end
+
+  def done_provisioning
+    update_and_notify_parent(:message => msg('done provisioning'))
+    signal :mark_as_completed
+  end
+
+  def mark_as_completed
+    update_and_notify_parent(:state => 'provisioned', :message => msg('provisioning completed'))
+    MiqEvent.raise_evm_event(source, 'generic_task_finish', :message => "Done provisioning PhysicalServer")
+    signal :finish
+  end
+
+  def finish
+    if status != 'Error'
+      _log.info("Executing provision task: [#{description}]... Complete")
+    else
+      _log.info("Executing provision task: [#{description}]... Errored")
+    end
+  end
+
+  def msg(txt)
+    "Provisioning PhysicalServer id=#{source.id}, name=#{source.name}, ems_ref=#{source.ems_ref}: #{txt}"
+  end
+end

--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     factory :miq_provision_request,              :class => "MiqProvisionRequest" do
       source { create(:miq_template) }
     end
+    factory :physical_server_provision_request,  :class => "PhysicalServerProvisionRequest"
 
     factory :service_template_transformation_plan_request, :class => "ServiceTemplateTransformationPlanRequest" do
       source { create(:service_template_transformation_plan) }

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -29,6 +29,9 @@ FactoryBot.define do
   factory :miq_provision_google,    :parent => :miq_provision_cloud, :class => "ManageIQ::Providers::Google::CloudManager::Provision"
   factory :miq_provision_openstack, :parent => :miq_provision_cloud, :class => "ManageIQ::Providers::Openstack::CloudManager::Provision"
 
+  # Physical Infrastructure
+  factory :physical_server_provision_task, :parent => :miq_provision, :class => "PhysicalServerProvisionTask"
+
   # Automate
   factory :automation_task, :parent => :miq_request_task, :class => "AutomationTask"
 

--- a/spec/models/physical_server_provision_request_spec.rb
+++ b/spec/models/physical_server_provision_request_spec.rb
@@ -1,0 +1,51 @@
+describe PhysicalServerProvisionRequest do
+  it '.TASK_DESCRIPTION' do
+    expect(described_class::TASK_DESCRIPTION).to eq('Physical Server Provisioning')
+  end
+
+  it '.SOURCE_CLASS_NAME' do
+    expect(described_class::SOURCE_CLASS_NAME).to eq('PhysicalServer')
+  end
+
+  it '.request_task_class' do
+    expect(described_class.request_task_class).to eq(PhysicalServerProvisionTask)
+  end
+
+  it '#description' do
+    expect(subject.description).to eq('Physical Server Provisioning')
+  end
+
+  it '#my_role' do
+    expect(subject.my_role).to eq('ems_operations')
+  end
+
+  describe '.new_request_task' do
+    before do
+      allow(ems.class).to receive(:provision_class).and_return(task)
+    end
+
+    let(:server) { FactoryBot.create(:physical_server, :ext_management_system => ems) }
+    let(:ems)    { FactoryBot.create(:ems_physical_infra) }
+    let(:task)   { double('TASK') }
+
+    context 'when source is ok' do
+      it do
+        expect(task).to receive(:new).with(:source_id => server.id)
+        described_class.new_request_task(:source_id => server.id)
+      end
+    end
+
+    context 'when source is missing' do
+      it do
+        expect { described_class.new_request_task(:source_id => 'missing') }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+
+    context 'when source is lacking EMS' do
+      before { server.update!(:ext_management_system => nil) }
+      it do
+        expect { described_class.new_request_task(:source_id => server.id) }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+  end
+end

--- a/spec/models/physical_server_provision_task/state_machine_spec.rb
+++ b/spec/models/physical_server_provision_task/state_machine_spec.rb
@@ -1,0 +1,55 @@
+describe PhysicalServerProvisionTask do
+  let(:server) { FactoryBot.create(:physical_server) }
+
+  subject { described_class.new(:source => server) }
+
+  describe '#run_provision' do
+    context 'when missing source' do
+      let(:server) { nil }
+      it do
+        expect { subject.run_provision }.to raise_error(MiqException::MiqProvisionError)
+      end
+    end
+
+    context 'when ok' do
+      it do
+        expect(subject).to receive(:signal).with(:start_provisioning)
+        subject.run_provision
+      end
+    end
+  end
+
+  it '#done_provisioning' do
+    expect(subject).to receive(:signal).with(:mark_as_completed)
+    expect(subject).to receive(:update_and_notify_parent)
+    subject.done_provisioning
+  end
+
+  it '#mark_as_completed' do
+    expect(subject).to receive(:signal).with(:finish)
+    expect(subject).to receive(:update_and_notify_parent)
+    subject.mark_as_completed
+  end
+
+  describe '#finish' do
+    before { allow(subject).to receive(:_log).and_return(log) }
+
+    let(:log) { double('LOG') }
+
+    context 'when task has errored' do
+      before { subject.update_attribute(:status, 'Error') }
+      it do
+        expect(log).to receive(:info).with(satisfy { |msg| msg.include?('Errored') })
+        subject.finish
+      end
+    end
+
+    context 'when task has completed' do
+      before { subject.update_attribute(:status, 'Ok') }
+      it do
+        expect(log).to receive(:info).with(satisfy { |msg| msg.include?('... Complete') })
+        subject.finish
+      end
+    end
+  end
+end

--- a/spec/models/physical_server_provision_task_spec.rb
+++ b/spec/models/physical_server_provision_task_spec.rb
@@ -1,0 +1,30 @@
+describe PhysicalServerProvisionTask do
+  it '#description' do
+    expect(subject.description).to eq('Provision Physical Server')
+  end
+
+  it '#model_class' do
+    expect(subject.model_class).to eq(PhysicalServer)
+  end
+
+  it '.request_class' do
+    expect(described_class.request_class).to eq(PhysicalServerProvisionRequest)
+  end
+
+  describe '#deliver_to_automate' do
+    before do
+      allow(subject).to receive(:approved?).and_return(true)
+      allow(subject).to receive(:get_user).and_return(double('USER').as_null_object)
+      allow(subject).to receive(:my_zone).and_return(double('ZONE').as_null_object)
+    end
+
+    let(:request) { FactoryBot.create(:physical_server_provision_request) }
+
+    subject { described_class.new(:miq_request => request) }
+
+    it do
+      expect(MiqQueue).to receive(:put).with(satisfy { |args| args[:class_name] == 'MiqAeEngine' })
+      subject.deliver_to_automate
+    end
+  end
+end


### PR DESCRIPTION
We implement PhysicalServerProvisionRequest with one or more tasks - one per server to be provisioned. Each task is provider-specific (depending on PhysicalServer instance type). Tasks are implemented with internal state machine; each provider implements its own steps for provisioning like this:

```
:run_provision
:start_provisioning
     #
...  # provider-specific steps here
     #
:done_provisioning
:mark_as_completed
:finish
```

Please note that internal state machine gets triggered by external one to allow for more customization.

Related to 
https://github.com/ManageIQ/manageiq-automation_engine/pull/306
https://github.com/ManageIQ/manageiq-content/pull/516

@miq-bot add_label enhancement
@miq-bot assign @agrare 