### PR TITLE
Add option to load MiqReport with filename and save filename to extras

### DIFF
--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -107,10 +107,16 @@ module MiqReport::ImportExport
     # @param cache [Hash] cache that holds yaml for the views
     def load_from_view_options(db, current_user = nil, options = {}, cache = {})
       filename = MiqReport.view_yaml_filename(db, current_user, options)
-      yaml     = cache[filename] ||= YAML.load_file(filename)
-      view     = MiqReport.new(yaml)
-      view.db  = db if filename.ends_with?("Vm__restricted.yaml")
+      view = load_from_filename(filename, cache)
+      view.db = db if filename.ends_with?("Vm__restricted.yaml")
+      view
+    end
+
+    def load_from_filename(filename, cache)
+      yaml = cache[filename] ||= YAML.load_file(filename)
+      view = MiqReport.new(yaml)
       view.extras ||= {}                        # Always add in the extras hash
+      view.extras[:filename] = File.basename(filename, '.yaml')
       view
     end
 

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -172,4 +172,31 @@ describe MiqReport::ImportExport do
       expect(MiqReport.view_yaml_filename(VmCloud.name, user, {})).to include("ManageIQ_Providers_CloudManager_Vm.yaml")
     end
   end
+
+  context ".load_from_view_options" do
+    let(:current_user) { FactoryBot.create(:user_admin) }
+
+    before do
+      EvmSpecHelper.seed_specific_product_features("vm_infra_explorer", "host_edit")
+    end
+
+    it "saves filename in extras" do
+      view = MiqReport.load_from_view_options(VmCloud.name, current_user)
+      expect(view.extras[:filename]).to eq("ManageIQ_Providers_CloudManager_Vm")
+    end
+  end
+
+  context ".load_from_filename" do
+    let(:current_user) { FactoryBot.create(:user_admin) }
+
+    before do
+      EvmSpecHelper.seed_specific_product_features("vm_infra_explorer", "host_edit")
+    end
+
+    it "saves filename in extras" do
+      filename = MiqReport.view_yaml_filename(VmCloud.name, current_user, {})
+      view = MiqReport.load_from_filename(filename, {})
+      expect(view.extras[:filename]).to eq("ManageIQ_Providers_CloudManager_Vm")
+    end
+  end
 end


### PR DESCRIPTION
There's no unique id for `MiqReport` templates and it's needed to make [this ugly switch](https://github.com/ManageIQ/manageiq-ui-classic/blob/3f609dab512cf49350cb10545d2a80ca9b343a0d/app/controllers/application_controller.rb#L989-L1012) more stable by checking also the correct template not  just name of column. That's why template name is saved to `extras[:filename]`.

Add `MiqReport.load_from_filename` to replace `Miq.new` to make sure it has `extras[:filename]` set.  It's used [here in UI](https://github.com/ManageIQ/manageiq-ui-classic/blob/3f609dab512cf49350cb10545d2a80ca9b343a0d/app/controllers/application_controller.rb#L1412)

Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/5371

@miq-bot add_label wip hammer/no, wip
