### PR TITLE
Re-Add API_OPTIONS to EmbeddedAnsible credentials

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -1,4 +1,35 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Access Key'),
+      :help_text => N_('AWS Access Key for this credential'),
+      :required  => true
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Secret Key'),
+      :help_text => N_('AWS Secret Key for this credential'),
+      :required  => true
+    }
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :security_token => {
+      :type       => :password,
+      :label      => N_('STS Token'),
+      :help_text  => N_('Security Token Service(STS) Token for this credential'),
+      :max_length => 1024
+    }
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Amazon'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (Amazon)', 'Credentials (Amazon)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -1,4 +1,52 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('The username to use to connect to the Microsoft Azure account')
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password'),
+      :help_text => N_('The password to use to connect to the Microsoft Azure account')
+    }
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :subscription => {
+      :type       => :string,
+      :label      => N_('Subscription ID'),
+      :help_text  => N_('The Subscription UUID for the Microsoft Azure account'),
+      :max_length => 1024,
+      :required   => true
+    },
+    :tenant       => {
+      :type       => :string,
+      :label      => N_('Tenant ID'),
+      :help_text  => N_('The Tenant ID for the Microsoft Azure account'),
+      :max_length => 1024
+    },
+    :secret       => {
+      :type       => :password,
+      :label      => N_('Client Secret'),
+      :help_text  => N_('The Client Secret for the Microsoft Azure account'),
+      :max_length => 1024,
+    },
+    :client       => {
+      :type       => :string,
+      :label      => N_('Client ID'),
+      :help_text  => N_('The Client ID for the Microsoft Azure account'),
+      :max_length => 128
+    },
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Azure'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (Microsoft Azure)', 'Credentials (Microsoft Azure)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -6,6 +6,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
   alias_attribute :manager_id, :resource_id
   alias_attribute :manager, :resource
 
+  COMMON_ATTRIBUTES = {}.freeze
+  EXTRA_ATTRIBUTES = {}.freeze
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
   FRIENDLY_NAME = "Ansible Automation Inside Credential".freeze
 
   def self.provider_params(params)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -1,4 +1,42 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  COMMON_ATTRIBUTES = {
+    :userid => {
+      :type      => :email,
+      :label     => N_('Service Account Email Address'),
+      :help_text => N_('The email address assigned to the Google Compute Engine service account'),
+      :required  => true
+    }
+  }.freeze
+
+  # rubocop:disable Layout/AlignHash
+  #
+  # looks better to align the nested keys to the same distance, instead of
+  # scope just for the hash in question (which is what rubocop does.
+  EXTRA_ATTRIBUTES = {
+    :ssh_key_data => {
+      :type       => :password,
+      :multiline  => true,
+      :label      => N_('RSA Private Key'),
+      :help_text  => N_('Contents of the PEM file associated with the service account email'),
+      :required   => true
+    },
+    :project      => {
+      :type       => :string,
+      :label      => N_('Project'),
+      :help_text  => N_('The GCE assigned identification. It is constructed as two words followed by a three digit number, such as: squeamish-ossifrage-123'),
+      :max_length => 100,
+    }
+  }.freeze
+  # rubocop:enable Layout/AlignHash
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('Google Compute Engine'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (Google)', 'Credentials (Google)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -1,4 +1,62 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('Username for this credential')
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password'),
+      :help_text => N_('Password for this credential')
+    }
+  }.freeze
+
+  # rubocop:disable Layout/AlignHash
+  #
+  # looks better to align the nested keys to the same distance, instead of
+  # scope just for the hash in question (which is what rubocop does.
+  EXTRA_ATTRIBUTES = {
+    :ssh_key_data => {
+      :type       => :password,
+      :multiline  => true,
+      :label      => N_('Private key'),
+      :help_text  => N_('RSA or DSA private key to be used instead of password')
+    },
+    :ssh_key_unlock => {
+      :type       => :password,
+      :label      => N_('Private key passphrase'),
+      :help_text  => N_('Passphrase to unlock SSH private key if encrypted'),
+      :max_length => 1024
+    },
+    :become_method => {
+      :type       => :choice,
+      :label      => N_('Privilege Escalation'),
+      :help_text  => N_('Privilege escalation method'),
+      :choices    => ['', 'sudo', 'su', 'pbrun', 'pfexec']
+    },
+    :become_username => {
+      :type       => :string,
+      :label      => N_('Privilege Escalation Username'),
+      :help_text  => N_('Privilege escalation username'),
+      :max_length => 1024
+    },
+    :become_password => {
+      :type       => :password,
+      :label      => N_('Privilege Escalation Password'),
+      :help_text  => N_('Password for privilege escalation method'),
+      :max_length => 1024
+    }
+  }.freeze
+  # rubocop:enable Layout/AlignHash
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => N_('Machine'),
+    :type       => 'machine',
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (Machine)', 'Credentials (Machine)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -1,4 +1,56 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('Username for this credential'),
+      :required  => true
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password'),
+      :help_text => N_('Password for this credential'),
+      :required  => true
+    }
+  }.freeze
+
+  # rubocop:disable Layout/AlignHash
+  #
+  # looks better to align the nested keys to the same distance, instead of
+  # scope just for the hash in question (which is what rubocop does.
+  EXTRA_ATTRIBUTES = {
+    :authorize      => {
+      :type         => :boolean,
+      :label        => N_('Authorize'),
+      :help_text    => N_('Whether to use the authorize mechanism')
+    },
+    :authorize_password => {
+      :type         => :password,
+      :label        => N_('Authorize password'),
+      :help_text    => N_('Password used by the authorize mechanism')
+    },
+    :ssh_key_data   => {
+      :type         => :password,
+      :multiline    => true,
+      :label        => N_('SSH key'),
+      :help_text    => N_('RSA or DSA private key to be used instead of password')
+    },
+    :ssh_key_unlock => {
+      :type         => :password,
+      :label        => N_('Private key passphrase'),
+      :help_text    => N_('Passphrase to unlock SSH private key if encrypted'),
+      :max_length   => 1024
+    }
+  }.freeze
+  # rubocop:enable Layout/AlignHash
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => N_('Network'),
+    :type       => 'network',
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (Network)', 'Credentials (Network)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -1,4 +1,49 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('The username to use to connect to OpenStack'),
+      :required  => true
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password (API Key)'),
+      :help_text => N_('The password or API key to use to connect to OpenStack'),
+      :required  => true
+    }
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :host    => {
+      :type       => :string,
+      :label      => N_('Host (Authentication URL)'),
+      :help_text  => N_('The host to authenticate with. For example, https://openstack.business.com/v2.0'),
+      :max_length => 1024,
+      :required   => true
+    },
+    :project => {
+      :type       => :string,
+      :label      => N_('Project (Tenant Name)'),
+      :help_text  => N_('This is the tenant name. This value is usually the same as the username'),
+      :max_length => 100,
+      :required   => true
+    },
+    :domain  => {
+      :type       => :string,
+      :label      => N_('Domain Name'),
+      :help_text  => N_('OpenStack domains define administrative boundaries. It is only needed for Keystone v3 authentication URLs'),
+      :max_length => 100
+    }
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :type       => 'cloud',
+    :label      => N_('OpenStack'),
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (OpenStack)', 'Credentials (OpenStack)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
@@ -1,4 +1,34 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('Username for this credential')
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password'),
+      :help_text => N_('Password for this credential')
+    }
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :host => {
+      :type       => :string,
+      :label      => N_('Host'),
+      :help_text  => N_('The host to authenticate with'),
+      :max_length => 1024,
+      :required   => true
+    }
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => N_('Red Hat Virtualization'),
+    :type       => 'cloud',
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (RHV)', 'Credentials (RHV)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
@@ -1,4 +1,44 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('Username for this credential')
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password'),
+      :help_text => N_('Password for this credential')
+    }
+  }.freeze
+
+  # rubocop:disable Layout/AlignHash
+  #
+  # looks better to align the nested keys to the same distance, instead of
+  # scope just for the hash in question (which is what rubocop does.
+  EXTRA_ATTRIBUTES = {
+    :ssh_key_unlock => {
+      :type       => :password,
+      :label      => N_('Private key passphrase'),
+      :help_text  => N_('Passphrase to unlock SSH private key if encrypted'),
+      :max_length => 1024
+    },
+    :ssh_key_data => {
+      :type       => :password,
+      :multiline  => true,
+      :label      => N_('Private key'),
+      :help_text  => N_('RSA or DSA private key to be used instead of password')
+    }
+  }.freeze
+  # rubocop:enable Layout/AlignHash
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => N_('Scm'),
+    :type       => 'scm',
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (SCM)', 'Credentials (SCM)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
@@ -1,4 +1,23 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential
+  COMMON_ATTRIBUTES = {}.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :vault_password => {
+      :type       => :password,
+      :label      => N_('Vault password'),
+      :help_text  => N_('Vault password'),
+      :max_length => 1024
+    }
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => N_('Vault'),
+    :type       => 'vault',
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (Vault)', 'Credentials (Vault)', number)
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
@@ -1,4 +1,36 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential < ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential
+  COMMON_ATTRIBUTES = {
+    :userid   => {
+      :label     => N_('Username'),
+      :help_text => N_('Username for this credential'),
+      :required  => true
+    },
+    :password => {
+      :type      => :password,
+      :label     => N_('Password'),
+      :help_text => N_('Password for this credential'),
+      :required  => true
+    }
+  }.freeze
+
+  EXTRA_ATTRIBUTES = {
+    :host => {
+      :type       => :string,
+      :label      => N_('vCenter Host'),
+      :help_text  => N_('The hostname or IP address of the vCenter Host'),
+      :max_length => 1024,
+      :required   => true
+    }
+  }.freeze
+
+  API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
+
+  API_OPTIONS = {
+    :label      => N_('VMware'),
+    :type       => 'cloud',
+    :attributes => API_ATTRIBUTES
+  }.freeze
+
   def self.display_name(number = 1)
     n_('Credential (VMware)', 'Credentials (VMware)', number)
   end


### PR DESCRIPTION
Removed as part of the ansible-runner effort, but added back manually now (instead of inheriting from `manageiq-providers-ansible_tower`).

This only allows the UI to display and insert credentials, but it does not implement them when using runner.

Unsure if this deservse a `[WIP]` label.  When testing this on an appliance, it seems like adding a credential will make the API request, but the worker doesn't seem to process anything and produce a result.  Unsure if this deserves to be fixed here or we can fix in a later PR.

Before
------

<img width="1193" alt="01_new_credentials_before" src="https://user-images.githubusercontent.com/314014/59313523-08507c00-8c77-11e9-94b1-155fe4904d56.png">


After
-----

<img width="1208" alt="02_new_credentials_after" src="https://user-images.githubusercontent.com/314014/59313538-0f778a00-8c77-11e9-8db8-81cf3ceee0b0.png">



Steps for Testing/QA
--------------------

To confirm this now works, with this code in place:

1. Go to "Anisble > Automation > Credentials"
2. Click "Configure > Add New Credential"
3. A bunch of options should be available, and you should be able to create/save a new credential record

But, as mentioned above, doesn't seem to create records anywhere so unsure if we should be merging this as is or fix other things as well before doing so.