### PR TITLE
[V2V] Conversion Host - Handle CA bundle from UI

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -202,7 +202,7 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, osp_ca_bundle = nil, miq_task_id = nil)
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, openstack_tls_ca_certs = nil, miq_task_id = nil)
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
@@ -211,7 +211,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
-      :v2v_ca_bundle        => osp_ca_bundle || resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => openstack_tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars, miq_task_id)
   ensure

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -202,7 +202,7 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, miq_task_id = nil)
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, osp_ca_bundle = nil, miq_task_id = nil)
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
@@ -211,7 +211,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
-      :v2v_ca_bundle        => resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => osp_ca_bundle || resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars, miq_task_id)
   ensure

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -68,7 +68,7 @@ module ConversionHost::Configurations
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
-      osp_ca_bundle = params.delete(:osp_ca_bundle)
+      openstack_tls_ca_certs = params.delete(:openstack_tls_ca_certs)
 
       new(params).tap do |conversion_host|
         if ssh_key
@@ -80,7 +80,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, osp_ca_bundle, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, openstack_tls_ca_certs, miq_task_id)
         conversion_host.save!
 
         if miq_task_id

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -68,6 +68,8 @@ module ConversionHost::Configurations
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
+      osp_ca_bundle = params.delete(:osp_ca_bundle)
+
       new(params).tap do |conversion_host|
         if ssh_key
           conversion_host.authentications << AuthPrivateKey.create!(
@@ -78,7 +80,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, osp_ca_bundle, miq_task_id)
         conversion_host.save!
 
         if miq_task_id

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -282,7 +282,8 @@ RSpec.describe ConversionHost, :v2v do
         enable_extra_vars = {
           :v2v_host_type        => 'openstack',
           :v2v_transport_method => 'ssh',
-          :v2v_ssh_private_key  => 'fake ssh private key'
+          :v2v_ssh_private_key  => 'fake ssh private key',
+          :v2v_ca_bundle        => 'fake CA bundle'
         }
         check_extra_vars = {
           :v2v_host_type        => 'openstack',
@@ -290,7 +291,7 @@ RSpec.describe ConversionHost, :v2v do
         }
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars, nil)
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, nil)
-        conversion_host.enable_conversion_host_role(nil, 'fake ssh private key')
+        conversion_host.enable_conversion_host_role(nil, 'fake ssh private key', 'fake CA bundle')
       end
     end
   end


### PR DESCRIPTION
In current implementation, we look for the CA bundle in the provider configuration. However, for OpenStack provider, it's not possible to provide the certificate authority in the UI. So, we plan on asking the user to provide it in the conversion host wizard, until we have a way to provide it when configuring the provider. This PR adds support for an API param named ~~`osp_ca_bundle`~~ `openstack_tls_ca_certs` that will be passed to the backend, which will pass it as the `v2v_ca_bundle` extra var.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708359