### PR TITLE
Update rubocop channel to 0.69

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,7 +28,7 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: rubocop-0-68
+    channel: 'rubocop-0-69'
 exclude_patterns:
 - config/dictionary_strings.rb
 - config/model_attributes.rb


### PR DESCRIPTION
This updates the rubocop channel for codeclimate to 0.69, which aligns with the version of rubocop that we're using.