### PR TITLE
add custom provisioning timeout feature

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -200,7 +200,7 @@ class MiqRequest < ApplicationRecord
       :method_name => "call_automate_event",
       :args        => [event_name],
       :zone        => options.fetch(:miq_zone, my_zone),
-      :msg_timeout => 3600
+      :msg_timeout => options[:msg_timeout].presence || 3600,
     )
   end
 

--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -200,7 +200,7 @@ class MiqRequest < ApplicationRecord
       :method_name => "call_automate_event",
       :args        => [event_name],
       :zone        => options.fetch(:miq_zone, my_zone),
-      :msg_timeout => options[:msg_timeout].presence || 3600,
+      :msg_timeout => options[:msg_timeout].presence || 3600
     )
   end
 

--- a/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_microsoft_dialogs_template.yaml
@@ -357,6 +357,11 @@
           :display: :edit
           :default: immediately
           :data_type: :string
+        :msg_timeout:
+          :description: Task timeout
+          :required: false
+          :display: :edit
+          :data_type: :integer
         :vm_auto_start:
           :values:
             false: 0


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1657934

- Now we can pass a custom timeout into vm provision task.
- Added timeout field into scvmm provision dialog.

Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/5877