### PR TITLE
[WIP] Attempt to update ar_migration_spec.rb

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,6 +1,6 @@
 module ArPglogicalMigrationHelper
   def self.discover_schema_migrations_ran_class
-    return unless ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
+    return unless ActiveRecord::Base.connection.data_source_exists?("schema_migrations_ran")
     Class.new(ActiveRecord::Base) do
       require 'active_record-id_regions'
       include ActiveRecord::IdRegions

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -1,7 +1,7 @@
 describe ArPglogicalMigrationHelper do
   shared_context "without the schema_migrations_ran table" do
     before do
-      allow(ActiveRecord::Base.connection).to receive(:table_exists?).with("schema_migrations_ran").and_return(false)
+      allow(ActiveRecord::Base.connection).to receive(:data_source_exists?).with("schema_migrations_ran").and_return(false)
     end
   end
 
@@ -23,7 +23,6 @@ describe ArPglogicalMigrationHelper do
         include_context "without the schema_migrations_ran table"
 
         it "does nothing" do
-          expect(ActiveRecord::SchemaMigration).not_to receive(:normalized_versions)
           described_class.update_local_migrations_ran("12345", :up)
         end
       end

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -23,6 +23,7 @@ describe ArPglogicalMigrationHelper do
         include_context "without the schema_migrations_ran table"
 
         it "does nothing" do
+          expect(ActiveRecord::SchemaMigration).not_to receive(:normalized_versions)
           described_class.update_local_migrations_ran("12345", :up)
         end
       end


### PR DESCRIPTION
I fix an rspec error for the `ArPglogicalMigrationHelper` module when partial double verification is turned on. This originally consisted of replacing the deprecated method `table_exists?` with `data_source_exists?`.

There is a slight semantic difference between the two (the former checks views and tables, the latter only tables), but I don't think that's the source of the error, since it fails with or without this change when strict double verification is turned on. See below:

```
<snip>
expected: ("schema_migrations_ran")
              got: ("schema_migrations")
        Please stub a default value first if message might be received with other args as well. 
     # ./spec/lib/extensions/ar_migration_spec.rb:27:in `block (5 levels) in <top (required)>'

Finished in 0.0827 seconds (files took 7.28 seconds to load)
1 example, 1 failure
```

By itself this wasn't that helpful, but there was another clue:

```
Failed examples:

rspec ./spec/lib/extensions/ar_migration_spec.rb:26 # ArPglogicalMigrationHelper with a region
seeded .update_local_migrations_ran without the schema_migrations_ran table does nothing
```

To replicate this, apply these changes and modify the `spec/spec_helper.rb` file as follows:

```
# ...
  config.mock_with :rspec do |c|
    c.allow_message_expectations_on_nil = false
    c.syntax = :expect
    c.verify_partial_doubles = true # <----- Add this
  end
```

Then run `bundle exec rspec spec/lib/extensions/ar_migration_spec.rb`

Looking for help.