### PR TITLE
Update a service's lifecycle_state.

### DIFF
--- a/app/models/mixins/lifecycle_mixin.rb
+++ b/app/models/mixins/lifecycle_mixin.rb
@@ -1,0 +1,25 @@
+module LifecycleMixin
+  extend ActiveSupport::Concern
+
+  STATE_ERROR_PROVISIONING = 'error_in_provisioning'.freeze
+  STATE_PROVISIONED = 'provisioned'.freeze
+  STATE_PROVISIONING = 'provisioning'.freeze
+
+  def update_lifecycle_state
+    case miq_request.request_state
+    when "finished"
+      lifecycle_state = miq_request.status == 'Ok' ? STATE_PROVISIONED : STATE_ERROR_PROVISIONING
+      update(:lifecycle_state => lifecycle_state)
+    else
+      update(:lifecycle_state => STATE_PROVISIONING)
+    end
+  end
+
+  def provisioned?
+    lifecycle_state == STATE_PROVISIONED
+  end
+
+  def provision_failed?
+    lifecycle_state == STATE_ERROR_PROVISIONING
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -62,6 +62,7 @@ class Service < ApplicationRecord
   include ServiceMixin
   include OwnershipMixin
   include CustomAttributeMixin
+  include LifecycleMixin
   include NewWithTypeStiMixin
   include ProcessTasksMixin
   include TenancyMixin
@@ -88,6 +89,7 @@ class Service < ApplicationRecord
   default_value_for :display, false
   default_value_for :retired, false
   default_value_for :initiator, 'user'
+  default_value_for :lifecycle_state, 'unprovisioned'
 
   validates :display, :inclusion => { :in => [true, false] }
   validates :retired, :inclusion => { :in => [true, false] }

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -94,6 +94,7 @@ class ServiceTemplateProvisionTask < MiqRequestTask
       update_and_notify_parent(:message => message)
       queue_post_provision
     end
+    destination.update_lifecycle_state
   end
 
   def queue_post_provision
@@ -210,7 +211,10 @@ class ServiceTemplateProvisionTask < MiqRequestTask
 
   def task_finished
     service = destination
-    service.raise_provisioned_event unless service.nil?
+    return if service.nil?
+
+    service.raise_provisioned_event
+    service.update_lifecycle_state if miq_request_task.nil?
   end
 
   private

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -103,6 +103,7 @@ describe ServiceTemplateProvisionRequest do
     end
 
     it "generic service do_request" do
+      @task_1_1.destination = FactoryBot.create(:service)
       expect { @task_1_1.do_request }.not_to raise_error
       expect(@task_1_1.state).to eq('provisioned')
     end


### PR DESCRIPTION
Add lifecycle_state column to services to record a service's provision state. May be extended to the full lifecycle which contains provision, reconfigure and retirement.

Depends on https://github.com/ManageIQ/manageiq-schema/pull/374.
https://bugzilla.redhat.com/show_bug.cgi?id=1677571

@miq-bot assign @tinaafitz 
@miq-bot add_label enhancement, changelog/yes, services