### PR TITLE
Raise error on Ruby 2.6 until it is supported

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-raise "Ruby versions less than 2.3.1 are unsupported!" if RUBY_VERSION < "2.3.1"
+raise "Ruby versions < 2.3.1 are unsupported!" if RUBY_VERSION < "2.3.1"
+raise "Ruby versions >= 2.6 are unsupported!" if RUBY_VERSION >= "2.6.0"
 
 source 'https://rubygems.org'
 


### PR DESCRIPTION
As the project does not tell the user that Ruby 2.6 is not yet
supported, they frequently ask why their code is not working with the
following error:

    Error parsing classes in /root/manageiq/app/models/account.rb:
    RuntimeError: type should be a Symbol, not: 6

This commit is to prevent those questions until we can get Ruby 2.6
working.
