### PR TITLE
Use string class name instead of hitting autoload

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -18,7 +18,7 @@ class CloudNetwork < ApplicationRecord
   has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
   has_many :public_network_vms, -> { distinct }, :through => :public_network_routers, :source => :vms
-  has_many :public_network_routers, :foreign_key => :cloud_network_id, :class_name => NetworkRouter
+  has_many :public_network_routers, :foreign_key => :cloud_network_id, :class_name => "NetworkRouter"
   has_many :private_networks, -> { distinct }, :through => :public_network_routers, :source => :cloud_networks
 
   # TODO(lsmola) figure out what this means, like security groups used by VMs in the network? It's not being

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -16,9 +16,9 @@ class ContainerGroup < ApplicationRecord
   has_many :containers, :dependent => :destroy
   has_many :container_images, -> { distinct }, :through => :containers
   belongs_to  :ext_management_system, :foreign_key => "ems_id"
-  has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
+  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
   has_many :node_selector_parts, -> { where(:section => "node_selectors") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
-  has_many :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
+  has_many :container_conditions, :class_name => "ContainerCondition", :as => :container_entity, :dependent => :destroy
   belongs_to :container_node
   has_and_belongs_to_many :container_services, :join_table => :container_groups_container_services
   belongs_to :container_replicator

--- a/app/models/container_group_performance.rb
+++ b/app/models/container_group_performance.rb
@@ -1,7 +1,7 @@
 class ContainerGroupPerformance < MetricRollup
   default_scope { where("resource_type = 'ContainerGroup' and resource_id IS NOT NULL") }
 
-  belongs_to :container_group, :foreign_key => :resource_id, :class_name => ContainerGroup.name
+  belongs_to :container_group, :foreign_key => :resource_id, :class_name => "ContainerGroup"
 
   def self.display_name(number = 1)
     n_('Pod Performance', 'Pod Performances', number)

--- a/app/models/container_image.rb
+++ b/app/models/container_image.rb
@@ -24,9 +24,9 @@ class ContainerImage < ApplicationRecord
   has_one :operating_system, :through => :computer_system
   has_one :openscap_result, :dependent => :destroy
   has_many :openscap_rule_results, :through => :openscap_result
-  has_many :labels, -> { where(:section => "labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
-  has_many :docker_labels, -> { where(:section => "docker_labels") }, :class_name => CustomAttribute, :as => :resource, :dependent => :destroy
-  has_one :last_scan_result, :class_name => ScanResult, :as => :resource, :dependent => :destroy, :autosave => true
+  has_many :labels, -> { where(:section => "labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_many :docker_labels, -> { where(:section => "docker_labels") }, :class_name => "CustomAttribute", :as => :resource, :dependent => :destroy
+  has_one :last_scan_result, :class_name => "ScanResult", :as => :resource, :dependent => :destroy, :autosave => true
 
   serialize :exposed_ports, Hash
   serialize :environment_variables, Hash

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -15,7 +15,7 @@ class ContainerNode < ApplicationRecord
   # :name, :uid, :creation_timestamp, :resource_version
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   has_many   :container_groups, -> { active }
-  has_many   :container_conditions, :class_name => ContainerCondition, :as => :container_entity, :dependent => :destroy
+  has_many   :container_conditions, :class_name => "ContainerCondition", :as => :container_entity, :dependent => :destroy
   has_many   :containers, :through => :container_groups
   has_many   :container_images, -> { distinct }, :through => :container_groups
   has_many   :container_services, -> { distinct }, :through => :container_groups

--- a/app/models/container_node_performance.rb
+++ b/app/models/container_node_performance.rb
@@ -1,7 +1,7 @@
 class ContainerNodePerformance < MetricRollup
   default_scope { where("resource_type = 'ContainerNode' and resource_id IS NOT NULL") }
 
-  belongs_to :container_node, :foreign_key => :resource_id, :class_name => ContainerNode.name
+  belongs_to :container_node, :foreign_key => :resource_id, :class_name => "ContainerNode"
 
   def self.display_name(number = 1)
     n_('Container Node Performance', 'Container Nodes Performances', number)

--- a/app/models/container_performance.rb
+++ b/app/models/container_performance.rb
@@ -1,7 +1,7 @@
 class ContainerPerformance < MetricRollup
   default_scope { where("resource_type = 'Container' and resource_id IS NOT NULL") }
 
-  belongs_to :container_node, :foreign_key => :resource_id, :class_name => Container.name
+  belongs_to :container_node, :foreign_key => :resource_id, :class_name => "Container"
 
   def self.display_name(number = 1)
     n_('Performance - Container', 'Performance - Containers', number)

--- a/app/models/container_project_performance.rb
+++ b/app/models/container_project_performance.rb
@@ -1,7 +1,7 @@
 class ContainerProjectPerformance < MetricRollup
   default_scope { where("resource_type = 'ContainerProject' and resource_id IS NOT NULL") }
 
-  belongs_to :container_node, :foreign_key => :resource_id, :class_name => ContainerProject.name
+  belongs_to :container_node, :foreign_key => :resource_id, :class_name => "ContainerProject"
 
   def self.display_name(number = 1)
     n_('Performance - Container Project', 'Performance - Container Projects', number)

--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -6,7 +6,7 @@ class ContainerTemplate < ApplicationRecord
   belongs_to :container_project
   has_many :container_template_parameters, :dependent => :destroy
   has_many :labels, -> { where(:section => "labels") },
-           :class_name => CustomAttribute,
+           :class_name => "CustomAttribute",
            :as         => :resource,
            :dependent  => :destroy
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -8,9 +8,8 @@ class ConversionHost < ApplicationRecord
 
   belongs_to :resource, :polymorphic => true
   has_many :service_template_transformation_plan_tasks, :dependent => :nullify
-
   has_many :active_tasks, -> { where(:state => ['active', 'migrate']) },
-    :class_name => ServiceTemplateTransformationPlanTask,
+    :class_name => "ServiceTemplateTransformationPlanTask",
     :inverse_of => :conversion_host
 
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,11 +2,11 @@ class Notification < ApplicationRecord
   include_concern 'Purging'
 
   belongs_to :notification_type
-  belongs_to :initiator, :class_name => User, :foreign_key => 'user_id'
+  belongs_to :initiator, :class_name => "User", :foreign_key => 'user_id'
   belongs_to :subject, :polymorphic => true
   belongs_to :cause, :polymorphic => true
   has_many :notification_recipients, :dependent => :delete_all
-  has_many :recipients, :class_name => User, :through => :notification_recipients, :source => :user
+  has_many :recipients, :class_name => "User", :through => :notification_recipients, :source => :user
 
   accepts_nested_attributes_for :notification_recipients
   before_create :set_notification_recipients


### PR DESCRIPTION
DEPRECATION WARNING: Passing a class to the `class_name` is deprecated
and will raise an ArgumentError in Rails 5.2. It eagerloads more classes
than necessary and potentially creates circular dependencies. Please
pass the class name as a string: `has_many :public_network_routers,
class_name: 'NetworkRouter'` (called from <class:CloudNetwork> at
/Users/joerafaniello/Code/manageiq/app/models/cloud_network.rb:21)

🤣 the branch name 🤣  cc @gtanzillo @Fryguy 