### PR TITLE
Add Utilization MiqShortcut for StartAt dropdown selection/setting

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -9,6 +9,11 @@
   :url: /report/explorer
   :rbac_feature_name: miq_report
   :startup: true
+- :name: miq_capacity_utilization
+  :description: Cloud Intel / Utilization
+  :url: /utilization
+  :rbac_feature_name: utilization
+  :startup: true
 - :name: chargeback
   :description: Cloud Intel / Chargeback
   :url: /chargeback/explorer


### PR DESCRIPTION
Fixes ability to select Cloud Intel Utilization as Start At page after log in.

**NOTE**: MiqShortcut may need to be re-seeded.

https://bugzilla.redhat.com/show_bug.cgi?id=1729136

Screen shot prior to code fix:
<img width="548" alt="Cloud Intel Utilization selection as StartAt missing prior to fix" src="https://user-images.githubusercontent.com/552686/61161285-0cf79280-a4b8-11e9-96a5-c2cc3bb5902f.png">


Screen shot post code fix:
<img width="493" alt="Cloud Intel Utilization selection as StartAt post fix" src="https://user-images.githubusercontent.com/552686/61161310-2567ad00-a4b8-11e9-8ad6-48b3391d7f3f.png">

Screen shot confirming selection and setting:
<img width="533" alt="Cloud Intel Utilization selection confirmation as StartAt post fix" src="https://user-images.githubusercontent.com/552686/61161326-344e5f80-a4b8-11e9-8845-6751144bf4f3.png">


Screen shot showing Cloud Intel Utilization page after log in:
<img width="944" alt="Cloud Intel Utilization after user log in post fix" src="https://user-images.githubusercontent.com/552686/61161351-49c38980-a4b8-11e9-8b50-d644affe7f2f.png">



