### PR TITLE
Parse days in integer value correctly for automation request scheduling

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -27,7 +27,7 @@ class AutomationRequest < MiqRequest
     options[:class_name]    = (options.delete(:class) || DEFAULT_CLASS).strip.gsub(/(^\/|\/$)/, "")
     options[:instance_name] = (options.delete(:instance) || DEFAULT_INSTANCE).strip
     options[:schedule_type] = parameters['schedule_time'].present? ? "schedule" : "immediately"
-    options[:schedule_time] = parameters['schedule_time'] if parameters['schedule_time']
+    options[:schedule_time] = parameters['schedule_time'].to_i.days.from_now if parameters['schedule_time']
 
     object_parameters = parse_out_objects(parameters)
     attrs = MiqRequestWorkflow.parse_ws_string(parameters)

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -54,27 +54,25 @@ describe AutomationRequest do
     end
 
     it "creates request with schedule" do
-      scheduling_time = (Time.now.utc + 2.days).change(:usec => 0)
-      @parameters['schedule_time'] = scheduling_time
+      @parameters['schedule_time'] = "10"
       ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
 
       expect(ar.options[:schedule_type]).to eq("schedule")
-      expect(ar.options[:schedule_time]).to eq(scheduling_time)
+      expect(ar.options[:schedule_time]).to be_within(1.second).of 10.days.from_now
     end
 
-    it 'doesnt downcase and stringify objects in the parameters hash' do
+    it 'does not downcase and stringify objects in the parameters hash' do
       @object_parameters = {'VmOrTemplate::vm' => 10, 'var2' => @ae_var2.to_s, 'var3' => @ae_var3.to_s}
       ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @object_parameters, {})
       expect(ar.options[:attrs]).to include("VmOrTemplate::vm" => 10, :var2 => @ae_var2.to_s)
     end
 
-    it "doesnt allow overriding userid who is NOT in the database" do
+    it "does not allow overriding userid who is NOT in the database" do
       user_name = 'oleg'
 
       expect do
         AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, "user_name" => user_name.to_s)
       end.to raise_error(ActiveRecord::RecordNotFound)
-
     end
 
     it "with requester string overriding userid who is in the database" do


### PR DESCRIPTION
Erps, dates should actually be dates for the request scheduling of ... dates ... to work. 

@miq-bot assign @jrafanie 
@miq-bot add_label bug, hammer/no

Yes, fine, I broke it here: https://github.com/ManageIQ/manageiq/pull/18741
It's for https://bugzilla.redhat.com/show_bug.cgi?id=1486765
