### PR TITLE
Do not get stuck on destroy

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -558,7 +558,7 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   def destroy(task_id = nil)
-    disable! if enabled?
+    disable!(:validate => false) if enabled?
 
     _log.info("Destroying #{child_managers.count} child_managers")
     child_managers.destroy_all
@@ -838,9 +838,10 @@ class ExtManagementSystem < ApplicationRecord
     errors.add(:base, "emstype #{self.class.name} is not supported for create") unless ExtManagementSystem.supported_types_and_descriptions_hash.key?(emstype)
   end
 
-  def disable!
+  def disable!(validate: true)
     _log.info("Disabling EMS [#{name}] id [#{id}].")
-    update!(:enabled => false)
+    self.enabled = false
+    save(:validate => validate)
     _log.info("Disabling EMS [#{name}] id [#{id}] successful.")
   end
 


### PR DESCRIPTION
**Can not destroy a none-valid EMS.**

`destroy!` calls `disable!` before destroying the object, `disable` check for object validity, and do not let us destroy the object.

When destroying the object, we do not care for object validity, we want to remove it from the DB even if it is not valid.

**Example**
```
ems = ManageIQ::Providers::Openshift::ContainerManager.first

ems.hostname = nil
ems.default_endpoint.save!

ems:send(disable!)
=> NoMethodError: undefined method `ipaddress?' for nil:NilClass
=> from /home/yzamir/go/src/github.com/ManageIQ/manageiq/app/models/ext_management_system.rb:130:in `hostname_format_valid?'

ems.send(:disable!, :validate => false)
=> true
```

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1733587