### PR TITLE
Fix the MiqWorker.systemd_supported? method

### DIFF
--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -6,6 +6,7 @@ class MiqWorker
       def supports_systemd?
         return unless worker_settings[:systemd_enabled]
         require "dbus/systemd"
+        true
       rescue LoadError
         false
       end


### PR DESCRIPTION
Only the first worker type was reporting as being supported for systemd
because all other require calls returned false as the gem was already
loaded.