### PR TITLE
fix_auth now handles recursive settings

### DIFF
--- a/lib/vmdb/settings_walker.rb
+++ b/lib/vmdb/settings_walker.rb
@@ -20,13 +20,14 @@ module Vmdb
           key_path = path.dup << key
 
           yield key, value, key_path, settings
+          next if key == settings || value == settings
 
           case value
           when settings.class
             walk(value, key_path, &block)
           when Array
             value.each_with_index do |v, i|
-              walk(v, key_path.dup << i, &block) if v.kind_of?(settings.class)
+              walk(v, key_path.dup << i, &block) if v.kind_of?(settings.class) && v != settings
             end
           end
         end


### PR DESCRIPTION
### situation:

1. For one customer, `miq_request_tasks` has an `options` hash with recursive values.
2. `fix_auth` recurses all the `options` looking for passwords to convert.

### before

it recurses forever

### after

it now detects the recursion and does not go forever

NOTE: this only detects very simple recursive cases.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1696237

(Review spec with ignore whitespace may be easier to view)