### PR TITLE
fix: swap makes vms out of disk space report false positive

### DIFF
--- a/product/reports/100_Configuration Management - Virtual Machines/028_VMs with Volume Free Space -= 20%.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/028_VMs with Volume Free Space -= 20%.yaml
@@ -10,9 +10,9 @@ conditions: !ruby/object:MiqExpression
         IS NOT EMPTY:
           field: Vm.hardware.volumes-name
       checkany:
-        "<=":
-          field: Vm.hardware.volumes-free_space_percent
-          value: 20
+        ">=":
+          field: Vm.hardware.volumes-used_space_percent
+          value: 80
 updated_on: 2008-10-23 17:23:34.503804 Z
 order: Ascending
 graph:


### PR DESCRIPTION
`MiqExpression`s convert nil to a floating point number. In ruby this is a 0.

```
nil <= 20
nil.to_f ==> 0
0 <= 20 == true
```

Swap partitions have a nil free_space / free_space_percentage.

so free_space_percentage <= 20 shows true for swap

So any vm with a swap partition will say it is low on disk space.

Fix is to ask if used space is over 80%

```
nil >= 80
nil.to_f ==> 0
0 >= 80 == false
```

Now, there are no false positives for running out of disk space.

https://bugzilla.redhat.com/show_bug.cgi?id=1686281
