### PR TITLE
Conversion host base class

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -1,3 +1,5 @@
+require 'resolv'
+
 class ConversionHost < ApplicationRecord
   include NewWithTypeStiMixin
   include AuthenticationMixin

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -34,7 +34,7 @@ module ConversionHost::Configurations
       resource = params.delete(:resource)
 
       params[:resource_id] = resource.id
-      params[:resource_type] = resource.class.name
+      params[:resource_type] = resource.class.base_class.name
 
       queue_configuration('enable', nil, resource, params, auth_user)
     end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -5,7 +5,7 @@ describe ConversionHost do
   let(:params) do
     {
       :name          => 'transformer',
-      :resource_type => vm.class.name,
+      :resource_type => vm.class.base_class.name,
       :resource_id   => vm.id,
       :resource      => vm
     }


### PR DESCRIPTION
When creating a conversion host, we want to set the `resource_type` to the base class name of the resource rather than the subclass. Setting it to the subtype can break polymorphic associations, as it did for `ExtManagementSystem`.

Fixes https://github.com/ManageIQ/manageiq/issues/18603

On an unrelated note, I had to add an explicit `require 'resolv'` to the top of the file because it started breaking without it. It's actually part of the stdlib, but something must have changed in the load ordering.
