### PR TITLE
Add models and save_inventory code for EmsLicense and EmsExtension

### DIFF
--- a/app/models/ems_extension.rb
+++ b/app/models/ems_extension.rb
@@ -1,0 +1,5 @@
+class EmsExtension < ApplicationRecord
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :ems_extensions
+
+  validates :ems_ref, :presence => true
+end

--- a/app/models/ems_license.rb
+++ b/app/models/ems_license.rb
@@ -1,0 +1,5 @@
+class EmsLicense < ApplicationRecord
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :ems_licenses
+
+  validates :ems_ref, :presence => true
+end

--- a/app/models/ems_refresh/save_inventory_infra.rb
+++ b/app/models/ems_refresh/save_inventory_infra.rb
@@ -31,6 +31,8 @@
 #   - ems_folders
 #   - resource_pools
 #   - customization_specs
+#   - ems_extensions
+#   - ems_licenses
 #
 #   - link
 #   - orchestration_stacks
@@ -66,6 +68,8 @@ module EmsRefresh::SaveInventoryInfra
       :folders,
       :resource_pools,
       :customization_specs,
+      :ems_extensions,
+      :ems_licenses,
       :orchestration_templates,
       :orchestration_stacks
     ]
@@ -306,6 +310,26 @@ module EmsRefresh::SaveInventoryInfra
 
     deletes = determine_deletes_using_association(ems, target, disconnect)
     save_inventory_multi(ems.customization_specs, hashes, deletes, [:name])
+  end
+
+  def save_ems_extensions_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil?
+
+    ems.ems_extensions.reset
+    deletes = determine_deletes_using_association(ems, target, disconnect)
+
+    save_inventory_multi(ems.ems_extensions, hashes, deletes, [:ems_ref], nil)
+    store_ids_for_new_records(ems.ems_extensions, hashes, :ems_ref)
+  end
+
+  def save_ems_licenses_inventory(ems, hashes, target = nil, disconnect = true)
+    target = ems if target.nil?
+
+    ems.ems_licenses.reset
+    deletes = determine_deletes_using_association(ems, target, disconnect)
+
+    save_inventory_multi(ems.ems_licenses, hashes, deletes, [:ems_ref], nil)
+    store_ids_for_new_records(ems.ems_licenses, hashes, :ems_ref)
   end
 
   def save_miq_scsi_targets_inventory(guest_device, hashes)

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -95,6 +95,9 @@ class ExtManagementSystem < ApplicationRecord
   has_many :host_conversion_hosts, :through => :hosts, :source => :conversion_host
   has_many :vm_conversion_hosts, :through => :vms, :source => :conversion_host
 
+  has_many :ems_licenses,   :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
+  has_many :ems_extensions, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
+
   validates :name,     :presence => true, :uniqueness => {:scope => [:tenant_id]}
   validates :hostname, :presence => true, :if => :hostname_required?
   validate :hostname_uniqueness_valid?, :hostname_format_valid?, :if => :hostname_required?

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -230,6 +230,14 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def ems_extensions
+          add_common_default_values
+        end
+
+        def ems_licenses
+          add_common_default_values
+        end
+
         def root_folder_relationship
           skip_auto_inventory_attributes
           skip_model_class


### PR DESCRIPTION
Add the models and save inventory code for licenses and extensions

Depends: https://github.com/ManageIQ/manageiq-schema/pull/376
Dependent: https://github.com/ManageIQ/manageiq-providers-vmware/pull/404