### PR TITLE
We shouldn't be using allows_nil => false

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -29,7 +29,8 @@ class DialogField < ApplicationRecord
                                   :message => "Field Name %{value} is reserved."}
 
   default_value_for :required, false
-  default_value_for(:visible, :allows_nil => false) { true }
+  default_value_for(:visible) { true }
+  validates :visible, :presence => true
   default_value_for :load_values_on_init, true
 
   serialize :values

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -3,7 +3,8 @@ require 'manageiq/automation_engine/syntax_checker'
 class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
-  default_value_for :embedded_methods, :value => [], :allows_nil => false
+  default_value_for(:embedded_methods) { [] }
+  validates :embedded_methods, :exclusion => { :in => [nil] }
   serialize :options, Hash
 
   belongs_to :ae_class, :class_name => "MiqAeClass", :foreign_key => :class_id


### PR DESCRIPTION
```allows_nil => false``` is problematic because when doing something like ```Vm.where(:id => 2).select(:id, :name).first; nil```. With the ```default_value_for``` that doesn't allow nil, extra attributes get populated. We should be using the presence check instead to avoid that behavior. 

It's the dialog field and miq_ae_method corollary to https://github.com/ManageIQ/manageiq/pull/18777:
https://github.com/ManageIQ/manageiq/pull/18777#issuecomment-493161975
