### PR TITLE
Keep widgets while cloning dashboard

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -79,6 +79,7 @@ class MiqWidgetSet < ApplicationRecord
                          :description => destination_description,
                          :owner_type  => "MiqGroup",
                          :set_type    => source_widget_set.set_type,
+                         :set_data    => source_widget_set.set_data,
                          :owner_id    => assign_to_group.id)
   end
 

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -157,5 +157,12 @@ describe MiqWidgetSet do
       dashboard = MiqWidgetSet.copy_dashboard(@ws_group, name, tab)
       expect(MiqWidgetSet.find_by(:owner_id => group.id, :name => name)).to eq dashboard
     end
+
+    it "keeps the same set of widgets and dashboard's settings" do
+      set_data = {:col1 => [1], :col2 => [2], :col3 => [], :locked => false, :reset_upon_login => false, :last_group_db_updated => Time.now.utc}
+      @ws_group.update(:set_data => set_data)
+      new_dashboard = MiqWidgetSet.copy_dashboard(@ws_group, name, tab)
+      expect(new_dashboard.set_data).to eq set_data
+    end
   end
 end


### PR DESCRIPTION
Keep widgets and dashboard settings while copying dashboard
Follow-up to https://github.com/ManageIQ/manageiq/pull/18550

https://bugzilla.redhat.com/show_bug.cgi?id=1314875

@miq-bot add-label bug, changelog/no

/cc @gtanzillo 