### PR TITLE
[ansible-runner] Add support to save credentials (attempt 2)

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/amazon_credential.rb
@@ -30,7 +30,15 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential 
     :attributes => API_ATTRIBUTES
   }.freeze
 
+  alias security_token auth_key
+
   def self.display_name(number = 1)
     n_('Credential (Amazon)', 'Credentials (Amazon)', number)
+  end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+    attrs[:auth_key] = attrs.delete(:security_token)
+    attrs
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/azure_credential.rb
@@ -47,7 +47,36 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential <
     :attributes => API_ATTRIBUTES
   }.freeze
 
+  alias secret auth_key
+
   def self.display_name(number = 1)
     n_('Credential (Microsoft Azure)', 'Credentials (Microsoft Azure)', number)
+  end
+
+  def self.params_to_attributes(params)
+    attrs            = params.dup
+    attrs[:auth_key] = attrs.delete(:secret)
+
+    if %i[client tenant subscription].any? {|opt| attrs.has_key? opt }
+      attrs[:options] = {
+        :client       => attrs.delete(:client),
+        :tenant       => attrs.delete(:tenant),
+        :subscription => attrs.delete(:subscription)
+      }
+    end
+
+    attrs
+  end
+
+  def client
+    options && options[:client]
+  end
+
+  def tenant
+    options && options[:tenant]
+  end
+
+  def subscription
+    options && options[:subscription]
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -16,10 +16,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
 
   include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
 
-  def self.provider_params(params)
-    super.merge(:organization => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
-  end
-
   def self.params_to_attributes(_params)
     raise NotImplementedError, "must be implemented in a subclass"
   end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -14,12 +14,26 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
 
   FRIENDLY_NAME = "Ansible Automation Inside Credential".freeze
 
+  include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
+
   def self.provider_params(params)
     super.merge(:organization => ManageIQ::Providers::EmbeddedAnsible::AutomationManager.first.provider.default_organization)
   end
 
-  def self.notify_on_provider_interaction?
-    true
+  def self.params_to_attributes(_params)
+    raise NotImplementedError, "must be implemented in a subclass"
+  end
+
+  def self.raw_create_in_provider(_manager, params)
+    create!(params_to_attributes(params))
+  end
+
+  def raw_update_in_provider(params)
+    update!(self.class.params_to_attributes(params.except(:task_id, :miq_task_id)))
+  end
+
+  def raw_delete_in_provider
+    destroy!
   end
 
   def native_ref

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/google_credential.rb
@@ -37,7 +37,22 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential 
     :attributes => API_ATTRIBUTES
   }.freeze
 
+  alias ssh_key_data auth_key
+
   def self.display_name(number = 1)
     n_('Credential (Google)', 'Credentials (Google)', number)
+  end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+
+    attrs[:auth_key] = attrs.delete(:ssh_key_data)
+    attrs[:options]  = { :project => attrs.delete(:project) } if attrs[:project]
+
+    attrs
+  end
+
+  def project
+    options && options[:project]
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -57,7 +57,27 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
     :attributes => API_ATTRIBUTES
   }.freeze
 
+  alias ssh_key_data   auth_key
+  alias ssh_key_unlock auth_key_password
+
   def self.display_name(number = 1)
     n_('Credential (Machine)', 'Credentials (Machine)', number)
+  end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+
+    attrs[:auth_key]                = attrs.delete(:ssh_key_data)
+    attrs[:auth_key_password]       = attrs.delete(:ssh_key_unlock)
+
+    if attrs[:become_method]
+      attrs[:options] = { :become_method => attrs.delete(:become_method) }
+    end
+
+    attrs
+  end
+
+  def become_method
+    options && options[:become_method]
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/network_credential.rb
@@ -51,7 +51,29 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential
     :attributes => API_ATTRIBUTES
   }.freeze
 
+  alias ssh_key_data       auth_key
+  alias ssh_key_unlock     auth_key_password
+  alias authorize_password become_password
+
   def self.display_name(number = 1)
     n_('Credential (Network)', 'Credentials (Network)', number)
+  end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+
+    attrs[:auth_key]            = attrs.delete(:ssh_key_data)
+    attrs[:auth_key_password]   = attrs.delete(:ssh_key_unlock)
+    attrs[:become_password]     = attrs.delete(:authorize_password)
+
+    if attrs[:authorize]
+      attrs[:options] = { :authorize => attrs.delete(:authorize) }
+    end
+
+    attrs
+  end
+
+  def authorize
+    options && options[:authorize]
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/openstack_credential.rb
@@ -47,4 +47,31 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredenti
   def self.display_name(number = 1)
     n_('Credential (OpenStack)', 'Credentials (OpenStack)', number)
   end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+
+    if %i[host domain project].any? {|opt| attrs.has_key? opt }
+      attrs[:options] = {
+        :host    => attrs.delete(:host),
+        :domain  => attrs.delete(:domain),
+        :project => attrs.delete(:project)
+      }
+    end
+
+
+    attrs
+  end
+
+  def host
+    options && options[:host]
+  end
+
+  def domain
+    options && options[:domain]
+  end
+
+  def project
+    options && options[:project]
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/rhv_credential.rb
@@ -32,4 +32,14 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential < M
   def self.display_name(number = 1)
     n_('Credential (RHV)', 'Credentials (RHV)', number)
   end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+    attrs[:options] = { :host => attrs.delete(:host) } if attrs[:host]
+    attrs
+  end
+
+  def host
+    options && options[:host]
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/scm_credential.rb
@@ -39,7 +39,19 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential < M
     :attributes => API_ATTRIBUTES
   }.freeze
 
+  alias ssh_key_data   auth_key
+  alias ssh_key_unlock auth_key_password
+
   def self.display_name(number = 1)
     n_('Credential (SCM)', 'Credentials (SCM)', number)
+  end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+
+    attrs[:auth_key]          = attrs.delete(:ssh_key_data)
+    attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)
+
+    attrs
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vault_credential.rb
@@ -21,4 +21,12 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential <
   def self.display_name(number = 1)
     n_('Credential (Vault)', 'Credentials (Vault)', number)
   end
+
+  alias vault_password password
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+    attrs[:password] = attrs.delete(:vault_password)
+    attrs
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/vmware_credential.rb
@@ -34,4 +34,14 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential 
   def self.display_name(number = 1)
     n_('Credential (VMware)', 'Credentials (VMware)', number)
   end
+
+  def self.params_to_attributes(params)
+    attrs = params.dup
+    attrs[:options] = { :host => attrs.delete(:host) } if attrs[:host]
+    attrs
+  end
+
+  def host
+    options && options[:host]
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_ansible/crud_common.rb
@@ -55,7 +55,7 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
     private
 
     def send_notification(op_type, manager_id, params, success)
-      op_arg = params.except(:name, :manager_ref).collect { |k, v| "#{k}=#{v}" }.join(', ')
+      op_arg = params.except(*notification_excludes).collect { |k, v| "#{k}=#{v}" }.join(', ')
       _log.send(success ? :info : :error, "#{name} #{op_type} with parameters: #{op_arg.inspect} #{success ? 'succeeded' : 'failed'}")
       Notification.create!(
         :type    => success ? :tower_op_success : :tower_op_failure,
@@ -65,6 +65,11 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
           :tower   => "EMS(manager_id=#{manager_id})"
         }
       )
+    end
+
+    # Override in subclass if necessary
+    def notification_excludes
+      [:name, :manager_ref] + Authentication.encrypted_columns
     end
   end
 

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -1,10 +1,25 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential do
+describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
   let(:manager) do
     FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first
   end
 
   before do
     EvmSpecHelper.assign_embedded_ansible_role
+  end
+
+  context "#native_ref" do
+    let(:simple_credential) { described_class.new(:manager_ref => '1', :resource => manager) }
+
+    it "returns integer" do
+      expect(simple_credential.manager_ref).to eq('1')
+      expect(simple_credential.native_ref).to eq(1)
+    end
+
+    it "blows up for nil manager_ref" do
+      simple_credential.manager_ref = nil
+      expect(simple_credential.manager_ref).to be_nil
+      expect { simple_credential.native_ref }.to raise_error(TypeError)
+    end
   end
 
   # it_behaves_like 'ansible credential'

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -135,4 +135,56 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "MachineCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::MachineCredential }
+
+      let(:params) do
+        {
+          :name            => "Machine Credential",
+          :userid          => "userid",
+          :password        => "secret1",
+          :ssh_key_data    => "secret2",
+          :become_method   => "sudo",
+          :become_password => "secret3",
+          :become_username => "admin",
+          :ssh_key_unlock  => "secret4"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name              => "Machine Credential",
+          :userid            => "userid",
+          :password          => "secret1",
+          :auth_key          => "secret2",
+          :become_password   => "secret3",
+          :become_username   => "admin",
+          :auth_key_password => "secret4",
+          :options           => {
+            :become_method => "sudo"
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name                        => "Machine Credential",
+          :userid                      => "userid",
+          :password                    => "secret1",
+          :ssh_key_data                => "secret2",
+          :become_password             => "secret3",
+          :become_username             => "admin",
+          :become_method               => "sudo",
+          :auth_key_password           => "secret4",
+          :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
+          :auth_key_encrypted          => ManageIQ::Password.try_encrypt("secret2"),
+          :become_password_encrypted   => ManageIQ::Password.try_encrypt("secret3"),
+          :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret4"),
+          :options                     => {
+            :become_method => "sudo"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -320,4 +320,53 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "AzureCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::AzureCredential }
+
+      let(:params) do
+        {
+          :name         => "Azure Credential",
+          :userid       => "userid",
+          :password     => "secret1",
+          :secret       => "secret2",
+          :client       => "client",
+          :tenant       => "tenant",
+          :subscription => "subscription"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name     => "Azure Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :auth_key => "secret2",
+          :options  => {
+            :client       => "client",
+            :tenant       => "tenant",
+            :subscription => "subscription"
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "Azure Credential",
+          :userid             => "userid",
+          :password           => "secret1",
+          :secret             => "secret2",
+          :client             => "client",
+          :tenant             => "tenant",
+          :subscription       => "subscription",
+          :password_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :auth_key_encrypted => ManageIQ::Password.try_encrypt("secret2"),
+          :options            => {
+            :client       => "client",
+            :tenant       => "tenant",
+            :subscription => "subscription"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -451,4 +451,41 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "RhvCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::RhvCredential }
+
+      let(:params) do
+        {
+          :name     => "Rhv Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :host     => "host"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name     => "Rhv Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :options  => {
+            :host => "host"
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "Rhv Credential",
+          :userid             => "userid",
+          :password           => "secret1",
+          :host               => "host",
+          :password_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :options            => {
+            :host => "host"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -236,4 +236,41 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "ScmCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::ScmCredential }
+
+      let(:params) do
+        {
+          :name           => "Scm Credential",
+          :userid         => "userid",
+          :password       => "secret1",
+          :ssh_key_data   => "secret2",
+          :ssh_key_unlock => "secret3"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name              => "Scm Credential",
+          :userid            => "userid",
+          :password          => "secret1",
+          :auth_key          => "secret2",
+          :auth_key_password => "secret3",
+        }
+      end
+      let(:expected_values) do
+        {
+          :name                        => "Scm Credential",
+          :userid                      => "userid",
+          :password                    => "secret1",
+          :ssh_key_data                => "secret2",
+          :ssh_key_unlock              => "secret3",
+          :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
+          :auth_key_encrypted          => ManageIQ::Password.try_encrypt("secret2"),
+          :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret3")
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -488,4 +488,41 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "VmwareCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::VmwareCredential }
+
+      let(:params) do
+        {
+          :name     => "VMware Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :host     => "host"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name     => "VMware Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :options  => {
+            :host => "host"
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "VMware Credential",
+          :userid             => "userid",
+          :password           => "secret1",
+          :host               => "host",
+          :password_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :options            => {
+            :host => "host"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -294,4 +294,30 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "AmazonCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class)     { embedded_ansible::AmazonCredential }
+      let(:params_to_attributes) { params.except(:security_token).merge(:auth_key => "secret2") }
+
+      let(:params) do
+        {
+          :name           => "Amazon Credential",
+          :userid         => "userid",
+          :password       => "secret1",
+          :security_token => "secret2",
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "Amazon Credential",
+          :userid             => "userid",
+          :password           => "secret1",
+          :security_token     => "secret2",
+          :password_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :auth_key_encrypted => ManageIQ::Password.try_encrypt("secret2")
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -273,4 +273,25 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "VaultCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class)     { embedded_ansible::VaultCredential }
+      let(:params_to_attributes) { params.except(:vault_password).merge(:password => "secret1") }
+
+      let(:params) do
+        {
+          :name           => "Vault Credential",
+          :vault_password => "secret1"
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "Vault Credential",
+          :vault_password     => "secret1",
+          :password_encrypted => ManageIQ::Password.try_encrypt("secret1")
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -369,4 +369,41 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "GoogleCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::GoogleCredential }
+
+      let(:params) do
+        {
+          :name         => "Google Credential",
+          :userid       => "userid",
+          :ssh_key_data => "secret1",
+          :project      => "project"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name     => "Google Credential",
+          :userid   => "userid",
+          :auth_key => "secret1",
+          :options  => {
+            :project => "project"
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "Google Credential",
+          :userid             => "userid",
+          :ssh_key_data       => "secret1",
+          :project            => "project",
+          :auth_key_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :options            => {
+            :project => "project"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -187,4 +187,53 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "NetworkCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::NetworkCredential }
+
+      let(:params) do
+        {
+          :name               => "Network Credential",
+          :userid             => "userid",
+          :password           => "secret1",
+          :authorize          => "true",
+          :ssh_key_data       => "secret2",
+          :authorize_password => "secret3",
+          :ssh_key_unlock     => "secret4"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name              => "Network Credential",
+          :userid            => "userid",
+          :password          => "secret1",
+          :auth_key          => "secret2",
+          :become_password   => "secret3",
+          :auth_key_password => "secret4",
+          :options           => {
+            :authorize => "true",
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name                        => "Network Credential",
+          :userid                      => "userid",
+          :password                    => "secret1",
+          :authorize                   => "true",
+          :ssh_key_data                => "secret2",
+          :authorize_password          => "secret3",
+          :ssh_key_unlock              => "secret4",
+          :password_encrypted          => ManageIQ::Password.try_encrypt("secret1"),
+          :auth_key_encrypted          => ManageIQ::Password.try_encrypt("secret2"),
+          :become_password_encrypted   => ManageIQ::Password.try_encrypt("secret3"),
+          :auth_key_password_encrypted => ManageIQ::Password.try_encrypt("secret4"),
+          :options                     => {
+            :authorize => "true"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -406,4 +406,49 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
       end
     end
   end
+
+  context "OpenstackCredential" do
+    it_behaves_like 'an embedded_ansible credential' do
+      let(:credential_class) { embedded_ansible::OpenstackCredential }
+
+      let(:params) do
+        {
+          :name     => "OpenstackCredential Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :host     => "host",
+          :domain   => "domain",
+          :project  => "project"
+        }
+      end
+      let(:params_to_attributes) do
+        {
+          :name     => "OpenstackCredential Credential",
+          :userid   => "userid",
+          :password => "secret1",
+          :options  => {
+            :host    => "host",
+            :domain  => "domain",
+            :project => "project"
+          }
+        }
+      end
+      let(:expected_values) do
+        {
+          :name               => "OpenstackCredential Credential",
+          :userid             => "userid",
+          :password           => "secret1",
+          :host               => "host",
+          :domain             => "domain",
+          :project            => "project",
+          :password_encrypted => ManageIQ::Password.try_encrypt("secret1"),
+          :options            => {
+            :host    => "host",
+            :domain  => "domain",
+            :project => "project"
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -1,4 +1,5 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
+  let(:embedded_ansible) { ManageIQ::Providers::EmbeddedAnsible::AutomationManager }
   let(:manager) do
     FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first
   end
@@ -22,5 +23,116 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
     end
   end
 
-  # it_behaves_like 'ansible credential'
+  shared_examples_for "an embedded_ansible credential" do
+    let(:base_excludes) { [:password, :auth_key, :service_account] }
+
+    context "CREATE" do
+      it ".create_in_provider creates a record" do
+        expect(credential_class).to receive(:create!).with(params_to_attributes).and_call_original
+        expect(Notification).to     receive(:create!).never
+
+        record = credential_class.create_in_provider(manager.id, params)
+
+        expect(record).to be_a(credential_class)
+        expected_values.each do |attr, val|
+          expect(record.send(attr)).to eq(val)
+        end
+      end
+
+      it ".create_in_provider can create with `nil` options" do
+        keys_to_remove  = params_to_attributes.fetch(:options, {}).keys
+        passed_params   = params.except(*keys_to_remove)
+
+        params_to_attributes.delete(:options)
+        expected_values.delete(:options)
+        keys_to_remove.each { |key| expected_values[key] = nil }
+
+        expect(credential_class).to receive(:create!).with(params_to_attributes).and_call_original
+        expect(Notification).to     receive(:create!).never
+
+        record = credential_class.create_in_provider(manager.id, passed_params)
+
+        expect(record).to be_a(credential_class)
+        expected_values.each do |attr, val|
+          expect(record.send(attr)).to eq(val)
+        end
+      end
+
+      it ".create_in_provider_queue queues a create task" do
+        task_id       = credential_class.create_in_provider_queue(manager.id, params)
+        expected_name = "Creating #{described_class::FRIENDLY_NAME} (name=#{params[:name]})"
+        expect(MiqTask.find(task_id)).to have_attributes(:name => expected_name)
+        expect(MiqQueue.first).to have_attributes(
+          :args        => [manager.id, params],
+          :class_name  => credential_class.name,
+          :method_name => "create_in_provider",
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => "embedded_ansible",
+          :zone        => manager.my_zone
+        )
+      end
+
+      it ".create_in_provider_queue will fail with incompatible manager" do
+        wrong_manager = FactoryBot.create(:configuration_manager_foreman)
+        expect { credential_class.create_in_provider_queue(wrong_manager.id, params) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "UPDATE" do
+      let(:update_params) { {:name => "Updated Credential" } }
+      let(:ansible_cred)  { credential_class.raw_create_in_provider(nil, params.merge(:manager => manager)) }
+
+      it "#update_in_provider to succeed" do
+        expect(Notification).to receive(:create!).never
+
+        result = ansible_cred.update_in_provider update_params
+
+        expect(result).to be_a(credential_class)
+        expect(result.name).to eq("Updated Credential")
+      end
+
+      it "#update_in_provider_queue" do
+        task_id   = ansible_cred.update_in_provider_queue(update_params)
+        task_name = "Updating #{described_class::FRIENDLY_NAME} (name=#{ansible_cred.name})"
+
+        update_params[:task_id] = task_id
+
+        expect(MiqTask.find(task_id)).to have_attributes(:name => task_name)
+        expect(MiqQueue.first).to have_attributes(
+          :instance_id => ansible_cred.id,
+          :args        => [update_params],
+          :class_name  => credential_class.name,
+          :method_name => "update_in_provider",
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => "embedded_ansible",
+          :zone        => manager.my_zone
+        )
+      end
+    end
+
+    context "DELETE" do
+      let(:ansible_cred) { credential_class.raw_create_in_provider(nil, params.merge(:manager => manager)) }
+
+      it "#delete_in_provider will delete the record" do
+        expect(Notification).to receive(:create!).never
+        ansible_cred.delete_in_provider
+      end
+
+      it "#delete_in_provider_queue will queue a a delete task" do
+        task_id   = ansible_cred.delete_in_provider_queue
+        task_name = "Deleting #{described_class::FRIENDLY_NAME} (name=#{ansible_cred.name})"
+
+        expect(MiqTask.find(task_id)).to have_attributes(:name => task_name)
+        expect(MiqQueue.first).to have_attributes(
+          :instance_id => ansible_cred.id,
+          :args        => [],
+          :class_name  => credential_class.name,
+          :method_name => "delete_in_provider",
+          :priority    => MiqQueue::HIGH_PRIORITY,
+          :role        => "embedded_ansible",
+          :zone        => manager.my_zone
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq/pull/18857

Will most likely require the following being merged to implement the Machine, Network, and SCM credentials:

- https://github.com/ManageIQ/manageiq-schema/pull/382
- https://github.com/ManageIQ/manageiq/pull/18866

Effectively implements CRUD for each of the credential types, and tests that they work as expected.  Attributes that are required to be encrypted are aliased to columns where that is done already, and extra metadata or non-sensitive data is tossed into the options hash (the `host`, `domain`, `tenant`, `project`, etc. fields).


Links
-----

* 1st Pass: https://github.com/ManageIQ/manageiq/pull/18857
* Required Schema change: https://github.com/ManageIQ/manageiq-schema/pull/382
* Required Authentication class change: https://github.com/ManageIQ/manageiq/pull/18866


Steps for Testing/QA
--------------------

Similar steps to what was in #18854 but now you should be able to see the results saved in the database.