### PR TITLE
[V2V] Allow the ConversionHost#address field to be empty

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -22,7 +22,8 @@ class ConversionHost < ApplicationRecord
     :uniqueness => true,
     :format     => { :with => Resolv::AddressRegex },
     :inclusion  => { :in => ->(conversion_host) { conversion_host.resource.ipaddresses } },
-    :unless     => ->(conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? }
+    :unless     => ->(conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? },
+    :presence   => false
 
   validate :resource_supports_conversion_host
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -215,6 +215,11 @@ describe ConversionHost do
       conversion_host = ConversionHost.new(:name => "test", :resource => vm, :address => "127.0.0.2")
       expect(conversion_host.valid?).to be(true)
     end
+
+    it "is valid if an address is not provided" do
+      conversion_host = ConversionHost.new(:name => "test", :resource => vm)
+      expect(conversion_host.valid?).to be(true)
+    end
   end
 
   context "resource validation" do


### PR DESCRIPTION
Something of a followup to #18516, this again is based on feedback from the V2V team where it was decided that making the address field mandatory was a problem. Since the UI doesn't (currently) allow users to specify an IP, attempts to connect to the conversion host will fail without this atm.

~~https://bugzilla.redhat.com/show_bug.cgi?id=1622728~~
https://bugzilla.redhat.com/show_bug.cgi?id=1695797

Supersedes https://github.com/ManageIQ/manageiq/pull/18577 which originally set the default value. However, since the underlying IP address could change, it could get out of sync. Internally we use the `ipaddress` method, which will use the associated resource's IP already.

So, I think the best thing is to just loosen the restriction on setting the address.