### PR TITLE
Queue ServiceAnsiblePlaybook#execute for the embedded_ansible role

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -14,6 +14,29 @@ class ServiceAnsiblePlaybook < ServiceGeneric
   end
 
   def execute(action)
+    launch_ansible_job_queue(action)
+  end
+
+  def launch_ansible_job_queue(action)
+    task_opts = {
+      :action => "Launching Ansible Job",
+      :userid => "system"
+    }
+
+    queue_opts = {
+      :args        => [action],
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => "launch_ansible_job",
+      :role        => "embedded_ansible"
+    }
+
+    task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    task = MiqTask.wait_for_taskid(task_id)
+    raise task.message unless task.status_ok?
+  end
+
+  def launch_ansible_job(action)
     jt = job_template(action)
     opts = get_job_options(action).deep_merge(
       :extra_vars => {

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -46,12 +46,12 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     )
     opts[:hosts] = hosts_array(opts.delete(:hosts))
 
-    _log.info("Launching Ansible Tower job with options:")
+    _log.info("Launching Ansible job with options:")
     $log.log_hashes(opts)
     new_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create_job(jt, decrypt_options(opts))
     update_job_for_playbook(action, new_job, opts[:hosts])
 
-    _log.info("Ansible Tower job with ref #{new_job.ems_ref} was created.")
+    _log.info("Ansible job with ref #{new_job.ems_ref} was created.")
     add_resource!(new_job, :name => action)
   end
 

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -195,7 +195,7 @@ describe(ServiceAnsiblePlaybook) do
     end
   end
 
-  describe '#execute' do
+  describe '#launch_ansible_job' do
     let(:control_extras) { {'a' => 'A', 'b' => 'B', 'c' => 'C'} }
     before do
       FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number)
@@ -219,7 +219,7 @@ describe(ServiceAnsiblePlaybook) do
         expect(opts).to include(expected_opts)
         runner_job
       end
-      loaded_service.execute(action)
+      loaded_service.launch_ansible_job(action)
       expected_job_attributes = {
         :id                           => runner_job.id,
         :hosts                        => config_info_options.fetch_path(:config_info, :provision, :hosts).split(','),


### PR DESCRIPTION
Before this change the actual playbook run could happen on any
appliance with the automate role. We need the playbook run to happen
specifically on the embedded_ansible appliance so that we can ensure
the repo update/clone process will run successfully.

cc @gmcculloug @tinaafitz I'm not sure if this can be done in any better way. I wasn't able to find a higher level place to change how this was getting queued. It seems like the actual call stack for execute ends somewhere in automate engine and drb so I feel like that would be harder to tackle than this.

But if someone knows that there's somewhere else I can make this change, then I'm open for suggestions.