### PR TITLE
Drop id_region dependency and let manageiq-schema do it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-virtual_attributes", "~>1.1.0"
-gem "activerecord-id_regions",        "~>0.2.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.4",       :require => false


### PR DESCRIPTION
Schema defines what id_regions we need to use, there's no need to do it here. 

See: https://github.com/ManageIQ/manageiq-schema/pull/365