### PR TITLE
Use latest rubocop channel for codeclimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,6 +28,7 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
+    channel: rubocop-0-68
 exclude_patterns:
 - config/dictionary_strings.rb
 - config/model_attributes.rb


### PR DESCRIPTION
This is an attempt to deal with the fallout from https://github.com/ManageIQ/miq_bot/pull/442, which has caused our codeclimate setup to fail. They split out the performance cops into its own library, but codeclimate hasn't caught up yet.

However, apparently you can subscribe to channels for a particular plugin. The latest one so far is 0.68. I realize this doesn't quite line up with what we have (0.6.9), but I *think* this will be close enough for it to start working again.

https://github.com/codeclimate/codeclimate-rubocop/pull/173

https://docs.codeclimate.com/docs/engine-channels