### PR TITLE
Explicitly require the websocket driver in the remote console server

### DIFF
--- a/lib/remote_console/rack_server.rb
+++ b/lib/remote_console/rack_server.rb
@@ -21,6 +21,7 @@
 # hash has been used to access the corresponding wrappers.
 
 require 'surro-gate'
+require 'websocket/driver'
 
 module RemoteConsole
   class RackServer


### PR DESCRIPTION
This fixes a regression caused by #18593, the `WebSocket::Driver.websocket?` method fails in production as the code loading is different from development. 

```
Rack app error handling request { GET /ws/console/077ed6eb81229ed9212653ef70bc832f }
#<NameError: uninitialized constant RemoteConsole::RackServer::WebSocket>
/var/www/miq/vmdb/lib/remote_console/rack_server.rb:60:in `call'
/usr/share/gems/gems/puma-3.7.1/lib/puma/configuration.rb:232:in `call'
/usr/share/gems/gems/puma-3.7.1/lib/puma/server.rb:578:in `handle_request'
/usr/share/gems/gems/puma-3.7.1/lib/puma/server.rb:415:in `process_client'
/usr/share/gems/gems/puma-3.7.1/lib/puma/server.rb:275:in `block in run'
/usr/share/gems/gems/puma-3.7.1/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```

The solution is to explicitly require the file that provides this method.

@miq-bot add_label bug, hammer/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1723351