### PR TITLE
Add feature detection for selecting AZs for cloud volumes

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -206,6 +206,7 @@ class ExtManagementSystem < ApplicationRecord
   virtual_column :supports_volume_resizing, :type => :boolean
   virtual_column :supports_cloud_object_store_container_create, :type => :boolean
   virtual_column :supports_cinder_volume_types, :type => :boolean
+  virtual_column :supports_volume_availability_zones, :type => :boolean
 
   virtual_aggregate :total_vcpus, :hosts, :sum, :total_vcpus
   virtual_aggregate :total_memory, :hosts, :sum, :ram_size
@@ -663,6 +664,10 @@ class ExtManagementSystem < ApplicationRecord
 
   def supports_cinder_volume_types
     supports_cinder_volume_types?
+  end
+
+  def supports_volume_availability_zones
+    supports_volume_availability_zones?
   end
 
   def get_reserve(field)

--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -35,12 +35,22 @@ module ManageIQ::Providers
     has_many :vm_and_template_taggings,      -> { joins(:tag).merge(Tag.controlled_by_mapping) },
                                              :through     => :vms_and_templates, :source => :taggings
 
+    virtual_has_many :volume_availability_zones, :class_name => "AvailabilityZone", :uses => :availability_zones
+
     validates_presence_of :zone
 
     include HasNetworkManagerMixin
     include HasManyOrchestrationStackMixin
 
     after_destroy :destroy_mapped_tenants
+
+    # These are availability zones that are available to be chosen
+    # when creating a new cloud volume for providers that support it.
+    # By default this is all AZs, individual cloud managers
+    # can override this.
+    def volume_availability_zones
+      availability_zones
+    end
 
     # Development helper method for Rails console for opening a browser to the EMS.
     #

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -147,7 +147,8 @@ module SupportsFeatureMixin
     :vm_import                           => 'VM Import',
     :volume_multiattachment              => 'Volume Multiattachment',
     :volume_resizing                     => 'Volume Resizing',
-    :change_password                     => 'Change Password'
+    :change_password                     => 'Change Password',
+    :volume_availability_zones           => 'Volume Availability Zones'
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1549128

This PR is part of the implementation to allow choosing an availability zone when creating a new Openstack Cinder volume. It supports https://github.com/ManageIQ/manageiq-ui-classic/pull/5522 which makes the existing AWS-specific AZ selection code generic, and it supports https://github.com/ManageIQ/manageiq-providers-openstack/pull/447/files which enables the Openstack specific behavior.

Besides adding the `supports_volume_availability_zones` feature, this PR adds a new property to the CloudManager class, `volume_availability_zones`, which is a virtual column aliasing `availability_zones`. This can be overridden by providers that need to specify which AZs can be used by the storage service, such as Openstack. The linked UI PR causes the volume creation form to request `volume_availability_zones` instead of `availability_zones` in order to permit this distinction for providers that require it.

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/5522
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/447
* https://github.com/ManageIQ/manageiq-schema/pull/346
