### PR TITLE
[V2V] Use authentication_check instead of verify credentials

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -68,11 +68,8 @@ class ConversionHost < ApplicationRecord
         raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
       end
 
-      # Don't connect again if the authentication was valid (and also not invalid)
-      # within the last 10 minutes. This helps reduce unnecessary ssh connections.
-      if auth.last_valid_on && auth.last_valid_on > 10.minutes.ago
-        return true unless auth.last_invalid_on && auth.last_invalid_on > 10.minutes.ago
-      end
+      # Don't connect again if the authentication is still valid
+      return true if authentication_status_ok?(auth_type)
 
       # Options from STI subclasses will override the defaults we've set above.
       ssh_options.merge!(options)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -68,9 +68,11 @@ class ConversionHost < ApplicationRecord
         raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
       end
 
-      # Don't connect again if the authentication was valid within the last 15
-      # minutes. This helps reduce unnecessary ssh connections.
-      return true if auth.last_valid_on && auth.last_valid_on > 15.minutes.ago
+      # Don't connect again if the authentication was valid (and also not invalid)
+      # within the last 10 minutes. This helps reduce unnecessary ssh connections.
+      if auth.last_valid_on && auth.last_valid_on > 10.minutes.ago
+        return true unless auth.last_invalid_on && auth.last_invalid_on > 10.minutes.ago
+      end
 
       # Options from STI subclasses will override the defaults we've set above.
       ssh_options.merge!(options)

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -7,15 +7,9 @@ class InfraConversionThrottler
       _log.debug("- EMS: #{ems.name}")
       _log.debug("-- Number of pending jobs: #{jobs.size}")
       running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.count }
-      _log.debug("-- Currently running jobs in EMS: #{running}")
-      slots = (ems.miq_custom_get('Max Transformation Runners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
-
-      if slots <= 0
-        _log.debug("-- No available slot in EMS. Stopping.")
-        next
-      end
-      _log.debug("-- Available slots in EMS: #{slots}")
-
+      $log&.debug("There are currently #{running} conversion hosts running.")
+      slots = (ems.miq_custom_get('MaxTransformationRunners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
+      $log&.debug("The maximum number of concurrent tasks for the EMS is: #{slots}.")
       jobs.each do |job|
         vm_name = job.migration_task.source.name
         _log.debug("- Looking for a conversion host for task for #{vm_name}")

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -7,9 +7,15 @@ class InfraConversionThrottler
       _log.debug("- EMS: #{ems.name}")
       _log.debug("-- Number of pending jobs: #{jobs.size}")
       running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.count }
-      $log&.debug("There are currently #{running} conversion hosts running.")
+      _log.debug("-- Currently running jobs in EMS: #{running}")
       slots = (ems.miq_custom_get('MaxTransformationRunners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
-      $log&.debug("The maximum number of concurrent tasks for the EMS is: #{slots}.")
+
+      if slots <= 0
+        _log.debug("-- No available slot in EMS. Stopping.")
+        next
+      end
+      _log.debug("-- Available slots in EMS: #{slots}")
+
       jobs.each do |job|
         vm_name = job.migration_task.source.name
         _log.debug("- Looking for a conversion host for task for #{vm_name}")

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -437,24 +437,22 @@ RSpec.describe ConversionHost, :v2v do
       expect(conversion_host_vm.verify_credentials).to be_truthy
     end
 
-    it "makes an ssh call if the authentication was not valid within the last 10 minutes" do
-      authentication = FactoryBot.create(:authentication_ssh_keypair, :last_valid_on => Time.now.utc - 20.minutes)
+    it "makes an ssh call if the authentication is not valid" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair, :status => 'Error', :authtype => 'v2v')
       conversion_host_vm.authentications << authentication
       expect(Net::SSH).to receive(:start)
       conversion_host_vm.verify_credentials
     end
 
-    it "does not make an ssh call if the authentication was valid within the last 10 minutes" do
-      authentication = FactoryBot.create(:authentication_ssh_keypair, :last_valid_on => Time.now.utc - 5.minutes)
+    it "does not make an ssh call if the authentication is valid" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair, :status => 'Valid', :authtype => 'v2v')
       conversion_host_vm.authentications << authentication
       expect(Net::SSH).not_to receive(:start)
       conversion_host_vm.verify_credentials
     end
 
-    it "does make an ssh call if the authentication was both valid and invalid within the last 10 minutes" do
-      authentication = FactoryBot.create(:authentication_ssh_keypair,
-                                         :last_valid_on => Time.now.utc - 5.minutes,
-                                         :last_invalid_on => Time.now.utc - 7.minutes)
+    it "makes an ssh call if the authentication status is not set" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair, :status => nil, :authtype => 'v2v')
       conversion_host_vm.authentications << authentication
       expect(Net::SSH).to receive(:start)
       conversion_host_vm.verify_credentials

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -437,17 +437,25 @@ RSpec.describe ConversionHost, :v2v do
       expect(conversion_host_vm.verify_credentials).to be_truthy
     end
 
-    it "makes an ssh call if the authentication was not valid within the last 15 minutes" do
+    it "makes an ssh call if the authentication was not valid within the last 10 minutes" do
       authentication = FactoryBot.create(:authentication_ssh_keypair, :last_valid_on => Time.now.utc - 20.minutes)
       conversion_host_vm.authentications << authentication
       expect(Net::SSH).to receive(:start)
       conversion_host_vm.verify_credentials
     end
 
-    it "does not make an ssh call if the authentication was valid within the last 15 minutes" do
+    it "does not make an ssh call if the authentication was valid within the last 10 minutes" do
       authentication = FactoryBot.create(:authentication_ssh_keypair, :last_valid_on => Time.now.utc - 5.minutes)
       conversion_host_vm.authentications << authentication
       expect(Net::SSH).not_to receive(:start)
+      conversion_host_vm.verify_credentials
+    end
+
+    it "does make an ssh call if the authentication was both valid and invalid within the last 10 minutes" do
+      authentication = FactoryBot.create(:authentication_ssh_keypair, :last_valid_on => Time.now.utc - 5.minutes)
+      authentication = FactoryBot.create(:authentication_ssh_keypair, :last_invalid_on => Time.now.utc - 7.minutes)
+      conversion_host_vm.authentications << authentication
+      expect(Net::SSH).to receive(:start)
       conversion_host_vm.verify_credentials
     end
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -452,8 +452,9 @@ RSpec.describe ConversionHost, :v2v do
     end
 
     it "does make an ssh call if the authentication was both valid and invalid within the last 10 minutes" do
-      authentication = FactoryBot.create(:authentication_ssh_keypair, :last_valid_on => Time.now.utc - 5.minutes)
-      authentication = FactoryBot.create(:authentication_ssh_keypair, :last_invalid_on => Time.now.utc - 7.minutes)
+      authentication = FactoryBot.create(:authentication_ssh_keypair,
+                                         :last_valid_on => Time.now.utc - 5.minutes,
+                                         :last_invalid_on => Time.now.utc - 7.minutes)
       conversion_host_vm.authentications << authentication
       expect(Net::SSH).to receive(:start)
       conversion_host_vm.verify_credentials


### PR DESCRIPTION
This alters the `ConversionHost#eligible?` method so that it calls the `authentication_check` method instead of `verify_credentials` directly.

Internally the `authentication_check` method calls the `verify_credentials` method, and then updates the authentications object, including the `last_valid_on` field. We use that field to skip the ssh connection check if it was valid within the last 15 minutes. This will help reduce unnecessary ssh connections if the method happens to be called multiple times in a short period of time, e.g. `InfraConversionThrottler.start_conversions`. Plus it reduces the chance of unexpected timeout errors, etc.

Update: The 15 minute idea was dropped in favor of just using the `authentication_status_ok?` method that already exists in the Authentication mixin.

~~WIP until I can get some tests added.~~

Some other updates included in this PR:

* I set the default auth_type to "v2v" in the `verify_credentials` method.

* I changed the resources in the throttler specs to be provider-specific.

* I added an "RSpec" to the outer describe for future rspec 4 compliance.

* I added the "v2v" tag to the throttler specs.

* I changed "Max Transformation Runners" to "MaxTransformationRunners" because it was causing a deprecation warning:

`DEPRECATION WARNING: Invalid custom attribute: 'Max Transformation Runners'.  A custom attribute name must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters can be letters, underscores, digits (0-9), or dollar signs ($) (called from block (3 levels) in <top (required)> at /Users/dberger/Dev/manageiq-djberg96/spec/lib/infra_conversion_throttler_spec.rb:31)`

Not exactly related, but does obliquely help with https://github.com/ManageIQ/manageiq/pull/18880 a bit.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1723420