### PR TITLE
Count the number of files for widgets when testing seed

### DIFF
--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,7 +1,9 @@
 describe MiqWidget do
   describe '.seed' do
     before { [MiqReport].each(&:seed) }
-    include_examples(".seed called multiple times", 24)
+    include_examples(".seed called multiple times", begin
+      Dir.glob(Rails.root.join(MiqWidget::WIDGET_DIR, "**", "*.yaml")).count
+    end)
   end
 
   before do


### PR DESCRIPTION
Same fix as https://github.com/ManageIQ/manageiq/pull/19019 but for widgets.

@miq-bot add_reviewer @martinpovolny
cc @vestival 
@miq-bot add_label test, reporting, hammer/no

