### PR TITLE
[V2V] Filter certain options in the ConversionHost#run_conversion method

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -151,13 +151,21 @@ class ConversionHost < ApplicationRecord
     raise "Could not apply the limits in '#{path}' on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
+  # Run the virt-v2v-wrapper.py script on the remote host and return a hash
+  # result from the parsed JSON output.
+  #
+  # Certain sensitive fields are filtered in the error messages to prevent
+  # that information from showing up in the UI or logs.
+  #
   def run_conversion(conversion_options)
+    ignore = %w[password fingerprint key]
+    filtered_options = conversion_options.clone.tap { |h| h.each { |k, _v| h[k] = "__FILTERED__" if ignore.any? { |i| k.to_s.end_with?(i) } } }
     result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', nil, nil, conversion_options.to_json) }
     JSON.parse(result)
   rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
-    raise "Failed to connect and run conversion using options #{conversion_options} with [#{err.class}: #{err}]"
+    raise "Failed to connect and run conversion using options #{filtered_options} with [#{err.class}: #{err}]"
   rescue JSON::ParserError
-    raise "Could not parse result data after running virt-v2v-wrapper.py using options: #{conversion_options}. Result was: #{result}."
+    raise "Could not parse result data after running virt-v2v-wrapper.py using options: #{filtered_options}. Result was: #{result}."
   rescue StandardError => err
     raise "Starting conversion failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -462,7 +462,8 @@ RSpec.describe ConversionHost, :v2v do
   context "#run_conversion" do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
-    let(:conversion_options) { {:foo => 1, :bar => 'hello' } }
+    let(:conversion_options) { {:foo => 1, :bar => 'hello', :password => 'xxx', :ssh_key => 'xyz' } }
+    let(:filtered_options) { conversion_options.clone.update(:ssh_key => '__FILTERED__', :password => '__FILTERED__') }
 
     it "works as expected if the connection is successful and the JSON is valid" do
       allow(conversion_host).to receive(:connect_ssh).and_return({:alpha => {:beta => 'hello'}}.to_json)
@@ -472,13 +473,13 @@ RSpec.describe ConversionHost, :v2v do
     it "works as expected if the connection is successful but the JSON is invalid" do
       allow(conversion_host).to receive(:connect_ssh).and_return('bogus')
       expected_message = "Could not parse result data after running virt-v2v-wrapper.py using "\
-        "options: #{conversion_options}. Result was: bogus."
+        "options: #{filtered_options}. Result was: bogus."
       expect { conversion_host.run_conversion(conversion_options) }.to raise_error(expected_message)
     end
 
     it "works as expected if the connection is unsuccessful" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
-      expected_message = "Failed to connect and run conversion using options #{conversion_options}"
+      expected_message = "Failed to connect and run conversion using options #{filtered_options}"
       expect { conversion_host.run_conversion(conversion_options) }.to raise_error(/#{expected_message}/)
     end
 


### PR DESCRIPTION
At the moment the `ConversionHost#run_conversion` method potentially exposes some sensitive data on failure. This PR filters anything that ends with "password", "key" or "fingerprint" from the logs and/or UI.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1716415