### PR TITLE
[wip] Rbac no references

### DIFF
--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -45,7 +45,7 @@ class Flavor < ApplicationRecord
 
   def self.tenant_joins_clause(scope)
     scope.includes(:cloud_tenants => "source_tenant", :ext_management_system => {})
-         .references(:cloud_tenants => "source_tenant", :ext_management_system => {})
+         .references(:cloud_tenants, :tenants, :ext_management_system)
   end
 
   def self.create_flavor_queue(userid, ext_management_system, options = {})

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -258,7 +258,7 @@ module MiqReport::Generator
                             .where(options[:where_clause])
                             .where(:timestamp => time_range)
                             .includes(db_includes)
-                            .references(db_includes)
+                            .references(Rbac.includes_to_references(db_klass, db_includes))
                             .includes(exp_includes || [])
                             .limit(options[:limit])
     results = Rbac.filtered(results, :class        => db,

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -19,7 +19,7 @@ module CloudTenancyMixin
 
     def tenant_joins_clause(scope)
       scope.includes(QUERY_REFERENCES)
-           .references(QUERY_REFERENCES) # needed for the where to work
+           .references(:cloud_tenant, :tenants, :ext_management_systems) # needed for the where to work
     end
   end
 end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -90,7 +90,7 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def self.with_additional_tenants
-    includes(:service_template_tenants => :tenant)
+    references(table_name.to_sym, :tenants).includes(:service_template_tenants => :tenant)
   end
 
   def self.catalog_item_types

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -49,7 +49,7 @@ describe ContainerGroup do
     it "preloads the conditions" do
       condition_other
       cr = condition_ready
-      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status => {}).find_by(:id => container_group.id)
+      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status).find_by(:id => container_group.id)
 
       expect { expect(cg.ready_condition).to eq(cr) }.to match_query_limit_of(0)
     end

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -34,7 +34,7 @@ describe MetricRollup do
       # TODO: that causes the error "ActiveRecord::ConfigurationError: nil"
       # TODO: instead of the expected "ActiveRecord::EagerLoadPolymorphicError" error.
       expect do
-        Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table => {}).to_a
+        Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table).to_a
       end.to raise_error ActiveRecord::EagerLoadPolymorphicError
     end
   end


### PR DESCRIPTION
extracted

- [x] #18863 unrelated tests

## Overview

On a page, we reference multiple models. Some are referenced in the `WHERE` clause, while others are just needed in ruby.

Before rails 4.2, all models were brought back in a single query, so the 2 use cases were not distinguished. These joins were not the most efficient and a new approach was needed.

After rails 4.2, `references()` is used when a foreign model is referenced in the `WHERE` query, and `includes()` is used when a model is preloaded in ruby.

At the time, we punted and just called `references()` for all models, whether it was referenced or not. This conservative choice worked for a while, but the queries produced are bring back too much data. 

## Before

@NickLaMuro was able to remove a number of `references()` calls that were problematic. Both for polymorphic columns but also for some cases that joined to too many foreign tables and brought back too much data. (One query brought back 50GB of data). But it still plagues us in a number of queries.

While moving to Rails 5.1, virtual attributes has been updated to simplify `includes()`, but this means there are even more tables in the primary query.

## After

We no longer call `references()` for most relationships. To be honest, the only models needed in the query are those that come from the `miq_expression`. This is obvious if you think about it; the purpose of the miq_expression is to enhance the where clause. So those are the only references that could possibly introduce additional table references to the query. Nothing else enhances the query dynamically.

Removing `references()` allows rails to work the way it was designed. We tell it what to eager load with `includes()` and it takes care of how it wants to query those objects. Sometimes it uses the query and other times it performs separate queries.

The changes are mostly simplification:

- The `DISTINCT` no is longer needed in the primary query or the `COUNT(*)` query.
- The primary query is far shorter. (11,563 characters -> 1,671 characters.)
- There are now more queries (9 -> 16 in the case below).
- Even with additional queries, they run faster (459ms -> 114ms) 
- The number of rows in the primary query is lower (34 -> 20). Our pagination is 20
- For `VmOrTemplate`, the number of columns in the primary query goes from 175 columns to 76

## Numbers

|       ms |query |  qry ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  1,072.3 |    9 |   459.4 |       39 |before
|    997.3 |   16 |   114.7 |      111 |after
| 7.0% | -78% |  75.0% | -185% | delta

#### before

- I removed the same 6 queries from both tables to make it easier to read.
- The numbers in square brackets are the character count of the query.

|       ms |query |  qry ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|  1,072.3 |    9 |   459.4 |       39 |`/vm_infra/report_data#before`
|     28.4 |    1 |    28.4 |          |`SELECT DISTINCT COUNT(DISTINCT "vms"."id") -- [1220]`
|    104.6 |    1 |   104.6 |          |`SELECT DISTINCT "vms"."id", LOWER("vms"."name") AS alias_0 -- [1292]`
|     64.0 |    1 |    30.2 |       34 |`SELECT "vms".*, (SELECT "ems_clusters"."name" -- [11563]`

#### after

|       ms |query |  qry ms |     rows |`comments`
|      ---:|  ---:|     ---:|      ---:| ---
|    997.3 |   16 |   114.7 |      111 |`/vm_infra/report_data#after`
|      6.4 |    1 |     6.4 |          |`SELECT COUNT(*) -- [557]`
|     18.2 |    1 |    14.5 |       20 |`SELECT "vms".*, (SELECT "ems_clusters"."name" -- [1671]`
|      6.5 |    1 |     4.3 |       20 |`SELECT "hardwares".* -- [191]`
|      5.3 |    1 |     4.6 |        4 |`SELECT "networks".* -- [166]`
|      7.7 |    1 |     6.8 |        2 |`SELECT "hosts".* -- [60]`
|      8.2 |    1 |     7.4 |        2 |`SELECT "storages".* -- [68]`
|      7.3 |    1 |     6.0 |        1 |`SELECT "ext_management_systems".* -- [104]`
|      5.2 |    1 |     3.6 |       20 |`SELECT "operating_systems".* -- [215]`
|      7.0 |    1 |     5.2 |       34 |`SELECT "taggings".* -- [232]`
|      8.2 |    1 |     6.8 |        3 |`SELECT "tags".* -- [64]`

## Primary Query

#### before (pair)

```sql
SELECT  DISTINCT "vms"."id",
        LOWER("vms"."name") AS alias_0
FROM "vms"
LEFT OUTER JOIN "hardwares" ON "hardwares"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "hosts" ON "hosts"."id" = "vms"."host_id"
LEFT OUTER JOIN "storages" ON "storages"."id" = "vms"."storage_id"
LEFT OUTER JOIN "ext_management_systems" ON "ext_management_systems"."id" = "vms"."ems_id"
LEFT OUTER JOIN "operating_systems" ON "operating_systems"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "taggings" ON "taggings"."taggable_id" = "vms"."id" AND "taggings"."taggable_type" = $1
LEFT OUTER JOIN "tags" ON "tags"."id" = "taggings"."tag_id"
WHERE "vms"."type" IN (...)
ORDER BY LOWER("vms"."name") ASC LIMIT $2 OFFSET $3

SELECT "vms".*,
       (SELECT "ems_clusters"."name" ...) AS "last_compliance_status",
       (SELECT COUNT(*) ...) AS "v_total_snapshots",
       (SELECT  (SELECT SUM("disks"."size") ...) AS "allocated_disk_storage",
       (CASE WHEN ("vms"."ems_id" IS NULL ...) AS "normalized_state",
       "vms"."id" AS t0_r0, ... "vms"."hostname" AS t0_r76,
       "hardwares"."id" AS t1_r0, ..., "hardwares"."canister_id" AS t1_r38,
       "hosts"."id" AS t2_r0, ..., "hosts"."physical_server_id" AS t2_r36,
       "storages"."id" AS t3_r0, ..., "storages"."status" AS t3_r19,
       "ext_management_systems"."id" AS t4_r0, ..., "ext_management_systems"."last_inventory_date" AS t4_r27,
       "operating_systems"."id" AS t5_r0, ..., "operating_systems"."kernel_version" AS t5_r25,
       "tags"."id" AS t6_r0, "tags"."name" AS t6_r1
FROM "vms"
LEFT OUTER JOIN "hardwares" ON "hardwares"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "hosts" ON "hosts"."id" = "vms"."host_id"
LEFT OUTER JOIN "storages" ON "storages"."id" = "vms"."storage_id"
LEFT OUTER JOIN "ext_management_systems" ON "ext_management_systems"."id" = "vms"."ems_id"
LEFT OUTER JOIN "operating_systems" ON "operating_systems"."vm_or_template_id" = "vms"."id"
LEFT OUTER JOIN "taggings" ON "taggings"."taggable_id" = "vms"."id" AND "taggings"."taggable_type" = $1
LEFT OUTER JOIN "tags" ON "tags"."id" = "taggings"."tag_id"
WHERE "vms"."type" IN (...)
AND "vms"."id" IN (1872, 2199, 2080, 2079, 2222, 2216, 2255, 2211, 2250, 2212, 2251, 2213, 2252, 2214, 2253, 2221, 50, 51, 64, 62)
ORDER BY LOWER("vms"."name") ASC ["VmOrTemplate"]
```

#### after

```sql
SELECT  "vms".*,
        (SELECT "ems_clusters"."name" ...) AS "ems_cluster_name",
        (SELECT  "compliances"."compliant" ...) AS "last_compliance_status",
        (SELECT COUNT(*) ...) AS "v_total_snapshots",
        (SELECT  (SELECT SUM("disks"."size") FROM "disks" ...) AS "allocated_disk_storage",
        (CASE WHEN ("vms"."ems_id" IS NULL ...) AS "normalized_state"
FROM "vms"
WHERE "vms"."type" IN (...)
ORDER BY LOWER("vms"."name") ASC LIMIT $1 OFFSET $2 [20, 0]`
```