### PR TITLE
reduce query count for chargeback currency seed

### DIFF
--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -48,7 +48,7 @@ class ChargebackRateDetailCurrency < ApplicationRecord
           rec.attributes = currency
           if rec.changed?
             _log.info("Updating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
-            rec.update_attributes(:created_at => fixture_mtime_currency)
+            rec.update(:created_at => fixture_mtime_currency)
           end
         end
       end

--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -36,16 +36,20 @@ class ChargebackRateDetailCurrency < ApplicationRecord
   end
 
   def self.seed
+    db_currencies = ChargebackRateDetailCurrency.all.index_by(&:code)
     if File.exist?(currency_file_source)
       fixture_mtime_currency = File.mtime(currency_file_source).utc
       currencies.each do |currency|
-        rec = ChargebackRateDetailCurrency.find_by(:code => currency[:code])
+        rec = db_currencies[currency[:code]]
         if rec.nil?
           _log.info("Creating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
           ChargebackRateDetailCurrency.create(currency)
         elsif fixture_mtime_currency > rec.created_at
-          _log.info("Updating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
-          rec.update_attributes(currency.merge(:created_at => fixture_mtime_currency))
+          rec.attributes = currency
+          if rec.changed?
+            _log.info("Updating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
+            rec.update_attributes(:created_at => fixture_mtime_currency)
+          end
         end
       end
     end


### PR DESCRIPTION
`ChargebackRateDetailCurrency.seed` is the second slowest seed

This reduces the N+1 so while we are still fetching all the currencies, we are performing a single query for them.

We are also not saving any currencies where the data does not change.

|        ms |       bytes |  objects |query |   qry ms |     rows |comments
|       ---:|         ---:|      ---:|  ---:|      ---:|      ---:| ---
|     781.9 | 25,276,676* |  256,818 |  674 |    316.1 |      164 |before
|      88.6 |  3,611,241* |   41,323 |   13 |     19.3 |      164 |after

/cc @lpichler could you confirm that this works the way you want?