### PR TITLE
[V2V] Add a helper method to check if virtv2v is running

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -259,8 +259,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def virtv2v_running?
-    return false if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
-    true
+    options[:virtv2v_started_on].present? && options[:virtv2v_finished_on].blank? && options[:virtv2v_wrapper].present?
   end
 
   def create_error_status_task(userid, msg)

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -238,7 +238,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   def kill_virtv2v(signal = 'TERM')
     get_conversion_state
 
-    if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
+    unless virtv2v_running?
       _log.info("virt-v2v is not running, so there is nothing to do.")
       return false
     end
@@ -256,6 +256,11 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def vm_resource
     miq_request.vm_resources.find_by(:resource => source)
+  end
+
+  def virtv2v_running?
+    return false if options[:virtv2v_started_on].blank? || options[:virtv2v_finished_on].present? || options[:virtv2v_wrapper].blank?
+    true
   end
 
   def create_error_status_task(userid, msg)


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq/pull/18853, @agrare suggested to create a helper method to check whether virt-v2v is running. This makes it more comprehensive.