### PR TITLE
Load MiqProductFeature#feature in a single query

### DIFF
--- a/app/models/miq_product_feature.rb
+++ b/app/models/miq_product_feature.rb
@@ -112,7 +112,8 @@ class MiqProductFeature < ApplicationRecord
     @feature_cache ||= begin
       # create hash with parent identifier and details
       features = select(:id, :identifier).select(*DETAIL_ATTRS)
-                                         .select(arel_attribute(:parent_identifier).as("parent_identifier"))
+                                         .select(:parent_identifier)
+                                         .includes(:tenant)
                                          .each_with_object({}) do |f, h|
         parent_ident = f.parent_identifier
         details      = DETAIL_ATTRS.each_with_object({}) { |a, dh| dh[a] = f.send(a) }


### PR DESCRIPTION
we were performing an N+1 to load tenant for the product feature
name and description fields when building @features cache

Many of these were cache hits, but in development mode, the logs
scrolled a few screens. And this is run on most dev mode pages.

It should have a minor (but much less significant) impact in production.


This change preloads the necessary tenants so the feature text
can be produced and cached.
