### PR TITLE
Add source to retire request to parse in parse_prov_category in engine

### DIFF
--- a/app/models/vm_retire_request.rb
+++ b/app/models/vm_retire_request.rb
@@ -3,6 +3,9 @@ class VmRetireRequest < MiqRetireRequest
   SOURCE_CLASS_NAME = 'Vm'.freeze
   ACTIVE_STATES     = %w(retired) + base_class::ACTIVE_STATES
 
+  default_value_for(:source_id)    { |r| r.get_option(:src_ids) }
+  default_value_for :source_type,  SOURCE_CLASS_NAME
+
   def my_zone
     vm = Vm.find_by(:id => options[:src_ids])
     vm.nil? ? super : vm.my_zone

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -558,6 +558,11 @@ describe MiqRequest do
     end
   end
 
+  let(:vm_retire_request) { FactoryBot.create(:vm_retire_request, :requester => fred) }
+  it "retire_request has source" do
+    expect(vm_retire_request.source_type).not_to eq(nil)
+  end
+
   context "retire request source classes" do
     let(:vm_retire_request)      { FactoryBot.create(:vm_retire_request, :requester => fred) }
     let(:service_retire_request) { FactoryBot.create(:service_retire_request, :requester => fred) }


### PR DESCRIPTION
We hadn't kept the source_id and source_type in the vm_retire_request previously because Automate hadn't been wired to do the auto-approval correctly. With the recent removal of auto-approval from the retirement mixin make_request, we need this change and also an incoming Automate change to have the state machine handle approval correctly. 

Part of fix for
https://bugzilla.redhat.com/show_bug.cgi?id=1706208

## related to
https://github.com/ManageIQ/manageiq-content/pull/532
