### PR TITLE
Add 2.6.2 to the tested rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
 - 2.4.5
 - 2.5.3
+- 2.6.2
 sudo: false
 cache:
   bundler: true
@@ -18,8 +19,11 @@ env:
 matrix:
   allow_failures:
   - rvm: 2.5.3
+  - rvm: 2.6.2
   exclude:
   - rvm: 2.5.3
+    env: TEST_SUITE=brakeman
+  - rvm: 2.6.2
     env: TEST_SUITE=brakeman
   fast_finish: true
 addons:


### PR DESCRIPTION
May as well get a jump on Ruby 2.6.2, so I've added it to the list of tested rubies, though of course it's allowed to fail.