### PR TITLE
Add parent network to networks

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -78,7 +78,11 @@ FactoryBot.define do
   factory :ems_network,
           :aliases => ["manageiq/providers/network_manager"],
           :class   => "ManageIQ::Providers::Openstack::NetworkManager",
-          :parent  => :ext_management_system
+          :parent  => :ext_management_system do
+    parent_manager { FactoryBot.create(:ext_management_system) }
+  end
+
+
 
   factory :ems_storage,
           :aliases => ["manageiq/providers/storage_manager"],


### PR DESCRIPTION
This is ugly but ems_network relies on having child and parent networks so the specs need to reflect that somehow. It'll fix a couple of the currently failing api tests. Not all. Some. It's necessary since earlier today when https://github.com/ManageIQ/manageiq/pull/18842, making specs for emses use leaf classes, got merged. 
