### PR TITLE
Remove unused HOST_CREATE/DISCOVERY_TYPE

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -24,16 +24,6 @@ class Host < ApplicationRecord
     nil               => "Unknown",
   }.freeze
 
-  HOST_DISCOVERY_TYPES = {
-    'vmware' => 'esx',
-    'ipmi'   => 'ipmi'
-  }.freeze
-
-  HOST_CREATE_OS_TYPES = {
-    'VMware ESX' => 'linux_generic',
-    # 'Microsoft Hyper-V' => 'windows_generic'
-  }.freeze
-
   validates_presence_of     :name
   validates_inclusion_of    :user_assigned_os, :in => ["linux_generic", "windows_generic", nil]
   validates_inclusion_of    :vmm_vendor, :in => VENDOR_TYPES.keys
@@ -1701,12 +1691,18 @@ class Host < ApplicationRecord
   # Host Discovery Types and Platforms
 
   def self.host_discovery_types
-    HOST_DISCOVERY_TYPES.values
+    # TODO: This feature has been removed, once the UI no longer calls this
+    # method we can delete it
+    []
   end
+  Vmdb::Deprecation.deprecate_methods(self, :host_discovery_types)
 
   def self.host_create_os_types
-    HOST_CREATE_OS_TYPES
+    # TODO: This feature has been removed, once the UI no longer calls this
+    # method we can delete it
+    []
   end
+  Vmdb::Deprecation.deprecate_methods(self, :host_create_os_types)
 
   def has_compliance_policies?
     _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "host_compliance_check")

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -189,14 +189,6 @@ describe Host do
     it("nil vendor")   { expect(FactoryBot.build(:host, :vmm_vendor => nil).vmm_vendor_display).to eq("Unknown") }
   end
 
-  it ".host_discovery_types" do
-    expect(Host.host_discovery_types).to match_array ["esx", "ipmi"]
-  end
-
-  it ".host_create_os_types" do
-    expect(Host.host_create_os_types).to eq("VMware ESX" => "linux_generic")
-  end
-
   context "host validation" do
     before do
       EvmSpecHelper.local_miq_server


### PR DESCRIPTION
We are removing the ability to add/discover standalone hosts not
connected to an ext_management_system.

https://bugzilla.redhat.com/show_bug.cgi?id=1733294