### PR TITLE
Update VmdbDatabase::Seeding.seed_self error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "rubyzip",                        "~>1.2.2",       :require => false
 gem "rugged",                         "~>0.27.0",      :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
-gem "sys-filesystem",                 "~>1.2.0",       :require => false
+gem "sys-filesystem",                 "~>1.2.0"
 
 # Modified gems (forked on Github)
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"

--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -41,11 +41,17 @@ module VmdbDatabase::Seeding
       host
     end
 
+    # Get the name of the data disk, if possible. If an error occurs for any
+    # reason just bail and return nil.
+    #--
+    # Note that we scope the the Sys::Filesystem class in order to prevent it
+    # from accidentally picking up the local Filesystem model from our app.
+    #
     def data_disk_name(disk)
       if disk && EvmDatabase.local?
         begin
-          mount_point = Sys::Filesystem.mount_point(disk)
-          Sys::Filesystem.mounts.find { |fs| fs.mount_point == mount_point }.name
+          mount_point = ::Sys::Filesystem.mount_point(disk)
+          ::Sys::Filesystem.mounts.find { |fs| fs.mount_point == mount_point }.name
         rescue StandardError
           nil
         end

--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -43,7 +43,6 @@ module VmdbDatabase::Seeding
 
     def data_disk_name(disk)
       if disk && EvmDatabase.local?
-        require 'sys-filesystem'
         begin
           mount_point = Sys::Filesystem.mount_point(disk)
           Sys::Filesystem.mounts.find { |fs| fs.mount_point == mount_point }.name

--- a/app/models/vmdb_database/seeding.rb
+++ b/app/models/vmdb_database/seeding.rb
@@ -47,7 +47,7 @@ module VmdbDatabase::Seeding
         begin
           mount_point = Sys::Filesystem.mount_point(disk)
           Sys::Filesystem.mounts.find { |fs| fs.mount_point == mount_point }.name
-        rescue Errno::ENOENT
+        rescue StandardError
           nil
         end
       end

--- a/spec/models/vmdb_database/seeding_spec.rb
+++ b/spec/models/vmdb_database/seeding_spec.rb
@@ -86,6 +86,14 @@ describe VmdbDatabase do
 
         expect(db.ipaddress).to eq("192.255.255.1")
       end
+
+      it "returns nil for the data disk name if it cannot be determined" do
+        FactoryBot.create(:vmdb_database, :ipaddress => "127.0.0.1")
+        db = described_class.send(:seed_self)
+
+        allow(Sys::Filesystem).to receive(:mount_point).with(db.data_directory).and_raise(Errno::EACCES)
+        expect(db.data_disk).to be_nil
+      end
     end
 
     describe ".seed_tables (private)" do

--- a/spec/models/vmdb_database/seeding_spec.rb
+++ b/spec/models/vmdb_database/seeding_spec.rb
@@ -88,7 +88,7 @@ describe VmdbDatabase do
       end
 
       it "returns nil for the data disk name if it cannot be determined" do
-        allow(Sys::Filesystem).to receive(:mount_point).with(any_args).and_raise(Errno::EACCES)
+        allow(::Sys::Filesystem).to receive(:mount_point).with(any_args).and_raise(Errno::EACCES)
         db = described_class.send(:seed_self)
         expect(db.data_disk).to be_nil
       end

--- a/spec/models/vmdb_database/seeding_spec.rb
+++ b/spec/models/vmdb_database/seeding_spec.rb
@@ -88,8 +88,8 @@ describe VmdbDatabase do
       end
 
       it "returns nil for the data disk name if it cannot be determined" do
+        allow(Sys::Filesystem).to receive(:mount_point).with(any_args).and_raise(Errno::EACCES)
         db = described_class.send(:seed_self)
-        allow(Sys::Filesystem).to receive(:mount_point).with(db.data_directory).and_raise(Errno::EACCES)
         expect(db.data_disk).to be_nil
       end
     end

--- a/spec/models/vmdb_database/seeding_spec.rb
+++ b/spec/models/vmdb_database/seeding_spec.rb
@@ -88,9 +88,7 @@ describe VmdbDatabase do
       end
 
       it "returns nil for the data disk name if it cannot be determined" do
-        FactoryBot.create(:vmdb_database, :ipaddress => "127.0.0.1")
         db = described_class.send(:seed_self)
-
         allow(Sys::Filesystem).to receive(:mount_point).with(db.data_directory).and_raise(Errno::EACCES)
         expect(db.data_disk).to be_nil
       end


### PR DESCRIPTION
Apparently I was too specific for the error handling in https://github.com/ManageIQ/manageiq/pull/18785. This switches the exception handling from `Errno::ENOENT` to just `StandardError`.

I've also added a spec.