### PR TITLE
Fix strict partial validation errors for InterRegionApiMethodRelay specs

### DIFF
--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -1,4 +1,4 @@
-describe InterRegionApiMethodRelay do
+RSpec.describe InterRegionApiMethodRelay do
   let(:collection_name) { :test_class_collection }
   let(:api_config)      { double("Api::CollectionConfig") }
 
@@ -8,7 +8,12 @@ describe InterRegionApiMethodRelay do
       allow(api_config).to receive(:name_for_klass).and_return(collection_name)
 
       Class.new do
+        include ActiveRecord::IdRegions
         extend InterRegionApiMethodRelay
+
+        def id
+          1
+        end
 
         def self.name
           "RegionalMethodRelayTestClass"


### PR DESCRIPTION
This PR fixes two errors that crop up with strict partial validation turned on within the `spec/models/mixins/inter_region_api_method_relay_spec.rb` file.

The first is that the test class created via `Class.new` doesn't define a `in_current_region?` method. The easiest way to solve this was to explicitly include the `ActiveRecord::IdRegions`. While this specific method could have been stubbed, I thought it best to have the class actually include it in order to most closely simulate an actual record since we mix it into `ApplicationRecord`, and since I'm not sure what else is relying on that module's behavior.

The second was that the test class doesn't implement an `id` method, so I just created a dummy one that the specs later override anyway.

I also added an explicit `RSpec.describe` to the outer block in preparation for rspec 4.

With these two changes the specs pass with strict partial validation turned on.

