### PR TITLE
Add metrics_base table to default excludes and remove rollups view

### DIFF
--- a/config/default_replication_exclude_tables.yml
+++ b/config/default_replication_exclude_tables.yml
@@ -18,7 +18,7 @@
 - file_depots
 - jobs
 - log_files
-- metrics
+- metrics_base
 - metrics_00
 - metrics_01
 - metrics_02
@@ -43,7 +43,6 @@
 - metrics_21
 - metrics_22
 - metrics_23
-- metric_rollups
 - miq_actions
 - miq_ae_classes
 - miq_ae_fields


### PR DESCRIPTION
As of manageiq-schema/c9e05cc800 the base table for metrics is
metrics_base, not metrics. This is required for moving to the
built-in logical replication solution. Without this table excluded
all the child tables were being added to the publication when we
added metrics_base.

This behavior is documented in
https://www.postgresql.org/docs/10/sql-createpublication.html