### PR TITLE
[V2V] Conversion Host - Use JSON format for extra vars

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -332,7 +332,7 @@ class ConversionHost < ApplicationRecord
       raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
     end
 
-    extra_vars.each { |k, v| command << " --extra-vars '#{k}=#{v}'" }
+    command << " --extra-vars '#{extra_vars.to_json}'"
 
     result = AwesomeSpawn.run(command)
 


### PR DESCRIPTION
In current implementation, the extra vars passed to the conversion host enablement playbook are separate strings. The problem with that is string escaping can be tricky, and it already creates problems with long multiline strings.

A solution is to use a single JSON string that contains all the extra vars. This PR implements that and the string is generated by `.to_json` which handles all the escaping for us.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1710448