### PR TITLE
[GitRepository] Use multi-process file locking for git actions

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -4,6 +4,9 @@ class GitRepository < ApplicationRecord
   include AuthenticationMixin
 
   GIT_REPO_DIRECTORY = Rails.root.join('data/git_repos')
+  LOCKFILE_DIR       = GIT_REPO_DIRECTORY.join("locks")
+
+  attr_reader :git_lock
 
   validates :url, :format => URI::regexp(%w(http https file)), :allow_nil => false
 
@@ -86,6 +89,31 @@ class GitRepository < ApplicationRecord
     @updated_repo = true
   end
 
+  # Configures a file lock in LOCKFILE_DIR so that only a single process has
+  # access to make changes to the `GitWorktree` at a time.  Assumes the record
+  # has been saved, since there is no way store (clone, fetch, pull, etc.) the
+  # git data to disk if there isn't a `id`.
+  #
+  # Only a single `@git_lock` can be aquired per-process, and do avoid
+  # deadlocks, his method is just a passthrough if `@git_lock` has already been
+  # defined (another method has already started a `git_transaction`.
+  #
+  # This means that you can surround a couple of actions with this method, and
+  # the lock will only be enforced on the top level.
+  #
+  # NOTE: However, it is worth noting that if two threads in the same process
+  # try to share the same instance while using `git_transation` is not thread
+  # safe, so avoid sharing `GitRepository` objects across multiple threads
+  # (chances are you won't run into this scenario, but commenting just in case)
+  #
+  # Return value is the result of the yielded block
+  def git_transaction
+    should_unlock = acquire_git_lock
+    yield
+  ensure
+    release_git_lock if should_unlock
+  end
+
   private
 
   def ensure_refreshed
@@ -153,6 +181,32 @@ class GitRepository < ApplicationRecord
     raise MiqException::MiqUnreachableError, err.message
   rescue => err
     raise MiqException::Error, err.message
+  end
+
+  def git_lock_filename
+    @git_lock_filename ||= LOCKFILE_DIR.join(id.to_s)
+  end
+
+  def acquire_git_lock
+    return false if git_lock
+
+    FileUtils.mkdir_p(LOCKFILE_DIR)
+
+    @git_lock = File.open(git_lock_filename, File::RDWR | File::CREAT, 0o644)
+    @git_lock.flock(File::LOCK_EX)                         # block waiting for lock
+    @git_lock.write("#{Process.pid} - #{Time.zone.now}\n") # for debugging
+    @git_lock.flush                                        # write current data
+    @git_lock.truncate(@git_lock.pos)                      # clean up remaining chars
+
+    true
+  end
+
+  def release_git_lock
+    return if git_lock.nil?
+
+    @git_lock.flock(File::LOCK_UN)
+    @git_lock.close
+    @git_lock = nil
   end
 
   def worktree_params

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -110,7 +110,7 @@ class GitRepository < ApplicationRecord
   end
 
   def refresh_tags
-    with_worktree do
+    with_worktree do |worktree|
       current_tags = git_tags.index_by(&:name)
       worktree.tags.each do |tag|
         info = worktree.tag_info(tag)

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -97,7 +97,7 @@ describe GitRepository do
         tag_info_hash[name]
       end
 
-      expect(repo).to receive(:clone_repo).once.with(no_args).and_call_original
+      expect(repo).to receive(:clone_repo_if_missing).once.with(no_args).and_call_original
       expect(GitWorktree).to receive(:new).with(anything).and_return(gwt)
       expect(gwt).to receive(:fetch_and_merge).with(no_args)
 


### PR DESCRIPTION
Adds `GitRepository#git_transaction` method as well as the following private helper methods and constants:

```ruby
GitRepository::LOCKFILE_DIR  # Where the locks are stored on the appliance

repo = GitRepository.new
repo.git_lock_filename       # name of the lockfile for this record
repo.acquire_git_lock        # fetches a lock for the instance (one per)
repo.release_git_lock        # releases existing lock for other processes
```

`GitRepository#git_transaction` is meant to be a multi-purpose method for dealing with any file system changes so that only one process is able to interact with it at a time.  According to the docs (`ri File#flock`), `File#flock(FILE::LOCK_EX)` should block until the lock is available for the process, so the first process to acquire the lock will process first.

The method is also designed so that nested `GitRepository#git_transaction` calls will no-op and not release the lock pre-maturely.  This is important for running multiple actions that by design need to happen by a single process, but the sub actions are also configured to use the lock.

Implementation of this method will be done in a followup commit, but the method is also meant to be a public interface so that when existing methods implement this method, locks will work just fine with user defined `git_transaction` blocks as well as with the `GitRepository` public API.


Links
-----

* Addressing ["`git clone` not processes safe" concern](https://github.com/ManageIQ/manageiq-design/issues/45#issuecomment-514372257) from RFE
* `AndibleRunner` for `EmbeddedAnsible` RFE:  https://github.com/ManageIQ/manageiq-design/issues/45


Steps for Testing/QA
--------------------

¯\\(°\_o)/¯

~~But in all seriousness, this is really hard (impossible) to test since it requires running two processes and hitting a process timing where this would become an issue.  That said, hopefully it doesn't cause the existing specs to break.~~

While not ideal, I have put together a test script for this:

https://gist.github.com/NickLaMuro/20dc0795410abf448402c54f707a59dc

Running that seemed to prove that things were working as expected, in addition to the `Thread` based test I provided in a comment below:

https://github.com/ManageIQ/manageiq/pull/19074#issuecomment-516624369