### PR TITLE
assign value to a variable and return at the end.

### DIFF
--- a/lib/miq_expression/subst_mixin.rb
+++ b/lib/miq_expression/subst_mixin.rb
@@ -78,16 +78,20 @@ module MiqExpression::SubstMixin
   # Find an expression atom based on the token
   def exp_find_by_token(exp, token, parent_is_not = false)
     if exp.kind_of?(Array)                             # Is this and AND or OR
-      exp.find { |e| exp_find_by_token(e, token) }     # Look for token
+      result = nil
+      exp.find do |e|
+        result = exp_find_by_token(e, token) # Look for token
+      end
+      result
     elsif exp[:token] && exp[:token] == token       # This is the token exp
       @parent_is_not = true if parent_is_not        # Remember that token exp's parent is a NOT
-      exp                                           #   return it
+      exp # return it
     elsif exp["not"]
-      exp_find_by_token(exp["not"], token, true)    # Look for token under NOT (indicate we are a NOT)
+      exp_find_by_token(exp["not"], token, true) # Look for token under NOT (indicate we are a NOT)
     elsif exp["and"]
-      exp_find_by_token(exp["and"], token)          # Look for token under AND
+      exp_find_by_token(exp["and"], token) # Look for token under AND
     elsif exp["or"]
-      exp_find_by_token(exp["or"], token)           # Look for token under OR
+      exp_find_by_token(exp["or"], token) # Look for token under OR
     end
   end
 

--- a/spec/lib/miq_expression/subst_mixin_spec.rb
+++ b/spec/lib/miq_expression/subst_mixin_spec.rb
@@ -9,4 +9,38 @@ RSpec.describe MiqExpression::SubstMixin do
       expect(exp).to eq("and" => [{"=" => {"field" => "Vm-active", "value" => "true"}}, {"=" => {"field" => "Vm-archived", "value" => "true"}}])
     end
   end
+
+  describe "#exp_find_by_token" do
+    it "returns correct expression when expression has mixed operators" do
+      exp =
+        {
+          "and" =>
+            [
+              {"=" => {"field" => "ManageIQ::Providers::InfraManager::Vm-active", "value" => "true"}, :token => 1},
+              {"or" =>
+                [
+                  {"=" => {"count" => "ManageIQ::Providers::InfraManager::Vm.advanced_settings", "value" => "1"}, :token => 2},
+                  {"=" => {"count" => "ManageIQ::Providers::InfraManager::Vm.storages", "value" => "1"}, :token => 3}
+                ]
+              }
+            ]
+        }
+      result = test_obj.exp_find_by_token(exp, 2)
+      expect(result).to eq("=" => {"count" => "ManageIQ::Providers::InfraManager::Vm.advanced_settings", "value" => "1"}, :token => 2)
+    end
+
+    it "returns correct expression when expressions is simple has single operator" do
+      exp =
+        {
+          "and" =>
+            [
+              {"=" => {"field" => "ManageIQ::Providers::InfraManager::Vm-active", "value" => "true"}, :token => 1},
+              {"CONTAINS" => {"tag" => "ManageIQ::Providers::InfraManager::Vm.managed-prov_max_cpu", "value" => "2"}, :token => 2},
+              {"CONTAINS" => {"tag" => "ManageIQ::Providers::InfraManager::Vm.managed-prov_max_retirement_days", "value" => "60"}, :token => 3}
+            ]
+        }
+      result = test_obj.exp_find_by_token(exp, 3)
+      expect(result).to eq("CONTAINS" => {"tag" => "ManageIQ::Providers::InfraManager::Vm.managed-prov_max_retirement_days", "value" => "60"}, :token => 3)
+    end
+  end
 end


### PR DESCRIPTION
Fixed `exp_find_by_token` method to return values correctly when finding token within an expression with mixed operators

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1660460

before
![before](https://user-images.githubusercontent.com/3450808/59471267-9e67dc00-8e08-11e9-9964-7056017fcea5.png)

after
![after](https://user-images.githubusercontent.com/3450808/59470264-2e0b8b80-8e05-11e9-9874-387087ba6e5c.png)


@gtanzillo @jrafanie please review

@dclarizio cc