### PR TITLE
provider url has a uniqueness validation so the factory should reflect that

### DIFF
--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
 
   factory :provider_openstack, :class => "ManageIQ::Providers::Openstack::Provider", :parent => :provider
   factory(:provider_ansible_tower, :class => "ManageIQ::Providers::AnsibleTower::Provider", :parent => :provider) do
-    url { "example.com" }
+    sequence(:url) { |n| "example_#{seq_padded_for_sorting(n)}.com" }
     trait(:with_authentication) do
       after(:create) do |x|
         x.authentications << FactoryBot.create(:authentication)


### PR DESCRIPTION
url is delegated: https://github.com/ManageIQ/manageiq/blob/master/app/models/provider.rb#L17 which has a uniqueness validation: https://github.com/ManageIQ/manageiq/blob/master/app/models/endpoint.rb#L9 so maybe the factory shouldn't be setting ones that won't be unique? 

@miq-bot assign @jrafanie 