### PR TITLE
[HAMMER] [V2V] Refactor ConversionHost to use AuthenticationMixin

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -42,7 +42,7 @@ module ConversionHost::Configurations
       _log.info("Enabling a conversion_host with parameters: #{params}")
 
       params.delete(:task_id) # In case this is being called through *_queue which will stick in a :task_id
-      miq_task_id = params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
+      params.delete(:miq_task_id) # The miq_queue.activate_miq_task will stick in a :miq_task_id
 
       vmware_vddk_package_url = params.delete(:vmware_vddk_package_url)
       params[:vddk_transport_supported] = !vmware_vddk_package_url.nil?
@@ -61,15 +61,8 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key)
         conversion_host.save!
-
-        if miq_task_id
-          MiqTask.find(miq_task_id).tap do |task|
-            task.context_data.to_h[:conversion_host_id] = conversion_host.id
-            task.save
-          end
-        end
       end
     rescue StandardError => error
       raise

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -121,7 +121,7 @@ describe ConversionHost do
         task_id = described_class.enable_queue(params)
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [params.merge(:task_id => task_id).except(:resource)],
+          :args        => [params.merge(:task_id => task_id).except(:resource), nil],
           :class_name  => described_class.name,
           :method_name => "enable",
           :priority    => MiqQueue::NORMAL_PRIORITY,
@@ -138,7 +138,7 @@ describe ConversionHost do
         task_id = conversion_host.disable_queue
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
         expect(MiqQueue.first).to have_attributes(
-          :args        => [],
+          :args        => [{:task_id => task_id}, nil],
           :class_name  => described_class.name,
           :instance_id => conversion_host.id,
           :method_name => "disable",


### PR DESCRIPTION
This is essentially a clone of #18309. The primary difference is that this PR does not modify the AuthenticationMixin module. Doing so caused failures in at least one provider.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1702051

Replaces https://github.com/ManageIQ/manageiq/pull/18634 which I got goofed up on a botched rebase.