### PR TITLE
Add association methods for tenants (service templates, providers, au…

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -97,6 +97,18 @@ class Tenant < ApplicationRecord
     self.class.regional_tenants(self)
   end
 
+  def nested_service_templates
+    ServiceTemplate.with_tenant(id)
+  end
+
+  def nested_providers
+    ExtManagementSystem.with_tenant(id)
+  end
+
+  def nested_ae_namespaces
+    MiqAeDomain.with_tenant(id)
+  end
+
   def self.regional_tenants(tenant)
     where(arel_table.grouping(Arel::Nodes::NamedFunction.new("LOWER", [arel_attribute(:name)]).eq(tenant.name.downcase)))
   end


### PR DESCRIPTION
Add association methods for tenants (service templates, providers, automate domain).

To be used with https://github.com/ManageIQ/manageiq-ui-classic/pull/5675

These association can be used with the reporting interface through GTLs (unlike the scopes) because we are originating from the Tenant, not from the 3 different models.