### PR TITLE
Assume test assets are precompiled

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,7 +22,7 @@ Vmdb::Application.configure do
     env.cache = ActiveSupport::Cache.lookup_store(:memory_store)
   end
 
-  config.assets.compile = ENV['TEST_SUITE'] == 'spec:javascript'
+  config.assets.compile = true
 
   # Log error messages when you accidentally call methods on nil
   config.whiny_nils = true
@@ -66,3 +66,10 @@ require "timecop"
 require "vcr"
 require "webmock/rspec"
 require "capybara"
+
+module AssumeAssetPrecompiledInTest
+  def asset_precompiled?(_logical_path)
+    true
+  end
+end
+Vmdb::Application.prepend(AssumeAssetPrecompiledInTest)


### PR DESCRIPTION
Extracted from #18076 

Why?  First of all, live compiling of assets is true by default in the
test environment in rails so we need to get back to the defaults.

Sadly, this causes a 2 minute delay running any UI spec that calls
image_path/asset_path directly or indirectly.

Flamegraphs from rbspy show that the 2 minutes delay running a local
ui-classic test that calls image_path/asset_path is in sprocket-rails
in the call to asset_precompiled? which calls precompiled_assets(true)
if you're not caching classes, such as test.  It then needs to look
through all asset paths for precompiled assets to build a manifest and
ends up calling stat_tree / stat_directory in all these paths, such
as the node_modules.  We can assume the assets are precompiled as we
compile them on demand and can avoid this 2 minute stat'ing of files and
directories.  It's unclear if this has any negative consequences.

https://github.com/rails/sprockets-rails/blob/v3.2.1/lib/sprockets/railtie.rb#L39


![image](https://user-images.githubusercontent.com/19339/59476711-fe1db180-8e1f-11e9-9207-a3158f90c086.png)
