### PR TITLE
[HAMMER][V2V] Add validation on VM name based on destination EMS

### DIFF
--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -3,6 +3,7 @@ class TransformationMapping::VmMigrationValidator
 
   VM_CONFLICT = "conflict".freeze
   VM_EMPTY_NAME = "empty_name".freeze
+  VM_UNSUPPORTED_NAME = 'unsupported_name'.freeze
   VM_IN_OTHER_PLAN = "in_other_plan".freeze
   VM_INACTIVE = "inactive".freeze
   VM_INVALID = "invalid".freeze
@@ -84,6 +85,10 @@ class TransformationMapping::VmMigrationValidator
     validate_result = vm_migration_status(vm)
     return validate_result unless validate_result == VM_VALID
 
+    # The VM name must be valid in the destination provider
+    valid_vm_name = validate_vm_name(vm)
+    return valid_vm_name unless valid_vm_name == VM_VALID
+
     # a valid vm must find all resources in the mapping and has never been migrated
     invalid_list = []
     issue = no_mapping_list(invalid_list, "storages", vm.datastores - mapped_storages)
@@ -126,6 +131,24 @@ class TransformationMapping::VmMigrationValidator
 
   def mapped_lans
     @mapped_lans ||= Lan.where(:id => @mapping.transformation_mapping_items.where(:source_type => 'Lan').select(:source_id))
+  end
+
+  def destination_cluster(vm)
+    @mapping.transformation_mapping_items.find_by(:source => vm.ems_cluster)&.destination
+  end
+
+  def validate_vm_name(vm)
+    send("validate_vm_name_#{destination_cluster(vm).ext_management_system.emstype}", vm) ? VM_VALID : VM_UNSUPPORTED_NAME
+  end
+
+  def validate_vm_name_rhevm(vm)
+    # Regexp from oVirt code: frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/validation/BaseI18NValidation.java
+    vm.name =~ /^[\p{L}0-9._-]*$/
+  end
+
+  def validate_vm_name_openstack(vm)
+    # Regexp decided after discussion with Bernard Cafarelli
+    vm.name =~ /^[[:graph:]\s]+$/
   end
 
   class VmMigrateStruct < MiqHashStruct

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -5,7 +5,7 @@ describe TransformationMapping do
   let(:src_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => src_ems) }
   let(:dst_cluster_redhat) { FactoryGirl.create(:ems_cluster, :ext_management_system => dst_ems_redhat) }
   let(:dst_cloud_tenant_openstack) { FactoryGirl.create(:cloud_tenant, :ext_management_system => dst_ems_openstack) }
-  let(:vm)  { FactoryGirl.create(:vm_vmware, :ems_cluster => src_cluster) }
+  let(:vm) { FactoryGirl.create(:vm_vmware, :ems_cluster => src_cluster) }
 
   let(:mapping_redhat) do
     FactoryGirl.create(

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,59 +1,84 @@
 describe TransformationMapping do
-  let(:src) { FactoryGirl.create(:ems_cluster) }
-  let(:dst) { FactoryGirl.create(:ems_cluster) }
-  let(:vm)  { FactoryGirl.create(:vm_vmware, :ems_cluster => src) }
+  let(:src_ems) { FactoryGirl.create(:ems_vmware) }
+  let(:dst_ems_redhat) { FactoryGirl.create(:ems_redhat) }
+  let(:dst_ems_openstack) { FactoryGirl.create(:ems_openstack) }
+  let(:src_cluster) { FactoryGirl.create(:ems_cluster, :ext_management_system => src_ems) }
+  let(:dst_cluster_redhat) { FactoryGirl.create(:ems_cluster, :ext_management_system => dst_ems_redhat) }
+  let(:dst_cloud_tenant_openstack) { FactoryGirl.create(:cloud_tenant, :ext_management_system => dst_ems_openstack) }
+  let(:vm)  { FactoryGirl.create(:vm_vmware, :ems_cluster => src_cluster) }
 
-  let(:mapping) do
+  let(:mapping_redhat) do
     FactoryGirl.create(
       :transformation_mapping,
-      :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster_redhat)]
+    )
+  end
+
+  let(:mapping_openstack) do
+    FactoryGirl.create(
+      :transformation_mapping,
+      :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cloud_tenant_openstack)]
     )
   end
 
   describe '#destination' do
     it "finds the destination" do
-      expect(mapping.destination(src)).to eq(dst)
+      expect(mapping_redhat.destination(src_cluster)).to eq(dst_cluster_redhat)
     end
 
     it "returns nil for unmapped source" do
-      expect(mapping.destination(FactoryGirl.create(:ems_cluster))).to be_nil
+      expect(mapping_redhat.destination(FactoryGirl.create(:ems_cluster))).to be_nil
     end
   end
 
   describe '#service_templates' do
     let(:plan) { FactoryGirl.create(:service_template_transformation_plan) }
-    before { FactoryGirl.create(:service_resource, :resource => mapping, :service_template => plan) }
+    before { FactoryGirl.create(:service_resource, :resource => mapping_redhat, :service_template => plan) }
 
     it 'finds the transformation plans' do
-      expect(mapping.service_templates).to match([plan])
+      expect(mapping_redhat.service_templates).to match([plan])
     end
   end
 
   describe '#search_vms_and_validate' do
-    let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryGirl.create(:ext_management_system)) }
-    let(:vm2) { FactoryGirl.create(:vm_vmware, :ems_cluster => src, :ext_management_system => FactoryGirl.create(:ext_management_system)) }
-    let(:inactive_vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src, :ext_management_system => nil) }
+    let(:vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src_cluster, :ext_management_system => FactoryGirl.create(:ext_management_system)) }
+    let(:vm2) { FactoryGirl.create(:vm_vmware, :ems_cluster => src_cluster, :ext_management_system => FactoryGirl.create(:ext_management_system)) }
+    let(:inactive_vm) { FactoryGirl.create(:vm_vmware, :name => 'test_vm_inactive', :ems_cluster => src_cluster, :ext_management_system => nil) }
     let(:storage) { FactoryGirl.create(:storage) }
     let(:lan) { FactoryGirl.create(:lan) }
     let(:nic) { FactoryGirl.create(:guest_device_nic, :lan => lan) }
 
     before do
-      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => storage, :destination => storage)
-      mapping.transformation_mapping_items << TransformationMappingItem.new(:source => lan, :destination => lan)
+      mapping_redhat.transformation_mapping_items << TransformationMappingItem.new(:source => storage, :destination => storage)
+      mapping_redhat.transformation_mapping_items << TransformationMappingItem.new(:source => lan, :destination => lan)
       vm.storages << storage
       vm.hardware = FactoryGirl.create(:hardware, :guest_devices => [nic])
     end
 
     context 'with VM list' do
       context 'returns invalid vms' do
+        it 'if VM has an invalid name in rhevm' do
+          name = ' not allowed'
+          FactoryBot.create(:vm_vmware, :name => name, :ems_cluster => src_cluster, :ext_management_system => FactoryGirl.create(:ext_management_system))
+          result = mapping_redhat.search_vms_and_validate(['name' => name])
+          expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_UNSUPPORTED_NAME)
+        end
+
+        it 'if VM has an invalid name in openstack' do
+          name = 7.chr # beep, non-printable
+          FactoryBot.create(:vm_vmware, :name => name, :ems_cluster => src_cluster, :ext_management_system => src_ems)
+          result = mapping_openstack.search_vms_and_validate(['name' => name])
+          expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_UNSUPPORTED_NAME)
+        end
+
         it 'if VM does not exist' do
-          result = mapping.search_vms_and_validate(['name' => 'vm1'])
+          result = mapping_redhat.search_vms_and_validate(['name' => 'vm1'])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_NOT_EXIST)
         end
 
         it 'if VM is inactive' do
           inactive_vm.storages << FactoryGirl.create(:storage, :name => 'storage_for_inactive_vm')
-          result = mapping.search_vms_and_validate(['name' => 'test_vm_inactive'])
+          result = mapping_redhat.search_vms_and_validate(['name' => 'test_vm_inactive'])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_INACTIVE)
         end
 
@@ -64,26 +89,26 @@ describe TransformationMapping do
             :ems_cluster           => FactoryGirl.create(:ems_cluster, :name => 'cluster1'),
             :ext_management_system => FactoryGirl.create(:ext_management_system)
           )
-          result = mapping.search_vms_and_validate(['name' => 'vm2'])
+          result = mapping_redhat.search_vms_and_validate(['name' => 'vm2'])
           expect(result['invalid'].first.reason).to match(/not_exist/)
         end
 
         it "if VM's storages are not all in the mapping" do
           vm.storages << FactoryGirl.create(:storage, :name => 'storage2')
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2/)
         end
 
         it "if VM's lans are not all in the mapping" do
           vm.hardware.guest_devices << FactoryGirl.create(:guest_device_nic, :lan =>FactoryGirl.create(:lan, :name => 'lan2'))
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - lans: lan2/)
         end
 
         it "if any source is invalid" do
           vm.storages << FactoryGirl.create(:storage, :name => 'storage2')
           vm.hardware.guest_devices << FactoryGirl.create(:guest_device_nic, :lan =>FactoryGirl.create(:lan, :name => 'lan2'))
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/Mapping source not found - storages: storage2. lans: lan2/)
         end
 
@@ -96,7 +121,7 @@ describe TransformationMapping do
               :status           => status
             )
 
-            result = mapping.search_vms_and_validate(['name' => vm.name])
+            result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
             expect(result['invalid'].first.reason).to match(/in_other_plan/)
           end
         end
@@ -109,20 +134,20 @@ describe TransformationMapping do
             :status           => 'Completed'
           )
 
-          result = mapping.search_vms_and_validate(['name' => vm.name])
+          result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
           expect(result['invalid'].first.reason).to match(/migrated/)
         end
       end
 
       it 'returns valid vms' do
-        result = mapping.search_vms_and_validate(['name' => vm.name])
+        result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
         expect(result['valid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_VALID)
         expect(result['valid'].first.ems_cluster_id).to eq(vm.ems_cluster_id.to_s)
       end
 
       it 'returns conflict vms' do
-        FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src, :ext_management_system => FactoryGirl.create(:ext_management_system))
-        result = mapping.search_vms_and_validate(['name' => vm.name])
+        FactoryGirl.create(:vm_vmware, :name => 'test_vm', :ems_cluster => src_cluster, :ext_management_system => FactoryGirl.create(:ext_management_system))
+        result = mapping_redhat.search_vms_and_validate(['name' => vm.name])
         expect(result['conflicted'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_CONFLICT)
       end
     end
@@ -137,7 +162,7 @@ describe TransformationMapping do
           :service_template => service_template,
           :status           => "Active"
         )
-        result = mapping.search_vms_and_validate(['name' => vm2.name], service_template.id.to_s)
+        result = mapping_redhat.search_vms_and_validate(['name' => vm2.name], service_template.id.to_s)
         expect(result['valid'].first.reason).to match(/ok/)
       end
 
@@ -151,14 +176,14 @@ describe TransformationMapping do
           :service_template => service_template,
           :status           => "Active"
         )
-        result = mapping.search_vms_and_validate(['name' => vm2.name], service_template2.id.to_s)
+        result = mapping_redhat.search_vms_and_validate(['name' => vm2.name], service_template2.id.to_s)
         expect(result['invalid'].first.reason).to match(/in_other_plan/)
       end
     end
 
     context 'without VM list' do
       it 'returns valid vms' do
-        result = mapping.search_vms_and_validate
+        result = mapping_redhat.search_vms_and_validate
         expect(result['valid'].count).to eq(1)
       end
 
@@ -169,7 +194,7 @@ describe TransformationMapping do
           :ems_cluster           => FactoryGirl.create(:ems_cluster, :name => 'cluster1'),
           :ext_management_system => FactoryGirl.create(:ext_management_system)
         )
-        result = mapping.search_vms_and_validate
+        result = mapping_redhat.search_vms_and_validate
         expect(result['valid'].count).to eq(1)
       end
     end


### PR DESCRIPTION
This PR is a specific implementation of https://github.com/ManageIQ/manageiq/pull/18536 for Hammer.

_We know that some VM names are invalid in RHV and OpenStack. For example, RHV doesn't allow space and punctuation, and OpenStack doesn't allow special characters. The goal is to identify VMs in source provider whose name will not be allowed by the destination provider and make them unselectable in the UI.

This pull request adds a validation on the VM name to make VMs with invalid name unselectable._

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1726231