### PR TITLE
Remove invalid partial for local_db_finders_spec

### DIFF
--- a/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/local_db_finders_spec.rb
@@ -4,7 +4,7 @@ require_relative 'helpers/spec_parsed_data'
 require_relative 'test_persister'
 require_relative 'targeted_refresh_spec_helper'
 
-describe ManageIQ::Providers::Inventory::Persister do
+RSpec.describe ManageIQ::Providers::Inventory::Persister do
   include SpecMockedData
   include SpecParsedData
   include TargetedRefreshSpecHelper
@@ -18,9 +18,6 @@ describe ManageIQ::Providers::Inventory::Persister do
     @ems  = FactoryBot.create(:ems_cloud,
                                :zone            => @zone,
                                :network_manager => FactoryBot.create(:ems_network, :zone => @zone))
-
-    allow(@ems.class).to receive(:ems_type).and_return(:mock)
-    allow(Settings.ems_refresh).to receive(:mock).and_return({})
   end
 
   before do


### PR DESCRIPTION
The `Settings.ems_refresh` returns a `Config::Options` object which doesn't respond to the `:mock` method without help, and so violates strict partial double validation.

Rather than reworking the returned object, I just removed it because it doesn't appear to actually do anything. Removing it caused no failures.