### PR TITLE
[V2V] Add better logging to ConversionHost methods

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -253,9 +253,9 @@ class ConversionHost < ApplicationRecord
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system
       authentication = res.authentication_type('ssh_keypair') || res.authentication_type('default')
       if authentication
-        warning_message = "Unable to find v2v authentication for conversion host: #{name}. "\
-                          "Defaulting to authentication: #{authentication.name}/#{authentication.class}."
-        _log.warn(warning_message)
+        debug_message = "Unable to find v2v authentication for conversion host: #{name}. "\
+                        "Defaulting to authentication: #{authentication.name}/#{authentication.class}."
+        _log.debug(debug_message)
       end
     end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -252,11 +252,6 @@ class ConversionHost < ApplicationRecord
     if authentication.blank?
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system
       authentication = res.authentication_type('ssh_keypair') || res.authentication_type('default')
-      if authentication
-        debug_message = "Unable to find v2v authentication for conversion host: #{name}. "\
-                        "Defaulting to authentication: #{authentication.name}/#{authentication.class}."
-        _log.debug(debug_message)
-      end
     end
 
     unless authentication
@@ -343,7 +338,7 @@ class ConversionHost < ApplicationRecord
 
     if result.failure?
       error_message = result.error.presence || result.output
-      _log.error("#{result.command_line} => #{error_message}")
+      _log.error("#{result.command_line} ==> #{error_message}")
       raise
     end
   ensure

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -414,14 +414,14 @@ RSpec.describe ConversionHost, :v2v do
       expect(conversion_host_host.send(:find_credentials)).to eq(auth_default)
     end
 
-    it "logs the expected warning if a v2v authentication was not found" do
+    it "logs the expected debug message if a v2v authentication was not found" do
       vm.ext_management_system.authentications << auth_default
 
-      warning_message = "MIQ(ConversionHost#find_credentials) Unable to find v2v "\
+      debug_message = "MIQ(ConversionHost#find_credentials) Unable to find v2v "\
                         "authentication for conversion host: #{conversion_host_vm.name}. "\
                         "Defaulting to authentication: #{auth_default.name}/#{auth_default.class}."
 
-      expect($log).to receive(:warn).with(warning_message)
+      expect($log).to receive(:debug).with(debug_message)
       conversion_host_vm.send(:find_credentials)
     end
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe ConversionHost, :v2v do
         allow(conversion_host).to receive(:find_credentials).and_return(auth_v2v)
         allow(AwesomeSpawn).to receive(:run).and_return(result)
 
-        expect($log).to receive(:error).with("MIQ(ConversionHost#ansible_playbook) #{command} => oops")
+        expect($log).to receive(:error).with("MIQ(ConversionHost#ansible_playbook) #{command} ==> oops")
         expect { conversion_host.enable_conversion_host_role(package_url, nil) }.to raise_error(RuntimeError)
       end
     end
@@ -412,17 +412,6 @@ RSpec.describe ConversionHost, :v2v do
       host.authentications << auth_default
       expect(conversion_host_vm.send(:find_credentials)).to eq(auth_default)
       expect(conversion_host_host.send(:find_credentials)).to eq(auth_default)
-    end
-
-    it "logs the expected debug message if a v2v authentication was not found" do
-      vm.ext_management_system.authentications << auth_default
-
-      debug_message = "MIQ(ConversionHost#find_credentials) Unable to find v2v "\
-                        "authentication for conversion host: #{conversion_host_vm.name}. "\
-                        "Defaulting to authentication: #{auth_default.name}/#{auth_default.class}."
-
-      expect($log).to receive(:debug).with(debug_message)
-      conversion_host_vm.send(:find_credentials)
     end
   end
 


### PR DESCRIPTION
This adds some more verbose logging to the ConversionHost model. Specifically, it will log a ~~warning~~ debug message if we don't find a v2v auth type, and log an error with more information if the ansible_playbook command fails.