### PR TITLE
Set task's state to "finished" eventually

### DIFF
--- a/app/models/physical_server_provision_task/state_machine.rb
+++ b/app/models/physical_server_provision_task/state_machine.rb
@@ -16,7 +16,7 @@ module PhysicalServerProvisionTask::StateMachine
   end
 
   def mark_as_completed
-    update_and_notify_parent(:state => 'provisioned', :message => msg('provisioning completed'))
+    update_and_notify_parent(:state => 'finished', :message => msg('provisioning completed'))
     MiqEvent.raise_evm_event(source, 'generic_task_finish', :message => "Done provisioning PhysicalServer")
     signal :finish
   end


### PR DESCRIPTION
We were setting task's state to "provisioned" but that is not a final state so it doesn't get recognized by the Request which always assumes that task's final state be "finished".

@miq-bot add_label enhancement
@miq-bot assign @gmcculloug 