### PR TITLE
Use rails deprecation behavior but log in production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,7 @@ Vmdb::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
-  # Print deprecation notices to the Rails logger
+  # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
   # Only use best-standards-support built into browsers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,8 +60,12 @@ Vmdb::Application.configure do
   # the I18n.default_locale when a translation can not be found)
   config.i18n.fallbacks = [I18n.default_locale]
 
-  # Send deprecation notices to registered listeners
-  config.active_support.deprecation = :notify
+  # Send deprecation notices to registered listeners.
+  # config.active_support.deprecation = :notify
+
+  # Change from rails :notify default since it's unlikely we'll have users setup
+  # notifications for deprecation warnings.
+  config.active_support.deprecation = :log
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,8 +10,8 @@ Vmdb::Application.configure do
   config.cache_classes = true
   config.eager_load = false
 
-  # Print deprecation notices to the stderr
-  #ActiveSupport::Deprecation.behavior = :stderr
+  # Print deprecation notices to the stderr.
+  config.active_support.deprecation = :stderr
 
   # Configure static asset server for tests with Cache-Control for performance
   config.public_file_server.enabled = true


### PR DESCRIPTION
* Copy current edge rails defaults for test/dev
* Log deprecations in production mode
  Change from rails :notify default since it's unlikely we'll have users setup notifications for deprecation warnings.