### PR TITLE
[WIP] Add validation to model for FileDepots

### DIFF
--- a/app/models/mixins/file_depot_mixin.rb
+++ b/app/models/mixins/file_depot_mixin.rb
@@ -12,7 +12,7 @@ module FileDepotMixin
 
   included do
     include AuthenticationMixin
-    before_save :verify_uri_prefix_before_save
+    before_validation :verify_uri_prefix_before_save, :validate_depot_credentials
   end
 
   module ClassMethods

--- a/spec/models/pxe_menu_ipxe_spec.rb
+++ b/spec/models/pxe_menu_ipxe_spec.rb
@@ -87,8 +87,10 @@ PXEMENU
   end
 
   context "#synchronize_images" do
+    let(:auth) { FactoryBot.create(:authentication) }
+
     before do
-      @pxe_server = FactoryBot.create(:pxe_server)
+      @pxe_server = FactoryBot.create(:pxe_server, :authentications => [auth])
       @pxe_menu   = FactoryBot.create(:pxe_menu_ipxe, :contents => @contents, :pxe_server => @pxe_server)
     end
 

--- a/spec/models/pxe_menu_spec.rb
+++ b/spec/models/pxe_menu_spec.rb
@@ -130,8 +130,10 @@ PXEMENU
   end
 
   context "#synchronize" do
+    let(:auth) { FactoryBot.create(:authentication) }
+
     before do
-      @pxe_server = FactoryBot.create(:pxe_server)
+      @pxe_server = FactoryBot.create(:pxe_server, :authentications => [auth])
       allow(@pxe_server).to receive_messages(:read_file => @contents_ipxe)
     end
 


### PR DESCRIPTION
method `validate_depot_credentials` is not used anywhere but we can use it for validation when we are saving model which includes `FileDepotMixin` : `PxeServer`

cc @Hyperkid123 