### PR TITLE
Add spec to ensure plugins implement .plugin_name

### DIFF
--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -237,4 +237,9 @@ describe Vmdb::Plugins do
       end
     end
   end
+
+  it "all plugins will implement .plugin_name" do
+    bad_plugins = described_class.select { |plugin| plugin.try(:plugin_name).blank? }
+    expect(bad_plugins).to be_empty
+  end
 end


### PR DESCRIPTION
Depends on
- [x] https://github.com/ManageIQ/manageiq-decorators/pull/9
- [x] https://github.com/ManageIQ/manageiq-consumption/pull/159

Also see
- [ ] https://github.com/ManageIQ/manageiq-api/pull/587
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/5571