### PR TITLE
Make remote console worker dependencies optionally loaded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -210,8 +210,8 @@ group :web_server, :manageiq_default do
 end
 
 group :web_socket, :manageiq_default do
-  gem "surro-gate",                     "~>1.0.5"
-  gem "websocket-driver",               "~>0.6.3"
+  gem "surro-gate",                     "~>1.0.5", :require => false
+  gem "websocket-driver",               "~>0.6.3", :require => false
 end
 
 ### Start of gems excluded from the appliances.

--- a/lib/remote_console/client_adapter/web_mks.rb
+++ b/lib/remote_console/client_adapter/web_mks.rb
@@ -1,3 +1,5 @@
+require 'websocket/driver'
+
 module RemoteConsole
   module ClientAdapter
     class WebMKS < SSLSocket

--- a/lib/remote_console/rack_server.rb
+++ b/lib/remote_console/rack_server.rb
@@ -20,6 +20,8 @@
 # always returns with a socket to read and a socket to write, the `@adapters`
 # hash has been used to access the corresponding wrappers.
 
+require 'surro-gate'
+
 module RemoteConsole
   class RackServer
     attr_accessor :logger

--- a/lib/remote_console/server_adapter/websocket_binary.rb
+++ b/lib/remote_console/server_adapter/websocket_binary.rb
@@ -1,3 +1,5 @@
+require 'websocket/driver'
+
 module RemoteConsole
   module ServerAdapter
     class WebsocketBinary


### PR DESCRIPTION
Requiring the `websocket-driver` and the `surro-gate` gems is unnecessary, they're only used in a single worker.

@miq-bot add_label providers/console, dependencies
@miq-bot assign @Fryguy 