### PR TITLE
Move common collection overrides to core

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -85,42 +85,42 @@ module ManageIQ::Providers
 
         def ems_folders
           add_properties(
-            :manager_ref          => %i(uid_ems),
-            :attributes_blacklist => %i(ems_children),
+            :manager_ref          => %i[uid_ems],
+            :attributes_blacklist => %i[parent],
           )
           add_common_default_values
         end
 
         def datacenters
+          add_properties(:attributes_blacklist => %i[parent])
           add_common_default_values
         end
 
         def resource_pools
           add_properties(
-            :manager_ref          => %i(uid_ems),
-            :attributes_blacklist => %i(ems_children),
+            :manager_ref          => %i[uid_ems],
+            :attributes_blacklist => %i[parent],
           )
           add_common_default_values
         end
 
         def ems_clusters
-          add_properties(
-            :attributes_blacklist => %i(ems_children datacenter_id),
-          )
-
-          add_inventory_attributes(%i(datacenter_id))
+          add_properties(:attributes_blacklist => %i[datacenter_id parent])
+          add_inventory_attributes(%i[datacenter_id])
           add_common_default_values
         end
 
         def storages
           add_properties(
-            :manager_ref => %i(location),
-            :complete    => false,
-            :arel        => Storage,
+            :manager_ref          => %i[location],
+            :complete             => false,
+            :arel                 => Storage,
+            :attributes_blacklist => %i[parent],
           )
         end
 
         def hosts
+          add_properties(:attributes_blacklist => %i[parent])
           add_common_default_values
 
           add_custom_reconnect_block(
@@ -180,7 +180,8 @@ module ManageIQ::Providers
           end
 
           add_properties(
-            :custom_reconnect_block => custom_reconnect_block
+            :custom_reconnect_block => custom_reconnect_block,
+            :attributes_blacklist   => %i[parent]
           )
         end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/shared.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/shared.rb
@@ -61,7 +61,7 @@ module ManageIQ::Providers::Inventory::Persister::Builder::Shared
     def vm_template_shared
       add_properties(
         :delete_method          => :disconnect_inv,
-        :attributes_blacklist   => %i(genealogy_parent),
+        :attributes_blacklist   => %i[genealogy_parent parent resource_pool],
         :use_ar_object          => true, # Because of raw_power_state setter and hooks are needed for settings user
         :saver_strategy         => :default,
         :batch_extra_attributes => %i(power_state state_changed_on previous_state),


### PR DESCRIPTION
There are a number of commonly overridden properties of infra
collections that we can move to core.

Follow ups:
https://github.com/ManageIQ/manageiq-providers-scvmm/pull/114
https://github.com/ManageIQ/manageiq-providers-vmware/pull/398