### PR TITLE
Change: ovirt_metrics dependency version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,7 +155,7 @@ end
 
 group :ovirt, :manageiq_default do
   manageiq_plugin "manageiq-providers-ovirt"
-  gem "ovirt_metrics",                  "~>2.0.0",       :require => false
+  gem "ovirt_metrics",                  "~>3.0.0",       :require => false
 end
 
 group :scvmm, :manageiq_default do


### PR DESCRIPTION
The new ovirt_metrics is using standard 'postgresql' layer compatible
with ManageIQ supported postgresql version

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1705629


