### PR TITLE
Decrypt values from options hash

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -60,8 +60,8 @@ class MiqRequest < ApplicationRecord
 
   before_validation :initialize_attributes, :on => :create
 
-  include MiqRequestMixin
   include DialogOptionMixin
+  include MiqRequestMixin
 
   scope :created_recently,    ->(days_ago)   { where("miq_requests.created_on > ?", days_ago.days.ago) }
   scope :with_approval_state, ->(state)      { where(:approval_state => state) }

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -61,6 +61,7 @@ class MiqRequest < ApplicationRecord
   before_validation :initialize_attributes, :on => :create
 
   include MiqRequestMixin
+  include DialogOptionMixin
 
   scope :created_recently,    ->(days_ago)   { where("miq_requests.created_on > ?", days_ago.days.ago) }
   scope :with_approval_state, ->(state)      { where(:approval_state => state) }

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -24,6 +24,7 @@ class MiqRequestTask < ApplicationRecord
 
   include MiqRequestMixin
   include TenancyMixin
+  include DialogOptionMixin
 
   CANCEL_STATUS_REQUESTED  = "cancel_requested".freeze
   CANCEL_STATUS_PROCESSING = "canceling".freeze

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -22,9 +22,9 @@ class MiqRequestTask < ApplicationRecord
 
   validates_inclusion_of :status, :in => %w( Ok Warn Error Timeout )
 
+  include DialogOptionMixin
   include MiqRequestMixin
   include TenancyMixin
-  include DialogOptionMixin
 
   CANCEL_STATUS_REQUESTED  = "cancel_requested".freeze
   CANCEL_STATUS_PROCESSING = "canceling".freeze

--- a/app/models/mixins/dialog_option_mixin.rb
+++ b/app/models/mixins/dialog_option_mixin.rb
@@ -1,0 +1,33 @@
+module DialogOptionMixin
+  def self.get_dialog_option(key, value, from)
+    # Return value - Support array and non-array types
+    data = value.nil? ? from[key] : value
+    data.kind_of?(Array) ? data.first : data
+  end
+
+  def get_dialog_option(key, value = nil)
+    DialogOptionMixin.get_dialog_option(dialog_key(key), value, dialog_options)
+  end
+
+  def get_dialog_option_decrypted(key, value = nil)
+    raise ArgumentError, "#{key} cannot be decrypted" unless dialog_option_encrypted?(key)
+    enc_value = DialogOptionMixin.get_dialog_option(password_prefixed_key(key), value, dialog_options)
+    MiqPassword.decrypt(enc_value)
+  end
+
+  def dialog_options
+    options[:dialog]
+  end
+
+  def dialog_option_encrypted?(key)
+    dialog_options.key?(password_prefixed_key(key))
+  end
+
+  def password_prefixed_key(key)
+    key.to_s.start_with?("password::") ? key.to_s : "password::#{dialog_key(key)}"
+  end
+
+  def dialog_key(key)
+    key.to_s.start_with?("dialog_") ? key.to_s : "dialog_#{key}"
+  end
+end

--- a/app/models/mixins/dialog_option_mixin.rb
+++ b/app/models/mixins/dialog_option_mixin.rb
@@ -11,6 +11,7 @@ module DialogOptionMixin
 
   def get_dialog_option_decrypted(key, value = nil)
     raise ArgumentError, "#{key} cannot be decrypted" unless dialog_option_encrypted?(key)
+
     enc_value = DialogOptionMixin.get_dialog_option(password_prefixed_key(key), value, dialog_options)
     MiqPassword.decrypt(enc_value)
   end

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -10,17 +10,17 @@ module MiqRequestMixin
   end
 
   def get_option_decrypted(key, value = nil)
-    enc_value = MiqRequestMixin.get_option(key, value, options)
-    if enc_value.kind_of?(String) && enc_value.start_with?("password::")
-      MiqPassword.decrypt(enc_value.split("password::").last)
-    else
-      raise ArgumentError, "#{key} cannot be decrypted"
-    end
+    raise ArgumentError, "#{key} cannot be decrypted" unless option_encrypted?(key)
+    enc_value = MiqRequestMixin.get_option(password_prefixed_symbol_key(key), value, options)
+    MiqPassword.decrypt(enc_value)
   end
 
   def option_encrypted?(key)
-    enc_value = MiqRequestMixin.get_option(key, nil, options)
-    enc_value.kind_of?(String) && enc_value.start_with?("password::") ? true : false
+    options.key?(password_prefixed_symbol_key(key))
+  end
+
+  def password_prefixed_symbol_key(key)
+    key.to_s.start_with?("password::") ? key : "password::#{key}".to_sym
   end
 
   def display_message(default_msg = nil)

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -11,6 +11,7 @@ module MiqRequestMixin
 
   def get_option_decrypted(key, value = nil)
     raise ArgumentError, "#{key} cannot be decrypted" unless option_encrypted?(key)
+
     enc_value = MiqRequestMixin.get_option(password_prefixed_symbol_key(key), value, options)
     MiqPassword.decrypt(enc_value)
   end

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -9,6 +9,20 @@ module MiqRequestMixin
     MiqRequestMixin.get_option(key, value, options)
   end
 
+  def get_option_decrypted(key, value = nil)
+    enc_value = MiqRequestMixin.get_option(key, value, options)
+    if enc_value.kind_of?(String) && enc_value.start_with?("password::")
+      MiqPassword.decrypt(enc_value.split("password::").last)
+    else
+      raise ArgumentError, "#{key} cannot be decrypted"
+    end
+  end
+
+  def option_encrypted?(key)
+    enc_value = MiqRequestMixin.get_option(key, nil, options)
+    enc_value.kind_of?(String) && enc_value.start_with?("password::") ? true : false
+  end
+
   def display_message(default_msg = nil)
     MiqRequestMixin.get_option(:user_message, nil, options) || default_msg
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -63,6 +63,7 @@ class Service < ApplicationRecord
   include CiFeatureMixin
   include CustomActionsMixin
   include CustomAttributeMixin
+  include DialogOptionMixin
   include ExternalUrlMixin
   include LifecycleMixin
   include Metric::CiMixin

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -6,11 +6,11 @@ describe MiqProvision do
       @target_vm_name = 'clone test'
       @password = "pa$$word"
       @options = {
-        :pass          => 1,
-        :vm_name       => @target_vm_name,
-        :number_of_vms => 1,
-        :cpu_limit     => -1,
-        :cpu_reserve   => 0,
+        :pass                     => 1,
+        :vm_name                  => @target_vm_name,
+        :number_of_vms            => 1,
+        :cpu_limit                => -1,
+        :cpu_reserve              => 0,
         "password::mypass".to_sym => "#{ManageIQ::Password.encrypt(@password)}"
       }
     end

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -11,7 +11,7 @@ describe MiqProvision do
         :number_of_vms            => 1,
         :cpu_limit                => -1,
         :cpu_reserve              => 0,
-        "password::mypass".to_sym => "#{ManageIQ::Password.encrypt(@password)}"
+        "password::mypass".to_sym => ManageIQ::Password.encrypt(@password)
       }
     end
 

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -11,7 +11,7 @@ describe MiqProvision do
         :number_of_vms => 1,
         :cpu_limit     => -1,
         :cpu_reserve   => 0,
-        :mypass        => "password::#{ManageIQ::Password.encrypt(@password)}"
+        "password::mypass".to_sym => "#{ManageIQ::Password.encrypt(@password)}"
       }
     end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -949,11 +949,11 @@ describe Service do
     let(:service) { Service.create(:name => 'test', :options => {:dialog => dialog_opts}) }
 
     context "#get_dialog_option_decrypted" do
-      it "by symbol" do
+      it "with symbol" do
         expect(service.get_dialog_option_decrypted(:psighetti)).to eq(password)
       end
 
-      it "by name" do
+      it "with string" do
         expect(service.get_dialog_option_decrypted('psighetti')).to eq(password)
       end
 
@@ -967,11 +967,11 @@ describe Service do
     end
 
     context "#get_dialog_option" do
-      it "by symbol" do
+      it "with symbol" do
         expect(service.get_dialog_option(:netti)).to eq('hundley')
       end
 
-      it "by name" do
+      it "with string" do
         expect(service.get_dialog_option('netti')).to eq('hundley')
       end
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -944,7 +944,7 @@ describe Service do
 
   context "dialog_options" do
     let(:password) { "Gnocchi" }
-    let(:enc_value) { "#{ManageIQ::Password.encrypt(password)}" }
+    let(:enc_value) { ManageIQ::Password.encrypt(password) }
     let(:dialog_opts) { {'password::dialog_psighetti' => enc_value, 'dialog_netti' => 'hundley' } }
     let(:service) { Service.create(:name => 'test', :options => {:dialog => dialog_opts}) }
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -941,4 +941,39 @@ describe Service do
       expect(service.reconfigure_dialog).to eq("serialized_reconfigure_dialog")
     end
   end
+
+  context "dialog_options" do
+    let(:password) { "Gnocchi" }
+    let(:enc_value) { "#{ManageIQ::Password.encrypt(password)}" }
+    let(:dialog_opts) { {'password::dialog_psighetti' => enc_value, 'dialog_netti' => 'hundley' } }
+    let(:service) { Service.create(:name => 'test', :options => {:dialog => dialog_opts}) }
+
+    context "#get_dialog_option_decrypted" do
+      it "by symbol" do
+        expect(service.get_dialog_option_decrypted(:psighetti)).to eq(password)
+      end
+
+      it "by name" do
+        expect(service.get_dialog_option_decrypted('psighetti')).to eq(password)
+      end
+
+      it "with full name" do
+        expect(service.get_dialog_option_decrypted('password::dialog_psighetti')).to eq(password)
+      end
+
+      it "raises error if key not encrypted" do
+        expect { service.get_dialog_option_decrypted('netti') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "#get_dialog_option" do
+      it "by symbol" do
+        expect(service.get_dialog_option(:netti)).to eq('hundley')
+      end
+
+      it "by name" do
+        expect(service.get_dialog_option('netti')).to eq('hundley')
+      end
+    end
+  end
 end


### PR DESCRIPTION
We allow users to create encrypted parameters as part of the service dialog design. At runtime when a user executes the "Dialog" we don't have a way of decrypting passwords. This PR adds a mixin to allow decryption support based on key in a service and request object
 * service.get_dialog_option_decrypted(key)
or
 * request.get_dialog_option_decrypted(key)

Also the tasks have been enhanced to support fetching the decrypted string
 *  task.get_option_decrypted(key)

Once this PR is merged we will be exposing these methods from the REST API.