### PR TITLE
The endpoint factory sets urls

### DIFF
--- a/spec/factories/firmware_binary.rb
+++ b/spec/factories/firmware_binary.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
 
     trait :with_endpoints do
       after(:create) do |binary|
-        binary.endpoints << FactoryBot.create(:endpoint, :url => 'http://test.binary.1', :resource => binary)
-        binary.endpoints << FactoryBot.create(:endpoint, :url => 'http://test.binary.2', :resource => binary)
+        binary.endpoints << FactoryBot.create(:endpoint, :resource => binary)
+        binary.endpoints << FactoryBot.create(:endpoint, :resource => binary)
       end
     end
   end

--- a/spec/factories/firmware_registry.rb
+++ b/spec/factories/firmware_registry.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :firmware_registry do
     sequence(:name) { |n| "firmware_registry_#{seq_padded_for_sorting(n)}" }
-    endpoint { |n| FactoryBot.create(:endpoint, :url => "http://test.registry.#{n}") }
+    endpoint { FactoryBot.create(:endpoint) }
     authentication { FactoryBot.create(:authentication) }
   end
 


### PR DESCRIPTION
We don't need to set URLs on endpoints in factories.

@miq-bot assign @jrafanie 
for this *super-critical* change 🎉 
@miq-bot add_label hammer/no, refactoring, test, changelog/no, ivanchuk/no 
