### PR TITLE
Move 'region' and 'zone' product features out of Main Configuration

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2957,50 +2957,38 @@
           :feature_type: admin
           :hidden: true
           :identifier: schedule_disable
-    - :name: Zones
-      :description: Zones
-      :feature_type: node
+    - :name: Modify Zone
+      :description: Modify Zones
+      :feature_type: admin
+      :identifier: zone_admin
       :hidden: true
-      :identifier: zone
       :children:
-      - :name: Modify
-        :description: Modify Zones
+      - :name: Add
+        :description: Add a Zone
         :feature_type: admin
-        :identifier: zone_admin
         :hidden: true
-        :children:
-        - :name: Add
-          :description: Add a Zone
-          :feature_type: admin
-          :hidden: true
-          :identifier: zone_new
-        - :name: Edit
-          :description: Edit a Zone
-          :feature_type: admin
-          :hidden: true
-          :identifier: zone_edit
-        - :name: Delete
-          :description: Delete a Zone
-          :feature_type: admin
-          :hidden: true
-          :identifier: zone_delete
-    - :name: Regions
-      :description: Regions
-      :feature_type: node
+        :identifier: zone_new
+      - :name: Edit
+        :description: Edit a Zone
+        :feature_type: admin
+        :hidden: true
+        :identifier: zone_edit
+      - :name: Delete
+        :description: Delete a Zone
+        :feature_type: admin
+        :hidden: true
+        :identifier: zone_delete
+    - :name: Modify Region
+      :description: Modify Regions
+      :feature_type: admin
+      :identifier: region_admin
       :hidden: true
-      :identifier: region
       :children:
-      - :name: Modify
-        :description: Modify Regions
+      - :name: Edit
+        :description: Edit a Region
         :feature_type: admin
-        :identifier: region_admin
         :hidden: true
-        :children:
-        - :name: Edit
-          :description: Edit a Region
-          :feature_type: admin
-          :hidden: true
-          :identifier: region_edit
+        :identifier: region_edit
   - :name: Access Control
     :description: Access Control Accordion
     :feature_type: node
@@ -3438,6 +3426,15 @@
   :description: Show the About Information
   :feature_type: node
   :identifier: about
+  :children:
+  - :name: Zones
+    :description: Zones
+    :feature_type: node
+    :identifier: zone
+  - :name:
+    :description: Regions
+    :feature_type: node
+    :identifier: region
 
 # PXE Explorer
 - :name: PXE


### PR DESCRIPTION
**ISSUE**:
After refactoring product features tree and moving Configuration  out of main settings all users who does not have Main Configuration  lost access to api endpoint ```/api/region``` and ```/api/region```, which is needed to access "About" dialog

**FIX:**
Move ```region``` and ```zone``` hidden product features out of Main Configuration tree to under ```about``` product feature

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1703967

**BEFORE:**
![Screen Shot 2019-05-15 at 2 45 52 PM](https://user-images.githubusercontent.com/6556758/57800789-38f8d080-7720-11e9-8da0-e43b6f2bac7a.png)


AFTER:
![Screen Shot 2019-05-15 at 2 15 50 PM](https://user-images.githubusercontent.com/6556758/57800083-83794d80-771e-11e9-9909-29b4dab0a67f.png)

@miq-bot add-label bug, changelog/no, core