### PR TITLE
Don't update_attrs and then save on widget sets either 

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -62,8 +62,7 @@ class MiqWidgetSet < ApplicationRecord
     if ws
       if ws.updated_on.utc < File.mtime(filename).utc
         $log.info("Widget Set: [#{ws.description}] file has been updated on disk, synchronizing with model")
-        ws.update_attributes(attrs)
-        ws.save
+        widget.update!(attrs)
         ws.replace_children(members)
       end
     else


### PR DESCRIPTION
This is why I make the big bucks, PRs like this one. 

This should be one call, not two, just like [the widget code](https://github.com/ManageIQ/manageiq/pull/19021). 

benchmarks: ```bin/rails r "MiqWidgetSet.seed; puts Benchmark.realtime_block(:capture_state) { 10.times { MiqWidgetSet.seed } }.last"```

**huge difference** 🤣 

before:
```{:capture_state=>0.021094083786010742}```

after:
```{:capture_state=>0.019088029861450195}```

@miq-bot assign @jrafanie 
@miq-bot add_label performance, cleanup