### PR TITLE
Rails i18n - sort our locale/*yml when adding to i18n.load_path

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -1,10 +1,11 @@
+# The `gettext` gem unreasonably assumes that anyone with $DEBUG
+# enabled must want a flood of racc/yydebug output. As we're actually
+# trying to debug something other than their parser, we need to
+# temporarily force it off while we load stuff.
 old_debug, $DEBUG = $DEBUG, nil
 begin
-  # The `gettext` gem unreasonably assumes that anyone with $DEBUG
-  # enabled must want a flood of racc/yydebug output. As we're actually
-  # trying to debug something other than their parser, we need to
-  # temporarily force it off while we load stuff.
-  I18n.load_path += Dir[Rails.root.join('locale', '*.yml')]
+  # consistently sort en_foo.yml *after* en.yml; to_s because pathnames
+  I18n.load_path += Dir[Rails.root.join('locale', '*.yml')].sort_by(&:to_s)
   Vmdb::FastGettextHelper.register_locales
   Vmdb::FastGettextHelper.register_human_localenames
   gettext_options = %w(--sort-by-msgid --location --no-wrap)


### PR DESCRIPTION
On appliances using `locale/en_*.yml` to override locale strings,
we need those files to get loaded *after* `en.yml`, otherwise `en.yml` wins.
(Any language, not just en.)

But the Dir[] order is system-dependent, and doesn't guarantee alphabetic sorting.
Adding an explicit sort.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704909

Cc @jrafanie , thanks for finding this! :)
Cc @mzazrivec because i18n :)