### PR TITLE
Add option to schedule automation requests via workflow

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -26,6 +26,8 @@ class AutomationRequest < MiqRequest
     options[:namespace]     = (options.delete(:namespace) || DEFAULT_NAMESPACE).strip.gsub(/(^\/|\/$)/, "")  # Strip blanks and slashes from beginning and end of string
     options[:class_name]    = (options.delete(:class) || DEFAULT_CLASS).strip.gsub(/(^\/|\/$)/, "")
     options[:instance_name] = (options.delete(:instance) || DEFAULT_INSTANCE).strip
+    options[:schedule_type] = parameters['schedule_time'].present? ? "schedule" : "immediately"
+    options[:schedule_time] = parameters['schedule_time'] if parameters['schedule_time']
 
     object_parameters = parse_out_objects(parameters)
     attrs = MiqRequestWorkflow.parse_ws_string(parameters)

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -49,6 +49,17 @@ describe AutomationRequest do
       expect(ar.options[:attrs][:var2]).to eq(@ae_var2)
       expect(ar.options[:attrs][:var3]).to eq(@ae_var3)
       expect(ar.options[:attrs][:userid]).to eq(admin.userid)
+      expect(ar.options[:schedule_type]).to eq("immediately")
+      expect(ar.options[:schedule_time]).to eq(nil)
+    end
+
+    it "creates request with schedule" do
+      scheduling_time = (Time.now.utc + 2.days).change(:usec => 0)
+      @parameters['schedule_time'] = scheduling_time
+      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
+
+      expect(ar.options[:schedule_type]).to eq("schedule")
+      expect(ar.options[:schedule_time]).to eq(scheduling_time)
     end
 
     it 'doesnt downcase and stringify objects in the parameters hash' do


### PR DESCRIPTION
AutomationRequests should have the same scheduling option as we have with provisioning requests. This is the counterpart to https://github.com/ManageIQ/manageiq-api/pull/583. The option gets used https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request_task.rb#L174 when the task gets queued. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1486765

## related to
https://github.com/ManageIQ/manageiq-api/pull/583
