### PR TITLE
Add scope to list providers from ancestor tenants

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -2,6 +2,11 @@ class ExtManagementSystem < ApplicationRecord
   include CustomActionsMixin
   include SupportsFeatureMixin
 
+  def self.with_tenant(tenant_id)
+    tenant = Tenant.find(tenant_id)
+    where(:tenant_id => tenant.ancestor_ids + [tenant_id])
+  end
+
   def self.types
     leaf_subclasses.collect(&:ems_type)
   end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -1,4 +1,32 @@
 describe ExtManagementSystem do
+  describe ".with_tenant" do
+    # tenant_root
+    #   \___ tenant_eye_bee_em (service_template_eye_bee_em)
+    #     \__ subtenant_tenant_eye_bee_em_1 (ems_1)
+    #       \__ subtenant_tenant_eye_bee_em_1_1 (ems_1_1, ems_1_1_a)
+    #     \__ subtenant_tenant_eye_bee_em_3  (ems_3, ems_3_a)
+
+    let!(:tenant_root) { Tenant.seed }
+
+    let!(:tenant_eye_bee_em) { FactoryBot.create(:tenant, :parent => tenant_root) }
+    let!(:subtenant_tenant_eye_bee_em_1) { FactoryBot.create(:tenant, :parent => tenant_eye_bee_em) }
+    let!(:subtenant_tenant_eye_bee_em_3) { FactoryBot.create(:tenant, :parent => tenant_eye_bee_em) }
+
+    let!(:subtenant_tenant_eye_bee_em_1_1) { FactoryBot.create(:tenant, :parent => subtenant_tenant_eye_bee_em_1) }
+
+    let!(:ems_eye_bee_em) { FactoryBot.create(:ext_management_system, :tenant => tenant_eye_bee_em) }
+    let!(:ems_1)          { FactoryBot.create(:ext_management_system, :tenant => subtenant_tenant_eye_bee_em_1) }
+    let!(:ems_3)          { FactoryBot.create(:ext_management_system, :tenant => subtenant_tenant_eye_bee_em_3) }
+    let!(:ems_3_a)        { FactoryBot.create(:ext_management_system, :tenant => subtenant_tenant_eye_bee_em_3) }
+    let!(:ems_1_1)        { FactoryBot.create(:ext_management_system, :tenant => subtenant_tenant_eye_bee_em_1_1) }
+    let!(:ems_1_1_a)      { FactoryBot.create(:ext_management_system, :tenant => subtenant_tenant_eye_bee_em_1_1) }
+
+    it "lists ancestor service templates" do
+      expect(ExtManagementSystem.with_tenant(subtenant_tenant_eye_bee_em_1_1.id).ids).to match_array([ems_1_1.id, ems_1_1_a.id, ems_1.id, ems_eye_bee_em.id])
+      expect(ExtManagementSystem.with_tenant(subtenant_tenant_eye_bee_em_3.id).ids).to match_array([ems_3.id, ems_3_a.id, ems_eye_bee_em.id])
+    end
+  end
+
   it ".model_name_from_emstype" do
     described_class.leaf_subclasses.each do |klass|
       expect(described_class.model_name_from_emstype(klass.ems_type)).to eq(klass.name)


### PR DESCRIPTION
this scope will be used in IU in detail of tenants to list related(ancestor) providers.
so report data api is in IU of detail of tenant:

`/report_data?name_scope=with_tenant&db_model=ExtManagementSystem&tenant_id=3`
 (this is pretty vague - I have it here just example)

# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1678124
https://github.com/ManageIQ/manageiq/issues/18734 - tracking issue

@miq-bot assign @gtanzillo 
@miq-bot add_label changelog/yes, enhancement
