### PR TITLE
Fix for Default service dialog values not included in EVM when 'refresh_dialog_fields' action invoked

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -86,13 +86,13 @@ class Dialog < ApplicationRecord
     end
   end
 
-  def load_values_into_fields(values, overwrite = true)
+  def load_values_into_fields(values, ignore_nils = true)
     values = values.with_indifferent_access
 
     dialog_field_hash.each_value do |field|
       field.dialog = self
       new_value = values[field.automate_key_name] || values[field.name] || values.dig("parameters", field.name)
-      new_value ||= field.value unless overwrite
+      new_value ||= field.value unless ignore_nils
 
       field.value = new_value
     end

--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -118,6 +118,14 @@ class Dialog < ApplicationRecord
     dialog_field_hash.each_value(&:initialize_value_context)
   end
 
+  def initialize_static_values
+    dialog_field_hash.each_value do |field|
+      field.dialog = self
+    end
+
+    dialog_field_hash.each_value(&:initialize_static_values)
+  end
+
   def init_fields_with_values_for_request(values)
     values = values.with_indifferent_access
 

--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -103,6 +103,12 @@ class DialogField < ApplicationRecord
     end
   end
 
+  def initialize_static_values
+    if @value.blank? && !dynamic
+      @value = default_value
+    end
+  end
+
   def initialize_with_given_value(given_value)
     self.default_value = given_value
   end

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -107,7 +107,10 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       elsif options[:provision_workflow] || options[:init_defaults]
         dialog.initialize_value_context(values)
         dialog.load_values_into_fields(values, false)
-      elsif options[:refresh] || options[:submit_workflow]
+      elsif options[:submit_workflow]
+        dialog.load_values_into_fields(values)
+      elsif options[:refresh]
+        dialog.initialize_static_values
         dialog.load_values_into_fields(values)
       elsif options[:reconfigure]
         dialog.initialize_with_given_values(values)

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -147,7 +147,7 @@ class ResourceActionWorkflow < MiqRequestWorkflow
       dialog.load_values_into_fields(values)
     elsif options[:refresh]
       dialog.initialize_static_values
-      dialog.load_values_into_fields(values)
+      dialog.load_values_into_fields(values, false)
     elsif options[:reconfigure]
       dialog.initialize_with_given_values(values)
     else

--- a/app/models/resource_action_workflow.rb
+++ b/app/models/resource_action_workflow.rb
@@ -93,34 +93,6 @@ class ResourceActionWorkflow < MiqRequestWorkflow
     }
   end
 
-  def load_dialog(resource_action, values, options)
-    if resource_action.nil?
-      resource_action = load_resource_action(values)
-      @settings[:resource_action_id] = resource_action.id if resource_action
-    end
-
-    dialog = resource_action.dialog if resource_action
-    if dialog
-      dialog.target_resource = @target
-      if options[:display_view_only]
-        dialog.init_fields_with_values_for_request(values)
-      elsif options[:provision_workflow] || options[:init_defaults]
-        dialog.initialize_value_context(values)
-        dialog.load_values_into_fields(values, false)
-      elsif options[:submit_workflow]
-        dialog.load_values_into_fields(values)
-      elsif options[:refresh]
-        dialog.initialize_static_values
-        dialog.load_values_into_fields(values)
-      elsif options[:reconfigure]
-        dialog.initialize_with_given_values(values)
-      else
-        dialog.initialize_value_context(values)
-      end
-    end
-    dialog
-  end
-
   def init_field_hash
     @dialog.dialog_fields.each_with_object({}) { |df, result| result[df.name] = df }
   end
@@ -150,6 +122,38 @@ class ResourceActionWorkflow < MiqRequestWorkflow
   end
 
   private
+
+  def load_dialog(resource_action, values, options)
+    if resource_action.nil?
+      resource_action = load_resource_action(values)
+      @settings[:resource_action_id] = resource_action.id if resource_action
+    end
+
+    dialog = resource_action.dialog if resource_action
+    load_proper_dialog_values(dialog, options, values) if dialog
+
+    dialog
+  end
+
+  def load_proper_dialog_values(dialog, options, values)
+    dialog.target_resource = @target
+
+    if options[:display_view_only]
+      dialog.init_fields_with_values_for_request(values)
+    elsif options[:provision_workflow] || options[:init_defaults]
+      dialog.initialize_value_context(values)
+      dialog.load_values_into_fields(values, false)
+    elsif options[:submit_workflow]
+      dialog.load_values_into_fields(values)
+    elsif options[:refresh]
+      dialog.initialize_static_values
+      dialog.load_values_into_fields(values)
+    elsif options[:reconfigure]
+      dialog.initialize_with_given_values(values)
+    else
+      dialog.initialize_value_context(values)
+    end
+  end
 
   def create_request?(values)
     ra = load_resource_action(values)

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -168,24 +168,11 @@ describe DialogField do
 
     context "when the field is dynamic" do
       let(:dynamic) { true }
+      let(:value) { "value" }
 
-      context "when the value is blank" do
-        let(:value) { "" }
-        let(:automate_value) { "some value from automate" }
-
-        it "does not set the value to the automate value" do
-          field.initialize_static_values
-          expect(field.instance_variable_get(:@value)).to eq("")
-        end
-      end
-
-      context "when the value is not blank" do
-        let(:value) { "not blank" }
-
-        it "does not set the value to the automate value" do
-          field.initialize_static_values
-          expect(field.instance_variable_get(:@value)).to eq("not blank")
-        end
+      it "does not change the value" do
+        field.initialize_static_values
+        expect(field.instance_variable_get(:@value)).to eq("value")
       end
     end
 

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -162,6 +162,58 @@ describe DialogField do
     end
   end
 
+  describe "#initialize_static_values" do
+    let(:field) { described_class.new(:dynamic => dynamic, :value => value) }
+    let(:field_with_default) { described_class.new(:dynamic => dynamic, :value => value, :default_value => "test") }
+
+    context "when the field is dynamic" do
+      let(:dynamic) { true }
+
+      context "when the value is blank" do
+        let(:value) { "" }
+        let(:automate_value) { "some value from automate" }
+
+        it "does not set the value to the automate value" do
+          field.initialize_static_values
+          expect(field.instance_variable_get(:@value)).to eq("")
+        end
+      end
+
+      context "when the value is not blank" do
+        let(:value) { "not blank" }
+
+        it "does not set the value to the automate value" do
+          field.initialize_static_values
+          expect(field.instance_variable_get(:@value)).to eq("not blank")
+        end
+      end
+    end
+
+    context "when the field is not dynamic" do
+      let(:dynamic) { false }
+
+      context "with a user-adjusted value" do
+        let(:value) { "not dynamic" }
+
+        it "does not adjust the value" do
+          field.initialize_static_values
+          expect(field.instance_variable_get(:@value)).to eq("not dynamic")
+        end
+      end
+
+      context "without a user-adjusted value" do
+        context "with a default value" do
+          let(:value) { nil }
+
+          it "does adjust the value" do
+            field_with_default.initialize_static_values
+            expect(field_with_default.instance_variable_get(:@value)).to eq("test")
+          end
+        end
+      end
+    end
+  end
+
   describe "#initialize_with_given_value" do
     let(:field) { described_class.new(:default_value => "not the given value") }
 

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -520,16 +520,16 @@ describe Dialog do
       let(:dialog_group) { DialogGroup.new(:dialog_fields => [dialog_field1, dialog_field2]) }
       let(:dialog_field2) { DialogField.new(:value => "321", :name => "field2") }
 
-      context "when overwrite is true" do
-        it "sets nil values" do
+      context "when ignore_nils is true" do
+        it "accepts nil values as a value" do
           vars = {:field1 => "10.8.99.248"}
           dialog.load_values_into_fields(vars)
           expect(dialog_field2.value).to eq(nil)
         end
       end
 
-      context "when overwrite is false" do
-        it "does not set nil values" do
+      context "when ignore_nils is false" do
+        it "does not set values to nil" do
           vars = {:field1 => "10.8.99.248"}
           dialog.load_values_into_fields(vars, false)
           expect(dialog_field2.value).to eq("321")

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -59,6 +59,30 @@ describe Dialog do
     end
   end
 
+  describe "#initialize_static_values" do
+    let(:dialog) { described_class.new }
+    let(:field1) { DialogField.new(:name => "name1") }
+    let(:field2) { DialogField.new(:name => "name2") }
+
+    before do
+      allow(dialog).to receive(:dialog_fields).and_return([field1, field2])
+      allow(field1).to receive(:initialize_static_values)
+      allow(field2).to receive(:initialize_static_values)
+    end
+
+    it "sets the current dialog to each field" do
+      dialog.initialize_static_values
+      expect(field1.dialog).to eq(dialog)
+      expect(field2.dialog).to eq(dialog)
+    end
+
+    it "calls initialize_static_values on each field" do
+      expect(field1).to receive(:initialize_static_values)
+      expect(field2).to receive(:initialize_static_values)
+      dialog.initialize_static_values
+    end
+  end
+
   describe "#content" do
     it "returns the serialized content" do
       dialog = FactoryBot.create(:dialog, :description => "foo", :label => "bar")

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -242,13 +242,9 @@ describe ResourceActionWorkflow do
     context "when the options are set to a refresh request" do
       let(:options) { {:refresh => true} }
 
-      it "initializes the static values" do
-        expect(dialog).to receive(:initialize_static_values)
-        ResourceActionWorkflow.new(values, nil, resource_action, options)
-      end
-
-      it "loads the values into fields" do
-        expect(dialog).to receive(:load_values_into_fields).with(values)
+      it "initializes the static values and then loads the values into fields" do
+        expect(dialog).to receive(:initialize_static_values).ordered
+        expect(dialog).to receive(:load_values_into_fields).with(values, false).ordered
         ResourceActionWorkflow.new(values, nil, resource_action, options)
       end
     end

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -241,6 +241,11 @@ describe ResourceActionWorkflow do
     context "when the options are set to a refresh request" do
       let(:options) { {:refresh => true} }
 
+      it "initializes the static values" do
+        expect(dialog).to receive(:initialize_static_values)
+        ResourceActionWorkflow.new(values, nil, resource_action, options)
+      end
+
       it "loads the values into fields" do
         expect(dialog).to receive(:load_values_into_fields).with(values)
         ResourceActionWorkflow.new(values, nil, resource_action, options)

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -215,6 +215,7 @@ describe ResourceActionWorkflow do
       allow(ResourceAction).to receive(:find).and_return(resource_action)
       allow(dialog).to receive(:load_values_into_fields).with(values)
       allow(dialog).to receive(:initialize_value_context).with(values)
+      allow(dialog).to receive(:initialize_static_values)
       allow(dialog).to receive(:init_fields_with_values_for_request).with(values)
       allow(dialog).to receive(:target_resource=)
     end


### PR DESCRIPTION
When calling the API directly, the `refresh` option gets set to true, and ends up making a call to `load_values_into_fields`. This is fine if the API call provides the values that the field should be refreshed with, but without the values, customer was running into an issue where they had a few fields that were static and not visible to the user (so therefore just automatically filled in and ready to go) that they did not pass in to the API call in 5.9.6.5. On updating to 5.10.6.1, I believe that https://github.com/ManageIQ/manageiq/pull/17329 made the change to attempt to eliminate automate calls that were happening when calling refresh that didn't need to happen, but also this eliminated the "call" to get the static field values. Again, this is fine if the API call provides these static values in the POST request (which is what the UI does), but direct use of the API does not necessarily inform the user that they should do that.

For @tinaafitz and @gtanzillo (and anyone else) to review: it should be easier to track the "main" change if you go commit by commit, since the first commit contains the "meat" of the change, the second commit just moves the `#load_dialog` method into the `private` namespace since it's not used elsewhere and separates out the block of if/else logic into another method.

@miq-bot add_reviewer @tinaafitz
@miq-bot add_reviewer @gtanzillo 
@miq-bot add_label bug

@tinaafitz My apologies but I've been out of the cloudforms loop for a bit, so please add any other labels `hammer/yes`, `hammer/no` (?) that this might need.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1730813