### PR TITLE
Pluggable locale configuration

### DIFF
--- a/config/locale_task_config.yaml
+++ b/config/locale_task_config.yaml
@@ -1,6 +1,6 @@
 ---
 yaml_strings_to_extract:
-  db/fixtures/miq_product_features.*:
+  db/fixtures/miq_product_features{.yml,.yaml,/*.yml,/*.yaml}:
   - name
   - description
   db/fixtures/miq_report_formats.*:

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -72,6 +72,7 @@ namespace :locale do
     end
 
     config_file = args[:root].join('config/locale_task_config.yaml')
+    config_file = Rails.root.join('config/locale_task_config.yaml') unless config_file.exist?
     next unless config_file.exist?
 
     yamls = YAML.load_file(config_file)['yaml_strings_to_extract']


### PR DESCRIPTION
@mzazrivec Please review

This changes the way the locale configuration works by falling back to the core definition if a plugin does not provide an override.  I checked and manageiq-ui-classic is the only repo that provides an overriden locale_task_config.yaml.

Additionally this PR changes the locale_task_config's miq_product_features definition to a root file and a directory of files, so this handles the i18n concerns from #18806 .  I've tested this locally with dummy yamls and it all ends up in the translations files as expected.