### PR TITLE
Retirement - remove auto_approve flag on request creation.

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -14,7 +14,7 @@ module RetirementMixin
       klass = (name.demodulize + "RetireRequest").constantize
       options = {:src_ids => src_ids.presence, :__request_type__ => klass.request_types.first}
       set_retirement_requester(options[:src_ids], requester)
-      klass.make_request(nil, options, requester, true)
+      klass.make_request(nil, options, requester)
     end
 
     def retire(ids, options = {})

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -103,12 +103,12 @@ describe "Service Retirement Management" do
   end
 
   it "with one src_id" do
-    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@service.id], :__request_type__ => "service_retire"}, user, true)
+    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@service.id], :__request_type__ => "service_retire"}, user)
     @service.class.to_s.demodulize.constantize.make_retire_request(@service.id, user)
   end
 
   it "with src_ids" do
-    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@service.id, service_with_owner.id], :__request_type__ => "service_retire"}, user, true)
+    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@service.id, service_with_owner.id], :__request_type__ => "service_retire"}, user)
     @service.class.to_s.demodulize.constantize.make_retire_request(@service.id, service_with_owner.id, user)
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -106,12 +106,12 @@ describe "VM Retirement Management" do
 
   describe "retire request" do
     it "with one src_id" do
-      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id], :__request_type__ => "vm_retire"}, user, true)
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id], :__request_type__ => "vm_retire"}, user)
       Vm.make_retire_request(@vm.id, user)
     end
 
     it "with many src_ids" do
-      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id, vm2.id], :__request_type__ => "vm_retire"}, user, true)
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id, vm2.id], :__request_type__ => "vm_retire"}, user)
       Vm.make_retire_request(@vm.id, vm2.id, user)
     end
   end


### PR DESCRIPTION
Make_retire_request was setting auto_approve to true which approves the request before the Automate auto approval state machine.  Removing the auto_approve flag allows users to change the approval type in Automate.

Before the Retirement as a request enhancement, users would be able to stop/delay retirement by modifying the Automate state machine.  In order to stop/delay Retirement with retirement as a request, users will need to be able to prevent the request from being approved, either by denying it, or setting the approval type to manual. The code change in this PR will give them the ability to do that.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1697600
