### PR TITLE
By design Mail Attribut is not single value

### DIFF
--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -120,7 +120,7 @@ module Authenticator
       user.first_name = ldap.get_attr(lobj, :givenname)
       user.last_name  = ldap.get_attr(lobj, :sn)
       emails_attr     = ldap.get_attr(lobj, :mail)
-      email           = emails.kind_of?(Array) ? emails.first : emails
+      email           = emails_attr.kind_of?(Array) ? emails_attr.first : emails_attr
       user.email      = email unless email.blank?
       user.name       = ldap.get_attr(lobj, :displayname)
       user.name       = "#{user.first_name} #{user.last_name}" if user.name.blank?

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -119,7 +119,8 @@ module Authenticator
       user.userid     = ldap.normalize(ldap.get_attr(lobj, :userprincipalname) || ldap.get_attr(lobj, :dn))
       user.first_name = ldap.get_attr(lobj, :givenname)
       user.last_name  = ldap.get_attr(lobj, :sn)
-      email           = ldap.get_attr(lobj, :mail).first
+      emails_attr     = ldap.get_attr(lobj, :mail)
+      email           = emails.kind_of?(Array) ? emails.first : emails
       user.email      = email unless email.blank?
       user.name       = ldap.get_attr(lobj, :displayname)
       user.name       = "#{user.first_name} #{user.last_name}" if user.name.blank?

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -119,7 +119,7 @@ module Authenticator
       user.userid     = ldap.normalize(ldap.get_attr(lobj, :userprincipalname) || ldap.get_attr(lobj, :dn))
       user.first_name = ldap.get_attr(lobj, :givenname)
       user.last_name  = ldap.get_attr(lobj, :sn)
-      email           = ldap.get_attr(lobj, :mail)
+      email           = ldap.get_attr(lobj, :mail).first
       user.email      = email unless email.blank?
       user.name       = ldap.get_attr(lobj, :displayname)
       user.name       = "#{user.first_name} #{user.last_name}" if user.name.blank?

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -119,8 +119,8 @@ module Authenticator
       user.userid     = ldap.normalize(ldap.get_attr(lobj, :userprincipalname) || ldap.get_attr(lobj, :dn))
       user.first_name = ldap.get_attr(lobj, :givenname)
       user.last_name  = ldap.get_attr(lobj, :sn)
-      emails_attr     = ldap.get_attr(lobj, :mail)
-      email           = emails_attr.kind_of?(Array) ? emails_attr.first : emails_attr
+      email           = ldap.get_attr(lobj, :mail)
+      email           = email.first if email.kind_of?(Array)
       user.email      = email unless email.blank?
       user.name       = ldap.get_attr(lobj, :displayname)
       user.name       = "#{user.first_name} #{user.last_name}" if user.name.blank?

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -77,7 +77,8 @@ describe Authenticator::Ldap do
       :displayname       => 'Alice Aardvark',
       :givenname         => 'Alice',
       :sn                => 'Aardvark',
-      :mail              => ['alice@example.com','a.aardvark@example.com'],
+      :mail              => ['alice@example.com',
+                             'a.aardvark@example.com'],
       :groups            => %w(wibble bubble),
     }
   end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -77,8 +77,7 @@ describe Authenticator::Ldap do
       :displayname       => 'Alice Aardvark',
       :givenname         => 'Alice',
       :sn                => 'Aardvark',
-      :mail              => ['alice@example.com',
-                             'a.aardvark@example.com'],
+      :mail              => ['alice@example.com', 'a.aardvark@example.com'],
       :groups            => %w(wibble bubble),
     }
   end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -77,7 +77,7 @@ describe Authenticator::Ldap do
       :displayname       => 'Alice Aardvark',
       :givenname         => 'Alice',
       :sn                => 'Aardvark',
-      :mail              => 'alice@example.com',
+      :mail              => ['alice@example.com','a.aardvark@example.com'],
       :groups            => %w(wibble bubble),
     }
   end


### PR DESCRIPTION
It is impossible to connect via ldap authentication if the user has multiple mail attributs.

By definition, the mail attribute is not unique (not SINGLE_VALUE):
https://tools.ietf.org/html/rfc4524#section-2.16