### PR TITLE
Allow textarea boxes to dynamically set validator type and rule

### DIFF
--- a/app/models/dialog_field_text_area_box.rb
+++ b/app/models/dialog_field_text_area_box.rb
@@ -1,3 +1,3 @@
 class DialogFieldTextAreaBox < DialogFieldTextBox
-  AUTOMATE_VALUE_FIELDS = %w(required read_only visible description).freeze
+  AUTOMATE_VALUE_FIELDS = %w[required read_only visible description validator_rule validator_type].freeze
 end

--- a/spec/models/dialog_field_text_area_box_spec.rb
+++ b/spec/models/dialog_field_text_area_box_spec.rb
@@ -20,16 +20,20 @@ describe DialogFieldTextAreaBox do
         dialog_field.normalize_automate_values(automate_hash)
       end
 
+      it "does not set the data_type" do
+        expect(dialog_field.data_type).to be_nil
+      end
+
       it "does not set the protected" do
         expect(dialog_field.protected?).to be_falsey
       end
 
-      it "does not set the validator type" do
-        expect(dialog_field.validator_type).to be_nil
+      it "sets the validator type" do
+        expect(dialog_field.validator_type).to eq("regex")
       end
 
-      it "does not set the validator rule" do
-        expect(dialog_field.validator_rule).to be_nil
+      it "sets the validator rule" do
+        expect(dialog_field.validator_rule).to eq("rule")
       end
 
       it "sets the required" do


### PR DESCRIPTION
Currently, only regular text boxes can set their regex validations dynamically, but the below linked BZ was specifically testing with textarea boxes and thus wasn't getting the benefit of dynamic validation rule setting.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1702064

@miq-bot add_label bug, hammer/yes
@miq-bot assign @tinaafitz 