### PR TITLE
Count the number of files for (compare) reports when testing seed

### DIFF
--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -2,7 +2,9 @@ require 'fileutils'
 
 describe MiqReport do
   describe "::Seeding" do
-    include_examples(".seed called multiple times", 146)
+    include_examples(".seed called multiple times", begin
+      (Dir.glob(MiqReport::REPORT_DIR.join("**/*.yaml")) + Dir.glob(MiqReport::COMPARE_DIR.join("**/*.yaml"))).count
+    end)
 
     describe ".seed" do
       let(:tmpdir)      { Pathname.new(Dir.mktmpdir) }


### PR DESCRIPTION
It's an ugly but working solution for not having a static number to test against in the seeding spec. We're counting the files instead, so if someone adds a new report, the number doesn't have to be increased.

@miq-bot add_reviewer @martinpovolny 
cc @vestival 
@miq-bot add_label test, reporting, hammer/no