### PR TITLE
Seed plugin ansible content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 # content/
-content/*
+content/ansible_consolidated
 
 # db/
 db/*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
+# content/
+content/*
+
 # db/
 db/*.sqlite3
 db/schema.rb

--- a/app/models/manageiq/providers/embedded_ansible/seeding.rb
+++ b/app/models/manageiq/providers/embedded_ansible/seeding.rb
@@ -19,6 +19,43 @@ module ManageIQ::Providers::EmbeddedAnsible::Seeding
       ).find_or_create_by!(
         :name => "#{Vmdb::Appliance.PRODUCT_NAME} Default Credential"
       )
+
+      create_local_playbook_repo
+      local_repo = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.find_or_create_by!(
+        :name       => "#{Vmdb::Appliance.PRODUCT_NAME} Default Project",
+        :manager_id => manager.id
+      )
+      local_repo.raw_update_in_provider(
+        :scm_type             => "git",
+        :scm_url              => "file://#{local_playbook_repo_dir}",
+        :scm_update_on_launch => false
+      )
+    end
+
+    private
+
+    def create_local_playbook_repo
+      Ansible::Content.consolidate_plugin_playbooks
+
+      Dir.chdir(local_playbook_repo_dir) do
+        require 'rugged'
+        repo = Rugged::Repository.init_at(".")
+        index = repo.index
+        index.add_all("*")
+        index.write
+
+        options              = {}
+        options[:tree]       = index.write_tree(repo)
+        options[:author]     = options[:committer] = { :email => "system@localhost", :name => "System", :time => Time.now.utc }
+        options[:message]    = "Initial Commit"
+        options[:parents]    = []
+        options[:update_ref] = 'HEAD'
+        Rugged::Commit.create(repo, options)
+      end
+    end
+
+    def local_playbook_repo_dir
+      Ansible::Content::PLUGIN_CONTENT_DIR
     end
   end
 end

--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -1,6 +1,6 @@
 module Ansible
   class Content
-    PLUGIN_CONTENT_DIR = Rails.root.join("content", "ansible").to_s.freeze
+    PLUGIN_CONTENT_DIR = Rails.root.join("content", "ansible_consolidated").to_s.freeze
 
     attr_accessor :path
 

--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -1,0 +1,17 @@
+module Ansible
+  class Content
+    attr_accessor :path
+
+    def initialize(path)
+      @path = path
+    end
+
+    def fetch_galaxy_roles
+      roles_path = path.join('roles')
+      role_file  = path.join('requirements.yml')
+
+      params = ["install", :roles_path= => roles_path, :role_file= => role_file]
+      AwesomeSpawn.run!("ansible-galaxy", :params => params)
+    end
+  end
+end

--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -1,5 +1,7 @@
 module Ansible
   class Content
+    PLUGIN_CONTENT_DIR = Rails.root.join("content", "ansible").to_s.freeze
+
     attr_accessor :path
 
     def initialize(path)
@@ -12,6 +14,15 @@ module Ansible
 
       params = ["install", :roles_path= => roles_path, :role_file= => role_file]
       AwesomeSpawn.run!("ansible-galaxy", :params => params)
+    end
+
+    def self.consolidate_plugin_playbooks(dir = PLUGIN_CONTENT_DIR)
+      FileUtils.rm_rf(dir)
+      FileUtils.mkdir_p(dir)
+
+      Vmdb::Plugins.ansible_content.each do |content|
+        FileUtils.cp_r(Dir.glob("#{content.path}/*"), dir)
+      end
     end
   end
 end

--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -6,15 +6,11 @@ namespace :evm do
     desc "Seed galaxy roles for provider playbooks"
     task :seed do
       Vmdb::Plugins.ansible_runner_content.each do |plugin, content_dir|
+        content = Ansible::Content.new(content_dir)
+
         puts "Seeding roles for #{plugin.name}..."
-
-        roles_path = content_dir.join('roles')
-        role_file  = content_dir.join('requirements.yml')
-
-        params = ["install", :roles_path= => roles_path, :role_file= => role_file]
-
         begin
-          AwesomeSpawn.run!("ansible-galaxy", :params => params)
+          content.fetch_galaxy_roles
           puts "Seeding roles for #{plugin.name}...Complete"
         rescue AwesomeSpawn::CommandResultError => err
           puts "Seeding roles for #{plugin.name}...Failed - #{err.result.error}"

--- a/spec/models/manageiq/providers/embedded_ansible_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible_spec.rb
@@ -1,0 +1,40 @@
+describe ManageIQ::Providers::EmbeddedAnsible do
+  describe ".seed" do
+    let(:provider) { ManageIQ::Providers::EmbeddedAnsible::Provider.first }
+    let(:manager)  { provider.automation_manager }
+
+    let(:consolidated_repo_path) { Ansible::Content::PLUGIN_CONTENT_DIR }
+    let(:manager_repo_path)      { ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource::REPO_DIR }
+
+    before do
+      EvmSpecHelper.local_miq_server
+      described_class.seed
+    end
+
+    after do
+      FileUtils.rm_rf(Dir.glob(File.join(manager_repo_path, "*")))
+      FileUtils.rm_rf(Dir.glob(File.join(consolidated_repo_path, "*")))
+    end
+
+    it "creates a provider with a manager" do
+      expect(provider.name).to eq("Embedded Ansible")
+      expect(manager.name).to eq("Embedded Ansible")
+      expect(manager.zone.id).to eq(MiqServer.my_server.zone.id)
+    end
+
+    it "creates the default authentication" do
+      auth = manager.authentications.find_by(:name => "ManageIQ Default Credential")
+      expect(auth).to be_an_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential)
+    end
+
+    it "creates the local playbook repo" do
+      repo = manager.configuration_script_sources.find_by(:name => "ManageIQ Default Project")
+
+      expect(repo.scm_type).to eq("git")
+      expect(repo.scm_url).to eq("file://#{consolidated_repo_path}")
+      expect(repo.scm_update_on_launch).to be_falsey
+
+      expect(Dir.exist?(File.join(consolidated_repo_path, ".git"))).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
This allows plugins (like [manageiq-content](https://github.com/ManageIQ/manageiq-content/tree/a805eac343be9d9adfcd95b5890548641705cd58/content/ansible)) to provide ansible playbooks and roles to embedded ansible.

The directory trees at `/content/ansible` in the plugins will be merged into the `/content/ansible_consolidated` directory in the manageiq repo root directory. From there the `roles` directory should be added to the [`roles_path`](https://docs.ansible.com/ansible/2.4/intro_configuration.html#roles-path) in your local ansible config (and is added to the path on the appliance by the changes in https://github.com/ManageIQ/manageiq-appliance/pull/240) so that all playbooks will have access to the roles provided by plugins.

The playbooks in the `/content/ansible_consolidated` directory will be available in a special playbook repository and can be used as targets for service templates and/or automate methods.

NOTE: As of now, plugin roles are *not* fetched from ansible-galaxy if a requirements file is provided.