### PR TITLE
Remove invalid partial double in server_template_helper.rb.

### DIFF
--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -131,7 +131,7 @@ module Spec
       end
 
       def user_helper
-        @user = FactoryBot.create(:user_with_group, :name => 'Wilma', :userid => 'wilma')
+        @user = FactoryBot.create(:user_admin)
       end
     end
   end

--- a/spec/support/service_template_helper.rb
+++ b/spec/support/service_template_helper.rb
@@ -131,7 +131,6 @@ module Spec
       end
 
       def user_helper
-        allow_any_instance_of(User).to receive(:role).and_return("admin")
         @user = FactoryBot.create(:user_with_group, :name => 'Wilma', :userid => 'wilma')
       end
     end


### PR DESCRIPTION
The User model doesn't implement a `role` method, so the line `allow_any_instance_of(User).to receive(:role).and_return("admin")` violates strict partial verification. Removing it caused no failures.