### PR TITLE
Remove unused partial in RequestStartedOnMiddleware specs

### DIFF
--- a/spec/lib/request_started_on_middleware_spec.rb
+++ b/spec/lib/request_started_on_middleware_spec.rb
@@ -1,8 +1,7 @@
-describe RequestStartedOnMiddleware do
+RSpec.describe RequestStartedOnMiddleware do
   context ".long_running_requests" do
     before do
       allow(described_class).to receive(:relevant_thread_list) { fake_threads }
-      allow(described_class).to receive(:request_timeout).and_return(2.minutes)
     end
 
     let(:fake_threads) { [@fake_thread] }


### PR DESCRIPTION
This PR removes an unused partial from the `RequestStartedOnMiddleware` specs. Specifically, there is no `RequestStartedOnMiddleware.request_timeout` method. Removing this line caused no failures.

I also added an explicit `RSpec` to the outer describe block for future rspec 4 compliance.