### PR TITLE
[WIP] Support different name enumeration schemas for VM provisioning

### DIFF
--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -18,21 +18,21 @@ module MiqProvision::Naming
     end
 
     def get_vm_full_name(unresolved_vm_name, prov_obj, determine_index)
-      # Split name to find the index substitution string
-      if unresolved_vm_name =~ NAME_SEQUENCE_REGEX
-        name = {:prefix => $`, :suffix => $', :index => $&, :index_length => Regexp.last_match(1).to_i}
-      else
-        # If we did not find the index substitution string just return what was passed in
-        return unresolved_vm_name
-      end
+      return unresolved_vm_name unless unresolved_vm_name =~ NAME_SEQUENCE_REGEX
+
+      name = {:prefix => $`, :suffix => $', :index => $&, :index_length => Regexp.last_match(1).to_i}
 
       # if we are just building a sample of what the vm_name will look like use '#' inplace of actual number.
       return "#{name[:prefix]}#{'#' * name[:index_length]}#{name[:suffix]}" if determine_index == false
 
+      resolve_vm_name(name, unresolved_vm_name, prov_obj)
+    end
+
+    def resolve_vm_name(name, unresolved_vm_name, prov_obj)
       index_length = name[:index_length]
       loop do
         next_number = MiqRegion.my_region.next_naming_sequence(unresolved_vm_name, SOURCE_IDENTIFIER)
-        idx_str = "%0#{index_length}d" % next_number
+        idx_str = next_number.to_s.rjust(index_length, '0')
         if idx_str.length > index_length
           index_length += 1
           unresolved_vm_name = "#{name[:prefix]}$n{#{index_length}}#{name[:suffix]}"
@@ -40,16 +40,14 @@ module MiqProvision::Naming
         end
 
         fullname = "#{name[:prefix]}#{idx_str}#{name[:suffix]}"
-        vm       = check_vm_name_uniqueness(fullname, prov_obj)
-        return fullname if vm.nil?
+        return fullname if vm_name_unique?(fullname, prov_obj)
       end
     end
 
-    def check_vm_name_uniqueness(fullname, prov_obj)
-      return nil if prov_obj.vm_template.nil?
-      ems = prov_obj.vm_template.ext_management_system
-      return nil if ems.nil?
-      VmOrTemplate.find_by("ems_id = ? and lower(name) = ?", ems.id, fullname.downcase)
+    def vm_name_unique?(fullname, prov_obj)
+      ems = prov_obj&.vm_template&.ext_management_system
+      return true if ems.nil?
+      !VmOrTemplate.find_by("ems_id = ? and lower(name) = ?", ems.id, fullname.downcase)
     end
   end
 

--- a/app/models/miq_provision/naming.rb
+++ b/app/models/miq_provision/naming.rb
@@ -1,7 +1,7 @@
 module MiqProvision::Naming
   extend ActiveSupport::Concern
 
-  NAME_SEQUENCE_REGEX = /\$n\{(\d+)\}/
+  NAME_SEQUENCE_REGEX = /\$n\{(\d+),?\s?(-?\d+)?\}/.freeze
   SOURCE_IDENTIFIER = "provisioning".freeze # a unique name for the source column in custom_attributes table
 
   module ClassMethods
@@ -18,36 +18,51 @@ module MiqProvision::Naming
     end
 
     def get_vm_full_name(unresolved_vm_name, prov_obj, determine_index)
-      return unresolved_vm_name unless unresolved_vm_name =~ NAME_SEQUENCE_REGEX
+      return unresolved_vm_name if unresolved_vm_name !~ NAME_SEQUENCE_REGEX
 
-      name = {:prefix => $`, :suffix => $', :index => $&, :index_length => Regexp.last_match(1).to_i}
+      name = {
+        :prefix       => $`,
+        :suffix       => $',
+        :index        => $&,
+        :index_length => Regexp.last_match(1).to_i,
+        :process_flag => Regexp.last_match(2).to_i,
+        :unresolved   => unresolved_vm_name
+      }
 
       # if we are just building a sample of what the vm_name will look like use '#' inplace of actual number.
       return "#{name[:prefix]}#{'#' * name[:index_length]}#{name[:suffix]}" if determine_index == false
 
-      resolve_vm_name(name, unresolved_vm_name, prov_obj)
+      resolve_vm_name(name, prov_obj)
     end
 
-    def resolve_vm_name(name, unresolved_vm_name, prov_obj)
+    def resolve_vm_name(name, prov_obj)
       index_length = name[:index_length]
       loop do
-        next_number = MiqRegion.my_region.next_naming_sequence(unresolved_vm_name, SOURCE_IDENTIFIER)
+        name[:unresolved] = build_unresolved_name(name, index_length)
+        next_number = MiqRegion.my_region.next_naming_sequence(name[:unresolved], SOURCE_IDENTIFIER)
+
         idx_str = next_number.to_s.rjust(index_length, '0')
-        if idx_str.length > index_length
+
+        if name[:process_flag] != -1 && idx_str.length > index_length
           index_length += 1
-          unresolved_vm_name = "#{name[:prefix]}$n{#{index_length}}#{name[:suffix]}"
+          name[:unresolved] = build_unresolved_name(name, index_length)
           next
         end
 
         fullname = "#{name[:prefix]}#{idx_str}#{name[:suffix]}"
-        return fullname if vm_name_unique?(fullname, prov_obj)
+        return fullname if unique_name?(fullname, prov_obj)
       end
     end
 
-    def vm_name_unique?(fullname, prov_obj)
+    def unique_name?(fullname, prov_obj)
       ems = prov_obj&.vm_template&.ext_management_system
       return true if ems.nil?
+
       !VmOrTemplate.find_by("ems_id = ? and lower(name) = ?", ems.id, fullname.downcase)
+    end
+
+    def build_unresolved_name(name, index_length)
+      "#{name[:prefix]}$n{#{index_length}}#{name[:suffix]}"
     end
   end
 

--- a/spec/models/miq_provision/naming_spec.rb
+++ b/spec/models/miq_provision/naming_spec.rb
@@ -1,0 +1,63 @@
+describe MiqProvision::Naming do
+  let(:miq_region) { MiqRegion.create }
+
+  before do
+    @os = OperatingSystem.new(:product_name => 'Microsoft Windows')
+    @admin = FactoryBot.create(:user_with_group, :role => "admin")
+    @target_vm_name = 'clone test'
+    @options = {
+      :pass          => 1,
+      :vm_name       => @target_vm_name,
+      :number_of_vms => 1,
+      :cpu_limit     => -1,
+      :cpu_reserve   => 0
+    }
+  end
+
+  context "when auto naming sequence exceeds the range" do
+    before do
+      @ems         = FactoryBot.create(:ems_vmware_with_authentication)
+      @vm_template = FactoryBot.create(:template_vmware, :name => "template1", :ext_management_system => @ems, :operating_system => @os, :cpu_limit => -1, :cpu_reserve => 0)
+      @vm          = FactoryBot.create(:vm_vmware, :name => "vm1", :location => "abc/def.vmx")
+
+      @pr = FactoryBot.create(:miq_provision_request, :requester => @admin, :src_vm_id => @vm_template.id)
+      @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
+      @vm_prov = FactoryBot.create(:miq_provision, :userid => @admin.userid, :miq_request => @pr, :source => @vm_template, :request_type => 'template', :state => 'pending', :status => 'Ok', :options => @options)
+
+      miq_region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
+      miq_region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
+    end
+
+    it "should advance to next range but based on the existing sequence number for the new range" do
+      expect(MiqRegion).to receive(:my_region).exactly(3).times.and_return(miq_region)
+
+      ae_workspace = double("ae_workspace")
+      expect(ae_workspace).to receive(:root).and_return("#{@target_vm_name}$n{3}").twice
+      expect(MiqAeEngine).to receive(:resolve_automation_object).and_return(ae_workspace).twice
+
+      @vm_prov.options[:number_of_vms] = 2
+      @vm_prov.after_request_task_create
+      expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}999")  # 3 digits
+
+      @vm_prov.options[:pass] = 2
+      @vm_prov.after_request_task_create
+      expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}0011") # 4 digits
+    end
+
+    it "should advance to next range but based on the existing sequence number for the new range" do
+      expect(MiqRegion).to receive(:my_region).exactly(2).times.and_return(miq_region)
+
+      ae_workspace = double("ae_workspace")
+      expect(ae_workspace).to receive(:root).and_return("#{@target_vm_name}$n{3, -1}").twice
+      expect(MiqAeEngine).to receive(:resolve_automation_object).and_return(ae_workspace).twice
+
+      @vm_prov.options[:number_of_vms] = 2
+      @vm_prov.after_request_task_create
+      expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}999")  # 3 digits
+
+      @vm_prov.options[:pass] = 2
+      @vm_prov.after_request_task_create
+      expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}1000") # 4 digits
+    end
+  end
+end

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -120,28 +120,6 @@ RSpec.describe MiqProvision do
           end
         end
 
-        context "when auto naming sequence exceeds the range" do
-          before do
-            expect(MiqRegion).to receive(:my_region).exactly(3).times.and_return(miq_region)
-            miq_region.naming_sequences.create(:name => "#{@target_vm_name}$n{3}", :source => "provisioning", :value => 998)
-            miq_region.naming_sequences.create(:name => "#{@target_vm_name}$n{4}", :source => "provisioning", :value => 10)
-          end
-
-          it "should advance to next range but based on the existing sequence number for the new range" do
-            ae_workspace = double("ae_workspace")
-            expect(ae_workspace).to receive(:root).and_return("#{@target_vm_name}$n{3}").twice
-            expect(MiqAeEngine).to receive(:resolve_automation_object).and_return(ae_workspace).twice
-
-            @vm_prov.options[:number_of_vms] = 2
-            @vm_prov.after_request_task_create
-            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}999")  # 3 digits
-
-            @vm_prov.options[:pass] = 2
-            @vm_prov.after_request_task_create
-            expect(@vm_prov.get_option(:vm_target_name)).to eq("#{@target_vm_name}0011") # 4 digits
-          end
-        end
-
         it "should create a hostname with a valid length based on the OS" do
           # Hostname lengths by platform:
           #   Linux   : 63


### PR DESCRIPTION
This proof-of-concept PR is a little bit refactoring (1st commit) and an attempt to start supporting different functionality in the name enumeration logic based on the BZ https://bugzilla.redhat.com/show_bug.cgi?id=1688672.

The existing logic is based on passing `$n{#}` as part of the VM name which can be used to generate a unique name.  Example: `test$n{3} => test001`

The updated logic allows a second (optional) parameter, like `$n{#, #}` which can be used to further control the logic.  With the changes in this PR, passing `-1` as the second parameter will cause the naming to skip incrementing the zero-padding value which can have the side-effect of selecting lower numerical values as it is considered a different naming sequence and has it's own enumeration record for tracking.

For example:  
Passing `$n{1}` could cause the naming to progress as follows: `test8`, `test9`,`test01`, `test02`, ...
Passing `$n{1, -1}` would cause the naming to progress: `test8`, `test9`,`test10`, `test11`, ...

I'm posting this PR so we can discuss some ideas of what naming schemas would be desirable as well as what the naming sequence should be to control the functionality.  I used `-1` as the second parameter for no other reason then just to get something working.  It could be letters or numbers or something else.

Links
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1688672

Steps for Testing/QA
-------------------------------

Tests have been extracted out into a separate spec file and could be reworked to be more efficient and comprehensive.  Would like to avoid requiring as much of the request stack as it currently does and pair it down to the region and naming sequence objects.

cc @tinaafitz @d-m-u 