### PR TITLE
Add scope for EMSes that that can be assigned to a Group/Alert Profile

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -105,6 +105,7 @@ class ExtManagementSystem < ApplicationRecord
   validate :validate_ems_enabled_when_zone_changed?, :validate_zone_not_maintenance_when_ems_enabled?
 
   scope :with_eligible_manager_types, ->(eligible_types) { where(:type => Array(eligible_types).collect(&:to_s)) }
+  scope :assignable, -> { where.not(:type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager") }
 
   serialize :options
 


### PR DESCRIPTION
We discussed with @kbrock that [this is wrong](https://github.com/ManageIQ/manageiq-ui-classic/blob/5c66951f12f43018598ca0f024f8cc41c268759c/app/presenters/tree_builder_belongs_to_hac.rb#L49) and we should prefer using named scopes instead, so here we go.

@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label hammer/no, enhancement