### PR TITLE
Allow state machines to specify max polling retries

### DIFF
--- a/spec/models/miq_request_task/state_machine_spec.rb
+++ b/spec/models/miq_request_task/state_machine_spec.rb
@@ -16,5 +16,27 @@ describe MiqRequestTask do
         expect(task.status).to eq("Error")
       end
     end
+
+    describe "#requeue_phase" do
+      before { allow(MiqServer).to receive(:my_server).and_return(double(:id => 123)) }
+      let(:task) do
+        FactoryBot.create(:miq_request_task).tap do |task|
+          allow(task).to receive(:my_role)
+          allow(task).to receive(:my_zone)
+        end
+      end
+
+      describe 'will honor max_retries' do
+        it 'when exeeds' do
+          task.options = { :executed_on_servers => [1, 1, 1] }
+          expect { task.requeue_phase(:max_retries => 3) }.to raise_error(/max retries exceeded/)
+        end
+
+        it 'when not exeeds' do
+          task.options = { :executed_on_servers => [1, 1] }
+          expect { task.requeue_phase(:max_retries => 3) }.not_to raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, the internal state machine can perform polling by means of `requeue_phase` but if the fulfillment condition is never met the state machine will run for eternity.

With this commit we give state machine option to specify its own number of retries, by default we set 10k which means the state machine will be retrying for 27 hours (assuming 10 second delay between consequent retry).

@miq-bot add_label enhancement
@miq-bot assign @gmcculloug 