### PR TITLE
What's thousandths of a second between friends

### DIFF
--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -33,7 +33,7 @@ describe Storage do
     allow(Storage).to receive_messages(:scan_watchdog_interval => scan_watchdog_interval)
     start = Time.parse("Sun March 10 01:00:00 UTC 2010")
     Timecop.travel(start) do
-      expect(Storage.scan_watchdog_deliver_on - (start + scan_watchdog_interval)).to be_within(0.001).of(0.0)
+      expect(Storage.scan_watchdog_deliver_on - (start + scan_watchdog_interval)).to be_within(1).of(0.0)
     end
   end
 


### PR DESCRIPTION
Fix sporadic failure due to incredible precision

Seen in the tests for #19093.

I doubt we'll ever notice a scan_watchdog starting 2 thousandths of a
second too early or late.

It's more reasonable to expect within 1 second of the desired time.