### PR TITLE
Fix ServiceTemplate#picture= with models

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -401,9 +401,11 @@ class ServiceTemplate < ApplicationRecord
 
   def picture=(value)
     if value
-      super unless value.kind_of?(Hash)
-
-      super(create_picture(value))
+      if value.kind_of?(Hash)
+        super(create_picture(value))
+      else
+        super
+      end
     end
   end
 

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1002,6 +1002,27 @@ describe ServiceTemplate do
       expect(service_template.resource_actions.last.dialog).to eq(service_dialog)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
     end
+
+    context "with an existing picture" do
+      let(:picture) { Picture.create(catalog_item_options.delete(:picture)) }
+
+      it "creates the picture without error" do
+        expect {
+          service_template = ServiceTemplate.create_catalog_item(catalog_item_options, user)
+          service_template.picture = picture
+        }.not_to raise_error
+      end
+
+      it "has the picture assigned properly" do
+        service_template = ServiceTemplate.create_catalog_item(catalog_item_options, user)
+        service_template.picture = picture
+        service_template.save
+
+        service_template.reload
+
+        expect(service_template.picture.id).to eq picture.id
+      end
+    end
   end
 
   describe '#update_catalog_item' do


### PR DESCRIPTION
When creating a service template with a `Picture` that already exists (done in some of specs in other repos), the previous form of this method would break as `create_picture` was not relevant for updating pictures that already exist.

This fix #should™ fix that, but more relevant eyes should probably take a look just to make sure...


Where it fails...
-----------------

Currently fails in the `manageiq-api` specs:

* https://github.com/ManageIQ/manageiq-api/blob/f12cf95d/spec/requests/service_templates_spec.rb#L16-L22
* https://github.com/ManageIQ/manageiq-api/blob/f12cf95d/spec/requests/pictures_spec.rb#L26-L36



Links
-----

* Introduced in:  https://github.com/ManageIQ/manageiq/pull/18689


Steps for Testing/QA
--------------------

Try running the API specs with and without this change to the models and confirm that it fails without, and passes with.