### PR TITLE
Allow MiqSchedule to accept nil and skip scheduling

### DIFF
--- a/app/models/miq_schedule_worker/scheduler.rb
+++ b/app/models/miq_schedule_worker/scheduler.rb
@@ -14,7 +14,11 @@ class MiqScheduleWorker
     end
 
     def schedule_every(duration = nil, callable = nil, opts = {}, &block)
-      raise ArgumentError if duration.nil?
+      if duration.blank?
+        logger.warn("Duration is empty, scheduling ingnored. Called from: #{block}.")
+        return
+      end
+
       role_schedule << rufus_scheduler.schedule_every(duration, callable, opts, &block)
     rescue ArgumentError => err
       logger.error("#{err.class} for schedule_every with [#{duration}, #{opts.inspect}].  Called from: #{caller[1]}.")

--- a/spec/models/miq_schedule_worker/scheduler_spec.rb
+++ b/spec/models/miq_schedule_worker/scheduler_spec.rb
@@ -49,8 +49,8 @@ describe MiqScheduleWorker::Scheduler do
     end
 
     context "with different parmeters" do
-      it "catches an error on nil first arg" do
-        expect(logger).to receive(:error).once.with(/scheduler_spec.rb/)
+      it "interprets first arg nil as trigger to skip scheduling" do
+        expect(logger).to receive(:warn).once.with(/Duration is empty, scheduling ingnored/)
         scheduler.schedule_every(nil) {}
       end
 


### PR DESCRIPTION
**ISSUE**:  there is no good way to disable not needed schedule.
**FIX**: accept nil or empty string as first argument to ```MiqScheduleWorker::Scheduler#schedule_every``` which will trigger skipping scheduling

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1736749

@miq-bot add-label enhancement, core, changelog/yes, hammer/yes, ivanchuk/yes

\cc @gtanzillo 
