### PR TITLE
Fix sporadic firmware binary spec

### DIFF
--- a/app/models/firmware_binary.rb
+++ b/app/models/firmware_binary.rb
@@ -10,6 +10,6 @@ class FirmwareBinary < ApplicationRecord
   end
 
   def urls
-    endpoints.pluck(:url)
+    endpoints.loaded? ? endpoints.map(&:url) : endpoints.pluck(:url)
   end
 end

--- a/spec/models/firmware_binary_spec.rb
+++ b/spec/models/firmware_binary_spec.rb
@@ -21,7 +21,7 @@ describe FirmwareBinary do
     it 'lists from all endpoints' do
       subject.endpoints << FactoryBot.create(:endpoint, :url => 'url1')
       subject.endpoints << FactoryBot.create(:endpoint, :url => 'url2')
-      expect(subject.urls).to eq(%w[url1 url2])
+      expect(subject.urls).to match_array(%w[url1 url2])
     end
   end
 

--- a/spec/models/firmware_binary_spec.rb
+++ b/spec/models/firmware_binary_spec.rb
@@ -22,6 +22,8 @@ describe FirmwareBinary do
       subject.endpoints << FactoryBot.create(:endpoint, :url => 'url1')
       subject.endpoints << FactoryBot.create(:endpoint, :url => 'url2')
       expect(subject.urls).to match_array(%w[url1 url2])
+      subject.endpoints.load
+      expect(subject.urls).to match_array(%w[url1 url2])
     end
   end
 


### PR DESCRIPTION
`firmware_binary` spec for `urls` had no order statement - so it had sporadic failures

While I was in there, I allowed endpoints to be preloaded.

/cc @miha-plesko 