### PR TITLE
Check that reconfigure is supported before we try it

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -339,6 +339,7 @@ class Service < ApplicationRecord
   end
 
   def reconfigure_dialog
+    return nil unless supports_reconfigure?
     resource_action = reconfigure_resource_action
     options = {:target => self, :reconfigure => true}
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -895,19 +895,20 @@ describe Service do
     let(:service) { described_class.new(:options => {:dialog => "dialog_options"}) }
     let(:dialog_serializer) { instance_double("DialogSerializer") }
     let(:workflow) { instance_double("ResourceActionWorkflow", :dialog => "workflow_dialog") }
+    let(:ra) { FactoryBot.create(:resource_action, :dialog_id => 58, :ae_namespace => "foo", :ae_class => "bar", :ae_instance => "baz", :ae_attributes => {:service_action=>"reconfigure"}) }
 
     before do
       allow(DialogSerializer).to receive(:new).and_return(dialog_serializer)
       allow(dialog_serializer).to receive(:serialize).and_return("serialized_reconfigure_dialog")
       allow(ResourceActionWorkflow).to receive(:new).and_return(workflow)
-      allow(service).to receive(:reconfigure_resource_action).and_return("reconfigure_resource_action")
+      allow(service).to receive(:reconfigure_resource_action).and_return(ra)
     end
 
     it "creates a new resource action workflow" do
       expect(ResourceActionWorkflow).to receive(:new).with(
         "dialog_options",
         User.current_user,
-        "reconfigure_resource_action",
+        ra,
         :target => service, :reconfigure => true
       )
       service.reconfigure_dialog


### PR DESCRIPTION
I would expect ```GET /api/services/:id?attributes=reconfigure_dialog``` to check that the reconfigure is valid before running it rather than getting an ```internal_server_error from undefined method `dialog_tabs' for nil:NilClass``` because the reconfigure was called on a dialog without the endpoint set up (or without fields set to be reconfigureable). We have the supports_feature mixin on the reconfigure so we should use it. 

" services shouldn't behave different than anything else with virtual associations", the man says. 

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1663972