### PR TITLE
Add .rspec-local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .loadpath
 .project
 .redcar/
+.rspec-local
 .rubocop-*
 .ruby-version
 .sass-cache/


### PR DESCRIPTION
The `.rspec-local` should be ignored. This file lets us do per-project preferences as we see fit.