### PR TITLE
Save unsaved changes before locking

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -187,6 +187,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def update_options(opts)
+    save if changed?
     with_lock do
       # Automate is updating this options hash (various keys) as well, using with_lock.
       options.merge!(opts)


### PR DESCRIPTION
Fixes a deprecation in rails 5.1:

DEPRECATION WARNING: Locking a record with unpersisted changes is
deprecated and will raise an exception in Rails 5.2. Use `save` to
persist the changes, or `reload` to discard them explicitly. (called
from update_options at
../app/models/service_template_transformation_plan_task.rb:190)

Seen in #18076