### PR TITLE
Move persister properties out of mixin

### DIFF
--- a/app/models/manageiq/providers/inventory/persister.rb
+++ b/app/models/manageiq/providers/inventory/persister.rb
@@ -52,6 +52,27 @@ class ManageIQ::Providers::Inventory::Persister
     collections.keys
   end
 
+  def strategy
+    nil
+  end
+
+  def saver_strategy
+    :default
+  end
+
+  # Persisters for targeted refresh can override to true
+  def targeted?
+    false
+  end
+
+  def parent
+    manager.presence
+  end
+
+  def assert_graph_integrity?
+    !Rails.env.production?
+  end
+
   # @return [InventoryRefresh::InventoryCollection] returns a defined InventoryCollection or undefined method
   def method_missing(method_name, *arguments, &block)
     if inventory_collections_names.include?(method_name)

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -89,27 +89,6 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
     opts.merge(extra_settings)
   end
 
-  def strategy
-    nil
-  end
-
-  def saver_strategy
-    :default
-  end
-
-  # Persisters for targeted refresh can override to true
-  def targeted?
-    false
-  end
-
-  def parent
-    manager.presence
-  end
-
-  def assert_graph_integrity?
-    !Rails.env.production?
-  end
-
   # @return [Hash] kwargs shared for all InventoryCollection objects
   def shared_options
     {


### PR DESCRIPTION
A number of persister properties were in the persister builder mixin for
some reason.  These are overridden by child classes so its nice to have
them in the main class file not buried in a mixin.