### PR TITLE
Create multiple requests for multiple service retirement

### DIFF
--- a/app/models/miq_retire_task.rb
+++ b/app/models/miq_retire_task.rb
@@ -5,18 +5,14 @@ class MiqRetireTask < MiqRequestTask
 
   def self.get_description(req_obj)
     name = if req_obj.source.nil?
-             if req_obj.options[:src_ids].length == 1
-               m = model_being_retired.find_by(:id => req_obj.options[:src_ids].first)
-               m.nil? ? "" : m.name
-             else
-               "Multiple " + model_being_retired.to_s.pluralize
-             end
+             m = model_being_retired.find_by(:id => req_obj.options[:src_ids].first)
+             m.nil? ? "" : m.name
            else
              req_obj.source.name
            end
 
     new_settings = []
-    "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
+    "#{request_class::TASK_DESCRIPTION} for: #{name}"
   end
 
   def deliver_to_automate(req_type = request_type, zone = nil)

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -9,7 +9,10 @@ module ProcessTasksMixin
     def process_tasks(options)
       raise _("No ids given to process_tasks") if options[:ids].blank?
       if options[:task] == 'retire_now'
-        name.constantize.make_retire_request(*options[:ids], User.current_user)
+        options[:ids].each do |id|
+          $log.info("Creating retire request for id #{id} with #{User.current_user}")
+          name.constantize.make_retire_request(id, User.current_user)
+        end
       elsif options[:task] == "refresh_ems" && respond_to?("refresh_ems")
         refresh_ems(options[:ids])
         msg = "'#{options[:task]}' initiated for #{options[:ids].length} #{ui_lookup(:table => base_class.name).pluralize}"

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -26,6 +26,17 @@ describe ProcessTasksMixin do
       end
     end
 
+    context "with multiple ids" do
+      let(:service1) { FactoryBot.create(:service) }
+      let(:service2) { FactoryBot.create(:service) }
+      let(:service3) { FactoryBot.create(:service) }
+      it "creates multiple requests" do
+        User.current_user = FactoryBot.create(:user)
+        Service.process_tasks(:task => "retire_now", :ids => [service1.id, service2.id, service3.id], :userid => User.current_user.userid)
+        expect(MiqRequest.count).to eq(3)
+      end
+    end
+
     it "queues a message for the specified task" do
       EvmSpecHelper.create_guid_miq_server_zone
       test_class.process_tasks(:task => "test_method", :ids => [5], :userid => "admin")

--- a/spec/models/orchestration_stack_retire_task_spec.rb
+++ b/spec/models/orchestration_stack_retire_task_spec.rb
@@ -1,7 +1,7 @@
 describe OrchestrationStackRetireTask do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:orchestration_stack) { FactoryBot.create(:orchestration_stack) }
-  let(:miq_request) { FactoryBot.create(:orchestration_stack_retire_request, :requester => user) }
+  let(:miq_request) { FactoryBot.create(:orchestration_stack_retire_request, :requester => user, :source => orchestration_stack) }
   let(:orchestration_stack_retire_task) { FactoryBot.create(:orchestration_stack_retire_task, :source => orchestration_stack, :miq_request => miq_request, :options => {:src_ids => [orchestration_stack.id] }) }
   let(:approver) { FactoryBot.create(:user_miq_request_approver) }
 
@@ -23,6 +23,12 @@ describe OrchestrationStackRetireTask do
         :message => 'Automation Starting'
       )
       orchestration_stack_retire_task.deliver_to_automate
+    end
+  end
+
+  describe "#self.get_description" do
+    it "returns a description based upon the source service name" do
+      expect(OrchestrationStackRetireTask.get_description(miq_request)).to eq("OrchestrationStack Retire for: #{orchestration_stack.name}")
     end
   end
 end

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -2,7 +2,7 @@ describe ServiceRetireTask do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:vm) { FactoryBot.create(:vm) }
   let(:service) { FactoryBot.create(:service) }
-  let(:miq_request) { FactoryBot.create(:service_retire_request, :requester => user) }
+  let(:miq_request) { FactoryBot.create(:service_retire_request, :requester => user, :source => service) }
   let(:service_retire_task) { FactoryBot.create(:service_retire_task, :source => service, :miq_request => miq_request, :options => {:src_ids => [service.id] }) }
   let(:reason) { "Why Not?" }
   let(:approver) { FactoryBot.create(:user_miq_request_approver) }
@@ -35,7 +35,7 @@ describe ServiceRetireTask do
       ap_service.add_resource!(FactoryBot.create(:vm_vmware))
       ap_service_retire_task.after_request_task_create
 
-      expect(ap_service_retire_task.description).to eq("Service Retire for: #{ap_service.name} - ")
+      expect(ap_service_retire_task.description).to eq("Service Retire for: #{ap_service.name}")
       expect(ServiceRetireTask.count).to eq(1)
       expect(VmRetireTask.count).to eq(0)
     end
@@ -46,7 +46,7 @@ describe ServiceRetireTask do
       ap_service.add_resource!(FactoryBot.create(:vm_vmware))
       ap_service_retire_task.after_request_task_create
 
-      expect(ap_service_retire_task.description).to eq("Service Retire for: #{ap_service.name} - ")
+      expect(ap_service_retire_task.description).to eq("Service Retire for: #{ap_service.name}")
       expect(ServiceRetireTask.count).to eq(1)
       expect(VmRetireTask.count).to eq(1)
     end
@@ -57,7 +57,7 @@ describe ServiceRetireTask do
       it "doesn't create subtask" do
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(VmRetireTask.count).to eq(0)
         expect(ServiceRetireTask.count).to eq(1)
       end
@@ -74,7 +74,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:service_orchestration))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(ServiceRetireTask.count).to eq(2)
       end
 
@@ -112,7 +112,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:service))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(ServiceRetireTask.count).to eq(2)
       end
 
@@ -120,7 +120,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:orchestration_stack))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(OrchestrationStackRetireTask.count).to eq(1)
         expect(ServiceRetireTask.count).to eq(1)
       end
@@ -131,7 +131,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:miq_provision_request_template, :requester => admin, :src_vm_id => vm_template.id))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(MiqRetireTask.count).to eq(1)
         expect(ServiceRetireTask.count).to eq(1)
       end
@@ -140,7 +140,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:vm_openstack))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(VmRetireTask.count).to eq(1)
         expect(ServiceRetireTask.count).to eq(1)
       end
@@ -149,7 +149,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:vm_openstack, :retired => true))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(VmRetireTask.count).to eq(0)
         expect(ServiceRetireTask.count).to eq(1)
       end
@@ -166,6 +166,12 @@ describe ServiceRetireTask do
 
           expect(VmRetireTask.count).to eq(2)
         end
+      end
+    end
+
+    describe "#self.get_description" do
+      it "returns a description based upon the source service name" do
+        expect(ServiceRetireTask.get_description(miq_request)).to eq("Service Retire for: #{service.name}")
       end
     end
 

--- a/spec/models/vm_retire_task_spec.rb
+++ b/spec/models/vm_retire_task_spec.rb
@@ -12,7 +12,7 @@ describe VmRetireTask do
   describe "#after_request_task_create" do
     it "should set the task description" do
       vm_retire_task.after_request_task_create
-      expect(vm_retire_task.description).to eq("VM Retire for: #{vm.name} - ")
+      expect(vm_retire_task.description).to eq("VM Retire for: #{vm.name}")
     end
   end
 


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1723833

We should be creating multiple requests for when you hit retire_now for multiple services. Thus the description with multiple services on one request should never get used and can get ✂️ 