### PR TITLE
Update fast_gettext to 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false
-gem "fast_gettext",                   "~>1.2.0"
+gem "fast_gettext",                   "~>2.0.0"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.8.5"

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false
-gem "fast_gettext",                   "~>2.0.0"
+gem "fast_gettext",                   "~>2.0.1"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.8.5"


### PR DESCRIPTION
Updates the fast_gettext gem from 1.2.0 to ~~2.0.0~~ 2.0.1.

https://github.com/grosser/fast_gettext/blob/master/CHANGELOG

Among other things this will get rid of a large amount of uninitialized warnings if we run with warnings on.