### PR TITLE
[WIP][V2V] Added Storage Validations for Transformation Mapping Items.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ bundler.d/*
 # yardoc
 /doc/
 .yardoc
+.rspec-local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Add conversion_host option to the SupportsFeatureMixin module [(#18232)](https://github.com/ManageIQ/manageiq/pull/18232)
-- Alter ansible_playbook method so that some arguments are optional [(#18323)](https://github.com/ManageIQ/manageiq/pull/18323)
 - Modify the enable ConversionHost::Configurations#enable method to handle arguments more robustly [(#18336)](https://github.com/ManageIQ/manageiq/pull/18336)
-- Add ConversionHost validations [(#18277)](https://github.com/ManageIQ/manageiq/pull/18277)
 - Tag associated resource for conversion hosts [(#18505)](https://github.com/ManageIQ/manageiq/pull/18505)
 - Add the resource name to the task action for conversion hosts [(#18525)](https://github.com/ManageIQ/manageiq/pull/18525)
 - Default to resource name for conversion hosts [(#18516)](https://github.com/ManageIQ/manageiq/pull/18516)
@@ -51,6 +49,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Deprecate invalid custom attribute names [(#18538)](https://github.com/ManageIQ/manageiq/pull/18538)
+- Add ConversionHost validations [(#18277)](https://github.com/ManageIQ/manageiq/pull/18277)
+- Alter ansible_playbook method so that some arguments are optional [(#18323)](https://github.com/ManageIQ/manageiq/pull/18323)
 - Tenancy for central admin [(#18263)](https://github.com/ManageIQ/manageiq/pull/18263)
 - [V2V] Expose virt-v2v-wrapper error message in options hash [(#18564)](https://github.com/ManageIQ/manageiq/pull/18564)
 - updating infra conversion job polling timers [(#18597)](https://github.com/ManageIQ/manageiq/pull/18597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 
+## Hammer-6
+
+### Added
+- Add conversion_host option to the SupportsFeatureMixin module [(#18232)](https://github.com/ManageIQ/manageiq/pull/18232)
+- Alter ansible_playbook method so that some arguments are optional [(#18323)](https://github.com/ManageIQ/manageiq/pull/18323)
+- Modify the enable ConversionHost::Configurations#enable method to handle arguments more robustly [(#18336)](https://github.com/ManageIQ/manageiq/pull/18336)
+- Add ConversionHost validations [(#18277)](https://github.com/ManageIQ/manageiq/pull/18277)
+- Tag associated resource for conversion hosts [(#18505)](https://github.com/ManageIQ/manageiq/pull/18505)
+- Add the resource name to the task action for conversion hosts [(#18525)](https://github.com/ManageIQ/manageiq/pull/18525)
+- Default to resource name for conversion hosts [(#18516)](https://github.com/ManageIQ/manageiq/pull/18516)
+- [V2V] Generate extra vars for conversion host playbooks [(#18537)](https://github.com/ManageIQ/manageiq/pull/18537)
+- [V2V] Add CPU and network throttling in model [(#18576)](https://github.com/ManageIQ/manageiq/pull/18576)
+- [V2V] Set context data for the task associated with conversion host creation [(#18541)](https://github.com/ManageIQ/manageiq/pull/18541)
+
+### Fixed
+- [V2V] Fix placeholder name for conversion hosts [(#18535)](https://github.com/ManageIQ/manageiq/pull/18535)
+- Conversion host base class [(#18604)](https://github.com/ManageIQ/manageiq/pull/18604)
+- fix_auth now handles recursive settings [(#18631)](https://github.com/ManageIQ/manageiq/pull/18631)
+- Retirement - remove auto_approve flag on request creation. [(#18638)](https://github.com/ManageIQ/manageiq/pull/18638)
+- Fix Container belongsto filter in Rbac::Filterer [(#18654)](https://github.com/ManageIQ/manageiq/pull/18654)
+- Fix: convert string representation of sizes to numbers when generating SQL for expression [(#18649)](https://github.com/ManageIQ/manageiq/pull/18649)
+- Use admin user in get_user for service show if user's deleted [(#18663)](https://github.com/ManageIQ/manageiq/pull/18663)
+- Fix address validation for ConversionHost model [(#18381)](https://github.com/ManageIQ/manageiq/pull/18381)
+- [V2V] Run the playbook on the appliance with the conversion host in inventory [(#18613)](https://github.com/ManageIQ/manageiq/pull/18613)
+- [V2V] Fix allowing address to be blank for the ConversionHost model, and update spec. [(#18690)](https://github.com/ManageIQ/manageiq/pull/18690)
+- [V2V] Provide placeholder params for the ConversionHost#disable method [(#18691)](https://github.com/ManageIQ/manageiq/pull/18691)
+- Service template picture [(#18689)](https://github.com/ManageIQ/manageiq/pull/18689)
+- Fix ServiceTemplate#picture= with models [(#18705)](https://github.com/ManageIQ/manageiq/pull/18705)
+- Add source to retire request to parse in parse_prov_category in engine [(#18738)](https://github.com/ManageIQ/manageiq/pull/18738)
+- [V2V] Add default credentials to ansible_playbook method [(#18724)](https://github.com/ManageIQ/manageiq/pull/18724)
+- Allow textarea boxes to dynamically set validator type and rule [(#18743)](https://github.com/ManageIQ/manageiq/pull/18743)
+
 ## Unreleased as of Sprint 111 ending 2019-05-13
 
 ### Added
@@ -15,17 +47,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Group AND expressions properly to account for nesting [(#18709)](https://github.com/ManageIQ/manageiq/pull/18709)
 - Rename Configuration feature to Main Configuration [(#18707)](https://github.com/ManageIQ/manageiq/pull/18707)
 
-## Unreleased as of Sprint 110 ending 2019-04-29
-
-### Fixed
-- Fix: convert string representation of sizes to numbers when generating SQL for expression [(#18649)](https://github.com/ManageIQ/manageiq/pull/18649)
-
-## Hammer-5
+## Hammer-5 - Released 2019-04-23
 
 ### Added
 - Deprecate invalid custom attribute names [(#18538)](https://github.com/ManageIQ/manageiq/pull/18538)
-- Add ConversionHost validations [(#18277)](https://github.com/ManageIQ/manageiq/pull/18277)
-- Alter ansible_playbook method so that some arguments are optional [(#18323)](https://github.com/ManageIQ/manageiq/pull/18323)
 - Tenancy for central admin [(#18263)](https://github.com/ManageIQ/manageiq/pull/18263)
 - [V2V] Expose virt-v2v-wrapper error message in options hash [(#18564)](https://github.com/ManageIQ/manageiq/pull/18564)
 - updating infra conversion job polling timers [(#18597)](https://github.com/ManageIQ/manageiq/pull/18597)
@@ -46,7 +71,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix for incorrect key sent back for dynamic non sorted items [(#18650)](https://github.com/ManageIQ/manageiq/pull/18650)
-- Retirement - remove auto_approve flag on request creation. [(#18638)](https://github.com/ManageIQ/manageiq/pull/18638)
 - Check that reconfigure is supported before we try it [(#18636)](https://github.com/ManageIQ/manageiq/pull/18636)
 - Fix Key Pairs from refresh being returned with provider AuthPrivateKeys [(#18633)](https://github.com/ManageIQ/manageiq/pull/18633)
 - Check ems_ref before uid_ems when saving VMs [(#18616)](https://github.com/ManageIQ/manageiq/pull/18616)
@@ -56,12 +80,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add zone to service provisioning. [(#18601)](https://github.com/ManageIQ/manageiq/pull/18601)
 - Add report interval date and report generation to Chargeback reports [(#18569)](https://github.com/ManageIQ/manageiq/pull/18569)
-- [V2V] Set context data for the task associated with conversion host creation [(#18541)](https://github.com/ManageIQ/manageiq/pull/18541)
 - Speed up Service access  [(#18487)](https://github.com/ManageIQ/manageiq/pull/18487)
 - [V2V] Refactor ConversionHost to use AuthenticationMixin [(#18309)](https://github.com/ManageIQ/manageiq/pull/18309)
 
 ### Fixed
-- Conversion host base class [(#18604)](https://github.com/ManageIQ/manageiq/pull/18604)
 - Don't start another refresh worker while another is stopping [(#18583)](https://github.com/ManageIQ/manageiq/pull/18583)
 - Add region checking for all user schedules [(#18512)](https://github.com/ManageIQ/manageiq/pull/18512)
 - Fix saving network manager in belongsto filter [(#18504)](https://github.com/ManageIQ/manageiq/pull/18504)
@@ -89,15 +111,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Added ability to destroy all users dashboards [(#18555)](https://github.com/ManageIQ/manageiq/pull/18555)
 - Added MiqWidgetSet.copy_dashboard [(#18550)](https://github.com/ManageIQ/manageiq/pull/18550)
 - Loosen the Postgres version initializer check [(#18547)](https://github.com/ManageIQ/manageiq/pull/18547)
-- [V2V] Generate extra vars for conversion host playbooks [(#18537)](https://github.com/ManageIQ/manageiq/pull/18537)
-- Add the resource name to the task action for conversion hosts [(#18525)](https://github.com/ManageIQ/manageiq/pull/18525)
-- Tag associated resource for conversion hosts [(#18505)](https://github.com/ManageIQ/manageiq/pull/18505)
 - Add volume multiattachment capability [(#18371)](https://github.com/ManageIQ/manageiq/pull/18371)
 
 ### Fixed
 - use like (vs ilike) for service query [(#18549)](https://github.com/ManageIQ/manageiq/pull/18549)
 - Fix: started_on and state attributes for task linked to chargeback for service [(#18542)](https://github.com/ManageIQ/manageiq/pull/18542)
-- [V2V] Fix placeholder name for conversion hosts [(#18535)](https://github.com/ManageIQ/manageiq/pull/18535)
 - dynamic DatePicker value isn't being set correctly [(#18523)](https://github.com/ManageIQ/manageiq/pull/18523)
 - Delegate vms_and_templates and miq_templates to parent_manager [(#18488)](https://github.com/ManageIQ/manageiq/pull/18488)
 - Fix graph refresh overwriting smartstate OS info [(#18477)](https://github.com/ManageIQ/manageiq/pull/18477)
@@ -157,7 +175,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Override add resource to no-op in service orchestration subclass [(#18358)](https://github.com/ManageIQ/manageiq/pull/18358)
-- Modify the enable ConversionHost::Configurations#enable method to handle arguments more robustly [(#18336)](https://github.com/ManageIQ/manageiq/pull/18336)
 - Add a 'name' parameter to backup restore and make volumeid optional [(#17952)](https://github.com/ManageIQ/manageiq/pull/17952)
 
 ### Changed

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -202,7 +202,7 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, osp_ca_bundle = nil, miq_task_id = nil)
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, openstack_tls_ca_certs = nil, miq_task_id = nil)
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
@@ -211,7 +211,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
-      :v2v_ca_bundle        => osp_ca_bundle || resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => openstack_tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars, miq_task_id)
   ensure

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -202,7 +202,7 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, miq_task_id = nil)
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, osp_ca_bundle = nil, miq_task_id = nil)
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
@@ -211,7 +211,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
-      :v2v_ca_bundle        => resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => osp_ca_bundle || resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars, miq_task_id)
   ensure

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -68,7 +68,7 @@ module ConversionHost::Configurations
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
-      osp_ca_bundle = params.delete(:osp_ca_bundle)
+      openstack_tls_ca_certs = params.delete(:openstack_tls_ca_certs)
 
       new(params).tap do |conversion_host|
         if ssh_key
@@ -80,7 +80,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, osp_ca_bundle, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, openstack_tls_ca_certs, miq_task_id)
         conversion_host.save!
 
         if miq_task_id

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -68,6 +68,8 @@ module ConversionHost::Configurations
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
+      osp_ca_bundle = params.delete(:osp_ca_bundle)
+
       new(params).tap do |conversion_host|
         if ssh_key
           conversion_host.authentications << AuthPrivateKey.create!(
@@ -78,7 +80,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, osp_ca_bundle, miq_task_id)
         conversion_host.save!
 
         if miq_task_id

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -29,7 +29,8 @@ class DialogField < ApplicationRecord
                                   :message => "Field Name %{value} is reserved."}
 
   default_value_for :required, false
-  default_value_for(:visible, :allows_nil => false) { true }
+  default_value_for(:visible) { true }
+  validates :visible, :presence => true
   default_value_for :load_values_on_init, true
 
   serialize :values

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -3,7 +3,8 @@ require 'manageiq/automation_engine/syntax_checker'
 class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
-  default_value_for :embedded_methods, :value => [], :allows_nil => false
+  default_value_for(:embedded_methods) { [] }
+  validates :embedded_methods, :exclusion => { :in => [nil] }
   serialize :options, Hash
 
   belongs_to :ae_class, :class_name => "MiqAeClass", :foreign_key => :class_id

--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -7,6 +7,10 @@ class TransformationMapping < ApplicationRecord
 
   validates :name, :presence => true, :uniqueness => true
 
+  VALID_SOURCE_CLUSTER_TYPES = %w[
+    ManageIQ::Providers::Vmware::InfraManager
+  ]
+
   def destination(source)
     transformation_mapping_items.find_by(:source => source).try(:destination)
   end
@@ -14,5 +18,41 @@ class TransformationMapping < ApplicationRecord
   # vm_list: collection of hashes, each descriping a VM.
   def search_vms_and_validate(vm_list = nil, service_template_id = nil)
     VmMigrationValidator.new(self, vm_list, service_template_id).validate
+  end
+
+  # Return the source cluster for the TransformationMapping, if any.
+  #
+  def source_cluster
+    transformation_mapping_items.find_by(:source_type => 'EmsCluster')&.source
+  end
+
+  # Return a list of source datastores associated with the TransformationMapping, if any.
+  #
+  def source_datastores
+    transformation_mapping_items.where(:source_type => 'Storage').map(&:source)
+  end
+
+  # Return a list of source networks associated with the TransformationMapping, if any.
+  #
+  def source_networks
+    transformation_mapping_items.where(:source_type => 'Lan').map(&:source)
+  end
+
+  # Return the target cluster for the TransformationMapping, if any.
+  #
+  def destination_cluster
+    transformation_mapping_items.find_by(:destination_type => ['EmsCluster', 'CloudTenant'])&.destination
+  end
+
+  # Return a list of target datastores associated with the TransformationMapping, if any.
+  #
+  def destination_datastores
+    transformation_mapping_items.where(:destination_type => 'Storage').map(&:source)
+  end
+
+  # Return a list of target networks associated with the TransformationMapping, if any.
+  #
+  def destination_networks
+    transformation_mapping_items.where(:destination_type => 'Lan').map(&:source)
   end
 end

--- a/app/models/transformation_mapping.rb
+++ b/app/models/transformation_mapping.rb
@@ -9,7 +9,7 @@ class TransformationMapping < ApplicationRecord
 
   VALID_SOURCE_CLUSTER_TYPES = %w[
     ManageIQ::Providers::Vmware::InfraManager
-  ]
+  ].freeze
 
   def destination(source)
     transformation_mapping_items.find_by(:source => source).try(:destination)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -11,16 +11,19 @@ class TransformationMapping::VmMigrationValidator
   VM_VALID = "ok".freeze
 
   def initialize(mapping, vm_list = nil, service_template_id = nil)
+    Rails.logger.info("ARIF - TM::VM.initialize entering...")
     @mapping = mapping
     @vm_list = vm_list
     @service_template_id = service_template_id.try(:to_i)
   end
 
   def validate
+    Rails.logger.info("ARIF - TM::VM.validate entering...")
     @vm_list.present? ? identify_vms : select_vms
   end
 
   def select_vms
+    Rails.logger.info("ARIF - TM::VM.select_vms entering...")
     valid_list = []
 
     Vm.where(:ems_cluster => mapped_clusters).includes(:lans, :storages).each do |vm|
@@ -32,11 +35,14 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def identify_vms
+    Rails.logger.info("ARIF - TM::VM.identify_vms entering...")
     valid_list = []
     invalid_list = []
     conflict_list = []
 
     vm_names = @vm_list.collect { |row| row['name'] }
+    Rails.logger.info("ARIF - TM::VM.identify_vms vm_name: " + vm_names.to_s)
+
     vm_objects = Vm.where(:name => vm_names).includes(:ems_cluster, :lans, :storages, :host, :ext_management_system)
 
     @vm_list.each do |row|
@@ -81,6 +87,7 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def validate_vm(vm, quick = true)
+    Rails.logger.info("ARIF - TM::VM.validate_vm entering...")
     validate_result = vm_migration_status(vm)
     return validate_result unless validate_result == VM_VALID
 
@@ -95,6 +102,7 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def vm_migration_status(vm)
+    Rails.logger.info("ARIF - TM::VM.vm_migration_status entering...")
     vm_as_resources = ServiceResource.joins(:service_template).where(:resource => vm, :service_templates => {:type => 'ServiceTemplateTransformationPlan'})
 
     # VM has not been migrated before
@@ -107,29 +115,35 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def no_mapping_list(invalid_list, data_type, new_records)
+    Rails.logger.info("ARIF - TM::VM.no_mapping_list entering...")
     return false if new_records.blank?
     invalid_list << "#{data_type}: %{list}" % {:list => new_records.collect(&:name).join(", ")}
     true
   end
 
   def no_mapping_msg(list)
+    Rails.logger.info("ARIF - TM::VM.no_mapping_msg entering...")
     "Mapping source not found - %{list}" % {:list => list.join('. ')}
   end
 
   def mapped_clusters
+    Rails.logger.info("ARIF - TM::VM.mapped_clusters entering...")
     @mapped_clusters ||= EmsCluster.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'EmsCluster').select(:source_id))
   end
 
   def mapped_storages
+    Rails.logger.info("ARIF - TM::VM.mapped_storages entering...")
     @mapped_storages ||= Storage.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Storage').select(:source_id))
   end
 
   def mapped_lans
+    Rails.logger.info("ARIF - TM::VM.mapped_lans entering...")
     @mapped_lans ||= Lan.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Lan').select(:source_id))
   end
 
   class VmMigrateStruct < MiqHashStruct
     def initialize(vm_name, vm, status, reason)
+    Rails.logger.info("ARIF - TM::VM::VMS.initialize entering...")
       options = {"name" => vm_name, "status" => status, "reason" => reason}
 
       if vm.present?

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -4,4 +4,122 @@ class TransformationMappingItem < ApplicationRecord
   belongs_to :destination, :polymorphic => true
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
-end
+
+  validates :destination_type,
+            :inclusion => { :in => %w[EmsCluster CloudTenant Storage Lan CloudVolumeType CloudNetwork] }
+
+  validate :destination_cluster, :if => -> { destination_type.casecmp?('EmsCluster') }
+  validate :source_cluster, :if => -> { source_type.casecmp?('EmsCluster') }
+
+  validate :destination_datastore, :if => lambda {
+                                            destination_type.casecmp?('Storage') ||
+                                              destination_type.casecmp?('CloudVolumeType')
+                                          }
+
+  validate :source_datastore, :if => -> { source_type.casecmp?('Storage') }
+
+  validate :destination_network, :if => lambda {
+                                          source_type.casecmp?('Lan') ||
+                                            source_type.casecmp?('CloudNetwork')
+                                        }
+  validate :source_network,      :if => -> { destination_type.casecmp?('Lan') }
+
+  VALID_SOURCE_CLUSTER_PROVIDERS    = %w[vmwarews].freeze
+  VALID_DESTINATION_CLUSTER_TYPES   = %w[rhevm].freeze
+
+  VALID_SOURCE_DATASTORE_TYPES      = %w[Storage].freeze
+  VALID_DESTINATION_DATASTORE_TYPES = %w[Storage CloudVolumeType].freeze
+
+  VALID_SOURCE_NETWORK_TYPES        = %w[Lan].freeze
+  VALID_DESTINATION_NETWORK_TYPES   = %w[Lan CloudNetwork].freeze
+
+  private
+
+  # Validator used if the source type is an EMS cluster. In this case, both
+  # the source and target types must be validated.
+  #
+  # Note that the validation here for the target is more flexible than the
+  # target_cluster validator since it allows either an EmsCluster or CloudTenant.
+  #
+  def source_cluster
+    unless VALID_SOURCE_CLUSTER_PROVIDERS.include?(source.ext_management_system.emstype)
+      source_types = VALID_SOURCE_CLUSTER_PROVIDERS.join(', ')
+      errors.add(:source_type, "EMS type of source cluster must be in: #{source_types}")
+    end
+
+    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination.ext_management_system.emstype)
+      destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
+      errors.add(:destination_type, "Class of target cluster must be in: #{destination_types}")
+    end
+  end # of source_cluster
+
+  # Validator used if the target is an EMS cluster. This is more specific than
+  # the source_cluster validation because here it only validates against
+  # EmsCluster types.
+  #
+  def destination_cluster
+    unless VALID_DESTINATION_CLUSTER_TYPES.include?(destination.ext_management_system.emstype)
+      destination_types = VALID_DESTINATION_CLUSTER_TYPES.join(', ')
+      errors.add(:destination_type, "EMS type of target cluster must be in: #{destination_types}")
+    end
+  end # of destination_cluster
+
+  # How to check the datastore(s) belong to the source.
+  #
+  def source_datastore
+    source_storage = source
+
+    cluster_storages = source.hosts # Get hosts using this source storage
+                             .collect(&:ems_cluster) # How many clusters does each host has
+                             .collect(&:storages).flatten # How many storages each host is mapped to that belong to the cluster
+
+    unless cluster_storages.include?(source_storage)
+      storage_types = VALID_SOURCE_DATASTORE_TYPES.join(', ')
+      errors.add(:storage_type, "The type of destination type must be in: #{storage_types}")
+    end
+  end # of source_datastore
+
+  # check if destination storage belongs to the cluster
+  #
+  def destination_datastore
+    destination_storage = destination
+
+    cluster_storages = destination.hosts # Get hosts using this source storage
+                                  .collect(&:ems_cluster) # How many clusters does each host has
+                                  .collect(&:storages).flatten # How many storages each host is mapped to that belong to the cluster
+
+    unless cluster_storages.include?(destination_storage)
+      store_types = VALID_DESTINATION_DATASTORE_TYPES.join(', ')
+      errors.add(:store_type, "The type of destination type must be in: #{store_types}")
+    end
+  end # of destination_datastore
+
+  # Verify that Network type is LAN and belongs the source cluster .
+  #
+  def source_network
+    source_lan       = source
+    ems_cluster_lans = source_lan.switch.host.ems_cluster.lans.flatten
+    logger.info("******* source_cluster_lans: " + ems_cluster_lans.inspect)
+    logger.info("******* source_cluster_lans_count: " + ems_cluster_lans.count.to_s)
+
+    unless ems_cluster_lans.include?(source_lan)
+      network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
+      errors.add(:network_types, "The network type must be in: #{network_types}")
+    end
+  end # of source_network
+
+  # Verify that Network type is LAN or CloudNetwork and belongs the destination cluster.
+  #
+  def destination_network
+    destination_lan = destination
+    ems_cluster_lans = destination_lan.switch.host.ems_cluster.lans.flatten
+
+    logger.info("******* destination_cluster_lans: " + ems_cluster_lans.inspect)
+    logger.info("******* destination_cluster_lans_count: " + ems_cluster_lans.count.to_s)
+
+    unless ems_cluster_lans.include?(destination_lan)
+      network_types = VALID_SOURCE_NETWORK_TYPES.join(', ')
+      errors.add(:network_types, "The network type must be in: #{network_types}")
+    end
+  end # of destination_network
+end # of class

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -407,7 +407,7 @@
         :feature_type: admin
         :identifier: service_delete
       - :name: Set Ownership
-        :description: Set Ownership of VMs
+        :description: Set Ownership of Services
         :feature_type: control
         :identifier: service_ownership
       - :name: Reconfigure Services

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -256,6 +256,10 @@
         :description: Remove Catalog Items
         :feature_type: admin
         :identifier: catalogitem_delete
+      - :name: Set Ownership
+        :description: Set Ownership of Catalog Item
+        :feature_type: control
+        :identifier: catalogitem_ownership
       - :name: Edit Composite Catalog Item
         :description: Edit a Composite Catalog Item
         :feature_type: admin

--- a/lib/uuid_mixin.rb
+++ b/lib/uuid_mixin.rb
@@ -1,7 +1,7 @@
 module UuidMixin
   extend ActiveSupport::Concern
   included do
-    default_value_for(:guid, :allows_nil => false) { SecureRandom.uuid }
+    default_value_for(:guid) { SecureRandom.uuid }
     validates :guid,  :uniqueness => true, :presence => true
   end
 

--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -36,6 +36,18 @@ module Vmdb
       "#{self.PRODUCT_NAME}/#{self.VERSION}".freeze
     end
 
+    def self.check_automate_disk_version_against_db(fh)
+      ae_domains = MiqAeDomain.where(:source => MiqAeDomain::SYSTEM_SOURCE)
+      ae_domains.each do |domain|
+        if domain.version.blank? || domain.available_version.blank?
+          fh.warn("Cannot check #{domain.name} Automate domain version because version information not found")
+        elsif domain.version != domain.available_version
+          fh.warn("#{domain.name} domain version on disk differs from db version:")
+          fh.warn("Current version - #{domain.version}, Available version - #{domain.available_version}")
+        end
+      end
+    end
+
     def self.log_config(*args)
       options = args.extract_options!
       fh = options[:logger] || $log
@@ -50,6 +62,7 @@ module Vmdb
       fh.info("Codename: #{self.CODENAME}")
       fh.info("RUBY Environment:  #{Object.const_defined?(:RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE} patchlevel #{RUBY_PATCHLEVEL}) [#{RUBY_PLATFORM}]"}")
       fh.info("RAILS Environment: #{Rails.env} version #{Rails.version}")
+      check_automate_disk_version_against_db(fh)
 
       fh.info("VMDB settings:")
       VMDBLogger.log_hashes(fh, ::Settings, :filter => Vmdb::Settings::PASSWORD_FIELDS)

--- a/spec/factories/switch.rb
+++ b/spec/factories/switch.rb
@@ -1,3 +1,4 @@
 FactoryBot.define do
-  factory :switch_vmware, :class => 'ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch'
+  factory :switch # generic needed for transformation_mapping_item_spec.rb
+  factory :switch_vmware, :class => 'ManageIQ::Providers::Vmware::InfraManager::HostVirtualSwitch', :parent => :switch
 end

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -46,6 +46,7 @@ describe EvmDatabaseOps do
 
     it "without enough free space" do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(file_storage).to receive(:class).and_return(MiqSmbSession)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(100.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(200.megabytes)
       expect { EvmDatabaseOps.backup(@db_opts, @connect_opts) }.to raise_error(MiqException::MiqDatabaseBackupInsufficientSpace)
@@ -74,6 +75,8 @@ describe EvmDatabaseOps do
       allow(described_class).to receive(:backup_file_name).and_return("miq_backup")
       expect(PostgresAdmin).to receive(:backup).with(run_db_ops)
 
+      allow(file_storage).to receive(:class).and_return(MiqSmbSession)
+
       log_stub = instance_double("_log")
       expect(described_class).to receive(:_log).twice.and_return(log_stub)
       expect(log_stub).to        receive(:info).with(any_args)
@@ -88,8 +91,8 @@ describe EvmDatabaseOps do
     before do
       @connect_opts = {:username => 'blah', :password => 'blahblah', :uri => "smb://myserver.com/share"}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
-      allow(MiqSmbSession).to receive(:runcmd)
       allow(file_storage).to  receive(:settings_mount_point).and_return(tmpdir)
+      allow(file_storage).to  receive(:uri_to_local_path).and_return(tmpdir.join("share").to_s)
       allow(file_storage).to  receive(:add).and_yield(input_path)
 
       allow(MiqUtil).to        receive(:runcmd)
@@ -122,6 +125,7 @@ describe EvmDatabaseOps do
 
     it "without enough free space" do
       EvmSpecHelper.create_guid_miq_server_zone
+      allow(file_storage).to receive(:class).and_return(MiqSmbSession)
       allow(EvmDatabaseOps).to receive(:backup_destination_free_space).and_return(100.megabytes)
       allow(EvmDatabaseOps).to receive(:database_size).and_return(200.megabytes)
       expect(PostgresAdmin).to receive(:backup_pg_dump).never
@@ -149,8 +153,6 @@ describe EvmDatabaseOps do
       @connect_opts = {:username => 'blah', :password => 'blahblah'}
       @db_opts =      {:dbname => 'vmdb_production', :username => 'root'}
 
-      allow(MiqSmbSession).to receive(:runcmd)
-      allow(MiqSmbSession).to receive(:raw_disconnect)
       allow(file_storage).to  receive(:settings_mount_point).and_return(tmpdir)
       allow(file_storage).to  receive(:magic_number_for).and_return(:pgdump)
       allow(file_storage).to  receive(:download).and_yield(input_path)

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -237,4 +237,9 @@ describe Vmdb::Plugins do
       end
     end
   end
+
+  it "all plugins will implement .plugin_name" do
+    bad_plugins = described_class.select { |plugin| plugin.try(:plugin_name).blank? }
+    expect(bad_plugins).to be_empty
+  end
 end

--- a/spec/models/arif_test_spec.rb
+++ b/spec/models/arif_test_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe TransformationMapping, :v2v do
+  let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+  let(:ems_vmware) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
+
+  let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
+  let(:dst) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
+  let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src) }
+
+  let(:mapping) do
+    FactoryBot.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+    )
+  end
+
+  let(:arifs_mapping) do
+    FactoryBot.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+    )
+  end
+
+  logger = Rails.logger
+
+  describe '#search_vms_and_validate' do
+
+    let(:source_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
+    let(:source_storage) { FactoryBot.create(:storage, :hosts => [source_host] ) }
+
+    let(:destination_storage) { FactoryBot.create(:storage) }
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
+    let(:destination_storage) { FactoryBot.create(:storage, :hosts => [destination_host] ) }
+
+    let(:source_cluster) { FactoryBot.create(:ems_cluster ) }
+    let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
+    let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
+    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch)}
+
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
+    let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
+    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch)}
+
+    let(:arifs_vm) { FactoryBot.create(:vm_vmware, :name => 'arifs_test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:vm2) { FactoryBot.create(:vm_vmware, :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+    let(:inactive_vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src, :ext_management_system => nil) }
+    let(:nic) { FactoryBot.create(:guest_device_nic, :lan => source_lan) }
+
+    before do
+    end
+
+    context 'with VM list' do
+      logger.info("CONTEXT: with VM list")
+      it 'returns valid vms' do
+        logger.info("TESTCASE: returns valid vms" )
+        result = arifs_mapping.search_vms_and_validate(['name' => arifs_vm.name])
+        expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
+        expect(result['valid'].first.ems_cluster_id).to eq(vm.ems_cluster_id.to_s)
+      end
+
+    end
+=begin
+    context 'without VM list' do
+      logger.info("CONTEXT: without VM list")
+      it 'returns valid vms' do
+        logger.info("TESTCASE: returns valid vms" )
+        result = mapping.search_vms_and_validate
+
+        Rails.logger.info("ARIF - mapping in \"without VM list returns valid VMs\": " + mapping.to_s)
+
+        expect(result['valid'].count).to eq(1)
+        # expect(result['valid'].count).to eq(0)
+      end
+
+      it 'skips invalid vms' do
+        logger.info("TESTCASE: skips invalid vms" )
+        FactoryBot.create(
+          :vm_vmware,
+          :name                  => 'vm2',
+          :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
+          :ext_management_system => FactoryBot.create(:ext_management_system)
+        )
+        Rails.logger.info("ARIF - mapping in \"without VM list - skips invalid VMs\": " + mapping.to_s)
+
+        result = mapping.search_vms_and_validate
+
+        Rails.logger.info("ARIF - mapping in \"without VM list - skips invalid VMs\": " + mapping.to_s)
+        expect(result['valid'].count).to eq(1) # original
+        # expect(result['valid'].count).to eq(0)
+      end
+    end
+=end
+  end
+end

--- a/spec/models/arif_test_spec.rb
+++ b/spec/models/arif_test_spec.rb
@@ -23,25 +23,24 @@ RSpec.describe TransformationMapping, :v2v do
   logger = Rails.logger
 
   describe '#search_vms_and_validate' do
-
-    let(:source_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
-    let(:source_storage) { FactoryBot.create(:storage, :hosts => [source_host] ) }
+    let(:source_storage) { FactoryBot.create(:storage, :hosts => [source_host]) }
 
     let(:destination_storage) { FactoryBot.create(:storage) }
-    let(:destination_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
-    let(:destination_storage) { FactoryBot.create(:storage, :hosts => [destination_host] ) }
+    let(:destination_storage) { FactoryBot.create(:storage, :hosts => [destination_host]) }
 
-    let(:source_cluster) { FactoryBot.create(:ems_cluster ) }
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
     let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
-    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch)}
+    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch) }
 
     let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
     let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
-    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch)}
+    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch) }
 
     let(:arifs_vm) { FactoryBot.create(:vm_vmware, :name => 'arifs_test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
     let(:vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
@@ -55,43 +54,40 @@ RSpec.describe TransformationMapping, :v2v do
     context 'with VM list' do
       logger.info("CONTEXT: with VM list")
       it 'returns valid vms' do
-        logger.info("TESTCASE: returns valid vms" )
+        logger.info("TESTCASE: returns valid vms")
         result = arifs_mapping.search_vms_and_validate(['name' => arifs_vm.name])
         expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
         expect(result['valid'].first.ems_cluster_id).to eq(vm.ems_cluster_id.to_s)
       end
-
     end
-=begin
-    context 'without VM list' do
-      logger.info("CONTEXT: without VM list")
-      it 'returns valid vms' do
-        logger.info("TESTCASE: returns valid vms" )
-        result = mapping.search_vms_and_validate
-
-        Rails.logger.info("ARIF - mapping in \"without VM list returns valid VMs\": " + mapping.to_s)
-
-        expect(result['valid'].count).to eq(1)
-        # expect(result['valid'].count).to eq(0)
-      end
-
-      it 'skips invalid vms' do
-        logger.info("TESTCASE: skips invalid vms" )
-        FactoryBot.create(
-          :vm_vmware,
-          :name                  => 'vm2',
-          :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
-          :ext_management_system => FactoryBot.create(:ext_management_system)
-        )
-        Rails.logger.info("ARIF - mapping in \"without VM list - skips invalid VMs\": " + mapping.to_s)
-
-        result = mapping.search_vms_and_validate
-
-        Rails.logger.info("ARIF - mapping in \"without VM list - skips invalid VMs\": " + mapping.to_s)
-        expect(result['valid'].count).to eq(1) # original
-        # expect(result['valid'].count).to eq(0)
-      end
-    end
-=end
+    #     context 'without VM list' do
+    #       logger.info("CONTEXT: without VM list")
+    #       it 'returns valid vms' do
+    #         logger.info("TESTCASE: returns valid vms" )
+    #         result = mapping.search_vms_and_validate
+    #
+    #         Rails.logger.info("ARIF - mapping in \"without VM list returns valid VMs\": " + mapping.to_s)
+    #
+    #         expect(result['valid'].count).to eq(1)
+    #         # expect(result['valid'].count).to eq(0)
+    #       end
+    #
+    #       it 'skips invalid vms' do
+    #         logger.info("TESTCASE: skips invalid vms" )
+    #         FactoryBot.create(
+    #           :vm_vmware,
+    #           :name                  => 'vm2',
+    #           :ems_cluster           => FactoryBot.create(:ems_cluster, :name => 'cluster1'),
+    #           :ext_management_system => FactoryBot.create(:ext_management_system)
+    #         )
+    #         Rails.logger.info("ARIF - mapping in \"without VM list - skips invalid VMs\": " + mapping.to_s)
+    #
+    #         result = mapping.search_vms_and_validate
+    #
+    #         Rails.logger.info("ARIF - mapping in \"without VM list - skips invalid VMs\": " + mapping.to_s)
+    #         expect(result['valid'].count).to eq(1) # original
+    #         # expect(result['valid'].count).to eq(0)
+    #       end
+    #     end
   end
 end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -282,7 +282,8 @@ RSpec.describe ConversionHost, :v2v do
         enable_extra_vars = {
           :v2v_host_type        => 'openstack',
           :v2v_transport_method => 'ssh',
-          :v2v_ssh_private_key  => 'fake ssh private key'
+          :v2v_ssh_private_key  => 'fake ssh private key',
+          :v2v_ca_bundle        => 'fake CA bundle'
         }
         check_extra_vars = {
           :v2v_host_type        => 'openstack',
@@ -290,7 +291,7 @@ RSpec.describe ConversionHost, :v2v do
         }
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(enable_playbook, enable_extra_vars, nil)
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, nil)
-        conversion_host.enable_conversion_host_role(nil, 'fake ssh private key')
+        conversion_host.enable_conversion_host_role(nil, 'fake ssh private key', 'fake CA bundle')
       end
     end
   end

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
+RSpec.describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
   include Spec::Support::WorkflowHelper
 
   let(:admin) { FactoryBot.create(:user_with_group) }
@@ -31,7 +31,6 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
     it "should retrieve cloud-init templates when cloning" do
       options = {'key' => 'value' }
-      allow(workflow).to receive(:supports_native_clone?).and_return(true)
 
       result = workflow.allowed_customization_templates(options)
       customization_template = workflow.instance_variable_get(:@values)[:customization_template_script]
@@ -46,7 +45,6 @@ describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
 
     it "should retrieve sysprep templates when cloning" do
       options = {'key' => 'value' }
-      allow(sysprep_workflow).to receive(:supports_native_clone?).and_return(true)
       allow(sysprep_workflow).to receive(:supports_sysprep?).and_return(true)
       allow(sysprep_workflow).to receive(:load_ar_obj).and_return(template)
       allow(template).to receive(:platform).and_return('windows')

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -1,4 +1,4 @@
-describe InterRegionApiMethodRelay do
+RSpec.describe InterRegionApiMethodRelay do
   let(:collection_name) { :test_class_collection }
   let(:api_config)      { double("Api::CollectionConfig") }
 
@@ -8,7 +8,12 @@ describe InterRegionApiMethodRelay do
       allow(api_config).to receive(:name_for_klass).and_return(collection_name)
 
       Class.new do
+        include ActiveRecord::IdRegions
         extend InterRegionApiMethodRelay
+
+        def id
+          1
+        end
 
         def self.name
           "RegionalMethodRelayTestClass"

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe 'Tests transformation items', :v2v do
+  let(:ems_redhat) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+  let(:ems_vmware) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
+
+  let(:ext_management_system)  { FactoryBot.create(:ext_management_system) }
+  let(:host)                   { FactoryBot.create(:host) }
+  let(:storage)                { FactoryBot.create(:storage) }
+
+  let(:storage) { FactoryBot.create(:storage) }
+  let(:lan) { FactoryBot.create(:lan) }
+
+  # only vmware source is supported for migration
+  context "Cluster validation" do
+    let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
+    let(:dst) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst) }
+    it "Source is valid" do
+      expect(tmi).to be_valid
+    end
+    it "Destination is valid" do
+      expect(tmi).to be_valid
+    end
+  end # end of cluster context
+
+  context "Storage validation" do
+    # todo
+    # 1.  Create a host
+    # 2.  Add host to a cluster
+    # 3.  Add cluster to a storage
+    let(:source_storage) { FactoryBot.create(:storage) }
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
+    let(:src) { FactoryBot.create(:storage, :hosts => [source_host]) }
+
+    let(:destination_storage) { FactoryBot.create(:storage) }
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
+    let(:dst) { FactoryBot.create(:storage, :hosts => [destination_host]) }
+
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => src, :destination => dst) }
+
+    # add the src storage to the source cluster, then call valid
+    before do
+      allow(source_cluster).to receive(:storages).and_return([src])
+    end
+    it "Source datastore is valid" do
+      expect(tmi.valid?).to be true
+    end
+
+    # add the dst storage to the destination cluster, then call valid
+    before do
+      allow(destination_cluster).to receive(:storages).and_return([dst])
+    end
+    it "Destination datastore is valid" do
+      expect(tmi.valid?).to be true
+    end
+  end # end of storage context
+
+  context "Lan validation" do
+    # todo
+    # 1. Create a cluster
+    # 2. Add cluster to a host
+    # 3. Add host to a switch
+    # 4. Add switch to the lan
+
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
+    let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
+    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch) }
+
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
+    let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
+    let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
+    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch) }
+
+    let(:tmi) { FactoryBot.create(:transformation_mapping_item, :source => source_lan, :destination => destination_lan) }
+
+    before do
+      allow(source_cluster).to receive(:lans).and_return([source_lan])
+    end
+
+    it "Source is valid" do
+      expect(tmi).to be_valid
+    end
+
+    before do
+      allow(destination_cluster).to receive(:lans).and_return([destination_lan])
+    end
+    it "Destination is valid" do
+      expect(tmi).to be_valid
+    end
+  end # end of lan context
+end # describe

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe TransformationMapping, :v2v do
 
   describe '#destination' do
     it "finds the destination" do
-      logger.info("TESTCASE: finds the destination" )
+      logger.info("TESTCASE: finds the destination")
       expect(mapping.destination(src)).to eq(dst)
     end
 
     it "returns nil for unmapped source" do
-      logger.info("TESTCASE: returns nil for unmapped source" )
+      logger.info("TESTCASE: returns nil for unmapped source")
       expect(mapping.destination(FactoryBot.create(:ems_cluster))).to be_nil
     end
   end
@@ -32,31 +32,30 @@ RSpec.describe TransformationMapping, :v2v do
     before { FactoryBot.create(:service_resource, :resource => mapping, :service_template => plan) }
 
     it 'finds the transformation plans' do
-      logger.info("TESTCASE: finds the transformation plans" )
+      logger.info("TESTCASE: finds the transformation plans")
       expect(mapping.service_templates).to match([plan])
     end
   end
 
   describe '#search_vms_and_validate' do
-
-    let(:source_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
-    let(:source_storage) { FactoryBot.create(:storage, :hosts => [source_host] ) }
+    let(:source_storage) { FactoryBot.create(:storage, :hosts => [source_host]) }
 
     let(:destination_storage) { FactoryBot.create(:storage) }
-    let(:destination_cluster) { FactoryBot.create(:ems_cluster)}
+    let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
-    let(:destination_storage) { FactoryBot.create(:storage, :hosts => [destination_host] ) }
+    let(:destination_storage) { FactoryBot.create(:storage, :hosts => [destination_host]) }
 
-    let(:source_cluster) { FactoryBot.create(:ems_cluster ) }
+    let(:source_cluster) { FactoryBot.create(:ems_cluster) }
     let(:source_host) { FactoryBot.create(:host, :ems_cluster => source_cluster) }
     let(:source_switch) { FactoryBot.create(:switch, :host => source_host) }
-    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch)}
+    let(:source_lan) { FactoryBot.create(:lan, :switch => source_switch) }
 
     let(:destination_cluster) { FactoryBot.create(:ems_cluster) }
     let(:destination_host) { FactoryBot.create(:host, :ems_cluster => destination_cluster) }
     let(:destination_switch) { FactoryBot.create(:switch, :host => destination_host) }
-    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch)}
+    let(:destination_lan) { FactoryBot.create(:lan, :switch => destination_switch) }
 
     let(:vm) { FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
     let(:vm2) { FactoryBot.create(:vm_vmware, :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system)) }
@@ -70,13 +69,13 @@ RSpec.describe TransformationMapping, :v2v do
       vm.hardware = FactoryBot.create(:hardware, :guest_devices => [nic])
     end
 
-   context 'with VM list' do
+    context 'with VM list' do
       logger.info("CONTEXT: with VM list")
       it 'returns valid vms' do
-        logger.info("TESTCASE: returns valid vms" )
+        logger.info("TESTCASE: returns valid vms")
 
         this_vm = FactoryBot.create(:vm_vmware, :name => 'this_test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system))
-        this_mapping = FactoryBot.create(:transformation_mapping, :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)] )
+        this_mapping = FactoryBot.create(:transformation_mapping, :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)])
         result = this_mapping.search_vms_and_validate(['name' => this_vm.name])
 
         expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
@@ -84,7 +83,7 @@ RSpec.describe TransformationMapping, :v2v do
       end
 
       it 'returns conflict vms' do
-        logger.info("TESTCASE: returns conflict vms" )
+        logger.info("TESTCASE: returns conflict vms")
         FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryBot.create(:ext_management_system))
         result = mapping.search_vms_and_validate(['name' => vm.name])
         expect(result['conflicted'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_CONFLICT)
@@ -93,20 +92,20 @@ RSpec.describe TransformationMapping, :v2v do
       context 'returns invalid vms' do
         logger.info("CONTEXT: with VM list::returns invalid")
         it 'if VM does not exist' do
-          logger.info("TESTCASE: if VM does not exist" )
+          logger.info("TESTCASE: if VM does not exist")
           result = mapping.search_vms_and_validate(['name' => 'vm1'])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_NOT_EXIST)
         end
 
         it 'if VM is inactive' do
-          logger.info("TESTCASE: if VM is inactive" )
+          logger.info("TESTCASE: if VM is inactive")
           inactive_vm.storages << FactoryBot.create(:storage, :name => 'storage_for_inactive_vm')
           result = mapping.search_vms_and_validate(['name' => 'test_vm_inactive'])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_INACTIVE)
         end
 
         it "if VM's cluster is not in the mapping" do
-          logger.info("TESTCASE: if VM's cluster is not in the mapping" )
+          logger.info("TESTCASE: if VM's cluster is not in the mapping")
           FactoryBot.create(
             :vm_vmware,
             :name                  => 'vm2',
@@ -118,21 +117,21 @@ RSpec.describe TransformationMapping, :v2v do
         end
 
         it "if VM's storages are not all in the mapping" do
-          logger.info("TESTCASE: if VM's storages are not all in the mapping" )
+          logger.info("TESTCASE: if VM's storages are not all in the mapping")
           vm.storages << FactoryBot.create(:storage, :name => 'storage2')
           result = mapping.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2/)
         end
 
         it "if VM's lans are not all in the mapping" do
-          logger.info("TESTCASE: if VM's lans are not all in the mapping" )
+          logger.info("TESTCASE: if VM's lans are not all in the mapping")
           vm.hardware.guest_devices << FactoryBot.create(:guest_device_nic, :lan =>FactoryBot.create(:lan, :name => 'lan2'))
           result = mapping.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - lans: lan2/)
         end
 
         it "if any source is invalid" do
-          logger.info("TESTCASE: if any source is invalid" )
+          logger.info("TESTCASE: if any source is invalid")
           vm.storages << FactoryBot.create(:storage, :name => 'storage2')
           vm.hardware.guest_devices << FactoryBot.create(:guest_device_nic, :lan =>FactoryBot.create(:lan, :name => 'lan2'))
           result = mapping.search_vms_and_validate(['name' => vm.name])
@@ -140,8 +139,8 @@ RSpec.describe TransformationMapping, :v2v do
         end
 
         it 'if VM is in another migration plan' do
-          logger.info("TESTCASE: if VM is in another migration plan" )
-          %w(Queued Approved Active).each do |status|
+          logger.info("TESTCASE: if VM is in another migration plan")
+          %w[Queued Approved Active].each do |status|
             FactoryBot.create(
               :service_resource,
               :resource         => vm,
@@ -155,7 +154,7 @@ RSpec.describe TransformationMapping, :v2v do
         end
 
         it 'if VM has been migrated' do
-          logger.info("TESTCASE: if VM has been migrated" )
+          logger.info("TESTCASE: if VM has been migrated")
           FactoryBot.create(
             :service_resource,
             :resource         => vm,
@@ -167,13 +166,12 @@ RSpec.describe TransformationMapping, :v2v do
           expect(result['invalid'].first.reason).to match(/migrated/)
         end
       end
-
     end
 
     context 'with VM list and service_template_id' do
       logger.info("CONTEXT: with VM list and service_template_it")
       it 'returns valid vms when a ServiceTemplate record is edited with CSV containing the same VM already included in the ServiceTemplate record' do
-        logger.info("TESTCASE: returns valid vms when a ServiceTemplate record is edited with CSV containing the same VM already included in the ServiceTemplate record" )
+        logger.info("TESTCASE: returns valid vms when a ServiceTemplate record is edited with CSV containing the same VM already included in the ServiceTemplate record")
         service_template = FactoryBot.create(:service_template_transformation_plan)
 
         FactoryBot.create(
@@ -187,7 +185,7 @@ RSpec.describe TransformationMapping, :v2v do
       end
 
       it 'returns invalid vms when the Service Template record is edited with CSV containing a different VM that belongs to a different ServiceTemplate record' do
-        logger.info("TESTCASE: returns invalid vms when the Service Template record is edited with CSV containing a different VM that belongs to a different ServiceTemplate record" )
+        logger.info("TESTCASE: returns invalid vms when the Service Template record is edited with CSV containing a different VM that belongs to a different ServiceTemplate record")
         service_template = FactoryBot.create(:service_template_transformation_plan)
         service_template2 = FactoryBot.create(:service_template_transformation_plan)
 
@@ -205,7 +203,7 @@ RSpec.describe TransformationMapping, :v2v do
     context 'without VM list' do
       logger.info("CONTEXT: without VM list")
       it 'returns valid vms' do
-        logger.info("TESTCASE: returns valid vms" )
+        logger.info("TESTCASE: returns valid vms")
         result = mapping.search_vms_and_validate
 
         Rails.logger.info("ARIF - mapping in \"without VM list returns valid VMs\": " + mapping.to_s)
@@ -215,7 +213,7 @@ RSpec.describe TransformationMapping, :v2v do
       end
 
       it 'skips invalid vms' do
-        logger.info("TESTCASE: skips invalid vms" )
+        logger.info("TESTCASE: skips invalid vms")
         FactoryBot.create(
           :vm_vmware,
           :name                  => 'vm2',


### PR DESCRIPTION
Though the PR says Storage, it contains validations for cluster and lans also

**Target Datastores**
	**RHV** (Class:  Storage, Filters:  Must belong to target cluster)
	**OSP** (Class:  CloudVolumeType, Filters:  Must belong to target CloudTenant's ExtManagementSystem)
**Source Datastores**
	**VMW** (Class:  Storage, Filters:  Must belong to one of the source clusters)
