### PR TITLE
Move common physical infra code from Lenovo provider

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -24,6 +24,8 @@ class Hardware < ApplicationRecord
   has_many    :physical_ports, -> { where("device_type = 'physical_port'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
   has_many    :connected_physical_switches, :through => :guest_devices
 
+  has_many    :management_devices, -> { where("device_type = 'management'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+
   virtual_column :ipaddresses,   :type => :string_set, :uses => :networks
   virtual_column :hostnames,     :type => :string_set, :uses => :networks
   virtual_column :mac_addresses, :type => :string_set, :uses => :nics

--- a/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb
@@ -6,42 +6,12 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
-        def physical_server_details
-          add_properties(
-            :model_class                  => ::AssetDetail,
-            :manager_ref                  => %i(resource),
-            :parent_inventory_collections => %i(physical_servers)
-          )
-        end
-
-        def computer_systems
-          add_properties(
-            :manager_ref                  => %i(managed_entity),
-            :parent_inventory_collections => %i(physical_servers)
-          )
-        end
-
-        def hardwares
-          add_properties(
-            :manager_ref                  => %i(computer_system),
-            :parent_inventory_collections => %i(physical_servers)
-          )
-        end
-
         def physical_racks
           add_common_default_values
         end
 
         def physical_chassis
           add_common_default_values
-        end
-
-        def physical_chassis_details
-          add_properties(
-            :model_class                  => ::AssetDetail,
-            :manager_ref                  => %i(resource),
-            :parent_inventory_collections => %i(physical_chassis)
-          )
         end
 
         def physical_storages
@@ -56,6 +26,113 @@ module ManageIQ::Providers
         def customization_scripts
           add_properties(:manager_ref => %i(manager_ref))
           add_default_values(:manager_id => ->(persister) { persister.manager.id })
+        end
+
+        # Asset details
+        def physical_server_details
+          add_asset_detail_properties(:physical_servers)
+        end
+
+        def physical_chassis_details
+          add_asset_detail_properties(:physical_chassis)
+        end
+
+        def physical_storage_details
+          add_asset_detail_properties(:physical_storages)
+        end
+
+        def physical_switch_details
+          add_asset_detail_properties(:physical_switches)
+        end
+
+        # Computer systems
+        def physical_server_computer_systems
+          add_computer_system_properties(:physical_servers)
+        end
+
+        def physical_chassis_computer_systems
+          add_computer_system_properties(:physical_chassis)
+        end
+
+        def physical_storage_computer_systems
+          add_computer_system_properties(:physical_storages)
+        end
+
+        # Hardwares
+        def physical_server_hardwares
+          add_hardware_properties(:computer_system, :physical_servers)
+        end
+
+        def physical_chassis_hardwares
+          add_hardware_properties(:computer_system, :physical_chassis)
+        end
+
+        def physical_storage_hardwares
+          add_hardware_properties(:computer_system, :physical_storages)
+        end
+
+        def physical_switch_hardwares
+          add_hardware_properties(:physical_switch, :physical_switches)
+        end
+
+        # Guest devices
+        def physical_server_network_devices
+          add_guest_device_properties
+        end
+
+        def physical_server_storage_adapters
+          add_guest_device_properties
+        end
+
+        # Firmwares
+        def physical_server_firmwares
+          add_firmware_properties(:physical_servers)
+        end
+
+        def physical_switch_firmwares
+          add_firmware_properties(:physical_switches)
+        end
+
+        private
+
+        def add_asset_detail_properties(parent)
+          add_properties(
+            :model_class                  => ::AssetDetail,
+            :manager_ref                  => %i[resource],
+            :parent_inventory_collections => [parent]
+          )
+        end
+
+        def add_computer_system_properties(parent)
+          add_properties(
+            :model_class                  => ::ComputerSystem,
+            :manager_ref                  => %i[managed_entity],
+            :parent_inventory_collections => [parent]
+          )
+        end
+
+        def add_hardware_properties(manager_ref, parent)
+          add_properties(
+            :model_class                  => ::Hardware,
+            :manager_ref                  => [manager_ref],
+            :parent_inventory_collections => [parent]
+          )
+        end
+
+        def add_guest_device_properties
+          add_properties(
+            :model_class                  => ::GuestDevice,
+            :manager_ref                  => %i[device_type uid_ems],
+            :parent_inventory_collections => %i[physical_servers]
+          )
+        end
+
+        def add_firmware_properties(parent)
+          add_properties(
+            :model_class                  => ::Firmware,
+            :manager_ref                  => %i[name resource],
+            :parent_inventory_collections => [parent]
+          )
         end
       end
     end

--- a/app/models/manageiq/providers/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/physical_infra_manager.rb
@@ -8,6 +8,53 @@ module ManageIQ::Providers
     has_many :physical_switches, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
     has_many :physical_storages, :foreign_key => "ems_id", :dependent => :destroy, :inverse_of => :ext_management_system
 
+    # Asset details
+    has_many :physical_server_details,  :through => :physical_servers,  :source => :asset_detail
+    has_many :physical_chassis_details, :through => :physical_chassis,  :source => :asset_detail
+    has_many :physical_storage_details, :through => :physical_storages, :source => :asset_detail
+    has_many :physical_switch_details,  :through => :physical_switches, :source => :asset_detail
+
+    # Computer systems
+    has_many :physical_server_computer_systems,  :through => :physical_servers,  :source => :computer_system
+    has_many :physical_chassis_computer_systems, :through => :physical_chassis,  :source => :computer_system
+    has_many :physical_storage_computer_systems, :through => :physical_storages, :source => :canister_computer_systems
+
+    # Hardwares
+    has_many :physical_server_hardwares,  :through => :physical_server_computer_systems,  :source => :hardware
+    has_many :physical_chassis_hardwares, :through => :physical_chassis_computer_systems, :source => :hardware
+    has_many :physical_storage_hardwares, :through => :physical_storage_computer_systems, :source => :hardware
+    has_many :physical_switch_hardwares,  :through => :physical_switches,                 :source => :hardware
+
+    # Guest devices
+    has_many :physical_server_network_devices,     :through => :physical_server_hardwares,  :source => :nics
+    has_many :physical_server_storage_adapters,    :through => :physical_server_hardwares,  :source => :storage_adapters
+    has_many :physical_server_management_devices,  :through => :physical_server_hardwares,  :source => :management_devices
+    has_many :physical_chassis_management_devices, :through => :physical_chassis_hardwares, :source => :management_devices
+    has_many :physical_storage_management_devices, :through => :physical_storage_hardwares, :source => :management_devices
+
+    # Firmwares
+    has_many :physical_server_firmwares,                 :through => :physical_server_hardwares,        :source => :firmwares
+    has_many :physical_server_network_device_firmwares,  :through => :physical_server_network_devices,  :source => :firmwares
+    has_many :physical_server_storage_adapter_firmwares, :through => :physical_server_storage_adapters, :source => :firmwares
+    has_many :physical_switch_firmwares,                 :through => :physical_switch_hardwares,        :source => :firmwares
+
+    # Network
+    has_many :physical_server_networks,  :through => :physical_server_management_devices,  :source => :network
+    has_many :physical_chassis_networks, :through => :physical_chassis_management_devices, :source => :network
+    has_many :physical_storage_networks, :through => :physical_storage_management_devices, :source => :network
+    has_many :physical_switch_networks,  :through => :physical_switch_hardwares,           :source => :networks
+
+    # Physical network ports
+    has_many :physical_server_network_ports,  :through => :physical_server_network_devices,     :source => :physical_network_ports
+    has_many :physical_switch_network_ports,  :through => :physical_switches,                   :source => :physical_network_ports
+    has_many :physical_storage_network_ports, :through => :physical_storage_management_devices, :source => :physical_network_ports
+
+    # Physical disks
+    has_many :physical_disks, :through => :physical_storages
+
+    # Canisters
+    has_many :canisters, :through => :physical_storages
+
     virtual_total :total_physical_chassis,  :physical_chassis
     virtual_total :total_physical_racks,    :physical_racks
     virtual_total :total_physical_servers,  :physical_servers


### PR DESCRIPTION
Various relationship definitions that Lenovo provider has defined in their physical infra class could be used by other physical infra providers. This is why we decided to move the definitions to the core.

The same reasoning goes for the inventory builder definitions.

Follow-up PRs for physical infra providers:

  * https://github.com/ManageIQ/manageiq-providers-redfish/pull/84
  * https://github.com/ManageIQ/manageiq-providers-lenovo/pull/273

@miq-bot assign @agrare 