### PR TITLE
Small refactoring to allow cleaner fix

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -105,20 +105,22 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     set_value_from_list(:sysprep_domain_name, field, data_value, nil, true)
   end
 
+  def fields_to_clear
+    [:placement_host_name,
+     :placement_ds_name,
+     :placement_folder_name,
+     :placement_cluster_name,
+     :placement_rp_name,
+     :linked_clone,
+     :snapshot,
+     :placement_dc_name]
+  end
+
   def set_on_vm_id_changed
     src = get_source_and_targets
     vm, ems = load_ar_obj(src[:vm]), src[:ems]
 
-    clear_field_values(
-      [:placement_host_name,
-       :placement_ds_name,
-       :placement_folder_name,
-       :placement_cluster_name,
-       :placement_rp_name,
-       :linked_clone,
-       :snapshot,
-       :placement_dc_name]
-    )
+    clear_field_values(fields_to_clear)
 
     if vm.nil?
       clear_field_values([:number_of_cpus, :number_of_sockets, :cores_per_socket, :vm_memory, :cpu_limit, :memory_limit, :cpu_reserve, :memory_reserve])


### PR DESCRIPTION
Small refactoring to allow provider to decide which fields to clear in case "vm_changed" in provision dialog.

Required to fix: https://bugzilla.redhat.com/show_bug.cgi?id=1712934