### PR TITLE
only include tenant requires if in query

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -577,8 +577,11 @@ module Rbac
     def scope_to_cloud_tenant(scope, user, miq_group)
       klass = scope.respond_to?(:klass) ? scope.klass : scope
       user_or_group = user || miq_group
-      tenant_id_clause = klass.tenant_id_clause(user_or_group)
-      klass.tenant_joins_clause(scope).where(tenant_id_clause)
+      if (tenant_id_clause = klass.tenant_id_clause(user_or_group))
+        klass.tenant_joins_clause(scope).where(tenant_id_clause)
+      else
+        scope
+      end
     end
 
     def scope_for_user_role_group(klass, scope, miq_group, user, managed_filters)


### PR DESCRIPTION
## Overview

The `tenant_join_clause` is only necessary if we are including
the `tenant_id_clause`

## Before:

The extra includes and requires bring back quite a few extra columns.

```ruby
User.current_user = User.super_admin
Rbac.filtered(CloudTenant).first

SELECT  "cloud_tenants"."id" AS t0_r0, "cloud_tenants"."name" AS t0_r1, "cloud_tenants"."description" AS t0_r2, "cloud_tenants"."enabled" AS t0_r3, "cloud_tenants"."ems_ref" AS t0_r4, "cloud_tenants"."ems_id" AS t0_r5, "cloud_tenants"."created_at" AS t0_r6, "cloud_tenants"."updated_at" AS t0_r7, "cloud_tenants"."type" AS t0_r8, "cloud_tenants"."parent_id" AS t0_r9,
       "tenants"."id" AS t1_r0, "tenants"."domain" AS t1_r1, "tenants"."subdomain" AS t1_r2, "tenants"."name" AS t1_r3, "tenants"."login_text" AS t1_r4, "tenants"."logo_file_name" AS t1_r5, "tenants"."logo_content_type" AS t1_r6, "tenants"."logo_file_size" AS t1_r7, "tenants"."logo_updated_at" AS t1_r8, "tenants"."login_logo_file_name" AS t1_r9, "tenants"."login_logo_content_type" AS t1_r10, "tenants"."login_logo_file_size" AS t1_r11, "tenants"."login_logo_updated_at" AS t1_r12, "tenants"."ancestry" AS t1_r13, "tenants"."divisible" AS t1_r14, "tenants"."description" AS t1_r15, "tenants"."use_config_for_attributes" AS t1_r16, "tenants"."default_miq_group_id" AS t1_r17, "tenants"."source_type" AS t1_r18, "tenants"."source_id" AS t1_r19,
       "ext_management_systems"."id" AS t2_r0, "ext_management_systems"."name" AS t2_r1, "ext_management_systems"."created_on" AS t2_r2, "ext_management_systems"."updated_on" AS t2_r3, "ext_management_systems"."guid" AS t2_r4, "ext_management_systems"."zone_id" AS t2_r5, "ext_management_systems"."type" AS t2_r6, "ext_management_systems"."api_version" AS t2_r7, "ext_management_systems"."uid_ems" AS t2_r8, "ext_management_systems"."host_default_vnc_port_start" AS t2_r9, "ext_management_systems"."host_default_vnc_port_end" AS t2_r10, "ext_management_systems"."provider_region" AS t2_r11, "ext_management_systems"."last_refresh_error" AS t2_r12, "ext_management_systems"."last_refresh_date" AS t2_r13, "ext_management_systems"."provider_id" AS t2_r14, "ext_management_systems"."realm" AS t2_r15, "ext_management_systems"."tenant_id" AS t2_r16, "ext_management_systems"."project" AS t2_r17, "ext_management_systems"."parent_ems_id" AS t2_r18, "ext_management_systems"."subscription" AS t2_r19, "ext_management_systems"."last_metrics_error" AS t2_r20, "ext_management_systems"."last_metrics_update_date" AS t2_r21, "ext_management_systems"."last_metrics_success_date" AS t2_r22, "ext_management_systems"."tenant_mapping_enabled" AS t2_r23, "ext_management_systems"."enabled" AS t2_r24, "ext_management_systems"."options" AS t2_r25, "ext_management_systems"."zone_before_pause_id" AS t2_r26, "ext_management_systems"."last_inventory_date" AS t2_r27
FROM "cloud_tenants"
LEFT OUTER JOIN "tenants" ON "tenants"."source_id" = "cloud_tenants"."id" AND "tenants"."source_type" = 'CloudTenant'
LEFT OUTER JOIN "ext_management_systems" ON "ext_management_systems"."id" = "cloud_tenants"."ems_id"
```


## After:

```
User.current_user = User.super_admin
Rbac.filtered(CloudTenant).first
SELECT  "cloud_tenants".* FROM "cloud_tenants" LIMIT $1  [["LIMIT", 1]]
```

only include these extra fields if we are using the fields with the
where clause

Note, the query is the long form again when tenant clause is necessary, e.g.: non-admin users.