### PR TITLE
Add method to list supported providers for create

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -32,6 +32,14 @@ class ExtManagementSystem < ApplicationRecord
     %w[]
   end
 
+  def self.supported_types_for_create
+    leaf_subclasses.select(&:supported_for_create?)
+  end
+
+  def self.supported_for_create?
+    !reflections.include?("parent_manager")
+  end
+
   belongs_to :provider
   has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
 

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -6,6 +6,10 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
   require_nested :ConfiguredSystem
   require_nested :OrchestrationStack
 
+  def supported_for_create?
+    false
+  end
+
   def supported_catalog_types
     %w(generic_ansible_playbook)
   end


### PR DESCRIPTION
Add a generalized way of getting a list of provider types which can be
added through the UI/API.  Essentially do not support "child_managers"
aka a sub network-manager and/or storage-manager.

Fixes https://github.com/ManageIQ/manageiq/issues/18568