### PR TITLE
[V2V] Add uniqueness constraint to conversion host resource id

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -16,7 +16,7 @@ class ConversionHost < ApplicationRecord
 
   validates :name, :presence => true
   validates :resource, :presence => true
-  validates_uniqueness_of :resource_id, :scope => :resource_type
+  validates :resource_id, :uniqueness => { :scope => :resource_type }
 
   validates :address,
     :uniqueness => true,

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -16,6 +16,7 @@ class ConversionHost < ApplicationRecord
 
   validates :name, :presence => true
   validates :resource, :presence => true
+  validates_uniqueness_of :resource_id, :scope => :resource_type
 
   validates :address,
     :uniqueness => true,

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -352,6 +352,13 @@ RSpec.describe ConversionHost, :v2v do
       expect(conversion_host.valid?).to be(false)
       expect(conversion_host.errors[:resource].first).to eql("can't be blank")
     end
+
+    it "is invalid if the resource is already a conversion host" do
+      FactoryBot.create(:conversion_host, :resource => redhat_host)
+      conversion_host = ConversionHost.new(:resource => redhat_host)
+      expect(conversion_host.valid?).to be(false)
+      expect(conversion_host.errors[:resource_id].first).to eql("has already been taken")
+    end
   end
 
   context "name validation" do


### PR DESCRIPTION
This PR adds a validation that ensures that the same resource isn't used when creating multiple conversion hosts.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1727131