### PR TITLE
[WIP] Update rspec options in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,13 +48,13 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.order = :random
-  config.warnings = true
 
   unless ENV['CI']
     # File store for --only-failures option
     config.example_status_persistence_file_path = Rails.root.join("tmp/rspec_example_store.txt")
     config.profile_examples = 10
     config.default_formatter = "doc" if config.files_to_run.one?
+    config.warnings = true
   end
 
   config.include Spec::Support::RakeTaskExampleGroup, :type => :rake_task

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,12 +26,15 @@ Dir[ManageIQ::Gems::Pending.root.join("spec/support/custom_matchers/*.rb")].each
 require "manageiq/password/rspec_matchers"
 
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
-  config.mock_with :rspec do |c|
-    c.allow_message_expectations_on_nil = false
-    c.syntax = :expect
+
+  config.mock_with :rspec do |mocks|
+    mocks.allow_message_expectations_on_nil = false
+    mocks.syntax = :expect
+    mocks.verify_partial_doubles = true
   end
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -42,9 +45,15 @@ RSpec.configure do |config|
   # `post` methods in spec/controllers, without specifying type
   config.infer_spec_type_from_file_location!
 
+  config.filter_run_when_matching :focus
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.order = :random
+
   unless ENV['CI']
     # File store for --only-failures option
     config.example_status_persistence_file_path = Rails.root.join("tmp/rspec_example_store.txt")
+    config.profile_examples = 10
+    config.default_formatter = "doc" if config.files_to_run.one?
   end
 
   config.include Spec::Support::RakeTaskExampleGroup, :type => :rake_task

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.order = :random
+  config.warnings = true
 
   unless ENV['CI']
     # File store for --only-failures option


### PR DESCRIPTION
Adding some options to make the specs a little more robust, and in preparation for what will be the default for some options in rspec 4.

Update: almost done, one spec failure left!

```
1) MiqRequestTask::StateMachine #signal will deal with exceptions
     Failure/Error: allow(task).to receive(:some_state).and_raise(exception)
       #<MiqRequestTask id: 15000000000063, description: nil, state: "pending", request_type: nil, userid: nil, options: {}, created_on: "2020-02-24 22:30:53", updated_on: "2020-02-24 22:30:53", message: nil, status: "Ok", type: nil, miq_request_id: nil, source_id: nil, source_type: nil, destination_id: nil, destination_type: nil, miq_request_task_id: nil, phase: nil, phase_context: {}, tenant_id: nil, cancelation_status: nil, conversion_host_id: nil> does not implement: some_state
     # ./spec/models/miq_request_task/state_machine_spec.rb:8:in `block (4 levels) in <top (required)>'
```