### PR TITLE
Replace embedded ansible git repos with GitRepository

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
   FRIENDLY_NAME = "Ansible Automation Inside Project".freeze
-  REPO_DIR      = Rails.root.join("tmp", "git_repos")
 
   validates :name,       :presence => true # TODO: unique within region?
   validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }
@@ -68,17 +67,13 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     queue("sync", [], "Synchronizing", auth_user)
   end
 
-  def path_to_playbook(playbook_name)
-    repo_dir.join(playbook_name)
-  end
-
-  private
-
   def playbooks_in_git_repository
-    git_repository.entries("").grep(/\.ya?ml$/)
+    git_repository.update_repo
+    git_repository.entries(scm_branch, "").grep(/\.ya?ml$/)
   end
 
-  def repo_dir
-    @repo_dir ||= REPO_DIR.join(id.to_s)
+  def checkout_git_repository(target_directory)
+    git_repository.update_repo
+    git_repository.checkout(scm_branch, target_directory)
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   default_value_for :scm_type,   "git"
   default_value_for :scm_branch, "master"
 
+  belongs_to :git_repository, :dependent => :destroy
+
   include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
 
   def self.display_name(number = 1)
@@ -34,15 +36,32 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   end
 
   def raw_delete_in_provider
-    transaction do
-      destroy!
-      remove_clone
+    destroy!
+  end
+
+  def git_repository
+    super || begin
+      transaction do
+        update!(:git_repository => GitRepository.create!(:url => scm_url))
+      end
+      super
     end
   end
 
   def sync
-    ensure_clone
-    sync_playbooks
+    transaction do
+      current = configuration_script_payloads.index_by(&:name)
+
+      playbooks_in_git_repository.each do |f|
+        found = current.delete(f) || self.class.parent::Playbook.new(:configuration_script_source_id => id)
+        found.update_attributes!(:name => f, :manager_id => manager_id)
+      end
+
+      current.values.each(&:destroy)
+
+      configuration_script_payloads.reload
+    end
+    true
   end
 
   def sync_queue(auth_user = nil)
@@ -55,70 +74,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
   private
 
-  def git(*params, chdir: true)
-    args = {:params => params, :chdir => repo_dir}
-    args.delete(:chdir) unless chdir
-    AwesomeSpawn.run!("git", args).tap do |result|
-      _log.debug(result.output)
-    end
-  end
-
-  def ensure_clone
-    _log.info("Ensuring presence of git repo #{scm_url.inspect}...")
-
-    if !repo_dir.exist?
-      _log.info("Cloning git repo #{scm_url.inspect}...")
-      git("clone", scm_url, repo_dir, :chdir => false)
-    else
-      _log.info("Fetching latest from #{scm_url.inspect}...")
-      git("remote", "set-url", "origin", scm_url) # In case the url has changed
-      git("fetch")
-    end
-
-    _log.info("Checking out #{scm_branch.inspect}...")
-    git("checkout", scm_branch)
-    git("reset", :hard, "origin/#{scm_branch}")
-
-    _log.info("Ensuring presence of git repo #{scm_url.inspect}...Complete")
-  end
-
-  def remove_clone
-    return unless repo_dir.exist?
-
-    dir = repo_dir.to_s
-    _log.info("Ensuring removal of git repo located at #{dir.inspect}...")
-    raise ArgumentError, "invalid repo dir #{dir.inspect}" unless dir.start_with?(REPO_DIR.to_s)
-
-    FileUtils.rm_rf(dir)
-    _log.info("Ensuring removal of git repo located at #{dir.inspect}...Complete")
-  end
-
-  def sync_playbooks
-    transaction do
-      current = configuration_script_payloads.index_by(&:name)
-
-      playbooks_in_repo_dir.each do |e|
-        found = current.delete(e[:name]) || self.class.parent::Playbook.new(:configuration_script_source_id => id)
-        found.update_attributes!(e)
-      end
-
-      current.values.each(&:destroy)
-
-      configuration_script_payloads.reload
-    end
-    true
-  end
-
-  def playbooks_in_repo_dir
-    Dir.glob(repo_dir.join("*.y{a,}ml")).collect do |file|
-      name = File.basename(file)
-      description = begin
-                      YAML.safe_load(File.read(file)).fetch_path(0, "name")
-                    rescue StandardError
-                      nil
-                    end
-      {:name => name, :description => description, :manager_id => manager_id}
-    end
+  def playbooks_in_git_repository
+    git_repository.entries("").grep(/\.ya?ml$/)
   end
 
   def repo_dir

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -1,10 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
 
-  def path
-    configuration_script_source.path_to_playbook(name)
-  end
-
   def run(options, userid = nil)
     options[:playbook_id] = id
     options[:userid]      = userid || 'system'

--- a/lib/git_worktree_exception.rb
+++ b/lib/git_worktree_exception.rb
@@ -12,5 +12,6 @@ module GitWorktreeException
   class DirectoryAlreadyExists < RuntimeError; end
   class BranchMissing < RuntimeError; end
   class TagMissing < RuntimeError; end
+  class RefMissing < RuntimeError; end
   class InvalidCredentials < RuntimeError; end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -27,7 +27,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
   # Below are `let` calls from there was well.
   #
 
-  let(:manager)      { manager_with_configuration_scripts }
+  let(:manager) { manager_with_configuration_scripts }
 
   it "belongs_to the manager" do
     expect(manager.configuration_scripts.size).to eq 1
@@ -36,43 +36,47 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
   end
 
   context "#run" do
+    let(:cs) { manager.configuration_scripts.first }
+
+    before do
+      expect(cs.parent.configuration_script_source).to receive(:checkout_git_repository)
+    end
+
     it "launches the referenced ansible job template" do
-      job = manager.configuration_scripts.first.run
+      job = cs.run
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:env_vars]).to eq({})
       expect(job.options[:extra_vars]).to eq(:instance_ids => ["i-3434"])
-      expect(job.options[:playbook_path]).to eq(playbook.path)
+      expect(File.basename(job.options[:playbook_path])).to eq(playbook.name)
       expect(job.options[:timeout]).to eq(1.hour)
       expect(job.options[:verbosity]).to eq(0)
     end
 
     it "accepts different variables to launch a job template against" do
-      added_extras = {:extra_vars => {:some_key => :some_value}}
-      job          = manager.configuration_scripts.first.run(added_extras)
+      job = cs.run(:extra_vars => {:some_key => :some_value})
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:env_vars]).to eq({})
       expect(job.options[:extra_vars]).to eq(:instance_ids => ["i-3434"], :some_key => :some_value)
-      expect(job.options[:playbook_path]).to eq(playbook.path)
     end
 
     it "passes execution_ttl to the job as its timeout" do
-      job = manager.configuration_scripts.first.run(:execution_ttl => "5")
+      job = cs.run(:execution_ttl => "5")
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:timeout]).to eq(5.minutes)
     end
 
     it "passes verbosity to the job when specified" do
-      job = manager.configuration_scripts.first.run(:verbosity => "5")
+      job = cs.run(:verbosity => "5")
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:verbosity]).to eq(5)
     end
 
     it "passes become_enabled to the job when specified" do
-      job = manager.configuration_scripts.first.run(:become_enabled => true)
+      job = cs.run(:become_enabled => true)
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:become_enabled]).to eq(true)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -9,6 +9,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
   context "when embedded_ansible role is enabled" do
     before do
       EvmSpecHelper.assign_embedded_ansible_role
+
+      allow_any_instance_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource).to receive(:checkout_git_repository)
     end
 
     let(:ansible_script_source) { FactoryBot.create(:embedded_ansible_configuration_script_source, :manager => manager) }

--- a/spec/models/manageiq/providers/embedded_ansible_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible_spec.rb
@@ -4,7 +4,7 @@ describe ManageIQ::Providers::EmbeddedAnsible do
     let(:manager)  { provider.automation_manager }
 
     let(:consolidated_repo_path) { Ansible::Content::PLUGIN_CONTENT_DIR }
-    let(:manager_repo_path)      { ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource::REPO_DIR }
+    let(:manager_repo_path)      { GitRepository::GIT_REPO_DIRECTORY }
 
     before do
       EvmSpecHelper.local_miq_server


### PR DESCRIPTION
@carbonin @NickLaMuro  Please review

Some "known" issues for future PRs:
- GitRepository's clone is not process-safe.  We need to add a clone lock around the Dir.exists? call and the actual clone.
- This does not yet use the SCM credentials.  SCM credentials are tied to a ConfigurationScriptSource, but GitRepository is expected to own it's *own* credentials, so I have a double-ownership problem.  GitRepository will have to be refactored somehow before I can handle it, hence why I want to do it in a follow up.
- The default ansible playbook consolidated thing may not update properly. (i.e. it can clone on first seed, but may not update on subsequent seed)
- The UI still has the 3 checkboxes that we are going to drop. - ManageIQ/manageiq-ui-classic#5848
- When we drop the 3 options, we need to create a data migration to remove them from the source.
- Checkouts created after running the playbook still need to be cleaned up.
- Git repos over ssh don't work just yet.