### PR TITLE
Fix: convert string representation of sizes to numbers when generating SQL for expression

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -309,8 +309,11 @@ class MiqExpression
       preprocess_for_sql(exp[operator], attrs)
       exp.delete(operator) if exp[operator].empty? # Clean out empty operands
     else
-      # check operands to see if they can be represented in sql
-      unless sql_supports_atom?(exp)
+      if sql_supports_atom?(exp)
+        # if field type is Integer and value is String representing size in units (like "2.megabytes") than convert
+        # this string to correct number using sub_type mappong defined in db/fixtures/miq_report_formats.yml:sub_types_by_column:
+        convert_size_in_units_to_integer(exp) if %w[= != <= >= > <].include?(operator)
+      else
         attrs[:supported_by_sql] = false
         exp.delete(operator)
       end
@@ -1278,6 +1281,27 @@ class MiqExpression
   end
 
   private
+
+  def convert_size_in_units_to_integer(exp)
+    return if (column_details = col_details[exp.values.first["field"]]).nil?
+    # attempt to do conversion only if db type of column is integer and value to compare to is String
+    return unless column_details[:data_type] == :integer && (value = exp.values.first["value"]).class == String
+
+    sub_type = column_details[:format_sub_type]
+
+    return if %i[mhz_avg hours kbps kbps_precision_2 mhz elapsed_time].include?(sub_type)
+
+    case sub_type
+    when :bytes
+      exp.values.first["value"] = value.to_i_with_method
+    when :kilobytes
+      exp.values.first["value"] = value.to_i_with_method / 1_024
+    when :megabytes, :megabytes_precision_2
+      exp.values.first["value"] = value.to_i_with_method / 1_048_576
+    else
+      _log.warn("No subtype defined for column #{exp.values.first["field"]} in 'miq_report_formats.yml'")
+    end
+  end
 
   # example:
   #   ruby_for_date_compare(:updated_at, :date, tz, "==", Time.now)

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -17,7 +17,7 @@ describe MiqExpression do
 
     it 'lists custom attributes in ChargebackVm' do
       skip('removing of virtual custom attributes is needed to do first in other specs')
-      
+
       displayed_columms = described_class.reporting_available_fields('ChargebackVm').map(&:second)
       expected_columns = (ChargebackVm.attribute_names - extra_fields).map { |x| "ChargebackVm-#{x}" }
 
@@ -219,6 +219,25 @@ describe MiqExpression do
         }
       )
       expect(expression).not_to be_valid
+    end
+  end
+
+  describe "#preprocess_for_sql" do
+    it "convert size value in units to integer for comparasing operators on integer field" do
+      expession_hash = {"=" => {"field" => "Vm-allocated_disk_storage", "value" => "5.megabytes"}}
+      expession = MiqExpression.new(expession_hash)
+      exp, _ = expession.preprocess_for_sql(expession_hash)
+      expect(exp.values.first["value"]).to eq("5.megabyte".to_i_with_method)
+
+      expession_hash = {">" => {"field" => "Vm-allocated_disk_storage", "value" => "5.kilobytes"}}
+      expession = MiqExpression.new(expession_hash)
+      exp, _ = expession.preprocess_for_sql(expession_hash)
+      expect(exp.values.first["value"]).to eq("5.kilobytes".to_i_with_method)
+
+      expession_hash = {"<" => {"field" => "Vm-allocated_disk_storage", "value" => "2.terabytes"}}
+      expession = MiqExpression.new(expession_hash)
+      exp, _ = expession.preprocess_for_sql(expession_hash)
+      expect(exp.values.first["value"]).to eq(2.terabytes.to_i_with_method)
     end
   end
 


### PR DESCRIPTION
**Issue**: 
New Expression editor allows to select unit of measurement for some field (like MB, GB, etc...) and those units saved in expression. Example:  ```{"<"=>{"field"=>"ManageIQ::Providers::InfraManager::Vm-allocated_disk_storage", "value"=>"2.gigabytes"}}```
However, during SQL generation "2.gigabytes" was not converting to Integer:
```[2019-04-04T15:00:08.320937 #24319:11ccf54] ERROR -- : 
[ActiveRecord::StatementInvalid]: PG::InvalidTextRepresentation:
ERROR:  invalid input syntax for type numeric: "2.gigabytes"
LINE 1: ...ares"."vm_or_template_id" = "vms"."id" LIMIT 1) < '2.gigabyt...
                                                             ^
: SELECT "vms".*, (SELECT  "hardwares"."memory_mb" FROM "hardwares"
WHERE "hardwares"."vm_or_template_id" = "vms"."id" LIMIT 1) AS mem_cpu FROM "vms"
WHERE "vms"."type" IN ('ManageIQ::Providers::InfraManager::Vm', 'VmXen', 
'ManageIQ::Providers::Kubevirt::InfraManager::Vm',
 'ManageIQ::Providers::Redhat::InfraManager::Vm',
'ManageIQ::Providers::Microsoft::InfraManager::Vm',
'ManageIQ::Providers::Vmware::InfraManager::Vm') AND "vms"."template" = $1
AND ((SELECT  (SELECT SUM("disks"."size") FROM "disks"
WHERE "hardwares"."id" = "disks"."hardware_id") FROM "hardwares"
WHERE "hardwares"."vm_or_template_id" = "vms"."id" LIMIT 1) < '2.gigabytes') 
```

**FIX**:
Convert human representation of sizes to Integer

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1696412

@miq-bot add-label bug, reporting, hammer/yes