### PR TITLE
Add factory for service retire request

### DIFF
--- a/spec/factories/miq_request.rb
+++ b/spec/factories/miq_request.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     end
 
     factory :service_reconfigure_request,        :class => "ServiceReconfigureRequest"
+    factory :service_retire_request,             :class => "ServiceRetireRequest"
     factory :service_template_provision_request, :class => "ServiceTemplateProvisionRequest" do
       source { create(:service_template) }
     end


### PR DESCRIPTION
This factory is needed for me to be able to test the ```self.create_retire_request(obj)``` in https://github.com/ManageIQ/manageiq-automation_engine/pull/314

part of fix for https://bugzilla.redhat.com/show_bug.cgi?id=1700524

## Related to:
https://github.com/ManageIQ/manageiq-automation_engine/pull/314