### PR TITLE
Minor rework of stub_server_settings_with_locale to deal with strict partials

### DIFF
--- a/spec/lib/services/locale_resolver_spec.rb
+++ b/spec/lib/services/locale_resolver_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe LocaleResolver do
 
   context "when the user's locale is 'default'" do
     context "and the server's locale is set" do
-      before { stub_server_settings_with_locale("en-US") }
+      before { stub_settings(:server => {:locale => "en-US"}) }
 
       it "returns the server's locale" do
         user = instance_double(User, :settings => {:display => {:locale => "default"}})
@@ -17,7 +17,7 @@ RSpec.describe LocaleResolver do
     end
 
     context "and the server's locale is 'default'" do
-      before { stub_server_settings_with_locale("default") }
+      before { stub_settings(:server => {:locale => "default"}) }
 
       it "returns the locale from the headers" do
         user = instance_double(User, :settings => {:display => {:locale => "default"}})
@@ -26,7 +26,7 @@ RSpec.describe LocaleResolver do
     end
 
     context "and the server's locale is not set" do
-      before { stub_server_settings_with_locale(nil) }
+      before { stub_settings(:server => {:locale => nil}) }
 
       it "returns the locale from the headers" do
         user = instance_double(User, :settings => {:display => {:locale => "default"}})
@@ -37,7 +37,7 @@ RSpec.describe LocaleResolver do
 
   context "when the user's locale is not set" do
     context "and the server's locale is set" do
-      before { stub_server_settings_with_locale("en-US") }
+      before { stub_settings(:server => {:locale => "en-US"}) }
 
       it "returns the server's locale" do
         user = instance_double(User, :settings => {:display => {:locale => nil}})
@@ -46,7 +46,7 @@ RSpec.describe LocaleResolver do
     end
 
     context "and the server's locale is 'default'" do
-      before { stub_server_settings_with_locale("default") }
+      before { stub_settings(:server => {:locale => "default"}) }
 
       it "returns the locale from the headers" do
         user = instance_double(User, :settings => {:display => {:locale => nil}})
@@ -55,17 +55,12 @@ RSpec.describe LocaleResolver do
     end
 
     context "and the server's locale is not set" do
-      before { stub_server_settings_with_locale(nil) }
+      before { stub_settings(:server => {:locale => nil}) }
 
       it "returns the locale from the headers" do
         user = instance_double(User, :settings => {:display => {:locale => nil}})
         expect(described_class.resolve(user, "Accept-Language" => "en-US")).to eq("en-US")
       end
     end
-  end
-
-  def stub_server_settings_with_locale(locale)
-    server = Config::Options.new(:locale => locale)
-    allow(Settings).to receive(:server).and_return(server)
   end
 end

--- a/spec/lib/services/locale_resolver_spec.rb
+++ b/spec/lib/services/locale_resolver_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe LocaleResolver do
   end
 
   def stub_server_settings_with_locale(locale)
-    allow(Settings.server).to receive(:locale).and_return(locale)
+    server = Config::Options.new(:locale => locale)
+    allow(Settings).to receive(:server).and_return(server)
   end
 end


### PR DESCRIPTION
Currently the locale_resolver_spec.rb file has multiple failures when run with strict partial verification turned on. This is because of `Settings.server` which returns a `Config::Options` object, which is something that uses `method_missing` extensively behind the scenes.

What happens in practice is that because the `locale` method isn't predefined, it fails a `respond_to?` check, which in turn makes rspec unhappy. The solution is to simply define `locale` when `Config::Options` is instantiated, and modify the `allow` to return that object instead.

Update: As per @Fryguy's suggestions, we can use the existing settings helper.