### PR TITLE
[HAMMER] specify virtual_delegate types to avoid deadlock

### DIFF
--- a/app/models/entitlement.rb
+++ b/app/models/entitlement.rb
@@ -7,7 +7,7 @@ class Entitlement < ApplicationRecord
 
   validate :one_kind_of_managed_filter
 
-  virtual_delegate :name, :to => :miq_user_role, :allow_nil => true, :prefix => true
+  virtual_delegate :name, :to => :miq_user_role, :allow_nil => true, :prefix => true, :type => :string
 
   def self.valid_filters?(filters_hash)
     return true  unless filters_hash                  # nil ok

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -114,13 +114,13 @@ class Host < ApplicationRecord
 
   virtual_column :os_image_name,                :type => :string,      :uses => [:operating_system, :hardware]
   virtual_column :platform,                     :type => :string,      :uses => [:operating_system, :hardware]
-  virtual_delegate :v_owning_cluster, :to => "ems_cluster.name", :allow_nil => true, :default => ""
+  virtual_delegate :v_owning_cluster, :to => "ems_cluster.name", :allow_nil => true, :default => "", :type => :string
   virtual_column :v_owning_datacenter,          :type => :string,      :uses => :all_relationships
   virtual_column :v_owning_folder,              :type => :string,      :uses => :all_relationships
-  virtual_delegate :cpu_total_cores, :cpu_cores_per_socket, :to => :hardware, :allow_nil => true, :default => 0
-  virtual_delegate :num_cpu,     :to => "hardware.cpu_sockets",        :allow_nil => true, :default => 0
-  virtual_delegate :total_vcpus, :to => "hardware.cpu_total_cores",    :allow_nil => true, :default => 0
-  virtual_delegate :ram_size,    :to => "hardware.memory_mb",          :allow_nil => true, :default => 0
+  virtual_delegate :cpu_total_cores, :cpu_cores_per_socket, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :num_cpu,     :to => "hardware.cpu_sockets",        :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :total_vcpus, :to => "hardware.cpu_total_cores",    :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :ram_size,    :to => "hardware.memory_mb",          :allow_nil => true, :default => 0, :type => :integer
   virtual_column :enabled_inbound_ports,        :type => :numeric_set  # The following are not set to use anything
   virtual_column :enabled_outbound_ports,       :type => :numeric_set  # because get_ports ends up re-querying the
   virtual_column :enabled_udp_inbound_ports,    :type => :numeric_set  # database anyway.
@@ -137,7 +137,7 @@ class Host < ApplicationRecord
   virtual_column :enabled_run_level_5_services, :type => :string_set,  :uses => :host_services
   virtual_column :enabled_run_level_6_services, :type => :string_set,  :uses => :host_services
   virtual_column :last_scan_on,                 :type => :time,        :uses => :last_drift_state_timestamp
-  virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true
+  virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true, :type => :string
   virtual_column :vmm_vendor_display,           :type => :string
   virtual_column :ipmi_enabled,                 :type => :boolean
   virtual_column :archived, :type => :boolean

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -16,7 +16,7 @@ class MiqGroup < ApplicationRecord
   has_many   :miq_product_features, :through => :miq_user_role
   has_many   :authentications, :dependent => :nullify
 
-  virtual_delegate :miq_user_role_name, :to => :entitlement, :allow_nil => true
+  virtual_delegate :miq_user_role_name, :to => :entitlement, :allow_nil => true, :type => :string
   virtual_column :read_only,          :type => :boolean
   virtual_has_one :sui_product_features, :class_name => "Array"
 

--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -11,7 +11,7 @@ class MiqProductFeature < ApplicationRecord
   has_many :shares, :through => :miq_product_features_shares
   belongs_to :tenant
 
-  virtual_delegate :identifier, :to => :parent, :prefix => true, :allow_nil => true
+  virtual_delegate :identifier, :to => :parent, :prefix => true, :allow_nil => true, :type => :string
 
   validates_presence_of   :identifier
   validates_uniqueness_of :identifier

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -10,7 +10,7 @@ class MiqReportResult < ApplicationRecord
 
   serialize :report
 
-  virtual_delegate :description, :to => :miq_group, :prefix => true, :allow_nil => true
+  virtual_delegate :description, :to => :miq_group, :prefix => true, :allow_nil => true, :type => :string
   virtual_attribute :status, :string
   virtual_column :status_message,        :type => :string, :uses => :miq_task
   virtual_has_one :result_set,           :class_name => "Hash"

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -37,7 +37,7 @@ class MiqServer < ApplicationRecord
   scope :active_miq_servers, -> { where(:status => STATUSES_ACTIVE) }
   scope :recently_active,    -> { where(:last_heartbeat => 10.minutes.ago.utc...Time.now.utc) }
   scope :with_zone_id, ->(zone_id) { where(:zone_id => zone_id) }
-  virtual_delegate :description, :to => :zone, :prefix => true
+  virtual_delegate :description, :to => :zone, :prefix => true, :type => :string
 
   STATUS_STARTING       = 'starting'.freeze
   STATUS_STARTED        = 'started'.freeze

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -42,8 +42,8 @@ class MiqWidget < ApplicationRecord
   end
 
   virtual_column :status,         :type => :string,    :uses => :miq_task
-  virtual_delegate :status_message, :to => "miq_task.message", :allow_nil => true, :default => "Unknown"
-  virtual_delegate :queued_at, :to => "miq_task.created_on", :allow_nil => true
+  virtual_delegate :status_message, :to => "miq_task.message", :allow_nil => true, :default => "Unknown", :type => :string
+  virtual_delegate :queued_at, :to => "miq_task.created_on", :allow_nil => true, :type => :datetime
   virtual_column :last_run_on,    :type => :datetime,  :uses => :miq_schedule
 
   def row_count(row_count_param = nil)

--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -5,7 +5,7 @@ module OwnershipMixin
     belongs_to :evm_owner, :class_name => "User"
     belongs_to :miq_group
 
-    virtual_delegate :email, :name, :userid, :to => :evm_owner, :prefix => true, :allow_nil => true
+    virtual_delegate :email, :name, :userid, :to => :evm_owner, :prefix => true, :allow_nil => true, :type => :string
 
     # Determine whether the selected object is owned by the current user
     # Resulting SQL:
@@ -25,7 +25,7 @@ module OwnershipMixin
       t.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:evm_owner_userid)]).eq(userid))
     end)
 
-    virtual_delegate :owning_ldap_group, :to => "miq_group.description", :allow_nil => true
+    virtual_delegate :owning_ldap_group, :to => "miq_group.description", :allow_nil => true, :type => :string
 
     # Determine whether to return objects owned by the current user's miq_group
     # or not.

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -156,9 +156,9 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :used_storage,                         :type => :integer,    :uses => [:used_disk_storage, :mem_cpu]
   virtual_column :used_storage_by_state,                :type => :integer,    :uses => :used_storage
   virtual_column :uncommitted_storage,                  :type => :integer,    :uses => [:provisioned_storage, :used_storage_by_state]
-  virtual_delegate :ram_size_in_bytes,                  :to => :hardware, :allow_nil => true, :default => 0
-  virtual_delegate :mem_cpu,                            :to => "hardware.memory_mb", :allow_nil => true, :default => 0
-  virtual_delegate :ram_size,                           :to => "hardware.memory_mb", :allow_nil => true, :default => 0
+  virtual_delegate :ram_size_in_bytes,                  :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :mem_cpu,                            :to => "hardware.memory_mb", :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :ram_size,                           :to => "hardware.memory_mb", :allow_nil => true, :default => 0, :type => :integer
   virtual_column :ipaddresses,                          :type => :string_set, :uses => {:hardware => :ipaddresses}
   virtual_column :hostnames,                            :type => :string_set, :uses => {:hardware => :hostnames}
   virtual_column :mac_addresses,                        :type => :string_set, :uses => {:hardware => :mac_addresses}
@@ -166,8 +166,8 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :num_hard_disks,                       :type => :integer,    :uses => {:hardware => :hard_disks}
   virtual_column :num_disks,                            :type => :integer,    :uses => {:hardware => :disks}
   virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
-  virtual_delegate :cpu_total_cores, :cpu_cores_per_socket, :to => :hardware, :allow_nil => true, :default => 0
-  virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true
+  virtual_delegate :cpu_total_cores, :cpu_cores_per_socket, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true, :type => :string
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
 
@@ -183,11 +183,11 @@ class VmOrTemplate < ApplicationRecord
   virtual_has_one   :service,              :class_name => 'Service'
   virtual_has_one   :parent_resource,      :class_name => "VmOrTemplate"
 
-  virtual_delegate :name, :to => :host, :prefix => true, :allow_nil => true
-  virtual_delegate :name, :to => :storage, :prefix => true, :allow_nil => true
-  virtual_delegate :name, :to => :ems_cluster, :prefix => true, :allow_nil => true
-  virtual_delegate :vmm_product, :to => :host, :prefix => :v_host, :allow_nil => true
-  virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true
+  virtual_delegate :name, :to => :host, :prefix => true, :allow_nil => true, :type => :string
+  virtual_delegate :name, :to => :storage, :prefix => true, :allow_nil => true, :type => :string
+  virtual_delegate :name, :to => :ems_cluster, :prefix => true, :allow_nil => true, :type => :string
+  virtual_delegate :vmm_product, :to => :host, :prefix => :v_host, :allow_nil => true, :type => :string
+  virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true, :type => :float
   delegate :connect_lans, :disconnect_lans, :to => :hardware, :allow_nil => true
 
   before_validation :set_tenant_from_group
@@ -1503,9 +1503,9 @@ class VmOrTemplate < ApplicationRecord
   #
 
   virtual_delegate :allocated_disk_storage, :used_disk_storage,
-                   :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}
+                   :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}, :type => :integer
 
-  virtual_delegate :provisioned_storage, :to => :hardware, :allow_nil => true, :default => 0
+  virtual_delegate :provisioned_storage, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
 
   def used_storage
     used_disk_storage.to_i + ram_size_in_bytes

--- a/lib/extensions/ar_virtual.rb
+++ b/lib/extensions/ar_virtual.rb
@@ -122,7 +122,8 @@ module VirtualDelegates
       end
 
       col = col.to_s
-      type = to_ref.klass.type_for_attribute(col)
+      type = options[:type] || to_ref.klass.type_for_attribute(col)
+      type = ActiveRecord::Type.lookup(type) if type.kind_of?(Symbol)
       raise "unknown attribute #{to}##{col} referenced in #{name}" unless type
       arel = virtual_delegate_arel(col, to_ref)
       define_virtual_attribute(method_name, type, :uses => (options[:uses] || to), :arel => arel)
@@ -194,7 +195,7 @@ module VirtualDelegates
     def virtual_delegate_arel(col, to_ref)
       # ensure the column has sql and the association is reachable via sql
       # There is currently no way to propagate sql over a virtual association
-      if to_ref.klass.arel_attribute(col) && reflect_on_association(to_ref.name)
+      if reflect_on_association(to_ref.name)
         if to_ref.macro == :has_one
           lambda do |t|
             src_model_id = arel_attribute(to_ref.association_primary_key, t)

--- a/spec/lib/extensions/ar_virtual_spec.rb
+++ b/spec/lib/extensions/ar_virtual_spec.rb
@@ -661,6 +661,37 @@ describe VirtualFields do
           query = CompSys.all.select(:id, :first_os_name)
           expect(query.map(&:first_os_name)).to match_array(["bar"])
         end
+
+        it "detects bad reference" do
+          TestOtherClass.virtual_delegate :bogus, :to => :oref1, :type => :integer
+          expect { TestOtherClass.new }.not_to raise_error
+          expect { TestOtherClass.new(:oref1 => TestClass.new).bogus }.to raise_error(NoMethodError)
+        end
+
+        it "detects bad reference in sql" do
+          TestOtherClass.virtual_delegate :bogus, :to => :oref1, :type => :integer
+          # any exception will do
+          expect { TestOtherClass.select(:bogus).first }.to raise_error(ActiveRecord::StatementInvalid)
+        end
+
+        it "doesn't reference target class when :type is specified" do
+          TestOtherClass.has_many :others, :class_name => "InvalidType"
+          TestOtherClass.virtual_delegate :col4, :to => :others, :type => :integer
+          # doesn't lookup InvalidType class with this model
+          expect { TestOtherClass.new }.not_to raise_error
+          # referencing the relation still accesses the model (which is invalid so blows up)
+          expect { TestOtherClass.new.col4 }.to raise_error(NameError)
+        end
+
+        it "catches invalid references" do
+          TestOtherClass.virtual_delegate :col4, :to => :others, :type => :integer
+          expect { model.new }.to raise_error(NameError)
+        end
+
+        it "catches invalid column" do
+          TestOtherClass.virtual_delegate :col4, :to => :oref1, :type => :integer
+          expect { model.new }.to raise_error(NameError)
+        end
       end
     end
 


### PR DESCRIPTION
Hammer version of https://github.com/ManageIQ/manageiq/pull/18798

deriving the attribute type for delegates required the target
class to be loaded.
This forced a cascade of load_schema calls that end up
introducing a race condition.

This PR explicitly declares the attribute type so the target class
no longer needs to be loaded and the race condition
(and subsequent deadlocks) are avoided.

https://bugzilla.redhat.com/show_bug.cgi?id=1714615

**CHERRY PICK ISSUES:**

- A few delegates were not present in `hammer`, these did not need to be updated and were removed.
- The virtual attribute functionality is part of the `hammer` code base. So it was made here.
- virtual attribute tests were brought across, but the underlying spec file is very different. Kept specs the same.

This is based upon:

- https://github.com/ManageIQ/activerecord-virtual_attributes/pull/21
- https://github.com/ManageIQ/manageiq/pull/18798

