### PR TITLE
Turbo distinct

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -304,7 +304,7 @@ class MiqReport < ApplicationRecord
   end
 
   def self.default_use_sql_view
-    false
+    ::Settings.reporting.use_sql_view
   end
 
   private

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -979,6 +979,7 @@
     :keep_reports: 6.months
     :purge_window_size: 100
   :queue_timeout: 1.hour
+  :use_sql_view: false
 :repository_scanning:
   :defaultsmartproxy:
 :server:

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -389,17 +389,13 @@ module Rbac
       return scope unless includes
       includes = Array(includes) unless includes.kind_of?(Enumerable)
       includes.each do |association, value|
-        if table_include?(klass, association)
+        reflection = klass.reflect_on_association(association)
+        if reflection && !reflection.polymorphic?
           scope = value ? scope.left_outer_joins(association => value) : scope.left_outer_joins(association)
+          scope = scope.distinct if reflection.try(:collection?)
         end
       end
       scope
-    end
-
-    # this is a reference to a non polymorphic table
-    def table_include?(target_klass, association)
-      reflection = target_klass.reflect_on_association(association)
-      reflection && !reflection.polymorphic?
     end
 
     def polymorphic_include?(target_klass, includes)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -742,7 +742,7 @@ module Rbac
     end
 
     def apply_select(klass, scope, extra_cols)
-      scope.select(scope.select_values.blank? ? klass.arel_table[Arel.star] : nil).select(extra_cols)
+      (scope.select_values.blank? ? scope.select(klass.arel_table[Arel.star]) : scope).select(extra_cols)
     end
 
     def get_belongsto_matches(blist, klass)


### PR DESCRIPTION
We had merged and enabled turbo button into the product.
All was working well except sorting was off and we were not properly calling `distinct` on saome pages.

This PR fixes those 2 remaining issues. It does the following:

- Add the `SORT BY` to the inner and outer query.
- Add `DISTINCT` to queries that `requires()` a `has_many` model.
- Add functions from the `ORDER BY` clause to the `SELECT` clause. These are needed for `DISTINCT` queries


### Before

When we were using inline sql views (turbo button), the `distinct` was getting dropped from the query.

So we were getting an inflated number of rows and an inconsistent number of records per page.

https://bugzilla.redhat.com/show_bug.cgi?id=1718102

### After

This introduces the `distinct` back into the query.
So now the counts are right and the correct number of records are on each page.

The distinct on the query means that the order by clause can now pose an issue:  The order by clause typically contains a function (e.g.: `lower(name)`), which is not in the select clause. So we now add any functions in the order by clause to the select clause.


