### PR TITLE
Rename Configuration feature to Main Configuration

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2856,7 +2856,7 @@
       :identifier: miq_task_canceljob
 
 # Configuration
-- :name: Configuration
+- :name: Main Configuration
   :description: Everything under Configuration
   :feature_type: node
   :identifier: ops_explorer


### PR DESCRIPTION
As the `Configuration` under the `Settings` dropdown has been [extracted](https://github.com/ManageIQ/manageiq-ui-classic/pull/5453) into a separate button in the top-right corner of the UI, the RBAC feature tree structure introduced a collision: there are two `Configuration` nodes on the same level.

![Screenshot from 2019-04-30 13-06-13](https://user-images.githubusercontent.com/649130/56958373-6fdcbd00-6b4a-11e9-82c7-e0615510140a.png)

Based on a discussion with @loicavenel I'm renaming the `Configuration` to `Main Configuration` to avoid any confusion in the area.

![Screenshot from 2019-04-30 13-21-37](https://user-images.githubusercontent.com/649130/56958578-ebd70500-6b4a-11e9-880f-ecdd2bf48e2a.png)

@miq-bot add_label hammer/no, bug
@miq-bot add_reviewer @martinpovolny 

http://bugzilla.redhat.com/show_bug.cgi?id=1704163
