### PR TITLE
This scope accepts class objects, pass strings to where

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -104,7 +104,7 @@ class ExtManagementSystem < ApplicationRecord
 
   validate :validate_ems_enabled_when_zone_changed?, :validate_zone_not_maintenance_when_ems_enabled?
 
-  scope :with_eligible_manager_types, ->(eligible_types) { where(:type => eligible_types) }
+  scope :with_eligible_manager_types, ->(eligible_types) { where(:type => Array(eligible_types).collect(&:to_s)) }
 
   serialize :options
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -85,6 +85,15 @@ describe ExtManagementSystem do
     expect(described_class.ems_infra_discovery_types).to match_array(expected_types)
   end
 
+  it ".with_eligible_manager_types" do
+    v = FactoryBot.create(:ems_vmware)
+    r = FactoryBot.create(:ems_redhat)
+
+    expect(described_class.with_eligible_manager_types([v.class, r.class]).count).to eq(2)
+    expect(described_class.with_eligible_manager_types([v.class]).count).to eq(1)
+    expect(described_class.with_eligible_manager_types(r.class).count).to eq(1)
+  end
+
   context "#ipaddress / #ipaddress=" do
     it "will delegate to the default endpoint" do
       ems = FactoryBot.build(:ems_vmware, :ipaddress => "1.2.3.4")


### PR DESCRIPTION
Fixes:
```
DEPRECATION WARNING: Passing a class as a value in an Active Record query is deprecated and will be removed. Pass a string instead. (called from block in <class:ExtManagementSystem> at /Users/joerafaniello/Code/manageiq/app/models/ext_management_system.rb:107)
```
Similar to https://github.com/ManageIQ/manageiq/pull/18827