### PR TITLE
Don't create retirement tasks for things that are already retired

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -36,6 +36,7 @@ class ServiceRetireTask < MiqRetireTask
 
   def create_retire_subtasks(parent_service, parent_task)
     parent_service.service_resources.collect do |svc_rsc|
+      next if svc_rsc.resource.respond_to?(:retired?) && svc_rsc.resource.retired?
       next unless svc_rsc.resource.try(:retireable?)
       # TODO: the next line deals with the filtering for provisioning
       # (https://github.com/ManageIQ/manageiq/blob/3921e87915b5a69937b9d4a70bb24ab71b97c165/app/models/service_template/filter.rb#L5)

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -144,6 +144,15 @@ describe ServiceRetireTask do
         expect(VmRetireTask.count).to eq(1)
         expect(ServiceRetireTask.count).to eq(1)
       end
+
+      it "does not create vm retire subtask for retired vm" do
+        service.add_resource!(FactoryBot.create(:vm_openstack, :retired => true))
+        service_retire_task.after_request_task_create
+
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(VmRetireTask.count).to eq(0)
+        expect(ServiceRetireTask.count).to eq(1)
+      end
     end
 
     context "bundled service retires all children" do


### PR DESCRIPTION
We shouldn't create tasks for already retired VMs. 
bz is https://bugzilla.redhat.com/show_bug.cgi?id=1720338


This is ugly but it'll work for now. The refactor ideally involves using the general status check that Lucy's working on, but until that's baked in and finished and well-tested, we have to do something kinda hacky like this. This check doesn't belong inside the retireable? mixin check because that was intended as a class check for, can this class of thing actually be retired? So since this is an instance method check, it has to be here for now. 