### PR TITLE
Fix: do not raise error if schedule for widget exists but not linked

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -493,7 +493,7 @@ class MiqWidget < ApplicationRecord
   end
 
   def filter_for_schedule
-    %["=" => {"field" => "MiqWidget-id", "value" => #{id}}]
+    {"=" => {"field" => "MiqWidget-id", "value" => id}}
   end
 
   def sync_schedule(schedule_info)
@@ -515,7 +515,7 @@ class MiqWidget < ApplicationRecord
       raise _("Unsupported interval '%{interval}'") % {:interval => interval}
     end
 
-    sched = existing_scheduler
+    sched = existing_schedule
     sched ||= MiqSchedule.create!(
       :name          => description,
       :description   => description,
@@ -537,20 +537,16 @@ class MiqWidget < ApplicationRecord
     sched
   end
 
-  def existing_scheduler
+  def existing_schedule
     return nil if (sched = MiqSchedule.find_by(:name => description)).nil?
 
     # return existing sheduler if filter referr to the same widget
-    return sched if sched.filter == filter_for_schedule
+    return sched if sched.filter.exp == filter_for_schedule
 
     # change name of existed schedule in case it is in use
-
-    suff = Time.new.utc.to_s
-    _log.warn("Schedule #{sched.name} already exists, renaming it to `#{sched.name} #{suff}`")
-    sched.name = "#{sched.name} #{suff}"
-    sched.description = "#{sched.description} #{suff}"
-    sched.save
-
+    suffix = Time.new.utc.to_s
+    _log.warn("Schedule #{sched.name} already exists, renaming it to `#{sched.name} #{suffix}`")
+    sched.update(:name => "#{sched.name} #{suffix}", :description => "#{sched.description} #{suffix}")
     nil
   end
 

--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -493,7 +493,7 @@ class MiqWidget < ApplicationRecord
   end
 
   def filter_for_schedule
-    "\"=\" => {\"field\" => \"MiqWidget-id\", \"value\" => #{id}}"
+    %["=" => {"field" => "MiqWidget-id", "value" => #{id}}]
   end
 
   def sync_schedule(schedule_info)

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -56,6 +56,33 @@ describe MiqWidget do
       '))
     end
 
+    describe "#sync_schedule" do
+      let(:schedule) do
+        filter = @widget_chart_vendor_and_guest_os.filter_for_schedule
+        FactoryBot.create(:miq_schedule, :filter => filter,
+                                           :resource_type => "MiqWidget", :name => @widget_chart_vendor_and_guest_os.name)
+      end
+
+      it "uses existing schedule if link between widget and schedule broken" do
+        expect(@widget_chart_vendor_and_guest_os.miq_schedule).to be_nil
+        @widget_chart_vendor_and_guest_os.sync_schedule(:run_at => schedule.run_at)
+
+        expect(MiqSchedule.count).to eq(1)
+        expect(@widget_chart_vendor_and_guest_os.miq_schedule.id).to eq(schedule.id)
+      end
+
+      it "rename existing scheduler by adding timestamp go name if existing scheduler use different filter" do
+        schedule.update(:filter => "\"=\" => {\"field\" => \"MiqWidget-id\", \"value\" => 9999}")
+
+        time_now = Time.now.utc
+        Timecop.freeze(time_now) { @widget_chart_vendor_and_guest_os.sync_schedule(:run_at => schedule.run_at) }
+        schedule.reload
+
+        expect(MiqSchedule.count).to eq(2)
+        expect(schedule.name.end_with?(time_now.to_s)).to be_truthy
+      end
+    end
+
     context "#queue_generate_content_for_users_or_group" do
       before do
         @widget = @widget_report_vendor_and_guest_os

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -56,11 +56,18 @@ describe MiqWidget do
       '))
     end
 
+    describe "#filter_for_schedule" do
+      it "returns Hash object representing valid MiqExpression" do
+        exp = MiqExpression.new(@widget_chart_vendor_and_guest_os.filter_for_schedule)
+        expect(exp.valid?).to be_truthy
+      end
+    end
+
     describe "#sync_schedule" do
       let(:schedule) do
         filter = @widget_chart_vendor_and_guest_os.filter_for_schedule
-        FactoryBot.create(:miq_schedule, :filter => filter,
-                                           :resource_type => "MiqWidget", :name => @widget_chart_vendor_and_guest_os.name)
+        FactoryBot.create(:miq_schedule, :filter => MiqExpression.new(filter), :resource_type => "MiqWidget",
+                          :name => @widget_chart_vendor_and_guest_os.name)
       end
 
       it "uses existing schedule if link between widget and schedule broken" do
@@ -71,8 +78,8 @@ describe MiqWidget do
         expect(@widget_chart_vendor_and_guest_os.miq_schedule.id).to eq(schedule.id)
       end
 
-      it "rename existing scheduler by adding timestamp go name if existing scheduler use different filter" do
-        schedule.update(:filter => "\"=\" => {\"field\" => \"MiqWidget-id\", \"value\" => 9999}")
+      it "rename existing scheduler by adding timestamp to name if existing scheduler use different filter" do
+        schedule.update(:filter => MiqExpression.new("=" => {"field" => "MiqWidget-id", "value" => 9999}))
 
         time_now = Time.now.utc
         Timecop.freeze(time_now) { @widget_chart_vendor_and_guest_os.sync_schedule(:run_at => schedule.run_at) }


### PR DESCRIPTION
It would resolve issue with failing seeding in case when schedule exists but not linked to corresponding widget.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1729441

@miq-bot add-label bug, core, hammer/yes

\cc @gtanzillo 