### PR TITLE
Don't load BinaryBlobParts when determining if MiqReportResult is blank

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -73,7 +73,16 @@ class MiqReportResult < ApplicationRecord
     if miq_task
       miq_task.human_status
     else
-      report_results.blank? ? "Error" : "Complete"
+      report_results_blank? ? "Error" : "Complete"
+    end
+  end
+
+  # This method doesn't run through all binary blob parts to determine if it has any
+  def report_results_blank?
+    if binary_blob
+      binary_blob.parts.zero?
+    elsif report.kind_of?(MiqReport)
+      report.blank?
     end
   end
 

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -190,6 +190,25 @@ describe MiqReportResult do
     end
   end
 
+  describe '#report_results_blank?' do
+    let(:report_result) { FactoryBot.create(:miq_report_result) }
+    subject { report_result.report_results_blank? }
+
+    context 'report has a binary blob' do
+      let(:binary_blob) { FactoryBot.create(:binary_blob) }
+      before { report_result.binary_blob = binary_blob }
+
+      context 'binary blob is empty' do
+        it { is_expected.to be_truthy }
+      end
+
+      context 'binary blob has parts' do
+        before { binary_blob.binary = "foo" }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
+
   describe "serializing and deserializing report results" do
     it "can serialize and deserialize an MiqReport" do
       report = FactoryBot.build(:miq_report)


### PR DESCRIPTION
When loading Saved Reports with `BinaryBlob` under `Cloud Inter -> Reports`, we're loading all the `BinaryBlobPart` records for each model to determine the status of the Saved Report. If we have a lot of data in one of these blobs (like the BZ below) we end up with a very slow `report_data` request.

Thanks to @kbrock's we know where the bottleneck is and it can be easily fixed by counting the number of `BinaryBlobPart` records instead of actually deserializing them. Without this fix on the testing DB the request crashed after :turtle: 45 seconds, with the fix it succeeded after :zap: 262ms. 

@miq-bot add_label performance, bug, reporting, ui, hammer/yes, ivanchuk/yes, changelog/yes
@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @yrudman 
@miq-bot add_reviewer @lpichler 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1725142