### PR TITLE
[evm:ansible_runner:seed] Add missing require

### DIFF
--- a/lib/tasks/evm_ansible_runner.rake
+++ b/lib/tasks/evm_ansible_runner.rake
@@ -1,10 +1,11 @@
-require 'awesome_spawn'
-require "vmdb/plugins"
-
 namespace :evm do
   namespace :ansible_runner do
     desc "Seed galaxy roles for provider playbooks"
     task :seed do
+      require 'awesome_spawn'
+      require "vmdb/plugins"
+      require 'ansible/content'
+
       Vmdb::Plugins.ansible_runner_content.each do |plugin, content_dir|
         content = Ansible::Content.new(content_dir)
 


### PR DESCRIPTION
This was changed as a part of https://github.com/ManageIQ/manageiq/pull/18844 but without the explicit require, it fails to run.

Also as a part of this, I deferred the rest of the requires to inside of the method, so we aren't loading them when just initializing the `Rake::Application`.

Links
-----

* Introduced in https://github.com/ManageIQ/manageiq/pull/18844


Steps for Testing/QA
--------------------

On master, running `bin/rake evm:ansible_runner:seed` will fail with the following:

```console
$ bin/rake evm:ansible_runner:seed
rake aborted!
NameError: uninitialized constant Ansible
/var/www/miq/vmdb/lib/tasks/evm_ansible_runner.rake:9:in `block (4 levels) in <top (required)>'
/var/www/miq/vmdb/lib/tasks/evm_ansible_runner.rake:8:in `each'
/var/www/miq/vmdb/lib/tasks/evm_ansible_runner.rake:8:in `block (3 levels) in <top (required)>'
Tasks: TOP => evm:ansible_runner:seed
(See full trace by running task with --trace)
$
```

With the fix, it works as expected:

```console
$ bin/rake evm:ansible_runner:seed
Seeding roles for ManageIQ::Providers::Lenovo::Engine...
Seeding roles for ManageIQ::Providers::Lenovo::Engine...Complete
Seeding roles for ManageIQ::Providers::Nuage::Engine...
Seeding roles for ManageIQ::Providers::Nuage::Engine...Complete
$
```