### PR TITLE
Fix: make chargeback generation for service to be region aware and do not generate for retired service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -400,8 +400,8 @@ class Service < ApplicationRecord
   end
 
   def self.queue_chargeback_reports(options = {})
-    Service.all.each do |s|
-      s.queue_chargeback_report_generation(options) unless s.vms.empty?
+    Service.in_my_region.each do |s|
+      s.queue_chargeback_report_generation(options) unless s.vms.empty? || s.retired
     end
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -425,13 +425,28 @@ describe Service do
     end
 
     describe ".queue_chargeback_reports" do
-      it "queue request to generate chargeback report for each service" do
+      before do
         @service_c1 = FactoryBot.create(:service, :service => @service)
         @service_c1.name = "Test_Service_2"
         @service_c1 << @vm1
         @service_c1.save
+      end
 
+      it "queue request to generate chargeback report for each service" do
         expect(MiqQueue).to receive(:put).twice
+        described_class.queue_chargeback_reports
+      end
+
+      it "queue request to generate chargeback report only in service's region" do
+        allow(Service).to receive(:in_my_region).and_return([@service_c1])
+        expect(MiqQueue).to receive(:put).once
+        described_class.queue_chargeback_reports
+      end
+
+      it "does not queue request to generate chargeback report if service retired" do
+        @service_c1.update(:retired => true)
+        allow(Service).to receive(:in_my_region).and_return([@service_c1])
+        expect(MiqQueue).not_to receive(:put)
         described_class.queue_chargeback_reports
       end
     end


### PR DESCRIPTION
**Issue**: chargeback generation was triggered for all services, regardless service been retired or belongs to different region.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1736749

@miq-bot add-label bug, core, changelog/yes, hammer/yes, ivanchuk/yes

\cc @gtanzillo 