### PR TITLE
Re-add EmbeddedAnsible::ConfiguredSystem#ext_management_system

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configured_system.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfiguredSystem < ManageIQ::Providers::EmbeddedAutomationManager::ConfiguredSystem
   include ProviderObjectMixin
+
+  def ext_management_system
+    manager
+  end
 end


### PR DESCRIPTION
This was removed as part of 63be8484f2 when decoupling `EmbeddedAnsible` from the `AnsibleTower::Shared` code, however, this method is needed when going to:

    Configuration -> Management

In the UI.  For now, just adding this method back in to fix things up and unblock others, but some tests along with a evaluation of the other methods not brought over should be done to determine if those methods are needed should be done as well.


Links
-----

* Borked in https://github.com/ManageIQ/manageiq/pull/18687
* Reported [in gitter](https://gitter.im/ManageIQ/manageiq?at=5d080a102313502d385eb96d)


Steps for Testing/QA
--------------------

_**Note**_:  Currently unsure how to recreate, and the below were just a thought (seems to not work).  Will circle back and update these steps once I find out what needs to be done to replicate the issue.

On a master appliance:

1. Enable the `EmbeddedAnsible` role
2. Wait for everything to be seeded (you should be able to add a repository in `Automation -> Ansible -> Repository` when everything has been seeded)
3. Head to `Configuration -> Management`

On master (without this fix) this will cause the following error:

```
[----] F, [2000-00-00T00:00:00.000000 #1111:111111] FATAL -- : Error caught: [NoMethodError] undefined method `ext_management_system' for #<ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfiguredSystem:0x00007efdcd44ce98>
[gems]/ruby-2.4.4/gems/activemodel-5.0.7.2/lib/active_model/attribute_methods.rb:433:in `method_missing'
./manageiq/lib/rbac/filterer.rb:707:in `block in matches_via_descendants'
[gems]/ruby-2.4.4/gems/activerecord-5.0.7.2/lib/active_record/relation/delegation.rb:38:in `each'
[gems]/ruby-2.4.4/gems/activerecord-5.0.7.2/lib/active_record/relation/delegation.rb:38:in `each'
./manageiq/lib/rbac/filterer.rb:707:in `flat_map'
./manageiq/lib/rbac/filterer.rb:707:in `matches_via_descendants'
./manageiq/lib/rbac/filterer.rb:489:in `calc_filtered_ids'
./manageiq/lib/rbac/filterer.rb:640:in `scope_targets'
./manageiq/lib/rbac/filterer.rb:265:in `search'
./manageiq/lib/rbac/filterer.rb:147:in `search'
...
```

With this fix, it should render the page just fine.