### PR TITLE
[WIP] [V2V] Save conversion host record before enabling.

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -61,7 +61,7 @@ class ConversionHost < ApplicationRecord
       when AuthUseridPassword
         ssh_options[:auth_methods] = %w[password]
         ssh_options[:password] = auth.password
-      when AuthPrivateKey
+      when AuthPrivateKey, AuthToken
         ssh_options[:auth_methods] = %w[publickey hostbased]
         ssh_options[:key_data] = auth.auth_key
       else

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -320,7 +320,7 @@ class ConversionHost < ApplicationRecord
     case auth
     when AuthUseridPassword
       extra_vars[:ansible_ssh_pass] = auth.password
-    when AuthPrivateKey
+    when AuthPrivateKey, AuthToken
       ssh_private_key_file = Tempfile.new('ansible_key')
       begin
         ssh_private_key_file.write(auth.auth_key)

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -78,8 +78,8 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, miq_task_id)
         conversion_host.save!
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, miq_task_id)
 
         if miq_task_id
           MiqTask.find(miq_task_id).tap do |task|


### PR DESCRIPTION
This alters the `ConversionHost::Configurations#enable` method so that it saves the record before attempting to enable it. That way it will pick up the ssh key properly when trying to find credentials.

I also updated the `ConversionHost#verify_credentials` and `ConversionHost#ansible_playbook` methods to allow `AuthToken` as a valid type in cases where it needs to fall back.