### PR TITLE
Fix product features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -3423,7 +3423,7 @@
     :description: Zones
     :feature_type: node
     :identifier: zone
-  - :name:
+  - :name: Regions
     :description: Regions
     :feature_type: node
     :identifier: region

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -26,7 +26,10 @@ describe MiqProductFeature do
   def assert_product_feature_attributes(pf)
     expect(pf).to include(*described_class::REQUIRED_ATTRIBUTES)
     expect(pf.keys - described_class::ALLOWED_ATTRIBUTES).to be_empty
-    expect(pf[:children]).not_to be_empty if pf.key?(:children)
+    pf.each do |k, v|
+      next if k == :hidden
+      expect(v).not_to be_blank, "Identifier: '#{pf[:identifier]}'  Key: '#{k}' is blank"
+    end
   end
 
   def traverse_product_feature_children(pfs, &block)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/18770/files#diff-bccee92afbf0d3d195b7bcf343b1b6c4R3434 introduced an error with the missing value for `:name` which caused:
```ruby
         ArgumentError:
           comparison of Array with Array failed
           ...../manageiq/app/models/miq_product_feature.rb:137:in `sort_by'
```

I added a test, and based the PR on https://github.com/ManageIQ/manageiq/pull/18806