### PR TITLE
default inline_sql_views (aka turbo button) off

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -292,6 +292,10 @@ class MiqReport < ApplicationRecord
     [result_set_filtered, result_set_filtered.count]
   end
 
+  def self.default_use_sql_view
+    false
+  end
+
   private
 
   def va_sql_cols

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -318,7 +318,11 @@ module MiqReport::Generator
 
     ## add in virtual attributes that can be calculated from sql
     rbac_opts[:extra_cols] = va_sql_cols unless va_sql_cols.blank?
-    rbac_opts[:use_sql_view] = db_options.nil? || db_options.fetch(:use_sql_view) { true }
+    rbac_opts[:use_sql_view] = if db_options.nil? || db_options[:use_sql_view].nil?
+                                 MiqReport.default_use_sql_view
+                               else
+                                 db_options[:use_sql_view]
+                               end
 
     results, attrs = Rbac.search(rbac_opts)
     results = Metric::Helper.remove_duplicate_timestamps(results)

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -97,7 +97,11 @@ module MiqReport::Search
                                   )
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
     search_options[:extra_cols] = va_sql_cols if va_sql_cols.present?
-    search_options[:use_sql_view] = db_options.nil? || db_options.fetch(:use_sql_view) { true }
+    search_options[:use_sql_view] = if db_options.nil? || db_options[:use_sql_view].nil?
+                                      MiqReport.default_use_sql_view
+                                    else
+                                      db_options[:use_sql_view]
+                                    end
 
     if options[:parent]
       targets = get_parent_targets(options[:parent], options[:association] || options[:parent_method])


### PR DESCRIPTION
### Overview

Using an inline view (`SELECT` statement in the `FROM` clause) allows the database to do much less work. This resulted in some pages going from a few minutes to a few seconds:

- Services Screen (Hammer) /via ManageIQ/manageiq-ui-classic#5366
- All pages (Ivanchuck) /via #18822

### Problem (before)

Turbo Button is not mature and has bugs:

- Some queries are missing a `DISTINCT`.
- total record count is wrong and therefore page count
- not all pages contain 20 records
- the sorting (`ORDER`) is ignored

### After

We are temporarily turning it off `:inline_sql_views`.
This will slow down most pages, especially the `Hosts`, `Vms` and `Services` pages.

We will introduce these changes to fix bugs in `Hammer` and `Ivanchuck`.
We will possibly turn back on `:inline_sql_views` once these are fixed

See also:

- services page https://github.com/ManageIQ/manageiq-ui-classic/pull/5768
- https://bugzilla.redhat.com/show_bug.cgi?id=1722491