### PR TITLE
Allow skipping initrd option in iPXE scripts

### DIFF
--- a/app/models/pxe_image_ipxe.rb
+++ b/app/models/pxe_image_ipxe.rb
@@ -1,14 +1,9 @@
 class PxeImageIpxe < PxeImage
   def build_pxe_contents(ks_access_path, ks_device)
-    new_kernel  = kernel.to_s.dup
-    new_kernel << " #{super}"
-
-    <<-PXE
-#!ipxe
-kernel #{new_kernel.strip}
-initrd #{initrd}
-boot
-PXE
+    pxe = "#!ipxe\n"
+    pxe << "kernel #{kernel} #{super}\n"
+    pxe << "initrd #{initrd}\n" if initrd.present?
+    pxe << "boot\n"
   end
 
   def self.pxe_server_filename(mac_address)

--- a/spec/models/pxe_image_ipxe_spec.rb
+++ b/spec/models/pxe_image_ipxe_spec.rb
@@ -3,11 +3,28 @@ describe PxeImageIpxe do
 
   context "#build_pxe_contents" do
     it "updates ks and ks_device options" do
-      expected_output = "#!ipxe\nkernel ubuntu-10.10-desktop-i386/vmlinuz vga=788 -- quiet ks=http://1.1.1.1/ ksdevice=00:00:00:00:00:00\ninitrd \nboot\n"
+      expected_output = <<~PXE_SCRIPT
+        #!ipxe
+        kernel ubuntu-10.10-desktop-i386/vmlinuz vga=788 -- quiet ks=http://1.1.1.1/ ksdevice=00:00:00:00:00:00
+        boot
+      PXE_SCRIPT
 
       image.kernel_options += " ks=abc ksdevice="
 
       expect(image.build_pxe_contents("http://1.1.1.1/", "00:00:00:00:00:00")).to eq(expected_output)
+    end
+
+    it "inserts initrd option if present" do
+      expected_output = <<~PXE_SCRIPT
+        #!ipxe
+        kernel ubuntu-10.10-desktop-i386/vmlinuz vga=788 -- quiet ks=http://1.2.3.4/ ksdevice=12:34:56:78:90:ab
+        initrd /path/to/init.rd
+        boot
+      PXE_SCRIPT
+
+      image.initrd = "/path/to/init.rd"
+
+      expect(image.build_pxe_contents("http://1.2.3.4/", "12:34:56:78:90:ab")).to eq(expected_output)
     end
   end
 end


### PR DESCRIPTION
Previously, when we generated the MAC-specific iPXE script, we unconditionally added the initrd command into it. Calling initrd command without a parameter is not fatal, but it does pollute the
boot logs unnecessarily.

In this commit, we added simple if clause to the code, responsible for generating the iPXE scripts, that leaves out the initrd command if the PxeImage has initrd field set to nil.

Note that the code for generating the PXELINUX menus already had this condition in place.