### PR TITLE
Only use partial for the class that uses it in ToModelHash specs

### DIFF
--- a/spec/lib/extensions/ar_to_model_hash_spec.rb
+++ b/spec/lib/extensions/ar_to_model_hash_spec.rb
@@ -1,4 +1,4 @@
-describe ToModelHash do
+RSpec.describe ToModelHash do
   context "#to_model_hash" do
     let(:test_disk_class) do
       Class.new(ActiveRecord::Base) do
@@ -65,7 +65,7 @@ describe ToModelHash do
       test_vm_class.has_one          :test_operating_system, :anonymous_class => test_os_class,       :inverse_of => false,          :dependent => :destroy
 
       # we're testing the preload of associations, skip the recursive .to_model_hash
-      allow_any_instance_of(ActiveRecord::Base).to receive(:to_model_hash_recursive)
+      allow_any_instance_of(test_vm_class).to receive(:to_model_hash_recursive)
       allow(ActiveRecord::Associations::Preloader).to receive(:new).and_return(mocked_preloader)
     end
 


### PR DESCRIPTION
The `allow_any_instance_of(ActiveRecord::Base).to receive(:to_model_hash_recursive)` is too broad and fails strict partial validation, since within the specs only a few custom classes have actually mixed in the ToModelHash module. Thus, other instances won't understand `to_model_hash_recursive`.

Some experiments show that of the four custom classes where it actually *is* mixed in, only one is actually attempting to call `to_model_hash_recursive`, so I've restricted it to that class.

I've also updated the outer describe block to `RSpec.describe` for future compliance with rspec4.