### PR TITLE
When copying ServiceTemplate copy only direct_custom_buttons

### DIFF
--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -7,7 +7,7 @@ module ServiceTemplate::Copy
         dup.tap do |template|
           template.update_attributes(:name => new_name, :display => false)
           service_resources.each { |service_resource| resource_copy(service_resource, template) }
-          custom_buttons.each { |custom_button| custom_button_copy(custom_button, template) }
+          direct_custom_buttons.each { |custom_button| custom_button_copy(custom_button, template) }
           custom_button_sets.each { |custom_button_set| custom_button_set_copy(custom_button_set, template) }
         end.save!
       end


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/18954

Based on https://github.com/ManageIQ/manageiq/pull/18494#discussion_r302099371

Steps to reproduce:
```ruby
st = ServiceTemplate.create(:name => "ServiceTemplate")
cb = CustomButton.create(:name => "CustomButton", :applies_to => st)
service = Service.create(:name => "Service", :service_template_id => st.id)
service.save!
service_cb = CustomButton.create(:name => "CustomButton", :applies_to => service)
st.template_copy("Copy")
copy = ServiceTemplate.find_by(:name => "Copy")
copy_of_copy = copy.template_copy
```

Before:
```
       16: from app/models/service_template/copy.rb:10:in `block (2 levels) in template_copy'
       15: from app/models/service_template/copy.rb:10:in `each'
       14: from app/models/service_template/copy.rb:10:in `block (3 levels) in template_copy'
       13: from app/models/service_template/copy.rb:23:in `custom_button_copy'
       12: from app/models/custom_button.rb:233:in `copy'
       11: from app/models/custom_button.rb:233:in `tap'
       10: from activerecord (5.1.7) lib/active_record/suppressor.rb:46:in `save!'
        9: from activerecord (5.1.7) lib/active_record/transactions.rb:313:in `save!'
        8: from activerecord (5.1.7) lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
        7: from activerecord (5.1.7) lib/active_record/transactions.rb:210:in `transaction'
        6: from activerecord (5.1.7) lib/active_record/connection_adapters/abstract/database_statements.rb:233:in `transaction'
        5: from activerecord (5.1.7) lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
        4: from activerecord (5.1.7) lib/active_record/transactions.rb:313:in `block in save!'
        3: from activerecord (5.1.7) lib/active_record/attribute_methods/dirty.rb:43:in `save!'
        2: from activerecord (5.1.7) lib/active_record/validations.rb:50:in `save!'
        1: from activerecord (5.1.7) lib/active_record/validations.rb:78:in `raise_validation_error'
ActiveRecord::RecordInvalid (Validation failed: CustomButton: Name has already been taken, CustomButton: Description has already been taken)
```
After:
It works and `copy_of_copy` is created :)

@gmcculloug Please have look, thanks :)

cc @d-m-u 