### PR TITLE
Remove the old ask_*_on_launch options

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -37,10 +37,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < Manage
       :playbook                 => name,
       :become_enabled           => options[:become_enabled].present?,
       :verbosity                => options[:verbosity].presence || 0,
-      :ask_variables_on_launch  => true,
-      :ask_limit_on_launch      => true,
-      :ask_inventory_on_launch  => true,
-      :ask_credential_on_launch => true,
       :limit                    => options[:limit],
       :inventory                => options[:inventory] || manager.provider.default_inventory,
       :extra_vars               => options[:extra_vars].try(:to_json)

--- a/app/models/service_template_ansible_playbook.rb
+++ b/app/models/service_template_ansible_playbook.rb
@@ -93,11 +93,7 @@ class ServiceTemplateAnsiblePlaybook < ServiceTemplateGeneric
       :playbook                 => playbook.name,
       :inventory                => tower.provider.default_inventory,
       :become_enabled           => info[:become_enabled].present?,
-      :verbosity                => info[:verbosity].presence || 0,
-      :ask_variables_on_launch  => true,
-      :ask_limit_on_launch      => true,
-      :ask_inventory_on_launch  => true,
-      :ask_credential_on_launch => true
+      :verbosity                => info[:verbosity].presence || 0
     }
     if info[:extra_vars]
       params[:extra_vars] = info[:extra_vars].transform_values do |val|


### PR DESCRIPTION
These were relevant for AWX based embedded ansible implementation,
but are no-longer used with ansible runner