### PR TITLE
ansible options.key?(:config_info) check should be in the base class

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -492,6 +492,7 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def validate_update_config_info(options)
+    return unless options.key?(:config_info)
     if options[:service_type] && options[:service_type] != service_type
       raise _('service_type cannot be changed')
     end

--- a/app/models/service_template_ansible_tower.rb
+++ b/app/models/service_template_ansible_tower.rb
@@ -73,7 +73,6 @@ class ServiceTemplateAnsibleTower < ServiceTemplate
 
   def validate_update_config_info(options)
     super
-    return unless options.key?(:config_info)
     self.class.validate_config_info(options)
   end
 

--- a/app/models/service_template_orchestration.rb
+++ b/app/models/service_template_orchestration.rb
@@ -72,7 +72,6 @@ class ServiceTemplateOrchestration < ServiceTemplate
 
   def validate_update_config_info(options)
     super
-    return unless options.key?(:config_info)
     self.class.validate_config_info(options)
   end
 


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1716847. 

Currently for Ansible things this method looks similar across the leaf classes:

```ruby
  def validate_update_config_info(options)
    super
    return unless options.key?(:config_info)
    self.class.validate_config_info(options)
  end
```
The leaf classes that don't have the ```return unless ...```, right now, are 
service_template_ansible_playbook and
service_template_container_template

Since, according to Bill, ansible playbooks should also be doing this return, it's a safe bet that service template container templates should be as well. 

```bash
grep "def validate_update_config_info"
app/models/service_template.rb:494:  def validate_update_config_info(options)
app/models/service_template_ansible_playbook.rb:226:  def validate_update_config_info(options)
app/models/service_template_ansible_tower.rb:74:  def validate_update_config_info(options)
app/models/service_template_container_template.rb:73:  def validate_update_config_info(options)
app/models/service_template_orchestration.rb:73:  def validate_update_config_info(options)
```

Note: we still have an issue with https://github.com/ManageIQ/manageiq/blob/master/app/models/service_template_ansible_playbook.rb#L226 since we pass in options and then just drop them.  (addressed here: https://github.com/ManageIQ/manageiq/pull/18980)