### PR TITLE
move hashdiff reference to dependent gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,7 +201,6 @@ end
 
 group :consumption, :manageiq_default do
   manageiq_plugin "manageiq-consumption"
-  gem 'hashdiff'
 end
 
 group :ui_dependencies do # Added to Bundler.require in config/application.rb


### PR DESCRIPTION
moved the HashDiff dependency from core to the manageiq-consumption gem

https://github.com/ManageIQ/manageiq-consumption/pull/161

@simaishi this does not change any dependencies, it just moves them