### PR TITLE
Don't create the embedded ansible default project

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/seeding.rb
+++ b/app/models/manageiq/providers/embedded_ansible/seeding.rb
@@ -19,42 +19,7 @@ module ManageIQ::Providers::EmbeddedAnsible::Seeding
         :resource => manager
       )
 
-      create_local_playbook_repo
-      local_repo = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource.find_or_create_by!(
-        :name       => "#{Vmdb::Appliance.PRODUCT_NAME} Default Project",
-        :manager_id => manager.id
-      )
-      local_repo.raw_update_in_provider(
-        :scm_type             => "git",
-        :scm_url              => "file://#{local_playbook_repo_dir}",
-        :scm_update_on_launch => false
-      )
-    end
-
-    private
-
-    def create_local_playbook_repo
       Ansible::Content.consolidate_plugin_playbooks
-
-      Dir.chdir(local_playbook_repo_dir) do
-        require 'rugged'
-        repo = Rugged::Repository.init_at(".")
-        index = repo.index
-        index.add_all("*")
-        index.write
-
-        options              = {}
-        options[:tree]       = index.write_tree(repo)
-        options[:author]     = options[:committer] = { :email => "system@localhost", :name => "System", :time => Time.now.utc }
-        options[:message]    = "Initial Commit"
-        options[:parents]    = []
-        options[:update_ref] = 'HEAD'
-        Rugged::Commit.create(repo, options)
-      end
-    end
-
-    def local_playbook_repo_dir
-      Ansible::Content::PLUGIN_CONTENT_DIR
     end
   end
 end

--- a/spec/models/manageiq/providers/embedded_ansible_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible_spec.rb
@@ -28,14 +28,8 @@ describe ManageIQ::Providers::EmbeddedAnsible do
       expect(auth.manager_ref).to eq(auth.id.to_s)
     end
 
-    it "creates the local playbook repo" do
-      repo = manager.configuration_script_sources.find_by(:name => "ManageIQ Default Project")
-
-      expect(repo.scm_type).to eq("git")
-      expect(repo.scm_url).to eq("file://#{consolidated_repo_path}")
-      expect(repo.scm_update_on_launch).to be_falsey
-
-      expect(Dir.exist?(File.join(consolidated_repo_path, ".git"))).to be_truthy
+    it "consolidates the embedded ansible content" do
+      expect(Dir.exist?(File.join(consolidated_repo_path))).to be_truthy
     end
   end
 end


### PR DESCRIPTION
We don't currently provide any playbooks so we don't need this.
We do provide roles so we still need to gather up the content
provided by the plugins when the embedded_ansible role is enabled
on an appliance. So we still call
Ansible::Content.consolidate_plugin_playbooks here.

Making the roles accessible to other playbook runs is done by altering
the roles search path here:
https://github.com/ManageIQ/manageiq-appliance/blob/9f0e0ed0381785387207343867173888e0b60788/LINK/root/.ansible.cfg#L3

Creating this project will cause an issue when we need to run the
embedded ansible role on multiple appliances. Each appliance would
have created the source SCM locally and the git shas would not match
between the different appliances which would cause issues with the
GitRepository model we use for managing ConfigurationScriptSources.

In the future if we do choose to provide playbooks out of the box
from plugins we can re-evaluate how to deal with this scenario at
that time.