### PR TITLE
Use admin user in get_user for service show if user's deleted

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -31,8 +31,12 @@ module MiqRequestMixin
   end
 
   def get_user
-    @user ||= User.in_my_region.find_by(:userid => userid).tap do |u|
-      u.current_group_by_description = options[:requester_group] if options[:requester_group]
+    if @user || User.in_my_region.find_by(:userid => userid)
+      @user ||= User.in_my_region.find_by(:userid => userid).tap do |u|
+        u.current_group_by_description = options[:requester_group] if options[:requester_group]
+      end
+    else
+      @user = User.super_admin
     end
   end
   alias_method :tenant_identity, :get_user
@@ -141,8 +145,7 @@ module MiqRequestMixin
       tag_descript = Classification.find_by_name(tag_path).description
       ws_tag_data << {:category => parts.first, :category_display_name => cat_descript,
                       :tag_name => parts.last,  :tag_display_name => tag_descript,
-                      :tag_path =>  File.join(ns, tag_path), :display_name => "#{cat_descript}: #{tag_descript}"
-                     }
+                      :tag_path =>  File.join(ns, tag_path), :display_name => "#{cat_descript}: #{tag_descript}"}
     end
     ws_tag_data
   end

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -511,6 +511,12 @@ describe MiqRequest do
       expect(user.current_group).to eq(group1)
       expect(request.get_user.current_group).to eq(group1)
     end
+
+    it "returns superadmin if user was deleted" do
+      request = FactoryBot.create(:miq_provision_request, :requester => user)
+      user.destroy
+      expect(request.get_user).to eq(User.super_admin)
+    end
   end
 
   context "#update_request" do


### PR DESCRIPTION
If users are deleted, the SUI can break on service viewing. This allows us to resort to admin if the service user can't be found.

Yuri wants this opened for https://bugzilla.redhat.com/show_bug.cgi?id=1677744. 

