### PR TITLE
Add a method to filter password keys from settings

### DIFF
--- a/lib/vmdb/settings_walker.rb
+++ b/lib/vmdb/settings_walker.rb
@@ -50,6 +50,13 @@ module Vmdb
         walk_passwords(settings) { |k, _v, h| h[k] = "********" }
       end
 
+      # Filter out any password attributes from the settings
+      #
+      # @param settings (see .walk)
+      def filter_passwords!(settings)
+        walk_passwords(settings) { |k, _v, h| h.respond_to?(:delete_field) ? h.delete_field(k) : h.delete(k) }
+      end
+
       # Walks the settings and decrypts passwords it finds
       #
       # @param settings (see .walk)

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -516,6 +516,14 @@ describe Vmdb::Settings do
     include_examples "password handling"
   end
 
+  describe ".filter_passwords!" do
+    it "removes the field from the settings" do
+      stub_settings(:password => "abcd")
+      filtered = described_class.filter_passwords!(Settings.to_h)
+      expect(filtered.keys).to_not include(:password)
+    end
+  end
+
   describe ".for_resource" do
     let(:server) { FactoryBot.create(:miq_server) }
 


### PR DESCRIPTION
In some cases we want password keys stripped completely from the
settings, not just masked.

This adds a method which recursively walks the settings and deletes any
keys corresponding to a password attributes.