### PR TITLE
Use options if they're passed into ansible_playbook validate update

### DIFF
--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -224,8 +224,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
   end
 
   def validate_update_config_info(options)
-    opts = super
-    self.class.send(:validate_config_info, opts)
+    self.class.send(:validate_config_info, options || super)
   end
 
   # override


### PR DESCRIPTION
Cause at the moment we're just unceremoniously dropping them:
https://github.com/ManageIQ/manageiq/blob/master/app/models/service_template_ansible_playbook.rb#L227

Found when opening https://github.com/ManageIQ/manageiq/pull/18979

@miq-bot add_label bug
@miq-bot assign @tinaafitz 
@miq-bot add_reviewer @bzwei 
@miq-bot add_reviewer @tinaafitz 

It's going to fail the specs. I haven't looked into fixing them yet, will do so after someone who knows anything about this code reviews this. 
