### PR TITLE
[HAMMER] Update manageiq-smartstate dependency to backport BZ1696846

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,7 +184,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.2.18",       :require => false
+  gem "manageiq-smartstate", "~>0.2.18.1", :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Fix of OpenStack Snapshot removal after SSA introduced in
https://github.com/ManageIQ/manageiq-smartstate/pull/94 needs to be backported to Hammer.

In order to avoid unwanted code update, new branch hammer/5.10.z was
created and dependency from main repo is updated.

https://bugzilla.redhat.com/show_bug.cgi?id=1720649
