### PR TITLE
Use lambda, if validation with a string is deprecated

### DIFF
--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -41,7 +41,7 @@ class TenantQuota < ApplicationRecord
             :uniqueness => {:scope => :tenant_id, :message => "should be unique per tenant"}
   validates :unit, :value, :presence => true
   validates :value, :numericality => {:greater_than => 0}
-  validates :warn_value, :numericality => {:greater_than => 0}, :if => "warn_value.present?"
+  validates :warn_value, :numericality => {:greater_than => 0}, :if => -> { warn_value.present? }
 
   validate :check_for_over_allocation
 


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: Passing string to be evaluated in :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement. Pass a symbol for an instance method, or a lambda, proc or block, instead. (called from class:TenantQuota at /home/travis/build/ManageIQ/manageiq/app/models/tenant_quota.rb:44)