### PR TITLE
Allow non-root users to run miqssh as themselves.

### DIFF
--- a/tools/miqssh/miqssh
+++ b/tools/miqssh/miqssh
@@ -9,7 +9,7 @@ NAME=$(basename $0)
 DIR=$(dirname $0)
 miqhosts_cmd="$DIR/miqhosts.rb"
 miqhosts_file="$DIR/miqhosts"
-USER="root"
+USER=$(whoami)
 REQUEST=false
 
 if [ ! -f $miqhosts_file ]

--- a/tools/miqssh/miqssh-copy-id
+++ b/tools/miqssh/miqssh-copy-id
@@ -3,8 +3,9 @@
 DIR=$(dirname $0)
 
 HOSTS=$(awk '!/^#/ {print $1}' $DIR/miqhosts)
+USER=$(whoami)
 
 for i in $HOSTS
 do
-  ssh-copy-id -o StrictHostKeyChecking=no root@$i
+  ssh-copy-id -o StrictHostKeyChecking=no ${USER}@$i
 done


### PR DESCRIPTION
Allow non-root users to run miqssh as themselves using $(whoami) instead of hard coding to root.