### PR TITLE
Restore ServiceAnsiblePlaybook#postprocess method

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -53,11 +53,15 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     service_resources.find_by(:name => action, :resource_type => 'OrchestrationStack').try(:resource)
   end
 
+  def postprocess(action)
+    log_stdout(action)
+  end
+
   def on_error(action)
     _log.info("on_error called for service action: #{action}")
     update_attributes(:retirement_state => 'error') if action == "Retirement"
     job(action).try(:refresh_ems)
-    log_stdout(action)
+    postprocess(action)
   end
 
   def retain_resources_on_retirement?


### PR DESCRIPTION
This handled logging the playbook stdout in non-error cases
prior to e61bbfc7b28f2b65913b0145142b81ebf1061f60

Oops, @bzwei brought this up in https://github.com/ManageIQ/manageiq/pull/18946/files#r302117901, but I didn't completely understand what was going on at the time 

![image](https://user-images.githubusercontent.com/12697904/61318340-d630bd80-a7d2-11e9-95a5-09e9c745adbe.png)

This makes it so that the above dropdown works as expected, before this we would only log on error.