### PR TITLE
Add privilege needed for Queue up Schedules to run now

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2867,6 +2867,11 @@
       :hidden: true
       :identifier: schedule
       :children:
+      - :name: Run Now
+        :description: Queue up Schedules to run now
+        :feature_type: control
+        :hidden: true
+        :identifier: schedule_run_now
       - :name: Modify
         :description: Modify Schedules
         :feature_type: admin


### PR DESCRIPTION
I need this privilege to be added, so https://github.com/ManageIQ/manageiq-ui-classic/pull/5923 can work properly

