### PR TITLE
Add product "Release" info

### DIFF
--- a/lib/vmdb/appliance.rb
+++ b/lib/vmdb/appliance.rb
@@ -14,6 +14,11 @@ module Vmdb
       "Ivanchuk".freeze
     end
 
+    def self.RELEASE
+      release_file = File.join(File.expand_path(Rails.root), "RELEASE")
+      File.exist?(release_file) ? File.read(release_file).strip : self.CODENAME
+    end
+
     def self.BANNER
       "#{self.PRODUCT_NAME} #{self.VERSION}, codename: #{self.CODENAME}"
     end
@@ -57,6 +62,7 @@ module Vmdb
       fh.info(init_msg)
       fh.info(border)
 
+      fh.info("Release: #{self.RELEASE}")
       fh.info("Version: #{self.VERSION}")
       fh.info("Build:   #{self.BUILD}")
       fh.info("Codename: #{self.CODENAME}")


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1546108

As per discussion with @Fryguy, using `CODENAME` when `RELEASE` file doesn't exist. `RELEASE` file will be created for downstream only.