### PR TITLE
[HAMMER] Add create_subtasks method to service_retire_task for ansible playbooks

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -59,6 +59,10 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     postprocess(action)
   end
 
+  def retain_resources_on_retirement?
+    options.fetch_path(:config_info, :retirement, :remove_resources).to_s.start_with?("no_")
+  end
+
   private
 
   def manageiq_extra_vars(action)

--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -28,8 +28,10 @@ class ServiceRetireTask < MiqRetireTask
   def after_request_task_create
     update_attributes(:description => get_description)
     parent_svc = Service.find_by(:id => options[:src_ids])
-    _log.info("- creating service subtasks for service task <#{self.class.name}:#{id}>, service <#{parent_svc.id}>")
-    create_retire_subtasks(parent_svc, self)
+    if create_subtasks?(parent_svc)
+      _log.info("- creating service subtasks for service task <#{self.class.name}:#{id}>, service <#{parent_svc.id}>")
+      create_retire_subtasks(parent_svc, self)
+    end
   end
 
   def create_retire_subtasks(parent_service, parent_task)
@@ -67,6 +69,10 @@ class ServiceRetireTask < MiqRetireTask
   end
 
   private
+
+  def create_subtasks?(parent_svc)
+    !parent_svc.try(:retain_resources_on_retirement?)
+  end
 
   def retire_task_type(resource_type)
     (resource_type.base_class.name + "RetireTask").safe_constantize || (resource_type.name.demodulize + "RetireTask").safe_constantize

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -140,6 +140,42 @@ describe(ServiceAnsiblePlaybook) do
     end
   end
 
+  shared_examples_for "#retain_resources_on_retirement" do
+    it "has config_info retirement options" do
+      service_options = service.options
+      service_options[:config_info][:retirement] = service_options[:config_info][:provision]
+      service_options[:config_info][:retirement][:remove_resources] = remove_resources
+      service.update_attributes(:options => service_options)
+      expect(service.retain_resources_on_retirement?).to eq(!can_children_be_retired?)
+    end
+  end
+
+  describe '#retain_resources_on_retirement?' do
+    context "no_with_playbook returns true" do
+      let(:remove_resources) { 'no_with_playbook' }
+      let(:can_children_be_retired?) { false }
+      it_behaves_like "#retain_resources_on_retirement"
+    end
+
+    context "no_without_playbook returns true" do
+      let(:remove_resources) { 'no_without_playbook' }
+      let(:can_children_be_retired?) { false }
+      it_behaves_like "#retain_resources_on_retirement"
+    end
+
+    context "yes_with_playbook returns false" do
+      let(:remove_resources) { 'yes_with_playbook' }
+      let(:can_children_be_retired?) { true }
+      it_behaves_like "#retain_resources_on_retirement"
+    end
+
+    context "yes_without_playbook returns false" do
+      let(:remove_resources) { 'yes_without_playbook' }
+      let(:can_children_be_retired?) { true }
+      it_behaves_like "#retain_resources_on_retirement"
+    end
+  end
+
   describe '#execute' do
     let(:control_extras) { {'a' => 'A', 'b' => 'B', 'c' => 'C'} }
     before do

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -30,6 +30,28 @@ describe ServiceRetireTask do
     end
   end
 
+  shared_examples_for "no_remove_resource" do
+    it "creates 1 service retire subtask" do
+      ap_service.add_resource!(FactoryBot.create(:vm_vmware))
+      ap_service_retire_task.after_request_task_create
+
+      expect(ap_service_retire_task.description).to eq("Service Retire for: #{ap_service.name} - ")
+      expect(ServiceRetireTask.count).to eq(1)
+      expect(VmRetireTask.count).to eq(0)
+    end
+  end
+
+  shared_examples_for "yes_remove_resource" do
+    it "creates 1 service retire subtask and 1 vm retire subtask" do
+      ap_service.add_resource!(FactoryBot.create(:vm_vmware))
+      ap_service_retire_task.after_request_task_create
+
+      expect(ap_service_retire_task.description).to eq("Service Retire for: #{ap_service.name} - ")
+      expect(ServiceRetireTask.count).to eq(1)
+      expect(VmRetireTask.count).to eq(1)
+    end
+  end
+
   describe "#after_request_task_create" do
     context "sans resource" do
       it "doesn't create subtask" do
@@ -53,6 +75,36 @@ describe ServiceRetireTask do
 
         expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
         expect(ServiceRetireTask.count).to eq(2)
+      end
+
+      context "ansible playbook service" do
+        context "no_with_playbook" do
+          let(:ap_service) { FactoryBot.create(:service_ansible_playbook, :options => {:config_info => {:retirement => {:remove_resources => "no_with_playbook"} }}) }
+          let(:ap_service_retire_task) { FactoryBot.create(:service_retire_task, :source => ap_service, :miq_request => miq_request, :options => {:src_ids => [ap_service.id] }) }
+
+          it_behaves_like "no_remove_resource"
+        end
+
+        context "no_without_playbook" do
+          let(:ap_service) { FactoryBot.create(:service_ansible_playbook, :options => {:config_info => {:retirement => {:remove_resources => "no_without_playbook"} }}) }
+          let(:ap_service_retire_task) { FactoryBot.create(:service_retire_task, :source => ap_service, :miq_request => miq_request, :options => {:src_ids => [ap_service.id] }) }
+
+          it_behaves_like "no_remove_resource"
+        end
+
+        context "yes_with_playbook" do
+          let(:ap_service) { FactoryBot.create(:service_ansible_playbook, :options => {:config_info => {:retirement => {:remove_resources => "yes_with_playbook"} }}) }
+          let(:ap_service_retire_task) { FactoryBot.create(:service_retire_task, :source => ap_service, :miq_request => miq_request, :options => {:src_ids => [ap_service.id] }) }
+
+          it_behaves_like "yes_remove_resource"
+        end
+
+        context "yes_without_playbook" do
+          let(:ap_service) { FactoryBot.create(:service_ansible_playbook, :options => {:config_info => {:retirement => {:remove_resources => "yes_without_playbook"} }}) }
+          let(:ap_service_retire_task) { FactoryBot.create(:service_retire_task, :source => ap_service, :miq_request => miq_request, :options => {:src_ids => [ap_service.id] }) }
+
+          it_behaves_like "yes_remove_resource"
+        end
       end
 
       it "creates service retire subtask" do


### PR DESCRIPTION
... services. 

We are currently creating the service retire tasks before we send them to automate, which means that if the parent service is an ansible playbook service with config options specifying the resources to not be retired, we will have already created tasks for the retirement of said resources, and will not honor the playbook config options hash. This cuts off the task creation for APS's early if the config option to not retire resources is present.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1695627

**This is hammer version of https://github.com/ManageIQ/manageiq/pull/18609 because of https://github.com/ManageIQ/manageiq/pull/18609#issuecomment-479490143** 


