### PR TITLE
[V2V] Set default address for conversion host

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -20,6 +20,7 @@ class ConversionHost < ApplicationRecord
   validate :resource_supports_conversion_host
 
   before_validation :name, :default_name, :on => :create
+  before_validation :address, :default_address, :on => :create
 
   include_concern 'Configurations'
 
@@ -53,7 +54,7 @@ class ConversionHost < ApplicationRecord
 
   def ipaddress(family = 'ipv4')
     return address if address.present? && IPAddr.new(address).send("#{family}?")
-    resource.ipaddresses.detect { |ip| IPAddr.new(ip).send("#{family}?") }
+    resource&.ipaddresses&.detect { |ip| IPAddr.new(ip).send("#{family}?") }
   end
 
   def run_conversion(conversion_options)
@@ -228,5 +229,11 @@ class ConversionHost < ApplicationRecord
   #
   def default_name
     self.name ||= resource&.name
+  end
+
+  # Set the default address to the first IP address associated with the resource.
+  #
+  def default_address
+    self.address ||= self.ipaddress
   end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -190,6 +190,8 @@ describe ConversionHost do
 
   context "address validation" do
     let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+    let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
 
     it "is invalid if the address is not a valid IP address" do
       allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
@@ -216,11 +218,18 @@ describe ConversionHost do
       expect(conversion_host.valid?).to be(true)
     end
 
-    it "defaults to the first associated ip address if no address is explicitly provided" do
+    it "defaults to the first associated ip address if no address is explicitly provided for a vm" do
       allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1', '127.0.0.2'])
       conversion_host = ConversionHost.new(:name => "test", :resource => vm)
       expect(conversion_host.valid?).to be(true)
       expect(conversion_host.address).to eql(vm.ipaddresses.first)
+    end
+
+    it "defaults to the first associated ip address if no address is explicitly provided for a host" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.3', '127.0.0.4'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => host)
+      expect(conversion_host.valid?).to be(true)
+      expect(conversion_host.address).to eql(host.ipaddresses.first)
     end
   end
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -215,6 +215,13 @@ describe ConversionHost do
       conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
       expect(conversion_host.valid?).to be(true)
     end
+
+    it "defaults to the first associated ip address if no address is explicitly provided" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1', '127.0.0.2'])
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm)
+      expect(conversion_host.valid?).to be(true)
+      expect(conversion_host.address).to eql(vm.ipaddresses.first)
+    end
   end
 
   context "resource validation" do


### PR DESCRIPTION
Something of a followup to https://github.com/ManageIQ/manageiq/pull/18516, this again is based on feedback from the V2V team where it was decided that the address should default to the first IP address of the associated resource. There was already an internal `ipaddress` method, so we just use that.

Since the UI doesn't (currently) allow users to specify an IP, attempts to connect to the conversion host will fail without this atm.

https://bugzilla.redhat.com/show_bug.cgi?id=1622728

