### PR TITLE
support AWS STS assume role feature

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -158,19 +158,25 @@ module AuthenticationMixin
     # Invoke before callback
     before_update_authentication if self.respond_to?(:before_update_authentication) && options[:save]
 
-    is_amazon = kind_of?(ManageIQ::Providers::Amazon::CloudManager)
-
     data.each_pair do |type, value|
       cred = authentication_type(type)
       current = {:new => nil, :old => nil}
 
       unless value.key?(:userid) && value[:userid].blank?
-        current[:new] = {:user => value[:userid], :password => value[:password], :auth_key => value[:auth_key]}
-        current[:new][:service_account] = value[:service_account].presence if is_amazon
+        current[:new] = {
+          :user            => value[:userid],
+          :password        => value[:password],
+          :auth_key        => value[:auth_key],
+          :service_account => value[:service_account].presence,
+        }
       end
       if cred
-        current[:old] = {:user => cred.userid, :password => cred.password, :auth_key => cred.auth_key}
-        current[:old][:service_account] = cred.service_account if is_amazon
+        current[:old] = {
+          :user            => cred.userid,
+          :password        => cred.password,
+          :auth_key        => cred.auth_key,
+          :service_account => cred.service_account,
+        }
       end
 
       # Raise an error if required fields are blank
@@ -203,10 +209,10 @@ module AuthenticationMixin
                                             :type => "AuthUseridPassword")
         end
       end
-      cred.userid = value[:userid]
-      cred.password = value[:password]
-      cred.auth_key = value[:auth_key]
-      cred.service_account = value[:service_account].presence if is_amazon
+      cred.userid          = value[:userid]
+      cred.password        = value[:password]
+      cred.auth_key        = value[:auth_key]
+      cred.service_account = value[:service_account].presence
 
       cred.save if options[:save] && id
     end


### PR DESCRIPTION
This is support PR for AWS Security Token Service's "[assume role](https://stackoverflow.com/a/50083442/4393476)" feature.

Basically, it just saves additional auth field.

Here is the primary PR with technical info: https://github.com/ManageIQ/manageiq-providers-amazon/pull/538
Here is UI PR with pictures: https://github.com/ManageIQ/manageiq-ui-classic/pull/5621