### PR TITLE
Allow orch stacks, templates, cloud managers thru add_resource

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -139,6 +139,10 @@ module ManageIQ::Providers
       CloudTenant.create_cloud_tenant(self, options)
     end
 
+    def valid_service_orchestration_resource
+      true
+    end
+
     def self.display_name(number = 1)
       n_('Cloud Manager', 'Cloud Managers', number)
     end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -115,6 +115,10 @@ class OrchestrationStack < ApplicationRecord
     raise NotImplementedError, _("raw_update_stack must be implemented in a subclass")
   end
 
+  def valid_service_orchestration_resource
+    true
+  end
+
   def my_zone
     ext_management_system.try(:my_zone)
   end

--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -81,6 +81,10 @@ class OrchestrationTemplate < ApplicationRecord
     joins(:stacks).distinct
   end
 
+  def valid_service_orchestration_resource
+    true
+  end
+
   # Find all not in use thus editable templates
   def self.not_in_use
     includes(:stacks).where(:orchestration_stacks => {:orchestration_template_id => nil})

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -100,7 +100,7 @@ class ServiceOrchestration < Service
   end
 
   def add_resource(rsc, _options = {})
-    raise "Service Orchestration subclass does not support add_resource for #{rsc.class.name}" unless rsc.kind_of?(OrchestrationStack)
+    raise "Service Orchestration subclass does not support add_resource for #{rsc.class.name}" unless rsc.try(:valid_service_orchestration_resource)
     super
   end
 


### PR DESCRIPTION
Otherwise Heat template orch services won't provision. 

We over-limited what could be added to orch_services originally only to OrchestrationStacks because people were trying to add vms with add_resource, and things should be added to the stack, not the service, mostly. GM caught that we'd be overlimiting: https://github.com/ManageIQ/manageiq/pull/18358#discussion_r251974898 so this just fixes that. 

Bz is here: https://bugzilla.redhat.com/show_bug.cgi?id=1711828