### PR TITLE
[V2V] Added cluster validation for creating infra mapping

### DIFF
--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -6,7 +6,7 @@ class TransformationMappingItem < ApplicationRecord
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
 
   validate :source_cluster,      :if => -> { source.kind_of?(EmsCluster) }
-  validate :destination_cluster, :if => -> { source.kind_of?(EmsCluster) || source.kind_of?(CloudTenant) }
+  validate :destination_cluster, :if => -> { destination.kind_of?(EmsCluster) || destination.kind_of?(CloudTenant) }
 
   VALID_SOURCE_CLUSTER_PROVIDERS = %w[vmwarews].freeze
   VALID_DESTINATION_CLUSTER_PROVIDERS = %w[rhevm openstack].freeze

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -4,4 +4,24 @@ class TransformationMappingItem < ApplicationRecord
   belongs_to :destination, :polymorphic => true
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
+
+  validate :source_cluster,      :if => lambda { source.kind_of?(EmsCluster) }
+  validate :destination_cluster, :if => lambda { source.kind_of?(EmsCluster) || source.kind_of?(CloudTenant) }
+
+  VALID_SOURCE_CLUSTER_PROVIDERS = %w[vmwarews].freeze
+  VALID_DESTINATION_CLUSTER_PROVIDERS = %w[rhevm openstack].freeze
+
+  def source_cluster
+    unless VALID_SOURCE_CLUSTER_PROVIDERS.include?(source.ext_management_system.emstype)
+      source_types = VALID_SOURCE_CLUSTER_PROVIDERS.join(', ')
+      errors.add(:source, "EMS type of source cluster must be in: #{source_types}")
+    end
+  end
+
+   def destination_cluster
+    unless VALID_DESTINATION_CLUSTER_PROVIDERS.include?(destination.ext_management_system.emstype)
+      destination_types = VALID_DESTINATION_CLUSTER_PROVIDERS.join(', ')
+      errors.add(:destination, "EMS type of destination cluster or cloud tenant must be in: #{destination_types}")
+    end
+  end
 end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -5,8 +5,8 @@ class TransformationMappingItem < ApplicationRecord
 
   validates :source_id, :uniqueness => {:scope => [:transformation_mapping_id, :source_type]}
 
-  validate :source_cluster,      :if => lambda { source.kind_of?(EmsCluster) }
-  validate :destination_cluster, :if => lambda { source.kind_of?(EmsCluster) || source.kind_of?(CloudTenant) }
+  validate :source_cluster,      :if => -> { source.kind_of?(EmsCluster) }
+  validate :destination_cluster, :if => -> { source.kind_of?(EmsCluster) || source.kind_of?(CloudTenant) }
 
   VALID_SOURCE_CLUSTER_PROVIDERS = %w[vmwarews].freeze
   VALID_DESTINATION_CLUSTER_PROVIDERS = %w[rhevm openstack].freeze
@@ -18,7 +18,7 @@ class TransformationMappingItem < ApplicationRecord
     end
   end
 
-   def destination_cluster
+  def destination_cluster
     unless VALID_DESTINATION_CLUSTER_PROVIDERS.include?(destination.ext_management_system.emstype)
       destination_types = VALID_DESTINATION_CLUSTER_PROVIDERS.join(', ')
       errors.add(:destination, "EMS type of destination cluster or cloud tenant must be in: #{destination_types}")

--- a/spec/factories/ems_cluster.rb
+++ b/spec/factories/ems_cluster.rb
@@ -8,30 +8,5 @@ FactoryBot.define do
       x.perf_capture_enabled = toggle_on_name_seq(x)
     end
   end
-
-  trait :vmware_ems do
-    after(:create) do |cluster|
-      zone = FactoryBot.create(:zone)
-      ems = FactoryBot.create(:ems_vmware, :zone => zone)
-      cluster.ext_management_system = ems
-    end
-  end
-
-  trait :redhat_ems do
-    after(:create) do |cluster|
-      zone = FactoryBot.create(:zone)
-      ems = FactoryBot.create(:ems_redhat, :zone => zone)
-      cluster.ext_management_system = ems
-    end
-  end
-
   factory :ems_cluster_openstack, :class => "ManageIQ::Providers::Openstack::InfraManager::EmsCluster", :parent => :ems_cluster
-
-  trait :openstack_ems do
-    after(:create) do |cluster|
-      zone = FactoryBot.create(:zone)
-      ems = FactoryBot.create(:ems_openstack, :zone => zone)
-      cluster.ext_management_system = ems
-    end
-  end
 end

--- a/spec/factories/ems_cluster.rb
+++ b/spec/factories/ems_cluster.rb
@@ -9,5 +9,29 @@ FactoryBot.define do
     end
   end
 
+  trait :vmware_ems do
+    after(:create) do |cluster|
+      zone = FactoryBot.create(:zone)
+      ems = FactoryBot.create(:ems_vmware, :zone => zone)
+      cluster.ext_management_system = ems
+    end
+  end
+
+  trait :redhat_ems do
+    after(:create) do |cluster|
+      zone = FactoryBot.create(:zone)
+      ems = FactoryBot.create(:ems_redhat, :zone => zone)
+      cluster.ext_management_system = ems
+    end
+  end
+
   factory :ems_cluster_openstack, :class => "ManageIQ::Providers::Openstack::InfraManager::EmsCluster", :parent => :ems_cluster
+
+  trait :openstack_ems do
+    after(:create) do |cluster|
+      zone = FactoryBot.create(:zone)
+      ems = FactoryBot.create(:ems_openstack, :zone => zone)
+      cluster.ext_management_system = ems
+    end
+  end
 end

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
 
   describe '#validate_conversion_hosts' do
     context 'no conversion host exists in EMS' do
-      let(:dst_ems) { FactoryBot.create(:ext_management_system) }
-      let(:src_cluster) { FactoryBot.create(:ems_cluster) }
+      let(:src_ems) { FactoryBot.create(:ems_vmware) }
+      let(:dst_ems) { FactoryBot.create(:ems_openstack) }
+      let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
       let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
 
       let(:mapping) do
@@ -67,8 +68,9 @@ RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
     end
 
     context 'conversion host exists in EMS and resource is a Host' do
+      let(:src_ems) { FactoryBot.create(:ems_vmware) }
       let(:dst_ems) { FactoryBot.create(:ems_redhat, :api_version => '4.2.4') }
-      let(:src_cluster) { FactoryBot.create(:ems_cluster) }
+      let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
       let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
 
       let(:mapping) do
@@ -103,8 +105,9 @@ RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
     end
 
     context 'conversion host exists in EMS and resource is a Vm' do
+      let(:src_ems) { FactoryBot.create(:ems_vmware) }
       let(:dst_ems) { FactoryBot.create(:ems_openstack) }
-      let(:src_cluster) { FactoryBot.create(:ems_cluster) }
+      let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
       let(:dst_cloud_tenant) { FactoryBot.create(:cloud_tenant, :ext_management_system => dst_ems) }
 
       let(:mapping) do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -15,8 +15,10 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   end
 
   context 'independent of provider' do
-    let(:src) { FactoryBot.create(:ems_cluster) }
-    let(:dst) { FactoryBot.create(:ems_cluster) }
+    let(:src_ems) { FactoryBot.create(:ems_vmware) }
+    let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
+    let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
+    let(:dst) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems ) }
     let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
     let(:vm)  { FactoryBot.create(:vm_or_template) }
     let(:vm2)  { FactoryBot.create(:vm_or_template) }
@@ -240,9 +242,9 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   end
 
   context 'populated request and task' do
-    let(:src_ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)) }
+    let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
     let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
-    let(:dst_ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone)) }
+    let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
     let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
 
     let(:src_vm_1)  { FactoryBot.create(:vm_or_template, :ext_management_system => src_ems, :ems_cluster => src_cluster) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     let(:src_ems) { FactoryBot.create(:ems_vmware) }
     let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
     let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
-    let(:dst) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems ) }
+    let(:dst) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems) }
     let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
-    let(:vm)  { FactoryBot.create(:vm_or_template) }
+    let(:vm) { FactoryBot.create(:vm_or_template) }
     let(:vm2)  { FactoryBot.create(:vm_or_template) }
     let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
@@ -117,7 +117,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           allow(MiqTask).to receive(:wait_for_taskid) do
             request = MiqQueue.find_by(:class_name => described_class.name)
-            request.update_attributes(:state => MiqQueue::STATE_DEQUEUE)
+            request.update(:state => MiqQueue::STATE_DEQUEUE)
             request.delivered(*request.deliver)
           end
         end
@@ -309,25 +309,21 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       before do
         allow(Time).to receive(:now).and_return(time_now)
         allow(conversion_host).to receive(:run_conversion).with(task_1.conversion_options).and_return(
-          {
-            "wrapper_log" => "/tmp/wrapper.log",
-            "v2v_log"     => "/tmp/v2v.log",
-            "state_file"  => "/tmp/v2v.state"
-          }
+          "wrapper_log" => "/tmp/wrapper.log",
+          "v2v_log"     => "/tmp/v2v.log",
+          "state_file"  => "/tmp/v2v.state"
         )
       end
 
       it "collects the wrapper state hash" do
         task_1.run_conversion
         expect(task_1.options[:virtv2v_wrapper]).to eq(
-          {
-            "wrapper_log" => "/tmp/wrapper.log",
-            "v2v_log"     => "/tmp/v2v.log",
-            "state_file"  => "/tmp/v2v.state"
-          }
+          "wrapper_log" => "/tmp/wrapper.log",
+          "v2v_log"     => "/tmp/v2v.log",
+          "state_file"  => "/tmp/v2v.state"
         )
-       expect(task_1.options[:virtv2v_started_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
-       expect(task_1.options[:virtv2v_status]).to eq('active')
+        expect(task_1.options[:virtv2v_started_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
+        expect(task_1.options[:virtv2v_status]).to eq('active')
       end
     end
 
@@ -388,21 +384,19 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "raises when conversion is failed" do
           allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
-            {
-              "failed"       => true,
-              "finished"     => true,
-              "started"      => true,
-              "disks"        => [
-                { "path" => src_disk_1.filename, "progress" => 23.0 },
-                { "path" => src_disk_1.filename, "progress" => 0.0 }
-              ],
-              "pid"          => 5855,
-              "return_code"  => 1,
-              "disk_count"   => 2,
-              "last_message" => {
-                "message" => "virt-v2v failed somehow",
-                "type"    => "error"
-              }
+            "failed"       => true,
+            "finished"     => true,
+            "started"      => true,
+            "disks"        => [
+              { "path" => src_disk_1.filename, "progress" => 23.0 },
+              { "path" => src_disk_1.filename, "progress" => 0.0 }
+            ],
+            "pid"          => 5855,
+            "return_code"  => 1,
+            "disk_count"   => 2,
+            "last_message" => {
+              "message" => "virt-v2v failed somehow",
+              "type"    => "error"
             }
           )
           expect { task_1.get_conversion_state }.to raise_error("Disks transformation failed.")
@@ -413,21 +407,19 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "updates disks progress" do
           allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
-            {
-              "started"     => true,
-              "disks"       => [
-                { "path" => src_disk_1.filename, "progress" => 100.0 },
-                { "path" => src_disk_1.filename, "progress" => 50.0 }
-              ],
-              "pid"         => 5855,
-              "disk_count"  => 2
-            }
+            "started"    => true,
+            "disks"      => [
+              { "path" => src_disk_1.filename, "progress" => 100.0 },
+              { "path" => src_disk_1.filename, "progress" => 50.0 }
+            ],
+            "pid"        => 5855,
+            "disk_count" => 2
           )
           task_1.get_conversion_state
           expect(task_1.options[:virtv2v_disks]).to eq(
             [
-              { :path => src_disk_1.filename, :size => disk.size, :percent => 100, :weight  => 50 },
-              { :path => src_disk_2.filename, :size => disk.size, :percent => 50, :weight  => 50 }
+              { :path => src_disk_1.filename, :size => disk.size, :percent => 100, :weight => 50 },
+              { :path => src_disk_2.filename, :size => disk.size, :percent => 50, :weight => 50 }
             ]
           )
           expect(task_1.options[:virtv2v_status]).to eq('active')
@@ -435,17 +427,15 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "sets disks progress to 100% when conversion is finished and successful" do
           allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return(
-            {
-              "finished"    => true,
-              "started"     => true,
-              "disks"       => [
-                { "path" => src_disk_1.filename, "progress" => 100.0},
-                { "path" => src_disk_1.filename, "progress" => 100.0}
-              ],
-              "pid"         => 5855,
-              "return_code" => 0,
-              "disk_count"  => 1
-            }
+            "finished"    => true,
+            "started"     => true,
+            "disks"       => [
+              { "path" => src_disk_1.filename, "progress" => 100.0},
+              { "path" => src_disk_1.filename, "progress" => 100.0}
+            ],
+            "pid"         => 5855,
+            "return_code" => 0,
+            "disk_count"  => 1
           )
           task_1.get_conversion_state
           expect(task.options[:virtv2v_disks]).to eq(

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -1,7 +1,12 @@
 RSpec.describe TransformationMappingItem, :v2v do
-  let(:vmware_cluster) { FactoryBot.create(:ems_cluster, :vmware_ems) }
-  let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :redhat_ems) }
-  let(:openstack_cluster) { FactoryBot.create(:ems_cluster_openstack, :openstack_ems) }
+  let(:ems_vmware) { FactoryBot.create(:ems_vmware) }
+  let(:vmware_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
+
+  let(:ems_redhat) { FactoryBot.create(:ems_redhat) }
+  let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
+
+  let(:ems_openstack) { FactoryBot.create(:ems_openstack) }
+  let(:openstack_cluster) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => ems_openstack) }
 
   context "source cluster validation" do
     let(:valid_mapping_item) do

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -3,33 +3,33 @@ RSpec.describe TransformationMappingItem, :v2v do
   let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :redhat_ems) }
   let(:openstack_cluster) { FactoryBot.create(:ems_cluster_openstack, :openstack_ems) }
 
-   context "source cluster validation" do
-    let(:valid_mapping_item) {
+  context "source cluster validation" do
+    let(:valid_mapping_item) do
       FactoryBot.build(:transformation_mapping_item, :source => vmware_cluster, :destination => openstack_cluster)
-    }
+    end
 
-     let(:invalid_mapping_item) {
+    let(:invalid_mapping_item) do
       FactoryBot.build(:transformation_mapping_item, :source => openstack_cluster, :destination => openstack_cluster)
-    }
+    end
 
-     it "passes validation if the source cluster is not a supported type" do
+    it "passes validation if the source cluster is not a supported type" do
       expect(valid_mapping_item.valid?).to be true
     end
 
-     it "fails validation if the source cluster is not a supported type" do
+    it "fails validation if the source cluster is not a supported type" do
       expect(invalid_mapping_item.valid?).to be false
       expect(invalid_mapping_item.errors[:source].first).to match("EMS type of source cluster must be in")
     end
   end
 
   context "destination cluster validation" do
-    let(:valid_mapping_item) {
+    let(:valid_mapping_item) do
       FactoryBot.build(:transformation_mapping_item, :source => vmware_cluster, :destination => redhat_cluster)
-    }
+    end
 
-    let(:invalid_mapping_item) {
+    let(:invalid_mapping_item) do
       FactoryBot.build(:transformation_mapping_item, :source => vmware_cluster, :destination => vmware_cluster)
-    }
+    end
 
     it "passes validation if the source cluster is not a supported type" do
       expect(valid_mapping_item.valid?).to be true

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe TransformationMappingItem, :v2v do
+  let(:vmware_cluster) { FactoryBot.create(:ems_cluster, :vmware_ems) }
+  let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :redhat_ems) }
+  let(:openstack_cluster) { FactoryBot.create(:ems_cluster_openstack, :openstack_ems) }
+
+   context "source cluster validation" do
+    let(:valid_mapping_item) {
+      FactoryBot.build(:transformation_mapping_item, :source => vmware_cluster, :destination => openstack_cluster)
+    }
+
+     let(:invalid_mapping_item) {
+      FactoryBot.build(:transformation_mapping_item, :source => openstack_cluster, :destination => openstack_cluster)
+    }
+
+     it "passes validation if the source cluster is not a supported type" do
+      expect(valid_mapping_item.valid?).to be true
+    end
+
+     it "fails validation if the source cluster is not a supported type" do
+      expect(invalid_mapping_item.valid?).to be false
+      expect(invalid_mapping_item.errors[:source].first).to match("EMS type of source cluster must be in")
+    end
+  end
+
+  context "destination cluster validation" do
+    let(:valid_mapping_item) {
+      FactoryBot.build(:transformation_mapping_item, :source => vmware_cluster, :destination => redhat_cluster)
+    }
+
+    let(:invalid_mapping_item) {
+      FactoryBot.build(:transformation_mapping_item, :source => vmware_cluster, :destination => vmware_cluster)
+    }
+
+    it "passes validation if the source cluster is not a supported type" do
+      expect(valid_mapping_item.valid?).to be true
+    end
+
+    it "fails validation if the source cluster is not a supported type" do
+      expect(invalid_mapping_item.valid?).to be false
+      expect(invalid_mapping_item.errors[:destination].first).to match("EMS type of destination cluster or cloud tenant must be in")
+    end
+  end
+end

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe TransformationMapping, :v2v do
         end
 
         it 'if VM is in another migration plan' do
-          %w(Queued Approved Active).each do |status|
+          %w[Queued Approved Active].each do |status|
             FactoryBot.create(
               :service_resource,
               :resource         => vm,

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe TransformationMapping, :v2v do
-  let(:src) { FactoryBot.create(:ems_cluster) }
-  let(:dst) { FactoryBot.create(:ems_cluster) }
+  let(:src_ems) { FactoryBot.create(:ems_vmware) }
+  let(:dst_ems) { FactoryBot.create(:ems_redhat) }
+  let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
+  let(:dst) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
   let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src) }
 
   let(:mapping) do


### PR DESCRIPTION
Adding validations for source and target clusters inTransformationMappingItem.

Target Clusters
RHV (Class: EmsCluster, Filters: ext_management_system.emstype=rhevm)
OSP (Class: CloudTenant, Filters: none
Source Clusters
VMW (Class: EmsCluster, Filters: ext_management_system.emstype=vmwarews)

https://trello.com/c/1x31IdD0/241-spike-mapping-and-plan-api-validation-of-input

https://bugzilla.redhat.com/show_bug.cgi?id=1713443