### PR TITLE
New factory for the embedded ansible cloud credential

### DIFF
--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -87,6 +87,10 @@ FactoryBot.define do
           :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential"
 
+  factory :embedded_ansible_cloud_credential,
+          :parent => :embedded_ansible_credential,
+          :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential"
+
   factory :embedded_ansible_scm_credential,
           :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential"


### PR DESCRIPTION
New factory for the embedded ansible cloud credential. This PR is part of the https://github.com/ManageIQ/manageiq-automation_engine/pull/303.