### PR TITLE
[WIP] Get the thing to run on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,10 +136,10 @@ group :openstack, :manageiq_default do
   manageiq_plugin "manageiq-providers-openstack"
 end
 
-group :ovirt, :manageiq_default do
-  manageiq_plugin "manageiq-providers-ovirt"
-  gem "ovirt_metrics",                  "~>2.0.0",       :require => false
-end
+#group :ovirt, :manageiq_default do
+#  manageiq_plugin "manageiq-providers-ovirt"
+#  gem "ovirt_metrics",                  "~>2.0.0",       :require => false
+#end
 
 group :scvmm, :manageiq_default do
   manageiq_plugin "manageiq-providers-scvmm"
@@ -243,4 +243,8 @@ unless ENV["APPLIANCE"]
     gem "parallel_tests"
     gem "rspec-rails",      "~>3.6.0"
   end
+end
+
+group :windows do
+  gem "tzinfo-data", "~>1.2", :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -246,5 +246,5 @@ unless ENV["APPLIANCE"]
 end
 
 group :windows do
-  gem "tzinfo-data", "~>1.2", :require => false
+  gem "tzinfo-data", "~>1.2", :require => false, :platform => [:mswin, :mingw]
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,13 @@ gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => 
 gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
 
 # when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
-def manageiq_plugin(plugin_name)
+def manageiq_plugin(plugin_name, platforms = [])
   unless dependencies.detect { |d| d.name == plugin_name }
-    gem plugin_name, :git => "https://github.com/ManageIQ/#{plugin_name}", :branch => "master"
+    if platforms.empty?
+      gem plugin_name, :git => "https://github.com/ManageIQ/#{plugin_name}", :branch => "master"
+    else
+      gem plugin_name, :git => "https://github.com/ManageIQ/#{plugin_name}", :branch => "master", :platform => [platforms.join(',')]
+    end
   end
 end
 
@@ -136,10 +140,10 @@ group :openstack, :manageiq_default do
   manageiq_plugin "manageiq-providers-openstack"
 end
 
-#group :ovirt, :manageiq_default do
-#  manageiq_plugin "manageiq-providers-ovirt"
-#  gem "ovirt_metrics",                  "~>2.0.0",       :require => false
-#end
+group :ovirt, :manageiq_default do
+  manageiq_plugin("manageiq-providers-ovirt", [:ruby])
+  gem "ovirt_metrics", "~>2.0.0", :require => false, :platform => [:ruby]
+end
 
 group :scvmm, :manageiq_default do
   manageiq_plugin "manageiq-providers-scvmm"
@@ -246,5 +250,5 @@ unless ENV["APPLIANCE"]
 end
 
 group :windows do
-  gem "tzinfo-data", "~>1.2", :require => false, :platform => [:mswin, :mingw]
+  gem "tzinfo-data", "~>1.2", :require => false, :platform => [:mswin, :mingw, :x64_mingw]
 end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -62,7 +62,7 @@ module ManageIQ
 
     def self.install_bundler(root = APP_ROOT)
       system!("echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc") if ENV['CI']
-      system!("gem install bundler -v '#{bundler_version}' --conservative")
+      #system!("gem install bundler -v '#{bundler_version}' --conservative")
       system!("bundle config path #{root.join('vendor/bundle').expand_path}", :chdir => root) if ENV["CI"]
     end
 

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -62,7 +62,7 @@ module ManageIQ
 
     def self.install_bundler(root = APP_ROOT)
       system!("echo 'gem: --no-ri --no-rdoc --no-document' > ~/.gemrc") if ENV['CI']
-      #system!("gem install bundler -v '#{bundler_version}' --conservative")
+      system!("gem install bundler -v '#{bundler_version}' --conservative") unless Gem.win_platform?
       system!("bundle config path #{root.join('vendor/bundle').expand_path}", :chdir => root) if ENV["CI"]
     end
 


### PR DESCRIPTION
Just in case we want to get this running on Windows someday I'm putting together this WIP with the needed changes, along with the collective knowledge that Martin H and I have managed to cobble together.

**General Advice**

At each step of the way when installing software, please make sure that your `PATH` has been modified to include the directory to necessary executables, e.g. `C:\Ruby\bin;C:\Program Files\PostgreSQL\10\bin;` and so on, and that your shell has picked up the changes (probably by creating a new shell afterwards).

**ManageIQ changes:**

* Cannot deal with the ovirt gem because they're doing strange things with C extensions. So we skip it for now.
* Will have to assume the user has bundler already installed because of a shell quoting issue. It shouldn't be an issue in practice, for local development anyway. Just `gem install bundler` first.
* Rails seems to require the `tzinfo-data` gem on Windows, so I added that to the Gemfile.
* Minor modification to the `manageiq_plugin` method to handle the `:platform` option.

After you've cloned the manageiq repo and applied the changes here, you'll need to create `.bat` files for everything under the `bin` directory, one for each executable. They will all have identical contents:

```
@ECHO OFF
@"ruby.exe" "%~dpn0" %*
```

Your bin directory should look like this when you're done:

```
bundle
bundle.bat
eslint
eslint.bat
rails
rails.bat
rake
rake.bat
setup
setup.bat
update
update.bat
```

**System Preparation:**

* Install Ruby 2.5.x with devkit:

`https://rubyinstaller.org/downloads/`

We'll assume x64 ruby from here on, as well as a shell with admin rights.

* Install bundler

`gem install bundler`

* Install chocolatey:

`https://chocolatey.org/install`

Then install some packages:

```
choco install git
choco install cmake
choco install nodejs-lts
choco install python2
choco install yarn
```

You could also install ruby and the ruby2.devkit packages via chocolatey if you prefer. Just make sure you've got Ruby 2.5+ and the proper toolkit.

**GIT**

I ran into an issue with filenames being too long on Windows 7. I don't think you'll hit the issue on Windows 10, but if you get an error about filenames being too long when you (eventually) run `bundle install`, you'll need to do this:

`git config --system core.longpaths true`

Update: I had to do this even on Windows 2016, so it's mandatory.

**Install PostgreSQL**

In theory you can install PostgreSQL via chocolatey, but it failed for me, so I just used an installer:

https://www.enterprisedb.com/downloads/postgres-postgresql-downloads

Afterwards run this from the shell:

`psql -U postgres -c "CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'"`

I installed version 10.8 without issue. Just keep in mind that if you set a postgresql password you'll need to edit `config/database.yml` and add the password there.

**Install Memcached**

`http://downloads.northscale.com/memcached-win64-1.4.4-14.zip`

Unpack the thing somewhere, then run this:

`c:/path/to/memcached  -d install`

Edit the registry via regedit and look for `HKEY_LOCAL_MACHINE/SYSTEM/CurrentControlSet/Services/memcached`

Change the `ImagePath` to `“C:/path/to/memcached” -d runservice -m 512`

Then run `c:/path/to/memcached -d start`, or just use the Windows services GUI to start it.

**NPM**

This is where the fun starts. You'll need to install the windows build tools (large) and do some configuration:

```
npm install --global --production windows-build-tools --vs2015
npm config set msvs_version 2015 --global
npm config set python python2.7 --global
```

I also had to do this, but am not entirely sure why. You may be able to skip it.

```
npm install express
npm init -y
```

Now install the remaining necessary npm modules for ManageIQ:

~~npm install -g yarn~~ # Use choco instead
~~npm install -g gulp-cli~~ # No longer required

```
npm install webpack
```

**ManageIQ UI Classic**

We need the commands under in the UI classic repo to have batch files as well, so clone the manageiq-ui-classic repo, and create `.bat` files for each file under `/bin` the same way you did for the core repo mentioned above.

Then within the spec directory run `mklink /d manageiq C:/Users/your_home/path/to/manageiq`.

Within your core manageiq repo, update `bundler.d/overrides.rb` to point at your local UI classic repository.

**THE ACID TEST**

Finally, run `bin\setup` and see it works. If it does, then run `bundle exec rails s` and try to visit `http://localhost:3000`.

