### PR TITLE
Group AND expressions properly to account for nesting

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -1379,7 +1379,7 @@ class MiqExpression
         next if arel.blank?
         result << arel
       end
-      Arel::Nodes::And.new(operands)
+      Arel::Nodes::Grouping.new(Arel::Nodes::And.new(operands))
     when "or"
       operands = exp[operator].each_with_object([]) do |operand, result|
         next if operand.blank?


### PR DESCRIPTION
The sql generated for a nested expression à la ```c OR(a AND b)``` is incorrect because we're not wrapping the inside expression when it's an ```AND```. This just adds the wrapping to all ANDs. It results in extra parens in a couple cases but while not having the parens is occasionally detrimental, having too many is never going to hurt us so we should err on the side of too many, methinks.  


Fixes part of https://bugzilla.redhat.com/show_bug.cgi?id=1660460
It'll require UI changes as well because https://bugzilla.redhat.com/show_bug.cgi?id=1660460#c8 is still an issue 
