### PR TITLE
Update ovirt_metrics for check_version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,7 +155,7 @@ end
 
 group :ovirt, :manageiq_default do
   manageiq_plugin "manageiq-providers-ovirt"
-  gem "ovirt_metrics",                  "~>3.0.0",       :require => false
+  gem "ovirt_metrics",                  "~>3.0.1",       :require => false
 end
 
 group :scvmm, :manageiq_default do


### PR DESCRIPTION
Latest version of ovirt_metrics implements a custom PostgreSQLAdapter
to override the MIQ check_version method and allow connections to PG
older than v.10.

Related to #19090

This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1734770

Describe the rationale and use case for this pull request.  Provide any background, examples, and images that provide further information to accurately describe what it is that you are adding to the repo.  Add subsections as necessary to organize and feel free to link and reference other PRs as necessary, but also include them in the links section below as a quick reference.

Guidelines:
* Keep Pull Request titles short and to the point, ideally under 72 characters
* Provide as much context/info in the description as necessary to get the reviewer up to the same domain knowledge level as yourself
* Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
* Please, make reviewers work easier by checking, if you are not introducing any technical debt: https://github.com/ManageIQ/guides/blob/master/reviewers_guidelines.md

Links [Optional]
----------------

* http://documentation.for/library/that/I/am/adding
* [PR relevant issue or pull_request](#123)

Steps for Testing/QA [Optional]
-------------------------------

If there are any manual steps that you would like the reviewer(s) to take to verify your changes, please describe in detail the steps to reproduce the features added by the pull request, or the bug before and after the change.
