### PR TITLE
Log only unique servers id used to process miq_request

### DIFF
--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -187,6 +187,7 @@ module MiqRequestMixin
 
   def mark_execution_servers
     options[:executed_on_servers] ||= []
+    # remove duplicates and ensure that last element of array is the last server
     (options[:executed_on_servers] -= [MiqServer.my_server.id]) << MiqServer.my_server.id
     update_attributes(:options => options)
   end

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -187,7 +187,7 @@ module MiqRequestMixin
 
   def mark_execution_servers
     options[:executed_on_servers] ||= []
-    options[:executed_on_servers] << MiqServer.my_server.id
+    (options[:executed_on_servers] -= [MiqServer.my_server.id]) << MiqServer.my_server.id
     update_attributes(:options => options)
   end
 end

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -287,17 +287,17 @@ describe ServiceTemplateProvisionTask do
       let(:server) { FactoryBot.create(:miq_server) }
       before { allow(MiqServer).to receive(:my_server).and_return(server) }
 
-      it "with new server id" do
+      it "adds server id to the list of servers to log" do
         @task_0.mark_execution_servers
         expect(@task_0.options[:executed_on_servers]).to eq([server.id])
       end
 
-      it "with existing server id" do
+      it "keeps only unique server's ids" do
         @task_0.options[:executed_on_servers] = [server.id]
         @task_0.save!
 
         @task_0.mark_execution_servers
-        expect(@task_0.options[:executed_on_servers]).to eq([server.id, server.id])
+        expect(@task_0.options[:executed_on_servers]).to eq([server.id])
       end
     end
   end


### PR DESCRIPTION
**ISSUE:**
In some situations `miq_request` may start re-queuing : 
in log: 
![Screen Shot 2019-07-11 at 1 36 16 PM](https://user-images.githubusercontent.com/6556758/61072246-e6b2f380-a3e0-11e9-867f-d4a37044e6fe.png)

**FIX:**
Log only unique servers id

this PR is follow-up to https://github.com/ManageIQ/manageiq/pull/17451

@miq-bot add-label core, hammer/yes, changelog/yes, technical debt