### PR TITLE
Re-worded "Ansible Automation Inside" to "Embedded Ansible" for standardisation

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
-  FRIENDLY_NAME = "Ansible Automation Inside Job Template".freeze
+  FRIENDLY_NAME = "Embedded Ansible Job Template".freeze
 
   include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
 

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptSource
-  FRIENDLY_NAME = "Ansible Automation Inside Project".freeze
+  FRIENDLY_NAME = "Embedded Ansible Project".freeze
 
   validates :name,       :presence => true # TODO: unique within region?
   validates :scm_type,   :presence => true, :inclusion => { :in => %w[git] }

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/credential.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential < Mana
   EXTRA_ATTRIBUTES = {}.freeze
   API_ATTRIBUTES = COMMON_ATTRIBUTES.merge(EXTRA_ATTRIBUTES).freeze
 
-  FRIENDLY_NAME = "Ansible Automation Inside Credential".freeze
+  FRIENDLY_NAME = "Embedded Ansible Credential".freeze
 
   include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
 


### PR DESCRIPTION
Although the marketing term for Embedded Ansible is (was?) "Ansible Automation Inside", all references to the feature in the project and product mention "Embedded Ansible", for example the server role, and all related object types. Having pop-up notifications that mention "Ansible Automation Inside" is non-standard and confusing.

This PR standardises the text to "Embedded Ansible" and implements https://bugzilla.redhat.com/show_bug.cgi?id=1734906