### PR TITLE
Allow ssh auth for RHV

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -291,7 +291,7 @@ class ConversionHost < ApplicationRecord
     when 'AuthUseridPassword'
       [host, authentication.userid, authentication.password, nil, nil]
     else
-      raise 'Unsupported authentication type: #{authentication.type}'
+      raise "Unsupported authentication type: #{authentication.type}"
     end
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -283,12 +283,13 @@ class ConversionHost < ApplicationRecord
   # Collect appropriate authentication information based on the authentication type.
   #
   def miq_ssh_util_args
+    host = hostname || ipaddress
     authentication = find_credentials
     case authentication.type
     when 'AuthPrivateKey', 'AuthToken'
-      return [hostname || ipaddress, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
+      [host, authentication.userid, nil, nil, nil, { :key_data => authentication.auth_key, :passwordless_sudo => true }]
     when 'AuthUseridPassword'
-      return [hostname || ipaddress, authentication.userid, authentication.password, nil, nil]
+      [host, authentication.userid, authentication.password, nil, nil]
     else
       raise 'Unsupported authentication type: #{authentication.type}'
     end


### PR DESCRIPTION
Previously, RHV conversion hosts only supported userid/password authentication. With the conversion host management UI, we're now using SSH private key. This PR updates the method that build the MiqSshUtil args to not look at the provider type, but the authentication type.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1712135