### PR TITLE
MiqServer creates worker records so we always need to pass the GUID

### DIFF
--- a/app/models/miq_worker/systemd_common.rb
+++ b/app/models/miq_worker/systemd_common.rb
@@ -24,7 +24,7 @@ class MiqWorker
       end
 
       def service_name
-        scalable? ? service_base_name : "#{service_base_name}@"
+        "#{service_base_name}@"
       end
 
       def service_file_name
@@ -131,7 +131,7 @@ class MiqWorker
     end
 
     def unit_instance
-      scalable? ? "" : "@#{guid}"
+      "@#{guid}"
     end
 
     def write_unit_settings_file


### PR DESCRIPTION
For now MiqServer is creating the worker records and assigning a guid,
so we need to pass the guid to the systemd service in all cases for now.