### PR TITLE
Do not run the remote console proxy with the UI by default in dev

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Vmdb::Application.routes.draw do
-  if Rails.env.development? && defined?(Rails::Server)
+  if Rails.env.development? && ENV['MOUNT_REMOTE_CONSOLE_PROXY']
     logger = Logger.new(STDOUT)
     logger.level = Logger.const_get(::Settings.log.level_remote_console.upcase)
     mount RemoteConsole::RackServer.new(:logger => logger) => '/ws/console'


### PR DESCRIPTION
When running the UI with `rails serve` in development, we were always mounting the remote console proxy as well. I think no one else works with the remote console on a daily basis, so I'm switching off the feature by default. This will solve the problems with having `Initializing RemoteConsole server!` messages when running migrations/console.

If you'd like to run the remote console in development, you can do it by setting an ENV variable:
```sh
MOUNT_REMOTE_CONSOLE_PROXY=1 bin/rails serve
```

There's no change in production, there we're running the proxy in a separate worker and HTTPD does the rest of the magic.

@miq-bot add_label developer, providers/console, ivanchuk/no, changelog/yes
@miq-bot add_reviewer @djberg96 
@miq-bot add_reviewer @jrafanie 
@miq-bot add_reviewer @Fryguy 