### PR TITLE
Create retire subtasks for multiple services

### DIFF
--- a/app/models/service_retire_task.rb
+++ b/app/models/service_retire_task.rb
@@ -27,10 +27,11 @@ class ServiceRetireTask < MiqRetireTask
 
   def after_request_task_create
     update_attributes(:description => get_description)
-    parent_svc = Service.find_by(:id => options[:src_ids])
-    if create_subtasks?(parent_svc)
-      _log.info("- creating service subtasks for service task <#{self.class.name}:#{id}>, service <#{parent_svc.id}>")
-      create_retire_subtasks(parent_svc, self)
+    Service.where(:id => options[:src_ids]).each do |parent_svc|
+      if create_subtasks?(parent_svc)
+        _log.info("- creating service subtasks for service task <#{self.class.name}:#{id}>, service <#{parent_svc.id}>")
+        create_retire_subtasks(parent_svc, self)
+      end
     end
   end
 

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -153,6 +153,20 @@ describe ServiceRetireTask do
         expect(VmRetireTask.count).to eq(0)
         expect(ServiceRetireTask.count).to eq(1)
       end
+
+      context "multiple service retirement" do
+        it "creates multiple retire subtasks" do
+          s1 = FactoryBot.create(:service)
+          s2 = FactoryBot.create(:service)
+          s1.add_resource!(FactoryBot.create(:vm_openstack))
+          s2.add_resource!(FactoryBot.create(:vm_openstack))
+
+          service_retire_task1 = FactoryBot.create(:service_retire_task, :source => s1, :miq_request => miq_request, :options => {:src_ids => [s1.id, s2.id] })
+          service_retire_task1.after_request_task_create
+
+          expect(VmRetireTask.count).to eq(2)
+        end
+      end
     end
 
     context "bundled service retires all children" do


### PR DESCRIPTION
Retiring multiple services from the UI means we have multiple options[:src_ids] and should create retire subtasks for all of them, not just the first one. 

For https://bugzilla.redhat.com/show_bug.cgi?id=1722194