### PR TITLE
Use admin to auto approve a request.

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -529,7 +529,7 @@ class MiqRequest < ApplicationRecord
 
     if process_on_create?
       call_automate_event_queue("request_created")
-      approve(requester, "Auto-Approved") if auto_approve
+      approve(User.super_admin.userid, "Auto-Approved") if auto_approve
       reload if auto_approve
     end
 

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -98,6 +98,7 @@ describe AutomationRequest do
     end
 
     it "with requester string overriding userid AND auto_approval" do
+      FactoryBot.create(:user_admin, :userid => 'admin')
       ar = AutomationRequest.create_from_ws(@version, admin,
                                             @uri_parts, @parameters,
                                             "user_name" => @approver.userid.to_s, 'auto_approve' => 'true')
@@ -120,6 +121,7 @@ describe AutomationRequest do
 
   context ".create_from_scheduled_task" do
     let(:admin) { FactoryBot.create(:user_miq_request_approver) }
+    before { FactoryBot.create(:user_admin, :userid => 'admin') }
 
     it "with prescheduled task" do
       ar = described_class.create_from_scheduled_task(admin, @uri_parts, @parameters)
@@ -241,6 +243,7 @@ describe AutomationRequest do
 
   context "validate zone" do
     before do
+      FactoryBot.create(:user_admin, :userid => 'admin')
       allow_any_instance_of(MiqRequest).to receive(:automate_event_failed?).and_return(false)
     end
 

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -192,6 +192,18 @@ describe MiqRequest do
         end
       end
 
+      it "with auto approval" do
+        FactoryBot.create(:user_admin, :userid => 'admin')
+        allow(MiqServer).to receive_messages(:my_zone => "default")
+
+        expect(request).to receive(:set_description)
+        expect(request).to receive(:log_request_success)
+        expect(request).to receive(:call_automate_event_queue).with("request_created")
+        expect(request).to receive(:call_automate_event_queue).with("request_approved")
+        expect(request).to receive(:execute)
+        request.post_create(true)
+      end
+
       context "with user approvals" do
         let(:reason)          { "Why Not?" }
         let(:fred_approval)   { FactoryBot.create(:miq_approval, :approver => fred, :reason => reason, :stamper => barney, :stamped_on => Time.now) }

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -531,6 +531,7 @@ describe MiqSchedule do
       end
 
       it "should create 1 automation request" do
+        FactoryBot.create(:user_admin, :userid => 'admin')
         automate_sched.action_automation_request(AutomationRequest, '')
         expect(AutomationRequest.where(:description => "Automation Task", :userid => admin.userid).count).to eq(1)
       end


### PR DESCRIPTION
The approver needs to have miq_request_approval role and admin is the only default user with that role.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1687597

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, changelog/yes
