### PR TITLE
[EvmDatabaseOps] Fix .validate_free_space target

### DIFF
--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -88,7 +88,6 @@ describe EvmDatabaseOps do
     before do
       @connect_opts = {:username => 'blah', :password => 'blahblah', :uri => "smb://myserver.com/share"}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
-      allow(MiqSmbSession).to receive(:runcmd)
       allow(file_storage).to  receive(:settings_mount_point).and_return(tmpdir)
       allow(file_storage).to  receive(:add).and_yield(input_path)
 
@@ -149,8 +148,6 @@ describe EvmDatabaseOps do
       @connect_opts = {:username => 'blah', :password => 'blahblah'}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
 
-      allow(MiqSmbSession).to receive(:runcmd)
-      allow(MiqSmbSession).to receive(:raw_disconnect)
       allow(file_storage).to  receive(:settings_mount_point).and_return(tmpdir)
       allow(file_storage).to  receive(:magic_number_for).and_return(:pgdump)
       allow(file_storage).to  receive(:download).and_yield(input_path)

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -46,6 +46,7 @@ describe EvmDatabaseOps do
 
     it "without enough free space" do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(file_storage).to receive(:class).and_return(MiqSmbSession)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(100.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(200.megabytes)
       expect { EvmDatabaseOps.backup(@db_opts, @connect_opts) }.to raise_error(MiqException::MiqDatabaseBackupInsufficientSpace)
@@ -74,6 +75,8 @@ describe EvmDatabaseOps do
       allow(described_class).to receive(:backup_file_name).and_return("miq_backup")
       expect(PostgresAdmin).to receive(:backup).with(run_db_ops)
 
+      allow(file_storage).to receive(:class).and_return(MiqSmbSession)
+
       log_stub = instance_double("_log")
       expect(described_class).to receive(:_log).twice.and_return(log_stub)
       expect(log_stub).to        receive(:info).with(any_args)
@@ -89,6 +92,7 @@ describe EvmDatabaseOps do
       @connect_opts = {:username => 'blah', :password => 'blahblah', :uri => "smb://myserver.com/share"}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
       allow(file_storage).to  receive(:settings_mount_point).and_return(tmpdir)
+      allow(file_storage).to  receive(:uri_to_local_path).and_return(tmpdir.join("share").to_s)
       allow(file_storage).to  receive(:add).and_yield(input_path)
 
       allow(MiqUtil).to        receive(:runcmd)
@@ -121,6 +125,7 @@ describe EvmDatabaseOps do
 
     it "without enough free space" do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(file_storage).to receive(:class).and_return(MiqSmbSession)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(100.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(200.megabytes)
       expect(PostgresAdmin).to receive(:backup_pg_dump).never


### PR DESCRIPTION
Currently, `db_opts[:local_file]` will always be a FIFO with the new file_storage mechanisms, so `.validate_free_space` will only check against the tmp dir, which usually isn't very large and not the target destination for the DB backup/dump.

This fix moves the check to a place were we can get access to the file_storage object directly and target the directory of the mounted filesystem that will receive the backup/dump.

To that end, the check now only applies to file storage classes that are "mountable", since checking against non-mountable storages don't make sense (s3/swift don't have this capability, and they are assumed to be "infinite" anyway, and I don't think you can query FTP for available storage as well so I think the same assumption is also fair to apply)


Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703278


Steps for Testing/QA
--------------------

I think this should work (in theory), but currently looking into a way to validate this or possibly add a spec to confirm this functionality is working as expected.  Once this is done, I will remove the `[WIP]` label.