### PR TITLE
Webmock uses old hashdiff gem with non-standard constant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -253,7 +253,7 @@ unless ENV["APPLIANCE"]
     gem "faker",            "~>1.8",    :require => false
     gem "timecop",          "~>0.7.3",  :require => false
     gem "vcr",              "~>3.0.2",  :require => false
-    gem "webmock",          "~>3.6.0",  :require => false
+    gem "webmock",          "~>3.7.0",  :require => false
   end
 
   group :development, :test do


### PR DESCRIPTION
https://github.com/bblimke/webmock/issues/822

Hashdiff 0.4.0 was realised which fixed it's non-standard constant.

Updating Webmock to the lastest version to use Hashdiff 0.4.0