### PR TITLE
 Save playbook set_stats data for successive playbook methods

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -92,6 +92,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
   end
 
   def post_ansible_run(message, status)
+    save_playbook_set_stats
     inventory_not_deleted = !delete_inventory
     jt_not_deleted = !delete_job_template
 
@@ -198,5 +199,12 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
   rescue => err
     _log.error("Failed to get stdout from playbook #{playbook.name}")
     _log.log_backtrace(err)
+  end
+
+  def save_playbook_set_stats
+    #
+    # save playbook set_stats data into MiqTask#task_results for future usage
+    #
+    miq_task.update(:task_results => {'ansible_stats' => ansible_job.raw_stdout('json').dig(-1, 'event_data', 'artifact_data')})
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -165,6 +165,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
 
   def temp_configuration_script
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.new(
+      :name        => playbook.name,
       :manager     => playbook.manager,
       :manager_ref => options[:job_template_ref],
       :parent_id   => playbook.id,

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -205,6 +205,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
 
     context 'playbook runs successfully' do
       it 'removes temporary inventory and job template and finishes the job' do
+        expect(subject).to receive(:save_playbook_set_stats)
         expect(subject).to receive(:delete_inventory)
         expect(subject).to receive(:delete_job_template)
         subject.post_ansible_run('Playbook ran successfully', 'ok')
@@ -214,6 +215,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
 
     context 'playbook runs with error' do
       it 'removes temporary inventory and job template and finishes the job with error' do
+        expect(subject).to receive(:save_playbook_set_stats)
         expect(subject).to receive(:delete_inventory)
         expect(subject).to receive(:delete_job_template)
         subject.post_ansible_run('Ansible engine returned an error for the job', 'error')
@@ -223,6 +225,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
 
     context 'cleaning up has error' do
       it 'does fail the job but logs the error' do
+        expect(subject).to receive(:save_playbook_set_stats)
         expect(subject).to receive(:delete_inventory)
         allow(subject).to receive(:temp_configuration_script).and_raise('fake error')
         expect($log).to receive(:log_backtrace)


### PR DESCRIPTION
set_stats data in a playbook would be saved and passed to successive playbook methods via automate workspace.

Part of https://github.com/ManageIQ/manageiq-automation_engine/pull/333

https://bugzilla.redhat.com/show_bug.cgi?id=1678135

@miq-bot assign @tinaafitz 
@miq-bot add_label enhancement, automate