### PR TITLE
[HAMMER] [V2V] Refactor ConversionHost to use AuthenticationMixin

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -2,6 +2,7 @@ require 'resolv'
 
 class ConversionHost < ApplicationRecord
   include NewWithTypeStiMixin
+  include AuthenticationMixin
 
   acts_as_miq_taggable
 
@@ -25,15 +26,62 @@ class ConversionHost < ApplicationRecord
 
   include_concern 'Configurations'
 
-  after_create :tag_resource_as_enabled
-  after_destroy :tag_resource_as_disabled
+  # Use the +auth_type+ if present, or check the first associated authentication
+  # if any are directly associated with the conversion host. Otherwise, use the
+  # default check which uses the associated resource's authentications.
+  #
+  # In practice there should only be one associated authentication.
+  #
+  # Subclasses should pass provider-specific +options+, such as proxy information.
+  #
+  # This method is necessary to comply with AuthenticationMixin interface.
+  #--
+  # TODO: Use the verify_credentials_ssh method in host.rb? Move that to the
+  # AuthenticationMixin?
+  #
+  def verify_credentials(auth_type = nil, options = {})
+    if authentications.empty?
+      check_ssh_connection
+    else
+      require 'net/ssh'
+      host = hostname || ipaddress
+
+      auth = authentication_type(auth_type) || authentications.first
+
+      ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
+
+      case auth
+      when AuthUseridPassword
+        ssh_options[:auth_methods] = %w[password]
+        ssh_options[:password] = auth.password
+      when AuthPrivateKey
+        ssh_options[:auth_methods] = %w[publickey hostbased]
+        ssh_options[:key_data] = auth.auth_key
+      else
+        raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
+      end
+
+      # Options from STI subclasses will override the defaults we've set above.
+      ssh_options.merge!(options)
+
+      Net::SSH.start(host, auth.userid, ssh_options) { |ssh| ssh.exec!('uname -a') }
+    end
+  rescue Net::SSH::AuthenticationFailed => err
+    raise MiqException::MiqInvalidCredentialsError, _("Incorrect credentials - %{error_message}") % {:error_message => err.message}
+  rescue Net::SSH::HostKeyMismatch => err
+    raise MiqException::MiqSshUtilHostKeyMismatch, _("Host key mismatch - %{error_message}") % {:error_message => err.message}
+  rescue Exception => err
+    raise _("Unknown error - %{error_message}") % {:error_message => err.message}
+  else
+    true
+  end
 
   # To be eligible, a conversion host must have the following properties
   #  - A transport mechanism is configured for source (set by 3rd party)
   #  - Credentials are set on the resource and SSH connection works
   #  - The number of concurrent tasks has not reached the limit
   def eligible?
-    source_transport_method.present? && check_ssh_connection && check_concurrent_tasks
+    source_transport_method.present? && verify_credentials && check_concurrent_tasks
   end
 
   def check_concurrent_tasks
@@ -145,35 +193,24 @@ class ConversionHost < ApplicationRecord
 
   private
 
-  # The Vm or Host provider subclass must support conversion hosts
-  # using the SupportsFeature mixin.
+  # Find the credentials for the associated resource. By default it will
+  # look for a v2v auth type. If that is not found, it will look for the
+  # authentication associated with the resource using ssh_keypair or default,
+  # in that order, as the authtype.
   #
-  def resource_supports_conversion_host
-    if resource && !resource.supports_conversion_host?
-      errors.add(:resource, resource.unsupported_reason(:conversion_host))
-    end
-  end
+  def find_credentials(msg = nil)
+    authentication = authentication_type('v2v') ||
+      resource.authentication_type('ssh_keypair') ||
+      resource.authentication_type('default')
 
-  def check_resource_credentials(fatal = false, extra_msg = nil)
-    success = send("check_resource_credentials_#{resource.ext_management_system.emstype}")
-    if !success and fatal
-      msg = "Credential not found for #{resource.name}."
-      msg += " #{extra_msg}" unless extra_msg.blank?
-      _log.error(:msg)
+    unless authentication
+      msg = "Credentials not found for conversion host #{name} or resource #{resource.name}"
+      msg << " #{msg}" if msg
+      _log.error(msg)
       raise MiqException::Error, msg
     end
-    success
-  end
 
-  def check_resource_credentials_rhevm
-    !(resource.authentication_userid.nil? || resource.authentication_password.nil?)
-  end
-
-  def check_resource_credentials_openstack
-    ssh_authentications = resource.ext_management_system.authentications
-                                  .where(:authtype => 'ssh_keypair')
-                                  .where.not(:userid => nil, :auth_key => nil)
-    !ssh_authentications.empty?
+    authentication
   end
 
   def connect_ssh
@@ -191,14 +228,12 @@ class ConversionHost < ApplicationRecord
   end
 
   def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
-    [hostname || ipaddress, resource.authentication_userid, resource.authentication_password, nil, nil]
+    authentication = find_credentials
+    [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
   end
 
   def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
-    authentication = resource.ext_management_system.authentications
-                             .where(:authtype => 'ssh_keypair')
-                             .where.not(:userid => nil, :auth_key => nil)
-                             .first
+    authentication = find_credentials
     [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
   end
 

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -22,7 +22,7 @@ module ConversionHost::Configurations
         :instance_id => instance_id,
         :role        => 'ems_operations',
         :zone        => resource.ext_management_system.my_zone,
-        :args        => params
+        :args        => [params, auth_user]
       }
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
@@ -34,25 +34,37 @@ module ConversionHost::Configurations
       params[:resource_id] = resource.id
       params[:resource_type] = resource.class.base_class.name
 
-      queue_configuration('enable', nil, resource, [params], auth_user)
+      queue_configuration('enable', nil, resource, params, auth_user)
     end
 
-    def enable(params)
+    def enable(params, auth_user = nil)
       params = params.symbolize_keys
       _log.info("Enabling a conversion_host with parameters: #{params}")
 
-      params.delete(:task_id)     # In case this is being called through *_queue which will stick in a :task_id
+      params.delete(:task_id) # In case this is being called through *_queue which will stick in a :task_id
       params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
 
       vmware_vddk_package_url = params.delete(:vmware_vddk_package_url)
-      params[:vddk_transport_supported] = !vmware_vddk_package_url.nil?
-      vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
-      params[:ssh_transport_supported] = !vmware_ssh_private_key.nil?
+      params[:vddk_transport_supported] = vmware_vddk_package_url.present?
 
-      conversion_host = new(params)
-      conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
-      conversion_host.save!
-      conversion_host
+      vmware_ssh_private_key = params.delete(:vmware_ssh_private_key)
+      params[:ssh_transport_supported] = vmware_ssh_private_key.present?
+
+      ssh_key = params.delete(:conversion_host_ssh_private_key)
+
+      new(params).tap do |conversion_host|
+        if ssh_key
+          conversion_host.authentications << AuthPrivateKey.create!(
+            :name     => conversion_host.name,
+            :auth_key => ssh_key,
+            :userid   => auth_user,
+            :authtype => 'v2v'
+          )
+        end
+
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
+        conversion_host.save!
+      end
     rescue StandardError => error
       raise
     ensure
@@ -62,7 +74,7 @@ module ConversionHost::Configurations
   end
 
   def disable_queue(auth_user = nil)
-    self.class.queue_configuration('disable', id, resource, [], auth_user)
+    self.class.queue_configuration('disable', id, resource, {}, auth_user)
   end
 
   def disable

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -121,7 +121,7 @@ describe ConversionHost do
         task_id = described_class.enable_queue(params)
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [params.merge(:task_id => task_id).except(:resource)],
+          :args        => [params.merge(:task_id => task_id).except(:resource), nil],
           :class_name  => described_class.name,
           :method_name => "enable",
           :priority    => MiqQueue::NORMAL_PRIORITY,
@@ -138,7 +138,7 @@ describe ConversionHost do
         task_id = conversion_host.disable_queue
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [],
+          :args        => [{:task_id => task_id}, nil],
           :class_name  => described_class.name,
           :instance_id => conversion_host.id,
           :method_name => "disable",


### PR DESCRIPTION
This is essentially a clone of https://github.com/ManageIQ/manageiq/pull/18309. The primary difference is that this PR does not modify the AuthenticationMixin module. Doing so caused failures in at least [one provider](https://github.com/ManageIQ/manageiq-providers-google/issues/94).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1702051

