### PR TITLE
[V2V] Run the playbook on the appliance with the conversion host in inventory

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -182,8 +182,8 @@ class ConversionHost < ApplicationRecord
   end
 
   def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil)
-    raise "vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
-    raise "ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
+    raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
+    raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -317,11 +317,10 @@ class ConversionHost < ApplicationRecord
   rescue => e
     errormsg = "Ansible playbook '#{playbook}' failed for '#{resource.name}' with [#{e.class}: #{e}]"
     _log.error(errormsg)
-    task.error(errormsg) unless task.nil?
+    task&.error(errormsg)
     raise e
   ensure
-    context = task.context_data
-    task.update_context(task.context_data.merge!(:ansible_output => result.output)) unless task.nil? || result.nil?
+    task&.update_context(task.context_data.merge!(:ansible_output => result.output)) unless result.nil?
     File.delete(runner_password_file) if !runner_password_file.nil? && File.exist?(runner_password_file)
     File.delete(runner_ssh_key_file) if !runner_ssh_key_file.nil? && File.exist?(runner_ssh_key_file)
   end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -286,7 +286,7 @@ class ConversionHost < ApplicationRecord
   def ansible_playbook(playbook, extra_vars = {}, auth_type = nil)
     task = MiqTask.all.select { |t| t.context_data.present? && t.context_data[:conversion_host_id] == id }.sort_by(&:created_on).last
     runner_basedir = Dir.mktmpdir("ansible-runner")
-    %w(env inventory).each { |d| Dir.mkdir(File.join(runner_basedir, d)) }
+    %w[env inventory].each { |d| Dir.mkdir(File.join(runner_basedir, d)) }
 
     host = hostname || ipaddress
     File.open(File.join(runner_basedir, 'inventory', 'hosts'), 'w') { |f| f.write(host) }
@@ -319,9 +319,9 @@ class ConversionHost < ApplicationRecord
     task.status = 'Error' unless task.nil?
     raise e
   ensure
-     task.context_data[:ansible_output] = result.output unless task.nil? || result.nil?
-     File.delete(runner_password_file) if !runner_password_file.nil? && File.exist?(runner_password_file)
-     File.delete(runner_ssh_key_file) if !runner_ssh_key_file.nil? && File.exist?(runner_ssh_key_file)
+    task.context_data[:ansible_output] = result.output unless task.nil? || result.nil?
+    File.delete(runner_password_file) if !runner_password_file.nil? && File.exist?(runner_password_file)
+    File.delete(runner_ssh_key_file) if !runner_ssh_key_file.nil? && File.exist?(runner_ssh_key_file)
   end
 
   # Wrapper method for the various tag_resource_as_xxx methods.

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -173,7 +173,7 @@ class ConversionHost < ApplicationRecord
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,
-      :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh'
+      :v2v_transport_method => source_transport_method
     }
     ansible_playbook(playbook, extra_vars, false)
     tag_resource_as('enabled')
@@ -187,7 +187,7 @@ class ConversionHost < ApplicationRecord
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,
-      :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh',
+      :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
       :v2v_ca_bundle        => resource.ext_management_system.connection_configurations['default'].certificate_authority
@@ -201,7 +201,7 @@ class ConversionHost < ApplicationRecord
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_disable.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,
-      :v2v_transport_method => vddk_transport_supported ? 'vddk' : 'ssh'
+      :v2v_transport_method => source_transport_method
     }
     ansible_playbook(playbook, extra_vars)
   ensure

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -283,7 +283,7 @@ class ConversionHost < ApplicationRecord
     command = "ansible-playbook #{playbook} --inventory #{host}, --become -vvv"
 
     auth = authentication_type(auth_type) || authentications.first
-    command += " --user #{auth.userid}"
+    command << " --user #{auth.userid}"
 
     case auth
     when AuthUseridPassword
@@ -291,13 +291,12 @@ class ConversionHost < ApplicationRecord
     when AuthPrivateKey
       ssh_private_key_file = Tempfile.new('ansible_key')
       ssh_private_key_file.write(auth.auth_key)
-      command += " --private-key #{ssh_private_key_file.path}"
+      command << " --private-key #{ssh_private_key_file.path}"
     else
       raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
     end
 
-
-    extra_vars.each { |k, v| command += " --extra-vars '#{k}=#{v}'" }
+    extra_vars.each { |k, v| command << " --extra-vars '#{k}=#{v}'" }
 
     _log.info("FDUPONT - Calling Ansible playbook: #{command}")
     result = AwesomeSpawn.run(command)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -308,7 +308,7 @@ class ConversionHost < ApplicationRecord
     extra_vars.each { |k, v| command << " --extra-vars '#{k}=#{v}'" }
 
     result = AwesomeSpawn.run(command)
-    raise unless result.exit_status.zero? 
+    raise unless result.exit_status.zero?
   rescue => e
     errormsg = "Ansible playbook '#{playbook}' failed for '#{resource.name}' with [#{e.class}: #{e}]"
     _log.error(errormsg)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -291,7 +291,7 @@ class ConversionHost < ApplicationRecord
     command = "ansible-playbook #{playbook} --inventory #{host}, --become --extra-vars=\"ansible_ssh_common_args='-o StrictHostKeyChecking=no'\""
 
     auth = authentication_type(auth_type) || authentications.first
-    command += " --user #{auth.userid}"
+    command << " --user #{auth.userid}"
 
     case auth
     when AuthUseridPassword
@@ -300,12 +300,12 @@ class ConversionHost < ApplicationRecord
       ssh_private_key_file = Tempfile.new('ansible_key')
       ssh_private_key_file.write(auth.auth_key)
       ssh_private_key_file.close
-      command += " --private-key #{ssh_private_key_file.path}"
+      command << " --private-key #{ssh_private_key_file.path}"
     else
       raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
     end
 
-    extra_vars.each { |k, v| command += " --extra-vars '#{k}=#{v}'" }
+    extra_vars.each { |k, v| command << " --extra-vars '#{k}=#{v}'" }
 
     result = AwesomeSpawn.run(command)
     raise unless result.exit_status.zero? 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -313,11 +313,8 @@ class ConversionHost < ApplicationRecord
     result = AwesomeSpawn.run(command)
     raise unless result.exit_status.zero?
   ensure
-    unless result.nil?
-      ansible_output_name = playbook.split('/').last.split('.').first
-      task&.update_context(task.context_data.merge!(ansible_output_name => result.output))
-    end
-    File.delete(ssh_private_key_file) if ssh_private_key_file.present? && File.exist?(ssh_private_key_file.path)
+    task&.update_context(task.context_data.merge!(File.basename(playbook, '.yml') => result.output)) unless result.nil?
+    ssh_private_key_file&.unlink
   end
 
   # Wrapper method for the various tag_resource_as_xxx methods.

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -55,7 +55,7 @@ module ConversionHost::Configurations
 
     def enable(params, auth_user = nil)
       params = params.symbolize_keys
-      _log.info("Enabling a conversion_host with parameters: #{params}")
+      _log.debug("Enabling a conversion_host with parameters: #{params}")
 
       params.delete(:task_id) # In case this is being called through *_queue which will stick in a :task_id
       miq_task_id = params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
@@ -78,7 +78,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, miq_task_id)
         conversion_host.save!
 
         if miq_task_id
@@ -102,7 +102,7 @@ module ConversionHost::Configurations
 
   def disable
     resource_info = "type=#{resource.class.name} id=#{resource.id}"
-    _log.info("Disabling a conversion_host #{resource_info}")
+    _log.debug("Disabling a conversion_host #{resource_info}")
 
     disable_conversion_host_role
     destroy!

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -171,7 +171,7 @@ describe ConversionHost do
           :v2v_host_type        => 'rhevm',
           :v2v_transport_method => 'vddk'
         }
-        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, false)
+        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars)
         conversion_host.check_conversion_host_role
       end
 
@@ -184,7 +184,7 @@ describe ConversionHost do
         }
         check_extra_vars = disable_extra_vars
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, false)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
         conversion_host.disable_conversion_host_role
       end
 
@@ -205,7 +205,7 @@ describe ConversionHost do
           :v2v_transport_method => 'vddk'
         }
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, false)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
         conversion_host.enable_conversion_host_role('http://file.example.com/vddk-stable.tar.gz', nil)
       end
     end
@@ -240,7 +240,7 @@ describe ConversionHost do
           :v2v_host_type        => 'openstack',
           :v2v_transport_method => 'ssh'
         }
-        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, false)
+        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars)
         conversion_host.check_conversion_host_role
       end
 
@@ -253,7 +253,7 @@ describe ConversionHost do
         }
         check_extra_vars = disable_extra_vars
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, false)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
         conversion_host.disable_conversion_host_role
       end
 
@@ -274,7 +274,7 @@ describe ConversionHost do
           :v2v_transport_method => 'ssh'
         }
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, false)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
         conversion_host.enable_conversion_host_role(nil, 'fake ssh private key')
       end
     end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -171,8 +171,8 @@ describe ConversionHost do
           :v2v_host_type        => 'rhevm',
           :v2v_transport_method => 'vddk'
         }
-        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars)
-        conversion_host.check_conversion_host_role
+        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, 1)
+        conversion_host.check_conversion_host_role(1)
       end
 
       it "disable_conversion_host_role calls ansible_playbook with extra_vars" do
@@ -183,9 +183,9 @@ describe ConversionHost do
           :v2v_transport_method => 'vddk'
         }
         check_extra_vars = disable_extra_vars
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
-        conversion_host.disable_conversion_host_role
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars, 1)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, 1)
+        conversion_host.disable_conversion_host_role(1)
       end
 
       it "enable_conversion_host_role raises if vmware_vddk_package_url is nil" do
@@ -204,8 +204,8 @@ describe ConversionHost do
           :v2v_host_type        => 'rhevm',
           :v2v_transport_method => 'vddk'
         }
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars, nil)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, nil)
         conversion_host.enable_conversion_host_role('http://file.example.com/vddk-stable.tar.gz', nil)
       end
     end
@@ -240,8 +240,8 @@ describe ConversionHost do
           :v2v_host_type        => 'openstack',
           :v2v_transport_method => 'ssh'
         }
-        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars)
-        conversion_host.check_conversion_host_role
+        expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, 1)
+        conversion_host.check_conversion_host_role(1)
       end
 
       it "disable_conversion_host_role calls ansible_playbook with extra_vars" do
@@ -252,9 +252,9 @@ describe ConversionHost do
           :v2v_transport_method => 'ssh'
         }
         check_extra_vars = disable_extra_vars
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
-        conversion_host.disable_conversion_host_role
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars, 1)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, 1)
+        conversion_host.disable_conversion_host_role(1)
       end
 
       it "enable_conversion_host_role raises if vmware_ssh_private_key is nil" do
@@ -273,8 +273,8 @@ describe ConversionHost do
           :v2v_host_type        => 'openstack',
           :v2v_transport_method => 'ssh'
         }
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars)
-        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars, nil)
+        expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, nil)
         conversion_host.enable_conversion_host_role(nil, 'fake ssh private key')
       end
     end


### PR DESCRIPTION
In existing implementation, CloudForms connect to the conversion host via SSH to execute the `ansible-runner` command. The Ansible playbooks are now shipped in the appliance to keep the playbooks in sync with the backend capabilities. This PR updates the `extra_vars` hash to match `v2v-conversion-host-ansible-1.12` requirements and calls `ansible-runner` on the CloudForms appliance.

To do so, it generates the runtime directory for the playbook:

- the inventory contains the conversion host hostname or IP address
- the credentials are passed in temporary files, which are deleted as soon as `ansible-runner` ends
- the extra vars are passed in a file

The `ansible-runner` command is then run via `AwesomeSpawn.run`.

Note: this PR is dedicated to Hammer. Another one will be created to use `Ansible::Runner`. This will require some changes to `Ansible::Runner` class to allow specifying the inventory and the credentials.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1694229

Depends on: https://github.com/ManageIQ/manageiq-api/pull/535, https://github.com/ManageIQ/manageiq/pull/18541