### PR TITLE
[V2V] Modify active_tasks so that it always reloads

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -97,9 +97,12 @@ class ConversionHost < ApplicationRecord
   # Returns a boolean indicating whether or not the current number of active tasks
   # exceeds the maximum number of allowable concurrent tasks specified in settings.
   #
+  # Note that we force a reload of the active tasks via .count because we don't
+  # want that value cached.
+  #
   def check_concurrent_tasks
     max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
-    active_tasks.size < max_tasks
+    active_tasks.count < max_tasks
   end
 
   # Check to see if we can connect to the conversion host using a simple 'uname -a'

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -1,15 +1,24 @@
 class InfraConversionThrottler
   def self.start_conversions
     pending_conversion_jobs.each do |ems, jobs|
-      running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.size }
+      running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.count }
+      $log&.debug("There are currently #{running} conversion hosts running.")
       slots = (ems.miq_custom_get('Max Transformation Runners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
+      $log&.debug("The maximum number of concurrent tasks for the EMS is: #{slots}.")
       jobs.each do |job|
-        eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.size }
+        eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.count }
+
+        if eligible_hosts.size > 0
+          $log&.debug("The following conversion hosts are currently eligible: " + eligible_hosts.map(&:name).join(', '))
+        end
+
         break if slots <= 0 || eligible_hosts.empty?
         job.migration_task.update_attributes!(:conversion_host => eligible_hosts.first)
         job.queue_signal(:start)
         _log.info("Pending InfraConversionJob: id=#{job.id} signaled to start")
         slots -= 1
+
+        $log&.debug("The current number of available tasks is: #{slots}.")
       end
     end
   end


### PR DESCRIPTION
At the moment the relation we created for `active_tasks` is getting cached, which is causing failures for v2v concurrency. By calling `count` instead of `size` it effectively forces a reload on active tasks so that we always get an up to date value when checking for the number of concurrent tasks.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1716283

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1698761

Thanks to @Fryguy for the suggestion. :)