### PR TITLE
Drop scss_lint as ruby-sass is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -238,7 +238,6 @@ unless ENV["APPLIANCE"]
     gem "rubocop-performance", "~>1.3",    :require => false
     # ruby_parser is required for i18n string extraction
     gem "ruby_parser",                     :require => false
-    gem "scss_lint",           "~>0.48.0", :require => false
     gem "yard"
   end
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq/pull/18886 but a different deprecation: http://sass.logdown.com/posts/7828841

@miq-bot add_reviewer @jrafanie 
@miq-bot add_reviewer @himdel 