### PR TITLE
New method for getting the instance without domain prefix.

### DIFF
--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -132,12 +132,21 @@ class MiqAeInstance < ApplicationRecord
     end
   end
 
-  def self.get_homonymic_across_domains(user, fqname, enabled = nil)
+  def self.display_name(number = 1)
+    n_('Automate Instance', 'Automate Instances', number)
+  end
+
+  def self.get_homonymic_across_domains(user, fqname, enabled = nil, prefix: true)
+    return get_homonymic_across_domains_noprefix(user, fqname, enabled) unless prefix
+
     MiqAeDatastore.get_homonymic_across_domains(user, ::MiqAeInstance, fqname, enabled)
   end
 
-  def self.display_name(number = 1)
-    n_('Automate Instance', 'Automate Instances', number)
+  private_class_method def self.get_homonymic_across_domains_noprefix(user, path, enabled = nil)
+    return [] if path.blank?
+
+    ns, klass, instance, _ = MiqAeEngine::MiqAePath.split(path)
+    MiqAeDatastore.get_sorted_matching_objects(user, ::MiqAeInstance, ns, klass, instance, enabled)
   end
 
   private


### PR DESCRIPTION
Description
----------------
Modifying the `MiqAeInstance.get_homonymic_across_domains` method to get the `MiqAeInstance` by `fqname` without domain prefix if the `:prefix` parameter is `false`.

Example:
`MiqAeInstance.get_homonymic_across_domains(user, fqname_without_domain_prefix, :prefix => false)`
 -> result: Returns an array of matching results sorted by domain priority.

Links
----------------

* requested for https://bugzilla.redhat.com/show_bug.cgi?id=1553846
