### PR TITLE
[V2V] Fix allowing address to be blank for the ConversionHost model, and update spec.

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -21,7 +21,7 @@ class ConversionHost < ApplicationRecord
     :uniqueness => true,
     :format     => { :with => Resolv::AddressRegex },
     :inclusion  => { :in => ->(conversion_host) { conversion_host.resource.ipaddresses } },
-    :unless     => ->(conversion_host) { conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? },
+    :unless     => ->(conversion_host) { conversion_host.address.blank? || conversion_host.resource.blank? || conversion_host.resource.ipaddresses.blank? },
     :presence   => false
 
   validate :resource_supports_conversion_host

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -309,6 +309,7 @@ describe ConversionHost do
     end
 
     it "is valid if an address is not provided" do
+      allow(vm).to receive(:ipaddresses).and_return(['127.0.0.1'])
       conversion_host = ConversionHost.new(:name => "test", :resource => vm)
       expect(conversion_host.valid?).to be(true)
     end


### PR DESCRIPTION
Apparently adding `:presence => false` to the address validation for the `ConversionHost` model wasn't good enough due to some AR precedence issue, and my spec didn't catch it because it already skipped the validation if the underlying resource didn't return an address.

So, this explicitly skips the check if the address is blank, and updates the spec to make sure that it will return at least one address.

I validated that without this change, the spec will now fail.

Followup to: https://github.com/ManageIQ/manageiq/pull/18610
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1695797

