### PR TITLE
Use erubi instead of erubis, upgrade haml/haml_lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,12 @@ gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false
+gem "erubi",                          "~>1.8"
 gem "fast_gettext",                   "~>2.0.1"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.8.5"
+gem "haml",                           "~>5.0"
 gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "inventory_refresh",              "~>0.2.0",       :require => false
@@ -234,7 +236,7 @@ end
 unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
-    gem "haml_lint",           "~>0.20.0", :require => false
+    gem "haml_lint",           "~>0.22.0", :require => false
     gem "rubocop",             "~>0.69.0", :require => false
     gem "rubocop-performance", "~>1.3",    :require => false
     # ruby_parser is required for i18n string extraction


### PR DESCRIPTION
Fixes deprecation:
```
DEPRECATION WARNING: ActionView::Template::Handlers::Erubis is
deprecated and will be removed from Rails 5.2. Switch to
ActionView::Template::Handlers::ERB::Erubi instead. (called from <top
(required)> at
/Users/joerafaniello/Code/manageiq/config/application.rb:31)
```

Rails changed their default templating engine from erubis to erubi and
started deprecating it in 5.1:
https://github.com/rails/rails/pull/27757

Even though we're only using erubis in WinRM, which is outside of
actionview, we're getting the deprecation because:

1) We require hamlit in our Gemfile
2) hamlit tries to require haml in the template [here](https://github.com/k0kubun/hamlit/blob/94b14839cd42e8b70715ba7c0caf18c2c47ec67a/lib/hamlit/template.rb#L8)
3) It loads the haml railtie
4) Which loads the erubis template:
https://github.com/haml/haml/blob/4.0.7/lib/haml/railtie.rb#L21
5) Which autoloads the deprecated constant:
https://github.com/haml/haml/blob/4.0.7/lib/haml/helpers/safe_erubis_template.rb#L3

Haml 5.0.0 fixes this loading of the deprecated constant:
https://github.com/haml/haml/issues/895