### PR TITLE
Update rubocop to 0.69 and add rubocop-performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -221,11 +221,12 @@ end
 unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
-    gem "haml_lint",        "~>0.20.0", :require => false
-    gem "rubocop",          "~>0.52.1", :require => false
+    gem "haml_lint",           "~>0.20.0", :require => false
+    gem "rubocop",             "~>0.69.0", :require => false
+    gem "rubocop-performance", "~>1.3",    :require => false
     # ruby_parser is required for i18n string extraction
-    gem "ruby_parser",                  :require => false
-    gem "scss_lint",        "~>0.48.0", :require => false
+    gem "ruby_parser",                     :require => false
+    gem "scss_lint",           "~>0.48.0", :require => false
     gem "yard"
   end
 


### PR DESCRIPTION
Upgrade rubocop to 0.69 and add the rubocop-performance gem to get the performance cops since they were split out. Some minor re-spacing to keep everything nicely aligned.

Followup to https://github.com/ManageIQ/miq_bot/pull/442.