### PR TITLE
Replace class objects in query values with strings to fix a rails 5.0 deprecation

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -57,7 +57,7 @@ class CloudTenant < ApplicationRecord
       :userid => userid
     }
     queue_opts = {
-      :class_name  => class_by_ems(ext_management_system),
+      :class_name  => class_by_ems(ext_management_system).name,
       :method_name => 'create_cloud_tenant',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
@@ -156,7 +156,7 @@ class CloudTenant < ApplicationRecord
     ems = ExtManagementSystem.find(ems_id)
 
     MiqQueue.put_unless_exists(
-      :class_name  => ems.class,
+      :class_name  => ems.class.name,
       :instance_id => ems_id,
       :method_name => 'sync_cloud_tenants_with_tenants',
       :zone        => ems.my_zone

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -237,7 +237,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
       :userid => userid
     }
     queue_opts = {
-      :class_name  => vm.class,
+      :class_name  => vm.class.name,
       :method_name => 'live_migrate',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
@@ -253,7 +253,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
       :userid => userid
     }
     queue_opts = {
-      :class_name  => vm.class,
+      :class_name  => vm.class.name,
       :method_name => 'evacuate',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -31,7 +31,7 @@ module AuthenticationMixin
 
       queue_opts = {
         :args        => [*args],
-        :class_name  => self,
+        :class_name  => name,
         :method_name => "raw_connect?",
         :queue_name  => "generic",
         :role        => "ems_operations",

--- a/app/models/mixins/miq_provision_quota_mixin.rb
+++ b/app/models/mixins/miq_provision_quota_mixin.rb
@@ -153,7 +153,7 @@ module MiqProvisionQuotaMixin
   end
 
   def quota_vm_stats(vms_method, options)
-    result = {:count => 0, :memory => 0, :cpu => 0, :snapshot_storage => 0, :used_storage => 0, :allocated_storage => 0, :ids => [], :class_name => Vm.name}
+    result = {:count => 0, :memory => 0, :cpu => 0, :snapshot_storage => 0, :used_storage => 0, :allocated_storage => 0, :ids => [], :class_name => "Vm"}
     vms = send(vms_method, options)
     result[:count] = vms.length
     vms.each do |vm|
@@ -330,9 +330,9 @@ module MiqProvisionQuotaMixin
   end
 
   def quota_provision_stats(prov_method, options)
-    result = {:count => 0, :memory => 0, :cpu => 0, :storage => 0, :ids => [], :class_name => MiqProvisionRequest.name,
+    result = {:count => 0, :memory => 0, :cpu => 0, :storage => 0, :ids => [], :class_name => "MiqProvisionRequest",
               :active => {
-                :class_name => MiqProvision.name, :ids => [], :storage_by_id => Hash.new { |k, v| k[v] = 0 },
+                :class_name => "MiqProvision", :ids => [], :storage_by_id => Hash.new { |k, v| k[v] = 0 },
                 :memory_by_host_id => Hash.new { |k, v| k[v] = 0 },  :cpu_by_host_id => Hash.new { |k, v| k[v] = 0 },
                 :vms_by_storage_id => Hash.new { |k, v| k[v] = [] }
               }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -146,7 +146,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
     _log.info("Queuing the download of #{log_type} log for #{description} with ID [#{id}]")
     task_options = {:userid => userid, :action => 'transformation_log'}
-    queue_options = {:class_name  => self.class,
+    queue_options = {:class_name  => self.class.name,
                      :method_name => 'transformation_log',
                      :instance_id => id,
                      :args        => [log_type],

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -271,7 +271,7 @@ describe AuthenticationMixin do
       let(:queue_opts) do
         {
           :args        => [*args],
-          :class_name  => ExtManagementSystem,
+          :class_name  => "ExtManagementSystem",
           :method_name => "raw_connect?",
           :queue_name  => "generic",
           :role        => "ems_operations",


### PR DESCRIPTION
Fixes the following on rails 5.0:
```
DEPRECATION WARNING: Passing a class as a value in an Active
Record query is deprecated and will be removed. Pass a string instead.
(called from put_or_update at
/var/www/miq/vmdb/app/models/miq_queue.rb:343)
```
In rails 5.1, you get this if you try using a class object:
```
> MiqQueue.where(:class_name => MiqServer)
TypeError (can't cast Class)
```

Note, these were picked up in the QE test suite.