### PR TITLE
Fix specs for MiqEnvironment.is_production? and update comments

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -34,9 +34,11 @@ module MiqEnvironment
       @is_appliance = is_linux? && File.exist?('/var/www/miq/vmdb')
     end
 
+    # Return whether or not the current ManageIQ environment is a production
+    # environment. Assumes production if Rails is not defined or if the Rails
+    # environment is set to 'production'.
+    #
     def self.is_production?
-      # Note: This method could be called outside of Rails, so check defined?(Rails)
-      # Assume production if not defined or if set to 'production'
       defined?(Rails) ? Rails.env.production? : true
     end
 

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -1,4 +1,4 @@
-describe MiqEnvironment do
+RSpec.describe MiqEnvironment do
   context "with linux platform" do
     before do
       @old_impl = Sys::Platform::IMPL

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -32,9 +32,10 @@ describe MiqEnvironment do
       end
 
       context ".is_production?" do
-        it "should return false if Rails undefined" do
-          allow(Object).to receive(:defined?).with(:Rails).and_return(false)
-          expect(MiqEnvironment::Command.is_production?).to be_falsey
+        it "should return true if Rails undefined" do
+          hide_const('Rails')
+          expect { Rails }.to raise_error(NameError)
+          expect(MiqEnvironment::Command.is_production?).to be_truthy
         end
 
         it "will return true if linux and /var/www/miq/vmdb exists and cache the result" do


### PR DESCRIPTION
As per the current comments, the `MiqEnvironment.is_production?` method should return `true` if the `Rails` constant isn't defined. If we proceed with this assumption, the specs for it are busted.

The first issue is that `allow(Object).to receive(:defined?).with(:Rails).and_return(false)` does nothing. The `defined?` method is an instance method of Object, not a singleton, so you aren't actually altering any behavior.

You can test this yourself by simply removing that line and running the specs again. You'll notice it has no effect on the results. Note that this was originally smoked out by running rspec with partial doubles verified.

The second issue is that the specs actually assume `false` if Rails is not defined. Since the `Rails` constant wasn't *actually* being undefined, in reality it was checking for 'production' mode. Since the tests run in 'test' mode, it returned false. Thus, the specs "passed".

So, I've updated the specs to use the rspec helper `hide_const`, added a spec to prove that the `Rails` constant actually is undefined (which can be removed if you feel it's redundant), and changed the expected result to match what the comments and code say it should be.

I also updated the outer describe block to `RSpec.describe` for future compliance with rspec4.