### PR TITLE
FirmwareRegistry create

### DIFF
--- a/app/models/firmware_registry.rb
+++ b/app/models/firmware_registry.rb
@@ -31,6 +31,20 @@ class FirmwareRegistry < ApplicationRecord
     raise NotImplementedError, 'Must be implemented in subclass'
   end
 
+  def self.create_firmware_registry(options)
+    klass = options.delete(:type).constantize
+    options = klass.validate_options(options.deep_symbolize_keys)
+    klass.do_create_firmware_registry(options).tap(&:sync_fw_binaries_queue)
+  end
+
+  def self.validate_options(options)
+    options
+  end
+
+  def self.do_create_firmware_registry(_options)
+    raise NotImplementedError, 'Must be implemented in subclass'
+  end
+
   def self.display_name(number = 1)
     n_('Firmware Registry', 'Firmware Registries', number)
   end

--- a/spec/models/firmware_registry/rest_api_depot_spec.rb
+++ b/spec/models/firmware_registry/rest_api_depot_spec.rb
@@ -168,6 +168,52 @@ describe FirmwareRegistry::RestApiDepot do
     end
   end
 
+  describe '.do_create_firmware_registry' do
+    let(:options) do
+      {
+        :name     => 'name',
+        :url      => 'http://my-registry.com:1234/images',
+        :userid   => 'username',
+        :password => 'password'
+      }
+    end
+
+    context 'when options are valid' do
+      it 'creates new firmware registry' do
+        registry = described_class.do_create_firmware_registry(options)
+        expect(registry.name).to eq('name')
+        expect(registry.authentication).to have_attributes(:userid => 'username', :password => 'password')
+        expect(registry.endpoint).to have_attributes(:url => 'http://my-registry.com:1234/images')
+      end
+    end
+  end
+
+  describe '.validate_options' do
+    let(:options) do
+      {
+        :name     => 'name',
+        :url      => 'http://my-registry.com:1234/images',
+        :userid   => 'username',
+        :password => 'password'
+      }
+    end
+
+    it 'when options are valid' do
+      expect { described_class.validate_options(options) }.not_to raise_error
+    end
+
+    context 'when options are invalid' do
+      %i[name userid password url].each do |key|
+        context "(#{key} is missing)" do
+          before { options.delete(key) }
+          it 'error is raised' do
+            expect { described_class.validate_options(options) }.to raise_error(MiqException::Error)
+          end
+        end
+      end
+    end
+  end
+
   def with_vcr(suffix)
     path = "#{described_class.name.underscore}_#{suffix}"
     VCR.use_cassette(path, :match_requests_on => [:method, :path]) { yield }

--- a/spec/models/firmware_registry_spec.rb
+++ b/spec/models/firmware_registry_spec.rb
@@ -61,4 +61,14 @@ describe FirmwareRegistry do
       end
     end
   end
+
+  describe '.create_firmware_registry' do
+    let(:registry) { double('registry') }
+    it 'creates registry and triggers refresh' do
+      expect(FirmwareRegistry::RestApiDepot).to receive(:validate_options) { |options| options }
+      expect(FirmwareRegistry::RestApiDepot).to receive(:do_create_firmware_registry).with(:a => 'A').and_return(registry)
+      expect(registry).to receive(:sync_fw_binaries_queue)
+      described_class.create_firmware_registry(:type => 'FirmwareRegistry::RestApiDepot', :a => 'A')
+    end
+  end
 end


### PR DESCRIPTION
It is currently cumbersome to add a new FirmwareRegistry because it's split into three models:

- FirmwareRegistry
- Authentication
- Endpoint

Furthermore, each different type of registry can potentially require different authentication/endpoint parameters.

With this commit we therefore introduce a utility method that adds a new FirmwareRegistry, Authentication and Endpoint based on options hash for us. We do it as an asynchronous task because function will actually be invoked from UI (React will invoke it via API).

With this commit we also implement similar method for deletion.

@miq-bot add_label enhancement
@miq-bot assign @agrare 

(this is expected to become ivanchuk/yes as soon as we prepare BZ)