### PR TITLE
[V2V] Restore auth_user in conversion host context data

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -35,6 +35,7 @@ module ConversionHost::Configurations
       #
       MiqTask.find(task_id).tap do |task|
         params = params&.except(:task_id, :miq_task_id)
+        params = params&.update(:auth_user => auth_user) if auth_user
         hash = {:request_params => params&.reject { |key, _value| key.to_s.end_with?('private_key') }}
         task.context_data = hash
         task.save


### PR DESCRIPTION
The code for ConversionHost::Configurations splits out the `auth_user` from the incoming params, so it needs to be restored as a param in the context data so that a retry will pick it up again.