### PR TITLE
Add logging to standard output for report generator tool

### DIFF
--- a/tools/generate_report.rb
+++ b/tools/generate_report.rb
@@ -8,11 +8,19 @@ include Rails.application.routes.url_helpers
 options = Optimist.options do
   opt :user, "userid", :default => "admin"
   opt :report_name_or_id, "report name or report id", :short => "n", :type => :string
+  opt :log_level, "log level (#{Vmdb::LogProxy::LEVELS.join(", ")})", :type => :string
 end
 
 # backward compatibility
 if ARGV[0].present? && options[:report_name_or_id].nil?
   options[:report_name_or_id] = ARGV[0]
+end
+
+if options[:log_level]
+  Optimist.die "Log level #{options[:log_level]} is not supported, supported levels are: #{Vmdb::LogProxy::LEVELS.join(", ")}" unless Vmdb::LogProxy::LEVELS.include?(options[:log_level].to_sym)
+  $log = VMDBLogger.new(STDOUT)
+  $log.level = Vmdb::LogProxy::LEVELS.index(options[:log_level].to_sym)
+  puts "Logging on standard output, log level set to: #{options[:log_level]}"
 end
 
 REPORT_PARAMS = {:userid => options[:user], :mode => "async", :report_source => "Requested by user"}.freeze

--- a/tools/generate_report.rb
+++ b/tools/generate_report.rb
@@ -1,31 +1,39 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
+require 'optimist'
 
 include ActionDispatch::Routing::UrlFor
 include Rails.application.routes.url_helpers
 
-USER_ID       = "admin".freeze
-REPORT_PARAMS = {:userid => USER_ID, :mode => "async", :report_source => "Requested by user"}.freeze
+options = Optimist.options do
+  opt :user, "userid", :default => "admin"
+  opt :report_name_or_id, "report name or report id", :short => "n", :type => :string
+end
 
-def report_from_args
-  if ARGV.empty?
+# backward compatibility
+if ARGV[0].present? && options[:report_name_or_id].nil?
+  options[:report_name_or_id] = ARGV[0]
+end
+
+REPORT_PARAMS = {:userid => options[:user], :mode => "async", :report_source => "Requested by user"}.freeze
+
+def report_from_args(options)
+  if options[:report_name_or_id].nil?
     MiqReport.last
-  elsif is_numeric?(ARGV[0])
-    MiqReport.find_by(:id => ARGV[0])
+  elsif is_numeric?(options[:report_name_or_id])
+    MiqReport.find_by(:id => options[:report_name_or_id])
   else
-    MiqReport.find_by(:name => ARGV[0])
+    MiqReport.find_by(:name => options[:report_name_or_id])
   end
 end
 
-report = report_from_args
-if report.nil?
-  puts "Report #{ARGV[0]} doesn't exist"
-  exit 1
-end
+report = report_from_args(options)
+
+Optimist.die "Report #{options[:report_name_or_id]} doesn't exist" if report.nil?
 
 puts "Generating report... #{report.name}"
 
-report.queue_generate_table(:userid => USER_ID)
+report.queue_generate_table(:userid => options[:user])
 report._async_generate_table(MiqTask.last.id, REPORT_PARAMS)
 
 default_url_options[:host] = "localhost"


### PR DESCRIPTION
I added parsing with https://github.com/ManageIQ/optimist in first commit.

example of output with logging:
```
./tools/generate_report.rb  -n 'vms' -l debug

Logging on standard output, log level set to: debug
Generating report... vms
I, [2019-04-09T12:30:37.853104 #48837]  INFO -- : <AuditSuccess> MIQ(Generator.queue_generate_table) userid: [admin] - Generate Report: 'vms', successfully initiated
I, [2019-04-09T12:30:37.853170 #48837]  INFO -- : MIQ(MiqTask#update_status) Task: [366203] [Queued] [Ok] [Task has been queued]
I, [2019-04-09T12:30:37.921521 #48837]  INFO -- : MIQ(MiqQueue.put) Message id: [123135345],  id: [], Zone: [], Role: [reporting], Server: [], MiqTask id: [], Ident: [generic], Target id: [], Instance id: [525], Task id: [], Command: [MiqReport._async_generate_table], Timeout: [3600], Priority: [100], State: [ready], Deliver On: [], Data: [], Args: [366203, {:userid=>"admin", :mode=>"async", :report_source=>"Requested by user"}]
I, [2019-04-09T12:30:37.925455 #48837]  INFO -- : MIQ(MiqTask#update_status) Task: [366203] [Active] [Ok] [Generating report]
I, [2019-04-09T12:30:42.472756 #48837]  INFO -- : MIQ(MiqReport#build_create_results) Creating report results with hash: [{:name=>"vms1", :userid=>"admin", :report_source=>"Requested by user", :db=>"ManageIQ::Providers::InfraManager::Vm", :last_run_on=>2019-04-09 10:30:42 UTC, :last_accessed_on=>2019-04-09 10:30:42 UTC, :miq_report_id=>525, :miq_group_id=>nil}]
I, [2019-04-09T12:30:44.616015 #48837]  INFO -- : MIQ(MiqReport#build_create_results) Finished creating report result with id [20906] for report id: [525], name: [vms]
I, [2019-04-09T12:30:44.636990 #48837]  INFO -- : MIQ(MiqTask#update_status) Task: [366203] [Finished] [Ok] [Generating report complete]
```




cc @gtanzillo 


@miq-bot assign @jrafanie 
@miq-bot add_label report, tools