### PR TITLE
Add `has_many :through` association for `switches` in `EmsCluster`

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -22,6 +22,8 @@ class EmsCluster < ApplicationRecord
   has_many    :miq_events,         :as => :target,   :dependent => :destroy
   has_many    :miq_alert_statuses, :as => :resource, :dependent => :destroy
 
+  has_many :switches, -> { distinct }, :through => :hosts
+
   virtual_column :v_ram_vr_ratio,      :type => :float,   :uses => [:aggregate_memory, :aggregate_vm_memory]
   virtual_column :v_cpu_vr_ratio,      :type => :float,   :uses => [:aggregate_cpu_total_cores, :aggregate_vm_cpus]
   virtual_column :v_parent_datacenter, :type => :string,  :uses => :all_relationships


### PR DESCRIPTION
This one is required by our GTLs in the UI if we want to display switches belonging to a cluster. 

https://bugzilla.redhat.com/show_bug.cgi?id=1726280

@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @himdel 
@miq-bot add_label hammer/yes, ivanchuk/yes, bug