### PR TITLE
honor storage_file_collection_time_utc setting

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -220,11 +220,11 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
     # Schedule every 24 hours
     at = worker_settings[:storage_file_collection_time_utc]
-    if Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc) < Time.now.utc
-      time_at = 1.day.from_now.utc.strftime("%Y-%m-%d #{at}").to_time(:utc)
-    else
-      time_at = Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc)
-    end
+    time_at = if Time.zone.today.to_time(:utc) + at.seconds < Time.now.utc
+                Time.zone.today.to_time(:utc) + at.seconds + 1.day
+              else
+                Time.zone.today.to_time(:utc) + at.seconds
+              end
     scheduler.schedule_every(
       worker_settings[:storage_file_collection_interval],
       :first_at => time_at


### PR DESCRIPTION
Currently the `storage_file_collection_time_utc` setting is not honored, instead the seconds setting is disregarded and its just sets the time to midnight utc.

Default Setting:
``` yaml
...
:workers:
  ...
  :worker_base:
    ...
    :schedule_worker:
       ...
       :storage_file_collection_time_utc: 21600
...
```

Current operation of adding the seconds to the current date being disregarded:
``` ruby
irb(main):061:0> at=21600
=> 21600
irb(main):062:0> Time.now.strftime("%Y-%m-%d #{at}").to_time(:utc)
=> 2019-03-22 00:00:00 UTC
```

Changes to support adding the defined seconds to the beginning of the current day:
``` ruby
irb(main):061:0> at=21600
=> 21600
irb(main):063:0>Time.zone.today.to_time(:utc) + at.seconds
=> 2019-03-22 06:00:00 UTC
```

This was the simplest change but it might be worth adjusting the default setting to more align with other time settings and define it as `x.seconds` 

fixes https://github.com/ManageIQ/manageiq/issues/18586