### PR TITLE
[V2V] Enhance throttler logging

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -55,7 +55,7 @@ class ConversionHost < ApplicationRecord
 
       auth = authentication_type(auth_type) || authentications.first
 
-      ssh_options = { :timeout => 10, :logger => $log, :verbose => :error, :use_agent => false }
+      ssh_options = { :timeout => 10, :use_agent => false }
 
       case auth
       when AuthUseridPassword

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -1,41 +1,43 @@
 class InfraConversionThrottler
+  include Vmdb::Logging
+
   def self.start_conversions
-    $log&.debug("InfraConversionThrottler.start_conversions")
+    _log.debug("InfraConversionThrottler.start_conversions")
     pending_conversion_jobs.each do |ems, jobs|
-      $log&.debug("- EMS: #{ems.name}")
-      $log&.debug("-- Number of pending jobs: #{jobs.size}")
+      _log.debug("- EMS: #{ems.name}")
+      _log.debug("-- Number of pending jobs: #{jobs.size}")
       running = ems.conversion_hosts.inject(0) { |sum, ch| sum + ch.active_tasks.count }
-      $log&.debug("-- Currently running jobs in EMS: #{running}")
+      _log.debug("-- Currently running jobs in EMS: #{running}")
       slots = (ems.miq_custom_get('Max Transformation Runners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
-      $log&.debug("-- Available slots in EMS: #{slots}")
+      _log.debug("-- Available slots in EMS: #{slots}")
       jobs.each do |job|
         vm_name = job.migration_task.source.name
-        $log&.debug("- Looking for a conversion host for task for #{vm_name}")
+        _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
         if slots <= 0
-          $log&.debug("-- No available slot in EMS. Stopping.")
+          _log.debug("-- No available slot in EMS. Stopping.")
           break
         end
 
         eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.count }
         if eligible_hosts.empty?
-          $log&.debug("-- No eligible conversion host for task for '#{vm_name}'")
+          _log.debug("-- No eligible conversion host for task for '#{vm_name}'")
           break
         end
 
-        $log&.debug("-- Eligible conversion hosts:")
+        _log.debug("-- Eligible conversion hosts:")
         eligible_hosts.each do |eh|
           max_tasks = eh.max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
-          $log&.debug("--- #{eh.name} [#{eh.active_tasks.count}/#{max_tasks}]")
+          _log.debug("--- #{eh.name} [#{eh.active_tasks.count}/#{max_tasks}]")
         end
 
         eligible_host = eligible_hosts.first
-        $log&.debug("-- Associating  #{eligible_host.name} to the task for '#{vm_name}'.")
+        _log.debug("-- Associating  #{eligible_host.name} to the task for '#{vm_name}'.")
         job.migration_task.update_attributes!(:conversion_host => eligible_hosts.first)
 
-        $log&.debug("-- Queuing :start signal for the job for '#{vm_name}': current state is '#{job.state}'.")
+        _log.debug("-- Queuing :start signal for the job for '#{vm_name}': current state is '#{job.state}'.")
         job.queue_signal(:start)
-        $log&.info("Pending InfraConversionJob: id=#{job.id} signaled to start")
+        _log.info("Pending InfraConversionJob: id=#{job.id} signaled to start")
         slots -= 1
       end
     end


### PR DESCRIPTION
While trying to identify the reason for odd balancing on a migration plan execution, we realized that we didn't have enough information to nail the cause. This PR adds extra logging in debug mode, so that we can understand the current limits at the EMS and Conversion Host levels.

The PR also changes the configuration of the SSH connection in `ConversionHost.verify_credentials`, because it currently overrides the log level of the global throttler. We will need another PR to keep the SSH errors, but the current setting is counter productive.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1726186