### PR TITLE
[V2V] Store the conversion host name in the task options

### DIFF
--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -34,7 +34,8 @@ class InfraConversionThrottler
 
         eligible_host = eligible_hosts.first
         _log.debug("-- Associating  #{eligible_host.name} to the task for '#{vm_name}'.")
-        job.migration_task.update_attributes!(:conversion_host => eligible_hosts.first)
+        job.migration_task.update_attributes!(:conversion_host => eligible_host)
+        job.migration_task.update_options(:conversion_host_name => eligible_host.name)
 
         _log.debug("-- Queuing :start signal for the job for '#{vm_name}': current state is '#{job.state}'.")
         job.queue_signal(:start)

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -34,7 +34,7 @@ class InfraConversionThrottler
 
         eligible_host = eligible_hosts.first
         _log.debug("-- Associating  #{eligible_host.name} to the task for '#{vm_name}'.")
-        job.migration_task.update_attributes!(:conversion_host => eligible_host)
+        job.migration_task.update!(:conversion_host => eligible_host)
         job.migration_task.update_options(:conversion_host_name => eligible_host.name)
 
         _log.debug("-- Queuing :start signal for the job for '#{vm_name}': current state is '#{job.state}'.")

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
       expect(job_waiting).to receive(:queue_signal).with(:start)
       described_class.start_conversions
       expect(task_waiting.conversion_host.id).to eq(conversion_host2.id)
+      expect(task_waiting.options[:conversion_host_name]).to eq(conversion_host2.name)
     end
   end
 


### PR DESCRIPTION
If a conversion host is unconfigured by the user, the ConversionHost record is also deleted. This means that the relationship in the ServiceTemplateTransformationPlanTask records is set to nil. In the migration plan details, each migration displays the conversion host name, but then it becomes empty. 

This PR adds the conversion host name in the task options hash, so that UI can reliably display it. A migration task has one conversion host during its lifetime, so the information remains accurate.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1693994