### PR TITLE
Fix for incorrect key sent back for dynamic non sorted items

### DIFF
--- a/app/models/dialog_field_serializer.rb
+++ b/app/models/dialog_field_serializer.rb
@@ -17,7 +17,9 @@ class DialogFieldSerializer < Serializer
     }
 
     if dialog_field.dynamic?
-      extra_attributes["values"] = dialog_field.extract_dynamic_values
+      key_to_update = dialog_field.kind_of?(DialogFieldSortedItem) ? "values" : "default_value"
+
+      extra_attributes[key_to_update] = dialog_field.extract_dynamic_values
     end
 
     if dialog_field.type == "DialogFieldTagControl"


### PR DESCRIPTION
As described in the below linked BZ, there was an issue when verifying the original fix which can be found [here on the ui-components repo](https://github.com/ManageIQ/ui-components/pull/381).

Basically, for dynamic dialogs, we were returning the dynamically computed result in a key called `"values"`. But, this does not really make sense for text boxes, check boxes, or date/times because those fields can only have one value, not a list of values. So, this PR changes that so that we can still continue to use `ng-model=vm.dialogField.default_value` which makes the most sense while also passing through the correctly computed `default_value` from the automate side for those various types of dialog fields.

This will also need [this other ui-components PR](https://github.com/ManageIQ/ui-components/pull/382) to revert the `ng-model` changes made in 381.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1698586

/cc @tinaafitz @d-m-u @himdel @gmcculloug 