### PR TITLE
Generalize process of adding kernel arguments

### DIFF
--- a/app/models/customization_template.rb
+++ b/app/models/customization_template.rb
@@ -66,4 +66,8 @@ class CustomizationTemplate < ApplicationRecord
     require 'erb'
     ERB.new(erb_text).result(binding)
   end
+
+  def self.kernel_args(_pxe_server, _pxe_image, _mac_address)
+    {}
+  end
 end

--- a/app/models/customization_template_kickstart.rb
+++ b/app/models/customization_template_kickstart.rb
@@ -9,7 +9,7 @@ class CustomizationTemplateKickstart < CustomizationTemplate
     File.join(pxe_server.customization_directory, pxe_server_filename(pxe_image, mac_address))
   end
 
-  def self.ks_settings_for_pxe_image(pxe_server, pxe_image, mac_address)
+  def self.kernel_args(pxe_server, pxe_image, mac_address)
     ks_access_path =
       if pxe_server.access_url.nil?
         nil
@@ -17,7 +17,7 @@ class CustomizationTemplateKickstart < CustomizationTemplate
         File.join(pxe_server.access_url, pxe_server_filepath(pxe_server, pxe_image, mac_address))
       end
 
-    {:ks_access_path => ks_access_path, :ks_device => mac_address}
+    { :ks => ks_access_path, :ksdevice => mac_address }
   end
 
   def default_filename

--- a/app/models/pxe_image.rb
+++ b/app/models/pxe_image.rb
@@ -20,11 +20,9 @@ class PxeImage < ApplicationRecord
     @corresponding_menu ||= "PxeMenu#{model_suffix}".constantize
   end
 
-  def build_pxe_contents(ks_access_path, ks_device)
+  def build_pxe_contents(kernel_args)
     options = kernel_options.to_s.split(" ")
-    update_pxe_content_option(options, "ks=",       ks_access_path)
-    update_pxe_content_option(options, "ksdevice=", ks_device)
-
+    kernel_args.each { |k, v| update_pxe_content_option(options, "#{k}=", v) }
     options.compact.join(" ").strip
   end
 
@@ -44,12 +42,13 @@ class PxeImage < ApplicationRecord
   def create_files_on_server(pxe_server, mac_address, customization_template = nil)
     filepath = self.class.pxe_server_filepath(pxe_server, mac_address)
 
-    if customization_template.kind_of?(CustomizationTemplateKickstart)
-      ks_settings = CustomizationTemplateKickstart.ks_settings_for_pxe_image(pxe_server, self, mac_address)
-    else
-      ks_settings = {}
-    end
-    contents = build_pxe_contents(*ks_settings.values_at(:ks_access_path, :ks_device))
+    # If the customization_template is nil, we set :ks and :ksdevice set to
+    # nil for backwards compatibility. This will remova any ks and ksdevice
+    # arguments from final kernel command line.
+    kernel_args = customization_template&.class&.kernel_args(
+      pxe_server, self, mac_address
+    ) || { :ks => nil, :ksdevice => nil }
+    contents = build_pxe_contents(kernel_args)
 
     pxe_server.write_file(filepath, contents)
   end

--- a/app/models/pxe_image.rb
+++ b/app/models/pxe_image.rb
@@ -43,7 +43,7 @@ class PxeImage < ApplicationRecord
     filepath = self.class.pxe_server_filepath(pxe_server, mac_address)
 
     # If the customization_template is nil, we set :ks and :ksdevice set to
-    # nil for backwards compatibility. This will remova any ks and ksdevice
+    # nil for backwards compatibility. This will remove any ks and ksdevice
     # arguments from final kernel command line.
     kernel_args = customization_template&.class&.kernel_args(
       pxe_server, self, mac_address

--- a/app/models/pxe_image_ipxe.rb
+++ b/app/models/pxe_image_ipxe.rb
@@ -1,5 +1,5 @@
 class PxeImageIpxe < PxeImage
-  def build_pxe_contents(ks_access_path, ks_device)
+  def build_pxe_contents(kernel_args)
     pxe = "#!ipxe\n"
     pxe << "kernel #{kernel} #{super}\n"
     pxe << "initrd #{initrd}\n" if initrd.present?

--- a/app/models/pxe_image_pxelinux.rb
+++ b/app/models/pxe_image_pxelinux.rb
@@ -1,5 +1,5 @@
 class PxeImagePxelinux < PxeImage
-  def build_pxe_contents(ks_access_path, ks_device)
+  def build_pxe_contents(kernel_args)
     options = super
     options.insert(0, "initrd=#{initrd} ") unless initrd.blank?
 

--- a/spec/models/pxe_image_ipxe_spec.rb
+++ b/spec/models/pxe_image_ipxe_spec.rb
@@ -11,7 +11,9 @@ describe PxeImageIpxe do
 
       image.kernel_options += " ks=abc ksdevice="
 
-      expect(image.build_pxe_contents("http://1.1.1.1/", "00:00:00:00:00:00")).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => "http://1.1.1.1/",
+                                      :ksdevice => "00:00:00:00:00:00"))
+        .to eq(expected_output)
     end
 
     it "inserts initrd option if present" do
@@ -24,7 +26,9 @@ describe PxeImageIpxe do
 
       image.initrd = "/path/to/init.rd"
 
-      expect(image.build_pxe_contents("http://1.2.3.4/", "12:34:56:78:90:ab")).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => "http://1.2.3.4/",
+                                      :ksdevice => "12:34:56:78:90:ab"))
+        .to eq(expected_output)
     end
   end
 end

--- a/spec/models/pxe_image_pxelinux_spec.rb
+++ b/spec/models/pxe_image_pxelinux_spec.rb
@@ -3,11 +3,22 @@ describe PxeImagePxelinux do
 
   context "#build_pxe_contents" do
     it "updates ks and ks_device options" do
-      expected_output = "timeout 0\ndefault #{image.name}\n\nlabel #{image.name}\n   menu label #{image.description}\n   kernel ubuntu-10.10-desktop-i386/vmlinuz\n   append vga=788 -- quiet ks=http://1.1.1.1/ ksdevice=00:00:00:00:00:00\n\n"
+      expected_output = <<~PXE_MENU
+        timeout 0
+        default #{image.name}
+
+        label #{image.name}
+           menu label #{image.description}
+           kernel ubuntu-10.10-desktop-i386/vmlinuz
+           append vga=788 -- quiet ks=http://1.1.1.1/ ksdevice=00:00:00:00:00:00
+
+      PXE_MENU
 
       image.kernel_options += " ks=abc ksdevice="
 
-      expect(image.build_pxe_contents("http://1.1.1.1/", "00:00:00:00:00:00")).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => "http://1.1.1.1/",
+                                      :ksdevice => "00:00:00:00:00:00"))
+        .to eq(expected_output)
     end
   end
 end

--- a/spec/models/pxe_image_spec.rb
+++ b/spec/models/pxe_image_spec.rb
@@ -7,7 +7,9 @@ describe PxeImage do
 
       image.kernel_options += " ks=abc ksdevice="
 
-      expect(image.build_pxe_contents("http://1.1.1.1/", "00:00:00:00:00:00")).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => "http://1.1.1.1/",
+                                      :ksdevice => "00:00:00:00:00:00"))
+        .to eq(expected_output)
     end
 
     it "appends ksdevice if missing" do
@@ -15,7 +17,9 @@ describe PxeImage do
 
       image.kernel_options += " ks=abc"
 
-      expect(image.build_pxe_contents("http://1.1.1.1/", "00:00:00:00:00:00")).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => "http://1.1.1.1/",
+                                      :ksdevice => "00:00:00:00:00:00"))
+        .to eq(expected_output)
     end
 
     it "appends ks if missing" do
@@ -23,13 +27,17 @@ describe PxeImage do
 
       image.kernel_options += " ksdevice=abc"
 
-      expect(image.build_pxe_contents("http://1.1.1.1/", "00:00:00:00:00:00")).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => "http://1.1.1.1/",
+                                      :ksdevice => "00:00:00:00:00:00"))
+        .to eq(expected_output)
     end
 
     it "removes ks and ksdevice if blank" do
       expected_output = "vga=788 -- quiet"
 
-      expect(image.build_pxe_contents(nil, nil)).to eq(expected_output)
+      expect(image.build_pxe_contents(:ks       => nil,
+                                      :ksdevice => nil))
+        .to eq(expected_output)
     end
   end
 end


### PR DESCRIPTION
Up until now, only kickstart templates were able to inject arguments to the kernel command line, which severely limits the usefulness of customization templates.

This PR removes the kickstart-only function for retrieving kernel arguments with a generic one that implementation can override.