### PR TITLE
Pull roles from ansible galaxy before running a playbook

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -94,7 +94,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   def checkout_git_repository(target_directory)
     git_repository.update_repo
     git_repository.checkout(scm_branch, target_directory)
-    Ansible::Content.new(target_directory).fetch_galaxy_roles
   end
 
   ERROR_MAX_SIZE = 50.kilobytes

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -94,6 +94,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   def checkout_git_repository(target_directory)
     git_repository.update_repo
     git_repository.checkout(scm_branch, target_directory)
+    Ansible::Content.new(target_directory).fetch_galaxy_roles
   end
 
   ERROR_MAX_SIZE = 50.kilobytes

--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -5,7 +5,7 @@ module Ansible
     attr_accessor :path
 
     def initialize(path)
-      @path = path
+      @path = Pathname.new(path)
     end
 
     def fetch_galaxy_roles

--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -9,10 +9,9 @@ module Ansible
     end
 
     def fetch_galaxy_roles
-      roles_path = path.join('roles')
-      role_file  = path.join('requirements.yml')
+      return true unless requirements_file.exist?
 
-      params = ["install", :roles_path= => roles_path, :role_file= => role_file]
+      params = ["install", :roles_path= => roles_dir, :role_file= => requirements_file]
       AwesomeSpawn.run!("ansible-galaxy", :params => params)
     end
 
@@ -22,6 +21,21 @@ module Ansible
 
       Vmdb::Plugins.ansible_content.each do |content|
         FileUtils.cp_r(Dir.glob("#{content.path}/*"), dir)
+      end
+    end
+
+    private
+
+    def roles_dir
+      @roles_dir ||= path.join('roles')
+    end
+
+    def requirements_file
+      @requirements_file ||= begin
+        local_file     = path.join('requirements.yml')
+        roles_dir_file = roles_dir.join('requirements.yml')
+
+        roles_dir_file.exist? ? roles_dir_file : local_file
       end
     end
   end

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -254,6 +254,12 @@ module Ansible
         runner_args[:role_skip_facts] = nil if runner_args.delete(:role_skip_facts)
         runner_args[:ident] = "result"
 
+        playbook = runner_args.delete(:playbook)
+        if playbook
+          runner_args[:playbook]    = File.basename(playbook)
+          runner_args[:project_dir] = File.dirname(playbook)
+        end
+
         if verbosity.to_i > 0
           v_flag = "-#{"v" * verbosity.to_i.clamp(1, 5)}"
           runner_args[v_flag] = nil

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -216,6 +216,7 @@ module Ansible
         params = runner_params(base_dir, ansible_runner_method, playbook_or_role_args, verbosity)
 
         begin
+          fetch_galaxy_roles(playbook_or_role_args)
           result = AwesomeSpawn.run("ansible-runner", :env => env_vars_hash, :params => params)
           res = response(base_dir, ansible_runner_method, result)
         ensure
@@ -290,6 +291,13 @@ module Ansible
         errors << "roles path doesn't exist: #{roles_path}" if roles_path && !File.exist?(roles_path)
 
         raise ArgumentError, errors.join("; ") if errors.any?
+      end
+
+      def fetch_galaxy_roles(playbook_or_role_args)
+        return unless playbook_or_role_args[:playbook]
+
+        playbook_dir = File.dirname(playbook_or_role_args[:playbook])
+        Ansible::Content.new(playbook_dir).fetch_galaxy_roles
       end
 
       def credentials_info(credentials, base_dir)

--- a/spec/lib/ansible/content_spec.rb
+++ b/spec/lib/ansible/content_spec.rb
@@ -56,5 +56,18 @@ RSpec.describe Ansible::Content do
 
       subject.fetch_galaxy_roles
     end
+
+    it "works with a string path" do
+      FileUtils.touch(local_requirements)
+
+      expected_params = [
+        "install",
+        :roles_path= => roles_dir,
+        :role_file=  => local_requirements
+      ]
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
+
+      described_class.new(content_dir.to_s).fetch_galaxy_roles
+    end
   end
 end

--- a/spec/lib/ansible/content_spec.rb
+++ b/spec/lib/ansible/content_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe Ansible::Content do
+  let(:content_dir)        { Pathname.new(Dir.mktmpdir) }
+  let(:roles_dir)          { content_dir.join("roles") }
+  let(:local_requirements) { content_dir.join("requirements.yml") }
+  let(:roles_requirements) { content_dir.join("roles", "requirements.yml") }
+
+  subject { described_class.new(content_dir) }
+
+  after { FileUtils.rm_rf(content_dir) }
+
+  describe "#fetch_galaxy_roles" do
+    it "doesn't run anything if there is no requirements file" do
+      expect(AwesomeSpawn).not_to receive(:run!)
+
+      subject.fetch_galaxy_roles
+    end
+
+    it "runs ansible-galaxy using the local requirements file" do
+      FileUtils.touch(local_requirements)
+
+      expected_params = [
+        "install",
+        :roles_path= => roles_dir,
+        :role_file=  => local_requirements
+      ]
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
+
+      subject.fetch_galaxy_roles
+    end
+
+    it "runs ansible-runner using the roles requirements file" do
+      FileUtils.mkdir(roles_dir)
+      FileUtils.touch(roles_requirements)
+
+      expected_params = [
+        "install",
+        :roles_path= => roles_dir,
+        :role_file=  => roles_requirements
+      ]
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
+
+      subject.fetch_galaxy_roles
+    end
+
+    it "prefers the roles requirements file" do
+      FileUtils.mkdir(roles_dir)
+      FileUtils.touch(roles_requirements)
+      FileUtils.touch(local_requirements)
+
+      expected_params = [
+        "install",
+        :roles_path= => roles_dir,
+        :role_file=  => roles_requirements
+      ]
+      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
+
+      subject.fetch_galaxy_roles
+    end
+  end
+end

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -32,6 +32,8 @@ describe Ansible::Runner do
         expect(File.exist?(File.join(dir, "env", "cmdline"))).to be_falsey
       end.and_return(result)
 
+      expect_galaxy_roles_fetched
+
       described_class.run(env_vars, extra_vars, playbook)
     end
 
@@ -55,6 +57,8 @@ describe Ansible::Runner do
         cmdline = File.read(File.join(dir, "env", "cmdline"))
         expect(cmdline).to eq("--tags #{tags}")
       end.and_return(result)
+
+      expect_galaxy_roles_fetched
 
       described_class.run(env_vars, extra_vars, playbook, :tags => tags)
     end
@@ -105,6 +109,8 @@ describe Ansible::Runner do
           expect(extravars).to eq("name" => "john's server", "ansible_connection" => "local")
         end.and_return(result)
 
+        expect_galaxy_roles_fetched
+
         described_class.run(env_vars, extra_vars, playbook)
       end
     end
@@ -136,6 +142,8 @@ describe Ansible::Runner do
 
         expect(File.exist?(File.join(dir, "env", "cmdline"))).to be_falsey
       end.and_return(result)
+
+      expect_galaxy_roles_fetched
 
       runner_result = described_class.run_async(env_vars, extra_vars, playbook)
       expect(runner_result).kind_of?(Ansible::Runner::ResponseAsync)
@@ -256,5 +264,11 @@ describe Ansible::Runner do
       expect(MiqQueue.count).to eq(1)
       expect(MiqQueue.first.zone).to eq(zone.name)
     end
+  end
+
+  def expect_galaxy_roles_fetched
+    content_double = instance_double(Ansible::Content)
+    expect(Ansible::Content).to receive(:new).with("/path/to/my").and_return(content_double)
+    expect(content_double).to receive(:fetch_galaxy_roles)
   end
 end

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -21,7 +21,7 @@ describe Ansible::Runner do
 
         expect(method).to eq("run")
         expect(json).to   eq(:json)
-        expect(args).to   eq(:ident => "result", :playbook => playbook)
+        expect(args).to   eq(:ident => "result", :playbook => "playbook", :project_dir => "/path/to/my")
 
         hosts = File.read(File.join(dir, "inventory", "hosts"))
         expect(hosts).to eq("localhost")
@@ -44,7 +44,7 @@ describe Ansible::Runner do
 
         expect(method).to eq("run")
         expect(json).to   eq(:json)
-        expect(args).to   eq(:ident => "result", :playbook => playbook)
+        expect(args).to   eq(:ident => "result", :playbook => "playbook", :project_dir => "/path/to/my")
 
         hosts = File.read(File.join(dir, "inventory", "hosts"))
         expect(hosts).to eq("localhost")
@@ -64,7 +64,7 @@ describe Ansible::Runner do
         expect(command).to eq("ansible-runner")
 
         _method, _dir, _json, args = options[:params]
-        expect(args).to eq(:ident => "result", :playbook => playbook, "-vvvvv" => nil)
+        expect(args).to eq(:ident => "result", :playbook => "playbook", :project_dir => "/path/to/my", "-vvvvv" => nil)
       end.and_return(result)
 
       described_class.run(env_vars, extra_vars, playbook, :verbosity => 6)
@@ -96,7 +96,7 @@ describe Ansible::Runner do
 
           expect(method).to eq("run")
           expect(json).to   eq(:json)
-          expect(args).to   eq(:ident => "result", :playbook => playbook)
+          expect(args).to   eq(:ident => "result", :playbook => "playbook", :project_dir => "/path/to/my")
 
           hosts = File.read(File.join(dir, "inventory", "hosts"))
           expect(hosts).to eq("localhost")
@@ -126,7 +126,7 @@ describe Ansible::Runner do
 
         expect(method).to eq("start")
         expect(json).to   eq(:json)
-        expect(args).to   eq(:ident => "result", :playbook => playbook)
+        expect(args).to   eq(:ident => "result", :playbook => "playbook", :project_dir => "/path/to/my")
 
         hosts = File.read(File.join(dir, "inventory", "hosts"))
         expect(hosts).to eq("localhost")


### PR DESCRIPTION
This PR installs any roles defined in the `requirements.yml` file into the `roles` directory next to the requested playbook right before the playbook is run. It also gives ansible-runner some more information about the playbook context so it knows to use the roles we pull down rather than looking for them in the system roles path (where it will not find them).