### PR TITLE
Don't do anything in a function meant for override

### DIFF
--- a/app/models/physical_server_provision_task/state_machine.rb
+++ b/app/models/physical_server_provision_task/state_machine.rb
@@ -6,7 +6,6 @@ module PhysicalServerProvisionTask::StateMachine
   end
 
   def start_provisioning
-    update_and_notify_parent(:message => msg('start provisioning'))
     # Implement provisioning in subclass, user-defined values are stored in options field.
     raise NotImplementedError, 'Must be implemented in subclass and signal :done_provisioning when done'
   end


### PR DESCRIPTION
Providers should override the `start_provisioning` function so it makes no sense to execute any logic in it.

@miq-bot add_label enhancement
@miq-bot assign @agrare 