### PR TITLE
Add a tool to purge archived storages

### DIFF
--- a/tools/purge_archived_storages.rb
+++ b/tools/purge_archived_storages.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+require "optimist"
+
+opts = Optimist.options do
+  opt :dry_run, "Just print out what would be done without modifying anything", :type => :boolean, :default => true
+end
+
+if opts[:dry_run]
+  puts "\n"
+  puts "* This is a dry run and will not modify the database"
+  puts "* To actually delete archived datastores pass --no-dry-run\n\n"
+end
+
+active_storage_ids = HostStorage.pluck(:storage_id).uniq
+archived_storages = Storage.where.not(:id => active_storage_ids).pluck(:id, :name)
+
+if archived_storages.empty?
+  puts "No archived storages found"
+else
+  puts "Deleting the following storages:"
+  puts archived_storages.map { |id, name| "ID [#{id}] Name [#{name}]" }.join("\n")
+end
+
+return if opts[:dry_run]
+
+archived_storage_ids = archived_storages.map(&:first)
+Storage.destroy(archived_storage_ids)

--- a/tools/purge_archived_storages.rb
+++ b/tools/purge_archived_storages.rb
@@ -7,9 +7,12 @@ opts = Optimist.options do
 end
 
 if opts[:dry_run]
-  puts "\n"
-  puts "* This is a dry run and will not modify the database"
-  puts "* To actually delete archived datastores pass --no-dry-run\n\n"
+  puts "**** This is a dry run and will not modify the database"
+  puts "     To actually purge the storages pass --no-dry-run"
+else
+  puts "**** This will modify your database ****"
+  puts "     Press Enter to Continue: "
+  STDIN.getc
 end
 
 active_storage_ids = HostStorage.pluck(:storage_id).uniq


### PR DESCRIPTION
Storages that aren't connected to any hosts aren't automatically deleted
and thus a tool is needed to clean them up.

This looks for storages which aren't represented in the host_storages
table which means they aren't a part of any EMS and can be removed.

```
>> Storage.create!(:name => "my storage")
>> Storage.create!(:name => "my other storage")

$ tools/purge_archived_storages.rb
* This is a dry run and will not modify the database
* To actually delete archived datastores pass --no-dry-run

Deleting the following storages:
ID [11] Name [my storage]
ID [12] Name [my other storage]

$ tools/purge_archived_storages.rb --no-dry-run
Deleting the following storages:
ID [11] Name [my storage]
ID [12] Name [my other storage]
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1721612