### PR TITLE
Dialog import/export - add versioning, migrate load_values_on_init

### DIFF
--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -7,7 +7,7 @@ class DialogFieldImporter
       dialog_field_attributes["dynamic"] = true
     end
 
-    if export_version < 2
+    if Gem::Version.new(export_version) < Gem::Version.new('5.11')
       dialog_field_attributes["load_values_on_init"] = if !dialog_field_attributes["show_refresh_button"]
                                                          # no refresh button, always true
                                                          true

--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -7,6 +7,18 @@ class DialogFieldImporter
       dialog_field_attributes["dynamic"] = true
     end
 
+    if export_version < 2
+      dialog_field_attributes["load_values_on_init"] = if !dialog_field_attributes["show_refresh_button"]
+                                                         # no refresh button, always true
+                                                         true
+                                                       elsif dialog_field_attributes["load_values_on_init"].nil?
+                                                         # unspecified, default to true
+                                                         true
+                                                       else
+                                                         !!dialog_field_attributes["load_values_on_init"]
+                                                       end
+    end
+
     if DialogField::DIALOG_FIELD_TYPES.include?(dialog_field_attributes["type"])
       dialog_field_type_class = dialog_field_attributes["type"].constantize
       resource_action_attributes = dialog_field_attributes.delete("resource_action")

--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -1,7 +1,7 @@
 class DialogFieldImporter
   class InvalidDialogFieldTypeError < StandardError; end
 
-  def import_field(dialog_field_attributes)
+  def import_field(dialog_field_attributes, export_version = DialogImportService::CURRENT_DIALOG_VERSION)
     if dialog_field_attributes["type"] == "DialogFieldDynamicList"
       dialog_field_attributes["type"] = "DialogFieldDropDownList"
       dialog_field_attributes["dynamic"] = true

--- a/app/models/dialog_serializer.rb
+++ b/app/models/dialog_serializer.rb
@@ -20,7 +20,7 @@ class DialogSerializer < Serializer
   def serialize_dialogs(dialogs, all_attributes)
     dialogs.map do |dialog|
       serialized_dialog_tabs = serialize_dialog_tabs(dialog.dialog_tabs, all_attributes)
-      included_attributes(dialog.attributes, all_attributes).merge("dialog_tabs" => serialized_dialog_tabs)
+      included_attributes(dialog.attributes, all_attributes).merge("dialog_tabs" => serialized_dialog_tabs, 'export_version' => DialogImportService::CURRENT_DIALOG_VERSION)
     end
   end
 end

--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -3,7 +3,8 @@ class DialogImportService
   class ParsedNonDialogYamlError < StandardError; end
   class DialogFieldAssociationCircularReferenceError < StandardError; end
 
-  CURRENT_DIALOG_VERSION = 2
+  DEFAULT_DIALOG_VERSION = '5.10' # assumed for dialogs without version info
+  CURRENT_DIALOG_VERSION = '5.11'
 
   def initialize(dialog_field_importer = DialogFieldImporter.new, dialog_import_validator = DialogImportValidator.new, dialog_field_association_validator = DialogFieldAssociationValidator.new)
     @dialog_field_importer = dialog_field_importer
@@ -27,7 +28,7 @@ class DialogImportService
         if dialog_with_label?(dialog["label"])
           yield dialog if block_given?
         else
-          Dialog.create(dialog.except('export_version').merge("dialog_tabs" => build_dialog_tabs(dialog, dialog['export_version'] || 1)))
+          Dialog.create(dialog.except('export_version').merge("dialog_tabs" => build_dialog_tabs(dialog, dialog['export_version'] || DEFAULT_DIALOG_VERSION)))
         end
       end
     rescue DialogFieldImporter::InvalidDialogFieldTypeError
@@ -102,7 +103,7 @@ class DialogImportService
     @dialog_import_validator.determine_dialog_validity(dialog)
     new_dialog = Dialog.create(dialog.except('dialog_tabs', 'export_version'))
     association_list = build_association_list(dialog)
-    new_dialog.update!(dialog.merge('dialog_tabs' => build_dialog_tabs(dialog, dialog['export_version'] || 1)))
+    new_dialog.update!(dialog.merge('dialog_tabs' => build_dialog_tabs(dialog, dialog['export_version'] || DEFAULT_DIALOG_VERSION)))
     build_associations(new_dialog, association_list)
     new_dialog
   end
@@ -149,7 +150,7 @@ class DialogImportService
       new_associations = build_association_list(dialog)
       new_or_existing_dialog.update_attributes(
         dialog.except('export_version').merge(
-          "dialog_tabs"      => build_dialog_tabs(dialog, dialog['export_version'] || 1),
+          "dialog_tabs"      => build_dialog_tabs(dialog, dialog['export_version'] || DEFAULT_DIALOG_VERSION),
           "resource_actions" => build_resource_actions(dialog)
         )
       )

--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -27,7 +27,7 @@ class DialogImportService
         if dialog_with_label?(dialog["label"])
           yield dialog if block_given?
         else
-          Dialog.create(dialog.merge("dialog_tabs" => build_dialog_tabs(dialog, dialog['export_version'] || 1)))
+          Dialog.create(dialog.except('export_version').merge("dialog_tabs" => build_dialog_tabs(dialog, dialog['export_version'] || 1)))
         end
       end
     rescue DialogFieldImporter::InvalidDialogFieldTypeError

--- a/lib/services/dialog_import_service.rb
+++ b/lib/services/dialog_import_service.rb
@@ -3,8 +3,8 @@ class DialogImportService
   class ParsedNonDialogYamlError < StandardError; end
   class DialogFieldAssociationCircularReferenceError < StandardError; end
 
-  DEFAULT_DIALOG_VERSION = '5.10' # assumed for dialogs without version info
-  CURRENT_DIALOG_VERSION = '5.11'
+  DEFAULT_DIALOG_VERSION = '5.10'.freeze # assumed for dialogs without version info
+  CURRENT_DIALOG_VERSION = '5.11'.freeze
 
   def initialize(dialog_field_importer = DialogFieldImporter.new, dialog_import_validator = DialogImportValidator.new, dialog_field_association_validator = DialogFieldAssociationValidator.new)
     @dialog_field_importer = dialog_field_importer

--- a/spec/lib/services/dialog_import_service_spec.rb
+++ b/spec/lib/services/dialog_import_service_spec.rb
@@ -115,7 +115,7 @@ describe DialogImportService do
         end
 
         it "imports the dialog fields" do
-          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
+          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], DialogImportService::DEFAULT_DIALOG_VERSION)
           dialog_import_service.import_from_file(filename)
         end
       end
@@ -153,8 +153,8 @@ describe DialogImportService do
         allow(YAML).to receive(:load_file).with(filename).and_return(dialogs)
       end
 
-      it "defaults to version 1" do
-        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
+      it "defaults to DEFAULT_DIALOG_VERSION" do
+        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], DialogImportService::DEFAULT_DIALOG_VERSION)
         dialog_import_service.import_from_file(filename)
       end
     end
@@ -209,7 +209,7 @@ describe DialogImportService do
       end
 
       it "imports the dialog fields" do
-        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
+        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], DialogImportService::DEFAULT_DIALOG_VERSION)
         dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
       end
 
@@ -320,7 +320,7 @@ describe DialogImportService do
         end
 
         it "imports the dialog fields" do
-          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
+          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], DialogImportService::DEFAULT_DIALOG_VERSION)
           dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
         end
       end

--- a/spec/lib/services/dialog_import_service_spec.rb
+++ b/spec/lib/services/dialog_import_service_spec.rb
@@ -111,7 +111,7 @@ describe DialogImportService do
         end
 
         it "imports the dialog fields" do
-          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0])
+          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
           dialog_import_service.import_from_file(filename)
         end
       end
@@ -182,7 +182,7 @@ describe DialogImportService do
       end
 
       it "imports the dialog fields" do
-        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0])
+        expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
         dialog_import_service.import_all_service_dialogs_from_yaml_file("filename")
       end
 
@@ -293,7 +293,7 @@ describe DialogImportService do
         end
 
         it "imports the dialog fields" do
-          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0])
+          expect(dialog_field_importer).to receive(:import_field).with(dialog_fields[0], 1)
           dialog_import_service.import_service_dialogs(import_file_upload, dialogs_to_import)
         end
       end

--- a/spec/lib/task_helpers/exports/service_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/service_dialogs_spec.rb
@@ -36,18 +36,29 @@ describe TaskHelpers::Exports::ServiceDialogs do
     FileUtils.remove_entry export_dir
   end
 
-  def loaded(data)
-    YAML.safe_load(data).map do |dialog|
+  def load_yaml(filename)
+    data = File.read(filename)
+    YAML.safe_load(data)
+  end
+
+  def without_version(data)
+    data.map do |dialog|
       dialog.except('export_version')
     end
   end
 
   it 'exports service dialogs as individual files in a given directory' do
     TaskHelpers::Exports::ServiceDialogs.new.export(:directory => export_dir)
-    file_contents = File.read("#{export_dir}/the_first_label.yaml")
-    file_contents2 = File.read("#{export_dir}/TheSecondLabel.yaml")
-    expect(loaded(file_contents)).to eq(expected_data1)
-    expect(loaded(file_contents2)).to eq(expected_data2)
+    file_contents = load_yaml("#{export_dir}/the_first_label.yaml")
+    file_contents2 = load_yaml("#{export_dir}/TheSecondLabel.yaml")
+    expect(without_version(file_contents)).to eq(expected_data1)
+    expect(without_version(file_contents2)).to eq(expected_data2)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
+  end
+
+  it 'exports with current export_version' do
+    TaskHelpers::Exports::ServiceDialogs.new.export(:directory => export_dir)
+    file_contents = load_yaml("#{export_dir}/the_first_label.yaml")
+    expect(file_contents.first).to include('export_version' => DialogImportService::CURRENT_DIALOG_VERSION)
   end
 end

--- a/spec/lib/task_helpers/exports/service_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/service_dialogs_spec.rb
@@ -36,12 +36,18 @@ describe TaskHelpers::Exports::ServiceDialogs do
     FileUtils.remove_entry export_dir
   end
 
+  def loaded(data)
+    YAML.safe_load(data).map do |dialog|
+      dialog.except('export_version')
+    end
+  end
+
   it 'exports service dialogs as individual files in a given directory' do
     TaskHelpers::Exports::ServiceDialogs.new.export(:directory => export_dir)
     file_contents = File.read("#{export_dir}/the_first_label.yaml")
     file_contents2 = File.read("#{export_dir}/TheSecondLabel.yaml")
-    expect(YAML.safe_load(file_contents)).to eq(expected_data1)
-    expect(YAML.safe_load(file_contents2)).to eq(expected_data2)
+    expect(loaded(file_contents)).to eq(expected_data1)
+    expect(loaded(file_contents2)).to eq(expected_data2)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(2)
   end
 end

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -299,12 +299,12 @@ describe DialogFieldImporter do
       context "from version 1" do
         context "load_values_on_init" do
           it "is set to true when no refresh button" do
-            dialog_field_importer.import_field(dialog_field_show_false, 1)
+            dialog_field_importer.import_field(dialog_field_show_false, DialogImportService::DEFAULT_DIALOG_VERSION)
             expect(DialogField.first.load_values_on_init).to eq(true)
           end
 
           it "is preserved when refresh button" do
-            dialog_field_importer.import_field(dialog_field_load_false, 1)
+            dialog_field_importer.import_field(dialog_field_load_false, DialogImportService::DEFAULT_DIALOG_VERSION)
             expect(DialogField.first.load_values_on_init).to eq(false)
           end
         end

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -284,5 +284,40 @@ describe DialogFieldImporter do
         end.to raise_error(DialogFieldImporter::InvalidDialogFieldTypeError)
       end
     end
+
+    context "version migrations" do
+      let(:type) { "DialogFieldDynamicList" }
+      let(:dialog_field_show_false) do
+        dialog_field.merge('show_refresh_button' => false,
+                           'load_values_on_init' => false)
+      end
+      let(:dialog_field_load_false) do
+        dialog_field.merge('show_refresh_button' => true,
+                           'load_values_on_init' => false)
+      end
+
+      context "from version 1" do
+        context "load_values_on_init" do
+          it "is set to true when no refresh button" do
+            dialog_field_importer.import_field(dialog_field_show_false, 1)
+            expect(DialogField.first.load_values_on_init).to eq(true)
+          end
+
+          it "is preserved when refresh button" do
+            dialog_field_importer.import_field(dialog_field_load_false, 1)
+            expect(DialogField.first.load_values_on_init).to eq(false)
+          end
+        end
+      end
+
+      context "from current version" do
+        context "load_values_on_init" do
+          it "is not touched" do
+            dialog_field_importer.import_field(dialog_field_show_false)
+            expect(DialogField.first.load_values_on_init).to eq(false)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/dialog_import_validator_spec.rb
+++ b/spec/models/dialog_import_validator_spec.rb
@@ -146,7 +146,9 @@ describe DialogImportValidator do
 
     context 'when the loaded yaml has invalid version' do
       let(:dialog_with_invalid_version) do
-        {"label" => "Test", "dialog_tabs" => [], 'export_version' => DialogImportService::CURRENT_DIALOG_VERSION + 1}
+        left, dot, last = DialogImportService::CURRENT_DIALOG_VERSION.rpartition('.')
+        version = "#{left}#{dot}#{last.to_i + 1}" # one more than current version
+        {"label" => "Test", "dialog_tabs" => [], 'export_version' => version}
       end
 
       it "raises a InvalidDialogVersionError" do

--- a/spec/models/dialog_import_validator_spec.rb
+++ b/spec/models/dialog_import_validator_spec.rb
@@ -143,5 +143,17 @@ describe DialogImportValidator do
         end.to raise_error(DialogImportValidator::ParsedNonDialogError)
       end
     end
+
+    context 'when the loaded yaml has invalid version' do
+      let(:dialog_with_invalid_version) do
+        {"label" => "Test", "dialog_tabs" => [], 'export_version' => DialogImportService::CURRENT_DIALOG_VERSION + 1}
+      end
+
+      it "raises a InvalidDialogVersionError" do
+        expect do
+          dialog_import_validator.determine_dialog_validity(dialog_with_invalid_version)
+        end.to raise_error(DialogImportValidator::InvalidDialogVersionError)
+      end
+    end
   end
 end

--- a/spec/models/dialog_serializer_spec.rb
+++ b/spec/models/dialog_serializer_spec.rb
@@ -22,10 +22,11 @@ describe DialogSerializer do
 
     let(:expected_data) do
       {
-        "description"  => description,
-        "buttons"      => buttons,
-        "label"        => label,
-        "dialog_tabs"  => %w(serialized_dialog1 serialized_dialog2)
+        "description"    => description,
+        "buttons"        => buttons,
+        "label"          => label,
+        "dialog_tabs"    => %w[serialized_dialog1 serialized_dialog2],
+        "export_version" => DialogImportService::CURRENT_DIALOG_VERSION,
       }
     end
 

--- a/spec/models/dialog_yaml_serializer_spec.rb
+++ b/spec/models/dialog_yaml_serializer_spec.rb
@@ -22,10 +22,11 @@ describe DialogYamlSerializer do
 
     let(:expected_data) do
       {
-        "description"  => description,
-        "buttons"      => buttons,
-        "label"        => label,
-        "dialog_tabs"  => ["serialized_dialog1", "serialized_dialog2"],
+        "description"    => description,
+        "buttons"        => buttons,
+        "label"          => label,
+        "dialog_tabs"    => %w[serialized_dialog1 serialized_dialog2],
+        "export_version" => DialogImportService::CURRENT_DIALOG_VERSION,
       }
     end
 


### PR DESCRIPTION
Continuation of ManageIQ/manageiq-schema#357, and https://github.com/ManageIQ/manageiq/pull/18600 (and ManageIQ/ui-components#376).
(+ Nice message about version in the UI: https://github.com/ManageIQ/manageiq-ui-classic/pull/5471)

This changes import and export of service dialogs so that:

* newly exported dialogs have an extra `export_version` field, set to `DialogImportService::CURRENT_DIALOG_VERSION` (currently `"5.11"`)
* importing a dialog looks for `export_version`, defaulting to 1 if not found, and passes it through the chain of `build_dialog_tabs` -> `build_dialog_groups` -> `build_dialog_fields` -> `import_field`.
* `DialogFieldImporter#import_field` now updates `load_values_on_init` when importing a version `"5.10"` export.

Related to
https://bugzilla.redhat.com/show_bug.cgi?id=1684575
https://bugzilla.redhat.com/show_bug.cgi?id=1684567

---

@miq-bot add_label wip

missing tests