### PR TITLE
Add a role for appliance internet connectivity

### DIFF
--- a/db/fixtures/server_roles.csv
+++ b/db/fixtures/server_roles.csv
@@ -11,6 +11,7 @@ ems_metrics_processor,Capacity & Utilization Data Processor,0,false,zone
 ems_operations,Provider Operations,0,false,zone
 event,Event Monitor,1,false,zone
 git_owner,Git Repositories Owner,1,false,zone
+internet_connectivity,Internet Connectivity,0,false,region
 notifier,Notifier,1,false,region
 reporting,Reporting,0,false,region
 scheduler,Scheduler,1,false,region

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -39,6 +39,7 @@ describe ServerRole do
         ems_metrics_processor,Capacity & Utilization Data Processor,0,false,zone
         ems_operations,Management System Operations,0,false,zone
         event,Event Monitor,1,false,zone
+        internet_connectivity,Internet Connectivity,0,false,region
         notifier,Alert Processor,1,false,region
         reporting,Reporting,0,false,region
         scheduler,Scheduler,1,false,region


### PR DESCRIPTION
Some tasks require that at least one appliance in a region have
connectivity to the internet.  It is not mandatory that an appliance
have this enabled but additional features can be used if it is.