### PR TITLE
[V2V] lookup active tasks in a single query

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -12,6 +12,7 @@ class ConversionHost < ApplicationRecord
     :class_name => "ServiceTemplateTransformationPlanTask",
     :inverse_of => :conversion_host
 
+  virtual_total :total_active_tasks, :active_tasks
   delegate :ext_management_system, :hostname, :ems_ref, :to => :resource, :allow_nil => true
 
   validates :name, :presence => true
@@ -99,7 +100,7 @@ class ConversionHost < ApplicationRecord
   #
   def check_concurrent_tasks
     max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
-    active_tasks.size < max_tasks
+    total_active_tasks < max_tasks
   end
 
   # Check to see if we can connect to the conversion host using a simple 'uname -a'

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -84,15 +84,16 @@ class ConversionHost < ApplicationRecord
     true
   end
 
-  # Returns a boolean indicating whether or not the conversion host is eligible
-  # for use. To be eligible, a conversion host must have the following properties:
+  # @return [Boolean] true if the conversion host is eligible for use.
+  # To be eligible, a conversion host must have the following properties:
   #
   #  - A transport mechanism is configured for source (set by 3rd party).
   #  - Credentials are set on the conversion host and the SSH connection works.
-  #  - The number of concurrent tasks has not reached the limit.
+  #
+  # Note: caller needs to check the task limit (via check_concurrent_tasks) closer to the time of use
   #
   def eligible?
-    source_transport_method.present? && verify_credentials && check_concurrent_tasks
+    source_transport_method.present? && verify_credentials
   end
 
   # Returns a boolean indicating whether or not the current number of active tasks

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -694,6 +694,10 @@ class ExtManagementSystem < ApplicationRecord
     host_conversion_hosts + vm_conversion_hosts
   end
 
+  def total_active_tasks
+    host_conversion_hosts.sum(:total_active_tasks) + vm_conversion_hosts.sum(:total_active_tasks)
+  end
+
   #
   # Metric methods
   #

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -1,10 +1,10 @@
 class InfraConversionThrottler
   def self.start_conversions
     pending_conversion_jobs.each do |ems, jobs|
-      running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.size }
+      running = ems.total_active_tasks
       slots = (ems.miq_custom_get('Max Transformation Runners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
       jobs.each do |job|
-        eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.size }
+        eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.total_active_tasks }
         break if slots <= 0 || eligible_hosts.empty?
         job.migration_task.update_attributes!(:conversion_host => eligible_hosts.first)
         job.queue_signal(:start)

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -26,28 +26,18 @@ RSpec.describe ConversionHost, :v2v do
       it "fails when no source transport method is enabled" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return(nil)
         allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
-        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
-      it "fails when no source transport method is enabled" do
+      it "fails when credentials are not verified" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
         allow(conversion_host_1).to receive(:verify_credentials).and_return(false)
-        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
-        expect(conversion_host_1.eligible?).to eq(false)
-      end
-
-      it "fails when no source transport method is enabled" do
-        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
-        allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
-        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(false)
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
       it "succeeds when all criteria are met" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
         allow(conversion_host_1).to receive(:verify_credentials).and_return(true)
-        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
         expect(conversion_host_1.eligible?).to eq(true)
       end
     end


### PR DESCRIPTION
## Overview

infrastructure conversion distributes work among nodes.
It does this by assigning tasks (the work) to the nodes with the least number of tasks.

refs:
- #18860 /cc @djberg96 @fdupont-redhat
- https://bugzilla.redhat.com/show_bug.cgi?id=1716283
- https://bugzilla.redhat.com/show_bug.cgi?id=1698761


## Before

We looked up the number of tasks (aka amount of work) being performed on each conversion host up front for each ems.

This means when we were assigning tasks, we never looked up the task count again, and the numbers never increased.
So the hosts with the least amount of work, still looked like they had the least amount of work.
A single host would get all the tasks for each timer event / round. Besides not distributing the work well, we also sometimes went over the max thresholds for hosts.

## After

We are looking up the eligible servers up front for each ems. This work is expensive and it is good to cache.

For each task we are assigning, we are re-calculating the number of tasks running for each conversion host in a single query.
Now we are able to see the increased work loads and we no longer assign all current work to the same conversion host.
