### PR TITLE
Remove Discover Cloud Providers option in toolbar drop-down

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -464,10 +464,6 @@
     :feature_type: control
     :identifier: ems_cloud_control
     :children:
-    - :name: Discover
-      :description: Discover Cloud Providers
-      :feature_type: control
-      :identifier: ems_cloud_discover
     - :name: Edit Tags
       :description: Edit Tags of Cloud Providers
       :feature_type: control

--- a/locale/manageiq.pot
+++ b/locale/manageiq.pot
@@ -5606,11 +5606,6 @@ msgid "Discover"
 msgstr ""
 
 #. TRANSLATORS: file: db/fixtures/miq_product_features.yml
-#: ../config/yaml_strings.rb:311
-msgid "Discover Cloud Providers"
-msgstr ""
-
-#. TRANSLATORS: file: db/fixtures/miq_product_features.yml
 #: ../config/yaml_strings.rb:615
 msgid "Discover Infrastructure Providers"
 msgstr ""


### PR DESCRIPTION
Fixes and removes deprecated Discover Cloud Providers option in the toolbar drop-down. This is part 2 of the required code removal, both should be merged at same time to fully complete the BZ issue. 

**NOTE: Requires MiqShortcut.seed prior to test/implementation.**

Cross linked PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/5395


https://bugzilla.redhat.com/show_bug.cgi?id=1686225

