### PR TITLE
Add port groups to rbac

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -34,6 +34,7 @@ module Rbac
       FloatingIp
       Host
       HostAggregate
+      Lan
       LoadBalancer
       MiddlewareDatasource
       MiddlewareDeployment

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -230,6 +230,24 @@ describe Rbac::Filterer do
         end
       end
 
+      context 'searching for instances of Lans' do
+        let!(:lan) { FactoryBot.create_list(:lan, 2).first }
+
+        before do
+          lan.tag_with('/managed/environment/prod', :ns => '*')
+        end
+
+        it 'lists only tagged Lans' do
+          results = described_class.search(:class => Lan, :user => user).first
+          expect(results).to match_array [lan]
+        end
+
+        it 'lists only all Lans' do
+          results = described_class.search(:class => Lan, :user => admin_user).first
+          expect(results).to match_array Lan.all
+        end
+      end
+
       context 'searching for instances of ConfigurationScriptSource' do
         let!(:configuration_script_source) { FactoryBot.create_list(:embedded_ansible_configuration_script_source, 2).first }
 


### PR DESCRIPTION
Port Groups are taggable and thus should be included in the list of ```CLASSES_THAT_PARTICIPATE_IN_RBAC```. Switches are already here, so I don't think anything needs to be done with them. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628228
It's just like https://github.com/ManageIQ/manageiq/pull/17964/files
in fact the switches got added in that pr. thanks, Libor

... except the customer case for that ticket is closed? I don't know what's even happening here. 
