### PR TITLE
Change simulate_queue_worker for quiet polling

### DIFF
--- a/lib/vmdb/console_methods.rb
+++ b/lib/vmdb/console_methods.rb
@@ -12,16 +12,27 @@ module Vmdb
       ActiveRecord::Base.logger.level == 0 ? disable_console_sql_logging : enable_console_sql_logging
     end
 
+    def with_console_sql_logging_level(level)
+      old_level = ActiveRecord::Base.logger.level
+      ActiveRecord::Base.logger.level = level
+      yield
+    ensure
+      ActiveRecord::Base.logger.level = old_level
+    end
+
     def backtrace(include_external = false)
       caller.select { |path| include_external || path.start_with?(Rails.root.to_s) }
     end
 
     # Development helper method for Rails console for simulating queue workers.
-    def simulate_queue_worker(break_on_complete = false)
+    def simulate_queue_worker(break_on_complete: false, quiet_polling: true)
       raise NotImplementedError, "not implemented in production mode" if Rails.env.production?
       loop do
-        q = MiqQueue.where(MiqQueue.arel_table[:queue_name].not_eq("miq_server")).order(:id).first
+        q = with_console_sql_logging_level(quiet_polling ? 1 : ActiveRecord::Base.logger.level) do
+          MiqQueue.where(MiqQueue.arel_table[:queue_name].not_eq("miq_server")).order(:id).first
+        end
         if q
+          puts "\e[33;1m\n** Delivering #{MiqQueue.format_full_log_msg(q)}\n\e[0;m"
           status, message, result = q.deliver
           q.delivered(status, message, result) unless status == MiqQueue::STATUS_RETRY
         else


### PR DESCRIPTION
simulate_queue_worker, while useful, is incredibly noisy.  The constant message showing the polling distracts from the actual queue items being executed.

This PR change turns off the polling output, and offers a keyword arg `quiet_polling` if you need to reenable it.  Additionally, simulate_queue_worker will now dump the MiqQueue message so you can know what it's actually running.

Example of what it looks like (the changes in this PR incorporate whether or not console_sql_logging is enabled or not, so the screenshot shows both modes)

<img width="1136" alt="bundle 2019-04-09 13-39-52" src="https://user-images.githubusercontent.com/52120/55822403-8785d000-5acd-11e9-8135-20c77155aefd.png">
