### PR TITLE
locale:report_changes to report new strings / word since last update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -237,6 +237,7 @@ end
 unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
+    gem "PoParser"
     gem "rubocop-performance", "~>1.3",    :require => false
     # ruby_parser is required for i18n string extraction
     gem "ruby_parser",                     :require => false

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -187,6 +187,23 @@ namespace :locale do
     system('rm', '-rf', tmp_dir)
   end
 
+  desc "Show changes in gettext strings since last catalog update"
+  task "report_changes", [:verbose] do |_t, args|
+    require 'poparser'
+
+    old_pot = PoParser.parse(File.read(Rails.root.join('locale', 'manageiq.pot'))).to_h.collect { |item| item[:msgid] }.sort
+    Rake::Task['locale:update_all'].invoke
+    new_pot = PoParser.parse(File.read(Rails.root.join('locale', 'manageiq.pot'))).to_h.collect { |item| item[:msgid] }.sort
+    diff = new_pot - old_pot
+    puts "--------------------------------------------------"
+    puts "Current string / word count: %{str} / %{word}" % {:str => old_pot.length, :word => old_pot.join(' ').split.size}
+    puts "Updated string / word count: %s{str} / %{word}" % {:str => new_pot.length, :word => new_pot.join(' ').split.size}
+    puts
+    puts "New string / word count: %{str} / %{word}" % {:str => diff.length, :word => diff.join(' ').split.size}
+    puts "--------------------------------------------------"
+    puts "New strings: ", diff if args.verbose == 'verbose'
+  end
+
   desc "Extract plugin strings - execute as: rake locale:plugin:find[plugin_name]"
   task "plugin:find", :engine do |_, args|
     unless args[:engine]


### PR DESCRIPTION
This PR implements a new rake taks in the `locale` namespace to report new strings / words since last catalog update.

This will help to determine whether or not a new translation cycle for given release is needed.

Sample run on current ManageIQ master:
```
$ bundle exec rake locale:report_changes[verbose]
...
--------------------------------------------------
Current string / word count: 16319 / 65595
Updated string / word count: 16313 / 65556

New string / word count: 4 / 12
--------------------------------------------------
New strings: 
Network Router (Microsoft Azure)
Network Routers (Microsoft Azure)
Publish Virtual Machine
Uri
```

@miq-bot add_label internationalization, ivanchuk/yes

@martinpovolny  and / or @himdel 