### PR TITLE
Fix dry-validation on ruby < 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "config",                         "~>1.6.0",       :require => false
 gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
+gem "dry-validation",                 "< 0.13.1",      :require => false #if RUBY_VERSION < "2.4.0"
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"


### PR DESCRIPTION
Dry-validation 0.13.1 dropped support for rubies less than 2.4 in
https://github.com/dry-rb/dry-validation/commit/451af83cc0a0e4943ed33f5205d534b56707f2cd
which was released in 0.13.1.

This is causing all of the providers to fail travis on ruby 2.3.8, e.g. https://travis-ci.org/ManageIQ/manageiq-providers-lenovo/jobs/510453001

I'm wondering if it'd be better to use `~> 0.12.0` since we'd be limited to 0.13.0 with this so no bugfixes, security fixes, etc...