### PR TITLE
Turn all non-leading chars in expression field model names into lowercase

### DIFF
--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -15,7 +15,7 @@ class MiqExpression::Target
     # {:model_name => 'User', :associations => ...}
     parsed_params = Hash[match.names.map(&:to_sym).zip(match.to_a[1..-1])]
     begin
-      parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize
+      parsed_params[:model_name] = parsed_params[:model_name].capitalize.classify.safe_constantize
     rescue LoadError # issues for case sensitivity (e.g.: VM vs vm)
       parsed_params[:model_name] = nil
     end


### PR DESCRIPTION
At the moment in the expression editor on VMs we don't ever turn the M lowercase, which means that that fails because the model name isn't found:

```parsed_params[:model_name] = parsed_params[:model_name].classify.safe_constantize``` with "VM" returns 
```LoadError: Unable to autoload constant VM, expected /Users/duhlmann/manageiq/app/models/vm.rb to define it```

(any field with VMs has the M capitalized when we come into the miq_expression things, presumably from the UI...)

so we should probably try to fix that instead of just returning a nil model name and breaking the field parsing.

I don't have a bug yet for this but there should be one. 