### PR TITLE
Add missing report headers

### DIFF
--- a/product/reports/300_Migration Readiness - Virtual Machines/030_VMware VM Summary.yaml
+++ b/product/reports/300_Migration Readiness - Virtual Machines/030_VMware VM Summary.yaml
@@ -34,6 +34,7 @@ headers:
 - VM Name
 - Operating System
 - Provider
+- Provider ID
 - Datacenter
 - Hypervisor
 - Storage

--- a/product/reports/310_Migration Readiness - Providers/010_VMware Environment Summary.yaml
+++ b/product/reports/310_Migration Readiness - Providers/010_VMware Environment Summary.yaml
@@ -28,6 +28,7 @@ headers:
 - Provider
 - vSphere Version
 - Hypervisor
+- Hypervisor ID
 - Product
 - Version
 - CPU Sockets


### PR DESCRIPTION
This PR adds missing report headers for report columns added in https://github.com/ManageIQ/manageiq/pull/18944

Without this the ui-classic CI is failing with:
```
1) YAML reports regular reports 300_Migration Readiness - Virtual Machines/030_VMware VM Summary defines headers that match col_order
     Failure/Error: expect(headers).to eq(col_order)
     
       expected: 9
            got: 8
     
       (compared using ==)
     Shared Example Group: "all report type examples" called from ./spec/product/reports_spec.rb:65
     # ./spec/product/reports_spec.rb:26:in `block (3 levels) in <top (required)>'
  2) YAML reports regular reports 310_Migration Readiness - Providers/010_VMware Environment Summary defines headers that match col_order
     Failure/Error: expect(headers).to eq(col_order)
     
       expected: 8
            got: 7
     
       (compared using ==)
     Shared Example Group: "all report type examples" called from ./spec/product/reports_spec.rb:65
     # ./spec/product/reports_spec.rb:26:in `block (3 levels) in <top (required)>'
```