### PR TITLE
Drop haml_lint to avoid deprecated haml constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -233,7 +233,6 @@ end
 unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
-    gem "haml_lint",           "~>0.20.0", :require => false
     gem "rubocop",             "~>0.69.0", :require => false
     gem "rubocop-performance", "~>1.3",    :require => false
     # ruby_parser is required for i18n string extraction


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/18868

This a development dependency that can be added individually for anyone
who needs it.

The problem is `hamlit` tries to require `haml` in the template [here](https://github.com/k0kubun/hamlit/blob/94b14839cd42e8b70715ba7c0caf18c2c47ec67a/lib/hamlit/template.rb#L8)
and because we have `haml` in our dependency tree due to `haml_lint` (for dev), it will be able to require it.
Because this causes the rails 5.1 deprecated constant to be loaded, we get this deprecation warning:

```
DEPRECATION WARNING: ActionView::Template::Handlers::Erubis is
deprecated and will be removed from Rails 5.2. Switch to
ActionView::Template::Handlers::ERB::Erubi instead. (called from <top
(required)> at
/Users/joerafaniello/Code/manageiq/config/application.rb:31)
```

Since haml_lint doesn't have a version that forces haml >= 5.0 (where this is fixed), we have to either:
* add haml it as a direct dependency so we can say >= 5.0 (like this PR)
* drop haml_lint entirely (so haml doesn't get in the dependency tree)
* ignore/live with this warning whenever you run tests or rails server/console/etc.

This commit takes option 2, drop haml_lint since it's a dev dependency
that can easily be added in bundler.d directory for any developers who want it.
