### PR TITLE
use non strings for default scopes

### DIFF
--- a/app/models/container_group_performance.rb
+++ b/app/models/container_group_performance.rb
@@ -1,5 +1,5 @@
 class ContainerGroupPerformance < MetricRollup
-  default_scope { where("resource_type = 'ContainerGroup' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'ContainerGroup').where.not(:resource_id => nil) }
 
   belongs_to :container_group, :foreign_key => :resource_id, :class_name => "ContainerGroup"
 

--- a/app/models/container_node_performance.rb
+++ b/app/models/container_node_performance.rb
@@ -1,5 +1,5 @@
 class ContainerNodePerformance < MetricRollup
-  default_scope { where("resource_type = 'ContainerNode' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'ContainerNode').where.not(:resource_id => nil) }
 
   belongs_to :container_node, :foreign_key => :resource_id, :class_name => "ContainerNode"
 

--- a/app/models/container_performance.rb
+++ b/app/models/container_performance.rb
@@ -1,5 +1,5 @@
 class ContainerPerformance < MetricRollup
-  default_scope { where("resource_type = 'Container' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'Container').where.not(:resource_id => nil) }
 
   belongs_to :container_node, :foreign_key => :resource_id, :class_name => "Container"
 

--- a/app/models/container_project_performance.rb
+++ b/app/models/container_project_performance.rb
@@ -1,5 +1,5 @@
 class ContainerProjectPerformance < MetricRollup
-  default_scope { where("resource_type = 'ContainerProject' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'ContainerProject').where.not(:resource_id => nil) }
 
   belongs_to :container_node, :foreign_key => :resource_id, :class_name => "ContainerProject"
 

--- a/app/models/ems_cluster_performance.rb
+++ b/app/models/ems_cluster_performance.rb
@@ -1,5 +1,5 @@
 class EmsClusterPerformance < MetricRollup
-  default_scope { where("resource_type = 'EmsCluster' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => "EmsCluster").where.not(:resource_id => nil) }
 
   belongs_to :ems_cluster, :foreign_key => :resource_id
 

--- a/app/models/ext_management_system_performance.rb
+++ b/app/models/ext_management_system_performance.rb
@@ -1,5 +1,5 @@
 class ExtManagementSystemPerformance < MetricRollup
-  default_scope { where("resource_type = 'ExtManagementSystem' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'ExtManagementSystem').where.not(:resource_id => nil) }
 
   belongs_to :ext_management_system, :foreign_key => :resource_id
 

--- a/app/models/host_metric.rb
+++ b/app/models/host_metric.rb
@@ -1,5 +1,5 @@
 class HostMetric < Metric
-  default_scope { where("resource_type = 'Host' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'Host').where.not(:resource_id => nil) }
 
   belongs_to                :host,        :foreign_key => :resource_id
   belongs_to                :ems_cluster, :foreign_key => :parent_ems_cluster_id

--- a/app/models/host_performance.rb
+++ b/app/models/host_performance.rb
@@ -1,5 +1,5 @@
 class HostPerformance < MetricRollup
-  default_scope { where("resource_type = 'Host' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'Host').where.not(:resource_id => nil) }
 
   belongs_to :ems_cluster, :foreign_key => :parent_ems_cluster_id
   belongs_to :host,        :foreign_key => :resource_id

--- a/app/models/storage_performance.rb
+++ b/app/models/storage_performance.rb
@@ -1,5 +1,5 @@
 class StoragePerformance < MetricRollup
-  default_scope { where("resource_type = 'Storage' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'Storage').where.not(:resource_id => nil) }
 
   belongs_to :storage, :foreign_key => :resource_id
 

--- a/app/models/vm_metric.rb
+++ b/app/models/vm_metric.rb
@@ -1,5 +1,5 @@
 class VmMetric < Metric
-  default_scope { where("resource_type = 'VmOrTemplate' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'VmOrTemplate').where.not(:resource_id => nil) }
 
   belongs_to :host,        :foreign_key => :parent_host_id
   belongs_to :ems_cluster, :foreign_key => :parent_ems_cluster_id

--- a/app/models/vm_performance.rb
+++ b/app/models/vm_performance.rb
@@ -1,5 +1,5 @@
 class VmPerformance < MetricRollup
-  default_scope { where("resource_type = 'VmOrTemplate' and resource_id IS NOT NULL") }
+  default_scope { where(:resource_type => 'VmOrTemplate').where.not(:resource_id => nil) }
 
   belongs_to :host,        :foreign_key => :parent_host_id
   belongs_to :ems_cluster, :foreign_key => :parent_ems_cluster_id


### PR DESCRIPTION
## Overview

This is a bug without a BZ, so I'm stating it is a refactor.

When a `WHERE` clause is defined as a string, the string goes directly into the query.
When a `WHERE` clause is defined as a hash, the table name is included in the query.

## Before

While running a report with EmsClusterPerformance:

The sql generated was not fully qualifying the table for the resource.
This caused an ambiguous resource_type reference in the sql.
The report blew up.

```ruby
puts EmsClusterPerformance.all.to_sql

SELECT "metric_rollups".* FROM "metric_rollups"
WHERE (resource_type = 'EmsCluster' AND resource_id IS NOT NULL)
```

## After

The sql generated fully qualifies resource.
The sql generated no longer fails

```ruby
puts EmsClusterPerformance.all.to_sql

SELECT "metric_rollups".* FROM "metric_rollups"
WHERE "metric_rollups"."resource_type" = 'EmsCluster'
  AND ("metric_rollups"."resource_id" IS NOT NULL)
```

