### PR TITLE
[EmbeddedAnsible] Handle nested playbooks

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -115,7 +115,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     git_repository.with_worktree do |worktree|
       worktree.ref = scm_branch
       worktree.blob_list.select do |filename|
-        playbook?(filename, worktree)
+        playbook_dir?(filename) && playbook?(filename, worktree)
       end
     end
   end
@@ -158,5 +158,15 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     end
 
     false
+  end
+
+  INVALID_DIRS = %w[roles tasks group_vars host_vars].freeze
+
+  # Given a Pathname, determine if it includes invalid directories so it can be
+  # removed from consideration.
+  def playbook_dir?(filepath)
+    elements = Pathname.new(filepath).each_filename.to_a
+
+    elements.none? { |el| INVALID_DIRS.include?(el) }
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -112,7 +112,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
   def playbooks_in_git_repository
     git_repository.update_repo
-    git_repository.entries(scm_branch, "").grep(/\.ya?ml$/)
+    git_repository.with_worktree do |worktree|
+      worktree.ref = scm_branch
+      worktree.blob_list.grep(/\.ya?ml$/)
+    end
   end
 
   def checkout_git_repository(target_directory)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -163,10 +163,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   INVALID_DIRS = %w[roles tasks group_vars host_vars].freeze
 
   # Given a Pathname, determine if it includes invalid directories so it can be
-  # removed from consideration.
+  # removed from consideration, and also ignore hidden files and directories.
   def playbook_dir?(filepath)
     elements = Pathname.new(filepath).each_filename.to_a
 
-    elements.none? { |el| INVALID_DIRS.include?(el) }
+    elements.none? { |el| el.starts_with?('.') || INVALID_DIRS.include?(el) }
   end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source.rb
@@ -140,12 +140,20 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
   # Confirms two things:
   #
   #   - The file extension is a yaml extension
-  #   - The content of the file has one line that matches VALID_PLAYBOOK_CHECK
+  #   - The content of the file is "a playbook"
+  #
+  # A file is considered a playbook if it has one line that matches
+  # VALID_PLAYBOOK_CHECK, or it starts with $ANSIBLE_VAULT, which in that case
+  # it is an encrypted file which it isn't possible to decern if it is a
+  # playbook or a different type of yaml file.
   #
   def playbook?(filename, worktree)
     return false unless filename.match?(/\.ya?ml$/)
 
-    worktree.read_file(filename).each_line do |line|
+    content = worktree.read_file(filename)
+    return true if content.start_with?("$ANSIBLE_VAULT")
+
+    content.each_line do |line|
       return true if line.match?(VALID_PLAYBOOK_CHECK)
     end
 

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -167,6 +167,16 @@ class GitWorktree
     tree.walk(:preorder).collect { |root, entry| "#{root}#{entry[:name]}" }
   end
 
+  # Like "file_list", but doesn't return directories
+  def blob_list
+    tree = lookup_commit_tree
+    return [] unless tree
+
+    [].tap do |blobs|
+      tree.walk_blobs(:preorder) { |root, entry| blobs << "#{root}#{entry[:name]}" }
+    end
+  end
+
   def find_entry(path)
     get_tree_entry(path)
   end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -188,6 +188,26 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
           expect(playbooks_for(record)).to eq(%w[ansible_project/hello_world.yml])
         end
       end
+
+      context "with a requirements.yml" do
+        let(:requirements_repo) { File.join(clone_dir, "hello_requirements") }
+
+        let(:requirements_repo_structure) do
+          %w[
+            hello_world.yml
+            requirements.yml
+          ]
+        end
+
+        it "finds only playbooks" do
+          Spec::Support::FakeAnsibleRepo.generate(requirements_repo, requirements_repo_structure)
+
+          params[:scm_url] = "file://#{requirements_repo}"
+          record           = build_record
+
+          expect(playbooks_for(record)).to eq(%w[hello_world.yml])
+        end
+      end
     end
 
     describe "#update_in_provider" do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -208,6 +208,26 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
           expect(playbooks_for(record)).to eq(%w[hello_world.yml])
         end
       end
+
+      context "with a encrypted playbooks" do
+        let(:encrypted_repo) { File.join(clone_dir, "hello_world_encrypted") }
+
+        let(:encrypted_repo_structure) do
+          %w[
+            hello_world.yml
+            hello_world.encrypted.yml
+          ]
+        end
+
+        it "finds all playbooks" do
+          Spec::Support::FakeAnsibleRepo.generate(encrypted_repo, encrypted_repo_structure)
+
+          params[:scm_url] = "file://#{encrypted_repo}"
+          record           = build_record
+
+          expect(playbooks_for(record)).to match_array(%w[hello_world.yml hello_world.encrypted.yml])
+        end
+      end
     end
 
     describe "#update_in_provider" do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -228,6 +228,32 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
           expect(playbooks_for(record)).to match_array(%w[hello_world.yml hello_world.encrypted.yml])
         end
       end
+
+      context "with 'ignorable dirs'" do
+        let(:roles_repo) { File.join(clone_dir, "hello_roles_and_things") }
+
+        let(:roles_repo_structure) do
+          %w[
+            roles/defaults/main.yml
+            roles/meta/main.yml
+            roles/tasks/main.yml
+            tasks/task_1.yml
+            tasks/task_2.yml
+            group_vars/vars.yml
+            host_vars/vars.yml
+            hello_world.yml
+          ]
+        end
+
+        it "finds only playbooks" do
+          Spec::Support::FakeAnsibleRepo.generate(roles_repo, roles_repo_structure)
+
+          params[:scm_url] = "file://#{roles_repo}"
+          record           = build_record
+
+          expect(playbooks_for(record)).to eq(%w[hello_world.yml])
+        end
+      end
     end
 
     describe "#update_in_provider" do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -159,6 +159,37 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
       end
     end
 
+    describe "#playbooks_in_git_repository" do
+      def playbooks_for(repo)
+        repo.configuration_script_payloads.pluck(:name)
+      end
+
+      it "finds top level playbooks" do
+        record = build_record
+
+        expect(playbooks_for(record)).to eq(%w[hello_world.yaml])
+      end
+
+      context "with a nested playbooks dir" do
+        let(:nested_repo) { File.join(clone_dir, "hello_world_nested") }
+
+        let(:nested_repo_structure) do
+          %w[
+            ansible_project/hello_world.yml
+          ]
+        end
+
+        it "finds all playbooks" do
+          Spec::Support::FakeAnsibleRepo.generate(nested_repo, nested_repo_structure)
+
+          params[:scm_url] = "file://#{nested_repo}"
+          record           = build_record
+
+          expect(playbooks_for(record)).to eq(%w[ansible_project/hello_world.yml])
+        end
+      end
+    end
+
     describe "#update_in_provider" do
       let(:update_params)      { { :scm_branch => "other_branch" } }
       let(:notify_update_args) { notification_args('update', update_params) }

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -254,6 +254,27 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
           expect(playbooks_for(record)).to eq(%w[hello_world.yml])
         end
       end
+
+      context "with hidden files" do
+        let(:hide_and_seek_repo) { File.join(clone_dir, "hello_world_is_hiding") }
+
+        let(:hide_and_seek_repo_structure) do
+          %w[
+            .ansible.d/hello_world.yml
+            .travis.yml
+            hello_world.yml
+          ]
+        end
+
+        it "finds only playbooks" do
+          Spec::Support::FakeAnsibleRepo.generate(hide_and_seek_repo, hide_and_seek_repo_structure)
+
+          params[:scm_url] = "file://#{hide_and_seek_repo}"
+          record           = build_record
+
+          expect(playbooks_for(record)).to eq(%w[hello_world.yml])
+        end
+      end
     end
 
     describe "#update_in_provider" do

--- a/spec/support/fake_ansible_repo.rb
+++ b/spec/support/fake_ansible_repo.rb
@@ -1,0 +1,278 @@
+# = Spec::Support::FakeAnsibleRepo
+#
+# Extracted from EmbeddedAnsible::AutomationManager::ConfigurationScriptSource
+#
+# Generates a dummy local git repository with a configurable file structure.
+# The repo just needs to be given a repo_path and a file tree definition.
+#
+#     file_tree_definition = %w[
+#       roles/foo/tasks/main.yml
+#       requirements.yml
+#       playbook.yml
+#     ]
+#     FakeAnsibleRepo.generate "/path/to/my_repo", file_tree_definition
+#
+#     other_repo = FakeAnsibleRepo.new "/path/to/my/other_repo", file_tree_definition
+#     other_repo.generate
+#     other_repo.git_branch_create "patch_1"
+#     other_repo.git_branch_create "patch_2"
+#
+#
+# == File Tree Definition
+#
+# The file tree definition (file_struct) is just passed in as a word array for
+# each file/empty-dir entry for the repo#
+#
+# So for a single file repo with a `hello_world.yml` playbook, the definition
+# as a HEREDOC string would be:
+#
+#     file_struct = %w[
+#       hello_world.yaml
+#     ]
+#
+# This will generate a repo with a single file called `hello_world.yml`.  For a
+# more complex example:
+#
+#     file_struct = %w[
+#       azure_servers/azure_playbook.yml
+#       azure_servers/roles/azure_stuffs/requirements.yml
+#       azure_servers/roles/azure_stuffs/tasks/main.yml
+#       azure_servers/roles/azure_stuffs/defaults/main.yml
+#       aws_servers/roles/s3_stuffs/tasks/main.yml
+#       aws_servers/roles/s3_stuffs/defaults/main.yml
+#       aws_servers/roles/ec2_config/tasks/main.yml
+#       aws_servers/roles/ec2_config/defaults/main.yml
+#       aws_servers/aws_playbook.yml
+#       aws_servers/s3_playbook.yml
+#       openshift/roles/
+#       localhost/requirements.yml
+#       localhost/localhost_playbook.yml
+#     ]
+#
+# NOTE:  directories only need to be defined on their own if they are intended
+# to be empty, otherwise a defining files in them is enough.
+#
+#
+# == Reserved file names/paths
+#
+# Most files with `.yml` or `.yaml` will be generated for some dummy content
+# for a playbook:
+#
+#     - name: filename.yml
+#       hosts: all
+#       tasks:
+#         - name: filename.yml Message
+#           debug:
+#             msg: "Hello World! (from filename.yml)"
+#
+# This is mostly to allow for testing playbook detecting code.  To the end,
+# there are also "reserved" filenames that you can use to generate alternative
+# dummy content that is not in a playbook format.
+#
+#
+# === requirements.yml
+#
+# Regardless of where you put this file, if found, it will generate a sample
+# `ansible-galaxy` requirements file.
+#
+#     - src: yatesr.timezone
+#     - src: https://github.com/bennojoy/nginx
+#     - src: https://github.com/bennojoy/nginx
+#       version: master
+#         name: nginx_role
+#
+#
+# === roles/**/meta/main.yml
+#
+# Will generate a "Role Dependencies" yaml definition:
+#
+#     ---
+#     dependencies:
+#       - role: common
+#         vars:
+#           some_parameter: 3
+#       - role: apache
+#         vars:
+#           apache_port: 80
+#
+#
+# === extra_vars.yml, roles/**/vars/*.yml, and roles/**/defaults/*.yml
+#
+# Generates sample variable files
+#
+#     ---
+#     var_1: foo
+#     var_2: bar
+#     var_3: baz
+#
+
+require "rugged"
+
+require "pathname"
+require "fileutils"
+
+module Spec
+  module Support
+    class FakeAnsibleRepo
+      REQUIREMENTS = <<~REQUIREMENTS.freeze
+        - src: yatesr.timezone
+        - src: https://github.com/bennojoy/nginx
+        - src: https://github.com/bennojoy/nginx
+          version: master
+            name: nginx_role
+      REQUIREMENTS
+
+      META_DATA = <<~ROLE_DEPS.freeze
+        ---
+        dependencies:
+          - role: common
+            vars:
+              some_parameter: 3
+          - role: apache
+            vars:
+              apache_port: 80
+      ROLE_DEPS
+
+      VAR_DATA = <<~VARS.freeze
+        ---
+        var_1: foo
+        var_2: bar
+        var_3: baz
+      VARS
+
+      attr_reader :file_struct, :repo_path, :repo, :index
+
+      def self.generate(repo_path, file_struct)
+        new(repo_path, file_struct).generate
+      end
+
+      def initialize(repo_path, file_struct)
+        @repo_path   = Pathname.new(repo_path)
+        @name        = @repo_path.basename
+        @file_struct = file_struct
+      end
+
+      def generate
+        build_repo(repo_path, file_struct)
+
+        git_init
+        git_add_all
+        git_commit_initial
+      end
+
+      # Create a new branch (don't checkout)
+      #
+      #   $ git branch other_branch
+      #
+      def git_branch_create(new_branch_name)
+        repo.create_branch(new_branch_name)
+      end
+
+      private
+
+      # Generate repo structure based on file_structure array
+      #
+      # By providing a directory location and an array of paths to generate,
+      # this will build a repository directory structure.  If a specific entry
+      # ends with a '/', then an empty directory will be generated.
+      #
+      # Example file structure array:
+      #
+      #     file_struct = %w[
+      #       roles/defaults/main.yml
+      #       roles/meta/main.yml
+      #       roles/tasks/main.yml
+      #       host_vars/
+      #       hello_world.yml
+      #     ]
+      #
+      def build_repo(repo_path, file_structure)
+        file_structure.each do |entry|
+          path          = repo_path.join(entry)
+          dir, filename = path.split unless entry.end_with?("/")
+          FileUtils.mkdir_p(dir || entry)
+
+          next unless filename
+
+          build_file(dir, filename)
+        end
+      end
+
+      VAR_FILE_FNMATCHES = [
+        "**/extra_vars.{yml,yaml}",
+        "**/roles/*/vars/*.{yml,yaml}",
+        "**/roles/*/defaults/*.{yml,yaml}"
+      ].freeze
+
+      # Generates a single file
+      #
+      # If it is a reserved file name/path, then the contents are generated,
+      # otherwise it will be a empty file.
+      #
+      def build_file(repo_rel_path, entry)
+        full_path = repo_rel_path.join(entry)
+        content   = if filepath_match?(full_path, "**/requirements.{yml,yaml}")
+                      REQUIREMENTS
+                    elsif filepath_match?(full_path, *VAR_FILE_FNMATCHES)
+                      VAR_DATA
+                    elsif filepath_match?(full_path, "**/roles/*/meta/main.{yml,yaml}")
+                      META_DATA
+                    elsif filepath_match?(full_path, "**/*.{yml,yaml}")
+                      dummy_playbook_data_for(full_path.basename)
+                    end
+
+        File.write(full_path, content)
+      end
+
+      # Given a collection of glob based `File.fnmatch` strings, confirm
+      # whether any of them match the given path.
+      #
+      def filepath_match?(path, *acceptable_matches)
+        acceptable_matches.any? { |match| path.fnmatch?(match, File::FNM_EXTGLOB) }
+      end
+
+      # Init new repo at local_repo
+      #
+      #   $ cd /tmp/clone_dir/hello_world_local && git init .
+      #
+      def git_init
+        @repo  = Rugged::Repository.init_at(repo_path.to_s)
+        @index = repo.index
+      end
+
+      # Add new files to index
+      #
+      #   $ git add .
+      #
+      def git_add_all
+        index.add_all
+        index.write
+      end
+
+      # Create initial commit
+      #
+      #   $ git commit -m "Initial Commit"
+      #
+      def git_commit_initial
+        Rugged::Commit.create(
+          repo,
+          :message    => "Initial Commit",
+          :parents    => [],
+          :tree       => index.write_tree(repo),
+          :update_ref => "HEAD"
+        )
+      end
+
+      def dummy_playbook_data_for(filename)
+        <<~PLAYBOOK_DATA
+          - name: #{filename}
+            hosts: all
+            tasks:
+              - name: #{filename} Message
+                debug:
+                  msg: "Hello World! (from #{filename})"
+        PLAYBOOK_DATA
+      end
+    end
+  end
+end


### PR DESCRIPTION
As mentioned by:

https://bugzilla.redhat.com/show_bug.cgi?id=1734446

We currently don't support nested playbooks with `EmbeddedAnsible` using `AnsibleRunner`.  This was an oversight that Ansible Tower / `awx` gave us for free, so this implements what those two were doing in the past.

Of note, we are saving the full relative file path for the name now in the ConfigurationScriptPayload record.  This is what was done previously when doing a refresh, but worth noting.


Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1734446
* `awx` links:
  - [`valid_playbook_re`](https://github.com/ansible/awx/blob/128fa894/awx/main/utils/ansible.py#L17)
  - [`skip_directory`](https://github.com/ansible/awx/blob/128fa894/awx/main/utils/ansible.py#L21-L36)
  - [`could_be_playbook`](https://github.com/ansible/awx/blob/128fa894/awx/main/utils/ansible.py#L39-L66)


Steps for Testing/QA
--------------------

Need to test this with an actual playbook run still...