### PR TITLE
fix confusing condition

### DIFF
--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -163,7 +163,7 @@ module AuthenticationMixin
       cred = authentication_type(type)
       current = {:new => nil, :old => nil}
 
-      unless value.key?(:userid) && value[:userid].blank?
+      if value[:userid].present?
         current[:new] = {
           :user            => value[:userid],
           :password        => value[:password],


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1718209

There was weird condition `unless value.key?(:userid) && value[:userid].blank?` which basically says that next lines should be skipped if we pass `userid` there. But that's exactly what we want - to update it. So, I assume, this condition was written wrong.

For clarity:
```ruby
[1] pry(main)> 'do it' unless true && true
=> nil
[2] pry(main)> 'do it' unless true && false
=> "do it"
[3] pry(main)> 'do it' unless false && false
=> "do it"
[4] pry(main)> 'do it' unless false && true
=> "do it"
```
