### PR TITLE
Ensure NotificationType#subscriber_ids always returns non-nil

### DIFF
--- a/app/models/notification_type.rb
+++ b/app/models/notification_type.rb
@@ -32,7 +32,7 @@ class NotificationType < ApplicationRecord
       User.superadmins.pluck(:id)
     when AUDIENCE_NONE
       []
-    end
+    end || []
   end
 
   # this disables notifications, but allows the notification to still exist

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -1,12 +1,15 @@
 describe NotificationType, :type => :model do
   describe '.seed' do
-    subject { described_class.count }
-    context 'before the seed is run' do
-      it { is_expected.to be_zero }
+    it 'has not seeded records before seed is run' do
+      expect(described_class.count).to be_zero
     end
+
     context 'after the seed is run' do
       before { described_class.seed }
-      it { is_expected.to be > 0 }
+      it 'has added rows' do
+        expect(described_class.count).to be > 0
+      end
+
       it 'can be run again without any effects' do
         expect { described_class.seed }.not_to change(described_class, :count)
       end
@@ -18,29 +21,30 @@ describe NotificationType, :type => :model do
     let(:tenant) { FactoryBot.create(:tenant) }
     let!(:user2) { FactoryBot.create(:user_with_group, :tenant => tenant) }
     let(:vm) { FactoryBot.create(:vm, :tenant => tenant) }
-    subject { notification.subscriber_ids(vm, user1) }
+
     context 'global notification type' do
       let(:notification) { FactoryBot.create(:notification_type, :audience => 'global') }
       it 'returns all the users' do
-        is_expected.to match_array(User.pluck(:id))
+        expect(notification.subscriber_ids(vm, user1)).to match_array(User.pluck(:id))
       end
     end
 
     context 'user specific notification type' do
       let(:notification) { FactoryBot.create(:notification_type, :audience => 'user') }
       it 'returns just the user, who initiated the task' do
-        is_expected.to match_array([user1.id])
+        expect(notification.subscriber_ids(vm, user1)).to match_array([user1.id])
       end
     end
 
     context 'tenant specific notification type' do
       let(:notification) { FactoryBot.create(:notification_type, :audience => 'tenant') }
       it 'returns the users in the tenant same tenant as concerned vm' do
-        is_expected.to match_array([user2.id])
+        expect(notification.subscriber_ids(vm, user1)).to match_array([user2.id])
       end
+
       it "returns single id if user belongs to different group" do
         user2.miq_groups << FactoryBot.create(:miq_group, :tenant => tenant)
-        is_expected.to match_array([user2.id])
+        expect(notification.subscriber_ids(vm, user1)).to match_array([user2.id])
       end
     end
   end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -43,6 +43,17 @@ describe NotificationType, :type => :model do
         expect(type.subscriber_ids(vm, user1)).to match_array([user2.id])
       end
     end
+
+    context "with seeded types" do
+      before { described_class.seed }
+
+      it "returns an array for all types without a subject" do
+        described_class.all.each do |type|
+          ids = type.subscriber_ids(nil, user1)
+          expect(ids).to be_an_instance_of(Array), "expected an array for notification type #{type.name}, got #{ids.inspect}"
+        end
+      end
+    end
   end
 
   describe "#enabled?" do

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -15,9 +15,9 @@ describe NotificationType, :type => :model do
 
   describe '#subscribers_ids' do
     let(:user1) { FactoryBot.create(:user) }
-    let(:tenant2) { FactoryBot.create(:tenant) }
-    let!(:user2) { FactoryBot.create(:user_with_group, :tenant => tenant2) }
-    let(:vm) { FactoryBot.create(:vm, :tenant => tenant2) }
+    let(:tenant) { FactoryBot.create(:tenant) }
+    let!(:user2) { FactoryBot.create(:user_with_group, :tenant => tenant) }
+    let(:vm) { FactoryBot.create(:vm, :tenant => tenant) }
     subject { notification.subscriber_ids(vm, user1) }
     context 'global notification type' do
       let(:notification) { FactoryBot.create(:notification_type, :audience => 'global') }
@@ -39,7 +39,7 @@ describe NotificationType, :type => :model do
         is_expected.to match_array([user2.id])
       end
       it "returns single id if user belongs to different group" do
-        user2.miq_groups << FactoryBot.create(:miq_group, :tenant => tenant2)
+        user2.miq_groups << FactoryBot.create(:miq_group, :tenant => tenant)
         is_expected.to match_array([user2.id])
       end
     end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -17,10 +17,10 @@ describe NotificationType, :type => :model do
   end
 
   describe '#subscribers_ids' do
-    let(:user1) { FactoryBot.create(:user) }
-    let(:tenant) { FactoryBot.create(:tenant) }
+    let(:user1)  { FactoryBot.create(:user) }
     let!(:user2) { FactoryBot.create(:user_with_group, :tenant => tenant) }
-    let(:vm) { FactoryBot.create(:vm, :tenant => tenant) }
+    let(:tenant) { FactoryBot.create(:tenant) }
+    let(:vm)     { FactoryBot.create(:vm, :tenant => tenant) }
 
     context 'global notification type' do
       let(:notification) { FactoryBot.create(:notification_type, :audience => 'global') }

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -22,29 +22,25 @@ describe NotificationType, :type => :model do
     let(:tenant) { FactoryBot.create(:tenant) }
     let(:vm)     { FactoryBot.create(:vm, :tenant => tenant) }
 
-    context 'global notification type' do
-      let(:notification) { FactoryBot.create(:notification_type, :audience => 'global') }
-      it 'returns all the users' do
-        expect(notification.subscriber_ids(vm, user1)).to match_array(User.pluck(:id))
-      end
+    it 'returns all the users for a global notification type' do
+      type = FactoryBot.create(:notification_type, :audience => 'global')
+      expect(type.subscriber_ids(vm, user1)).to match_array(User.pluck(:id))
     end
 
-    context 'user specific notification type' do
-      let(:notification) { FactoryBot.create(:notification_type, :audience => 'user') }
-      it 'returns just the user, who initiated the task' do
-        expect(notification.subscriber_ids(vm, user1)).to match_array([user1.id])
-      end
+    it 'returns just the user who initiated the task for a user specific notification type' do
+      type = FactoryBot.create(:notification_type, :audience => 'user')
+      expect(type.subscriber_ids(vm, user1)).to match_array([user1.id])
     end
 
     context 'tenant specific notification type' do
-      let(:notification) { FactoryBot.create(:notification_type, :audience => 'tenant') }
+      let(:type) { FactoryBot.create(:notification_type, :audience => 'tenant') }
       it 'returns the users in the tenant same tenant as concerned vm' do
-        expect(notification.subscriber_ids(vm, user1)).to match_array([user2.id])
+        expect(type.subscriber_ids(vm, user1)).to match_array([user2.id])
       end
 
       it "returns single id if user belongs to different group" do
         user2.miq_groups << FactoryBot.create(:miq_group, :tenant => tenant)
-        expect(notification.subscriber_ids(vm, user1)).to match_array([user2.id])
+        expect(type.subscriber_ids(vm, user1)).to match_array([user2.id])
       end
     end
   end


### PR DESCRIPTION
Before this fix it was possible for a type to return nil which would
break notification creation in the #set_notification_recipients before
create hook even though it should be valid to create a notification
with no subscribers.

Note: the last commit fixes the issue, the prior 4 are spec cleanup.

cc @martinpovolny this should fix the spec failure you saw:
![image](https://user-images.githubusercontent.com/12697904/60523432-b10f5b80-9cb8-11e9-93b4-86b213a1a22f.png)
