### PR TITLE
Remove the deprecated call halt_callback_chains_on_return_false from config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -93,8 +93,6 @@ module Vmdb
 
     config.autoload_paths += config.eager_load_paths
 
-    config.active_support.halt_callback_chains_on_return_false = false
-
     # NOTE:  If you are going to make changes to autoload_paths, please make
     # sure they are all strings.  Rails will push these paths into the
     # $LOAD_PATH.


### PR DESCRIPTION
After updating to Rails 5.1.x, I started seeing this deprecation warning:

`DEPRECATION WARNING: ActiveSupport.halt_callback_chains_on_return_false= is deprecated and will be removed in Rails 5.2. (called from <top (required)> at /home/dberger/Dev/manageiq-providers-azure-djberg96/spec/manageiq/config/environment.rb:5)
** ManageIQ master, codename: Ivanchuk`

As per a conversation with @jrafanie I've removed it.