### PR TITLE
[V2V] Use full class name in task context data for conversion hosts

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -32,9 +32,9 @@ module ConversionHost::Configurations
       # certain options while ignoring the rest. We also don't want to store
       # any ssh key information. Useful for a retry option in the UI, and
       # informational purposes in general.
-      #
+
       MiqTask.find(task_id).tap do |task|
-        params = params&.except(:task_id, :miq_task_id)
+        params = params&.except(:task_id, :miq_task_id)&.update(:resource_type => resource.class.name)
         hash = {:request_params => params&.reject { |key, _value| key.to_s.end_with?('private_key') }}
         task.context_data = hash
         task.save

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -35,6 +35,7 @@ module ConversionHost::Configurations
 
       MiqTask.find(task_id).tap do |task|
         params = params&.except(:task_id, :miq_task_id)&.update(:resource_type => resource.class.name)
+        params = params&.update(:auth_user => auth_user) if auth_user
         hash = {:request_params => params&.reject { |key, _value| key.to_s.end_with?('private_key') }}
         task.context_data = hash
         task.save

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe ConversionHost, :v2v do
 
       it "to queue with a task" do
         task_id = described_class.enable_queue(params)
-        expected_context_data = {:request_params => params.except(:resource)}
+        expected_context_data = {:request_params => params.except(:resource).update(:resource_type => vm.class.name)}
 
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
         expect(MiqQueue.first).to have_attributes(
@@ -134,7 +134,7 @@ RSpec.describe ConversionHost, :v2v do
 
       it "rejects ssh key information as context data" do
         task_id = described_class.enable_queue(params.merge(:conversion_host_ssh_private_key => 'xxx', :vmware_ssh_private_key => 'yyy'))
-        expected_context_data = {:request_params => params.except(:resource)}
+        expected_context_data = {:request_params => params.except(:resource).update(:resource_type => vm.class.name)}
 
         expect(MiqTask.find(task_id)).to have_attributes(:name => expected_task_action, :context_data => expected_context_data)
       end


### PR DESCRIPTION
Originally we set the `resource_type` to the full name, e.g. `ManageIQ::Providers::Redhat::InfraManager::Host`, so that we could take advantage of the `SupportsFeature` mixin. And so, we added a validation to force the issue.

However, that broke Rails polymorphic associations, so we changed the param internally to just the base name, e.g. host, in https://github.com/ManageIQ/manageiq/pull/18604.

Unfortunately, this also got saved in the context data for the associated task. The upshot is that when a user tries to use the "retry" button, which uses the context data to resubmit the request, there is a validation failure because the resource type is no longer the full name.

So, this PR restores the full resource type in the `context_data` of the associated task internally.

https://bugzilla.redhat.com/show_bug.cgi?id=1713394