### PR TITLE
Create instance methods for miq_task status checking

### DIFF
--- a/app/models/miq_task.rb
+++ b/app/models/miq_task.rb
@@ -105,6 +105,18 @@ class MiqTask < ApplicationRecord
     task.update_status(state, status, message) unless task.nil?
   end
 
+  def status_ok?
+    self.class.status_ok?(status)
+  end
+
+  def status_error?
+    self.class.status_error?(status)
+  end
+
+  def status_timeout?
+    self.class.status_timeout?(status)
+  end
+
   def check_associations
     if job && job.is_active?
       _log.warn("Delete not allowed: Task [#{id}] has active job - id: [#{job.id}], guid: [#{job.guid}],")

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -204,6 +204,27 @@ describe MiqTask do
       expect(message.zone).to eq(zone.name)
       expect(message.miq_task_id).to eq(tid)
     end
+
+    describe "#status_ok?" do
+      it "returns true for STATUS_OK" do
+        miq_task.update_status(MiqTask::STATE_QUEUED, MiqTask::STATUS_OK, "")
+        expect(miq_task.status_ok?).to be_truthy
+      end
+    end
+
+    describe "#status_error?" do
+      it "returns true for STATUS_ERROR" do
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_ERROR, "")
+        expect(miq_task.status_error?).to be_truthy
+      end
+    end
+
+    describe "#status_timeout?" do
+      it "returns true for STATUS_TIMEOUT" do
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_TIMEOUT, "")
+        expect(miq_task.status_timeout?).to be_truthy
+      end
+    end
   end
 
   context "when there are multiple MiqTasks" do


### PR DESCRIPTION
These were only class methods, which is silly.
This also fixes a bug introduced in 11d517d4212e11119cca397e4b878d99a1bc1d96
because I thought they were instance methods.