### PR TITLE
Correctly specify includes to fix a 5.0 deprecation

### DIFF
--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -95,7 +95,7 @@ module Vmdb
         startup.info("Server EVM id and name: #{s.id} #{s.name}")
 
         startup.info("Currently assigned server roles:")
-        s.assigned_server_roles(:include => :server_role).each { |r| startup.info("Role: #{r.server_role.name}, Priority: #{r.priority}") }
+        s.assigned_server_roles.includes(:server_role).each { |r| startup.info("Role: #{r.server_role.name}, Priority: #{r.priority}") }
 
         issue = `cat /etc/issue 2> /dev/null` rescue nil
         startup.info("OS: #{issue.chomp}") unless issue.blank?


### PR DESCRIPTION
Fixes a deprecation found in the QE test suite:
```
 WARN -- : DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead. (called from log_server_identity at /var/www/miq/vmdb/lib/vmdb/appliance.rb:98)
```
Note, includes were not being specified correctly as you can see here with rails 5.0:

Before:

```
irb(main):001:0> s = MiqServer.my_server(true)
irb(main):002:0>  s.assigned_server_roles(:include => :server_role).collect {|asr| asr.server_role.id}
DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead. (called from irb_binding at (irb):2)
  AssignedServerRole Load (0.5ms)  SELECT "assigned_server_roles".* FROM "assigned_server_roles" WHERE "assigned_server_roles"."miq_server_id" = $1  [["miq_server_id", 1]]
  AssignedServerRole Inst Including Associations (6.7ms - 12rows)
  ServerRole Load (0.4ms)  SELECT  "server_roles".* FROM "server_roles" WHERE "server_roles"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  ServerRole Inst Including Associations (5.7ms - 1rows)
  ServerRole Load (0.3ms)  SELECT  "server_roles".* FROM "server_roles" WHERE "server_roles"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  ServerRole Inst Including Associations (0.0ms - 1rows)
... (many more lines)
  ServerRole Load (0.1ms)  SELECT  "server_roles".* FROM "server_roles" WHERE "server_roles"."id" = $1 LIMIT $2  [["id", 4], ["LIMIT", 1]]
  ServerRole Inst Including Associations (0.0ms - 1rows)
=> [1, 3, 6, 10, 11, 14, 15, 17, 18, 19, 20, 4]
```

After:

```
irb(main):001:0> s = MiqServer.my_server(true)
irb(main):002:0>  s.assigned_server_roles.includes(:server_role).collect {|asr| asr.server_role.id}
  AssignedServerRole Load (0.5ms)  SELECT "assigned_server_roles".* FROM "assigned_server_roles" WHERE "assigned_server_roles"."miq_server_id" = $1  [["miq_server_id", 1]]
  AssignedServerRole Inst Including Associations (7.0ms - 12rows)
  ServerRole Load (0.6ms)  SELECT "server_roles".* FROM "server_roles" WHERE "server_roles"."id" IN (1, 3, 6, 10, 11, 14, 15, 17, 18, 19, 20, 4)
  ServerRole Inst Including Associations (6.5ms - 12rows)
=> [1, 3, 6, 10, 11, 14, 15, 17, 18, 19, 20, 4]
```