### PR TITLE
Add credential handling to Ansible::Runner

### DIFF
--- a/lib/ansible/runner/credential.rb
+++ b/lib/ansible/runner/credential.rb
@@ -1,0 +1,54 @@
+module Ansible
+  class Runner
+    class Credential
+      attr_reader :auth, :base_dir
+
+      def self.new(authentication_id, base_dir)
+        auth_type = Authentication.find(authentication_id).type
+        self == Ansible::Runner::Credential ? detect_credential_type(auth_type).new(authentication_id, base_dir) : super
+      end
+
+      def self.detect_credential_type(auth_type)
+        subclasses.index_by(&:auth_type)[auth_type] || Ansible::Runner::GenericCredential
+      end
+
+      def initialize(authentication_id, base_dir)
+        @auth     = Authentication.find(authentication_id)
+        @base_dir = base_dir
+
+        FileUtils.mkdir_p(env_dir)
+      end
+
+      def command_line
+        {}
+      end
+
+      def env_vars
+        {}
+      end
+
+      def extra_vars
+        {}
+      end
+
+      def write_password_file
+      end
+
+      private
+
+      def password_file
+        File.join(env_dir, "passwords")
+      end
+
+      def ssh_key_file
+        File.join(env_dir, "ssh_key")
+      end
+
+      def env_dir
+        File.join(base_dir, "env")
+      end
+    end
+  end
+end
+
+Dir.glob(File.join(File.dirname(__FILE__), "credential/*.rb")).each { |f| require_dependency f }

--- a/lib/ansible/runner/credential/generic_credential.rb
+++ b/lib/ansible/runner/credential/generic_credential.rb
@@ -1,0 +1,9 @@
+module Ansible
+  class Runner
+    class GenericCredential < Credential
+      def self.auth_type
+        ""
+      end
+    end
+  end
+end

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -1,0 +1,40 @@
+module Ansible
+  class Runner
+    class MachineCredential < Credential
+      def self.auth_type
+        "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential"
+      end
+
+      def command_line
+        {:user => auth.userid}.delete_blanks.merge(become_args)
+      end
+
+      def write_password_file
+        password_hash = {
+          "^SSH [pP]assword:$"    => auth.password,
+          "^BECOME [pP]assword:$" => auth.become_password
+        }.delete_blanks
+
+        File.write(password_file, password_hash.to_yaml) if password_hash.present?
+
+        write_ssh_key if auth.auth_key.present?
+      end
+
+      private
+
+      def become_args
+        return {} if auth.become_username.blank?
+
+        {
+          :become        => nil,
+          :become_user   => auth.become_username,
+          :become_method => auth.options.try(:[], :become_method) || "sudo"
+        }
+      end
+
+      def write_ssh_key
+        File.write(ssh_key_file, auth.auth_key)
+      end
+    end
+  end
+end

--- a/spec/lib/ansible/runner/credential/generic_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/generic_credential_spec.rb
@@ -1,0 +1,40 @@
+require 'ansible/runner'
+require 'ansible/runner/credential'
+
+RSpec.describe Ansible::Runner::GenericCredential do
+  it ".auth_type is an empty string" do
+    expect(described_class.auth_type).to eq("")
+  end
+
+  context "with a credential object" do
+    around do |example|
+      Dir.mktmpdir("ansible-runner-credential-test") do |dir|
+        @base_dir = dir
+        example.run
+      end
+    end
+
+    let(:cred) do
+      auth = FactoryBot.create(:authentication)
+      described_class.new(auth.id, @base_dir)
+    end
+
+    it "#command_line is an empty hash" do
+      expect(cred.command_line).to eq({})
+    end
+
+    it "#env_vars is an empty hash" do
+      expect(cred.env_vars).to eq({})
+    end
+
+    it "#extra_vars is an empty hash" do
+      expect(cred.extra_vars).to eq({})
+    end
+
+    it "#write_password_file does not write a file" do
+      password_file = File.join(@base_dir, "env", "passwords")
+      cred.write_password_file
+      expect(File.exist?(password_file)).to be_falsey
+    end
+  end
+end

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -1,0 +1,103 @@
+require 'ansible/runner'
+require 'ansible/runner/credential'
+
+RSpec.describe Ansible::Runner::MachineCredential do
+  it ".auth_type is the correct Authentication sub-class" do
+    expect(described_class.auth_type).to eq("ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential")
+  end
+
+  context "with a credential object" do
+    around do |example|
+      Dir.mktmpdir("ansible-runner-credential-test") do |dir|
+        @base_dir = dir
+        example.run
+      end
+    end
+
+    let(:auth) do
+      auth_attributes = {
+        :userid            => "manageiq",
+        :password          => "secret",
+        :auth_key          => "key_data",
+        :become_username   => "root",
+        :become_password   => "othersecret",
+        :auth_key_password => "keypass",
+        :options           => {:become_method => "su"}
+      }
+      FactoryBot.create(:embedded_ansible_machine_credential, auth_attributes)
+    end
+
+    let(:cred) { described_class.new(auth.id, @base_dir) }
+
+    describe "#command_line" do
+      it "is correct with all attributes" do
+        expected = {
+          :become        => nil,
+          :become_user   => "root",
+          :become_method => "su",
+          :user          => "manageiq"
+        }
+        expect(cred.command_line).to eq(expected)
+      end
+
+      it "doesn't send :user if userid is not set" do
+        auth.update!(:userid => nil)
+
+        expected = {
+          :become        => nil,
+          :become_user   => "root",
+          :become_method => "su"
+        }
+        expect(cred.command_line).to eq(expected)
+      end
+
+      it "doesn't send the become keys if :become_user is not set" do
+        auth.update!(:become_username => nil)
+        expect(cred.command_line).to eq(:user => "manageiq")
+      end
+    end
+
+    it "#env_vars is an empty hash" do
+      expect(cred.env_vars).to eq({})
+    end
+
+    it "#extra_vars is an empty hash" do
+      expect(cred.extra_vars).to eq({})
+    end
+
+    describe "#write_password_file" do
+      let(:password_file) { File.join(@base_dir, "env", "passwords") }
+      let(:key_file)      { File.join(@base_dir, "env", "ssh_key") }
+
+      def password_hash
+        YAML.load_file(password_file)
+      end
+
+      it "writes out both the passwords file and the key file" do
+        cred.write_password_file
+
+        expect(password_hash).to eq(
+          "^SSH [pP]assword:$"    => "secret",
+          "^BECOME [pP]assword:$" => "othersecret"
+        )
+
+        expect(File.read(key_file)).to eq("key_data")
+      end
+
+      it "doesn't create the password file if there are no passwords" do
+        auth.update!(:password => nil, :become_password => nil)
+        cred.write_password_file
+        expect(File.exist?(password_file)).to be_falsey
+      end
+
+      it "writes the password file in valid yaml when the password contains quotes" do
+        password = '!compli-cat"ed&pass,"wor;d'
+        auth.update!(:password => password)
+
+        cred.write_password_file
+
+        expect(password_hash["^SSH [pP]assword:$"]).to eq(password)
+      end
+    end
+  end
+end

--- a/spec/lib/ansible/runner/credential_spec.rb
+++ b/spec/lib/ansible/runner/credential_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Ansible::Runner::Credential do
+  around do |example|
+    Dir.mktmpdir("ansible-runner-credential-test") do |dir|
+      @base_dir = dir
+      example.run
+    end
+  end
+
+  describe ".new" do
+    it "initializes a GenericCredential when given a missing auth_type" do
+      auth = FactoryBot.create(:authentication)
+      cred = described_class.new(auth.id, @base_dir)
+      expect(cred).to be_an_instance_of(Ansible::Runner::GenericCredential)
+    end
+
+    it "initializes a MachineCredential for ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredentials" do
+      auth = FactoryBot.create(:embedded_ansible_machine_credential)
+      cred = described_class.new(auth.id, @base_dir)
+      expect(cred).to be_an_instance_of(Ansible::Runner::MachineCredential)
+    end
+
+    it "initializes attributes" do
+      auth = FactoryBot.create(:authentication)
+      cred = described_class.new(auth.id, @base_dir)
+      expect(cred.auth.id).to eq(auth.id)
+      expect(cred.base_dir).to eq(@base_dir)
+    end
+  end
+end


### PR DESCRIPTION
This creates a null-object-like class which will return a subclass
based on the type of credential id passed to it.

Each subclass will implement methods which will augment the environment
that ansible-runner executes in. Specifically they may return a hash
representing environment variables, extra vars, command line arguments
(to ansible-playbook) and they may write out the password and ssh key
files.

This commit implements a MachineCredential subclass as a start

@NickLaMuro this should allow us to move forward on new credential types in parallel. I'm also working on a followup to push the credential ids down from the service to runner.