### PR TITLE
We don't need two calls for save in seeding chargeback rate detail measures

### DIFF
--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -36,9 +36,7 @@ class ChargebackRateDetailMeasure < ApplicationRecord
           fixture_mtime = File.mtime(fixture_file_measure).utc
           if fixture_mtime > rec.created_at
             _log.info("Updating [#{cbr[:name]}] with units=[#{cbr[:units]}]")
-            rec.update_attributes(cbr)
-            rec.created_at = fixture_mtime
-            rec.save
+            rec.update!(cbr, :created_at => fixture_mtime)
           end
         end
       end


### PR DESCRIPTION
Seeding chargeback rate details doesn't need both update_attrs and save. 

It's the same as https://github.com/ManageIQ/manageiq/pull/19026

@miq-bot assign @jrafanie 
🎉 

after: {:capture_state=>0.016232967376708984}
before: {:capture_state=>0.016462087631225586}
Big bucks. Definitely worth merging. Boooya. 
But easy github points. 