### PR TITLE
[WIP] [V2V] Add logging to kill_virtv2v method

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -235,9 +235,26 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def kill_virtv2v(signal = 'TERM')
-    return false if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
-    return false unless options[:virtv2v_wrapper]['pid']
-    conversion_host.kill_process(options[:virtv2v_wrapper]['pid'], signal)
+    rv = false
+
+    if options[:virtv2v_started_on].blank?
+      _log.warn("No start time found for task, ignoring kill attempt")
+    elsif options[:virtv2v_finished_on].present?
+      _log.warn("The task already appears to be complete, ignoring kill attempt")
+    elsif options[:virtv2v_wrapper].blank?
+      _log.warn("Could not find virtv2v wrapper, ignoring kill attempt")
+    else
+      pid = options[:virtv2v_wrapper]['pid']
+
+      if pid
+        _log.info("Attempting to kill virtv2v process: #{pid}")
+        rv = conversion_host.kill_process(pid, signal)
+      else
+        _log.warn("Could not find pid for InfraConversionJob using virtv2v wrapper: #{options[:virtv2v_wrapper]}")
+      end
+    end
+
+    rv
   end
 
   private

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -250,7 +250,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         _log.info("Attempting to kill virtv2v process: #{pid}")
         rv = conversion_host.kill_process(pid, signal)
       else
-        _log.warn("Could not find pid for InfraConversionJob using virtv2v wrapper: #{options[:virtv2v_wrapper]}")
+        _log.warn("Could not find PID for task using virtv2v wrapper: #{options[:virtv2v_wrapper]}")
       end
     end
 


### PR DESCRIPTION
Currently the `ServiceTemplateTransformationPlanTask#kill_virt2v2` method just returns false if certain options are missing. This updates the method to at least log some warnings for any given item.

https://bugzilla.redhat.com/show_bug.cgi?id=1666799