### PR TITLE
[HAMMER] [V2V] Allow ssh auth for RHV

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -237,7 +237,7 @@ class ConversionHost < ApplicationRecord
     when 'AuthPrivateKey', 'AuthToken'
       return [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
     when 'AuthUseridPassword'
-      return[hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+      return [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
     else
       raise 'Unsupported authentication type: #{authentication.type}'
     end

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -239,7 +239,7 @@ class ConversionHost < ApplicationRecord
     when 'AuthUseridPassword'
       return [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
     else
-      raise 'Unsupported authentication type: #{authentication.type}'
+      raise "Unsupported authentication type: #{authentication.type}"
     end
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -232,17 +232,15 @@ class ConversionHost < ApplicationRecord
   end
 
   def miq_ssh_util_args
-    send("miq_ssh_util_args_#{resource.type.gsub('::', '_').downcase}")
-  end
-
-  def miq_ssh_util_args_manageiq_providers_redhat_inframanager_host
     authentication = find_credentials
-    [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
-  end
-
-  def miq_ssh_util_args_manageiq_providers_openstack_cloudmanager_vm
-    authentication = find_credentials
-    [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+    case authentication.type
+    when 'AuthPrivateKey'
+      return [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+    when 'AuthUseridPassword'
+      return[hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+    else
+      raise 'Unsupported authentication type: #{authentication.type}'
+    end
   end
 
   # Run the specified ansible playbook using the ansible-playbook command. The

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -234,7 +234,7 @@ class ConversionHost < ApplicationRecord
   def miq_ssh_util_args
     authentication = find_credentials
     case authentication.type
-    when 'AuthPrivateKey'
+    when 'AuthPrivateKey', 'AuthToken'
       return [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
     when 'AuthUseridPassword'
       return[hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]


### PR DESCRIPTION
Previously, RHV conversion hosts only supported userid/password authentication. With the conversion host management UI, we're now using SSH private key. This PR updates the method that build the MiqSshUtil args to not look at the provider type, but the authentication type.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1712135