### PR TITLE
Remove unused partial for User instances in  MiqProvisionRequest specs

### DIFF
--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvisionRequest do
+RSpec.describe MiqProvisionRequest do
   context "#request_task_class_from" do
     it "retrieves the provision class when the vm has EMS" do
       ems = FactoryBot.create(:ems_vmware)
@@ -30,7 +30,6 @@ describe MiqProvisionRequest do
   end
 
   context "A new provision request," do
-    before            { allow_any_instance_of(User).to receive(:role).and_return("admin") }
     let(:approver)    { FactoryBot.create(:user_miq_request_approver) }
     let(:user)        { FactoryBot.create(:user) }
     let(:ems)         { FactoryBot.create(:ems_vmware) }


### PR DESCRIPTION
The call to `allow_any_instance_of(User).to receive(:role).and_return("admin")` breaks strict partial verifications. It doesn't appear to do anything since `User` doesn't implement a `role` method, and removing it caused no issues.

I also updated the outer describe block to `RSpec.describe` for future compliance with rspec 4.