### PR TITLE
Move EmsRefresh spec helper methods to core

### DIFF
--- a/spec/support/ems_refresh_helper.rb
+++ b/spec/support/ems_refresh_helper.rb
@@ -1,0 +1,45 @@
+module Spec
+  module Support
+    module EmsRefreshHelper
+      def serialize_inventory
+        # These models don't have tables behind them
+        skip_models = [MiqRegionRemote, VmdbDatabaseConnection, VmdbDatabaseLock, VmdbDatabaseSetting]
+        models = ApplicationRecord.subclasses - skip_models
+
+        # Skip attributes that always change between refreshes
+        skip_attrs_global   = ["created_on", "updated_on"]
+        skip_attrs_by_model = {
+          "ExtManagementSystem" => ["last_refresh_date", "last_inventory_date"],
+        }
+
+        models.each_with_object({}) do |model, inventory|
+          inventory[model.name] = model.all.map do |rec|
+            skip_attrs = skip_attrs_global + skip_attrs_by_model[model.name].to_a
+            rec.attributes.except(*skip_attrs)
+          end
+        end
+      end
+
+      def assert_inventory_not_changed(before, after)
+        expect(before.keys).to match_array(after.keys)
+
+        before.each_key do |model|
+          expect(before[model].count).to eq(after[model].count), <<~SPEC_FAILURE
+            #{model} count doesn't match
+            expected: #{before[model].count}
+            got:      #{after[model].count}
+          SPEC_FAILURE
+
+          before[model].each do |item_before|
+            item_after = after[model].detect { |i| i["id"] == item_before["id"] }
+            expect(item_before).to eq(item_after), <<~SPEC_FAILURE
+              #{model} ID [#{item_before["id"]}]
+              expected: #{item_before}
+              got:      #{item_after}
+            SPEC_FAILURE
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move these helper methods of of the vmware repo to core.  VMware and
Azure have similar methods and every provider with graph and classic
refresh can benefit from these methods.

This can be used to confirm the exact correctness of inventory between
two different methods, e.g. classic then graph refresh or full refresh
then targeted refresh:

Example:

```
  it "Classic same as graph refresh" do
    stub_settings_merge(:ems_refresh => {:scvmm => {:inventory_object_refresh => true}})
    EmsRefresh.refresh(@ems)
    inventory_after_graph_refresh = serialize_inventory

    stub_settings_merge(:ems_refresh => {:scvmm => {:inventory_object_refresh => false}})
    EmsRefresh.refresh(@ems)
    inventory_after_classic_refresh = serialize_inventory

    assert_inventory_not_changed(inventory_after_classic_refresh, inventory_after_graph_refresh)
  end
```

```
  1) ManageIQ::Providers::Microsoft::InfraManager::Refresher Classic same as graph refresh
     Failure/Error: assert_inventory_not_changed(inventory_after_classic_refresh, inventory_after_graph_refresh)

       GuestDevice ID [46000000000313]
       expected: {"id"=>46000000000313, "device_name"=>"Ethernet", "device_type"=>"ethernet", "location"=>"PCI bus 16, device 0, function 1", "filename"=>nil, "hardware_id"=>46000000000425, "mode"=>nil, "controller_type"=>"ethernet", "size"=>nil, "free_space"=>nil, "size_on_disk"=>nil, "address"=>"5C:F3:FC:1C:86:1E", "switch_id"=>46000000000049, "lan_id"=>nil, "model"=>"Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #52", "iscsi_name"=>nil, "iscsi_alias"=>nil, "present"=>true, "start_connected"=>true, "auto_detect"=>nil, "uid_ems"=>"96b9ae95-267d-4f54-a231-1fc9f8a044d2", "chap_auth_enabled"=>nil, "manufacturer"=>nil, "field_replaceable_unit"=>nil, "parent_device_id"=>nil, "vlan_key"=>nil, "vlan_enabled"=>nil, "peer_mac_address"=>nil}
       got:      {"id"=>46000000000313, "device_name"=>"Ethernet", "device_type"=>"ethernet", "location"=>"PCI bus 16, device 0, function 1", "filename"=>nil, "hardware_id"=>46000000000425, "mode"=>nil, "controller_type"=>"ethernet", "size"=>nil, "free_space"=>nil, "size_on_disk"=>nil, "address"=>"5C:F3:FC:1C:86:1E", "switch_id"=>nil, "lan_id"=>nil, "model"=>"Broadcom BCM5709S NetXtreme II GigE (NDIS VBD Client) #52", "iscsi_name"=>nil, "iscsi_alias"=>nil, "present"=>true, "start_connected"=>true, "auto_detect"=>nil, "uid_ems"=>"96b9ae95-267d-4f54-a231-1fc9f8a044d2", "chap_auth_enabled"=>nil, "manufacturer"=>nil, "field_replaceable_unit"=>nil, "parent_device_id"=>nil, "vlan_key"=>nil, "vlan_enabled"=>nil, "peer_mac_address"=>nil}
       Diff:
       @@ -22,7 +22,7 @@
        "size" => nil,
        "size_on_disk" => nil,
        "start_connected" => true,
       -"switch_id" => nil,
       +"switch_id" => 46000000000049,
        "uid_ems" => "96b9ae95-267d-4f54-a231-1fc9f8a044d2",
        "vlan_enabled" => nil,
        "vlan_key" => nil,
```

Follow ups:
https://github.com/ManageIQ/manageiq-providers-scvmm/pull/112
https://github.com/ManageIQ/manageiq-providers-vmware/pull/396