### PR TITLE
Add an option for per_ems_worker settings

### DIFF
--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -139,4 +139,12 @@ module PerEmsWorkerMixin
   def unit_environment_variables
     super << "EMS_ID=#{ems_id}"
   end
+
+  def worker_settings
+    super.merge(per_ems_worker_settings)
+  end
+
+  def per_ems_worker_settings
+    ext_management_system.options&.dig(:worker_settings, normalized_type.to_sym) || {}
+  end
 end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -145,6 +145,6 @@ module PerEmsWorkerMixin
   end
 
   def per_ems_worker_settings
-    ext_management_system.options&.dig(:worker_settings, normalized_type.to_sym) || {}
+    ext_management_system&.options&.dig(:worker_settings, normalized_type.to_sym) || {}
   end
 end


### PR DESCRIPTION
Check ExtManagementSystem#options for worker settings to allow things
like count/log_level to be set per-ems