### PR TITLE
[EmbeddedAnsible] Better handle ConfigurationScriptSource status/last_updated_on/last_update_error

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
       configuration_script_payloads.reload
     end
-    true
+    update_attributes!(:status => "successful")
   end
 
   def sync_queue(auth_user = nil)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -70,6 +70,9 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
       configuration_script_payloads.reload
     end
     update_attributes!(:status => "successful")
+  rescue => error
+    update_attributes!(:status => "error")
+    raise error
   end
 
   def sync_queue(auth_user = nil)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -88,6 +88,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         expect(result).to be_an(described_class)
         expect(result.scm_type).to eq("git")
         expect(result.scm_branch).to eq("master")
+        expect(result.status).to eq("successful")
 
         git_repo_dir = repo_dir.join(result.git_repository.id.to_s)
         expect(files_in_repository(git_repo_dir)).to eq ["hello_world.yaml"]

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -82,6 +82,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
     context "with valid params" do
       it "creates a record and initializes a git repo" do
         expect(Notification).to receive(:create!).with(notify_creation_args)
+        expect(Notification).to receive(:create!).with(notification_args("syncing", {}))
 
         result = described_class.create_in_provider(manager.id, params)
 
@@ -92,6 +93,22 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
 
         git_repo_dir = repo_dir.join(result.git_repository.id.to_s)
         expect(files_in_repository(git_repo_dir)).to eq ["hello_world.yaml"]
+      end
+
+      # NOTE:  Second `.notify` stub below prevents `.sync` from getting fired
+      it "sets the status to 'new' on create" do
+        expect(Notification).to receive(:create!).with(notify_creation_args)
+        expect(described_class).to receive(:notify).with(any_args).and_call_original
+        expect(described_class).to receive(:notify).with("syncing", any_args).and_return(true)
+
+        result = described_class.create_in_provider(manager.id, params)
+
+        expect(result).to be_an(described_class)
+        expect(result.scm_type).to eq("git")
+        expect(result.scm_branch).to eq("master")
+        expect(result.status).to eq("new")
+
+        expect(repos).to be_empty
       end
     end
 
@@ -217,7 +234,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
   end
 
   def build_record
-    expect(Notification).to receive(:create!).with(any_args)
+    expect(Notification).to receive(:create!).with(any_args).twice
     described_class.create_in_provider manager.id, params
   end
 


### PR DESCRIPTION
Currently, we don't set the status when doing a repo (ConfigurationScriptSource) sync.  With this change, we now:

- Create a new record with a `'new'` status
- Set the status to `'running'` at the beginning of `#sync`
- When the sync is completed `last_update_on` is updated to `Time.now`
- On error we update the status to `'error'` and `last_update_error` to provide the ruby error and stacktrace
- On error we update the status to `'successful'` and clear `last_update_error`

Worth noting:  A "create" action is now done in two transactions and `.notify` (from `CrudCommon`).  One for creating the record in the DB record and one for starting the sync.  This is mostly because they really are two atomic actions.  If a `.create!` passes, but the `.sync` fails, we shouldn't delete the record and just provide a notification in the UI and update the status.

Also, if there was an error, a simple refresh of the provider will re-attempt the sync, or if there is something like a credential error, the user can update and the `.sync` will be fired again.


TODO:
-----

* [x] ~~Handle translations (seperate PR?)~~
  - Talked with Nick C. on this one, and we think this is probably already done on the front end
* [ ] Do updates also in two transactions with notifications?