### PR TITLE
MiqReport.get_col_info - fix NoMethodError parse_field_or_tag

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -124,7 +124,7 @@ class MiqReport < ApplicationRecord
   end
 
   def self.get_col_info(path)
-    data_type = parse_field_or_tag(path).try(:column_type)
+    data_type = MiqExpression.parse_field_or_tag(path).try(:column_type)
     {
       :data_type         => data_type,
       :available_formats => get_available_formats(path, data_type),

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -1103,4 +1103,31 @@ describe MiqReport do
       end
     end
   end
+
+  context '.get_col_info' do
+    it "calls MiqExpression" do
+      expect(MiqExpression).to receive(:parse_field_or_tag).once
+      MiqReport.get_col_info('Vm-name')
+    end
+
+    it "is numeric for id columns" do
+      expect(MiqReport.get_col_info('Vm-id')[:numeric]).to eq(true)
+    end
+
+    it "is not numeric for string columns" do
+      expect(MiqReport.get_col_info('Vm-name')[:numeric]).to eq(false)
+    end
+
+    it "has default_format" do
+      expect(MiqReport.get_col_info('Vm-id')[:default_format]).to be_present
+    end
+
+    it "has available_formats" do
+      expect(MiqReport.get_col_info('Vm-id')[:available_formats]).to be_present
+    end
+
+    it "has data_type" do
+      expect(MiqReport.get_col_info('Vm-name')[:data_type]).to eq(:string)
+    end
+  end
 end


### PR DESCRIPTION
comes from https://github.com/ManageIQ/manageiq/pull/18784, the method exists, but not on MiqReport, only MiqExpression

and adding specs for MiqReport.get_col_info - this is being used by the UI, should have tests to catch failures

Cc @lpichler @kbrock 
@miq-bot add_label bug, 