### PR TITLE
[GAPRINDASHVILI] Lock ansible_tower_client to 0.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :amazon, :manageiq_default do
 end
 
 group :ansible, :manageiq_default do
-  gem "ansible_tower_client",           "~>0.17",        :require => false
+  gem "ansible_tower_client",           "=0.17.0",       :require => false
 end
 
 group :azure, :manageiq_default do


### PR DESCRIPTION
Locking ansible_tower_client to the version used in the last downstream G branch build. Without lock, it will download `0.19.1` which causes errors like [this](https://travis-ci.org/ManageIQ/manageiq/jobs/518291128#L2045)

As per discussion with @jrafanie [here](https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/165#issuecomment-479591941)