### PR TITLE
Cleanup sync_from_hash widget save

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -481,9 +481,7 @@ class MiqWidget < ApplicationRecord
       if filename
         $log.info("Widget: [#{widget.description}] file has been updated on disk, synchronizing with model")
         ["enabled", "visibility"].each { |a| attrs.delete(a) } # Don't updates these because they may have been modofoed by the end user.
-        widget.updated_at = Time.now.utc
-        widget.update_attributes(attrs)
-        widget.save!
+        widget.update!(attrs)
       end
     else
       $log.info("Widget: [#{attrs["description"]}] file has been added to disk, adding to model")


### PR DESCRIPTION
Widgets saving in ```sync_from_hash``` is saving twice and we don't really care what the time is.

before:
```bin/rails r "MiqWidget.seed; puts Benchmark.realtime_block(:capture_state) { 25.times { MiqWidget.seed } }.last" => {:capture_state=>6.840094804763794}```

after: ```{:capture_state=>4.449371099472046}```

@miq-bot assign @jrafanie 