### PR TITLE
[WIP] Provisioned lifecycle state maybe ought to be set by factory

### DIFF
--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :service do
     sequence(:name) { |n| "service_#{seq_padded_for_sorting(n)}" }
+    lifecycle_state { 'provisioned' }
   end
 
   factory :service_orchestration, :class => :ServiceOrchestration, :parent => :service


### PR DESCRIPTION
Okay so I just wanted to see what would happen. Since Lucy's changes to add this column, we should probably assume that ones used in tests are valid, that is, actually provisioned. It makes more sense to do that here rather than the nine hundred places we create services in specs although for most of the service tests it probably doesn't matter. 

I doubt we have tests around services getting retired and the lifecycle state column changing, so I don't know if there will be any failures here although that should be addressed sometime. 

