### PR TITLE
Dialog import should check for blank file 

### DIFF
--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -1,16 +1,19 @@
 class DialogImportValidator
+  class BlankFileError < StandardError; end
   class ImportNonYamlError < StandardError; end
   class InvalidDialogFieldTypeError < StandardError; end
+  class InvalidDialogVersionError < StandardError; end
   class ParsedNonDialogYamlError < StandardError; end
   class ParsedNonDialogError < StandardError; end
-  class InvalidDialogVersionError < StandardError; end
 
   def initialize(dialog_field_association_validator = DialogFieldAssociationValidator.new)
     @dialog_field_association_validator = dialog_field_association_validator
   end
 
   def determine_validity(import_file_upload)
-    potential_dialogs = YAML.load(import_file_upload.uploaded_content)
+    potential_dialogs = YAML.safe_load(import_file_upload.uploaded_content)
+    raise BlankFileError unless potential_dialogs
+
     check_dialogs_for_validity(potential_dialogs)
   rescue Psych::SyntaxError
     raise ImportNonYamlError

--- a/spec/models/dialog_import_validator_spec.rb
+++ b/spec/models/dialog_import_validator_spec.rb
@@ -27,6 +27,16 @@ describe DialogImportValidator do
       end
     end
 
+    context "when the yaml is invalid yaml" do
+      let(:uploaded_content) { "" }
+
+      it "raises a DialogImportValidator::BlankFileError" do
+        expect do
+          dialog_import_validator.determine_validity(import_file_upload)
+        end.to raise_error(DialogImportValidator::BlankFileError)
+      end
+    end
+
     context "when associations are blank" do
       let(:uploaded_content) do
         [{"dialog_tabs" => [{"dialog_groups" => [{"dialog_fields" => [{"name" => "df1"}]}]}]}].to_yaml


### PR DESCRIPTION
If you upload a dialog that is a blank file, it breaks badly at the moment, because ```potential_dialogs = YAML.load(import_file_upload.uploaded_content)``` with YAML.load("") is false and it won't be caught by Psych. So, we should safe_load to avoid the whole mess.