### PR TITLE
[V2V] Add V2V spec tags

### DIFF
--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -1,4 +1,4 @@
-describe ConversionHost do
+RSpec.describe ConversionHost, :v2v do
   let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
   let(:conversion_host_ssh) { FactoryBot.create(:conversion_host, :resource => vm, :ssh_transport_supported => true) }
   let(:conversion_host_vddk) { FactoryBot.create(:conversion_host, :resource => vm, :vddk_transport_supported => true) }

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -1,6 +1,6 @@
 require "MiqSshUtil"
 
-describe ConversionHost do
+RSpec.describe ConversionHost, :v2v do
   let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
 
   context "provider independent methods" do

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1,4 +1,4 @@
-describe InfraConversionJob do
+RSpec.describe InfraConversionJob, :v2v do
   let(:vm)      { FactoryBot.create(:vm_or_template) }
   let(:request) { FactoryBot.create(:service_template_transformation_plan_request) }
   let(:task)    { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :source => vm) }

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateTransformationPlanRequest do
+RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
   let(:vms) { Array.new(3) { FactoryBot.create(:vm_or_template) } }
   let(:vm_requests) do
     [ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_FAILED, ServiceResource::STATUS_APPROVED].zip(vms).collect do |status, vm|

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateTransformationPlan do
+RSpec.describe ServiceTemplateTransformationPlan, :v2v do
   subject { FactoryBot.create(:service_template_transformation_plan) }
 
   describe '#request_class' do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateTransformationPlanTask do
+RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   let(:infra_conversion_job) { FactoryBot.create(:infra_conversion_job) }
 
   describe '.base_model' do

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,4 +1,4 @@
-describe TransformationMapping do
+RSpec.describe TransformationMapping, :v2v do
   let(:src) { FactoryBot.create(:ems_cluster) }
   let(:dst) { FactoryBot.create(:ems_cluster) }
   let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src) }


### PR DESCRIPTION
This adds a small amount of metadata to specs that test the `ConversionHost` or `ConversionHost::Configuration` models in some way. This way if anyone makes a modification to the underlying model, it's easy to validate all of the changes via:

`bundle exec rspec --tag v2v`

This will only run those specs that are tagged with `v2v`. The others are skipped.

Also, I updated the outer `describe` block to `RSpec.describe` because starting in rspec 4 the RSpec module name will be mandatory in the outer describe block.