### PR TITLE
Retirement warn in days only

### DIFF
--- a/app/models/service/dialog_properties/retirement.rb
+++ b/app/models/service/dialog_properties/retirement.rb
@@ -23,9 +23,6 @@ class Service
         if @options['dialog_service_retires_on'].present?
           field_name = 'dialog_service_retires_on'
           self.retire_on_date = time_parse(@options[field_name])
-        elsif @options['dialog_service_retires_in_hours'].present?
-          field_name = 'dialog_service_retires_in_hours'
-          retires_in_duration(@options[field_name], :hours)
         elsif @options['dialog_service_retires_in_days'].present?
           field_name = 'dialog_service_retires_in_days'
           retires_in_duration(@options[field_name], :days)
@@ -62,12 +59,8 @@ class Service
           time_parse(value)
         when 'warn_in_days'
           time_now + offset_set(value, :days)
-        when 'warn_in_hours'
-          time_now + offset_set(value, :hours)
         when 'warn_offset_days'
           @attributes[:retires_on] - offset_set(value, :days)
-        when 'warn_offset_hours'
-          @attributes[:retires_on] - offset_set(value, :hours)
         end
       end
 

--- a/app/models/service/dialog_properties/retirement.rb
+++ b/app/models/service/dialog_properties/retirement.rb
@@ -48,7 +48,10 @@ class Service
 
       def retirement_warning
         warn_value = parse_retirement_warn
-        @attributes[:retirement_warn] = warn_value if warn_value
+        if warn_value
+          days_between_warn_and_retirement = (@attributes[:retires_on] - warn_value).to_i / 1.day
+          @attributes[:retirement_warn] = days_between_warn_and_retirement
+        end
       end
 
       def parse_retirement_warn

--- a/spec/models/service/dialog_properties/retirement_spec.rb
+++ b/spec/models/service/dialog_properties/retirement_spec.rb
@@ -74,29 +74,29 @@ describe Service::DialogProperties::Retirement do
         parsed_results = described_class.parse(options, user)
 
         expect(parsed_results[:retires_on]).to eq(time + 5.days)
-        expect(parsed_results[:retirement_warn]).to eq(time + 1.day)
+        expect(parsed_results[:retirement_warn]).to eq(4)
       end
     end
 
     it 'with retirement_warn_in_days' do
       Timecop.freeze(time) do
         options = {'dialog_service_retires_in_days'         => 5,
-                   'dialog_service_retirement_warn_in_days' => 1}
+                   'dialog_service_retirement_warn_in_days' => 2}
         parsed_results = described_class.parse(options, nil)
 
         expect(parsed_results[:retires_on]).to eq(time + 5.days)
-        expect(parsed_results[:retirement_warn]).to eq(time + 1.day)
+        expect(parsed_results[:retirement_warn]).to eq(3)
       end
     end
 
     it 'with retirement_warn_offset_days' do
       Timecop.freeze(time) do
-        options = {'dialog_service_retires_in_days'             => 5,
-                   'dialog_service_retirement_warn_offset_days' => 4}
+        options = {'dialog_service_retires_in_days'             => 10,
+                   'dialog_service_retirement_warn_offset_days' => 3}
         parsed_results = described_class.parse(options, nil)
 
-        expect(parsed_results[:retires_on]).to eq(time + 5.days)
-        expect(parsed_results[:retirement_warn]).to eq(time + 1.day)
+        expect(parsed_results[:retires_on]).to eq(time + 10.days)
+        expect(parsed_results[:retirement_warn]).to eq(3)
       end
     end
   end

--- a/spec/models/service/dialog_properties/retirement_spec.rb
+++ b/spec/models/service/dialog_properties/retirement_spec.rb
@@ -42,26 +42,6 @@ describe Service::DialogProperties::Retirement do
       end
     end
 
-    describe 'retires_in_hours' do
-      it 'with invalid time' do
-        options = {'dialog_service_retires_in_hours' => 'xyz'}
-        parsed_results = described_class.parse(options, nil)
-
-        expect(parsed_results[:retires_on]).to be_nil
-        expect(parsed_results[:retirement_warn]).to be_nil
-      end
-
-      it 'with valid time' do
-        Timecop.freeze(time) do
-          options = {'dialog_service_retires_in_hours' => 5}
-          parsed_results = described_class.parse(options, nil)
-
-          expect(parsed_results[:retires_on]).to eq(time + 5.hours)
-          expect(parsed_results[:retirement_warn]).to be_nil
-        end
-      end
-    end
-
     describe 'retires_in_days' do
       it 'with invalid time' do
         options = {'dialog_service_retires_in_days' => 'xyz'}
@@ -117,28 +97,6 @@ describe Service::DialogProperties::Retirement do
 
         expect(parsed_results[:retires_on]).to eq(time + 5.days)
         expect(parsed_results[:retirement_warn]).to eq(time + 1.day)
-      end
-    end
-
-    it 'with retirement_warn_in_hours' do
-      Timecop.freeze(time) do
-        options = {'dialog_service_retires_in_hours'         => 5,
-                   'dialog_service_retirement_warn_in_hours' => 1}
-        parsed_results = described_class.parse(options, nil)
-
-        expect(parsed_results[:retires_on]).to eq(time + 5.hours)
-        expect(parsed_results[:retirement_warn]).to eq(time + 1.hour)
-      end
-    end
-
-    it 'with retirement_warn_offset_hours' do
-      Timecop.freeze(time) do
-        options = {'dialog_service_retires_in_hours'             => 5,
-                   'dialog_service_retirement_warn_offset_hours' => 4}
-        parsed_results = described_class.parse(options, nil)
-
-        expect(parsed_results[:retires_on]).to eq(time + 5.hours)
-        expect(parsed_results[:retirement_warn]).to eq(time + 1.hour)
       end
     end
   end


### PR DESCRIPTION
Since [we only support days](https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb#L23) for retirement_warn, [the PR that added the hour granularity](https://github.com/ManageIQ/manageiq/pull/16799) needed to have those fields removed and remaining fields needed to be changed to make sure that we're staying true to storing an int in that field as a count of days like the UI sets. 

<img width="584" alt="Screen Shot 2019-04-08 at 2 10 58 PM" src="https://user-images.githubusercontent.com/16326669/55746630-29db8000-5a08-11e9-88b0-604bf468f52c.png">
So all these fields should set an int that reflects days before retirement. 



Fix for https://github.com/ManageIQ/manageiq/issues/18618.
https://bugzilla.redhat.com/show_bug.cgi?id=1695219 is the bz. 