### PR TITLE
locale rake tasks updates

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -185,6 +185,8 @@ namespace :locale do
       end
     end
 
+    system("mkdir -p #{@engine_root}/locale/en") # create initial locale/en directories if they don't exist
+
     FastGettext.add_text_domain(@domain,
                                 :path           => @engine_root.join('locale').to_s,
                                 :type           => :po,

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -177,7 +177,7 @@ namespace :locale do
       end
 
       def files_to_translate
-        Dir.glob("#{@engine.root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
+        Dir.glob("#{@engine_root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
       end
 
       def text_domain

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -250,25 +250,7 @@ namespace :locale do
         end
       end
 
-      js_plugins = {
-        'ui-components' => {
-          'en'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/en/ui-components.po',
-          'es'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/es/ui-components.po',
-          'fr'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/fr/ui-components.po',
-          'ja'    => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/ja/ui-components.po',
-          'pt_BR' => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/pt_BR/ui-components.po',
-          'zh_CN' => 'https://raw.githubusercontent.com/ManageIQ/ui-components/master/locale/zh_CN/ui-components.po',
-        },
-
-        'react-ui-components' => {
-          'en'    => 'https://raw.githubusercontent.com/ManageIQ/react-ui-components/master/locale/en/react-ui-components.po',
-          'es'    => 'https://raw.githubusercontent.com/ManageIQ/react-ui-components/master/locale/es/react-ui-components.po',
-          'fr'    => 'https://raw.githubusercontent.com/ManageIQ/react-ui-components/master/locale/fr/react-ui-components.po',
-          'ja'    => 'https://raw.githubusercontent.com/ManageIQ/react-ui-components/master/locale/ja/react-ui-components.po',
-          'pt_BR' => 'https://raw.githubusercontent.com/ManageIQ/react-ui-components/master/locale/pt_BR/react-ui-components.po',
-          'zh_CN' => 'https://raw.githubusercontent.com/ManageIQ/react-ui-components/master/locale/zh_CN/react-ui-components.po',
-        }
-      }
+      js_plugins = {} # currently we don't need to download any catalogs from JS/node plugins
 
       plugins_dir = File.join(Rails.root, 'locale/plugins')
       Dir.mkdir(plugins_dir, 0o700)

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -86,6 +86,8 @@ namespace :locale do
       end
     end
 
+    next if output.empty? # no yaml strings were found
+
     File.open(args[:root].join("config/yaml_strings.rb"), "w+") do |f|
       f.puts "# This is automatically generated file (rake locale:extract_yaml_strings)."
       f.puts "# The file contains strings extracted from various yaml files for gettext to find."

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -160,8 +160,8 @@ namespace :locale do
 
     pot_files = []
     Vmdb::Plugins.each do |plugin|
-      system("rm -vf #{plugin.root.join('/locale')}/*.pot")
-      system("bundle exec rake locale:plugin:find[#{plugin.to_s.sub('::Engine', '')}]")
+      system('rm', '-vf', "#{plugin.root.join('/locale')}/*.pot")
+      system('bundle', 'exec', 'rake', "locale:plugin:find[#{plugin.to_s.sub('::Engine', '')}]")
       pot_file = Dir.glob("#{plugin.root.join('locale')}/*.pot")[0]
       pot_files << pot_file if pot_file.present?
     end
@@ -176,15 +176,15 @@ namespace :locale do
     Dir.mkdir(tmp_dir, 0o700)
     extra_pots.each do |url|
       pot_file = "#{tmp_dir}/#{url.split('/')[-1]}"
-      ManageIQ::Environment.system! "curl -f -o #{pot_file} #{url}"
+      ManageIQ::Environment.system!('curl', '-f', '-o', pot_file, url)
       pot_files << pot_file
     end
 
-    system("rmsgcat -o #{Rails.root.join('locale', 'manageiq-all.pot')} #{Rails.root.join('locale', 'manageiq.pot')} #{pot_files.join(' ')}")
-    system("mv -v #{Rails.root.join('locale', 'manageiq-all.pot')} #{Rails.root.join('locale', 'manageiq.pot')}")
-    system("rmsgmerge -o #{Rails.root.join('locale', 'en', 'manageiq-all.po')} #{Rails.root.join('locale', 'en', 'manageiq.po')} #{Rails.root.join('locale', 'manageiq.pot')}")
-    system("mv -v #{Rails.root.join('locale', 'en', 'manageiq-all.po')} #{Rails.root.join('locale', 'en', 'manageiq.po')}")
-    system("rm -rf #{tmp_dir}")
+    system('rmsgcat', '-o', Rails.root.join('locale', 'manageiq-all.pot').to_s, Rails.root.join('locale', 'manageiq.pot').to_s, *pot_files)
+    system('mv', '-v', Rails.root.join('locale', 'manageiq-all.pot').to_s, Rails.root.join('locale', 'manageiq.pot').to_s)
+    system('rmsgmerge', '-o', Rails.root.join('locale', 'en', 'manageiq-all.po').to_s, Rails.root.join('locale', 'en', 'manageiq.po').to_s, Rails.root.join('locale', 'manageiq.pot').to_s)
+    system('mv', '-v', Rails.root.join('locale', 'en', 'manageiq-all.po').to_s, Rails.root.join('locale', 'en', 'manageiq.po').to_s)
+    system('rm', '-rf', tmp_dir)
   end
 
   desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
@@ -219,7 +219,7 @@ namespace :locale do
       end
     end
 
-    system("mkdir -p #{@engine_root}/locale/en") # create initial locale/en directories if they don't exist
+    system('mkdir', '-p', "#{@engine_root}/locale/en") # create initial locale/en directories if they don't exist
 
     FastGettext.add_text_domain(@domain,
                                 :path           => @engine_root.join('locale').to_s,
@@ -261,7 +261,7 @@ namespace :locale do
           lang_dir = File.join(plugin_dir, lang)
           Dir.mkdir(lang_dir)
           lang_file = "#{lang_dir}/#{url.split('/')[-1]}"
-          ManageIQ::Environment.system! "curl -f -o #{lang_file} #{url}"
+          ManageIQ::Environment.system!("curl -f -o #{lang_file} #{url}")
           po_files[lang] ||= []
           po_files[lang].push(Pathname(lang_file))
         end


### PR DESCRIPTION
Changes:
* fix error in `locale:extract_yaml_strings`: when no yaml strings found, there's no need to proceed with the task
* `locale:plugin:find`: create initial `locale` and `locale/en` directories if they don't exist
* new `locale:update_all` task: this task updates catalogs in core manageiq and all its plugins (including ui-components and react-ui-components) and merges all catalogs into one. This change is so that ManageIQ application can be translated as whole in Transifex in one project as opposed to ~30 projects, which was confusing for translators.
* rubocop fixes
* the list of JS/node plugins for which we need to download catalogs is currently empty