### PR TITLE
[HAMMER] Service retire task description dash was removed

### DIFF
--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -168,7 +168,7 @@ describe ServiceRetireTask do
         service.add_resource!(FactoryBot.create(:vm_openstack, :retired => true))
         service_retire_task.after_request_task_create
 
-        expect(service_retire_task.description).to eq("Service Retire for: #{service.name} - ")
+        expect(service_retire_task.description).to eq("Service Retire for: #{service.name}")
         expect(VmRetireTask.count).to eq(0)
         expect(ServiceRetireTask.count).to eq(1)
       end


### PR DESCRIPTION
The service retire task description no longer has the dash, so this needed fixing. 

Per https://github.com/ManageIQ/manageiq/pull/18895#issuecomment-513958558 

