### PR TITLE
Remove GraphQL, Cloud Timeline and RSS from StartAt shortcut dropdown.

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -14,16 +14,6 @@
   :url: /chargeback/explorer
   :rbac_feature_name: chargeback
   :startup: true
-- :name: timelines
-  :description: Cloud Intel / Timelines
-  :url: /dashboard/timeline
-  :rbac_feature_name: timeline
-  :startup: true
-- :name: rss
-  :description: Cloud Intel / RSS
-  :url: /alert/show_list
-  :rbac_feature_name: rss
-  :startup: true
 - :name: services
   :description: Services / My Services
   :url: /service/explorer
@@ -468,9 +458,4 @@
   :description: Settings / Tasks
   :url: /miq_task/index?jobs_tab=tasks
   :rbac_feature_name: tasks
-  :startup: true
-- :name: product
-  :description: GraphQL / Explorer
-  :url: /graphql_explorer
-  :rbac_feature_name: product
   :startup: true


### PR DESCRIPTION
Fixes deprecated menus for GraphQL, Cloud Timeline and RSS lists. Related PR (below) also removes settings in the default_menu definitions.

This PR goes together and is related to this PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/5697

https://bugzilla.redhat.com/show_bug.cgi?id=1656722

Screen shots prior to code fix:
![BZ1656722 Shortcuts drop down prior to code fix 1](https://user-images.githubusercontent.com/552686/59388262-32aa4400-8d20-11e9-871a-50ab56b5273e.png)

![BZ1656722 Shortcuts drop down prior to code fix 2](https://user-images.githubusercontent.com/552686/59388274-3ccc4280-8d20-11e9-8633-bfbf50a87459.png)


Screen shots post code fix:
![BZ1656722 Shortcuts drop down after code fix 1](https://user-images.githubusercontent.com/552686/59388309-4bb2f500-8d20-11e9-9c70-8b44b9a07e2b.png)

![BZ1656722 Shortcuts drop down after code fix 2](https://user-images.githubusercontent.com/552686/59388322-52416c80-8d20-11e9-82bf-8b6626464239.png)

