### PR TITLE
Allow order fields to be subqueries with order

### DIFF
--- a/lib/extensions/ar_order.rb
+++ b/lib/extensions/ar_order.rb
@@ -8,6 +8,10 @@ module ActiveRecord
           order_columns = orders.reject(&:blank?).map { |s|
               # Convert Arel node to string
               unless s.is_a?(String)
+                if s.kind_of?(Arel::Nodes::Ordering)
+                  s = s.expr
+                  keep_order = true
+                end
                 if s.respond_to?(:to_sql)
                   s = s.to_sql
                 else # for Arel::Nodes::Attribute
@@ -17,9 +21,14 @@ module ActiveRecord
                   s = collector.value
                 end
               end
+              # If we haven't already removed the order clause,
               # Remove any ASC/DESC modifiers
-              s.gsub(/\s+(?:ASC|DESC)\b/i, "")
-               .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
+              if keep_order
+                s
+              else
+                s.gsub(/\s+(?:ASC|DESC)\b/i, "")
+                 .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
+              end
             }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
 
           (order_columns << super).join(", ")

--- a/lib/extensions/ar_order.rb
+++ b/lib/extensions/ar_order.rb
@@ -1,3 +1,5 @@
+# This monkey patches rails to support proper joins
+# current PR: https://github.com/rails/rails/pull/36531
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
@@ -5,7 +7,16 @@ module ActiveRecord
         def columns_for_distinct(columns, orders) #:nodoc:
           order_columns = orders.reject(&:blank?).map { |s|
               # Convert Arel node to string
-              s = s.to_sql unless s.is_a?(String)
+              unless s.is_a?(String)
+                if s.respond_to?(:to_sql)
+                  s = s.to_sql
+                else # for Arel::Nodes::Attribute
+                  engine = Arel::Table.engine
+                  collector = Arel::Collectors::SQLString.new
+                  collector = engine.connection.visitor.accept s, collector
+                  s = collector.value
+                end
+              end
               # Remove any ASC/DESC modifiers
               s.gsub(/\s+(?:ASC|DESC)\b/i, "")
                .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")

--- a/lib/extensions/ar_order.rb
+++ b/lib/extensions/ar_order.rb
@@ -1,0 +1,19 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module SchemaStatements
+        def columns_for_distinct(columns, orders) #:nodoc:
+          order_columns = orders.reject(&:blank?).map { |s|
+              # Convert Arel node to string
+              s = s.to_sql unless s.is_a?(String)
+              # Remove any ASC/DESC modifiers
+              s.gsub(/\s+(?:ASC|DESC)\b/i, "")
+               .gsub(/\s+NULLS\s+(?:FIRST|LAST)\b/i, "")
+            }.reject(&:blank?).map.with_index { |column, i| "#{column} AS alias_#{i}" }
+
+          (order_columns << super).join(", ")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/extensions/ar_order_spec.rb
+++ b/spec/lib/extensions/ar_order_spec.rb
@@ -1,0 +1,7 @@
+describe "ar_order extension" do
+  it "supports order when distinct is present for basic column" do
+    expect do
+      VmOrTemplate.includes(:disks).references(:disks).order(:id).first
+    end.not_to raise_error
+  end
+end

--- a/spec/lib/extensions/ar_order_spec.rb
+++ b/spec/lib/extensions/ar_order_spec.rb
@@ -1,4 +1,16 @@
 describe "ar_order extension" do
+  # includes a has_many AND references the has many
+  # this introduces a DISTINCT to the query.
+  # rails uses limited_ids_for (which calls columns_for_distinct) to run a quick query
+  #
+  # when we use a virtual attribute in the sort (and the attribute has a descending order)
+  # the string munging gives us issues.
+  it "supports order when distinct is present for has_many virtual column" do
+    expect do
+      VmOrTemplate.includes(:disks).references(:disks).order(:last_compliance_status).first
+    end.not_to raise_error
+  end
+
   it "supports order when distinct is present for basic column" do
     expect do
       VmOrTemplate.includes(:disks).references(:disks).order(:id).first


### PR DESCRIPTION
Fixes: https://github.com/ManageIQ/manageiq-ui-classic/issues/5374

### Overview

Virtual fields that reference a `has_many` relationship, often need to have a `LIMIT` and `ORDER` in the field definition.

When rails works with these fields in an `ORDER BY` clause, they sometimes add that field to the `SELECT` clause for Sql reasons. In that process, they munge the field and break things.

### Before

We see this issue on the [Vm explorer] page. If we sort by `compliance` (i.e. [`last_compliance_status`]) it blows up:

```ruby
VmOrTemplate.includes(:hardware => :disks).references('x').order(:last_compliance_status).first

ActiveRecord::StatementInvalid (PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list)
LINE 1: ..."disks"."hardware_id" = "hardwares"."id" ORDER BY (SELECT  "...
```

### After

I put in a Rails [PR] that avoids string munging and leverages Arel. In the mean time, this PR is a monkey patch to our codebase with the same code that fixes the problem in the short term.

[PR]: https://github.com/rails/rails/pull/36531

[`last_compliance_status`]: https://github.com/ManageIQ/manageiq/blob/26978a4fe4db2797a3a3d4983a4a22d4ccbc77af/app/models/mixins/compliance_mixin.rb#L6
[Vm explorer]: https://github.com/kbrock/manageiq-ui-classic/blob/master/product/views/VmOrTemplate.yaml#L25
