### PR TITLE
Add ProviderObject mixin to the PhysicalServer

### DIFF
--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -4,6 +4,7 @@ class PhysicalServer < ApplicationRecord
   include TenantIdentityMixin
   include SupportsFeatureMixin
   include EventMixin
+  include ProviderObjectMixin
 
   include_concern 'Operations'
 


### PR DESCRIPTION
With this commit we include the mixin ProviderObjectMixin on the model because providers like Redfish would like to use the handy

```ruby
server.with_provider_object { |obj| ... }
```

@miq-bot add_label enhancement
@miq-bot assign @Ladas 
