### PR TITLE
Add ext_management_system.id to Migration Readiness summary reports

### DIFF
--- a/product/reports/300_Migration Readiness - Virtual Machines/030_VMware VM Summary.yaml
+++ b/product/reports/300_Migration Readiness - Virtual Machines/030_VMware VM Summary.yaml
@@ -16,6 +16,7 @@ include:
   ext_management_system:
     columns:
     - name
+    - id
   host:
     columns:
     - name
@@ -23,6 +24,7 @@ col_order:
 - name
 - operating_system.product_name
 - ext_management_system.name
+- ext_management_system.id
 - v_owning_datacenter
 - host.name
 - allocated_disk_storage

--- a/product/reports/310_Migration Readiness - Providers/010_VMware Environment Summary.yaml
+++ b/product/reports/310_Migration Readiness - Providers/010_VMware Environment Summary.yaml
@@ -14,7 +14,7 @@ include:
     columns:
     - name
     - api_version
-    - id 
+    - id
 col_order:
 - ext_management_system.name
 - ext_management_system.api_version

--- a/product/reports/310_Migration Readiness - Providers/010_VMware Environment Summary.yaml
+++ b/product/reports/310_Migration Readiness - Providers/010_VMware Environment Summary.yaml
@@ -14,9 +14,11 @@ include:
     columns:
     - name
     - api_version
+    - id 
 col_order:
 - ext_management_system.name
 - ext_management_system.api_version
+- ext_management_system.id
 - name
 - vmm_product
 - vmm_version


### PR DESCRIPTION
As part of the new Migration Analytics plugin that I am working on (https://github.com/mturley/cfme-migration_analytics), I need to consume the two Migration Readiness reports that were made available in https://github.com/ManageIQ/manageiq/pull/18749 to display the summary data required for https://bugzilla.redhat.com/show_bug.cgi?id=1708369.

I need to correlate the results of these two reports with other data from the ManageIQ API based on the `ext_management_system.id` column, which is not present in these reports. I could use `ext_management_system.name`, but that assumes the user has not created two providers with the same name, which is technically possible.

This PR adds the id field to these two reports so I can make a more robust relation with other `ext_management_system` API data.