### PR TITLE
Don't use string interpolation inside gettext calls

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -66,7 +66,7 @@ class ConversionHost < ApplicationRecord
         ssh_options[:auth_methods] = %w[publickey hostbased]
         ssh_options[:key_data] = auth.auth_key
       else
-        raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
+        raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: %{auth_type}") % {:auth_type => auth.authtype}
       end
 
       # Don't connect again if the authentication is still valid
@@ -336,7 +336,7 @@ class ConversionHost < ApplicationRecord
       end
       command << " --private-key #{ssh_private_key_file.path}"
     else
-      raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: #{auth.authtype}")
+      raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: %{auth_type}") % {:auth_type => auth.authtype}
     end
 
     command << " --extra-vars '#{extra_vars.to_json}'"

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -185,7 +185,7 @@ class Dialog < ApplicationRecord
   def reject_if_has_resource_actions
     if resource_actions.length > 0
       connected_components = resource_actions.collect { |ra| ra.resource_type.constantize.find(ra.resource_id) }
-      errors.add(:base, _("Dialog cannot be deleted because it is connected to other components: #{connected_components.map { |cc| cc.class.name + ":" + cc.id.to_s + " - " + cc.try(:name) }}"))
+      errors.add(:base, _("Dialog cannot be deleted because it is connected to other components: %{components}") % {:components => connected_components.map { |cc| cc.class.name + ":" + cc.id.to_s + " - " + cc.try(:name) }})
       throw :abort
     end
   end

--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -274,7 +274,7 @@ class MiqReport < ApplicationRecord
       if col_order&.include?(attr)
         attr
       else
-        raise ArgumentError, N_("#{attr} is not a valid attribute for #{name}")
+        raise ArgumentError, N_("%{attribute} is not a valid attribute for %{name}") % {:attribute => attr, :name => name}
       end
     end.compact
   end


### PR DESCRIPTION
We must not use string interpolation with `#{}` in gettext strings: http://manageiq.org/docs/guides/i18n#string-interpolation

Strings that come out of string interpolation with `#{}` are in fact new strings, which are not present in the catalog. We must use `%{}` instead.

Tagging authors @djberg96 @d-m-u @lpichler and mergers @kbrock @gmcculloug @agrare  