### PR TITLE
Tool for exporting and importing schedules

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,5 +1,7 @@
 class Authentication < ApplicationRecord
   acts_as_miq_taggable
+  include_concern 'ImportExport'
+  include YAMLImportExportMixin
 
   include NewWithTypeStiMixin
   def self.new(*args, &block)

--- a/app/models/authentication/import_export.rb
+++ b/app/models/authentication/import_export.rb
@@ -1,0 +1,11 @@
+module Authentication::ImportExport
+  extend ActiveSupport::Concern
+
+  def export_to_array
+    export_attributes = attributes.except('id', 'created_on', 'updated_on', 'resource_id', 'resource_type', 'credentials_changed_on', 'last_invalid_on', 'status', 'status_details', 'password')
+    export_attributes['miq_group_description'] = MiqGroup.find(export_attributes['miq_group_id'])&.description
+    export_attributes['tenant_name'] = Tenant.find(export_attributes['tenant_id'])&.name
+
+    [self.class.to_s => export_attributes]
+  end
+end

--- a/app/models/file_depot.rb
+++ b/app/models/file_depot.rb
@@ -1,6 +1,9 @@
 class FileDepot < ApplicationRecord
   include NewWithTypeStiMixin
   include AuthenticationMixin
+  include_concern 'ImportExport'
+  include YAMLImportExportMixin
+
   has_many              :miq_schedules, :dependent => :nullify
   has_many              :miq_servers,   :dependent => :nullify, :foreign_key => :log_file_depot_id
   has_many              :log_files

--- a/app/models/file_depot/import_export.rb
+++ b/app/models/file_depot/import_export.rb
@@ -1,0 +1,9 @@
+module FileDepot::ImportExport
+  extend ActiveSupport::Concern
+
+  def export_to_array
+    export_attributes = attributes.except('id', 'created_at', 'updated_at')
+    export_attributes['AuthenticationsContent'] = authentications.map(&:export_to_array)
+    [self.class.to_s => export_attributes]
+  end
+end

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -1,5 +1,7 @@
 class MiqSchedule < ApplicationRecord
   include DeprecationMixin
+  include_concern 'ImportExport'
+  include YAMLImportExportMixin
   deprecate_attribute :towhat, :resource_type
 
   validates :name, :uniqueness => {:scope => [:userid, :resource_type]}
@@ -38,6 +40,7 @@ class MiqSchedule < ApplicationRecord
   SYSTEM_SCHEDULE_CLASSES = %w(MiqReport MiqAlert MiqWidget).freeze
   VALID_INTERVAL_UNITS = %w(minutely hourly daily weekly monthly once).freeze
   ALLOWED_CLASS_METHOD_ACTIONS = %w(db_backup db_gc automation_request).freeze
+  IMPORT_CLASS_NAMES = %w[MiqSchedule].freeze
 
   default_value_for :userid,  "system"
   default_value_for :enabled, true

--- a/app/models/miq_schedule/import_export.rb
+++ b/app/models/miq_schedule/import_export.rb
@@ -1,0 +1,139 @@
+module MiqSchedule::ImportExport
+  extend ActiveSupport::Concern
+
+  SKIPPED_ATTRIBUTES = %w[id created_on updated_at last_run_on zone_id].freeze
+
+  def handle_attributes_for_miq_report(export_attributes)
+    export_attributes['sched_action'][:options][:miq_group_description] = MiqGroup.find(export_attributes['sched_action'][:options][:miq_group_id])&.description
+    export_attributes
+  end
+
+  def handle_attributes(export_attributes)
+    if export_attributes['resource_type'] == 'MiqReport' || export_attributes['resource_type'] == 'MiqWidget'
+      filter_record_id = export_attributes['filter'].exp["="]["value"]
+      resource = export_attributes["resource_type"].safe_constantize.find(filter_record_id)
+      export_attributes["filter_resource_name"] = export_attributes["resource_type"] == "MiqReport" ? resource.name : resource.description
+    elsif export_attributes["filter"]&.kind_of?(MiqExpression)
+      export_attributes['filter'] = MiqExpression.new(export_attributes['filter'].exp)
+    end
+
+    export_attributes['MiqSearchContent'] = MiqSearch.find(export_attributes['miq_search_id']).export_to_array if export_attributes['miq_search_id']
+
+    export_attributes['FileDepotContent'] = FileDepot.find(export_attributes['file_depot_id']).export_to_array if export_attributes['file_depot_id']
+
+    if export_attributes['resource_id']
+      schedule_resource = export_attributes["resource_type"].safe_constantize.find(export_attributes['resource_id'])
+      export_attributes['resource_name'] = schedule_resource&.name
+    end
+
+    export_attributes
+  end
+
+  def export_to_array
+    export_attributes = attributes.except(*SKIPPED_ATTRIBUTES)
+    export_attributes['filter'] = MiqExpression.new(export_attributes["filter"].exp) if export_attributes["filter"]&.kind_of?(MiqExpression)
+    export_attributes =
+      case export_attributes['resource_type']
+      when "MiqReport"
+        handle_attributes_for_miq_report(export_attributes)
+      else
+        export_attributes
+      end
+
+    export_attributes = handle_attributes(export_attributes)
+
+    [{self.class.to_s => export_attributes}]
+  end
+
+  module ClassMethods
+    def handle_miq_report_attributes_for_import(miq_schedule)
+      group_description = miq_schedule['sched_action'][:options].delete(:miq_group_description)
+      raise "Group description is empty from importing schedule" unless group_description
+
+      miq_group = MiqGroup.find_by(:description => group_description)
+      raise "Unable to find group #{group_description}" unless miq_group
+
+      miq_schedule['sched_action'][:options][:miq_group_id] = miq_group.id
+      miq_schedule
+    end
+
+    def import_from_hash(miq_schedule, _options = nil)
+      miq_schedule = handle_miq_report_attributes_for_import(miq_schedule) if miq_schedule["resource_type"] == "MiqReport"
+
+      unless miq_schedule['userid'] == 'admin' || miq_schedule['userid'] == 'system'
+        miq_schedule['userid'] = User.find_by(:id => report["userid"])
+      end
+
+      miq_schedule["name"] = miq_schedule["name"] + "EUEUE"
+      new_or_existing_schedule = MiqSchedule.where(:name => miq_schedule["name"], :resource_type => miq_schedule["resource_type"]).first_or_initialize
+
+      filter_resource_name = miq_schedule.delete("filter_resource_name")
+
+      miq_search = miq_schedule.delete("MiqSearchContent")
+      file_depot = miq_schedule.delete("FileDepotContent")
+      resource_name = miq_schedule.delete("resource_name")
+
+      was_new_record = new_or_existing_schedule.new_record?
+      new_or_existing_schedule.update(miq_schedule)
+
+      if new_or_existing_schedule
+        filter =
+          if miq_schedule["resource_type"] == "MiqReport" || miq_schedule["resource_type"] == "MiqWidget"
+            resource = miq_schedule["resource_type"].safe_constantize.find_by(:name => filter_resource_name)
+            raise "Unable to find  #{filter_resource_name}" unless resource
+
+            MiqExpression.new("=" => {"field" => "#{miq_schedule["resource_type"]}-id", "value" => resource.id})
+          else
+            miq_schedule['filter']
+          end
+
+        schedule_attributes = {:filter => filter}
+
+        if miq_search
+          search = MiqSearch.where(miq_search[0]['MiqSearch']).first_or_create
+          schedule_attributes[:miq_search_id] = search.id
+        end
+
+        if file_depot
+          authentication_content = file_depot[0].values[0].delete("AuthenticationsContent")
+          fd = FileDepot.where(file_depot[0].values[0]).first_or_create
+
+          authentication_content[0].each do |auth|
+            x = auth.values[0]
+            x['resource'] = fd
+
+            group_description = x.delete('miq_group_description')
+            miq_group = MiqGroup.find_by(:description => group_description) || User.find_by(:userid=>'admin').current_group
+            x['miq_group_id'] = miq_group.id
+
+            tenant_name = x.delete('tenant_name')
+            tenant = Tenant.find_by(:name => tenant_name) || Tenant.tenant_root
+            x['tenant_id'] = tenant.id
+
+            Authentication.where(x).first_or_create
+          end
+          new_or_existing_schedule.file_depot_id = fd.id
+        end
+
+        if resource_name
+          schedule_resource = miq_schedule["resource_type"].safe_constantize.find_by(:name => resource_name)
+          schedule_attributes['resource_id'] = schedule_resource.id if schedule_resource
+        end
+
+        new_or_existing_schedule.update(schedule_attributes)
+      end
+
+      status = :add
+      message = "Imported #{miq_schedule["resource_type"]} Schedule: [#{new_or_existing_schedule["name"]}]"
+      if new_or_existing_schedule.errors.messages.present?
+        status = :error
+        message = new_or_existing_schedule.errors.full_messages.join(', ')
+      elsif !was_new_record
+        status = :update
+        message = "Updated #{miq_schedule["resource_type"]} Schedule: [#{new_or_existing_schedule["name"]}]"
+      end
+
+      return new_or_existing_schedule, {:message => message, :level => :info, :status => status}
+    end
+  end
+end

--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -1,6 +1,8 @@
 class MiqSearch < ApplicationRecord
   serialize :options
   serialize :filter
+  include_concern 'ImportExport'
+  include YAMLImportExportMixin
 
   validates_uniqueness_of :name, :scope => "db"
 

--- a/app/models/miq_search/import_export.rb
+++ b/app/models/miq_search/import_export.rb
@@ -1,0 +1,8 @@
+module MiqSearch::ImportExport
+  extend ActiveSupport::Concern
+
+  def export_to_array
+    export_attributes = attributes.except('id')
+    [self.class.to_s => export_attributes]
+  end
+end

--- a/tools/import_export_schedules.rb
+++ b/tools/import_export_schedules.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+require File.expand_path('../config/environment', __dir__)
+require 'optimist'
+
+options = Optimist.options do
+  opt :user, "userid", :short => "u", :default => "admin"
+  opt :output_dir, "Output directory", :short => "d", :default => "./"
+  opt :schedule, "Schedule name or id", :short => "s", :type => :string
+  opt :operation, "export or import", :short => "o", :default => "export"
+  opt :import_yaml, "imported yaml", :short => "y", :type => :io
+end
+
+def schedule_from_args(schedule)
+  if is_numeric?(schedule)
+    MiqSchedule.find_by(:id => schedule)
+  else
+    MiqSchedule.find_by(:name => schedule)
+  end
+end
+
+case options[:operation]
+when 'export'
+  schedule = schedule_from_args(options[:schedule])
+  Optimist.die "Schedule #{options[:schedule]} doesn't exist" if schedule.nil?
+
+  Optimist.die "Output dir #{options[:output_dir]} doesn't exist" unless File.directory?(options[:output_dir])
+
+  exported_yaml = MiqSchedule.export_to_yaml([schedule], MiqSchedule)
+
+  output_path = File.join(options[:output_dir], "#{schedule.resource_type}_#{Time.now.to_i}.yaml")
+  puts "Schedule #{schedule.name} exported to #{output_path}"
+  File.write(output_path, exported_yaml)
+when 'import'
+  result = MiqSchedule.import(options[:import_yaml])
+  puts result.second[0][:message]
+end


### PR DESCRIPTION
**Usage:**

```
./tools/import_export_schedules.rb -h
Options:
  -u, --user=<s>                      userid (default: admin)
  -d, --output-dir=<s>                Output directory (default: ./)
  -s, --schedule=<s>                  Schedule name or id
  -o, --operation=<s>                 export or import (default: export)
  -y, --import-yaml=<filename/uri>    imported yaml
  -h, --help                          Show this message

Example:
Import:
./tools/import_export_schedules.rb -o import -y ./ServiceTemplate_1563538569.yaml

Export:
./tools/import_export_schedules.rb -s 158
```
**Type of schedules:**

- MiqReport, MiqWidget
- SmartState
- DatabaseBackup
- AutomationTask
- ServiceTemplate
- Generally should work for all types and especially between replicated databases.


# Links
https://bugzilla.redhat.com/show_bug.cgi?id=1560090