### PR TITLE
Update action_container_image_analyze specs for MiqAction

### DIFF
--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAction do
+RSpec.describe MiqAction do
   describe "#invoke_or_queue" do
     before do
       @action = MiqAction.new
@@ -207,13 +207,19 @@ describe MiqAction do
     end
 
     it "avoids non container images" do
-      expect(container_image_registry).to receive(:scan).exactly(0).times
-      action.action_container_image_analyze(action, container_image_registry, :event => event)
+      error_message = "MIQ(action_container_image_analyze): Unable to perform action [#{action.description}],"\
+        " object [#{container_image_registry.inspect}] is not a Container Image"
+
+      expect(MiqPolicy.logger).to receive(:error).with(error_message)
+      expect(action.action_container_image_analyze(action, container_image_registry, :event => event)).to be_nil
     end
 
     it "avoids an event loop" do
-      expect(container_image_registry).to receive(:scan).exactly(0).times
-      action.action_container_image_analyze(action, container_image_registry, :event => event_loop)
+      error_message = "MIQ(action_container_image_analyze): Invoking action [#{action.description}] for event"\
+        " [#{event_loop.description}] would cause infinite loop, skipping"
+
+      expect(MiqPolicy.logger).to receive(:warn).with(error_message)
+      expect(action.action_container_image_analyze(action, container_image, :event => event_loop)).to be_nil
     end
   end
 


### PR DESCRIPTION
Currently the specs for `action_container_image_analyze` violate partial double verification. Specifically, they try to call `scan` on an object that doesn't actually implement that method. Consequently, these specs are not actually testing anything:

`expect(container_image_registry).to receive(:scan).exactly(0).times`

We know it's called zero times because if it were called, it would blow up with a `NoMethodError`. That doesn't really test the internal logic, either.

Looking at the code, we can see that if it's not a `ContainerImage` then it logs an error and returns. Likewise, even if it is a `ContainerImage` it will log a warning and return if the event name is "request_containerimage_scan" in order to avoid an infinite loop.

So, I've updated the specs to reflect the actual logic, including policy log messages, including one fix where the wrong argument was being passed. I also changed the outer describe block to `RSpec.describe` for future compliance with rspec4.