### PR TITLE
Fix bad virtual relations

### DIFF
--- a/app/models/cloud_subnet.rb
+++ b/app/models/cloud_subnet.rb
@@ -45,7 +45,7 @@ class CloudSubnet < ApplicationRecord
   def dns_nameservers_show
     dns_nameservers.join(", ") if dns_nameservers
   end
-  virtual_column :dns_nameservers_show, :type => :string, :uses => :dns_nameservers
+  virtual_column :dns_nameservers_show, :type => :string
 
   virtual_total :total_vms, :vms, :uses => :vms
 

--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -39,7 +39,11 @@ class ContainerGroup < ApplicationRecord
   virtual_column :running_containers_summary, :type => :string
 
   def ready_condition
-    container_conditions.find_by(:name => "Ready")
+    if container_conditions.loaded?
+      container_conditions.detect { |condition| condition.name == "Ready" }
+    else
+      container_conditions.find_by(:name => "Ready")
+    end
   end
 
   def ready_condition_status

--- a/app/models/load_balancer_pool_member.rb
+++ b/app/models/load_balancer_pool_member.rb
@@ -22,8 +22,6 @@ class LoadBalancerPoolMember < ApplicationRecord
                  :type => :string_set,
                  :uses => :load_balancer_health_check_members
 
-  virtual_total :total_vms, :vms, :uses => :vms
-
   def load_balancer_health_check_states
     @load_balancer_health_check_states ||= load_balancer_health_check_members.collect(&:status)
   end

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateTransformationPlan < ServiceTemplate
   include_concern 'ValidateConfigInfo'
-  virtual_has_one :transformation_mapping, :uses => :transformation_mapping
+  virtual_has_one :transformation_mapping
   def request_class
     ServiceTemplateTransformationPlanRequest
   end

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -41,6 +41,27 @@ describe ContainerGroup do
     assert_pod_to_pv_relationships(group)
   end
 
+  context "#ready_condition_status" do
+    let(:condition_ready) { FactoryBot.create(:container_condition, :container_entity => container_group, :name => "Ready") }
+    let(:condition_other) { FactoryBot.create(:container_condition, :container_entity => container_group, :name => "Other") }
+    let(:container_group) { FactoryBot.create(:container_group) }
+
+    it "preloads the conditions" do
+      condition_other
+      cr = condition_ready
+      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status => {}).find_by(:id => container_group.id)
+
+      expect { expect(cg.ready_condition).to eq(cr) }.to match_query_limit_of(0)
+    end
+
+    it "handles non-preloaded conditions" do
+      condition_other
+      cr = condition_ready
+      cg = ContainerGroup.find_by(:id => container_group.id)
+      expect { expect(cg.ready_condition).to eq(cr) }.to match_query_limit_of(1)
+    end
+  end
+
   def assert_pod_to_pv_relationships(group)
     expect(group.persistent_volume_claim.first.name).to eq("test_claim")
     expect(group.persistent_volume_claim.count).to eq(1)


### PR DESCRIPTION
virtual attributes used to ignore invalid `:uses =>` and `includes()` clauses.
Now, both active record and virtual attributes want valid values

I went through our `:uses` clauses and found those that were never valid.

These problems showed up in a bulk scan.
