### PR TITLE
Drop unnecessary non-nil check since we have a presence check

### DIFF
--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -1,7 +1,7 @@
 module UuidMixin
   extend ActiveSupport::Concern
   included do
-    default_value_for(:guid, :allows_nil => false) { SecureRandom.uuid }
+    default_value_for(:guid) { SecureRandom.uuid }
     validates :guid,  :uniqueness => true, :presence => true
   end
 


### PR DESCRIPTION
Found when doing something like ```Vm.where(:id => 2).select(:id, :name).first; nil```. With the default_value_for that doesn't allow nil, extra attributes get populated. 

Discovered here: https://github.com/ManageIQ/manageiq/pull/18492#issuecomment-493139108.