### PR TITLE
Allow Symbol deserialization in YAML.safe_load

### DIFF
--- a/app/models/dialog_import_validator.rb
+++ b/app/models/dialog_import_validator.rb
@@ -11,7 +11,7 @@ class DialogImportValidator
   end
 
   def determine_validity(import_file_upload)
-    potential_dialogs = YAML.safe_load(import_file_upload.uploaded_content)
+    potential_dialogs = YAML.safe_load(import_file_upload.uploaded_content, [Symbol])
     raise BlankFileError unless potential_dialogs
 
     check_dialogs_for_validity(potential_dialogs)


### PR DESCRIPTION
Description of the issue taken from https://bugzilla.redhat.com/show_bug.cgi?id=1720611#c9

While trying to reproduce issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1729046, I've ran into an issue importing attached service dialogs, getting following error:

```
[----] F, [2019-07-12T11:55:54.504983 #13537:2ade125181a8] FATAL -- : Error caught: [Psych::DisallowedClass] Tried to load unspecified class: Symbol
...
/home/rblanco/devel/manageiq/app/models/dialog_import_validator.rb:14:in `determine_validity'
/home/rblanco/devel/manageiq/lib/services/dialog_import_service.rb:63:in `store_for_import'
/home/rblanco/devel/manageiq-ui-classic/app/controllers/miq_ae_customization_controller.rb:44:in `upload_import_file'
```

Issues comes from command `YAML.safe_load(import_file_upload.uploaded_content)`, here: https://github.com/ManageIQ/manageiq/pull/18951/files#diff-fe0ab1a41142d4f54834f71ce18888f3R14

`YAML.safe_load` is missing `permitted_classes` argument.

After applying changes in this PR, it's possible to import service dialogs again.

Links:

https://bugzilla.redhat.com/show_bug.cgi?id=1720611
https://github.com/ManageIQ/manageiq/pull/18951
