### PR TITLE
fix data type for compliance_mixin

### DIFF
--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -11,7 +11,7 @@ module ComplianceMixin
 
     virtual_delegate :last_compliance_status,
                      :to        => "last_compliance.compliant",
-                     :type      => :string,
+                     :type      => :boolean,
                      :allow_nil => true
     virtual_delegate :timestamp,
                      :to        => :last_compliance,


### PR DESCRIPTION
When we introduced `:type` for virtual delegates in #18798, `last_compliance_status` was incorrectly classified as a string rather than a boolean.

On the `VmOrTemplate` screen, it is incorrectly trying to `lower()` last_compliance_status` (display name of "compliance") and this is causing issues.

ASIDE: Sorting by `"compliance"` is busted in master right now for another reason as well.