### PR TITLE
Add scope to region validation and use it to fix miq_dialog seed

### DIFF
--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -2,7 +2,7 @@ class MiqDialog < ApplicationRecord
   include_concern "Seeding"
 
   validates :name, :description, :presence => true
-  validates :name, :uniqueness => { :scope => :dialog_type, :case_sensitive => false }
+  validates :name, :unique_within_region => { :scope => :dialog_type, :match_case => false }
 
   scope :with_dialog_type, ->(dialog_type) { where(:dialog_type => dialog_type) }
 

--- a/lib/unique_within_region_validator.rb
+++ b/lib/unique_within_region_validator.rb
@@ -3,13 +3,14 @@ class UniqueWithinRegionValidator < ActiveModel::EachValidator
     return if value.nil?
     match_case = options.key?(:match_case) ? options[:match_case] : true
     record_base_class = record.class.base_class
-    field_matches =
+    matches =
       if match_case
         record_base_class.where(attribute => value)
       else
         record_base_class.where(record_base_class.arel_attribute(attribute).lower.eq(value.downcase))
       end
-    unless field_matches.in_region(record.region_id).where.not(:id => record.id).empty?
+    matches = matches.where(options[:scope] => record.public_send(options[:scope])) if options.key?(:scope)
+    unless matches.in_region(record.region_id).where.not(:id => record.id).empty?
       record.errors.add(attribute, "is not unique within region #{record.region_id}")
     end
   end


### PR DESCRIPTION
After setting up replication the global region could not start because of a name validation error. Specifically, this one:

```
[----] I, [2019-04-30T14:36:20.676625 #6387:d6cf68]  INFO -- : MIQ(EvmDatabase.seed_classes) Seeding MiqDialog...
[----] I, [2019-04-30T14:36:20.696101 #6387:d6cf68]  INFO -- : MIQ(MiqDialog.seed_record) Updating MiqDialog "miq_provision_openstack_dialogs_template.yaml"
[----] E, [2019-04-30T14:36:20.717935 #6387:d6cf68] ERROR -- : [ActiveRecord::RecordInvalid]: Validation failed: MiqDialog: Name has already been taken  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2019-04-30T14:36:20.718086 #6387:d6cf68] ERROR -- : /usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/validations.rb:78:in `raise_validation_error'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/validations.rb:50:in `save!'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:324:in `block in save!'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:211:in `transaction'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:324:in `save!'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/suppressor.rb:45:in `save!'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/persistence.rb:288:in `block in update!'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:211:in `transaction'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/persistence.rb:286:in `update!'
/var/www/miq/vmdb/app/models/miq_dialog/seeding.rb:49:in `seed_record'
/var/www/miq/vmdb/app/models/miq_dialog/seeding.rb:13:in `block (2 levels) in seed'
/var/www/miq/vmdb/app/models/miq_dialog/seeding.rb:12:in `each'
/var/www/miq/vmdb/app/models/miq_dialog/seeding.rb:12:in `block in seed'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
/usr/local/lib/ruby/gems/2.4.0/gems/activerecord-5.0.7.2/lib/active_record/transactions.rb:211:in `transaction'
/var/www/miq/vmdb/app/models/miq_dialog/seeding.rb:9:in `seed'
```

I haven't looked closely enough to be sure, but could this have been introduced in bef8563a703f208ac75fa833bdcac2672156c6cc @Fryguy ?