### PR TITLE
Allow modification of "Create new Picture" product feature on a role.

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1810,17 +1810,6 @@
   :feature_type: node
   :identifier: rss
 
-# Pictures
-- :name: Pictures
-  :description: Everything under Pictures
-  :feature_type: admin
-  :identifier: pictures
-  :children:
-  - :name: Create new Picture
-    :description: Create a new picture
-    :feature_type: admin
-    :identifier: picture_new
-
 # Policy
 - :name: Explorer
   :description: Control Explorer
@@ -6253,6 +6242,16 @@
   :feature_type: node
   :identifier: api_exclusive
   :children:
+  # Pictures
+  - :name: Pictures
+    :description: Everything under Pictures
+    :feature_type: node
+    :identifier: pictures
+    :children:
+    - :name: Create new Picture
+      :description: Create a new picture
+      :feature_type: admin
+      :identifier: picture_new
   - :name: Metrics
     :description: Everything under Metrics
     :feature_type: node


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1727948

The ability to edit a _role_ to enable the _Create new Picture_ product feature was missing.
Prior to this PR the _role_ associated with the _user_ used to issue the _Create new Picture_
API call must have _Everything_ enable for _Product Features_.

This PR adds that functionality under the **API** _Product Features_, as this functionality is
only available from the API.

Steps for Testing/QA [Optional]
-------------------------------


Save the below script and set the **image omitted due to size** to be a valid image
in file, e.g.: _/tmp/create_one_pictures.rb_
```ruby
#!/usr/bin/env ruby

# Jump past this huge data to the bottom of this source file

request_hash =
{
    "extension": "png",
    "content": "image omitted due to size"
}

require 'json'
require 'net/http'
require 'openssl'
require 'uri'

uri = URI.parse("https://#{ENV['MIQ']}/api/pictures")

http = Net::HTTP.new(uri.host, uri.port)
http.use_ssl = true
http.verify_mode = OpenSSL::SSL::VERIFY_NONE

request = Net::HTTP::Post.new(uri.request_uri)
request.basic_auth("new_user_2", "smartvm")
request.body = JSON.generate(request_hash)
response = http.request(request)
puts JSON.pretty_generate(JSON.parse(response.body.strip))
```

Create a new role in ManageIQ
Edit the role and uncheck the Everything box
Click all other boxes next to all other product features, making sure the new
  **API/Pictures/Create new Picture** _Product Feature_ is checked.

Create a new group with the new role create above
Create a new user named, for example, new_user_2

Run the following shell commands on a separate system, e.g.
a laptop on the same network as the ManageIQ appliance:

> export MIQ="IP Address to the test MangeIQ appliance"
> chmod a+x /tmp/create_one_pictures.rb
> /tmp/create_one_pictures.rb

Confirm the new picture was create on the appliance 
