### PR TITLE
Use the leaf class for creating the default credential

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/seeding.rb
+++ b/app/models/manageiq/providers/embedded_ansible/seeding.rb
@@ -14,10 +14,9 @@ module ManageIQ::Providers::EmbeddedAnsible::Seeding
         :zone => MiqServer.my_server.zone # TODO: Do we even need zone?
       )
 
-      manager.authentications.create_with(
-        :type => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential"
-      ).find_or_create_by!(
-        :name => "#{Vmdb::Appliance.PRODUCT_NAME} Default Credential"
+      ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential.find_or_create_by!(
+        :name     => "#{Vmdb::Appliance.PRODUCT_NAME} Default Credential",
+        :resource => manager
       )
 
       create_local_playbook_repo

--- a/spec/models/manageiq/providers/embedded_ansible_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible_spec.rb
@@ -25,6 +25,7 @@ describe ManageIQ::Providers::EmbeddedAnsible do
     it "creates the default authentication" do
       auth = manager.authentications.find_by(:name => "ManageIQ Default Credential")
       expect(auth).to be_an_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential)
+      expect(auth.manager_ref).to eq(auth.id.to_s)
     end
 
     it "creates the local playbook repo" do


### PR DESCRIPTION
The after create hook for the leaf class would not fire when using
create_with so the instance was getting created without the manager_ref
set. This lead to errors when trying to create a catalog item which
referenced this credential

cc @gmcculloug this fixes the issue I hit yesterday.