### PR TITLE
Expand value to hash format with styling information for Report result API

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -272,16 +272,16 @@ class MiqReport < ApplicationRecord
     @col_format_hash ||= col_order.zip(col_formats).to_h
   end
 
-  def format_row(row, allowed_columns = nil)
+  def format_row(row, allowed_columns = nil, expand_value_format = nil)
     @tz ||= get_time_zone(Time.zone)
-
     row.map do |key, _|
-      [key, allowed_columns.nil? || allowed_columns&.include?(key) ? format_column(key, row, @tz, col_format_hash[key]) : row[key]]
+      value = allowed_columns.nil? || allowed_columns&.include?(key) ? format_column(key, row, @tz, col_format_hash[key]) : row[key]
+      [key, expand_value_format.present? ? { :value => value, :style_class => get_style_class(key, row, @tz) } : value]
     end.to_h
   end
 
-  def format_result_set(result_set, skip_columns = nil)
-    result_set.map { |row| format_row(row, skip_columns) }
+  def format_result_set(result_set, skip_columns = nil, hash_value_format = nil)
+    result_set.map { |row| format_row(row, skip_columns, hash_value_format) }
   end
 
   def filter_result_set(result_set, options)

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -10,6 +10,7 @@ module MiqReportResult::ResultSetOperations
       report = report_result.report_or_miq_report
       sorting_columns = report.validate_sorting_columns(options[:sort_by])
       result_set = report_result.result_set
+
       count_of_full_result_set = result_set.count
       if result_set.present? && report
         if options.key?(:filter_column) && options.key?(:filter_string)
@@ -22,7 +23,7 @@ module MiqReportResult::ResultSetOperations
         result_set = apply_limit_and_offset(result_set, options)
       end
 
-      {:result_set => report.format_result_set(result_set, allowed_columns_to_format), :count_of_full_result_set => count_of_full_result_set}
+      {:result_set => report.format_result_set(result_set, allowed_columns_to_format, options[:expand_value_format]), :count_of_full_result_set => count_of_full_result_set}
     end
   end
 end


### PR DESCRIPTION
we need info about style class information report result API for 


so when you call api request  for result set with parameter `expand_value_format=true`

`http://localhost:3000/api/results/24234?hash_attribute=result_set&sort_order=asc&offset=3&expand_value_format=true`
it will expand :value to hash with needed information:

without `expand_value_format=true`
```
 "result_set": [
        {
            "hostname": "",
            "name": "RHEL72_1",
            "managed.projectname": "",
            "type": "ManageIQ::Providers::Microsoft::InfraManager::Vm"
        },
        {
            "hostname": "",
            "name": "RHEL72_2",
            "managed.projectname": "",
            "type": "ManageIQ::Providers::Microsoft::InfraManager::Vm"
        },
        {
            "hostname": "",
            "name": "RHEL72_2",
            "managed.projectname": "",
            "type": "ManageIQ::Providers::Microsoft::InfraManager::Vm"
        },
```

with `expand_value_format=true`
```
  "result_set": [
        {
            "hostname": {
                "value": "",
                "style_class": null
            },
            "name": {
                "value": "RHEL72_1",
                "style_class": "miq_rpt_blue_text"
            },
            "managed.projectname": {
                "value": "",
                "style_class": null
            },
            "type": {
                "value": "ManageIQ::Providers::Microsoft::InfraManager::Vm",
                "style_class": null
            }
        },
        {
            "hostname": {
                "value": "",
                "style_class": null
            },
            "name": {
                "value": "RHEL72_2",
                "style_class": "miq_rpt_blue_text"
            },
```

and `style_class` is css class for 
```html
<td>
``` 
element in report result.

```html
<tr class="row1-nocursor">
<td></td>
<td class="miq_rpt_blue_text">RHEL72_1</td><td>
</td>
<td>ManageIQ::Providers::Microsoft::InfraManager::Vm</td></tr>
```
# Links
https://github.com/ManageIQ/manageiq-api/pull/547
https://bugzilla.redhat.com/show_bug.cgi?id=1678150

cc @kbrock 

@miq-bot assign @martinpovolny 