### PR TITLE
Don't pass class objects as values to where

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm_or_template.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm_or_template.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::CloudManager::VmOrTemplate < ActsAsArScope
   end
 
   def self.aar_scope
-    ::VmOrTemplate.where(:type => vm_descendants)
+    ::VmOrTemplate.where(:type => vm_descendants.collect(&:to_s))
   end
 
   def self.vm_descendants

--- a/app/models/manageiq/providers/infra_manager/vm_or_template.rb
+++ b/app/models/manageiq/providers/infra_manager/vm_or_template.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::InfraManager::VmOrTemplate < ActsAsArScope
   end
 
   def self.aar_scope
-    ::VmOrTemplate.where(:type => vm_descendants)
+    ::VmOrTemplate.where(:type => vm_descendants.collect(&:to_s))
   end
 
   def self.vm_descendants


### PR DESCRIPTION
Use where(:type => "MyClass") not where(:type => MyClass)

This is rails 5.1 and 5.2 safe.

Fixes:

```
  39) ManageIQ::Providers::CloudManager::VmOrTemplate#all scopes
      Failure/Error: expect(described_class.all).to match_array([vm, t])

      TypeError:
        can't cast Class
      # ./spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb:9:in `block (3 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # TypeError:
      #   TypeError
      #   ./spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb:9:in `block (3 levels) in <top (required)>'
```
