### PR TITLE
[V2V] Provide placeholder params for the ConversionHost#disable method

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -100,7 +100,7 @@ module ConversionHost::Configurations
     self.class.queue_configuration('disable', id, resource, {}, auth_user)
   end
 
-  def disable
+  def disable(_params, _auth_user = nil)
     resource_info = "type=#{resource.class.name} id=#{resource.id}"
     _log.debug("Disabling a conversion_host #{resource_info}")
 

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -100,7 +100,7 @@ module ConversionHost::Configurations
     self.class.queue_configuration('disable', id, resource, {}, auth_user)
   end
 
-  def disable(_params, _auth_user = nil)
+  def disable(_params = nil, _auth_user = nil)
     resource_info = "type=#{resource.class.name} id=#{resource.id}"
     _log.debug("Disabling a conversion_host #{resource_info}")
 

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -143,6 +143,16 @@ describe ConversionHost do
     context "#disable_queue" do
       let(:op) { 'disable' }
 
+      let(:expected_notify) do
+        {
+          :type    => :conversion_host_config_success,
+          :options => {
+            :op_name => "disable",
+            :op_arg  => "type=#{vm.class.name} id=#{vm.id}"
+          }
+        }
+      end
+
       it "to queue with a task" do
         task_id = conversion_host.disable_queue
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action)
@@ -155,6 +165,13 @@ describe ConversionHost do
           :role        => "ems_operations",
           :zone        => conversion_host.resource.ext_management_system.my_zone
         )
+      end
+
+      it "calls the disable method if delivered" do
+        allow_any_instance_of(ConversionHost).to receive(:disable_conversion_host_role)
+        expect(Notification).to receive(:create).with(expected_notify)
+        conversion_host.disable_queue
+        expect(MiqQueue.first.deliver).to include("ok")
       end
     end
   end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -168,7 +168,9 @@ describe ConversionHost do
       end
 
       it "calls the disable method if delivered" do
-        allow_any_instance_of(ConversionHost).to receive(:disable_conversion_host_role)
+        allow(conversion_host).to receive(:disable_conversion_host_role)
+        allow(ConversionHost).to receive(:find).with(conversion_host.id).and_return(conversion_host)
+
         expect(Notification).to receive(:create).with(expected_notify)
         conversion_host.disable_queue
         expect(MiqQueue.first.deliver).to include("ok")


### PR DESCRIPTION
Currently the `disable_queue` method will fail with `wrong number of arguments (given 2, expected 0)`. This is because the `disable_queue` method calls the `queue_configuration` method which automatically passes `params` and `args` to whatever the op is.

So, this PR just adds a couple dummy placeholder parameters in order to comply with the interface.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1703254