### PR TITLE
Fix spec OpenStack Cloud factory

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -279,7 +279,7 @@ FactoryBot.define do
   factory :ems_openstack,
           :aliases => ["manageiq/providers/openstack/cloud_manager"],
           :class   => "ManageIQ::Providers::Openstack::CloudManager",
-          :parent  => :ems_cloud
+          :parent  => :ext_management_system
 
   factory :ems_openstack_with_authentication,
           :parent => :ems_openstack do


### PR DESCRIPTION
Recent change in ems_cloud factory added region (assumed its Amazon only propably),
which broke OpenStack tests.

Changing ems_openstack parent directly to ext_management_system to bypass region setup.

Should fix OpenStack Travis.

Links
----------------
* related to https://github.com/ManageIQ/manageiq/pull/18842