### PR TITLE
Fix EmbeddedAutomationManager supported_for_create

### DIFF
--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -6,7 +6,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
   require_nested :ConfiguredSystem
   require_nested :OrchestrationStack
 
-  def supported_for_create?
+  def self.supported_for_create?
     false
   end
 


### PR DESCRIPTION
This should have been a class method not an instance method.

Follow-up: https://github.com/ManageIQ/manageiq/pull/18666