### PR TITLE
[EmbeddedAnsible] Fix manager ref for credentials

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -20,8 +20,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
     raise NotImplementedError, "must be implemented in a subclass"
   end
 
-  def self.raw_create_in_provider(_manager, params)
-    create!(params_to_attributes(params))
+  def self.raw_create_in_provider(manager, params)
+    create_params = params_to_attributes(params)
+    create_params[:resource] = manager
+    create!(create_params)
   end
 
   def raw_update_in_provider(params)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -28,12 +28,14 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
 
     context "CREATE" do
       it ".create_in_provider creates a record" do
-        expect(credential_class).to receive(:create!).with(params_to_attributes).and_call_original
+        create_params = params_to_attributes.merge(:resource => manager)
+        expect(credential_class).to receive(:create!).with(create_params).and_call_original
         expect(Notification).to     receive(:create!).never
 
         record = credential_class.create_in_provider(manager.id, params)
 
         expect(record).to be_a(credential_class)
+        expect(record.manager).to eq(manager)
         expected_values.each do |attr, val|
           expect(record.send(attr)).to eq(val)
         end
@@ -44,6 +46,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
         passed_params   = params.except(*keys_to_remove)
 
         params_to_attributes.delete(:options)
+        params_to_attributes.merge!(:resource => manager)
         expected_values.delete(:options)
         keys_to_remove.each { |key| expected_values[key] = nil }
 
@@ -53,6 +56,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
         record = credential_class.create_in_provider(manager.id, passed_params)
 
         expect(record).to be_a(credential_class)
+        expect(record.manager).to eq(manager)
         expected_values.each do |attr, val|
           expect(record.send(attr)).to eq(val)
         end
@@ -80,7 +84,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
 
     context "UPDATE" do
       let(:update_params) { {:name => "Updated Credential" } }
-      let(:ansible_cred)  { credential_class.raw_create_in_provider(nil, params.merge(:manager => manager)) }
+      let(:ansible_cred)  { credential_class.raw_create_in_provider(manager, params) }
 
       it "#update_in_provider to succeed" do
         expect(Notification).to receive(:create!).never
@@ -111,7 +115,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
     end
 
     context "DELETE" do
-      let(:ansible_cred) { credential_class.raw_create_in_provider(nil, params.merge(:manager => manager)) }
+      let(:ansible_cred) { credential_class.raw_create_in_provider(manager, params) }
 
       it "#delete_in_provider will delete the record" do
         expect(Notification).to receive(:create!).never


### PR DESCRIPTION
Makes sure we are properly assigning the manager (resource) when creating `AutomationManager::Credential` records.

Also updates the specs, not only to test this on create, but to also properly initialize the records for the UPDATE and DELETE specs (how I instantiated things were should have been a bit of a tip off that this was coded wrong... oh well...)


Steps for Testing/QA
--------------------

~~TODO: Want to confirm this fixes a few things on a VM, but need to make a separate branch to integrate this commit with the work in #18969 to confirm this is doing what I want it to.~~

* Enable `EmbeddedAnsible`
* Add a credential
* Create a catalog and catalog item
* When ordering the catalog item, you should see the credential in the dropdown:

<img width="1009" alt="Screen Shot 2019-07-12 at 9 44 30 PM" src="https://user-images.githubusercontent.com/314014/61166137-7e523800-a4ee-11e9-8091-fbc1b7d876fc.png">
