### PR TITLE
[V2V] Don't use the ssh agent when verifying credentials

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -55,7 +55,7 @@ class ConversionHost < ApplicationRecord
 
       auth = authentication_type(auth_type) || authentications.first
 
-      ssh_options = { :timeout => 10, :logger => $log, :verbose => :error }
+      ssh_options = { :timeout => 10, :logger => $log, :verbose => :error, :use_agent => false }
 
       case auth
       when AuthUseridPassword


### PR DESCRIPTION
When verifying credentials for V2V we should not attempt to use the ssh-agent because, in practice, it isn't running on the hosts we connect to.

At the moment the net-ssh library sets the `:use_agent` option to true by default: https://www.rubydoc.info/github/net-ssh/net-ssh/Net/SSH. While this does not prevent the verification from working, it does generate some potentially misleading log information:

`net.ssh.authentication.agent[a90031c]: Q-task_id([job_dispatcher]) could not connect to ssh-agent: Agent not configured`

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1724487