### PR TITLE
Cleanup Classification warnings

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -224,7 +224,7 @@ class Classification < ApplicationRecord
     end
 
     tag_ids = obj.tagged_with(:ns => ns).collect(&:id)
-    where(:tag_id => tag_ids) rescue []
+    where(:tag_id => tag_ids)
   end
 
   def self.first_cat_entry(name, obj)


### PR DESCRIPTION
This fixes *most* of the rubocop and/or rspec warnings in classification.rb. Specifically:

* Use `[]` instead of `()` now for arrays of strings.
* Freeze string constants.
* Disable `DynamicFindBy` warnings since we actually define methods with those names.
* Disable `NumericPredicate` warnings where a variable can be a zero or an actual object.
* Rescue `StandardError` explicitly.
* ~~Don't shadow variables inside a block.~~ Saving for a separate PR
* ~~Use `&.` shortcut instead of checking explicitly for nil.~~ Saving for a separate PR
* ~~Use `YAML.safe_load` instead of `YAML.load`~~ Saving for a separate PR
* Remove explicit `self` where not needed.
* Minor reorganization to avoid the appearance of `private` modifying singleton methods.
* Some minor whitespace/alignment updates.

What's Left?

There are two remaining Rubocop warnings, one of which is probably ignorable (rescuing `Exception`), but the other one has me scratching my head:

```
app/models/classification.rb:227:5: C: Style/RescueModifier: Avoid using rescue in its modifier form.
    where(:tag_id => tag_ids) rescue []
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/classification.rb:368:5: W: Lint/RescueException: Avoid rescuing the Exception class. Perhaps you meant to rescue StandardError?
    rescue Exception => err ...
```

If a `where` clause fails, I don't think we should be hiding the problem. I'm curious what could cause that, and why we would want to rescue it without some kind of warning.

**Update:** I removed the inline rescue since it doesn't appear to be necessary any more, and is returning the wrong object type anyway (an array instead of a relation).