### PR TITLE
Define through association before trying to use it

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -17,8 +17,8 @@ class CloudNetwork < ApplicationRecord
   has_many :floating_ips,  :dependent => :destroy
   has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
-  has_many :public_network_vms, -> { distinct }, :through => :public_network_routers, :source => :vms
   has_many :public_network_routers, :foreign_key => :cloud_network_id, :class_name => "NetworkRouter"
+  has_many :public_network_vms, -> { distinct }, :through => :public_network_routers, :source => :vms
   has_many :private_networks, -> { distinct }, :through => :public_network_routers, :source => :cloud_networks
 
   # TODO(lsmola) figure out what this means, like security groups used by VMs in the network? It's not being


### PR DESCRIPTION
Fixes a rails 5.1 failure below.  The solution is 5.0/5.1 safe.

From openstack provider specs:

```
  1) ManageIQ::Providers::Openstack::CloudManager::Refresher will perform a fast full legacy refresh against RHOS
     Failure/Error: expect(network.public_network_vms.count).to eq vms.count

     ActiveRecord::HasManyThroughOrderError:
       Cannot have a has_many :through association 'CloudNetwork#public_network_vms' which goes through 'CloudNetwork#public_network_routers' before the through association is defined.
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/reflection.rb:975:in `check_validity!'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/associations/association.rb:25:in `initialize'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/associations/has_many_through_association.rb:8:in `initialize'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/associations.rb:265:in `new'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/associations.rb:265:in `association'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/associations/builder/association.rb:111:in `public_network_vms'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb:542:in `block in assert_networks'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/relation/delegation.rb:39:in `each'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/relation/delegation.rb:39:in `each'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb:531:in `assert_networks'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresh_spec_common.rb:115:in `assert_common'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb:72:in `block (3 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb:64:in `times'
     # ./spec/models/manageiq/providers/openstack/cloud_manager/refresher_rhos_liberty_keystone_v3_spec.rb:64:in `block (2 levels) in <top (required)>'
```