### PR TITLE
Fix rbac filterer spec failure on Hammer

### DIFF
--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2104,7 +2104,7 @@ describe Rbac::Filterer do
       end
 
       it "handles added include from miq_expression" do
-        st = FactoryBot.create(:service_template)
+        st = FactoryBot.create(:service_template, :name => "st")
         service1, service2, _service3 = FactoryBot.create_list(:service, 3, :service_template => st)
         service1.tag_with("/managed/environment/prod", :ns => "*")
         service2.tag_with("/managed/environment/prod", :ns => "*")


### PR DESCRIPTION
The spec expects the factory produced service template to have a name
Only way to ensure this is to set the name in the factory call

addresses issue with #18543 in hammer's tests

/cc @simaishi this fixes hammer