### PR TITLE
[V2V] Add default credentials to ansible_playbook method

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -241,10 +241,10 @@ class ConversionHost < ApplicationRecord
   end
 
   # Find the credentials for the associated resource. By default it will
-  # look for a v2v auth type if no argument is passed in. If that is not found,
-  # it will look for the first associated authentication. If one still isn't
-  # found, then it will look for the authentication associated with the resource
-  # using the 'ssh_keypair' auth type, and finally 'default'.
+  # look for a v2v auth type if no argument is passed in.
+  #
+  # If one isn't found, then it will look for the authentication associated
+  # with the resource using the 'ssh_keypair' auth type, and finally 'default'.
   #
   def find_credentials(auth_type = 'v2v')
     authentication = authentication_type(auth_type)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -250,12 +250,8 @@ class ConversionHost < ApplicationRecord
     authentication = authentication_type(auth_type) || authentication_type('v2v') || authentications.first
 
     if authentication.blank?
-      if resource.respond_to?(:authentication_type)
-        authentication = resource.authentication_type('ssh_keypair') || resource.authentication_type('default')
-      else
-        ems = resource.ext_management_system
-        authentication = ems.authentication_type('ssh_keypair') || ems.authentication_type('default')
-      end
+      res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system
+      authentication = res.authentication_type('ssh_keypair') || res.authentication_type('default')
     end
 
     unless authentication

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -247,9 +247,7 @@ class ConversionHost < ApplicationRecord
   # using the 'ssh_keypair' auth type, and finally 'default'.
   #
   def find_credentials(auth_type = 'v2v')
-    authentication = authentication_type(auth_type) ||
-      authentication_type('ssh_keypair')            ||
-      authentication_type('default')
+    authentication = authentication_type(auth_type)
 
     if authentication.blank?
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -241,16 +241,22 @@ class ConversionHost < ApplicationRecord
   end
 
   # Find the credentials for the associated resource. By default it will
-  # look for a v2v auth type. If that is not found, it will look for the
-  # first associated authentication. If one still isn't found, then it will
-  # look for the authentication associated with the resource using the
-  # 'ssh_keypair' auth type, and finally 'default'.
+  # look for a v2v auth type if no argument is passed in. If that is not found,
+  # it will look for the first associated authentication. If one still isn't
+  # found, then it will look for the authentication associated with the resource
+  # using the 'ssh_keypair' auth type, and finally 'default'.
   #
-  def find_credentials(auth_type = 'v2v')
-    authentication = authentication_type(auth_type) ||
-      authentications.first ||
-      resource.authentication_type('ssh_keypair') ||
-      resource.authentication_type('default')
+  def find_credentials(auth_type = nil)
+    authentication = authentication_type(auth_type) || authentication_type('v2v') || authentications.first                         ||
+
+    if authentication.blank?
+      if resource.respond_to?(:authentication_type)
+        authentication ||= resource.authentication_type('ssh_keypair') || resource.authentication_type('default')
+      else
+        ems = resource.ext_management_system
+        authentication ||= ems.authentication_type('ssh_keypair') || ems.authentication_type('default')
+      end
+    end
 
     unless authentication
       error_msg = "Credentials not found for conversion host #{name} or resource #{resource.name}"
@@ -312,7 +318,7 @@ class ConversionHost < ApplicationRecord
 
     command = "ansible-playbook #{playbook} --inventory #{host}, --become --extra-vars=\"ansible_ssh_common_args='-o StrictHostKeyChecking=no'\""
 
-    auth = find_credentials
+    auth = find_credentials(auth_type)
     command << " --user #{auth.userid}"
 
     case auth

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -311,7 +311,7 @@ class ConversionHost < ApplicationRecord
 
     command = "ansible-playbook #{playbook} --inventory #{host}, --become --extra-vars=\"ansible_ssh_common_args='-o StrictHostKeyChecking=no'\""
 
-    auth = authentication_type(auth_type) || authentications.first
+    auth = authentication_type(auth_type) || authentications.first || find_credentials
     command << " --user #{auth.userid}"
 
     case auth

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -251,10 +251,10 @@ class ConversionHost < ApplicationRecord
 
     if authentication.blank?
       if resource.respond_to?(:authentication_type)
-        authentication ||= resource.authentication_type('ssh_keypair') || resource.authentication_type('default')
+        authentication = resource.authentication_type('ssh_keypair') || resource.authentication_type('default')
       else
         ems = resource.ext_management_system
-        authentication ||= ems.authentication_type('ssh_keypair') || ems.authentication_type('default')
+        authentication = ems.authentication_type('ssh_keypair') || ems.authentication_type('default')
       end
     end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -251,10 +251,10 @@ class ConversionHost < ApplicationRecord
       resource.authentication_type('default')
 
     unless authentication
-      msg = "Credentials not found for conversion host #{name} or resource #{resource.name}"
-      msg << " #{msg}" if msg
-      _log.error(msg)
-      raise MiqException::Error, msg
+      error_msg = "Credentials not found for conversion host #{name} or resource #{resource.name}"
+      error_msg << " #{msg}" if msg
+      _log.error(error_msg)
+      raise MiqException::Error, error_msg
     end
 
     authentication

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -247,7 +247,9 @@ class ConversionHost < ApplicationRecord
   # using the 'ssh_keypair' auth type, and finally 'default'.
   #
   def find_credentials(auth_type = 'v2v')
-    authentication = authentication_type(auth_type) || authentications.first
+    authentication = authentication_type(auth_type) ||
+      authentication_type('ssh_keypair')            ||
+      authentication_type('default')
 
     if authentication.blank?
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -246,8 +246,8 @@ class ConversionHost < ApplicationRecord
   # found, then it will look for the authentication associated with the resource
   # using the 'ssh_keypair' auth type, and finally 'default'.
   #
-  def find_credentials(auth_type = nil)
-    authentication = authentication_type(auth_type) || authentication_type('v2v') || authentications.first
+  def find_credentials(auth_type = 'v2v')
+    authentication = authentication_type(auth_type) || authentications.first
 
     if authentication.blank?
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -247,7 +247,7 @@ class ConversionHost < ApplicationRecord
   # using the 'ssh_keypair' auth type, and finally 'default'.
   #
   def find_credentials(auth_type = nil)
-    authentication = authentication_type(auth_type) || authentication_type('v2v') || authentications.first                         ||
+    authentication = authentication_type(auth_type) || authentication_type('v2v') || authentications.first
 
     if authentication.blank?
       if resource.respond_to?(:authentication_type)


### PR DESCRIPTION
In the `ansible_playbook` method it's possible that an authentication isn't yet directly associated with the conversion host, e.g. a rhev host without a provided ssh key. This modifies the method so that it calls `find_credentials` as a fallback which will (ultimately) use the authentication of the associated resource.

Without this a `undefined method 'userid' for nil:NilClass` error could result.

This wasn't caught in the specs because it's a private method. I think our own testing didn't catch it because we were either using openstack or were explicitly providing an ssh key. I personally was just stubbing that method out without checking it. Oops!

This fix also has the added advantage of raising a proper error if it still can't be found for some reason.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1622728

Edit: also fixed an error message bug in the `find_credentials` method while we were here.