### PR TITLE
Add currency to service template.

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -63,6 +63,7 @@ class ServiceTemplate < ApplicationRecord
 
   belongs_to :service_template_catalog
   belongs_to :zone
+  belongs_to :currency, :class_name => "ChargebackRateDetailCurrency", :inverse_of => false
 
   has_many   :dialogs, -> { distinct }, :through => :resource_actions
   has_many   :miq_schedules, :as => :resource, :dependent => :destroy


### PR DESCRIPTION
Add price and currency to service templates. So a service author can specify the price when creating a service template.

Part of https://github.com/ManageIQ/manageiq-schema/pull/367.

https://bugzilla.redhat.com/show_bug.cgi?id=1602072

@miq-bot add_label enhancement, hammer/no, changelog/yes
@miq-bot assign @tinaafitz 