### PR TITLE
[Fix] PID retrieval to kill virt-v2v

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -210,6 +210,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     updates = {}
     virtv2v_state = conversion_host.get_conversion_state(options[:virtv2v_wrapper]['state_file'])
     updated_disks = virtv2v_disks
+    updates[:virtv2v_pid] = virtv2v_state['pid'] if virtv2v_state['pid'].present?
     updates[:virtv2v_message] = virtv2v_state['last_message']['message'] if virtv2v_state['last_message'].present?
     if virtv2v_state['finished'].nil?
       updated_disks.each do |disk|
@@ -235,9 +236,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def kill_virtv2v(signal = 'TERM')
+    get_conversion_state
     return false if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
-    return false unless options[:virtv2v_wrapper]['pid']
-    conversion_host.kill_process(options[:virtv2v_wrapper]['pid'], signal)
+    return false unless options[:virtv2v_pid]
+    conversion_host.kill_process(options[:virtv2v_pid], signal)
   end
 
   private

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -237,8 +237,18 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def kill_virtv2v(signal = 'TERM')
     get_conversion_state
-    return false if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
-    return false unless options[:virtv2v_pid]
+
+    if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
+      _log.info("virt-v2v is not running, so there is nothing to do.")
+      return false
+    end
+    
+    unless options[:virtv2v_pid]
+      _log.info("No PID has been reported by virt-v2v-wrapper, so we can't kill it.")
+      return false
+    end
+
+    _log.info("Killing virt-v2v (PID: #{options[:virtv2v_pid]}) with #{signal} signal.")
     conversion_host.kill_process(options[:virtv2v_pid], signal)
   end
 

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -242,7 +242,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       _log.info("virt-v2v is not running, so there is nothing to do.")
       return false
     end
-    
+
     unless options[:virtv2v_pid]
       _log.info("No PID has been reported by virt-v2v-wrapper, so we can't kill it.")
       return false

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -198,11 +198,12 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     describe '#kill_virtv2v' do
       before do
         task.options = {
-          :virtv2v_wrapper    => { 'state_file' => '/tmp/v2v.state', 'pid' => '1234' },
+          :virtv2v_pid        => '1234',
+          :virtv2v_wrapper    => { 'state_file' => '/tmp/v2v.state' },
           :virtv2v_started_on => 1
         }
         task.conversion_host = conversion_host
-        allow(conversion_host).to receive(:get_conversion_state).with(task.options[:virtv2v_wrapper]['state_file']).and_return({})
+        allow(task).to receive(:get_conversion_state).and_return([])
       end
 
       it "returns false if not started" do
@@ -223,8 +224,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         expect(task.kill_virtv2v('KILL')).to eq(false)
       end
 
-      it "returns false if virtv2v_wrapper.pid is absent" do
-        task.options[:virtv2v_wrapper]['pid'] = nil
+      it "returns false if virtv2v_pid is absent" do
+        task.options[:virtv2v_pid] = nil
         expect(conversion_host).not_to receive(:kill_process)
         expect(task.kill_virtv2v('KILL')).to eq(false)
       end


### PR DESCRIPTION
When we cancel a migration, we need the PID of virt-v2v to kill it. However, due to some previous code changes, the PID is not stored any more in `task.options[:virtv2v_wrapper]`. This PR updates the `get_conversion_state` method to also store the PID as `task.options[:virtv2v_pid]`. Then the `kill_virtv2v` method calls `get_conversion_state` to be sure that the PID is retrieved if it exists.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1666799