### PR TITLE
Ensure our warning about db:reset/setup is first

### DIFF
--- a/lib/tasks/evm_dba.rake
+++ b/lib/tasks/evm_dba.rake
@@ -145,6 +145,12 @@ namespace :evm do
     desc "Resets the ManageIQ EVM Database (VMDB) of all tables, views and indices"
     task :reset => [:destroy, 'db:migrate']
 
+    # schema.rb doesn't support views which is used by metrics
+    task :db_setup_not_supported do
+      warn "db:setup and db:reset are not supported! Please use evm:db:reset, db:migrate, or test:vmdb:setup instead."
+      exit 1
+    end
+
     # Example usage:
     #   RAILS_ENV=production bin/rake evm:db:region -- --region 99
 
@@ -276,6 +282,5 @@ end
 
 Rake::Task["db:migrate"].enhance(["evm:db:environmentlegacykey"])
 
-Rake::Task["db:reset"].enhance do
-  warn "Caution: You ran db:reset which resets the DB from schema.rb. You probably want to re-run all the migrations with the current ruby/rails versions, so run bin/rake evm:db:reset instead."
-end
+Rake::Task["db:setup"].prerequisites.unshift("evm:db:db_setup_not_supported")
+Rake::Task["db:reset"].prerequisites.unshift("evm:db:db_setup_not_supported")


### PR DESCRIPTION
At some point, rails added other rake tasks as prerequisites to db:reset
and those would fail before our warning was run.  Ensure we're now first
in the prerequisite tasks, and that we exit 1 since loading from
schema.rb is completely unsupported.

@Fryguy left his coffee mug here so he clearly co-authored this ☕️ 🤣   ... tagging other people