### PR TITLE
Fix Key Pairs from refresh being returned with provider AuthPrivateKeys

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -27,7 +27,7 @@ module ManageIQ::Providers
     has_many :cloud_object_store_objects,    :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_services,                :foreign_key => :ems_id, :dependent => :destroy
     has_many :cloud_databases,               :foreign_key => :ems_id, :dependent => :destroy
-    has_many :key_pairs,                     :class_name  => "AuthPrivateKey", :as => :resource, :dependent => :destroy
+    has_many :key_pairs,                     :class_name  => "AuthKeyPair", :as => :resource, :dependent => :destroy
     has_many :host_aggregates,               :foreign_key => :ems_id, :dependent => :destroy
     has_one  :source_tenant, :as => :source, :class_name  => 'Tenant'
     has_many :vm_and_template_labels,        :through     => :vms_and_templates, :source => :labels

--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::CloudManager::AuthKeyPair < ::AuthPrivateKey
+class ManageIQ::Providers::CloudManager::AuthKeyPair < ::Authentication
   include AvailabilityMixin
 
   acts_as_miq_taggable

--- a/app/models/manageiq/providers/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/options_helper.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::CloudManager::Provision::OptionsHelper
   end
 
   def guest_access_key_pair
-    @guest_access_key_pair ||= AuthPrivateKey.find_by(:id => get_option(:guest_access_key_pair))
+    @guest_access_key_pair ||= Authentication.find_by(:id => get_option(:guest_access_key_pair))
   end
 
   def security_groups

--- a/app/models/manageiq/providers/cloud_manager/provision/options_helper.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/options_helper.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::CloudManager::Provision::OptionsHelper
   end
 
   def guest_access_key_pair
-    @guest_access_key_pair ||= Authentication.find_by(:id => get_option(:guest_access_key_pair))
+    @guest_access_key_pair ||= ManageIQ::Providers::CloudManager::AuthKeyPair.find_by(:id => get_option(:guest_access_key_pair))
   end
 
   def security_groups

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -85,8 +85,7 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
     end
 
     it "#allowed_guest_access_key_pairs" do
-      kp = AuthPrivateKey.create(:name => "auth_1")
-      ems.key_pairs << kp
+      kp = ems.key_pairs.create(:name => "auth_1")
       expect(workflow.allowed_guest_access_key_pairs).to eq(kp.id => kp.name)
     end
   end


### PR DESCRIPTION
`AuthPrivateKey`s are used to connect to providers, `ManageIQ::Provider::CloudManager::AuthKeyPair`s were being returned with these because they inherited from that class without actually using anything from it.

Update the CloudManager::AuthKeyPairs to inherit from the base Authentications class