### PR TITLE
Move AnsibleTowerJobTemplateDialogService from UI

### DIFF
--- a/app/models/dialog/ansible_tower_job_template_dialog_service.rb
+++ b/app/models/dialog/ansible_tower_job_template_dialog_service.rb
@@ -1,6 +1,7 @@
 class Dialog
   class AnsibleTowerJobTemplateDialogService
     def self.create_dialog(template, label = nil)
+      template, label = label, template if template.kind_of?(String)
       new.create_dialog(template, label)
     end
 

--- a/app/models/dialog/ansible_tower_job_template_dialog_service.rb
+++ b/app/models/dialog/ansible_tower_job_template_dialog_service.rb
@@ -1,0 +1,166 @@
+class Dialog
+  class AnsibleTowerJobTemplateDialogService
+    def self.create_dialog(template, label = nil)
+      new.create_dialog(template, label)
+    end
+
+    def create_dialog(template, label = nil)
+      label ||= template.name
+      Dialog.new(:label => label, :buttons => "submit,cancel").tap do |dialog|
+        tab = dialog.dialog_tabs.build(:display => "edit", :label => "Basic Information", :position => 0)
+
+        group_pos = 0
+        add_options_group(tab, group_pos, template)
+
+        if template.survey_spec.present?
+          group_pos += 1
+          add_survey_group(tab, group_pos, template)
+        end
+
+        if template.variables.present?
+          group_pos += 1
+          add_variables_group(tab, group_pos, template)
+        end
+
+        dialog.save!
+      end
+    end
+
+    private
+
+    def add_options_group(tab, position, template)
+      tab.dialog_groups.build(
+        :display  => "edit",
+        :label    => "Options",
+        :position => position
+      ).tap do |dialog_group|
+        add_service_name_field(dialog_group, 0)
+        add_limit_field(dialog_group, 1) if template.supports_limit?
+      end
+    end
+
+    def add_options_field(group, position, options)
+      group.dialog_fields.build(
+        :type           => "DialogFieldTextBox",
+        :name           => options[:name],
+        :description    => options[:description],
+        :data_type      => "string",
+        :display        => "edit",
+        :required       => false,
+        :options        => {:protected => false},
+        :label          => options[:label],
+        :position       => position,
+        :reconfigurable => true,
+        :dialog_group   => group
+      )
+    end
+
+    def add_service_name_field(group, position)
+      options = {
+        :name        => "service_name",
+        :description => "Name of the new service",
+        :label       => "Service Name",
+      }
+      add_options_field(group, position, options)
+    end
+
+    def add_limit_field(group, position)
+      options = {
+        :name        => "limit",
+        :description => "A ':'-separated string to constrain the list of hosts managed or affected by the playbook",
+        :label       => "Limit",
+      }
+      add_options_field(group, position, options)
+    end
+
+    def add_survey_group(tab, position, template)
+      parameters = template.survey_spec['spec'] || []
+      tab.dialog_groups.build(
+        :display  => "edit",
+        :label    => "Survey",
+        :position => position
+      ).tap do |dialog_group|
+        parameters.each_with_index { |param, index| add_parameter_field(param, dialog_group, index) }
+      end
+    end
+
+    def add_parameter_field(parameter, group, position)
+      if parameter['type'] == 'multiselect' || parameter['type'] == 'multiplechoice'
+        create_parameter_dropdown_list(parameter, group, position)
+      else
+        type = parameter['type'] == 'textarea' ? 'DialogFieldTextAreaBox' : 'DialogFieldTextBox'
+        create_parameter_textinput(parameter, group, position, type)
+      end
+    end
+
+    def create_parameter_dropdown_list(parameter, group, position)
+      dropdown_list = parameter['choices'].split("\n").collect { |v| [v, v] }
+      default_value = if parameter['type'] == 'multiselect'
+                        parameter['default'].try(:split, "\n")
+                      else # 'multiplechoice'
+                        parameter['default'].try(:split, "\n").try(:first)
+                      end
+      group.dialog_fields.build(
+        :type           => "DialogFieldDropDownList",
+        :name           => "param_#{parameter['variable']}",
+        :display        => "edit",
+        :required       => parameter['required'],
+        :options        => {:force_multi_value => parameter["type"] == "multiselect"},
+        :values         => dropdown_list,
+        :default_value  => default_value || dropdown_list.first,
+        :label          => parameter['question_name'],
+        :description    => parameter['question_description'],
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group
+      )
+    end
+
+    def create_parameter_textinput(parameter, group, position, type)
+      group.dialog_fields.build(
+        :type           => type,
+        :name           => "param_#{parameter['variable']}",
+        :data_type      => parameter['type'] == 'integer' ? 'integer' : 'string',
+        :display        => "edit",
+        :required       => parameter['required'],
+        :default_value  => parameter['default'],
+        :options        => {:protected => parameter['type'] == 'password'},
+        :label          => parameter['question_name'],
+        :description    => parameter['question_description'],
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group
+      )
+    end
+
+    def add_variables_group(tab, position, template)
+      tab.dialog_groups.build(
+        :display  => "edit",
+        :label    => "Extra Variables",
+        :position => position
+      ).tap do |dialog_group|
+        template.variables.each_with_index do |(key, value), index|
+          value = value.to_json if [Hash, Array].include?(value.class)
+          add_variable_field(key, value, dialog_group, index)
+        end
+      end
+    end
+
+    def add_variable_field(key, value, group, position)
+      group.dialog_fields.build(
+        :type           => "DialogFieldTextBox",
+        :name           => "param_#{key}",
+        :data_type      => "string",
+        :display        => "edit",
+        :required       => false,
+        :default_value  => value,
+        :label          => key,
+        :description    => key,
+        :reconfigurable => true,
+        :position       => position,
+        :dialog_group   => group,
+        :read_only      => true
+      )
+    end
+  end
+end

--- a/spec/models/dialog/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/models/dialog/ansible_tower_job_template_dialog_service_spec.rb
@@ -1,0 +1,91 @@
+describe Dialog::AnsibleTowerJobTemplateDialogService do
+  let(:template) { FactoryBot.create(:ansible_configuration_script) }
+
+  describe "#create_dialog" do
+    it "creates a dialog from a job template" do
+      survey =
+        "{\"spec\":[{\"index\": 0, \"question_name\": \"Param1\", \"min\": 10, \
+        \"default\": \"19\", \"max\": 100, \"question_description\": \"param 1\", \"required\": true, \"variable\": \
+        \"param1\", \"choices\": \"\", \"type\": \"integer\"}, {\"index\": 1, \"question_name\": \"Param2\", \"min\": \
+        2, \"default\": \"as\", \"max\": 5, \"question_description\": \"param 2\", \"required\": true, \"variable\": \
+        \"param2\", \"choices\": \"\", \"type\": \"text\"}, {\"index\": 2, \"question_name\": \"Param3\", \"min\": \
+        \"\", \"default\": \"no\\nhello\", \"max\": \"\", \"question_description\": \"param 3\", \"required\": false, \
+        \"variable\": \"param3\", \"choices\": \"\", \"type\": \"textarea\"}, {\"index\": 3, \"question_name\": \
+        \"Param4\", \"min\": \"\", \"default\": \"mypassword\", \"max\": \"\", \"question_description\": \"param 4\", \
+        \"required\": true, \"variable\": \"param4\", \"choices\": \"\", \"type\": \"password\"}, {\"index\": 4, \
+        \"question_name\": \"Param5\", \"min\": \"\", \"default\": \"Peach\", \"max\": \"\", \"question_description\": \
+        \"param 5\", \"required\": true, \"variable\": \"param5\", \"choices\": \"Apple\\nBanana\\nPeach\", \"type\": \
+        \"multiplechoice\"}, {\"index\": 5, \"question_description\": \"param 6\", \"min\": \"\", \"default\": \
+        \"opt1\\n222\", \"max\": \"\", \"question_name\": \"Param6\", \"required\": true, \"variable\": \"param6\", \
+        \"choices\": \"opt1\\n222\\nopt3\", \"type\": \"multiselect\"}, {\"index\": 6, \"question_name\": \"Param7\", \
+        \"min\": \"\", \"default\": \"14.5\", \"max\": \"\", \"question_description\": \"param 7\", \
+        \"required\": true, \"variable\": \"param7\", \"choices\": \"\", \"type\": \"float\"}],\"name\":\"\", \
+        \"description\":\"\"}"
+      allow(template).to receive(:survey_spec).and_return(JSON.parse(survey))
+
+      allow(template).to receive(:variables).and_return('some_extra_var'  => 'blah',
+                                                        'other_extra_var' => {'name' => 'some_value'},
+                                                        'array_extra_var' => [{'name' => 'some_value'}])
+      dialog = subject.create_dialog(template)
+
+      expect(dialog).to have_attributes(:label => template.name, :buttons => "submit,cancel")
+
+      tabs = dialog.dialog_tabs
+      expect(tabs.size).to eq(1)
+      assert_main_tab(tabs[0])
+    end
+  end
+
+  def assert_main_tab(tab)
+    assert_tab_attributes(tab)
+
+    groups = tab.dialog_groups
+    expect(groups.size).to eq(3)
+
+    assert_option_group(groups[0])
+    assert_survey_group(groups[1])
+    assert_variables_group(groups[2])
+  end
+
+  def assert_tab_attributes(tab)
+    expect(tab).to have_attributes(:label => "Basic Information", :display => "edit")
+  end
+
+  def assert_option_group(group)
+    expect(group).to have_attributes(:label => "Options", :display => "edit")
+    fields = group.dialog_fields
+    expect(fields.size).to eq(2)
+    expect(fields[0]).to have_attributes(:label => "Service Name", :name => "service_name", :required => false, :data_type => 'string')
+    expect(fields[1]).to have_attributes(:label => "Limit", :name => "limit", :required => false, :data_type => 'string')
+  end
+
+  def assert_field(field, clss, attributes)
+    expect(field).to be_kind_of clss
+    expect(field).to have_attributes(attributes)
+  end
+
+  def assert_survey_group(group)
+    expect(group).to have_attributes(:label => "Survey", :display => "edit")
+    fields = group.dialog_fields
+    expect(fields.size).to eq(7)
+
+    assert_field(fields[0], DialogFieldTextBox,      :name => 'param_param1', :data_type => 'integer',   :default_value => "19")
+    assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
+    assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
+    assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w[Apple Apple], %w[Banana Banana], %w[Peach Peach]], :options => {:force_multi_value => false})
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "[\"opt1\", \"222\"]",  :values => [%w[222 222], %w[opt1 opt1], %w[opt3 opt3]], :options => {:force_multi_value => true})
+    assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',    :default_value => "14.5")
+  end
+
+  def assert_variables_group(group)
+    expect(group).to have_attributes(:label => "Extra Variables", :display => "edit")
+
+    fields = group.dialog_fields
+    expect(fields.size).to eq(3)
+
+    assert_field(fields[0], DialogFieldTextBox, :name => 'param_some_extra_var', :default_value => 'blah', :data_type => 'string', :read_only => true)
+    assert_field(fields[1], DialogFieldTextBox, :name => 'param_other_extra_var', :default_value => '{"name":"some_value"}', :data_type => 'string', :read_only => true)
+    assert_field(fields[2], DialogFieldTextBox, :name => 'param_array_extra_var', :default_value => '[{"name":"some_value"}]', :data_type => 'string', :read_only => true)
+  end
+end


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/issues/18931

**Description**
- moves `AnsibleTowerJobTemplateDialogService` from ui-classic
- defines singleton create_dialog method
- `AnsibleTowerJobTemplateDialogService` is a child of Dialog
- allows to use reversed parameters because of API compatibility with other dialog creators (**EDIT**: or we could reorder the input variables as i dont see any case when the label could be nil)

**Merge together with** https://github.com/ManageIQ/manageiq-ui-classic/pull/5765

@Hyperkid123 