### PR TITLE
Only call capture_infra_targets on InfraManagers

### DIFF
--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -141,7 +141,7 @@ module Metric::Targets
   def self.capture_targets(zone = nil, options = {})
     zone = MiqServer.my_server.zone if zone.nil?
     zone = Zone.find(zone) if zone.kind_of?(Integer)
-    capture_infra_targets(zone.ext_management_systems, options) + \
+    capture_infra_targets(zone.ems_infras, options) + \
       capture_cloud_targets(zone.ems_clouds, options) + \
       capture_container_targets(zone.ems_containers, options)
   end


### PR DESCRIPTION
Fix an bug where metrics capture on a NetworkProvider blows up if it
doesn't have a parent manager (e.g. Nuage).  NetworkManagers delegate
hosts to the parent cloud_manager and capture_infra_targets calls
ems.hosts.