### PR TITLE
Fix rails 5.2 RecordNotSaved when trying to save a model association before the model

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -401,7 +401,7 @@ class ServiceTemplate < ApplicationRecord
 
   def picture=(value)
     if value.kind_of?(Hash)
-      super(create_picture(value))
+      super(Picture.new(value))
     else
       super
     end

--- a/spec/models/import_file_upload_spec.rb
+++ b/spec/models/import_file_upload_spec.rb
@@ -1,5 +1,5 @@
 describe ImportFileUpload do
-  let(:import_file_upload) { described_class.new }
+  let(:import_file_upload) { described_class.create }
 
   describe "#policy_import_data" do
     let(:policy_array) { "policy array" }


### PR DESCRIPTION
This is rails 5.1 and 5.2 "safe".

Fixes:

      ActiveRecord::RecordNotSaved:
        You cannot call create unless the parent is saved