### PR TITLE
Disable "turbo button" on Provisioning reports

### DIFF
--- a/product/reports/900_Provisioning - Activity Reports/110_Provisioning Activity - by Approver.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/110_Provisioning Activity - by Approver.yaml
@@ -50,7 +50,8 @@ categories:
 time_profile_id:
 rpt_type: Custom
 filename:
-db_options: {}
+db_options:
+  :use_sql_view: false
 
 col_formats:
 -

--- a/product/reports/900_Provisioning - Activity Reports/120_Provisioning Activity - by Datastore.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/120_Provisioning Activity - by Datastore.yaml
@@ -50,7 +50,8 @@ categories:
 time_profile_id:
 rpt_type: Custom
 filename:
-db_options: {}
+db_options:
+  :use_sql_view: false
 
 col_formats:
 -

--- a/product/reports/900_Provisioning - Activity Reports/130_Provisioning Activity - by Requester.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/130_Provisioning Activity - by Requester.yaml
@@ -50,7 +50,8 @@ categories:
 time_profile_id:
 rpt_type: Custom
 filename:
-db_options: {}
+db_options:
+  :use_sql_view: false
 
 col_formats:
 -

--- a/product/reports/900_Provisioning - Activity Reports/140_Provisioning Activity - by VM.yaml
+++ b/product/reports/900_Provisioning - Activity Reports/140_Provisioning Activity - by VM.yaml
@@ -50,7 +50,8 @@ categories:
 time_profile_id:
 rpt_type: Custom
 filename:
-db_options: {}
+db_options:
+  :use_sql_view: false
 
 col_formats:
 -


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/18822 caused issues in the UI test suite for a few reports in the `product/reports/900_Provisioning - Activity Reports/` directory.

This is a quick fix to get the UI build green again.  Will leave things to @kbrock to hack `ActiveRecord` in what ever way is necesary to get this working #theRightWay™ (after this is merged of course).


Links
-----

* Offending PR:  https://github.com/ManageIQ/manageiq/pull/18822
* Broken Build on CI:  https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/547432152


Steps for Testing/QA
--------------------

Run the following from the `manageiq-ui-classic` repo directory:

```console
$ bundle exec rspec -e 900_Provisioning spec/product/reports_spec.rb
```

Without this fix, you will get the following errors:

```
Finished in 11.25 seconds (files took 42.28 seconds to load)
16 examples, 8 failures

Failed examples:

rspec ./spec/product/reports_spec.rb[1:2:68:1] # YAML reports regular reports 900_Provisioning - Activity Reports/120_Provisioning Activity - by Datastore can be built even though without data
rspec ./spec/product/reports_spec.rb[1:2:68:3] # YAML reports regular reports 900_Provisioning - Activity Reports/120_Provisioning Activity - by Datastore defines fields for reporting by fully qualified name
rspec ./spec/product/reports_spec.rb[1:2:71:1] # YAML reports regular reports 900_Provisioning - Activity Reports/110_Provisioning Activity - by Approver can be built even though without data
rspec ./spec/product/reports_spec.rb[1:2:71:3] # YAML reports regular reports 900_Provisioning - Activity Reports/110_Provisioning Activity - by Approver defines fields for reporting by fully qualified name
rspec ./spec/product/reports_spec.rb[1:2:70:1] # YAML reports regular reports 900_Provisioning - Activity Reports/140_Provisioning Activity - by VM can be built even though without data
rspec ./spec/product/reports_spec.rb[1:2:70:3] # YAML reports regular reports 900_Provisioning - Activity Reports/140_Provisioning Activity - by VM defines fields for reporting by fully qualified name
rspec ./spec/product/reports_spec.rb[1:2:69:1] # YAML reports regular reports 900_Provisioning - Activity Reports/130_Provisioning Activity - by Requester can be built even though without data
rspec ./spec/product/reports_spec.rb[1:2:69:3] # YAML reports regular reports 900_Provisioning - Activity Reports/130_Provisioning Activity - by Requester defines fields for reporting by fully qualified name
```

With this fix applied to the `spec/manageiq/` directory in the UI classic, everything should pass.