### PR TITLE
Rails 5.2 raises an error for missing attribute default_tenant_role (miq_group never had it)

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -237,8 +237,7 @@ class MiqGroup < ApplicationRecord
     tenant_full_name = (tenant.ancestors.map(&:name) + [tenant.name]).join("/")
 
     create_with(
-      :description         => "Tenant #{tenant_full_name} access",
-      :default_tenant_role => MiqUserRole.default_tenant_role
+      :description => "Tenant #{tenant_full_name} access"
     ).find_or_create_by!(
       :group_type => TENANT_GROUP,
       :tenant_id  => tenant.id,


### PR DESCRIPTION
This is rails 5.1 and 5.2 safe. 

Rails 5.1 and 5.0 must silently ignore this.

default_tenant_role was never an attribute for miq_group

Fixes:

```
Failure/Error:
        create_with(
          :description         => "Tenant #{tenant_full_name} access",
          :default_tenant_role => MiqUserRole.default_tenant_role
        ).find_or_create_by!(
          :group_type => TENANT_GROUP,
          :tenant_id  => tenant.id,
        )

      ActiveModel::UnknownAttributeError:
        unknown attribute 'default_tenant_role' for MiqGroup.
```
