### PR TITLE
Allow specifying hosts to ansible runner

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -74,7 +74,7 @@ module Ansible
                     :tags            => tags,
                     :role            => role_name,
                     :roles_path      => roles_path,
-                    :role_skip_facts => role_skip_facts,)
+                    :role_skip_facts => role_skip_facts)
       end
 
       # Runs "run" method via queue
@@ -207,12 +207,12 @@ module Ansible
         errors << "extra_vars must be a Hash, got: #{hash.class}" unless extra_vars.kind_of?(Hash)
         errors << "tags must be a String, got: #{tags.class}" if tags.present? && !tags.kind_of?(String)
 
-        unless %w(run start).include?(ansible_runner_method.to_s)
+        unless %w[run start].include?(ansible_runner_method.to_s)
           errors << "ansible_runner_method must be 'run' or 'start'"
         end
 
-        unless playbook_or_role_args.keys == %i(playbook) || playbook_or_role_args.keys.sort == %i(role role_skip_facts roles_path)
-          errors << "Unexpected playbook/role args: #{args}"
+        unless playbook_or_role_args.keys == %i[playbook] || playbook_or_role_args.keys.sort == %i[role role_skip_facts roles_path]
+          errors << "Unexpected playbook/role args: #{playbook_or_role_args}"
         end
 
         playbook = playbook_or_role_args[:playbook]

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -3,52 +3,83 @@ describe Ansible::Runner do
   let(:env_vars)   { {"ENV1" => "VAL1", "ENV2" => "VAL2"} }
   let(:extra_vars) { {"id" => uuid} }
   let(:tags)       { "tag" }
+  let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", "0") }
 
   describe ".run" do
     let(:playbook) { "/path/to/my/playbook" }
-    before { expect(File).to receive(:exist?).with(playbook).and_return(true) }
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(playbook).and_return(true)
+    end
 
-    it "calls launch with expected arguments" do
-      expected_extra_vars = "--extra-vars\\ \\\\\\{\\\\\\\"id\\\\\\\":\\\\\\\"#{uuid}\\\\\\\"\\\\\\}"
+    it "calls run and writes the required files" do
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+        expect(options[:env]).to eq(env_vars)
 
-      expected_command_line = [
-        "ansible-runner run",
-        "--json --playbook /path/to/my/playbook --ident result --hosts localhost --cmdline #{expected_extra_vars}"
-      ]
+        method, dir, json, args = options[:params]
 
-      expect(AwesomeSpawn).to receive(:launch)
-        .with(env_vars, a_string_including(*expected_command_line), {})
+        expect(method).to eq("run")
+        expect(json).to   eq(:json)
+        expect(args).to   eq(:ident => "result", :playbook => playbook)
+
+        hosts = File.read(File.join(dir, "inventory", "hosts"))
+        expect(hosts).to eq("localhost")
+
+        extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+        expect(extravars).to eq("id" => uuid, "ansible_connection" => "local")
+
+        expect(File.exist?(File.join(dir, "env", "cmdline"))).to be_falsey
+      end.and_return(result)
 
       described_class.run(env_vars, extra_vars, playbook)
     end
 
     it "calls launch with expected tag" do
-      extra_vars_and_tag = "--extra-vars\\ \\\\\\{\\\\\\\"id\\\\\\\":\\\\\\\"#{uuid}\\\\\\\"\\\\\\}\\ --tags\\ tag"
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+        expect(options[:env]).to eq(env_vars)
 
-      expected_command_line = [
-        "ansible-runner run",
-        "--json --playbook /path/to/my/playbook --ident result --hosts localhost --cmdline #{extra_vars_and_tag}"
-      ]
+        method, dir, json, args = options[:params]
 
-      expect(AwesomeSpawn).to receive(:launch)
-        .with(env_vars, a_string_including(*expected_command_line), {})
+        expect(method).to eq("run")
+        expect(json).to   eq(:json)
+        expect(args).to   eq(:ident => "result", :playbook => playbook)
+
+        hosts = File.read(File.join(dir, "inventory", "hosts"))
+        expect(hosts).to eq("localhost")
+
+        extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+        expect(extravars).to eq("id" => uuid, "ansible_connection" => "local")
+
+        cmdline = File.read(File.join(dir, "env", "cmdline"))
+        expect(cmdline).to eq("--tags #{tags}")
+      end.and_return(result)
 
       described_class.run(env_vars, extra_vars, playbook, :tags => tags)
     end
 
     context "with special characters" do
-      let(:env_vars) { {"ENV1" => "pa$%w0rd!'"} }
+      let(:env_vars)   { {"ENV1" => "pa$%w0rd!'"} }
       let(:extra_vars) { {"name" => "john's server"} }
 
       it "calls launch with expected arguments" do
-        expected_extra_vars = "--extra-vars\\ \\\\\\{\\\\\\\"name\\\\\\\":\\\\\\\"john\\\\\\'s\\\\\\ server\\\\\\\"\\\\\\}"
-        expected_command_line = [
-          "ansible-runner run",
-          "--json --playbook /path/to/my/playbook --ident result --hosts localhost --cmdline #{expected_extra_vars}"
-        ]
+        expect(AwesomeSpawn).to receive(:run) do |command, options|
+          expect(command).to eq("ansible-runner")
+          expect(options[:env]).to eq(env_vars)
 
-        expect(AwesomeSpawn).to receive(:launch)
-          .with(env_vars, a_string_including(*expected_command_line), {})
+          method, dir, json, args = options[:params]
+
+          expect(method).to eq("run")
+          expect(json).to   eq(:json)
+          expect(args).to   eq(:ident => "result", :playbook => playbook)
+
+          hosts = File.read(File.join(dir, "inventory", "hosts"))
+          expect(hosts).to eq("localhost")
+
+          extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+          expect(extravars).to eq("name" => "john's server", "ansible_connection" => "local")
+        end.and_return(result)
 
         described_class.run(env_vars, extra_vars, playbook)
       end
@@ -57,20 +88,33 @@ describe Ansible::Runner do
 
   describe ".run_async" do
     let(:playbook) { "/path/to/my/playbook" }
-    before { expect(File).to receive(:exist?).with(playbook).and_return(true) }
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(playbook).and_return(true)
+    end
 
     it "calls ansible-runner with start" do
-      expected_extra_vars = "--extra-vars\\ \\\\\\{\\\\\\\"id\\\\\\\":\\\\\\\"201ac780-7bf4-0136-3b9e-54e1ad8b3cf4\\\\\\\"\\\\\\}"
-      expected_command_line = [
-        "ansible-runner start",
-        "--json --playbook #{playbook} --ident result --hosts localhost --cmdline #{expected_extra_vars}"
-      ]
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+        expect(options[:env]).to eq(env_vars)
 
-      expect(AwesomeSpawn).to receive(:launch)
-        .with(env_vars, a_string_including(*expected_command_line), {})
+        method, dir, json, args = options[:params]
 
-      result = described_class.run_async(env_vars, extra_vars, playbook)
-      expect(result).kind_of?(Ansible::Runner::ResponseAsync)
+        expect(method).to eq("start")
+        expect(json).to   eq(:json)
+        expect(args).to   eq(:ident => "result", :playbook => playbook)
+
+        hosts = File.read(File.join(dir, "inventory", "hosts"))
+        expect(hosts).to eq("localhost")
+
+        extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+        expect(extravars).to eq("id" => uuid, "ansible_connection" => "local")
+
+        expect(File.exist?(File.join(dir, "env", "cmdline"))).to be_falsey
+      end.and_return(result)
+
+      runner_result = described_class.run_async(env_vars, extra_vars, playbook)
+      expect(runner_result).kind_of?(Ansible::Runner::ResponseAsync)
     end
   end
 
@@ -90,27 +134,55 @@ describe Ansible::Runner do
   describe ".run_role" do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
-    before { expect(File).to receive(:exist?).with(File.join(role_path)).and_return(true) }
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(role_path).and_return(true)
+    end
 
     it "runs ansible-runner with the role" do
-      expected_command_line = [
-        "ansible-runner run",
-        "--extra-vars\\ \\\\\\{\\\\\\\"id\\\\\\\":\\\\\\\"201ac780-7bf4-0136-3b9e-54e1ad8b3cf4\\\\\\\"\\\\\\}"
-      ]
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+        expect(options[:env]).to eq(env_vars)
 
-      expect(AwesomeSpawn).to receive(:launch)
-        .with(env_vars, a_string_including(*expected_command_line), {})
+        method, dir, json, args = options[:params]
+
+        expect(method).to eq("run")
+        expect(json).to   eq(:json)
+        expect(args).to   eq(:ident => "result", :role => role_name, :roles_path => role_path, :role_skip_facts => nil)
+
+        hosts = File.read(File.join(dir, "inventory", "hosts"))
+        expect(hosts).to eq("localhost")
+
+        extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+        expect(extravars).to eq("id" => uuid, "ansible_connection" => "local")
+
+        expect(File.exist?(File.join(dir, "env", "cmdline"))).to be_falsey
+      end.and_return(result)
+
       described_class.run_role(env_vars, extra_vars, role_name, :roles_path => role_path)
     end
 
     it "runs ansible-runner with role and tag" do
-      expected_command_line = [
-        "ansible-runner run",
-        "--extra-vars\\ \\\\\\{\\\\\\\"id\\\\\\\":\\\\\\\"201ac780-7bf4-0136-3b9e-54e1ad8b3cf4\\\\\\\"\\\\\\}\\ --tags\\ tag"
-      ]
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+        expect(options[:env]).to eq(env_vars)
 
-      expect(AwesomeSpawn).to receive(:launch)
-        .with(env_vars, a_string_including(*expected_command_line), {})
+        method, dir, json, args = options[:params]
+
+        expect(method).to eq("run")
+        expect(json).to   eq(:json)
+        expect(args).to   eq(:ident => "result", :role => role_name, :roles_path => role_path, :role_skip_facts => nil)
+
+        hosts = File.read(File.join(dir, "inventory", "hosts"))
+        expect(hosts).to eq("localhost")
+
+        extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+        expect(extravars).to eq("id" => uuid, "ansible_connection" => "local")
+
+        cmdline = File.read(File.join(dir, "env", "cmdline"))
+        expect(cmdline).to eq("--tags #{tags}")
+      end.and_return(result)
+
       described_class.run_role(env_vars, extra_vars, role_name, :roles_path => role_path, :tags => tags)
     end
   end
@@ -118,16 +190,31 @@ describe Ansible::Runner do
   describe ".run_role_async" do
     let(:role_name) { "my-custom-role" }
     let(:role_path) { "/path/to/my/roles" }
-    before { expect(File).to receive(:exist?).with(File.join(role_path)).and_return(true) }
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(role_path).and_return(true)
+    end
 
     it "runs ansible-runner with the role" do
-      expected_command_line = [
-        "ansible-runner start",
-        "--extra-vars\\ \\\\\\{\\\\\\\"id\\\\\\\":\\\\\\\"201ac780-7bf4-0136-3b9e-54e1ad8b3cf4\\\\\\\"\\\\\\}"
-      ]
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+        expect(options[:env]).to eq(env_vars)
 
-      expect(AwesomeSpawn).to receive(:launch)
-        .with(env_vars, a_string_including(*expected_command_line), {})
+        method, dir, json, args = options[:params]
+
+        expect(method).to eq("start")
+        expect(json).to   eq(:json)
+        expect(args).to   eq(:ident => "result", :role => role_name, :roles_path => role_path, :role_skip_facts => nil)
+
+        hosts = File.read(File.join(dir, "inventory", "hosts"))
+        expect(hosts).to eq("localhost")
+
+        extravars = JSON.parse(File.read(File.join(dir, "env", "extravars")))
+        expect(extravars).to eq("id" => uuid, "ansible_connection" => "local")
+
+        expect(File.exist?(File.join(dir, "env", "cmdline"))).to be_falsey
+      end.and_return(result)
+
       described_class.run_role_async(env_vars, extra_vars, role_name, :roles_path => role_path)
     end
   end

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -226,7 +226,8 @@ describe Ansible::Runner do
     let(:user)      { FactoryBot.create(:user) }
 
     it "queues Ansible::Runner.run in the right zone" do
-      described_class.run_role_queue(env_vars, extra_vars, role_name, user.name, {:zone => zone.name}, :roles_path => role_path)
+      queue_args = {:zone => zone.name}
+      described_class.run_role_queue(env_vars, extra_vars, role_name, user.name, queue_args, :roles_path => role_path)
 
       expect(MiqQueue.count).to eq(1)
       expect(MiqQueue.first.zone).to eq(zone.name)


### PR DESCRIPTION
Prior to this we hardcoded running against `localhost`

Additionally, this reworks the existing ansible runner module to print out files to specify things like extravars, runner command line arguments, and target hosts. This also vastly simplifies the specs by preventing nasty command line json escaping.
