### PR TITLE
Fix typo in product feature identifier for sui_services_operations.

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6450,7 +6450,7 @@
     - :name: Operate
       :description: Service Operations
       :feature_type: node
-      :identifier: sui_servics_operations
+      :identifier: sui_services_operations
       :children:
       - :name: Start
         :description: Start services


### PR DESCRIPTION
I noticed a typo while looking at the file. I don't know if the identifier is used anywhere.