### PR TITLE
Remove unnecessary partial double call in specs for ServiceAnsibleTower

### DIFF
--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -97,8 +97,6 @@ describe ServiceAnsibleTower do
 
     it 'always saves options even when the manager fails to create a stack' do
       provision_error = MiqException::MiqOrchestrationProvisionError
-      allow_any_instance_of(ManageIQ::Providers::AnsibleTower::AutomationManager::Job).to receive(:stack_create).and_raise(provision_error, 'test failure')
-
       expect(service_mix_dialog_setter).to receive(:save_launch_options)
       expect { service_mix_dialog_setter.launch_job }.to raise_error(provision_error)
     end


### PR DESCRIPTION
This PR removes an `allow_any_instance_of` for a method that doesn't appear to exist for `ManageIQ::Providers::AnsibleTower::AutomationManager::Job`. This causes failures when strict partial verification is turned on.

Perhaps `create_stack` was intended, or perhaps the method name changed, but since its removal did not cause issues, it doesn't appear to be necessary.