### PR TITLE
Update source host factory in ServiceTemplateTransformationPlanTask specs to an esx host in 

### DIFF
--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
     context 'source is vmwarews' do
       let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
-      let(:src_host) { FactoryBot.create(:host, :ext_management_system => src_ems, :ipaddress => '10.0.0.1') }
+      let(:src_host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => src_ems, :ipaddress => '10.0.0.1') }
       let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems, :name => 'stockage récent') }
 
       let(:src_lan_1) { FactoryBot.create(:lan) }


### PR DESCRIPTION
Minor update to the `ServiceTemplateTransformationPlanTask` specs so that it complies with strict partial double validation.

In short, a regular host doesn't implement `thumbprint_sha1` or `virtv2v_disks` methods, so the current factory doesn't actually comply with the interface. I updated the host factory to a `host_vmware_esx` and now all is well.