### PR TITLE
Fix turbo order

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -274,7 +274,7 @@ module Rbac
         inner_scope = scope.except(:select, :includes, :references)
         scope.includes_values.each { |hash| inner_scope = add_joins(klass, inner_scope, hash) }
         scope = scope.from(Arel.sql("(#{inner_scope.to_sql})").as(scope.table_name))
-                     .except(:offset, :limit, :order, :where)
+                     .except(:offset, :limit, :where)
 
         # the auth_count needs to come from the inner query (the query with the limit)
         if !options[:skip_counts] && (attrs[:apply_limit_in_sql] && limit)


### PR DESCRIPTION
### Problem

On some pages, the sort order seems to be ignored.
In theory it could be any page, but it is only the Services page that exhibits this behavior.

### Underlying issue

Selecting from an ordered subquery does not properly sort the records.

### before

```sql
select * from (
  select *
  from vms
  order by id
  limit 10
)
```

In rare cases, the results are not ordered correctly.

### after

Instead, we needed the order in both clauses.
The inner order ensures that the limit works, the outer order ensures the order :

```sql
select * from (
  select *
  from vms
  order by id
  limit 10
)
order by id
```

The results are now always ordered correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1722491 - invalid sort order
https://bugzilla.redhat.com/show_bug.cgi?id=1718102 - turbo

