### PR TITLE
Use sys-filesystem for determining data disk in database seeding instead of MiqSystem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem "rubyzip",                        "~>1.2.2",       :require => false
 gem "rugged",                         "~>0.27.0",      :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
+gem "sys-filesystem",                 "~>1.2.0",       :require => false
 
 # Modified gems (forked on Github)
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"


### PR DESCRIPTION
Currently the `VMDBDatabase::Seeding` model is using `MiqSystem` from gems-pending to determine the disk name for the data directory. There are a couple issues with the current implementation.

First, the `MiqSystem` class is making a bunch of platform-specific shell calls, which I'm not a fan of and it can lead to platform-specific issues. Less importantly the method `db_disk_size` method name is misleading, because it is NOT returning the size, but rather the disk NAME.

So, this PR does a couple things. First, it replaces `MiqSystem` with `Sys::Filesystem`, which requires adding the `sys-filesystem` gem as a dependency. It's cross-platform, uses library calls (instead of shelling out), and I know the author (it's me). This library can probably be used elsewhere

Second, it renames the method to something sensical, and uses more robust exception handling instead of relying on string error output.