### PR TITLE
Fix Container* belongsto filter in Rbac::Filterer

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -68,6 +68,18 @@ module Rbac
     ).freeze
 
     BELONGSTO_FILTER_CLASSES = %w(
+      Container
+      ContainerBuild
+      ContainerGroup
+      ContainerImage
+      ContainerImageRegistry
+      ContainerNode
+      ContainerProject
+      ContainerReplicator
+      ContainerRoute
+      ContainerService
+      ContainerTemplate
+      ContainerVolume
       EmsCluster
       EmsFolder
       ExtManagementSystem
@@ -76,6 +88,22 @@ module Rbac
       Storage
       VmOrTemplate
     ) + NETWORK_MODELS_FOR_BELONGSTO_FILTER
+
+    ASSOCIATED_BELONGSTO_MODELS = [
+      VmOrTemplate,
+      Container,
+      ContainerBuild,
+      ContainerGroup,
+      ContainerImage,
+      ContainerImageRegistry,
+      ContainerNode,
+      ContainerProject,
+      ContainerReplicator,
+      ContainerRoute,
+      ContainerService,
+      ContainerTemplate,
+      ContainerVolume
+    ].freeze
 
     # key: descendant::klass
     # value:
@@ -724,7 +752,8 @@ module Rbac
 
     def belongsto_association_filtered?(vcmeta, klass)
       if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) }
-        return true if klass <= VmOrTemplate
+        # Eject early if true
+        return true if ASSOCIATED_BELONGSTO_MODELS.any? { |associated| klass <= associated }
       end
 
       if vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -714,13 +714,24 @@ module Rbac
         # typically, this is the only one we want:
         vcmeta = vcmeta_list.last
 
-        if ([ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) } && klass <= VmOrTemplate) ||
-           (vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)        && NETWORK_MODELS_FOR_BELONGSTO_FILTER.any? { |association_class| klass <= association_class.safe_constantize })
+        if belongsto_association_filtered?(vcmeta, klass)
           vcmeta.send(association_name).to_a
         else
           vcmeta_list.grep(klass) + vcmeta.descendants.grep(klass)
         end
       end.uniq
+    end
+
+    def belongsto_association_filtered?(vcmeta, klass)
+      if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) }
+        return true if klass <= VmOrTemplate
+      end
+
+      if vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)
+        NETWORK_MODELS_FOR_BELONGSTO_FILTER.any? do |association_class|
+          klass <= association_class.safe_constantize
+        end
+      end
     end
 
     def get_belongsto_matches_for_host(blist)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -89,22 +89,6 @@ module Rbac
       VmOrTemplate
     ) + NETWORK_MODELS_FOR_BELONGSTO_FILTER
 
-    ASSOCIATED_BELONGSTO_MODELS = [
-      VmOrTemplate,
-      Container,
-      ContainerBuild,
-      ContainerGroup,
-      ContainerImage,
-      ContainerImageRegistry,
-      ContainerNode,
-      ContainerProject,
-      ContainerReplicator,
-      ContainerRoute,
-      ContainerService,
-      ContainerTemplate,
-      ContainerVolume
-    ].freeze
-
     # key: descendant::klass
     # value:
     #   if it is a symbol/method_name:
@@ -753,7 +737,7 @@ module Rbac
     def belongsto_association_filtered?(vcmeta, klass)
       if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) }
         # Eject early if true
-        return true if ASSOCIATED_BELONGSTO_MODELS.any? { |associated| klass <= associated }
+        return true if associated_belongsto_models.any? { |associated| klass <= associated }
       end
 
       if vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)
@@ -761,6 +745,24 @@ module Rbac
           klass <= association_class.safe_constantize
         end
       end
+    end
+
+    def associated_belongsto_models
+      [
+        VmOrTemplate,
+        Container,
+        ContainerBuild,
+        ContainerGroup,
+        ContainerImage,
+        ContainerImageRegistry,
+        ContainerNode,
+        ContainerProject,
+        ContainerReplicator,
+        ContainerRoute,
+        ContainerService,
+        ContainerTemplate,
+        ContainerVolume
+      ]
     end
 
     def get_belongsto_matches_for_host(blist)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -362,6 +362,79 @@ describe Rbac::Filterer do
       end
     end
 
+    context "with ContainerManagers with user roles" do
+      let(:owned_ems) { FactoryBot.create(:ems_openshift) }
+      let(:other_ems) { FactoryBot.create(:ems_openshift) }
+
+      before do
+        filters = ["/belongsto/ExtManagementSystem|#{owned_ems.name}"]
+
+        owner_group.entitlement = Entitlement.new
+        owner_group.entitlement.set_managed_filters([])
+        owner_group.entitlement.set_belongsto_filters(filters)
+        owner_group.save!
+      end
+
+      %w[
+        Container
+        ContainerBuild
+        ContainerGroup
+        ContainerImage
+        ContainerImageRegistry
+        ContainerNode
+        ContainerProject
+        ContainerReplicator
+        ContainerRoute
+        ContainerService
+        ContainerTemplate
+      ].each do |object_klass|
+        context "with #{object_klass}s" do
+          let(:subklass) { owned_ems.class.const_get(object_klass) }
+          let!(:object1) { subklass.create(:ems_id => owned_ems.id) }
+          let!(:object2) { subklass.create(:ems_id => owned_ems.id) }
+          let!(:object3) { subklass.create(:ems_id => other_ems.id) }
+          let!(:object4) { subklass.create(:ems_id => other_ems.id) }
+
+          it "properly filters" do
+            search_opts = {
+              :targets => subklass,
+              :userid  => owner_user.userid
+            }
+            results = described_class.search(search_opts)
+            objects = results.first
+
+            expect(objects.length).to eq(2)
+            expect(objects.to_a).to match_array([object1, object2])
+          end
+        end
+      end
+
+      # ContainerVolumes are the only class that has a `has_many :through`
+      # relationship with EMS.
+      context "with ContainerVolumes" do
+        let(:subklass)     { owned_ems.class.const_get(:ContainerGroup) }
+        let(:volume_klass) { owned_ems.class.const_get(:ContainerVolume) }
+        let!(:group1)      { subklass.create(:ems_id => owned_ems.id) }
+        let!(:group2)      { subklass.create(:ems_id => other_ems.id) }
+        let!(:volume1)     { volume_klass.create(:parent => group1) }
+        let!(:volume2)     { volume_klass.create(:parent => group1) }
+        let!(:volume3)     { volume_klass.create(:parent => group2) }
+        let!(:volume4)     { volume_klass.create(:parent => group2) }
+
+        it "properly filters" do
+          search_opts = {
+            :targets => volume_klass,
+            :userid  => owner_user.userid
+          }
+          results = described_class.search(search_opts)
+          objects = results.first
+
+          expect(objects.length).to eq(2)
+          expect(objects.to_a).to match_array([volume1, volume2])
+        end
+      end
+    end
+
     context 'when class does not participate in RBAC' do
       before do
         @vm = FactoryBot.create(:vm_vmware, :name => "VM1", :host => @host1, :ext_management_system => @ems)


### PR DESCRIPTION
`ContainerGroup`, among other classes, were not being filter based on it's Entitlements for a given user's role, as reported by this BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1631694

This not only includes `ContainerGroup` in the `Rbac::Filterer`'s `BELONGSTO_FILTER_CLASSES` constant, but also makes sure it is one of the classes that is filtered via associations, and not as itself and it's descendants (which is what happens in `else` portion of `Rbac::Filterer#get_belongsto_matches`).  Applies the same treatment to all `Container*` classes, since they also suffered from the same problem, and specs were created for each class.

There was a small bit of refactoring done in this PR, which was just to make the `if` clause more legible, but it is doing it in a way that doesn't completely retain the clause in it's original form (but is arguably more readable), so some eyes on that portion of things would be necessary.  The refactoring effort can be put off if desired and done in a separate PR.


(Possible) Outstanding issue
----------------------------

While this does fix the issue described in the ticket, the `MiqProductFeature`s that are setup (and described as being present in the ticket) are not applied at all in `Rbac` (if at all).  I don't know if this is something that is filtered elsewhere, but currently, the following filters:

```
- [x] Everything
  - [ ] Cloud Intel
  - [ ] Services
  - [ ] Compute
    - [ ] Clouds
    - [ ] Infrastructure
    - [ ] Physical Infrastructure
    - [x] Containers
      - [ ] Containers Dashboard
      - [x] Container Providers
	- [x] View
	- [ ] Operate
	- [ ] Modify
      - [x] Projects
	- [x] View
	- [ ] Operate
      - [x] Routes
	- [x] View
	- [ ] Operate
      - [x] Services
	- [x] View
	- [ ] Operate
      - [x] Replicators
	- [x] View
	- [x] Operate
      - [x] Pods
	- [x] View
	- [ ] Operate
      - [x] Containers Explorer
	- [x] Relationships
	  - [x] View Containers
	- [x] All Containers
	  - [x] View Containers
	  - [ ] Modify
      - [ ] Nodes
      - [x] Volumes
	- [x] View
	- [ ] Modify
	- [ ] Operate
      - [x] Builds
	- [x] View
	- [ ] Operate
      - [x] Registries
	- [x] View
	- [ ] Operate
      - [x] Images
	- [x] View
	- [ ] Operate
      - [x] Templates
	- [x] View
	- [x] Operate
      - [x] Containers Topology
	- [x] View
```

Does not do anything to my knowledge to limit viewing permissions in `Rbac`.

That said, it might limit it in the view/UI, but that is not being tested here (even though it is being setup in the QA steps below)



Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1631694 (as reported)
* BZ replication and QA steps:  https://gist.github.com/NickLaMuro/9f0147a7416a53de1f82de05c66b00d8

Steps for Testing/QA
--------------------

The provided gist above has two scripts to run, so follow the `README.md` instructions there.