### PR TITLE
Remove partial double from ManageIQ::Providers::Inventory::Persister specs

### DIFF
--- a/spec/models/manageiq/providers/inventory/persister/finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/finders_spec.rb
@@ -2,7 +2,7 @@ require_relative 'helpers/spec_parsed_data'
 require_relative 'test_persister'
 require_relative 'targeted_refresh_spec_helper'
 
-describe ManageIQ::Providers::Inventory::Persister do
+RSpec.describe ManageIQ::Providers::Inventory::Persister do
   include SpecParsedData
   include TargetedRefreshSpecHelper
 
@@ -17,7 +17,6 @@ describe ManageIQ::Providers::Inventory::Persister do
                                :network_manager => FactoryBot.create(:ems_network, :zone => @zone))
 
     allow(@ems.class).to receive(:ems_type).and_return(:mock)
-    allow(Settings.ems_refresh).to receive(:mock).and_return({})
   end
 
   let(:persister) { create_persister }


### PR DESCRIPTION
Removed one line that not only breaks strict partial double validation, but also doesn't seem to be necessary since the specs pass without it.

While I was here I also changed the outer describe block to `RSpec.describe` for future rspec4 compliance.