### PR TITLE
Added support for decrypting values stored in options hash

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -9,6 +9,20 @@ module MiqRequestMixin
     MiqRequestMixin.get_option(key, value, options)
   end
 
+  def get_option_decrypted(key, value = nil)
+    enc_value = MiqRequestMixin.get_option(key, value, options)
+    if enc_value.kind_of?(String) && enc_value.start_with?("password::")
+      MiqPassword.decrypt(enc_value.split("password::").last)
+    else
+      raise ArgumentError, "#{key} cannot be decrypted"
+    end
+  end
+
+  def option_encrypted?(key)
+    enc_value = MiqRequestMixin.get_option(key, nil, options)
+    enc_value.kind_of?(String) && enc_value.start_with?("password::") ? true : false
+  end
+
   def display_message(default_msg = nil)
     MiqRequestMixin.get_option(:user_message, nil, options) || default_msg
   end


### PR DESCRIPTION
We allow customers to store encrypted values in dialog fields which
get stored in the options hash. Customers would like to decrypt these
values stored in the options hash. Added 2 new methods which can be
exposed from automate service model
 * **get_option_decrypted(key)**   If the key value is encrypted returns
                               the decrypted value
                               If the value is not encrypted it raises
                               an ArgumentError
 * **option_encrypted?(key)**      Returns true if the value is encrypted else returns a false


Since these are dialog_options they dont directly get into the vm provision tasks.