### PR TITLE
Add initiated_by to miq_requests

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -31,6 +31,7 @@ class MiqRequest < ApplicationRecord
   validates_inclusion_of :approval_state, :in => %w(pending_approval approved denied), :message => "should be 'pending_approval', 'approved' or 'denied'"
   validates_inclusion_of :status,         :in => %w(Ok Warn Error Timeout Denied)
 
+  validates :initiated_by, :inclusion => { :in => %w[user system] }, :allow_blank => true
   validates :cancelation_status, :inclusion => { :in        => CANCEL_STATUS,
                                                  :allow_nil => true,
                                                  :message   => "should be one of #{CANCEL_STATUS.join(", ")}" }
@@ -503,7 +504,8 @@ class MiqRequest < ApplicationRecord
   def self.create_request(values, requester, auto_approve = false)
     values[:src_ids] = values[:src_ids].to_miq_a unless values[:src_ids].nil?
     request_type = values.delete(:__request_type__) || request_types.first
-    request = create!(:options => values, :requester => requester, :request_type => request_type)
+    initiator = values.delete(:__initiated_by__) || 'user'
+    request = create!(:options => values, :requester => requester, :request_type => request_type, :initiated_by => initiator)
 
     request.post_create(auto_approve)
   end

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -10,9 +10,9 @@ module RetirementMixin
   end
 
   module ClassMethods
-    def make_retire_request(*src_ids, requester)
+    def make_retire_request(*src_ids, requester, initiated_by: 'user')
       klass = (name.demodulize + "RetireRequest").constantize
-      options = {:src_ids => src_ids.presence, :__request_type__ => klass.request_types.first}
+      options = {:src_ids => src_ids.presence, :__initiated_by__ => initiated_by, :__request_type__ => klass.request_types.first}
       set_retirement_requester(options[:src_ids], requester)
       klass.make_request(nil, options, requester)
     end
@@ -135,7 +135,7 @@ module RetirementMixin
       end
     end
 
-    self.class.make_retire_request(id, requester) if retirement_due?
+    self.class.make_retire_request(id, requester, :initiated_by => 'system') if retirement_due?
   end
 
   def retire_now(requester = nil)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -103,12 +103,14 @@ describe "Service Retirement Management" do
   end
 
   it "with one src_id" do
-    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@service.id], :__request_type__ => "service_retire"}, user)
+    expect(ServiceRetireRequest).to receive(:make_request)
+      .with(nil, {:src_ids => [@service.id], :__initiated_by__ => 'user', :__request_type__ => "service_retire"}, user)
     @service.class.to_s.demodulize.constantize.make_retire_request(@service.id, user)
   end
 
   it "with src_ids" do
-    expect(ServiceRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@service.id, service_with_owner.id], :__request_type__ => "service_retire"}, user)
+    expect(ServiceRetireRequest).to receive(:make_request)
+      .with(nil, {:src_ids => [@service.id, service_with_owner.id], :__initiated_by__ => 'user', :__request_type__ => "service_retire"}, user)
     @service.class.to_s.demodulize.constantize.make_retire_request(@service.id, service_with_owner.id, user)
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -106,13 +106,22 @@ describe "VM Retirement Management" do
 
   describe "retire request" do
     it "with one src_id" do
-      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id], :__request_type__ => "vm_retire"}, user)
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id], :__initiated_by__ => 'user', :__request_type__ => "vm_retire"}, user)
       Vm.make_retire_request(@vm.id, user)
     end
 
     it "with many src_ids" do
-      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id, vm2.id], :__request_type__ => "vm_retire"}, user)
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id, vm2.id], :__initiated_by__ => 'user', :__request_type__ => "vm_retire"}, user)
       Vm.make_retire_request(@vm.id, vm2.id, user)
+    end
+
+    it "initiated by system" do
+      expect(VmRetireRequest).to receive(:make_request).with(nil, {:src_ids => [@vm.id, vm2.id], :__initiated_by__ => 'system', :__request_type__ => "vm_retire"}, user)
+      Vm.make_retire_request(@vm.id, vm2.id, user, :initiated_by => 'system')
+    end
+
+    it "with user as initiated_by" do
+      expect { Vm.make_retire_request(@vm.id, vm2.id, user, :initiated_by => user) }.to raise_error(/Initiated by is not included in the list/)
     end
   end
 


### PR DESCRIPTION
To make it possible to distinguish if the retire request is initiated by a user or by the system retirement check.

Depends on https://github.com/ManageIQ/manageiq-schema/pull/404

https://bugzilla.redhat.com/show_bug.cgi?id=1700692

@miq-bot add_label Enhancement, ivanchuk/no, changelog/yes, retirement
@miq-bot assign @tinaafitz 