### PR TITLE
Dialog fields - make load_values_on_init independent of show_refresh_button

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -30,6 +30,7 @@ class DialogField < ApplicationRecord
 
   default_value_for :required, false
   default_value_for(:visible, :allows_nil => false) { true }
+  default_value_for :load_values_on_init, true
 
   serialize :values
   serialize :values_method_options,   Hash

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -2,7 +2,7 @@ class DialogFieldSortedItem < DialogField
   AUTOMATE_VALUE_FIELDS = %w(sort_by sort_order data_type default_value required read_only visible description).freeze
 
   def initialize_value_context
-    if load_values_on_init?
+    if load_values_on_init
       raw_values
     else
       @raw_values = initial_values
@@ -154,11 +154,6 @@ class DialogFieldSortedItem < DialogField
     else
       []
     end
-  end
-
-  def load_values_on_init?
-    return true unless show_refresh_button
-    load_values_on_init
   end
 
   def value_modifier

--- a/app/models/dialog_field_text_box.rb
+++ b/app/models/dialog_field_text_box.rb
@@ -3,7 +3,7 @@ class DialogFieldTextBox < DialogField
 
   def initialize_value_context
     if @value.blank?
-      @value = dynamic && load_values_on_init? ? values_from_automate : default_value
+      @value = dynamic && load_values_on_init ? values_from_automate : default_value
     end
   end
 
@@ -83,10 +83,5 @@ class DialogFieldTextBox < DialogField
 
   def value_supposed_to_be_int?
     data_type == "integer" && @value.to_s !~ /^[0-9]+$/
-  end
-
-  def load_values_on_init?
-    return true unless show_refresh_button
-    load_values_on_init
   end
 end

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -12,6 +12,7 @@ describe DialogFieldSortedItem do
     end
     let(:default_value) { "test2" }
     let(:automate_values) { [%w(test1 test1), %w(test2 test2), %w(test3 test3)] }
+    let(:empty_values) { [[nil, "<None>"]] }
 
     before do
       allow(DynamicDialogFieldValueProcessor).to receive(:values_from_automate).and_return(automate_values)
@@ -104,14 +105,14 @@ describe DialogFieldSortedItem do
         context "when the default_value is not included in the list of values" do
           let(:default_value) { "test4" }
 
-          it "uses the first value as the default" do
+          it "uses the given value as the default" do
             dialog_field.initialize_value_context
-            expect(dialog_field.default_value).to eq("test1")
+            expect(dialog_field.default_value).to eq("test4")
           end
 
-          it "sets the values to what should be returned from automate" do
+          it "sets the values to empty" do
             dialog_field.initialize_value_context
-            expect(dialog_field.extract_dynamic_values).to eq(automate_values)
+            expect(dialog_field.extract_dynamic_values).to eq(empty_values)
           end
         end
 
@@ -123,9 +124,9 @@ describe DialogFieldSortedItem do
             expect(dialog_field.default_value).to eq("test2")
           end
 
-          it "sets the values to what should be returned from automate" do
+          it "sets the values to empty" do
             dialog_field.initialize_value_context
-            expect(dialog_field.extract_dynamic_values).to eq(automate_values)
+            expect(dialog_field.extract_dynamic_values).to eq(empty_values)
           end
         end
       end

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -43,6 +43,7 @@ describe DialogFieldTextBox do
 
       context "when show_refresh_button is false" do
         let(:show_refresh_button) { false }
+        let(:load_values_on_init) { true }
 
         it "sets the value to the automate value" do
           field.initialize_value_context

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -43,11 +43,24 @@ describe DialogFieldTextBox do
 
       context "when show_refresh_button is false" do
         let(:show_refresh_button) { false }
-        let(:load_values_on_init) { true }
 
-        it "sets the value to the automate value" do
-          field.initialize_value_context
-          expect(field.instance_variable_get(:@value)).to eq("value from automate")
+
+        context "when load_values_on_init is true" do
+          let(:load_values_on_init) { true }
+
+          it "sets the value to the automate value" do
+            field.initialize_value_context
+            expect(field.instance_variable_get(:@value)).to eq("value from automate")
+          end
+        end
+
+        context "when load_values_on_init is false" do
+          let(:load_values_on_init) { false }
+
+          it "uses the default value" do
+            field.initialize_value_context
+            expect(field.instance_variable_get(:@value)).to eq("default value")
+          end
         end
       end
     end


### PR DESCRIPTION
Depends on (schema): https://github.com/ManageIQ/manageiq-schema/pull/357 (merged)
Depended on by (ui-components): https://github.com/ManageIQ/ui-components/pull/376

Before, `show_refresh_button` being falsy meant that `load_values_on_init` would be considered true.

Now, the two are independent, allowing for a field to only be refreshed by other fields.

https://bugzilla.redhat.com/show_bug.cgi?id=1684575
https://bugzilla.redhat.com/show_bug.cgi?id=1684567

Cc @gmcculloug @eclarizio 