### PR TITLE
Don't start another refresh worker while another is stopping

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -3,6 +3,8 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
 
   include PerEmsWorkerMixin
 
+  # Don't allow multiple refresh workers to run at once
+  self.include_stopping_workers_on_synchronize = true
   self.required_roles = "ems_inventory"
 
   def friendly_name


### PR DESCRIPTION
If a RefreshWorker is asked to stop (usually for exceeding memory) we
don't want to start another right away until the first has stopped.

This can lead to many refresh workers running at the same time since the
next worker that starts typically exceeds memory as well and will be
asked to shutdown also.

In addition to using a huge amount of memory
this can also lead to inventory integrity issues since it is possible
for multiple refresh workers to be running save_ems_inventory at once.