### PR TITLE
Fixed seeding failure if yaml file containing report was renamed

### DIFF
--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -7,14 +7,18 @@ module MiqReport::Seeding
   module ClassMethods
     def seed
       transaction do
+        # seeding from files, :filename attribute of existing record may be changed in this process
+        seed_files.each do |f|
+          seed_record(f, MiqReport.find_by(:filename => seed_filename(f)))
+        end
+
+        # now remove Default reports which are not suplied as yaml anymore
         reports = where(:rpt_type => 'Default').where.not(:filename => nil).index_by do |f|
           seed_filename(f.filename)
         end
-
         seed_files.each do |f|
-          seed_record(f, reports.delete(seed_filename(f)))
+          reports.delete(seed_filename(f))
         end
-
         if reports.any?
           _log.info("Deleting the following MiqReport(s) as they no longer exist: #{reports.keys.sort.collect(&:inspect).join(", ")}")
 
@@ -67,6 +71,9 @@ module MiqReport::Seeding
           duplicate = find_by(:name => name)
           if duplicate&.rpt_type == "Custom"
             _log.warn("A custom report already exists with the name #{duplicate.name.inspect}.  Skipping...")
+          elsif duplicate
+            _log.warn("A standard report named '#{duplicate.name.inspect}' loaded from '#{duplicate.filename}' already exists. Updating attributes of existing report...")
+            duplicate.update!(attrs)
           else
             raise
           end

--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -75,7 +75,7 @@ module MiqReport::Seeding
           if duplicate&.rpt_type == "Custom"
             _log.warn("A custom report already exists with the name #{duplicate.name.inspect}.  Skipping...")
           elsif duplicate
-            _log.warn("A standard report named '#{duplicate.name.inspect}' loaded from '#{duplicate.filename}' already exists. Updating attributes of existing report...")
+            _log.warn("A default report named '#{duplicate.name.inspect}' loaded from '#{duplicate.filename}' already exists. Updating attributes of existing report...")
             duplicate.update!(attrs)
           else
             raise

--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -15,7 +15,7 @@ module MiqReport::Seeding
           seed_record(f, reports[seed_filename(f)])
         end
 
-        # now remove Default reports which are not suplied as yaml anymore
+        # now remove Default reports which are not supplied as yaml anymore
         reports = where(:rpt_type => 'Default').where.not(:filename => nil).index_by do |f|
           seed_filename(f.filename)
         end

--- a/app/models/miq_report/seeding.rb
+++ b/app/models/miq_report/seeding.rb
@@ -7,9 +7,12 @@ module MiqReport::Seeding
   module ClassMethods
     def seed
       transaction do
+        reports = where(:rpt_type => 'Default').where.not(:filename => nil).index_by do |f|
+          seed_filename(f.filename)
+        end
         # seeding from files, :filename attribute of existing record may be changed in this process
         seed_files.each do |f|
-          seed_record(f, MiqReport.find_by(:filename => seed_filename(f)))
+          seed_record(f, reports[seed_filename(f)])
         end
 
         # now remove Default reports which are not suplied as yaml anymore

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -108,6 +108,20 @@ describe MiqReport do
         expect(described_class.where(:name => custom_compare.name).count).to eq(1)
         expect(custom_compare.reload.rpt_type).to eq("Custom")
       end
+
+      it "updates attributes of existing record if yaml renamed" do
+        old_yaml_file = "520_Events - Policy/110_Policy Events.yaml"
+        new_yaml_file = "520_Events - Policy/some_new_name.yaml"
+        described_class.seed
+        report = MiqReport.find_by(:name => "Policy Events for Last Week")
+        expect(report.filename).to eq(old_yaml_file)
+
+        FileUtils.mv(reports_dir.join(old_yaml_file), reports_dir.join(new_yaml_file))
+        described_class.seed
+
+        report = MiqReport.find_by(:name => "Policy Events for Last Week")
+        expect(report.filename).to eq(new_yaml_file)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixed seeding failure if yaml file containing report was renamed

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1734076

Issue https://github.com/ManageIQ/manageiq/issues/18489

Related PR: https://github.com/ManageIQ/manageiq/pull/18377


@miq-bot add-label bug, core, changelog/yes, hammer/yes,  ivanchuk/yes , blocker
