### PR TITLE
[WIP][V2V] Add storage validations for transformation_mapping_items

### DIFF
--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -7,6 +7,10 @@ class TransformationMapping < ApplicationRecord
 
   validates :name, :presence => true, :uniqueness => true
 
+  VALID_SOURCE_CLUSTER_TYPES = %w[
+    ManageIQ::Providers::Vmware::InfraManager
+  ]
+
   def destination(source)
     transformation_mapping_items.find_by(:source => source).try(:destination)
   end
@@ -14,5 +18,41 @@ class TransformationMapping < ApplicationRecord
   # vm_list: collection of hashes, each descriping a VM.
   def search_vms_and_validate(vm_list = nil, service_template_id = nil)
     VmMigrationValidator.new(self, vm_list, service_template_id).validate
+  end
+
+  # Return the source cluster for the TransformationMapping, if any.
+  #
+  def source_cluster
+    transformation_mapping_items.find_by(:source_type => 'EmsCluster')&.source
+  end
+
+  # Return a list of source datastores associated with the TransformationMapping, if any.
+  #
+  def source_datastores
+    transformation_mapping_items.where(:source_type => 'Storage').map(&:source)
+  end
+
+  # Return a list of source networks associated with the TransformationMapping, if any.
+  #
+  def source_networks
+    transformation_mapping_items.where(:source_type => 'Lan').map(&:source)
+  end
+
+  # Return the target cluster for the TransformationMapping, if any.
+  #
+  def destination_cluster
+    transformation_mapping_items.find_by(:destination_type => ['EmsCluster', 'CloudTenant'])&.destination
+  end
+
+  # Return a list of target datastores associated with the TransformationMapping, if any.
+  #
+  def destination_datastores
+    transformation_mapping_items.where(:destination_type => 'Storage').map(&:source)
+  end
+
+  # Return a list of target networks associated with the TransformationMapping, if any.
+  #
+  def destination_networks
+    transformation_mapping_items.where(:destination_type => 'Lan').map(&:source)
   end
 end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -133,10 +133,6 @@ class TransformationMappingItem < ApplicationRecord
   # Verify that Network type is LAN or CloudNetwork and belongs the destination cluster.
   #
   def destination_network
-    # transformation_mapping_items.where(:destination_type => 'Lan').map(&:source)
-    #
-    # source is a TransformationMappingItem
-    # tmi_lan = TransformationMappingItem.where(:source_type => "Lan").first
     destination_lan = destination
 
     tmi_cluster = TransformationMappingItem.where(:source_type => "EmsCluster").first  #TODO: handle collection?

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -13,10 +13,15 @@ class TransformationMappingItem < ApplicationRecord
   validate :destination_cluster, :if => -> { destination_type.casecmp?('EmsCluster') }
   validate :source_cluster, :if => -> { source_type.casecmp?('EmsCluster') }
 
-  validate :destination_datastore, :if => -> { destination_type.casecmp?('Storage') }
-  validate :source_datastore,      :if => -> { source_type.casecmp?('Storage') }
+  validate :destination_datastore, :if => -> { destination_type.casecmp?('Storage') ||
+                                               destination_type.casecmp?('CloudVolumeType')
+                                             }
 
-  validate :destination_network, :if => -> { destination_type.casecmp?('Lan') }
+  validate :source_datastore, :if => -> { source_type.casecmp?('Storage') }
+
+  validate :destination_network, :if => -> { source_type.casecmp?('Lan') ||
+                                             source_type.casecmp?('CloudNetwork')
+                                           }
   validate :source_network,      :if => -> { destination_type.casecmp?('Lan') }
 
   VALID_SOURCE_CLUSTER_PROVIDERS    = %w[vmwarews]
@@ -25,25 +30,10 @@ class TransformationMappingItem < ApplicationRecord
   VALID_SOURCE_DATASTORE_TYPES      = %w[Storage]
   VALID_DESTINATION_DATASTORE_TYPES = %w[Storage CloudVolumeType]
 
-  VALID_SOURCE_NETWORK_TYPES        = %w[LAN]
-  VALID_DESTINATION_NETWORK_TYPES   = %w[LAN CloudNetwork]
+  VALID_SOURCE_NETWORK_TYPES        = %w[Lan]
+  VALID_DESTINATION_NETWORK_TYPES   = %w[Lan CloudNetwork]
 
   private
-
-  # ----------------------------------------------------------------------------
-  # First check if types are valid
-  # ----------------------------------------------------------------------------
-
-  # Validator used if the target is an EMS cluster. This is more specific than
-  # the source_cluster validation because here it only validates against
-  # EmsCluster types.
-  #
-  def destination_cluster
-    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination.ext_management_system.emstype)
-      destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
-      errors.add(:destination_type, "EMS type of target cluster must be in: #{destination_types}")
-    end
-  end
 
   # Validator used if the source type is an EMS cluster. In this case, both
   # the source and target types must be validated.
@@ -61,45 +51,18 @@ class TransformationMappingItem < ApplicationRecord
       destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
       errors.add(:destination_type, "Class of target cluster must be in: #{destination_types}")
     end
-  end
+  end # of source_cluster
 
-  # Check the storage types are valid.
+  # Validator used if the target is an EMS cluster. This is more specific than
+  # the source_cluster validation because here it only validates against
+  # EmsCluster types.
   #
-  def destination_datastore
-    tmilogger = Rails.logger
-    # transformation_mapping_items.where(:destination_type => 'Storage').map(&:source)
-    #
-    # check the storages are valid types.
-    # Question: have to deal with multiple storages.  I guess only one storage is passed in.  Multiple storages have
-    # to be dealt by the validation call.
-    #
-    # Storage types can be NFS, VMFS, GlusterFS, do we need to verify those?  This doc doesnt talk about specific
-    # filesystem
-    #
-    # from IRB: tm.transformation_mapping_items.first.source.storages.second.store_type
-    # => "NFS"
-    # unless VALID_DESTINATION_DATASTORE_TYPES.include?(destination.ext_management_system.where(:destination_type => 'Storage').source.map(&:store_type))
-
-    # from irb
-    # myds.destination.hosts.collect{ |host| host.ems_cluster }.collect{ |cluster| cluster.storages }.flatten.include?(myds.destination)
-
-    storageClassNames = destination.hosts.     # Get hosts using this source storage
-        collect { |host| host.ems_cluster }.   # How many clusters does each host has
-        collect { |cluster| cluster.storages}. # How many storages each host is mapped to that belong to the cluster
-        flatten.collect { |s| s.class.name }   # Get storage types represented by its class name
-
-    tmilogger.info( "#{__method__.to_s} :  #{storageClassNames.to_s}" )
-
-    # check if desitination storage belongs to cluster storage.
-    if storageClassNames.include?(VALID_DESTINATION_DATASTORE_TYPES.first)
-      result = true
-    elsif storageClassNames.include?(VALID_DESTINATION_DATASTORE_TYPES.second)
-      result = true
-    else
-      store_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
-      errors.add(:store_type, "The type of destination type must be in: #{store_types}")
+  def destination_cluster
+    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination.ext_management_system.emstype)
+      destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
+      errors.add(:destination_type, "EMS type of target cluster must be in: #{destination_types}")
     end
-  end
+  end # of destination_cluster
 
   # How to check the datastore(s) belong to the source.
   #
@@ -120,24 +83,72 @@ class TransformationMappingItem < ApplicationRecord
       storage_types = VALID_SOURCE_DATASTORE_TYPES.join(', ')
       errors.add(:storage_type, "The type of destination type must be in: #{storage_types}")
     end
-  end
+  end # of source_datastore
+
+  # Check the storage types are valid.
+  #
+  def destination_datastore
+    tmilogger = Rails.logger
+    # from irb
+    # myds.destination.hosts.collect{ |host| host.ems_cluster }.collect{ |cluster| cluster.storages }.flatten.include?(myds.destination)
+
+    storageClassNames = destination.hosts. # Get hosts using this source storage
+    collect { |host| host.ems_cluster }.   # How many clusters does each host has
+    collect { |cluster| cluster.storages}. # How many storages each host is mapped to that belong to the cluster
+    flatten.collect { |s| s.class.name }   # Get storage types represented by its class name
+
+    logger.info("ARIF ARIF ARIF TEST TEST TEST")
+    tmilogger.info( "#{__method__.to_s} :  #{storageClassNames.to_s}" )
+
+    # check if desitination storage belongs to cluster storage.
+    if storageClassNames.include?(VALID_DESTINATION_DATASTORE_TYPES.first)
+      result = true
+    elsif storageClassNames.include?(VALID_DESTINATION_DATASTORE_TYPES.second)
+      result = true
+    else
+      tistore_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
+      errors.add(:store_type, "The type of destination type must be in: #{store_types}")
+    end
+  end # of destination_datastore
 
   # Verify that Network type is LAN and belongs the source cluster .
   # irb(main):043:0> tm.transformation_mapping_items.first.source.lans.count
   # => 16
   #
   def source_network
-    transformation_mapping_items.where(:source_type => 'Lan').map(&:source)
-  end
+    source_lan = source
+
+    tmi_cluster = TransformationMappingItem.where(:source_type => "EmsCluster").first #TODO: handle collection?
+    source_cluster = tmi_cluster.source
+    tempCluster = source_lan.switch.host.ems_cluster
+
+    if tempCluster == source_cluster
+      result = true
+    else
+      network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
+      errors.add(:network_types, "The network type must be in: #{network_types}")
+    end
+  end # of source_network
 
   # Verify that Network type is LAN or CloudNetwork and belongs the destination cluster.
   #
   def destination_network
-    transformation_mapping_items.where(:destination_type => 'Lan').map(&:source)
-  end
+    # transformation_mapping_items.where(:destination_type => 'Lan').map(&:source)
+    #
+    # source is a TransformationMappingItem
+    # tmi_lan = TransformationMappingItem.where(:source_type => "Lan").first
+    destination_lan = destination
 
-  # ----------------------------------------------------------------------------
-  # Verify that source and destination cluster type is not the same
-  # ----------------------------------------------------------------------------
+    tmi_cluster = TransformationMappingItem.where(:source_type => "EmsCluster").first  #TODO: handle collection?
+    destination_cluster = tmi_cluster.destination
+    tempCluster = destination_lan.switch.host.ems_cluster
 
-end
+    if tempCluster == destination_cluster
+      result = true
+    else
+      network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
+      errors.add(:network_types, "The network type must be in: #{network_types}")
+    end
+  end # of destination_network
+
+end # of cla

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -98,9 +98,20 @@ class TransformationMappingItem < ApplicationRecord
     source_lan    = source
     source_cluster = source_lan.switch.host.ems_cluster
 
+    logger.info ("Arif source_cluster: " + source_cluster.inspect.to_s )
+    logger.info ("Arif source_lan: " + source_lan.inspect.to_s )
+    logger.info ("Arif source_lan.switch: " + source_lan.switch.inspect.to_s)
+    logger.info ("Arif source_lan.switch.host" + source_lan.switch.host.inspect.to_s)
+    logger.info ("Arif source_lan.switch.host.ems_cluster" + source_lan.switch.host.ems_cluster.inspect.to_s)
+
     tmi_for_emsclusters = TransformationMappingItem.where(:source_type => "EmsCluster")
 
-    unless tmi_for_emsclusters.any? { |tmi| tmi.source == source_cluster }
+    logger.info ("Arif tmi_for_sourcecluster: " + tmi_for_emsclusters.to_s)
+
+    unless tmi_for_emsclusters.any? { |tmi|
+        logger.info("Arif tmi.source: " + tmi.source.inspect.to_s)
+        tmi.source == source_cluster
+      }
       network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
     end
@@ -112,9 +123,20 @@ class TransformationMappingItem < ApplicationRecord
     destination_lan = destination
     destination_cluster = destination_lan.switch.host.ems_cluster
 
+    logger.info ("Arif destination_cluster: " + destination_cluster.inspect.to_s)
+    logger.info ("Arif destination_lan: " + destination_lan.inspect.to_s )
+    logger.info ("Arif destination_lan.switch: " + destination_lan.switch.inspect.to_s)
+    logger.info ("Arif destination_lan.switch.host" + destination_lan.switch.host.inspect.to_s)
+    logger.info ("Arif destination_lan.switch.host.ems_cluster" + destination_lan.switch.host.ems_cluster.inspect.to_s)
+
     tmi_for_emsclusters = TransformationMappingItem.where(:source_type => "EmsCluster")
 
-    unless tmi_for_emsclusters.any? { |tmi| tmi.destination == destination_cluster }
+    logger.info("Arif tmi_for_destionationclusters: " + tmi_for_emsclusters.inspect.to_s) # to deleteme
+
+    unless tmi_for_emsclusters.any? { |tmi|
+        logger.info("Arif tmi.destination: " + tmi.destination.inspect.to_s)
+        tmi.destination == destination_cluster
+      }
       network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
     end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -97,24 +97,9 @@ class TransformationMappingItem < ApplicationRecord
   def source_network
     source_lan       = source
     ems_cluster_lans = source_lan.switch.host.ems_cluster.lans.flatten
-    logger.info ("Arif ems_source_cluster_lans: " + ems_cluster_lans.inspect)
-    logger.info ("Arif ems_source_cluster_lans_count: " + ems_cluster_lans.count.to_s)
-=begin
-    logger.info ("Arif source_cluster: " + source_cluster.inspect.to_s )
-    logger.info ("Arif source_lan: " + source_lan.inspect.to_s )
-    logger.info ("Arif source_lan.switch: " + source_lan.switch.inspect.to_s)
-    logger.info ("Arif source_lan.switch.host" + source_lan.switch.host.inspect.to_s)
-    logger.info ("Arif source_lan.switch.host.ems_cluster" + source_lan.switch.host.ems_cluster.inspect.to_s)
+    logger.info ("******* source_cluster_lans: " + ems_cluster_lans.inspect)
+    logger.info ("******* source_cluster_lans_count: " + ems_cluster_lans.count.to_s)
 
-    tmi_for_emsclusters = TransformationMappingItem.where(:source_type => "EmsCluster")
-
-    logger.info ("Arif tmi_for_sourcecluster: " + tmi_for_emsclusters.to_s)
-
-    unless tmi_for_emsclusters.any? { |tmi|
-        logger.info("Arif tmi.source: " + tmi.source.inspect.to_s)
-        tmi.source == source_cluster
-      }
-=end
     unless ems_cluster_lans.include?(source_lan)
     network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
@@ -126,25 +111,10 @@ class TransformationMappingItem < ApplicationRecord
   def destination_network
     destination_lan = destination
     ems_cluster_lans = destination_lan.switch.host.ems_cluster.lans.flatten
-    logger.info ("Arif ems_destination_cluster_lans: " + ems_cluster_lans.inspect)
-    logger.info ("Arif ems_destination_cluster_lans_count: " + ems_cluster_lans.count.to_s)
 
-=begin
-    logger.info ("Arif destination_cluster: " + destination_cluster.inspect.to_s)
-    logger.info ("Arif destination_lan: " + destination_lan.inspect.to_s )
-    logger.info ("Arif destination_lan.switch: " + destination_lan.switch.inspect.to_s)
-    logger.info ("Arif destination_lan.switch.host" + destination_lan.switch.host.inspect.to_s)
-    logger.info ("Arif destination_lan.switch.host.ems_cluster" + destination_lan.switch.host.ems_cluster.inspect.to_s)
+    logger.info ("******* destination_cluster_lans: " + ems_cluster_lans.inspect)
+    logger.info ("******* destination_cluster_lans_count: " + ems_cluster_lans.count.to_s)
 
-    tmi_for_emsclusters = TransformationMappingItem.where(:source_type => "EmsCluster")
-
-    logger.info("Arif tmi_for_destionationclusters: " + tmi_for_emsclusters.inspect.to_s) # to deleteme
-
-    unless tmi_for_emsclusters.any? { |tmi|
-        logger.info("Arif tmi.destination: " + tmi.destination.inspect.to_s)
-        tmi.destination == destination_cluster
-      }
-=end
     unless ems_cluster_lans.include?(destination_lan)
     network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -95,9 +95,11 @@ class TransformationMappingItem < ApplicationRecord
   # Verify that Network type is LAN and belongs the source cluster .
   #
   def source_network
-    source_lan    = source
-    source_cluster = source_lan.switch.host.ems_cluster
-
+    source_lan       = source
+    ems_cluster_lans = source_lan.switch.host.ems_cluster.lans
+    logger.info ("Arif ems_source_cluster_lans: " + ems_cluster_lans.inspect)
+    logger.info ("Arif ems_source_cluster_lans_count: " + ems_cluster_lans.count.to_s)
+=begin
     logger.info ("Arif source_cluster: " + source_cluster.inspect.to_s )
     logger.info ("Arif source_lan: " + source_lan.inspect.to_s )
     logger.info ("Arif source_lan.switch: " + source_lan.switch.inspect.to_s)
@@ -112,7 +114,9 @@ class TransformationMappingItem < ApplicationRecord
         logger.info("Arif tmi.source: " + tmi.source.inspect.to_s)
         tmi.source == source_cluster
       }
-      network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
+=end
+    unless ems_cluster_lans.include?(source_lan)
+    network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
     end
   end # of source_network
@@ -121,8 +125,11 @@ class TransformationMappingItem < ApplicationRecord
   #
   def destination_network
     destination_lan = destination
-    destination_cluster = destination_lan.switch.host.ems_cluster
+    ems_cluster_lans = destination_lan.switch.host.ems_cluster.lans
+    logger.info ("Arif ems_destination_cluster_lans: " + ems_cluster_lans.inspect)
+    logger.info ("Arif ems_destination_cluster_lans_count: " + ems_cluster_lans.count.to_s)
 
+=begin
     logger.info ("Arif destination_cluster: " + destination_cluster.inspect.to_s)
     logger.info ("Arif destination_lan: " + destination_lan.inspect.to_s )
     logger.info ("Arif destination_lan.switch: " + destination_lan.switch.inspect.to_s)
@@ -137,7 +144,9 @@ class TransformationMappingItem < ApplicationRecord
         logger.info("Arif tmi.destination: " + tmi.destination.inspect.to_s)
         tmi.destination == destination_cluster
       }
-      network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
+=end
+    unless ems_cluster_lans.include?(destination_lan)
+    network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
     end
   end # of destination_network

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -96,7 +96,7 @@ class TransformationMappingItem < ApplicationRecord
   #
   def source_network
     source_lan       = source
-    ems_cluster_lans = source_lan.switch.host.ems_cluster.lans
+    ems_cluster_lans = source_lan.switch.host.ems_cluster.lans.flatten
     logger.info ("Arif ems_source_cluster_lans: " + ems_cluster_lans.inspect)
     logger.info ("Arif ems_source_cluster_lans_count: " + ems_cluster_lans.count.to_s)
 =begin
@@ -125,7 +125,7 @@ class TransformationMappingItem < ApplicationRecord
   #
   def destination_network
     destination_lan = destination
-    ems_cluster_lans = destination_lan.switch.host.ems_cluster.lans
+    ems_cluster_lans = destination_lan.switch.host.ems_cluster.lans.flatten
     logger.info ("Arif ems_destination_cluster_lans: " + ems_cluster_lans.inspect)
     logger.info ("Arif ems_destination_cluster_lans_count: " + ems_cluster_lans.count.to_s)
 

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -23,7 +23,7 @@ class TransformationMappingItem < ApplicationRecord
   validate :source_network,      :if => -> { destination_type.casecmp?('Lan') }
 
   VALID_SOURCE_CLUSTER_PROVIDERS    = %w[vmwarews]
-  VALID_DESTINATION_CLUSTER_TYPES   = %w[EmsCluster CloudTenant]
+  VALID_DESTINATION_CLUSTER_TYPES   = %w[rhevm]
 
   VALID_SOURCE_DATASTORE_TYPES      = %w[Storage]
   VALID_DESTINATION_DATASTORE_TYPES = %w[Storage CloudVolumeType]
@@ -45,7 +45,7 @@ class TransformationMappingItem < ApplicationRecord
       errors.add(:source_type, "EMS type of source cluster must be in: #{source_types}")
     end
 
-    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination_type)
+    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination.ext_management_system.emstype)
       destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
       errors.add(:destination_type, "Class of target cluster must be in: #{destination_types}")
     end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -68,52 +68,35 @@ class TransformationMappingItem < ApplicationRecord
   #
   def source_datastore
     tmilogger = Rails.logger
-    storageClassNames = source.hosts.          # Get hosts using this source storage
-        collect { |host| host.ems_cluster }.   # How many clusters does each host has
-        collect { |cluster| cluster.storages}. # How many storages each host is mapped to that belong to the cluster
-        flatten.collect { |s| s.class.name }   # Get storage types represented by its class name
+    source_storage = source
 
-    tmilogger.info( "#{__method__.to_s} :  #{storageClassNames.to_s}" )
+    cluster_storages = source.hosts.                # Get hosts using this source storage
+      collect { |host| host.ems_cluster }.          # How many clusters does each host has
+      collect { |cluster| cluster.storages}.flatten # How many storages each host is mapped to that belong to the cluster
 
-    # check if source storage belongs to cluster storage.
-    # the only valid storage type is "Storage"
-    if storageClassNames.include?(VALID_SOURCE_DATASTORE_TYPES.first)
-      result = true
-    else
+    unless cluster_storages.include?(source_storage)
       storage_types = VALID_SOURCE_DATASTORE_TYPES.join(', ')
       errors.add(:storage_type, "The type of destination type must be in: #{storage_types}")
     end
   end # of source_datastore
 
-  # Check the storage types are valid.
+  # check if destination storage belongs to the cluster
   #
   def destination_datastore
     tmilogger = Rails.logger
-    # from irb
-    # myds.destination.hosts.collect{ |host| host.ems_cluster }.collect{ |cluster| cluster.storages }.flatten.include?(myds.destination)
+    destination_storage = destination
 
-    storageClassNames = destination.hosts. # Get hosts using this source storage
-    collect { |host| host.ems_cluster }.   # How many clusters does each host has
-    collect { |cluster| cluster.storages}. # How many storages each host is mapped to that belong to the cluster
-    flatten.collect { |s| s.class.name }   # Get storage types represented by its class name
+    cluster_storages = destination.hosts.           # Get hosts using this source storage
+      collect { |host| host.ems_cluster }.          # How many clusters does each host has
+      collect { |cluster| cluster.storages}.flatten # How many storages each host is mapped to that belong to the cluster
 
-    logger.info("ARIF ARIF ARIF TEST TEST TEST")
-    tmilogger.info( "#{__method__.to_s} :  #{storageClassNames.to_s}" )
-
-    # check if desitination storage belongs to cluster storage.
-    if storageClassNames.include?(VALID_DESTINATION_DATASTORE_TYPES.first)
-      result = true
-    elsif storageClassNames.include?(VALID_DESTINATION_DATASTORE_TYPES.second)
-      result = true
-    else
+    unless cluster_storages.include?(destination_storage)
       tistore_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
       errors.add(:store_type, "The type of destination type must be in: #{store_types}")
     end
   end # of destination_datastore
 
   # Verify that Network type is LAN and belongs the source cluster .
-  # irb(main):043:0> tm.transformation_mapping_items.first.source.lans.count
-  # => 16
   #
   def source_network
     source_lan = source
@@ -147,4 +130,4 @@ class TransformationMappingItem < ApplicationRecord
     end
   end # of destination_network
 
-end # of cla
+end # of class

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -2,8 +2,6 @@ class TransformationMappingItem < ApplicationRecord
   belongs_to :transformation_mapping
   belongs_to :source,      :polymorphic => true
   belongs_to :destination, :polymorphic => true
-  # TODO, What is the MIQ wide logging syntax and way
-  tmilogger = Rails.logger # todo remove me
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
 
@@ -67,7 +65,6 @@ class TransformationMappingItem < ApplicationRecord
   # How to check the datastore(s) belong to the source.
   #
   def source_datastore
-    tmilogger = Rails.logger # todo remove me
     source_storage = source
 
     cluster_storages = source.hosts.                # Get hosts using this source storage
@@ -83,7 +80,6 @@ class TransformationMappingItem < ApplicationRecord
   # check if destination storage belongs to the cluster
   #
   def destination_datastore
-    tmilogger = Rails.logger # todo remove me
     destination_storage = destination
 
     cluster_storages = destination.hosts.           # Get hosts using this source storage

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -3,7 +3,7 @@ class TransformationMappingItem < ApplicationRecord
   belongs_to :source,      :polymorphic => true
   belongs_to :destination, :polymorphic => true
   # TODO, What is the MIQ wide logging syntax and way
-  tmilogger = Rails.logger
+  tmilogger = Rails.logger # todo remove me
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
 
@@ -67,7 +67,7 @@ class TransformationMappingItem < ApplicationRecord
   # How to check the datastore(s) belong to the source.
   #
   def source_datastore
-    tmilogger = Rails.logger
+    tmilogger = Rails.logger # todo remove me
     source_storage = source
 
     cluster_storages = source.hosts.                # Get hosts using this source storage
@@ -83,7 +83,7 @@ class TransformationMappingItem < ApplicationRecord
   # check if destination storage belongs to the cluster
   #
   def destination_datastore
-    tmilogger = Rails.logger
+    tmilogger = Rails.logger # todo remove me
     destination_storage = destination
 
     cluster_storages = destination.hosts.           # Get hosts using this source storage
@@ -91,7 +91,7 @@ class TransformationMappingItem < ApplicationRecord
       collect { |cluster| cluster.storages}.flatten # How many storages each host is mapped to that belong to the cluster
 
     unless cluster_storages.include?(destination_storage)
-      tistore_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
+      store_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
       errors.add(:store_type, "The type of destination type must be in: #{store_types}")
     end
   end # of destination_datastore

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -99,15 +99,12 @@ class TransformationMappingItem < ApplicationRecord
   # Verify that Network type is LAN and belongs the source cluster .
   #
   def source_network
-    source_lan = source
+    source_lan    = source
+    source_cluster = source_lan.switch.host.ems_cluster
 
-    tmi_cluster = TransformationMappingItem.where(:source_type => "EmsCluster").first #TODO: handle collection?
-    source_cluster = tmi_cluster.source
-    tempCluster = source_lan.switch.host.ems_cluster
+    tmi_for_emsclusters = TransformationMappingItem.where(:source_type => "EmsCluster")
 
-    if tempCluster == source_cluster
-      result = true
-    else
+    unless tmi_for_emsclusters.any? { |tmi| tmi.source == source_cluster }
       network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
     end
@@ -117,14 +114,11 @@ class TransformationMappingItem < ApplicationRecord
   #
   def destination_network
     destination_lan = destination
+    destination_cluster = destination_lan.switch.host.ems_cluster
 
-    tmi_cluster = TransformationMappingItem.where(:source_type => "EmsCluster").first  #TODO: handle collection?
-    destination_cluster = tmi_cluster.destination
-    tempCluster = destination_lan.switch.host.ems_cluster
+    tmi_for_emsclusters = TransformationMappingItem.where(:source_type => "EmsCluster")
 
-    if tempCluster == destination_cluster
-      result = true
-    else
+    unless tmi_for_emsclusters.any? { |tmi| tmi.destination == destination_cluster }
       network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
       errors.add(:network_types, "The network type must be in: #{network_types}")
     end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -5,22 +5,101 @@ class TransformationMappingItem < ApplicationRecord
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
 
-  validates :destination_type, :inclusion => { :in => %w[EmsCluster CloudTenant Storage Lan CloudVolumeType CloudNetwork] }
+  validates :destination_type,
+            :inclusion => { :in => %w[EmsCluster CloudTenant Storage Lan CloudVolumeType CloudNetwork] }
 
-  validate :target_cluster, :if => -> { destination_type.casecmp?('EmsCluster') }
-  validate :source_cluster, :if => -> { source_type.casecmp?(EmsCluster) }
+  validate :destination_cluster, :if => -> { destination_type.casecmp?('EmsCluster') }
+  validate :source_cluster, :if => -> { source_type.casecmp?('EmsCluster') }
+
+  VALID_SOURCE_CLUSTER_PROVIDERS    = %w[vmwarews]
+  VALID_DESTINATION_CLUSTER_TYPES   = %w[EmsCluster CloudTenant]
+
+  VALID_SOURCE_DATASTORE_TYPES      = %w[Storage]
+  VALID_DESTINATION_DATASTORE_TYPES = %w[Storage CloudVolumeType]
+
+  VALID_SOURCE_NETWORK_TYPES        = %w[LAN]
+  VALID_DESTINATION_NETWORK_TYPES   = %w[LAN CloudNetwork]
 
   private
 
-  def target_cluster
-    unless destination.ext_management_system.emstype.casecmp?('rhevm')
-      errors.add(:destination_type, "EMS type of target cluster must be rhevm")
+  # ----------------------------------------------------------------------------
+  # First check if types are valid
+  # ----------------------------------------------------------------------------
+
+  # Validator used if the target is an EMS cluster. This is more specific than
+  # the source_cluster validation because here it only validates against
+  # EmsCluster types.
+  #
+  def destination_cluster
+    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination.ext_management_system.emstype)
+      destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
+      errors.add(:destination_type, "EMS type of target cluster must be in: #{destination_types}")
     end
   end
 
+  # Validator used if the source type is an EMS cluster. In this case, both
+  # the source and target types must be validated.
+  #
+  # Note that the validation here for the target is more flexible than the
+  # target_cluster validator since it allows either an EmsCluster or CloudTenant.
+  #
   def source_cluster
-    unless source.ext_management_system.emstype.casecmp?('vmwarews')
-      errors.add(:source_type, "EMS type of source cluster must be vmwarews")
+    unless VALID_SOURCE_CLUSTER_PROVIDERS.include?(source.ext_management_system.emstype)
+      source_types = VALID_SOURCE_CLUSTER_PROVIDERS.join(', ')
+      errors.add(:source_type, "EMS type of source cluster must be in: #{source_types}")
+    end
+
+    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination_type)
+      destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
+      errors.add(:destination_type, "Class of target cluster must be in: #{destination_types}")
     end
   end
+
+  # Check the storage types are valid.
+  #
+  def destination_datastores
+    # transformation_mapping_items.where(:destination_type => 'Storage').map(&:source)
+    #
+    # check the storages are valid types.
+    # Question: have to deal with multiple storages.  I guess only one storage is passed in.  Multiple storages have
+    # to be dealt by the validation call.
+    #
+    # Storage types can be NFS, VMFS, GlusterFS, do we need to verify those?  This doc doesnt talk about specific
+    # filesystem
+    #
+    # from IRB: tm.transformation_mapping_items.first.source.storages.second.store_type
+    # => "NFS"
+    unless VALID_DESTINATION_DATASTORE_TYPES.include?(destination.where(:destination_type => 'Storage').map(&:store_type))
+      store_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
+      errors.add(:store_type, "The type of destination type must be in: #{store_types}")
+    end
+  end
+
+  # How to check the datastore(s) belong to the source.
+  #
+  def source_datastores
+    # transformation_mapping_items.where(:source_type => 'Storage').map(&:source)
+    unless VALID_SOURCE_DATASTORE_TYPES.include?(destination.where(:source_type => 'Storage').map(&:store_type))
+      errors.add(:store_type, "The type of destination type must be in: #{store_types}")
+    end
+  end
+
+  # Verify that Network type is LAN and belongs the source cluster .
+  # irb(main):043:0> tm.transformation_mapping_items.first.source.lans.count
+  # => 16
+  #
+  def source_networks
+    transformation_mapping_items.where(:source_type => 'Lan').map(&:source)
+  end
+
+  # Verify that Network type is LAN or CloudNetwork and belongs the destination cluster.
+  #
+  def destination_networks
+    transformation_mapping_items.where(:destination_type => 'Lan').map(&:source)
+  end
+
+  # ----------------------------------------------------------------------------
+  # Verify that source and destination cluster type is not the same
+  # ----------------------------------------------------------------------------
+
 end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -4,4 +4,23 @@ class TransformationMappingItem < ApplicationRecord
   belongs_to :destination, :polymorphic => true
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
+
+  validates :destination_type, :inclusion => { :in => %w[EmsCluster CloudTenant Storage Lan CloudVolumeType CloudNetwork] }
+
+  validate :target_cluster, :if => -> { destination_type.casecmp?('EmsCluster') }
+  validate :source_cluster, :if => -> { source_type.casecmp?(EmsCluster) }
+
+  private
+
+  def target_cluster
+    unless destination.ext_management_system.emstype.casecmp?('rhevm')
+      errors.add(:destination_type, "EMS type of target cluster must be rhevm")
+    end
+  end
+
+  def source_cluster
+    unless source.ext_management_system.emstype.casecmp?('vmwarews')
+      errors.add(:source_type, "EMS type of source cluster must be vmwarews")
+    end
+  end
 end

--- a/spec/factories/switch.rb
+++ b/spec/factories/switch.rb
@@ -1,3 +1,4 @@
 FactoryBot.define do
-  factory :switch_vmware, :class => 'ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch'
+  factory :switch # generic needed for transformation_mapping_item_spec.rb
+  factory :switch_vmware, :class => 'ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch', :parent => :switch
 end

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -62,15 +62,12 @@ RSpec.describe 'Tests transformation items', :v2v do
     # 2. Add cluster to a host
     # 3. Add host to a switch
     # 4. Add switch to the lan
-    # let(:source_cluster_lans) { FactoryBot.create(:lans) }
-    # let(:source_cluster) { FactoryBot.create(:ems_cluster, :lans => source_cluster_lans ) }
+
     let(:source_cluster) { FactoryBot.create(:ems_cluster ) }
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
     let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
     let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch)}
 
-    # let(:destination_cluster_lans) { FactoryBot.create(:lans) }
-    # let(:destination_cluster) { FactoryBot.create(:ems_cluster, :lans => destination_cluster_lans) }
     let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
     let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
@@ -79,16 +76,15 @@ RSpec.describe 'Tests transformation items', :v2v do
     let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => source_lan, :destination => destination_lan)}
 
     before do
-      allow(source_cluster).to receive(:lan).and_return([source_lan])
+      allow(source_cluster).to receive(:lans).and_return([source_lan])
     end
 
     it "Source is valid" do
       expect(tmi).to be_valid
-      # expect(tmi.valid?).to be (true)
     end
 
      before do
-      allow(destination_cluster).to receive(:lan).and_return([destination_cluster])
+      allow(destination_cluster).to receive(:lans).and_return([destination_lan])
     end
     it "Destination is valid" do
       expect(tmi).to be_valid

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe 'Tests transformation items', :v2v do
+  let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+  let(:ems_vmware) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
+
+  let(:ext_management_system)  { FactoryBot.create(:ext_management_system) }
+  let(:host)                   { FactoryBot.create(:host) }
+  let(:storage)                { FactoryBot.create(:storage) }
+
+  let(:storage) { FactoryBot.create(:storage) }
+  let(:lan) { FactoryBot.create(:lan) }
+
+  # only vmware source is supported for migration
+  context "Cluster validation" do
+    let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
+    let(:dst) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst)}
+    it "Source is valid" do
+      expect(tmi).to be_valid
+    end
+    it "Destination is valid" do
+      expect(tmi).to be_valid
+    end
+  end # end of cluster context
+
+  context "Storage validation" do
+    #todo
+    # 1.  Create a host
+    # 2.  Add host to a cluster
+    # 3.  Add cluster to a storage
+    let(:source_storage) { FactoryBot.create(:storage) }
+    let(:source_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
+    let(:src) { FactoryBot.create(:storage, :hosts => [source_host] ) }
+    
+    let(:destination_storage) { FactoryBot.create(:storage) }
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
+    let(:dst) { FactoryBot.create(:storage, :hosts => [destination_host] ) }
+
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst) }
+   
+    # add the src storage to the source cluster, then call valid  
+    before do
+	allow(source_cluster).to receive(:storages).and_return([src])
+    end
+    it "Source datastore is valid" do
+      expect(tmi.valid?).to be (true)
+    end
+
+    # add the dst storage to the destination cluster, then call valid  
+    before do
+	allow(destination_cluster).to receive(:storages).and_return([dst])
+    end
+    it "Destination datastore is valid" do
+      expect(tmi.valid?).to be (true)
+    end
+  end # end of storage context
+
+  context "Lan validation" do
+    # todo
+    # 1. Create a cluster
+    # 2. Add cluster to a host
+    # 3. Add host to a switch
+    # 4. Add switch to the lan
+    let(:src) { FactoryBot.create(:lan)}
+    let(:dst) { FactoryBot.create(:lan)}
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst)}
+    it "Source is valid" do
+      expect(true).to be (true)
+      # expect(tmi.valid?).to be (true)
+    end
+    it "Destination is valid" do
+      expect(true).to be (true)
+    end
+  end # end of lan context
+
+end # describe

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -62,11 +62,15 @@ RSpec.describe 'Tests transformation items', :v2v do
     # 2. Add cluster to a host
     # 3. Add host to a switch
     # 4. Add switch to the lan
-    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
+    # let(:source_cluster_lans) { FactoryBot.create(:lans) }
+    # let(:source_cluster) { FactoryBot.create(:ems_cluster, :lans => source_cluster_lans ) }
+    let(:source_cluster) { FactoryBot.create(:ems_cluster ) }
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
     let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
     let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch)}
 
+    # let(:destination_cluster_lans) { FactoryBot.create(:lans) }
+    # let(:destination_cluster) { FactoryBot.create(:ems_cluster, :lans => destination_cluster_lans) }
     let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
     let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
@@ -75,7 +79,7 @@ RSpec.describe 'Tests transformation items', :v2v do
     let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => source_lan, :destination => destination_lan)}
 
     before do
-      allow(source_cluster).to receive(:ems_cluster).and_return([source_cluster])
+      allow(source_cluster).to receive(:lan).and_return([source_lan])
     end
 
     it "Source is valid" do
@@ -84,7 +88,7 @@ RSpec.describe 'Tests transformation items', :v2v do
     end
 
      before do
-      allow(destination_cluster).to receive(:ems_cluster).and_return([destination_cluster])
+      allow(destination_cluster).to receive(:lan).and_return([destination_cluster])
     end
     it "Destination is valid" do
       expect(tmi).to be_valid

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -31,25 +31,25 @@ RSpec.describe 'Tests transformation items', :v2v do
     let(:source_cluster) { FactoryBot.create(:ems_cluster)}
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
     let(:src) { FactoryBot.create(:storage, :hosts => [source_host] ) }
-    
+
     let(:destination_storage) { FactoryBot.create(:storage) }
     let(:destination_cluster) { FactoryBot.create(:ems_cluster)}
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
     let(:dst) { FactoryBot.create(:storage, :hosts => [destination_host] ) }
 
     let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst) }
-   
-    # add the src storage to the source cluster, then call valid  
+
+    # add the src storage to the source cluster, then call valid
     before do
-	allow(source_cluster).to receive(:storages).and_return([src])
+      allow(source_cluster).to receive(:storages).and_return([src])
     end
     it "Source datastore is valid" do
       expect(tmi.valid?).to be (true)
     end
 
-    # add the dst storage to the destination cluster, then call valid  
+    # add the dst storage to the destination cluster, then call valid
     before do
-	allow(destination_cluster).to receive(:storages).and_return([dst])
+      allow(destination_cluster).to receive(:storages).and_return([dst])
     end
     it "Destination datastore is valid" do
       expect(tmi.valid?).to be (true)
@@ -62,15 +62,32 @@ RSpec.describe 'Tests transformation items', :v2v do
     # 2. Add cluster to a host
     # 3. Add host to a switch
     # 4. Add switch to the lan
-    let(:src) { FactoryBot.create(:lan)}
-    let(:dst) { FactoryBot.create(:lan)}
-    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst)}
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
+    let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
+    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch)}
+
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
+    let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
+    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch)}
+
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => source_lan, :destination => destination_lan)}
+
+    before do
+      allow(source_cluster).to receive(:ems_cluster).and_return([source_cluster])
+    end
+
     it "Source is valid" do
-      expect(true).to be (true)
+      expect(tmi).to be_valid
       # expect(tmi.valid?).to be (true)
     end
+
+     before do
+      allow(destination_cluster).to receive(:ems_cluster).and_return([destination_cluster])
+    end
     it "Destination is valid" do
-      expect(true).to be (true)
+      expect(tmi).to be_valid
     end
   end # end of lan context
 


### PR DESCRIPTION
Creates Validations for Infra Mapping and Specs for Validation Code

**Target Datastores**
	•	RHV (Class:  Storage, Filters:  Must belong to target cluster)
	•	OSP (Class:  CloudVolumeType, Filters:  Must belong to target CloudTenant's ExtManagementSyste)

**Source Datastores**
	•	VMW (Class:  Storage, Filters:  Must belong to one of the source clusters )
