### PR TITLE
Deprecate any uses of class_name with Class objects in put_or_update

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -565,11 +565,17 @@ class MiqQueue < ApplicationRecord
 
   # default values for get operations
   def self.default_get_options(options)
-    options.reverse_merge(
+    result = options.reverse_merge(
       :queue_name => DEFAULT_QUEUE,
       :state      => STATE_READY,
       :zone       => Zone.determine_queue_zone(options)
     )
+
+    if result[:class_name].kind_of?(Class)
+      ActiveSupport::Deprecation.warn("Rails 5.1 dropped support for Class query values, use a String for class_name.", caller[1..-1])
+      result[:class_name] = result[:class_name].name
+    end
+    result
   end
 
   private_class_method :default_get_options

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -718,6 +718,16 @@ describe MiqQueue do
       expect(MiqQueue.first.args).to eq([3, 3])
     end
 
+    it "supports a Class object for the class name(deprecated)" do
+      expect(ActiveSupport::Deprecation).to receive(:warn).with(/use a String for class_name/, anything)
+      msg = MiqQueue.put_or_update(:class_name => MiqServer, :instance_id => @miq_server.id, :method_name => "my_zone")
+
+      status, message, result = msg.deliver
+      expect(status).to eq(MiqQueue::STATUS_OK)
+      expect(message).to eq("Message delivered successfully")
+      expect(result).to eq(@miq_server.my_zone)
+    end
+
     it "should use args param to find messages on the queue" do
       MiqQueue.put(
         :class_name  => 'MyClass',


### PR DESCRIPTION
Rails 5.1 dropped support for query values of type Class, and we should
have fixed most of them with #18827 and #18829, but since detecting
callers to put_or_update that do this could be difficult, we can still
support this by "fixing" it so rails 5.1 doesn't raise an exception,
and give us time to fix the caller.