### PR TITLE
Support for opening URL from the UI through automate.

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -4,6 +4,7 @@ class CloudTenant < ApplicationRecord
 
   include NewWithTypeStiMixin
   include CustomActionsMixin
+  include ExternalUrlMixin
   extend ActsAsTree::TreeWalker
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"

--- a/app/models/external_url.rb
+++ b/app/models/external_url.rb
@@ -1,0 +1,6 @@
+class ExternalUrl < ApplicationRecord
+  belongs_to :resource, :polymorphic => true
+  belongs_to :user
+
+  validates :url, :format => URI::regexp, :allow_nil => false
+end

--- a/app/models/generic_object.rb
+++ b/app/models/generic_object.rb
@@ -1,6 +1,8 @@
 class GenericObject < ApplicationRecord
   acts_as_miq_taggable
 
+  include ExternalUrlMixin
+
   virtual_has_one :custom_actions
   virtual_has_one :custom_action_buttons
 

--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -41,6 +41,7 @@ class MiqGroup < ApplicationRecord
   include TimezoneMixin
   include TenancyMixin
   include CustomActionsMixin
+  include ExternalUrlMixin
 
   alias_method :current_tenant, :tenant
 

--- a/app/models/mixins/external_url_mixin.rb
+++ b/app/models/mixins/external_url_mixin.rb
@@ -1,0 +1,12 @@
+module ExternalUrlMixin
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :external_urls, :as => :resource, :dependent => :destroy
+  end
+
+  def external_url=(url, user = User.current_user)
+    external_urls.where(:user => user).destroy_all
+    external_urls.create!(:url => url, :user => user)
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -6,6 +6,7 @@ class Provider < ApplicationRecord
   include SupportsFeatureMixin
   include TenancyMixin
   include UuidMixin
+  include ExternalUrlMixin
 
   belongs_to :tenant
   belongs_to :zone

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -68,6 +68,7 @@ class Service < ApplicationRecord
   include SupportsFeatureMixin
   include CiFeatureMixin
   include Metric::CiMixin
+  include ExternalUrlMixin
 
   extend InterRegionApiMethodRelay
 

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -9,6 +9,7 @@ class Tenant < ApplicationRecord
   include ActiveVmAggregationMixin
   include CustomActionsMixin
   include TenantQuotasMixin
+  include ExternalUrlMixin
 
   acts_as_miq_taggable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   include ActiveVmAggregationMixin
   include TimezoneMixin
   include CustomActionsMixin
+  include ExternalUrlMixin
 
   has_many   :miq_approvals, :as => :approver
   has_many   :miq_approval_stamps,  :class_name => "MiqApproval", :foreign_key => :stamper_id

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -5,6 +5,7 @@ class Vm < VmOrTemplate
   extend InterRegionApiMethodRelay
   include CustomActionsMixin
   include CiFeatureMixin
+  include ExternalUrlMixin
 
   include_concern 'Operations'
 

--- a/config/replication_exclude_tables.yml
+++ b/config/replication_exclude_tables.yml
@@ -15,6 +15,7 @@
 - customization_specs
 - database_backups
 - event_logs
+- external_urls
 - file_depots
 - jobs
 - log_files

--- a/spec/models/mixins/external_url_spec.rb
+++ b/spec/models/mixins/external_url_spec.rb
@@ -1,0 +1,43 @@
+describe ExternalUrlMixin do
+  let(:test_class) do
+    Class.new(ActiveRecord::Base) do
+      def self.name; 'TestClass'; end
+      self.table_name = 'vms'
+      include ExternalUrlMixin
+    end
+  end
+
+  describe '#external_url=' do
+    before do
+      User.current_user = FactoryBot.create(:user)
+    end
+
+    let(:test_instance) do
+      test_class.create.tap { |i| i.external_url = 'https://www.other.example.com' }
+    end
+
+    it 'sets url for the current user' do
+      expect(ExternalUrl.where(
+        :user          => User.current_user,
+        :resource_type => 'TestClass',
+        :resource_id   => test_instance.id
+      ).first.attributes).to include(
+        'url' => 'https://www.other.example.com',
+      )
+    end
+
+    it 'removes previously set url for the current user' do
+      test_instance.external_url = 'https://www.example.com'
+      test_instance.reload
+      expect(test_instance.external_urls.count).to eq(1)
+
+      expect(ExternalUrl.where(
+        :user          => User.current_user,
+        :resource_type => 'TestClass',
+        :resource_id   => test_instance.id
+      ).first.attributes).to include(
+        'url' => 'https://www.example.com',
+      )
+    end
+  end
+end


### PR DESCRIPTION
Adding a model and mixin for temporary storing URL returned from automate.

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1550002


UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/5688
Guides article: https://github.com/martinpovolny/guides/blob/automate_url_opener/automate_url_open.md (from PR: https://github.com/ManageIQ/guides/pull/355)
Automate PR: https://github.com/ManageIQ/manageiq-automation_engine/pull/328
Schema PR: https://github.com/ManageIQ/manageiq-schema/pull/380

https://bugzilla.redhat.com/show_bug.cgi?id=1550002

### TODO:

 * ~~tests (what should I test?)~~
 * ~~add user to the `SavedUrl`~~