### PR TITLE
Doesn't count with selection of belongsto filter if any object doesn't exist in the filter sentence

### DIFF
--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -5,6 +5,10 @@ module MiqFilter
     belongsto2object_list(tag).last
   end
 
+  def self.belongsto2path_human(tag)
+    tag.split("/").map { |x| x.split("|").second }.compact.join(" -> ")
+  end
+
   def self.find_descendant_class_by(klass, name)
     if ALLOWED_DESCENDANT_CLASSES_FROM_MODEL.include?(klass.to_s) && (descendant_class = klass.try(:belongsto_descendant_class, name))
       return descendant_class.constantize
@@ -58,7 +62,7 @@ module MiqFilter
         obj.children.grep(tag_part_klass).detect { |c| c.name == name }
       end
 
-      return result unless obj
+      return [] unless obj
       result.push(obj)
     end
   end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1317,17 +1317,17 @@ describe Rbac::Filterer do
       end
 
       context "with VMs and Templates" do
+        let(:root) { FactoryBot.create(:ems_folder, :name => "Datacenters").tap { |ems_folder| ems_folder.parent = @ems } }
+
+        let(:dc) { FactoryBot.create(:ems_folder, :name => "Datacenter1").tap { |data_center| data_center.parent = root } }
+
+        let(:hfolder) { FactoryBot.create(:ems_folder, :name => "host").tap { |hfolder| hfolder.parent = dc } }
+
         before do
           @ems = FactoryBot.create(:ems_vmware, :name => 'ems1')
           @host1.update_attributes(:ext_management_system => @ems)
           @host2.update_attributes(:ext_management_system => @ems)
 
-          root            = FactoryBot.create(:ems_folder, :name => "Datacenters")
-          root.parent     = @ems
-          dc              = FactoryBot.create(:datacenter, :name => "Datacenter1")
-          dc.parent       = root
-          hfolder         = FactoryBot.create(:ems_folder, :name => "host")
-          hfolder.parent  = dc
           @vfolder        = FactoryBot.create(:ems_folder, :name => "vm")
           @vfolder.parent = dc
           @host1.parent   = hfolder
@@ -1391,6 +1391,31 @@ describe Rbac::Filterer do
             results = described_class.search(:class => "ExtManagementSystem", :user => user)
             objects = results.first
             expect(objects).to eq([@ems])
+          end
+
+          context "deleted cluster from belongsto filter" do
+            let!(:group)   { FactoryBot.create(:miq_group, :tenant => default_tenant) }
+            let!(:user)    { FactoryBot.create(:user, :miq_groups => [group]) }
+            let(:cluster_1) { FactoryBot.create(:ems_cluster, :name => "MTC Development 1").tap { |cluster| cluster.parent = hfolder } }
+            let(:cluster_2) { FactoryBot.create(:ems_cluster, :name => "MTC Development 2").tap { |cluster| cluster.parent = hfolder } }
+            let(:vm_folder_path) { "/belongsto/ExtManagementSystem|#{@ems.name}/EmsFolder|#{root.name}/EmsFolder|#{dc.name}/EmsFolder|#{hfolder.name}/EmsCluster|#{cluster_1.name}" }
+
+            it "honors ems_id conditions" do
+              group.entitlement = Entitlement.new
+              group.entitlement.set_belongsto_filters([vm_folder_path])
+              group.entitlement.set_managed_filters([])
+              group.save!
+
+              results = described_class.filtered(EmsCluster, :user => user)
+
+              expect(results).to match_array([cluster_1])
+
+              cluster_1.destroy
+
+              results = described_class.filtered(EmsCluster, :user => user)
+
+              expect(results).to be_empty
+            end
           end
         end
 
@@ -1517,6 +1542,7 @@ describe Rbac::Filterer do
 
           @cluster = FactoryBot.create(:ems_cluster, :name => "MTC Development")
           @cluster.parent = @hfolder
+
           @cluster_folder_path = "#{@mtc_folder_path}/EmsFolder|#{@hfolder.name}/EmsCluster|#{@cluster.name}"
 
           @rp = FactoryBot.create(:resource_pool, :name => "Default for MTC Development")


### PR DESCRIPTION
let's have this structure
```
PROV1 (proder)
 -> DATAC1 (datacenter)
         -> Host1  (host)
               -> Cluster1 (cluster)
               -> Cluster2 (cluster)
               -> Cluster3 (cluster)
```

 belonsto filter stored in a group of user

```
/belongsto/ExtManagementSystem|PROV1/EmsFolder|Datacenters/EmsFolder|DATAC1/EmsFolder|host/EmsCluster|Host1/EmsCluster|Cluster1
```
it will display just `Cluster1`

but when you delete **Cluster1**

this belongsto filter will be unchanged in the group

and RBAC will display skip last element of belongsto filter (/EmsCluster|Cluster1) and 
then RBAC will start behave like filter is just (without cluster:

```
/belongsto/ExtManagementSystem|PROV1/EmsFolder|Datacenters/EmsFolder|DATAC1/EmsFolder|host/EmsCluster|Host1
```

so it will display everything under host

concretely it will display 

`Cluster2 (cluster)`
and
`Cluster3 (cluster)`


this fix will display everything under `Cluster1` and it means nothing when `Cluster1`  doesn't exist.
so and there is no way how remove this old filter from UI - so I guess, it is not good 

but pretending that there is no filter will display everything what it unintended  for user...

https://bugzilla.redhat.com/show_bug.cgi?id=1693183


# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1693183
https://github.com/ManageIQ/manageiq-ui-classic/pull/5511  - UI part

