### PR TITLE
Replace Array with ActiveRecord::Relation partial in MiqWidget::ContentGenerator specs

### DIFF
--- a/spec/models/miq_widget/content_generator_spec.rb
+++ b/spec/models/miq_widget/content_generator_spec.rb
@@ -1,8 +1,9 @@
-describe MiqWidget::ContentGenerator do
+RSpec.describe MiqWidget::ContentGenerator do
   let(:content_generator) { described_class.new }
 
   describe "#generate" do
-    let(:widget) { double("MiqWidget", :id => 123, :title => "title", :log_prefix => "") }
+    let(:widget) { instance_double("MiqWidget", :id => 123, :title => "title", :log_prefix => "") }
+    let(:records) { instance_double(ActiveRecord::Relation) }
 
     context "when the class is MiqGroup" do
       let(:klass) { "MiqGroup" }
@@ -15,7 +16,6 @@ describe MiqWidget::ContentGenerator do
       before do
         allow(User).to receive(:where).with(:userid => 1).and_return([user1])
         allow(User).to receive(:where).with(:userid => 2).and_return([user2])
-        records = Array(group)
         allow(MiqGroup).to receive(:in_my_region).and_return(records)
         allow(records).to receive(:find_by).with(:description => "description").and_return(group)
       end
@@ -65,7 +65,6 @@ describe MiqWidget::ContentGenerator do
       let(:group) { double("MiqGroup") }
 
       before do
-        records = Array(group)
         allow(MiqGroup).to receive(:in_my_region).and_return(records)
         allow(records).to receive(:find_by).with(:description => "EvmGroup-administrator").and_return(group)
       end


### PR DESCRIPTION
Currently the specs for `MiqWidget::ContentGenerator` break with partial double verification because `records` is an Array trying to call `find_by`.

This PR updates it so that it uses an actual AR relation. I also updated the outer describe block to `RSpec.describe` for future compliance with rspec 4.