### PR TITLE
Don't start httpd when the embedded ansible role is assigned

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -1,7 +1,7 @@
 module MiqServer::RoleManagement
   extend ActiveSupport::Concern
 
-  ROLES_NEEDING_APACHE = %w(user_interface web_services remote_console embedded_ansible cockpit_ws).freeze
+  ROLES_NEEDING_APACHE = %w(user_interface web_services remote_console cockpit_ws).freeze
 
   included do
     has_many :assigned_server_roles, :dependent => :destroy


### PR DESCRIPTION
We don't expose a webserver for this now that we've moved from AWX
to runner.

This essentially reverts 5a18a2e82affa524a25b3e022c6144df9e95fd75