### PR TITLE
Allow move_into_folder to optionally take string arg for automate engine exposure

### DIFF
--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -106,8 +106,25 @@ module VmOrTemplate::Operations::Relocation
     run_command_via_parent(:vm_move_into_folder, :folder => folder)
   end
 
-  def move_into_folder(folder)
+  def move_into_folder(folder_or_id)
+    folder = folder_or_id.kind_of?(Integer) ? EmsFolder.find(folder_or_id) : folder_or_id
     raw_move_into_folder(folder)
+  end
+
+  def move_into_folder_queue(userid, folder)
+    task_opts = {
+      :action => "moving Vm to Folder #{folder.name} for user #{userid}",
+      :userid => userid
+    }
+    queue_opts = {
+      :class_name  => self.class.name,
+      :method_name => 'move_into_folder',
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :zone        => my_zone,
+      :args        => [folder.id]
+    }
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
   def migrate_via_ids(host_id, pool_id = nil, priority = "defaultPriority", state = nil)

--- a/spec/models/vm_migrate_task_spec.rb
+++ b/spec/models/vm_migrate_task_spec.rb
@@ -1,6 +1,7 @@
 describe VmMigrateTask do
   describe '.do_request' do
     let(:vm) { Vm.new }
+    let(:folder) { FactoryBot.create(:ems_folder) }
     before do
       subject.vm = vm
       host = FactoryBot.create(:host, :name => "test")
@@ -13,7 +14,31 @@ describe VmMigrateTask do
       subject.do_request
     end
 
-    it 'catches migrate error and update the status' do
+    it "doesn't move vm without ems" do
+      subject.update(:options => {:placement_folder_name => folder.id})
+      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => "finished", :status => "Error", :message => "Failed. Reason[VM has no EMS, unable to move VM into a new folder]"))
+      subject.do_request
+    end
+
+    it "doesn't move vm if already in folder" do
+      vm.update(:name => 'aaa', :vendor => 'vmware', :location => 'somewhere')
+      vm.ext_management_system = FactoryBot.create(:ext_management_system)
+      folder.set_child(vm)
+      subject.update(:options => {:placement_folder_name => folder.id})
+      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => "finished", :status => "Error", :message => "Failed. Reason[The VM '#{vm.name}' is already running on the same folder as the destination.]"))
+      subject.do_request
+    end
+
+    it "moves vm" do
+      vm.update(:name => 'aaa', :vendor => 'vmware', :location => 'somewhere')
+      vm.ext_management_system = FactoryBot.create(:ext_management_system, :with_authentication)
+      subject.update(:options => {:placement_folder_name => folder.id})
+      expect(vm).to receive(:run_command_via_parent).with(:vm_move_into_folder, :folder => folder)
+      expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => "migrated", :status => "Ok", :message => "Finished VM Migrate"))
+      subject.do_request
+    end
+
+    it "catches migrate error and update the status" do
       expect(vm).to receive(:migrate).and_raise("Bad things happened")
       expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => 'finished', :status => 'Error', :message => 'Failed. Reason[Bad things happened]'))
       subject.do_request


### PR DESCRIPTION
We have to queue ems_folders for the automate exposure of ```move_into_folder```, so this method needs a change to handle being passed a string. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1716858
@miq-bot add_label enhancement

## Related:
https://github.com/ManageIQ/manageiq-automation_engine/pull/344