### PR TITLE
Silence deprecation warning for #table_exists?

### DIFF
--- a/lib/extensions/ar_migration.rb
+++ b/lib/extensions/ar_migration.rb
@@ -1,6 +1,7 @@
 module ArPglogicalMigrationHelper
   def self.discover_schema_migrations_ran_class
-    return unless ActiveRecord::Base.connection.table_exists?("schema_migrations_ran")
+    raise "Remove 'silence' block now that Rails version is >= 5.1" if Rails.version >= "5.1"
+    ActiveSupport::Deprecation.silence { return unless ActiveRecord::Base.connection.table_exists?("schema_migrations_ran") }
     Class.new(ActiveRecord::Base) do
       require 'active_record-id_regions'
       include ActiveRecord::IdRegions


### PR DESCRIPTION
Silence the warning because it doesn't apply to us.  We are using the behavior that will continue to work in Rails 5.1. Warning in the log:

DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead. (called from discover_schema_migrations_ran_class at /home/travis/build/ManageIQ/manageiq-ui-classic/spec/manageiq/lib/extensions/ar_migration.rb:3)