### PR TITLE
Pass credentials from ansible playbook automate methods to runner

### DIFF
--- a/spec/factories/authentication.rb
+++ b/spec/factories/authentication.rb
@@ -99,6 +99,10 @@ FactoryBot.define do
           :parent => :embedded_ansible_credential,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential"
 
+  factory :embedded_ansible_network_credential,
+          :parent => :embedded_ansible_credential,
+          :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential"
+
   factory :auth_key_pair_cloud,     :class => "ManageIQ::Providers::CloudManager::AuthKeyPair"
   factory :auth_key_pair_amazon,    :class => "ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair"
   factory :auth_key_pair_openstack, :class => "ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair"

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -103,6 +103,37 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
         subject.launch_ansible_tower_job
       end
     end
+
+    context 'with credentials' do
+      let(:cloud_credential)   { FactoryBot.create(:embedded_ansible_amazon_credential) }
+      let(:machine_credential) { FactoryBot.create(:embedded_ansible_machine_credential) }
+      let(:network_credential) { FactoryBot.create(:embedded_ansible_network_credential) }
+      let(:vault_credential)   { FactoryBot.create(:embedded_ansible_vault_credential) }
+
+      let(:options) do
+        {
+          :cloud_credential_id   => cloud_credential.id,
+          :credential_id         => machine_credential.id,
+          :network_credential_id => network_credential.id,
+          :vault_credential_id   => vault_credential.id
+        }
+      end
+
+      it 'passes them to the job' do
+        expected_options = {
+          :hosts              => ["localhost"],
+          :cloud_credential   => cloud_credential.native_ref,
+          :credential         => machine_credential.native_ref,
+          :network_credential => network_credential.native_ref,
+          :vault_credential   => vault_credential.native_ref
+        }
+        expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job)
+          .with(an_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript), expected_options)
+          .and_return(double(:id => 'jb1'))
+        expect(subject).to receive(:queue_signal)
+        subject.launch_ansible_tower_job
+      end
+    end
   end
 
   describe '#poll_ansible_tower_job_status' do


### PR DESCRIPTION
cc @NickLaMuro @Fryguy 

This bit of code to translate the credentials is now in 4 places :sob: if any of you want to help me work out a way to DRY that up I'd be grateful. That can also come in a follow-up too ...

Here's all the places for the record:
- https://github.com/ManageIQ/manageiq/blob/55ebb66b72fe6425b7e762c2422d9d721f9dbd5a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb#L49-L52
- https://github.com/ManageIQ/manageiq/blob/55ebb66b72fe6425b7e762c2422d9d721f9dbd5a/app/models/service_ansible_playbook.rb#L98-L104
- https://github.com/ManageIQ/manageiq/blob/55ebb66b72fe6425b7e762c2422d9d721f9dbd5a/app/models/service_template_ansible_playbook.rb#L108-L111
@tinaafitz @lfu please review
