### PR TITLE
Remove the worker restart_interval

### DIFF
--- a/app/models/miq_server/worker_management/monitor/settings.rb
+++ b/app/models/miq_server/worker_management/monitor/settings.rb
@@ -43,10 +43,6 @@ module MiqServer::WorkerManagement::Monitor::Settings
     heartbeat_timeout
   end
 
-  def get_restart_interval(worker)
-    @child_worker_settings[worker.class.settings_name][:restart_interval]
-  end
-
   def get_memory_threshold(worker)
     @child_worker_settings[worker.class.settings_name][:memory_threshold]
   end

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -3,7 +3,6 @@ module MiqServer::WorkerManagement::Monitor::Validation
 
   def validate_worker(w)
     time_threshold   = get_time_threshold(w)
-    restart_interval = get_restart_interval(w)
     memory_threshold = get_memory_threshold(w)
 
     w.validate_active_messages
@@ -38,14 +37,6 @@ module MiqServer::WorkerManagement::Monitor::Validation
       return false
     end
 
-    if time_interval_reached?(w.started_on, restart_interval)
-      msg = "#{w.format_full_log_msg} uptime has reached the interval of #{restart_interval} seconds, requesting worker to exit"
-      _log.info(msg)
-      MiqEvent.raise_evm_event_queue(w.miq_server, "evm_worker_uptime_exceeded", :event_details => msg, :type => w.class.name)
-      restart_worker(w)
-      return false
-    end
-
     true
   end
 
@@ -66,13 +57,6 @@ module MiqServer::WorkerManagement::Monitor::Validation
   end
 
   private
-
-  def time_interval_reached?(started_on, interval)
-    return false if started_on.nil?
-    return false unless interval.kind_of?(Numeric)
-    return false unless interval > 0
-    interval.seconds.ago.utc > started_on
-  end
 
   def usage_exceeds_threshold?(usage, threshold)
     return false unless usage.kind_of?(Numeric)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1123,7 +1123,6 @@
       :poll: 3.seconds
       :poll_escalate_max: 30.seconds
       :poll_method: :normal
-      :restart_interval: 0.hours
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
       :systemd_enabled: false
@@ -1181,7 +1180,6 @@
           :poll: 10.seconds
           :poll_method: :normal
           :queue_timeout: 120.minutes
-          :restart_interval: 2.hours
           :dequeue_method: :sql
         :ems_refresh_worker_ansible_tower_automation: {}
         :ems_refresh_worker_foreman_configuration: {}
@@ -1209,7 +1207,6 @@
         :count: 2
         :memory_threshold: 2.gigabytes
         :queue_timeout: 20.minutes
-        :restart_interval: 6.hours
         :heartbeat_thread_shutdown_timeout: 10.seconds
     :schedule_worker:
       :container_entities_purge_interval: 1.day

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -4,7 +4,6 @@ describe "MiqWorker Monitor" do
       allow(MiqWorker).to receive(:nice_increment).and_return("+10")
       allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(120)
       allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(100.megabytes)
-      allow_any_instance_of(MiqServer).to receive(:get_restart_interval).and_return(0)
 
       @miq_server = EvmSpecHelper.local_miq_server
     end
@@ -207,7 +206,6 @@ describe "MiqWorker Monitor" do
           @worker1 = FactoryBot.create(:miq_worker, :miq_server_id => @miq_server.id, :pid => 42, :type => 'MiqGenericWorker')
           allow_any_instance_of(MiqServer).to receive(:get_time_threshold).and_return(2.minutes)
           allow_any_instance_of(MiqServer).to receive(:get_memory_threshold).and_return(500.megabytes)
-          allow_any_instance_of(MiqServer).to receive(:get_restart_interval).and_return(0.hours)
           @miq_server.setup_drb_variables
           @miq_server.worker_add(@worker1.pid)
         end
@@ -329,7 +327,6 @@ describe "MiqWorker Monitor" do
         before do
           allow(server).to receive(:get_time_threshold).and_return(2.minutes)
           allow(server).to receive(:get_memory_threshold).and_return(500.megabytes)
-          allow(server).to receive(:get_restart_interval).and_return(0.hours)
           server.setup_drb_variables
         end
 


### PR DESCRIPTION
We already have memory limits to prevent workers from growing out of
control so the pre-emptive restart_interval is at best overkill.

The restart interval also causes issues with queueing full refreshes on
refresh_worker startup.  To prevent too many full refreshes we don't run
a full on VMware RefreshWorker start, but this causes other issues in
that when a second EMS is added it doesn't actually do a full refresh
and you have to do it manually.

Also all of our limit checks are supported by systemd except this one.