### PR TITLE
Update required versions in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-raise "Ruby versions < 2.3.1 are unsupported!" if RUBY_VERSION < "2.3.1"
+raise "Ruby versions < 2.4.0 are unsupported!" if RUBY_VERSION < "2.4.0"
 raise "Ruby versions >= 2.6 are unsupported!" if RUBY_VERSION >= "2.6.0"
 
 source 'https://rubygems.org'
@@ -31,7 +31,7 @@ gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false
 gem "bcrypt",                         "~> 3.1.10",     :require => false
-gem "bundler",                        ">=1.15",        :require => false
+gem "bundler",                        ">=1.16",        :require => false
 gem "byebug",                                          :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.6.0",       :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -233,7 +233,6 @@ end
 unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
-    gem "rubocop",             "~>0.69.0", :require => false
     gem "rubocop-performance", "~>1.3",    :require => false
     # ruby_parser is required for i18n string extraction
     gem "ruby_parser",                     :require => false


### PR DESCRIPTION
During my review of the new developer steps, I found the minimum required Ruby and Bundler versions in `Gemfile` were out of date. This sets them to their current minimums.