### PR TITLE
Add src_vm_or_dest_host_refresh_target.

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -268,6 +268,10 @@ class EmsEvent < EventStream
   end
   alias_method :src_vm_refresh_target, :vm_refresh_target
 
+  def src_vm_or_dest_host_refresh_target
+    vm_or_template ? vm_refresh_target : dest_host_refresh_target
+  end
+
   def host_refresh_target
     (host && host.ext_management_system ? host : ems_refresh_target)
   end

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -393,4 +393,23 @@ describe EmsEvent do
       end
     end
   end
+
+  context 'refresh target' do
+    describe 'src_vm_or_dest_host_refresh_target' do
+      let(:ems)   { FactoryBot.create(:ems_vmware) }
+      let(:vm)    { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+      let(:host1) { FactoryBot.create(:host, :ext_management_system => ems) }
+      let(:host2) { FactoryBot.create(:host, :ext_management_system => ems) }
+
+      it 'returns src_vm when it exists' do
+        event = FactoryBot.create(:ems_event, :vm_or_template => vm, :host => host1, :dest_host => host2)
+        expect(event.get_target("src_vm_or_dest_host_refresh_target")).to eq(vm)
+      end
+
+      it 'returns dest_host when src_vm does not exists' do
+        event = FactoryBot.create(:ems_event, :vm_or_template_id => 123, :host => host1, :dest_host => host2)
+        expect(event.get_target("src_vm_or_dest_host_refresh_target")).to eq(host2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If the VM was migrated off of the host before refresh adds the VM to the database then the src_vm target for this "/System/event_handlers/event_action_refresh?target=src_vm" won't work.
We need to refresh the dest_host.

Blocks https://github.com/ManageIQ/manageiq-content/pull/531.

https://bugzilla.redhat.com/show_bug.cgi?id=1696889

@miq-bot add_label bug, hammer/yes
@miq-bot assign @tinaafitz 
cc @gmcculloug @agrare 