### PR TITLE
default to using inline sql views for reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
-gem "activerecord-virtual_attributes", "~>1.2.0"
+gem "activerecord-virtual_attributes", "~>1.3.1"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.4",       :require => false

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -318,7 +318,7 @@ module MiqReport::Generator
 
     ## add in virtual attributes that can be calculated from sql
     rbac_opts[:extra_cols] = va_sql_cols unless va_sql_cols.blank?
-    rbac_opts[:use_sql_view] = true if db_options && db_options[:use_sql_view]
+    rbac_opts[:use_sql_view] = db_options.nil? || db_options.fetch(:use_sql_view) { true }
 
     results, attrs = Rbac.search(rbac_opts)
     results = Metric::Helper.remove_duplicate_timestamps(results)

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -97,7 +97,7 @@ module MiqReport::Search
                                   )
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
     search_options[:extra_cols] = va_sql_cols if va_sql_cols.present?
-    search_options[:use_sql_view] = true if db_options && db_options[:use_sql_view]
+    search_options[:use_sql_view] = db_options.nil? || db_options.fetch(:use_sql_view) { true }
 
     if options[:parent]
       targets = get_parent_targets(options[:parent], options[:association] || options[:parent_method])


### PR DESCRIPTION
Depends upon:

- [x] https://github.com/ManageIQ/activerecord-virtual_attributes/pull/30

## Overview

When we include virtual attributes in a query, it runs the query for every row in the result set.
For pages like the services explorer, this is very slow.

We solved this issue by introducing inline views and only running the virtual attribute for the rows in the result set. #18543 introduced it as an opt-in feature.

This has affectionately been called the "Turbo Button".

## Before

Only use the improved performance in certain screens since there is a concern this may break screens. Only the Services screen has opted-in for improved performance (on hammer and master/ivanchuk)

## After

Change the turbo button from op-in to an op-out. So all screens will have it.

This PR did require a change to virtual attributes and custom attribute: Fixed a bug in Virtual Attributes to properly escape sql aliases. Removed work around for said bug in Custom Attributes.

### Numbers

For one example, see #18543 
This will have impact on any screen that displays counts. e.g.: explorers for ems, host, and vms.