### PR TITLE
[V2V] Add retry in ConversionHost#get_conversion_state if data is blank

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -195,6 +195,7 @@ class ConversionHost < ApplicationRecord
 
     # For some reason Net::SFTP#download! will return a blank string in rare circumstances.
     if json_state.blank?
+      $log.warn("Conversion state data from file '#{path}' was blank, retrying.")
       sleep 1
       json_state = connect_ssh { |ssu| ssu.get_file(path, nil) }
     end


### PR DESCRIPTION
This solves an issue where  the `connect_ssh { |ssu| ssu.get_file(path, nil) }` code inside `ConversionHost#get_conversion_state` is inexplicably returning a blank string in rare cases. This causes the `JSON.parse` call to then bomb.

Originally I thought thought this would fix it: https://github.com/ManageIQ/manageiq-gems-pending/pull/437. But apparently that wasn't the only issue.

Ultimately that code is calling `Net::SFTP#download!`, part of the MiqSshUtil library, which you can see here:

https://github.com/ManageIQ/manageiq-gems-pending/blob/master/lib/gems/pending/util/MiqSshUtil.rb#L66-L73

There is nothing obviously wrong with that code that I can see, nor our wrapper. The state file definitely exists and contains valid json. A possible issue is that ruby's net-ssh channels are not thread safe, and we're hitting some sort of race condition in net-ssh. 

https://github.com/net-ssh/net-ssh/issues/302

Since jobs are threads (or are they processes?), this might be the cause, but I'm not sure how to test it. Local attempts to duplicate the issue using threads did not work for me.

Anyway, in testing with @istein, this code worked. I could see in the logs that in one case (out of 10), the first attempt returned a blank string, then the second attempt worked, and the migration succeeded.

Helps solve https://bugzilla.redhat.com/show_bug.cgi?id=1726439