### PR TITLE
Put back bundler >=1.15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false
 gem "bcrypt",                         "~> 3.1.10",     :require => false
-gem "bundler",                        ">=1.16",        :require => false
+gem "bundler",                        ">=1.15",        :require => false
 gem "byebug",                                          :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>1.6.0",       :require => false


### PR DESCRIPTION
Undo the bundler minimum version change done in https://github.com/ManageIQ/manageiq/pull/18913

Downstream build is using 1.15.4, so we can't go to 1.16.x until downstream is ready for upgrade.

cc @jrafanie @subpop 