### PR TITLE
Allow ovirt to implement their own pg version check

### DIFF
--- a/config/initializers/postgres_required_versions.rb
+++ b/config/initializers/postgres_required_versions.rb
@@ -1,7 +1,10 @@
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend Module.new {
   def initialize(*args)
     super
+    check_version if respond_to?(:check_version)
+  end
 
+  def check_version
     msg = "The version of PostgreSQL being connected to is incompatible with #{Vmdb::Appliance.PRODUCT_NAME} (10 required)"
 
     if postgresql_version < 90500


### PR DESCRIPTION
This doesn't fix the following bug but allows them to implement their
own adapter that opts-out of the manageiq pg version check and instead
implement their own via a check_version, something like this:

https://github.com/ManageIQ/ovirt_metrics/pull/33


https://bugzilla.redhat.com/show_bug.cgi?id=1734770