### PR TITLE
[ruby_require_leak_spec.rb] Better CI Ruby check

### DIFF
--- a/spec/lib/ruby_require_leak_spec.rb
+++ b/spec/lib/ruby_require_leak_spec.rb
@@ -36,12 +36,13 @@ describe "Ruby 'require' leak with Pathnames" do
       #     * https://github.com/ManageIQ/manageiq-ui-classic/pull/3266
       #     * https://github.com/ManageIQ/manageiq-graphql/pull/34
       #
-      it "is running on ruby >= 2.5.0" do
-        current_ruby_version = Gem::Version.new(RbConfig::CONFIG["ruby_version"])
+      it "is running on ruby >= 2.5.0 on travis only" do
         ruby_2_5_0_version   = Gem::Version.new("2.5.0")
-        err_msg              = "expected ruby to be less than 2.5.0"
+        travis_yaml          = YAML.load_file(File.expand_path("../../.travis.yml", __dir__))
+        travis_ruby_versions = travis_yaml["rvm"].map { |rb_ver| Gem::Version.new(rb_ver) }
+        err_msg              = "expected at least 1 ruby to be less than 2.5.0"
 
-        expect(current_ruby_version).to be < ruby_2_5_0_version, err_msg
+        expect(travis_ruby_versions.any? { |rb_ver| rb_ver < ruby_2_5_0_version }).to be_truthy, err_msg
       end
     end
   end


### PR DESCRIPTION
Previously, we were checking if Travis was disallowing failures on a version ruby to check if the memory leak was present.  This approach is flawed as it doesn't allow still maintaining specs for pre 2.5.x versions of ruby while still ensuring tests are passing on Ruby 2.5+.

Instead, this change makes it so that the test suite starts failing when we stop supporting pre 2.5.x versions of Ruby all together.  This should give a better indicator for when we are now also past affected versions on the appliance as well.


Links
-----

* PR adding the spec:  https://github.com/ManageIQ/manageiq/pull/16847/
* Convo in `gitter`: https://gitter.im/ManageIQ/manageiq/core?at=5c9927cbfcaf7b5f731363f4


Steps for Testing/QA
--------------------

1. Update the `spec/spec_helper.rb` to at the top by commenting out the following:
   
   ```ruby
   if ENV["TRAVIS"] || ENV['CI']
     require 'coveralls'
     require 'simplecov'
     SimpleCov.start
     Coveralls.wear!('rails') { add_filter("/spec/") }
   end
   ```
   
2. Run the spec, and confirm it is still passing when "on Travis":
   
   ```console
   $ TRAVIS=1 bundle exec rspec spec/lib/ruby_require_leak_spec.rb
   ```
   
3. Comment out any versions of Ruby below 2.5.x and confirm that the spec fails when running the above.