### PR TITLE
Update VCR gem to 5.0.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -247,7 +247,7 @@ unless ENV["APPLIANCE"]
     gem "faker",            "~>1.8",    :require => false
     gem "timecop",          "~>0.7.3",  :require => false
     gem "vcr",              "~>5.0.0",  :require => false
-    gem "webmock",          "~>2.3.1",  :require => false
+    gem "webmock",          "~>3.6.0",  :require => false
   end
 
   group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -246,7 +246,7 @@ unless ENV["APPLIANCE"]
     gem "factory_bot",      "~>4.11.1", :require => false
     gem "faker",            "~>1.8",    :require => false
     gem "timecop",          "~>0.7.3",  :require => false
-    gem "vcr",              "~>3.0.2",  :require => false
+    gem "vcr",              "~>5.0.0",  :require => false
     gem "webmock",          "~>2.3.1",  :require => false
   end
 


### PR DESCRIPTION
This updates the VCR gem to 5.0.0. You can find the changelog here:

https://github.com/vcr/vcr/blob/master/CHANGELOG.md

My real motivation is to get rid of the hashdiff warnings. :)

Update: I'm also including an update to webmock.