### PR TITLE
[GAPRINDASHVILI] Lock dry-validation to 0.11.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "config",                         "~>1.6.0",       :require => false
 gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
+gem "dry-validation",                 "=0.11.1",       :require => false
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
 gem "gettext_i18n_rails",             "~>1.7.2"


### PR DESCRIPTION
Locking dry-validation to the version used in the last downstream G branch build. Without lock, it will download `0.13.1` which requires ruby >= 2.4.0 and cause travis errors in multiple repos, like [this](https://travis-ci.org/ManageIQ/manageiq-providers-openshift/builds/518346447)
```
In Gemfile:
Gem::RuntimeRequirementNotMetError: dry-validation requires Ruby version >=
2.4.0. The current ruby version is 2.3.0.
An error occurred while installing dry-validation (0.13.1), and Bundler cannot
continue.
Make sure that `gem install dry-validation -v '0.13.1' --source
'https://rubygems.org/'` succeeds before bundling.
```

`dry-validation` comes as a dependency of `config` which is needed in `manageiq` and `manageiq-api` repos.