### PR TITLE
Add instance method to call make_retire_request

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -47,6 +47,10 @@ module RetirementMixin
     end
   end
 
+  def retire_request(user)
+    self.class.make_retire_request(id, user)
+  end
+
   def retirement_warned?
     !retirement_last_warn.nil?
   end

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -58,6 +58,11 @@ describe "Service Retirement Management" do
       @stack.reload
     end
 
+    it "#retire_request" do
+      expect(@stack.retirement_state).to be_nil
+      expect(@stack.retire_request(user)).to eq(OrchestrationStackRetireRequest.first)
+    end
+
     it "#retire_now with userid" do
       expect(@stack.retirement_state).to be_nil
       expect(OrchestrationStackRetireRequest).to_not receive(:make_request)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -53,6 +53,11 @@ describe "Service Retirement Management" do
     expect(@service.retirement_state).to eq('initializing')
   end
 
+  it "#retire_request" do
+    expect(@service.retirement_state).to be_nil
+    expect(@service.retire_request(user)).to eq(ServiceRetireRequest.first)
+  end
+
   it "#retire_now when called more than once" do
     expect(@service.retirement_state).to be_nil
     expect(MiqEvent).to receive(:raise_evm_event).once

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -57,6 +57,11 @@ describe "VM Retirement Management" do
     expect(@vm.retirement_state).to eq('initializing')
   end
 
+  it "#retire_request" do
+    expect(@vm.retirement_state).to be_nil
+    expect(@vm.retire_request(user)).to eq(VmRetireRequest.first)
+  end
+
   it "#retire_now when called more than once" do
     expect(MiqEvent).to receive(:raise_evm_event).once
     3.times { @vm.retire_now(user) }


### PR DESCRIPTION
We need to be able to call retirement as a request from Automate, and that requires exposing the retirement method on the engine, which in turn requires having an instance method to expose. Turtles on turtles on turtles. Madhu wanted it to return the request. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1700524

# Related to
https://github.com/ManageIQ/manageiq-automation_engine/pull/314

