### PR TITLE
Adding tenant stuff to service template copy

### DIFF
--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -22,10 +22,7 @@ module ServiceTemplate::Copy
   private
 
   def additional_tenant_copy(template)
-    template.additional_tenants << additional_tenants.each do |tenant|
-      tenant.name = "Copy of " + tenant.name + Time.zone.now.to_s
-      tenant.subdomain = "Copy of " + tenant.subdomain + Time.zone.now.to_s
-    end
+    template.additional_tenants << additional_tenants.dup
   end
 
   def custom_button_copy(custom_button, template)

--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -8,6 +8,7 @@ module ServiceTemplate::Copy
           template.update_attributes(:name => new_name, :display => false)
           service_resources.each { |service_resource| resource_copy(service_resource, template) }
           resource_action_copy(template)
+          additional_tenant_copy(template)
           picture_copy(template) if picture
 
           direct_custom_buttons.each { |custom_button| custom_button_copy(custom_button, template) }
@@ -20,9 +21,11 @@ module ServiceTemplate::Copy
 
   private
 
-  def resource_copy(service_resource, template)
-    resource = service_resource.resource.respond_to?(:service_template_resource_copy) ? service_resource.resource.service_template_resource_copy : service_resource.resource
-    template.add_resource(resource, service_resource)
+  def additional_tenant_copy(template)
+    template.additional_tenants << additional_tenants.each do |tenant|
+      tenant.name = "Copy of " + tenant.name + Time.zone.now.to_s
+      tenant.subdomain = "Copy of " + tenant.subdomain + Time.zone.now.to_s
+    end
   end
 
   def custom_button_copy(custom_button, template)
@@ -33,11 +36,16 @@ module ServiceTemplate::Copy
     custom_button_set.deep_copy(:owner => template)
   end
 
-  def resource_action_copy(template)
-    template.resource_actions << resource_actions.collect(&:dup)
-  end
-
   def picture_copy(template)
     template.picture = picture.dup
+  end
+
+  def resource_copy(service_resource, template)
+    resource = service_resource.resource.respond_to?(:service_template_resource_copy) ? service_resource.resource.service_template_resource_copy : service_resource.resource
+    template.add_resource(resource, service_resource)
+  end
+
+  def resource_action_copy(template)
+    template.resource_actions << resource_actions.collect(&:dup)
   end
 end

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -261,5 +261,17 @@ describe ServiceTemplate do
         expect(new_template.resource_actions.pluck(:action)).to match_array(%w[Provision Retire])
       end
     end
+
+    context "additional tenants" do
+      it "duplicates additional tenants" do
+        @st1.additional_tenants << [
+          FactoryBot.create(:tenant),
+          FactoryBot.create(:tenant)
+        ]
+        expect(@st1.additional_tenants.count).to eq(2)
+        new_template = @st1.template_copy
+        expect(new_template.additional_tenants.count).to eq(2)
+      end
+    end
   end
 end

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -109,7 +109,7 @@ describe ServiceTemplate do
         expect(MiqProvisionRequestTemplate.count).to eq(2)
         expect(new_service_template.guid).not_to eq(@st1.guid)
         expect(new_service_template.display).to be(false)
-        expect(new_service_template.service_resources).not_to be(nil)
+        expect(new_service_template.service_resources.count).not_to be(0)
         expect(@st1.service_resources.first.resource).not_to be(nil)
       end
 
@@ -143,7 +143,7 @@ describe ServiceTemplate do
         expect(MiqProvisionRequestTemplate.count).to eq(2)
         expect(new_service_template.guid).not_to eq(service_template_ansible_tower.guid)
         expect(new_service_template.display).to be(false)
-        expect(new_service_template.service_resources).not_to be(nil)
+        expect(new_service_template.service_resources.count).not_to be(0)
         expect(service_template_ansible_tower.service_resources.first.resource).not_to be(nil)
       end
 
@@ -159,7 +159,7 @@ describe ServiceTemplate do
         expect(MiqProvisionRequestTemplate.count).to eq(2)
         expect(new_service_template.guid).not_to eq(service_template_orchestration.guid)
         expect(new_service_template.display).to be(false)
-        expect(new_service_template.service_resources).not_to be(nil)
+        expect(new_service_template.service_resources.count).not_to be(0)
         expect(service_template_orchestration.service_resources.first.resource).not_to be(nil)
       end
     end
@@ -198,7 +198,7 @@ describe ServiceTemplate do
         expect(ExtManagementSystem.count).to eq(1)
         expect(new_service_template.guid).not_to eq(@st1.guid)
         expect(new_service_template.display).to be(false)
-        expect(new_service_template.service_resources).not_to be(nil)
+        expect(new_service_template.service_resources.count).not_to be(0)
         expect(@st1.service_resources.first.resource).not_to be(nil)
       end
 
@@ -212,7 +212,7 @@ describe ServiceTemplate do
         expect(OrchestrationTemplate.count).to eq(1)
         expect(new_service_template.guid).not_to eq(@st1.guid)
         expect(new_service_template.display).to be(false)
-        expect(new_service_template.service_resources).not_to be(nil)
+        expect(new_service_template.service_resources.count).not_to be(0)
         expect(@st1.service_resources.first.resource).not_to be(nil)
       end
 
@@ -228,7 +228,7 @@ describe ServiceTemplate do
         expect(MiqProvisionRequestTemplate.count).to eq(2)
         expect(new_service_template.guid).not_to eq(@st1.guid)
         expect(new_service_template.display).to be(false)
-        expect(new_service_template.service_resources).not_to be(nil)
+        expect(new_service_template.service_resources.count).not_to be(0)
         expect(@st1.service_resources.first.resource).not_to be(nil)
       end
     end
@@ -266,7 +266,7 @@ describe ServiceTemplate do
       it "duplicates additional tenants" do
         @st1.additional_tenants << [
           FactoryBot.create(:tenant),
-          FactoryBot.create(:tenant)
+          FactoryBot.create(:tenant, :subdomain => nil)
         ]
         expect(@st1.additional_tenants.count).to eq(2)
         new_template = @st1.template_copy


### PR DESCRIPTION
Service Template copy should include tenant info. 

Commit one adds the tenant info per https://github.com/ManageIQ/manageiq-ui-classic/pull/5667#issuecomment-512000726.
Commit two fixes https://github.com/ManageIQ/manageiq/pull/18973/files#r303953846. 

@miq-bot assign @tinaafitz 
@miq-bot add_reviewer @bdunne 

