### PR TITLE
Modify method to hide columns dynamically in GTL list

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -886,6 +886,56 @@ describe MiqReport do
       expect(report.column_is_hidden?(:ems_ref)).to be_truthy
       expect(report.column_is_hidden?(:vendor)).to be_falsey
     end
+
+    context "columns are hidden thanks to method" do
+      let(:report) do
+        MiqReport.new(
+          :name        => "VMs",
+          :title       => "Virtual Machines",
+          :db          => "Vm",
+          :cols        => %w[name guid hostname ems_ref vendor],
+          :col_order   => %w[name hostname vendor guid emf_ref],
+          :headers     => %w[Name Host Vendor Guid EMS],
+          :col_options => {"name" => {:display_method => :user_super_admin?}}
+        )
+      end
+
+      let(:test_controller) do
+        class TestController
+          # when this method returns true it means
+          # that column is displayed
+          DISPLAY_GTL_METHODS = [
+            :user_super_admin?
+          ].freeze
+
+          def user_super_admin?
+            User.current_user.super_admin_user?
+          end
+        end
+
+        TestController.new
+      end
+
+      let(:user) { FactoryBot.create(:user) }
+
+      it "hides column defined in #col_options with display_method display_method is returning false" do
+        User.with_user(user) do
+          expect(report.column_is_hidden?(:name, test_controller)).to be_truthy
+          expect(report.column_is_hidden?(:ems_ref, test_controller)).to be_falsey
+          expect(report.column_is_hidden?(:vendor, test_controller)).to be_falsey
+        end
+      end
+
+      let(:user_admin) { FactoryBot.create(:user_admin) }
+
+      it "doesn't hide column defined in #col_options when display_method is returning true" do
+        User.with_user(user_admin) do
+          expect(report.column_is_hidden?(:name, test_controller)).to be_falsey
+          expect(report.column_is_hidden?(:ems_ref, test_controller)).to be_falsey
+          expect(report.column_is_hidden?(:vendor, test_controller)).to be_falsey
+        end
+      end
+    end
   end
 
   context "chargeback reports" do


### PR DESCRIPTION
(extending https://github.com/ManageIQ/manageiq/pull/17133)

now it is possible to hide columns in GTL lists according to defined [method in controller.](https://github.com/ManageIQ/manageiq-ui-classic/pull/5616)

cc @himdel 

- [x] specs
- [x] https://github.com/ManageIQ/manageiq/pull/18882


# Links 
https://github.com/ManageIQ/manageiq-ui-classic/pull/5616
https://github.com/ManageIQ/manageiq-ui-classic/pull/5575

