### PR TITLE
[V2V] Prevent a finished transformation plan from starting

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -24,6 +24,8 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   end
 
   def validate_order
+    # Service template should not be orderable if all VMs have already been migrated
+    return false if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.empty?
     true
   end
   alias orderable? validate_order

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -25,8 +25,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
 
   def validate_order
     # Service template should not be orderable if all VMs have already been migrated
-    return false if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.empty?
-    true
+    vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.present?
   end
   alias orderable? validate_order
 


### PR DESCRIPTION
Currently, UI prevents users to start a migration plan that is already finished, simply by not showing the migrate button. However, the API doesn't prevent it. This PR adds a check on the service template order validation, so that a finished plan will fail validation. A plan is considered finished whenever all its virtual machines have been migrated, hence have been tagged as `transformation_status/migrated`.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1718858