### PR TITLE
Don't restrict the zone to the embedded ansible manager zone for CRUD

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_ansible/crud_common.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def queue(zone, instance_id, method_name, args, action, auth_user)
+    def queue(instance_id, method_name, args, action, auth_user)
       task_opts = {
         :action => action,
         :userid => auth_user || "system"
@@ -13,8 +13,7 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
         :priority    => MiqQueue::HIGH_PRIORITY,
         :class_name  => name,
         :method_name => method_name,
-        :role        => "embedded_ansible",
-        :zone        => zone
+        :role        => "embedded_ansible"
       }
       queue_opts[:instance_id] = instance_id if instance_id
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
@@ -53,7 +52,7 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
       manager = parent.find(manager_id)
       action = "Creating #{self::FRIENDLY_NAME}"
       action << " (name=#{params[:name]})" if params[:name]
-      queue(manager.my_zone, nil, "create_in_provider", [manager_id, encrypt_queue_params(params)], action, auth_user)
+      queue(nil, "create_in_provider", [manager_id, encrypt_queue_params(params)], action, auth_user)
     end
 
     private
@@ -116,7 +115,7 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
   def queue(method_name, args, action_prefix, auth_user)
     action = "#{action_prefix} #{self.class::FRIENDLY_NAME}"
     action << " (name=#{name})" if respond_to?(:name)
-    self.class.queue(manager.my_zone, id, method_name, args, action, auth_user)
+    self.class.queue(id, method_name, args, action, auth_user)
   end
 
   def notify(op_type, params = {}, &block)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -121,8 +121,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "create_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible",
-        :zone        => manager.my_zone
+        :role        => "embedded_ansible"
       )
     end
   end
@@ -176,8 +175,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "update_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible",
-        :zone        => manager.my_zone
+        :role        => "embedded_ansible"
       )
     end
   end
@@ -209,8 +207,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "delete_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible",
-        :zone        => manager.my_zone
+        :role        => "embedded_ansible"
       )
     end
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -183,8 +183,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "create_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible",
-        :zone        => manager.zone.name
+        :role        => "embedded_ansible"
       )
     end
 
@@ -200,8 +199,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "update_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible",
-        :zone        => manager.my_zone
+        :role        => "embedded_ansible"
       )
     end
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -71,8 +71,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
           :class_name  => credential_class.name,
           :method_name => "create_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible",
-          :zone        => manager.my_zone
+          :role        => "embedded_ansible"
         )
       end
 
@@ -107,8 +106,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
           :class_name  => credential_class.name,
           :method_name => "update_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible",
-          :zone        => manager.my_zone
+          :role        => "embedded_ansible"
         )
       end
     end
@@ -132,8 +130,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
           :class_name  => credential_class.name,
           :method_name => "delete_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible",
-          :zone        => manager.my_zone
+          :role        => "embedded_ansible"
         )
       end
     end


### PR DESCRIPTION
There's nothing special about the zone with the appliance that has the
embedded ansible role. If we're targeting the role we should target it
without regard for zone since it's region scoped.

If we leave embedded ansible only usable on one appliance at a time
then this is an unnecessary restriction as the manager zone is set
to the server's zone when the role is assigned.

If we add the ability to use multiple servers then this will ensure
that work is only completed in the zone where the server was assigned
the embedded ansible role most recently. Which will be a very difficult
to diagnose bug.