### PR TITLE
[WIP] Add rspec factory environments

### DIFF
--- a/spec/factories/environments/infra/redhat.rb
+++ b/spec/factories/environments/infra/redhat.rb
@@ -4,18 +4,18 @@
 #
 # Example:
 #
-# env = FactoryBot.build(:environment_redhat, :num_host => 2, :num_vm => 4)
+# env = FactoryBot.build(:environment_infra_redhat, :num_host => 2, :num_vm => 4)
 #
 # env.ems.hosts
 # env.ems.vms
 #
 # The possible options are:
 #
-# * num_hosts # => default: 1
-# * num_vm    # => default: 1
+# * num_host # => default: 1
+# * num_vm   # => default: 1
 #
 FactoryBot.define do
-  factory :environment_redhat, class: OpenStruct do
+  factory :environment_infra_redhat, class: OpenStruct do
     zone { FactoryBot.build(:zone) }
     ems  { FactoryBot.build(:ems_redhat, :zone => zone, :api_version => '4.2.4') }
 

--- a/spec/factories/environments/redhat.rb
+++ b/spec/factories/environments/redhat.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     ems  { FactoryBot.build(:ems_redhat, :zone => zone, :api_version => '4.2.4') }
 
     transient do
-      with_host { true }
-      with_vm { true }
+      num_host { 1 }
     end
 
-    host { FactoryBot.build(:host_redhat, :ext_management_system => ems) if with_host }
-    vm { FactoryBot.build(:vm_redhat, :ext_management_system => ems) if with_vm }
+    after(:build) do |env, evaluator|
+      FactoryBot.build_list(:host_redhat, evaluator.num_host, :ext_management_system => env.ems)
+    end
   end
 end

--- a/spec/factories/environments/redhat.rb
+++ b/spec/factories/environments/redhat.rb
@@ -1,15 +1,32 @@
-# Create a small environment for Redhat
+# Create a small test environment for Redhat. This will create an EMS with
+# an associated zone, and attach a number of other resources depending on
+# the options passed to the Factory builder.
+#
+# Example:
+#
+# env = FactoryBot.build(:environment_redhat, :num_host => 2, :num_vm => 4)
+#
+# env.ems.hosts
+# env.ems.vms
+#
+# The possible options are:
+#
+# * num_hosts # => default: 1
+# * num_vm    # => default: 1
+#
 FactoryBot.define do
   factory :environment_redhat, class: OpenStruct do
-    zone { FactoryBot.build(:zone, :name => "ozone") }
+    zone { FactoryBot.build(:zone) }
     ems  { FactoryBot.build(:ems_redhat, :zone => zone, :api_version => '4.2.4') }
 
     transient do
       num_host { 1 }
+      num_vm   { 1 }
     end
 
     after(:build) do |env, evaluator|
       env.ems.hosts = FactoryBot.build_list(:host_redhat, evaluator.num_host)
+      env.ems.vms = FactoryBot.build_list(:vm_redhat, evaluator.num_vm)
     end
   end
 end

--- a/spec/factories/environments/redhat.rb
+++ b/spec/factories/environments/redhat.rb
@@ -1,0 +1,15 @@
+# Create a small environment for Redhat
+FactoryBot.define do
+  factory :environment_redhat, class: OpenStruct do
+    zone { FactoryBot.build(:zone) }
+    ems  { FactoryBot.build(:ems_redhat, :zone => zone, :api_version => '4.2.4') }
+
+    transient do
+      with_host { true }
+      with_vm { true }
+    end
+
+    host { FactoryBot.build(:host_redhat, :ext_management_system => ems) if with_host }
+    vm { FactoryBot.build(:vm_redhat, :ext_management_system => ems) if with_vm }
+  end
+end

--- a/spec/factories/environments/redhat.rb
+++ b/spec/factories/environments/redhat.rb
@@ -1,7 +1,7 @@
 # Create a small environment for Redhat
 FactoryBot.define do
   factory :environment_redhat, class: OpenStruct do
-    zone { FactoryBot.build(:zone) }
+    zone { FactoryBot.build(:zone, :name => "ozone") }
     ems  { FactoryBot.build(:ems_redhat, :zone => zone, :api_version => '4.2.4') }
 
     transient do
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     after(:build) do |env, evaluator|
-      FactoryBot.build_list(:host_redhat, evaluator.num_host, :ext_management_system => env.ems)
+      env.ems.hosts = FactoryBot.build_list(:host_redhat, evaluator.num_host)
     end
   end
 end

--- a/spec/support/factory_bot_helper.rb
+++ b/spec/support/factory_bot_helper.rb
@@ -22,6 +22,7 @@ FactoryGirl = FactoryBot # Alias until all associated repositories are updated
 
 # In case we are running as an engine, the factories are located in the dummy app
 FactoryBot.definition_file_paths << 'spec/manageiq/spec/factories'
+FactoryBot.definition_file_paths << 'spec/manageiq/spec/factories/environments'
 
 # Also, add factories from provider gems until miq codebase does not use any provider specific factories anymore
 Rails::Engine.subclasses.select { |e| e.name.starts_with?("ManageIQ::Providers") }.each do |engine|


### PR DESCRIPTION
This is an attempt to DRY up some of our spec tests where we're creating a minimal set of resources for any given provider. At the moment our specs will often do something like this:

```
let(:zone) { FactoryBot.create(:zone) }
let(:ems) { FactoryBot.create(:ext_management_system, :zone => zone) }
let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
let(:vm) { FactoryBot.create(:vm_redhat, :ext_management_system => ems) }
# ... and so on, and so on
```

This PR would allow you to do something like this:

```
let(:env) { FactoryBot.build(:environment_redhat) }

context "stuff" do
  example "whatever" do
    expect(env.ems.hosts.first.name).to eq('something')
  end
end
```
It would also be configurable, so you could add some other types of resources as desired:

`let(:env) { FactoryBot.build(:environment_redhat, :num_host => 2, :num_vm => 4) }`

Organizationally, these would live under `/spec/factories/environments`, with the name of the provider (or whatever) as the name of the file.