### PR TITLE
Have ConversionHost explicitly search authentications for auth type

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -248,6 +248,7 @@ class ConversionHost < ApplicationRecord
   #
   def find_credentials(auth_type = 'v2v')
     authentication = authentication_type(auth_type)
+    authentication ||= authentications.detect { |a| a.authtype == auth_type }
 
     if authentication.blank?
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -247,8 +247,7 @@ class ConversionHost < ApplicationRecord
   # with the resource using the 'ssh_keypair' auth type, and finally 'default'.
   #
   def find_credentials(auth_type = 'v2v')
-    authentication = authentication_type(auth_type)
-    authentication ||= authentications.detect { |a| a.authtype == auth_type }
+    authentication = authentications.detect { |a| a.authtype == auth_type }
 
     if authentication.blank?
       res = resource.respond_to?(:authentication_type) ? resource : resource.ext_management_system

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -307,7 +307,7 @@ class ConversionHost < ApplicationRecord
   # +extra_vars+ option should be a hash of key/value pairs which, if present,
   # will be passed to the '-e' flag.
   #
-  def ansible_playbook(playbook, extra_vars = {}, miq_task_id = nil, auth_type = nil)
+  def ansible_playbook(playbook, extra_vars = {}, miq_task_id = nil, auth_type = 'v2v')
     task = MiqTask.find(miq_task_id) if miq_task_id.present?
 
     host = hostname || ipaddress

--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -35,6 +35,10 @@ FactoryBot.define do
     status      { "SomeMockedStatus" }
   end
 
+  factory :authentication_v2v, :parent => :authentication_ssh_keypair do
+    authtype    { "v2v" }
+  end
+
   factory :authentication_redhat_metric, :parent => :authentication do
     authtype { "metrics" }
   end


### PR DESCRIPTION
Within the `ConversionHost` model, because of the way the `Authentications` module was originally written, it's possible that the `authentication_type('v2v')` call won't actually pick up the properly authentication.

This adds a default where it will explicitly check for the `auth_type` if the first attempt doesn't find anything.