### PR TITLE
Rename the "Cloud Intel" menu item to "Overview"

### DIFF
--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -1,16 +1,16 @@
 ---
 - :name: dashboard_show
-  :description: Cloud Intel / Dashboard
+  :description: Overview / Dashboard
   :url: /dashboard/show
   :rbac_feature_name: dashboard_view
   :startup: true
 - :name: miq_report
-  :description: Cloud Intel / Reports
+  :description: Overview / Reports
   :url: /report/explorer
   :rbac_feature_name: miq_report
   :startup: true
 - :name: chargeback
-  :description: Cloud Intel / Chargeback
+  :description: Overview / Chargeback
   :url: /chargeback/explorer
   :rbac_feature_name: chargeback
   :startup: true


### PR DESCRIPTION
Making the db fixtures consistent with https://github.com/ManageIQ/manageiq-ui-classic/pull/5809

Parent issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/5808
https://bugzilla.redhat.com/show_bug.cgi?id=1678196

@miq-bot add_reviewer @lpichler 
@miq-bot add_label hammer/no, enhancement