### PR TITLE
Add missing `@` before pid to prevent cockpit worker from crashing

### DIFF
--- a/app/models/miq_cockpit_ws_worker/runner.rb
+++ b/app/models/miq_cockpit_ws_worker/runner.rb
@@ -151,7 +151,7 @@ class MiqCockpitWsWorker::Runner < MiqWorker::Runner
     stdin, stdout, stderr, wait_thr = Open3.popen3(env, *cockpit_ws.command(BINDING_ADDRESS))
     stdin.close
 
-    _log.info("#{log_prefix} cockpit-ws process started - pid=#{pid}")
+    _log.info("#{log_prefix} cockpit-ws process started - pid=#{@pid}")
     return wait_thr.pid, stdout, stderr
   end
 


### PR DESCRIPTION
In the context of `cockpit_ws_run` the `pid` variable is not defined, however, the `@pid` is and in other methods it's referenced to `pid`.

@miq-bot add_reviewer @martinpovolny 
@miq-bot add_label bug


BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1732502