### PR TITLE
Upgrade ripper_ruby_parser to 1.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "rails",                          "~>5.0.7.1"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
-gem "ripper_ruby_parser",             "~>1.2.0",       :require => false
+gem "ripper_ruby_parser",             "~>1.5.0",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.2",       :require => false
 gem "rugged",                         "~>0.27.0",      :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "rails",                          "~>5.0.7.1"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
-gem "ripper_ruby_parser",             "~>1.5.0",       :require => false
+gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.2",       :require => false
 gem "rugged",                         "~>0.27.0",      :require => false


### PR DESCRIPTION
This PR updates the `ripper_ruby_parser` gem to 1.5.1, up from 1.2.0. This would apply several bug fixes that have been applied since 1.2 and, notably, support Ruby 2.6.x.

For a full list of updates since 1.2.0 please see https://github.com/mvz/ripper_ruby_parser/blob/master/CHANGELOG.md