### PR TITLE
Add zone to service provisioning.

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -170,6 +170,18 @@ module MiqRequestMixin
     DialogSerializer.new.serialize(Array[dialog]).first
   end
 
+  def dialog_zone
+    zone = options.fetch_path(:dialog, "dialog_zone")
+    return nil if zone.blank?
+
+    unless Zone.where(:name => zone).exists?
+      _log.warn("unknown zone #{zone} specified in dialog, ignored.")
+      return nil
+    end
+
+    zone
+  end
+
   def mark_execution_servers
     options[:executed_on_servers] ||= []
     options[:executed_on_servers] << MiqServer.my_server.id

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -59,6 +59,7 @@ class ServiceTemplate < ApplicationRecord
   has_one :picture, :dependent => :destroy, :as => :resource, :autosave => true
 
   belongs_to :service_template_catalog
+  belongs_to :zone
 
   has_many   :dialogs, -> { distinct }, :through => :resource_actions
   has_many   :miq_schedules, :as => :resource, :dependent => :destroy
@@ -448,6 +449,12 @@ class ServiceTemplate < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Service Catalog Item', 'Service Catalog Items', number)
+  end
+
+  def my_zone
+    # Catalog items can specify a zone to run in.
+    # Catalog bundle are used for grouping catalog items and are therefore treated as zone-agnostic.
+    zone&.name if atomic?
   end
 
   private

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -43,6 +43,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
   end
 
   def my_zone
+    @my_zone ||= dialog_zone || service_template.my_zone
   end
 
   def provision_dialog


### PR DESCRIPTION
Add zone to service provisioning to allow the running of service-related automate tasks in a specific zone.

Zone could be set at following two places with priority from high to low:
1. Service catalog item dialog
2. Service template

Each individual catalog items could specify their zones to run in, but the catalog bundle is zone-agnostic as it’s not a real workflow item, more of an organizational / container thing.

Depends on ~~https://github.com/ManageIQ/manageiq-schema/pull/358.~~
https://bugzilla.redhat.com/show_bug.cgi?id=1415106

@miq-bot add_label enhancement, services
@miq-bot assign @gmcculloug 
cc @tinaafitz 