### PR TITLE
Move GIT_REPO_DIRECTORY constant from MiqAeDatastore

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -1,6 +1,8 @@
 class GitRepository < ApplicationRecord
   include AuthenticationMixin
 
+  GIT_REPO_DIRECTORY = Rails.root.join('data/git_repos')
+
   validates :url, :format => URI::regexp(%w(http https)), :allow_nil => false
   validate  :check_path
 
@@ -38,7 +40,7 @@ class GitRepository < ApplicationRecord
   def directory_name
     parsed = URI.parse(url)
     raise "Invalid URL missing path" if parsed.path.blank?
-    File.join(MiqAeDatastore::GIT_REPO_DIRECTORY, parsed.path)
+    File.join(GIT_REPO_DIRECTORY, parsed.path)
   end
 
   def self_signed_cert_cb(_valid, _host)

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -14,7 +14,7 @@ describe GitRepository do
   it "default dirname" do
     repo = FactoryBot.create(:git_repository,
                               :url => "http://www.example.com/repos/manageiq")
-    expect(repo.directory_name).to eq(File.join(MiqAeDatastore::GIT_REPO_DIRECTORY, 'repos/manageiq'))
+    expect(repo.directory_name).to eq(File.join(described_class::GIT_REPO_DIRECTORY, 'repos/manageiq'))
   end
 
   context "repo" do


### PR DESCRIPTION
@mkanoor Please review.  This decouples GitRepository from MiqAeDatastore.