### PR TITLE
Send nil explicitly when queueing embedded ansible CRUD

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/crud_common.rb
+++ b/app/models/manageiq/providers/embedded_ansible/crud_common.rb
@@ -13,7 +13,8 @@ module ManageIQ::Providers::EmbeddedAnsible::CrudCommon
         :priority    => MiqQueue::HIGH_PRIORITY,
         :class_name  => name,
         :method_name => method_name,
-        :role        => "embedded_ansible"
+        :role        => "embedded_ansible",
+        :zone        => nil
       }
       queue_opts[:instance_id] = instance_id if instance_id
       MiqTask.generic_action_with_callback(task_opts, queue_opts)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -121,7 +121,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "create_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible"
+        :role        => "embedded_ansible",
+        :zone        => nil
       )
     end
   end
@@ -175,7 +176,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "update_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible"
+        :role        => "embedded_ansible",
+        :zone        => nil
       )
     end
   end
@@ -207,7 +209,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "delete_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible"
+        :role        => "embedded_ansible",
+        :zone        => nil
       )
     end
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -183,7 +183,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "create_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible"
+        :role        => "embedded_ansible",
+        :zone        => nil
       )
     end
 
@@ -199,7 +200,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         :class_name  => described_class.name,
         :method_name => "update_in_provider",
         :priority    => MiqQueue::HIGH_PRIORITY,
-        :role        => "embedded_ansible"
+        :role        => "embedded_ansible",
+        :zone        => nil
       )
     end
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -71,7 +71,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
           :class_name  => credential_class.name,
           :method_name => "create_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible"
+          :role        => "embedded_ansible",
+          :zone        => nil
         )
       end
 
@@ -106,7 +107,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
           :class_name  => credential_class.name,
           :method_name => "update_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible"
+          :role        => "embedded_ansible",
+          :zone        => nil
         )
       end
     end
@@ -130,7 +132,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
           :class_name  => credential_class.name,
           :method_name => "delete_in_provider",
           :priority    => MiqQueue::HIGH_PRIORITY,
-          :role        => "embedded_ansible"
+          :role        => "embedded_ansible",
+          :zone        => nil
         )
       end
     end


### PR DESCRIPTION
Not sending a zone actually specifies MiqServer.my_server.zone
This is not what we want.

@simaishi this should "fix" the failures here https://travis-ci.org/ManageIQ/manageiq/jobs/563893224#L665, but only because we shouldn't be queueing the messages that way.