### PR TITLE
EvmDatabase spec - test that actual unmocked seed won't throw

### DIFF
--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -42,6 +42,13 @@ describe EvmDatabase do
     it "will fail if a class does not respond to .seed" do
       expect { described_class.seed(["VmOrTemplate"]) }.to raise_error(ArgumentError, /do not respond to seed/)
     end
+
+    # this spec takes about 30 seconds but is the only check that db:seed won't fail
+    it "doesn't fail" do
+      expect do
+        described_class.seed
+      end.not_to raise_error
+    end
   end
 
   describe ".seed_primordial" do


### PR DESCRIPTION
This adds a spec that actually runs `EvmDatabase.seed`, and fails if it throws.
This is to prevent situations where `rake db:seed` is broken but all tests are green.

It's a bit of a time hog unfortunately:

before:
```
$ be rspec spec/lib/evm_database_spec.rb
...
Finished in 0.82741 seconds (files took 6.38 seconds to load)
20 examples, 0 failures
```

now:
```
Finished in 29.78 seconds (files took 7.59 seconds to load)
21 examples, 0 failures
```

But, crucially, it does catch problems like the recent `db:seed` breakage introduced by https://github.com/ManageIQ/manageiq/pull/18778 and fixed in https://github.com/ManageIQ/manageiq-providers-ovirt/pull/370.

Without the fix:

```
  1) EvmDatabase.seed doesn't fail
     Failure/Error:
       expect do
         described_class.seed
       end.not_to raise_error
     
       expected no Exception, got #<NoMethodError: undefined method `position' for nil:NilClass> with backtrace:
         # ./lib/services/dialog_import_service.rb:179:in `block in absolute_position'
         # ./lib/services/dialog_import_service.rb:177:in `collect'
         # ./lib/services/dialog_import_service.rb:177:in `absolute_position'
         # ./lib/services/dialog_import_service.rb:164:in `build_old_association_list'
         # ./lib/services/dialog_import_service.rb:154:in `block in import_from_dialogs'
         # ./lib/services/dialog_import_service.rb:143:in `each'
         # ./lib/services/dialog_import_service.rb:143:in `import_from_dialogs'
         # ./lib/services/dialog_import_service.rb:41:in `import_all_service_dialogs_from_yaml_file'
         # ./app/models/dialog.rb:26:in `block (2 levels) in seed'
         # ./app/models/dialog.rb:25:in `each'
         # ./app/models/dialog.rb:25:in `block in seed'
         # ./lib/vmdb/plugins.rb:23:in `each'
         # ./lib/vmdb/plugins.rb:23:in `each'
         # ./lib/vmdb/plugins.rb:11:in `method_missing'
         # ./app/models/dialog.rb:24:in `seed'
         # ./lib/evm_database.rb:94:in `block (4 levels) in seed_classes'
         # ./lib/evm_database.rb:94:in `block (3 levels) in seed_classes'
         # ./lib/evm_database.rb:92:in `each'
         # ./lib/evm_database.rb:92:in `block (2 levels) in seed_classes'
         # ./lib/extensions/ar_table_lock.rb:21:in `block (2 levels) in with_lock'
         # ./lib/extensions/ar_table_lock.rb:21:in `block in with_lock'
         # ./lib/extensions/ar_table_lock.rb:15:in `with_lock'
         # ./lib/evm_database.rb:91:in `block in seed_classes'
         # ./lib/evm_database.rb:89:in `seed_classes'
         # ./lib/evm_database.rb:62:in `seed'
         # ./spec/lib/evm_database_spec.rb:48:in `block (4 levels) in <top (required)>'
         # ./spec/lib/evm_database_spec.rb:47:in `block (3 levels) in <top (required)>'
     # ./spec/lib/evm_database_spec.rb:47:in `block (3 levels) in <top (required)>'
```

Cc @Fryguy 