### PR TITLE
Use escalate privilege setting in ansible services and automate methods

### DIFF
--- a/app/models/manageiq/providers/ansible_playbook_workflow.rb
+++ b/app/models/manageiq/providers/ansible_playbook_workflow.rb
@@ -1,14 +1,15 @@
 class ManageIQ::Providers::AnsiblePlaybookWorkflow < ManageIQ::Providers::AnsibleRunnerWorkflow
-  def self.job_options(env_vars, extra_vars, playbook_options, timeout, poll_interval, hosts, credentials, verbosity)
+  def self.job_options(env_vars, extra_vars, playbook_options, timeout, poll_interval, hosts, credentials, verbosity, become_enabled)
     {
-      :credentials   => credentials,
-      :env_vars      => env_vars,
-      :extra_vars    => extra_vars,
-      :hosts         => hosts,
-      :playbook_path => playbook_options[:playbook_path],
-      :timeout       => timeout,
-      :poll_interval => poll_interval,
-      :verbosity     => verbosity
+      :become_enabled => become_enabled,
+      :credentials    => credentials,
+      :env_vars       => env_vars,
+      :extra_vars     => extra_vars,
+      :hosts          => hosts,
+      :playbook_path  => playbook_options[:playbook_path],
+      :timeout        => timeout,
+      :poll_interval  => poll_interval,
+      :verbosity      => verbosity
     }
   end
 
@@ -18,9 +19,10 @@ class ManageIQ::Providers::AnsiblePlaybookWorkflow < ManageIQ::Providers::Ansibl
   end
 
   def run_playbook
-    credentials, env_vars, extra_vars, hosts, playbook_path, verbosity = options.values_at(:credentials, :env_vars, :extra_vars, :hosts, :playbook_path, :verbosity)
+    env_vars, extra_vars, playbook_path = options.values_at(:env_vars, :extra_vars, :playbook_path)
+    kwargs = options.slice(:credentials, :hosts, :verbosity, :become_enabled)
 
-    response = Ansible::Runner.run_async(env_vars, extra_vars, playbook_path, :hosts => hosts, :credentials => credentials, :verbosity => verbosity)
+    response = Ansible::Runner.run_async(env_vars, extra_vars, playbook_path, kwargs)
     if response.nil?
       queue_signal(:abort, "Failed to run ansible playbook", "error")
     else

--- a/app/models/manageiq/providers/ansible_role_workflow.rb
+++ b/app/models/manageiq/providers/ansible_role_workflow.rb
@@ -1,6 +1,7 @@
 class ManageIQ::Providers::AnsibleRoleWorkflow < ManageIQ::Providers::AnsibleRunnerWorkflow
-  def self.job_options(env_vars, extra_vars, role_options, timeout, poll_interval, hosts, credentials, verbosity)
+  def self.job_options(env_vars, extra_vars, role_options, timeout, poll_interval, hosts, credentials, verbosity, become_enabled)
     {
+      :become_enabled  => become_enabled,
       :credentials     => credentials,
       :env_vars        => env_vars,
       :extra_vars      => extra_vars,

--- a/app/models/manageiq/providers/ansible_runner_workflow.rb
+++ b/app/models/manageiq/providers/ansible_runner_workflow.rb
@@ -1,9 +1,9 @@
 class ManageIQ::Providers::AnsibleRunnerWorkflow < Job
   def self.create_job(env_vars, extra_vars, role_or_playbook_options,
                       hosts = ["localhost"], credentials = [],
-                      timeout: 1.hour, poll_interval: 1.second, verbosity: 0)
+                      timeout: 1.hour, poll_interval: 1.second, verbosity: 0, become_enabled: false)
     options = job_options(env_vars, extra_vars, role_or_playbook_options, timeout,
-                          poll_interval, hosts, credentials, verbosity)
+                          poll_interval, hosts, credentials, verbosity, become_enabled)
     super(name, options)
   end
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
@@ -34,7 +34,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     playbook_vars = { :playbook_path => parent.path }
     credentials   = collect_credentials(vars)
 
-    kwargs = {}
+    kwargs = {:become_enabled => vars[:become_enabled]}
     kwargs[:timeout]   = vars[:execution_ttl].to_i.minutes if vars[:execution_ttl].present?
     kwargs[:verbosity] = vars[:verbosity].to_i             if vars[:verbosity].present?
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -45,6 +45,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
   end
 
   LAUNCH_OPTIONS_KEYS = %i[
+    become_enabled
     cloud_credential_id
     credential_id
     extra_vars

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -87,6 +87,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   CONFIG_OPTIONS_WHITELIST = %i[
+    become_enabled
     cloud_credential_id
     credential_id
     execution_ttl

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -20,17 +20,14 @@ module Ansible
       private
 
       def become_args
-        return {} if auth.become_username.blank?
-
         {
-          :become        => nil,
           :become_user   => auth.become_username,
           :become_method => auth.options.try(:[], :become_method) || "sudo"
-        }
+        }.delete_blanks
       end
 
-      SSH_KEY        = "^SSH [pP]assword:".freeze
-      BECOME_KEY     = "^BECOME [pP]assword:".freeze
+      SSH_KEY        = "^SSH [pP]assword".freeze
+      BECOME_KEY     = "^BECOME [pP]assword".freeze
       SSH_UNLOCK_KEY = "^Enter passphrase for [a-zA-Z0-9\-\/]+\/ssh_key_data:".freeze
       def write_password_file
         password_hash                 = initialize_password_data

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Ansible::Runner::MachineCredential do
       it "is correct with all attributes" do
         expected = {
           :ask_pass      => nil,
-          :become        => nil,
           :become_user   => "root",
           :become_method => "su",
           :user          => "manageiq"
@@ -46,16 +45,10 @@ RSpec.describe Ansible::Runner::MachineCredential do
 
         expected = {
           :ask_pass      => nil,
-          :become        => nil,
           :become_user   => "root",
           :become_method => "su"
         }
         expect(cred.command_line).to eq(expected)
-      end
-
-      it "doesn't send the become keys if :become_user is not set" do
-        auth.update!(:become_username => nil)
-        expect(cred.command_line).to eq(:ask_pass => nil, :user => "manageiq")
       end
     end
 
@@ -79,8 +72,8 @@ RSpec.describe Ansible::Runner::MachineCredential do
         cred.write_config_files
 
         expect(password_hash).to eq(
-          "^SSH [pP]assword:"                                     => "secret",
-          "^BECOME [pP]assword:"                                  => "othersecret",
+          "^SSH [pP]assword"                                      => "secret",
+          "^BECOME [pP]assword"                                   => "othersecret",
           "^Enter passphrase for [a-zA-Z0-9\-\/]+\/ssh_key_data:" => "keypass"
         )
 
@@ -99,7 +92,7 @@ RSpec.describe Ansible::Runner::MachineCredential do
 
         cred.write_config_files
 
-        expect(password_hash["^SSH [pP]assword:"]).to eq(password)
+        expect(password_hash["^SSH [pP]assword"]).to eq(password)
       end
 
       context "with an existing password_file" do
@@ -112,8 +105,8 @@ RSpec.describe Ansible::Runner::MachineCredential do
         it "clobbers existing ssh key unlock keys" do
           existing_data = { ssh_unlock_key => "hunter2" }
           expected_data = {
-            "^SSH [pP]assword:"    => "secret",
-            "^BECOME [pP]assword:" => "othersecret",
+            "^SSH [pP]assword"    => "secret",
+            "^BECOME [pP]assword" => "othersecret",
             ssh_unlock_key         => "keypass"
           }
           existing_env_password_file(existing_data)
@@ -126,8 +119,8 @@ RSpec.describe Ansible::Runner::MachineCredential do
           auth.update!(:auth_key_password => nil)
           existing_data = { ssh_unlock_key => "hunter2" }
           added_data    = {
-            "^SSH [pP]assword:"    => "secret",
-            "^BECOME [pP]assword:" => "othersecret"
+            "^SSH [pP]assword"    => "secret",
+            "^BECOME [pP]assword" => "othersecret"
           }
           existing_env_password_file(existing_data)
           cred.write_config_files

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -70,6 +70,19 @@ describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :verbosity => 6)
     end
 
+    it "calls run with become options" do
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+
+        _method, dir, _json, _args = options[:params]
+        cmdline = File.read(File.join(dir, "env", "cmdline"))
+
+        expect(cmdline).to eq("--become --ask-become-pass")
+      end.and_return(result)
+
+      described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
+    end
+
     context "with special characters" do
       let(:env_vars)   { {"ENV1" => "pa$%w0rd!'"} }
       let(:extra_vars) { {"name" => "john's server"} }

--- a/spec/models/manageiq/providers/ansible_playbook_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ansible_playbook_workflow_spec.rb
@@ -95,9 +95,10 @@ describe ManageIQ::Providers::AnsiblePlaybookWorkflow do
         %w[arg1 arg2],
         "/path/to/playbook",
         {
-          :hosts       => %w[192.0.2.0 192.0.2.1],
-          :credentials => [],
-          :verbosity   => 3
+          :become_enabled => false,
+          :hosts          => %w[192.0.2.0 192.0.2.1],
+          :credentials    => [],
+          :verbosity      => 3
         }
       ]
 

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -70,6 +70,13 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:verbosity]).to eq(5)
     end
+
+    it "passes become_enabled to the job when specified" do
+      job = manager.configuration_scripts.first.run(:become_enabled => true)
+
+      expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
+      expect(job.options[:become_enabled]).to eq(true)
+    end
   end
 
   context "#merge_extra_vars" do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner_spec.rb
@@ -83,10 +83,10 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner
     end
 
     context 'with launch options' do
-      let(:options) { {:job_template_ref => 'jt1', :extra_vars => {:thing => "stuff"}, :verbosity => "4"} }
+      let(:options) { {:job_template_ref => 'jt1', :extra_vars => {:thing => "stuff"}, :verbosity => "4", :become_enabled => true} }
       it 'passes them to the job' do
         expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job)
-          .with(an_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript), :hosts => ["localhost"], :extra_vars => {:thing => "stuff"}, :verbosity => "4")
+          .with(an_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript), :hosts => ["localhost"], :extra_vars => {:thing => "stuff"}, :verbosity => "4", :become_enabled => true)
           .and_return(double(:id => 'jb1'))
         expect(subject).to receive(:queue_signal)
         subject.launch_ansible_tower_job

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -50,6 +50,7 @@ describe(ServiceAnsiblePlaybook) do
           :playbook_id         => 10,
           :execution_ttl       => "5",
           :verbosity           => "3",
+          :become_enabled      => true,
           :extra_vars          => {
             "var1" => {:default => "default_val1"},
             :var2  => {:default => "default_val2"},
@@ -126,7 +127,8 @@ describe(ServiceAnsiblePlaybook) do
           :credential       => credential_0.native_ref,
           :vault_credential => credential_3.native_ref,
           :execution_ttl    => "5",
-          :verbosity        => "3"
+          :verbosity        => "3",
+          :become_enabled   => true
         )
       end
     end
@@ -141,6 +143,7 @@ describe(ServiceAnsiblePlaybook) do
           :vault_credential => credential_3.native_ref,
           :execution_ttl    => "5",
           :verbosity        => "3",
+          :become_enabled   => true,
           :extra_vars       => {
             'var1' => 'value1',
             'var2' => 'value2',
@@ -168,6 +171,7 @@ describe(ServiceAnsiblePlaybook) do
             :vault_credential => credential_3.native_ref,
             :execution_ttl    => "5",
             :verbosity        => "3",
+            :become_enabled   => true,
             :extra_vars       => {
               'var1' => 'default_val1',
               'var2' => 'default_val2',


### PR DESCRIPTION
This adds a new option for ansible runner for whether to attempt to escalate privileges during the playbook run.

A side-effect of this is that the credential no-longer determines whether the `--become` arg is passed in the command line hash rather it is only passed if ansible runner is given `:become_enabled == true`. The credentials will provide their privilege escalation passwords unconditionally.

The second commit passes the option from services and automate methods to the ansible runner invocation.