### PR TITLE
Make Classification.tag2human public as the UI depends on it

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -464,6 +464,21 @@ class Classification < ApplicationRecord
     n_('Category', 'Categories', number)
   end
 
+  def self.tag2human(tag)
+    c, e = tag.split("/")[2..-1]
+
+    cat = find_by_name(c)
+    cname = cat.nil? ? c.titleize : cat.description
+
+    ename = e.titleize
+    unless cat.nil?
+      ent = cat.find_entry_by_name(e)
+      ename = ent.description unless ent.nil?
+    end
+
+    "#{cname}: #{ename}"
+  end
+
   private
 
   def self.add_entries_from_hash(cat, entries)
@@ -504,23 +519,6 @@ class Classification < ApplicationRecord
   def tag2name(tag)
     File.split(tag).last unless tag.nil?
   end
-
-  def self.tag2human(tag)
-    c, e = tag.split("/")[2..-1]
-
-    cat = find_by_name(c)
-    cname = cat.nil? ? c.titleize : cat.description
-
-    ename = e.titleize
-    unless cat.nil?
-      ent = cat.find_entry_by_name(e)
-      ename = ent.description unless ent.nil?
-    end
-
-    "#{cname}: #{ename}"
-  end
-
-  private_class_method :tag2human
 
   def find_tag
     tag_name = Classification.name2tag(name, parent_id, ns)


### PR DESCRIPTION
Having the `private` keyword before defining class methods has no effect and rubocop is complaining about this. The [fix](https://github.com/ManageIQ/manageiq/pull/18039) that made rubocop happy made this method private, therefore, inaccessible for the UI code.

**Steps to reproduce:**
* Go to `Policy -> Explorer -> Actions`
* Open the form for adding a new action
* Select `Tag` as the action's type
* Try to select a tag in the tree

```
Error caught: [NoMethodError] private method `tag2human' called for #<Class:0x00007fdd321c7570>
```

@miq-bot add_label bug, ui, control
@miq-bot add_reviewer @h-kataria 
@miq-bot add_reviewer @martinpovolny 
