### PR TITLE
Remove bad includes from rbac spec and call

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -235,7 +235,6 @@ module MiqReport::Generator
         db_class.find_entries(ext_options).where(where_clause).where(options[:where_clause]),
         :category  => performance[:group_by_category],
         :cat_model => options[:cat_model],
-        :include   => get_include_for_find
       )
       build_correlate_tag_cols
     end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1030,8 +1030,7 @@ describe Rbac::Filterer do
           :max_disk_usage_rate_average     => {},
           :min_net_usage_rate_average      => {},
           :max_net_usage_rate_average      => {},
-          :v_derived_storage_used          => {},
-          :resource                        => {}
+          :v_derived_storage_used          => {}
         }
       end
 


### PR DESCRIPTION
This is extracted from #18848 

While working on that PR, I was looking at the `includes` and `references` passed around. These were not really related, but were wrong.

- Fix a bad test that has `MetricRollup.includes(:resource)` which is not valid because you can not `includes` a `field` (i.e.: resource).
- remove `group_by_tags(:includes => ...)` because it is not used. This 