### PR TITLE
[EmbeddedAnsible] Fix key unlock machine creds

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -67,8 +67,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
   def self.params_to_attributes(params)
     attrs = params.dup
 
-    attrs[:auth_key]                = attrs.delete(:ssh_key_data)
-    attrs[:auth_key_password]       = attrs.delete(:ssh_key_unlock)
+    attrs[:auth_key]          = attrs.delete(:ssh_key_data)
+    attrs[:auth_key_password] = attrs.delete(:ssh_key_unlock)
 
     if attrs[:become_method]
       attrs[:options] = { :become_method => attrs.delete(:become_method) }

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -14,8 +14,9 @@ module Ansible
 
       def write_password_file
         password_hash = {
-          "^SSH [pP]assword:"    => auth.password,
-          "^BECOME [pP]assword:" => auth.become_password
+          "^SSH [pP]assword:"                                     => auth.password,
+          "^BECOME [pP]assword:"                                  => auth.become_password,
+          "^Enter passphrase for [a-zA-Z0-9\-\/]+\/ssh_key_data:" => auth.ssh_key_unlock
         }.delete_blanks
 
         File.write(password_file, password_hash.to_yaml) if password_hash.present?

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -79,15 +79,16 @@ RSpec.describe Ansible::Runner::MachineCredential do
         cred.write_password_file
 
         expect(password_hash).to eq(
-          "^SSH [pP]assword:"    => "secret",
-          "^BECOME [pP]assword:" => "othersecret"
+          "^SSH [pP]assword:"                                     => "secret",
+          "^BECOME [pP]assword:"                                  => "othersecret",
+          "^Enter passphrase for [a-zA-Z0-9\-\/]+\/ssh_key_data:" => "keypass"
         )
 
         expect(File.read(key_file)).to eq("key_data")
       end
 
       it "doesn't create the password file if there are no passwords" do
-        auth.update!(:password => nil, :become_password => nil)
+        auth.update!(:password => nil, :become_password => nil, :auth_key_password => nil)
         cred.write_password_file
         expect(File.exist?(password_file)).to be_falsey
       end


### PR DESCRIPTION
`MachineCredential` records that have a `ssh_key_unlock` value aren't respected in `ansible-runner` and will spin forever when running.

This adds the necessary value to the `write_password_file` to allow the key unlock to happen in the `ssh-agent` calls when invoked via `ansible-runner`.

cc @carbonin

Links
-----

* `MachineCredential` support added here:  https://github.com/ManageIQ/manageiq/pull/18968


Steps for Testing/QA
--------------------

~~TODO:  Which is why this is marked as `[WIP]`, since I am still trying to get a working test run for this.  Also need to add some specs, and probably fix the ones that are there.~~

Update:  had a bad encrypted private key, so when I re-did things, everything was fine.


**Before**

Would hang indefinitely with the following in the being the last lines of STDOUT:

```console
[root@localhost vmdb]# cat /tmp/ansible-runner20190716-4428-2gxsnh/artifacts/result/stdout
Enter passphrase for /tmp/ansible-runner20190716-4428-2gxsnh/artifacts/result/ssh_key_data: 
```

**After**

The key is pass correctly:

```
PLAY [Hello World Sample] ******************************************************
 
TASK [Gathering Facts] *********************************************************
 
ok: [192.168.7.10]
 
TASK [Hello Message] ***********************************************************
 
ok: [192.168.7.10] => {
    "msg": "Hello World!"
}
 
PLAY RECAP *********************************************************************
192.168.7.10               : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

With the following output if only an invalid authkey is provided (if key isn't valid for host):

```
PLAY [Hello World Sample] ******************************************************
 
TASK [Gathering Facts] *********************************************************
 
fatal: [192.168.7.10]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Permission denied (publickey,password,keyboard-interactive).", "unreachable": true}
 
PLAY RECAP *********************************************************************
192.168.7.10               : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0   
```