### PR TITLE
Add provisioned? lifecycle status info to retireable? check

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -156,6 +156,10 @@ class Service < ApplicationRecord
   end
 
   def retireable?
+    return false unless provisioned?
+
+    # top level services do not have types; this method is used only in creating tasks for child services which always have types
+    # please see https://github.com/ManageIQ/manageiq/pull/17317#discussion_r186528878
     parent.present? ? true : type.present?
   end
 

--- a/spec/models/mixins/ci_feature_mixin_spec.rb
+++ b/spec/models/mixins/ci_feature_mixin_spec.rb
@@ -20,9 +20,15 @@ describe CiFeatureMixin do
     end
 
     it "service is retireable" do
-      FactoryBot.create(:service_resource, :service => service, :resource => FactoryBot.create(:service_ansible_tower, :type => ServiceAnsibleTower))
+      FactoryBot.create(:service_resource, :service => service, :resource => FactoryBot.create(:service_ansible_tower, :type => ServiceAnsibleTower, :lifecycle_state => 'provisioned'))
 
       expect(service.service_resources.first.resource.retireable?).to eq(true)
+    end
+
+    it "unprov'd service is not retireable" do
+      FactoryBot.create(:service_resource, :service => service, :resource => FactoryBot.create(:service_ansible_tower, :type => ServiceAnsibleTower))
+
+      expect(service.service_resources.first.resource.retireable?).to eq(false)
     end
   end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -674,13 +674,19 @@ describe Service do
   end
 
   describe "#retireable?" do
-    let(:service_with_type) { FactoryBot.create(:service, :type => "thing") }
+    let(:service_with_type) { FactoryBot.create(:service, :type => "thing", :lifecycle_state => 'provisioned') }
+    let(:unprovd_service_with_type) { FactoryBot.create(:service, :type => "thing") }
     let(:service_without_type) { FactoryBot.create(:service, :type => nil) }
-    let(:service_with_parent) { FactoryBot.create(:service, :service => FactoryBot.create(:service)) }
+    let(:service_with_parent) { FactoryBot.create(:service, :service => FactoryBot.create(:service), :lifecycle_state => 'provisioned') }
+    let(:unprovisioned_service_with_parent) { FactoryBot.create(:service, :service => FactoryBot.create(:service)) }
     context "with no parent" do
       context "with type" do
         it "true" do
           expect(service_with_type.retireable?).to be(true)
+        end
+
+        it "true" do
+          expect(unprovd_service_with_type.retireable?).to be(false)
         end
       end
 
@@ -694,6 +700,7 @@ describe Service do
     context "with parent" do
       it "true" do
         expect(service_with_parent.retireable?).to be(true)
+        expect(unprovisioned_service_with_parent.retireable?).to be(false)
       end
     end
   end


### PR DESCRIPTION
We need to factor in the lifecycle status when we ask a service if it's retireable. Contrary to previous suggestions, it makes no sense to use the supports_feature mixin, because that's a class check and this is specific to the instance. It may as well just be part of this check, as well. 

I just wanted to start the conversation and get feedback and buy-in. I'm not taking into account places this is overridden yet cause I wanted opinions first.

start for https://bugzilla.redhat.com/show_bug.cgi?id=1595511

@miq-bot assign @tinaafitz 