### PR TITLE
Add SSH support for Embedded Ansible repositories

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -9,7 +9,7 @@ class GitRepository < ApplicationRecord
 
   attr_reader :git_lock
 
-  validates :url, :format => URI::regexp(%w(http https file)), :allow_nil => false
+  validates :url, :format => URI.regexp(%w[http https file ssh]), :allow_nil => false
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}
@@ -219,7 +219,12 @@ class GitRepository < ApplicationRecord
     params[:certificate_check] = method(:self_signed_cert_cb) if verify_ssl == OpenSSL::SSL::VERIFY_NONE
     if (auth = authentication || default_authentication)
       params[:username] = auth.userid
-      params[:password] = auth.password
+      if auth.auth_key
+        params[:ssh_private_key] = auth.auth_key
+        params[:password] = auth.auth_key_password.presence
+      else
+        params[:password] = auth.password
+      end
     end
     params
   end

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -84,7 +84,7 @@ class GitRepository < ApplicationRecord
     with_worktree do |worktree|
       message = "Updating #{url} in #{directory_name}..."
       _log.info(message)
-      worktree.send(:fetch_and_merge)
+      worktree.send(:pull)
       _log.info("#{message}...Complete")
     end
     @updated_repo = true

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -10,19 +10,23 @@ class GitWorktree
     require 'rugged'
 
     raise ArgumentError, "Must specify path" unless options.key?(:path)
-    @path          = options[:path]
-    @email         = options[:email]
-    @username      = options[:username] || ""
-    @bare          = options[:bare]
-    @commit_sha    = options[:commit_sha]
-    @password      = options[:password] || ""
-    @fast_forward_merge = options[:ff] || true
-    @remote_name   = 'origin'
-    @cred          = Rugged::Credentials::UserPassword.new(:username => @username,
-                                                           :password => @password)
-    @credentials_set = false
-    @base_name = File.basename(@path)
+    @path                 = options[:path]
+    @email                = options[:email]
+    @username             = options[:username]
+    @bare                 = options[:bare]
+    @commit_sha           = options[:commit_sha]
+    @password             = options[:password]
+    @ssh_private_key      = options[:ssh_private_key]
+    @fast_forward_merge   = options[:ff] || true
     @certificate_check_cb = options[:certificate_check]
+
+    @remote_name = 'origin'
+    @base_name   = File.basename(@path)
+
+    if @ssh_private_key && !Rugged.features.include?(:ssh)
+      raise GitWorktreeException::InvalidCredentialType, "ssh credentials are not enabled for use. Recompile the rugged/libgit2 gem with ssh support to enable it."
+    end
+
     process_repo(options)
   end
 
@@ -201,16 +205,46 @@ class GitWorktree
     @repo.checkout_tree(tree, :target_directory => target_directory, :strategy => :force)
   end
 
-  def credentials_cb(url, _username, _types)
-    if @credentials_set
-      raise GitWorktreeException::InvalidCredentials, "Please provide username and password for URL #{url}" if @username.blank? || @password.blank?
-      raise GitWorktreeException::InvalidCredentials, "Invalid credentials for URL #{url}"
+  def with_credential_options
+    if @ssh_private_key
+      @ssh_private_key_file = Tempfile.new
+      @ssh_private_key_file.write(@ssh_private_key)
+      @ssh_private_key_file.close
     end
-    @credentials_set = true
-    @cred
+
+    options = {:credentials => method(:credentials_cb)}
+    options[:certificate_check] = @certificate_check_cb if @certificate_check_cb
+
+    yield options
+  ensure
+    if @ssh_private_key_file
+      @ssh_private_key_file.unlink
+      @ssh_private_key_file = nil
+    end
   end
 
   private
+
+  def credentials_cb(url, username_from_url, _allowed_types)
+    username = @username || username_from_url
+
+    if @ssh_private_key_file
+      raise GitWorktreeException::InvalidCredentials, "Please provide username for URL #{url}" if username.blank?
+
+      Rugged::Credentials::SshKey.new(
+        :username   => username,
+        :privatekey => @ssh_private_key_file.path,
+        :passphrase => @password.presence
+      )
+    else
+      raise GitWorktreeException::InvalidCredentials, "Please provide username and password for URL #{url}" if @username.blank? || @password.blank?
+
+      Rugged::Credentials::UserPassword.new(
+        :username => @username,
+        :password => @password
+      )
+    end
+  end
 
   def current_branch
     @repo.head_unborn? ? 'master' : @repo.head.name.sub(/^refs\/heads\//, '')
@@ -231,9 +265,9 @@ class GitWorktree
   end
 
   def fetch
-    @credentials_set = false
-    options = {:credentials => method(:credentials_cb), :certificate_check => @certificate_check_cb}
-    @repo.fetch(@remote_name, options)
+    with_credential_options do |cred_options|
+      @repo.fetch(@remote_name, cred_options)
+    end
   end
 
   def pull
@@ -246,8 +280,9 @@ class GitWorktree
       @saved_cid = @repo.ref(local_ref).target.oid
       merge(commit, rebase)
       rebase = true
-      @credentials_set = false
-      @repo.push(@remote_name, [local_ref], :credentials => method(:credentials_cb))
+      with_credential_options do |cred_options|
+        @repo.push(@remote_name, [local_ref], cred_options)
+      end
     end
   end
 
@@ -300,9 +335,10 @@ class GitWorktree
   end
 
   def clone(url)
-    @credentials_set = false
-    options = {:credentials => method(:credentials_cb), :bare => true, :remote => @remote_name, :certificate_check => @certificate_check_cb}
-    @repo = Rugged::Repository.clone_at(url, @path, options)
+    @repo = with_credential_options do |cred_options|
+      options = cred_options.merge(:bare => true, :remote => @remote_name)
+      Rugged::Repository.clone_at(url, @path, options)
+    end
   end
 
   def fetch_entry(path)
@@ -356,7 +392,7 @@ class GitWorktree
   end
 
   def create_commit(message, tree, parents)
-    author = {:email => @email, :name => @username, :time => Time.now}
+    author = {:email => @email, :name => @username || @email, :time => Time.now}
     # Create the actual commit but dont update the reference
     Rugged::Commit.create(@repo, :author  => author,  :committer  => author,
                                  :message => message, :parents    => parents,

--- a/lib/git_worktree_exception.rb
+++ b/lib/git_worktree_exception.rb
@@ -14,4 +14,5 @@ module GitWorktreeException
   class TagMissing < RuntimeError; end
   class RefMissing < RuntimeError; end
   class InvalidCredentials < RuntimeError; end
+  class InvalidCredentialType < RuntimeError; end
 end

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -64,7 +64,7 @@ describe GitRepository do
         repo.update_authentication(:default => {:userid => userid, :password => password})
         expect(GitWorktree).to receive(:new).with(clone_args).and_return(gwt)
         expect(GitWorktree).to receive(:new).with(args).and_return(gwt)
-        expect(gwt).to receive(:fetch_and_merge).with(no_args)
+        expect(gwt).to receive(:pull).with(no_args)
 
         repo.refresh
         expect(repo.default_authentication.userid).to eq(userid)
@@ -79,7 +79,7 @@ describe GitRepository do
           args[:certificate_check] = repo.method(:self_signed_cert_cb)
           expect(GitWorktree).to receive(:new).with(clone_args).and_return(gwt)
           expect(GitWorktree).to receive(:new).with(args).and_return(gwt)
-          expect(gwt).to receive(:fetch_and_merge).with(no_args)
+          expect(gwt).to receive(:pull).with(no_args)
 
           repo.refresh
         end
@@ -99,7 +99,7 @@ describe GitRepository do
 
       expect(repo).to receive(:clone_repo_if_missing).once.with(no_args).and_call_original
       expect(GitWorktree).to receive(:new).with(anything).and_return(gwt)
-      expect(gwt).to receive(:fetch_and_merge).with(no_args)
+      expect(gwt).to receive(:pull).with(no_args)
 
       repo.refresh
       expect(repo.git_branches.collect(&:name)).to match_array(branch_list)
@@ -110,7 +110,7 @@ describe GitRepository do
       expect(GitWorktree).to receive(:new).twice.with(anything).and_return(gwt)
       expect(gwt).to receive(:branches).with(anything).and_return(branch_list)
       expect(gwt).to receive(:tags).with(no_args).and_return(tag_list)
-      expect(gwt).to receive(:fetch_and_merge).with(no_args)
+      expect(gwt).to receive(:pull).with(no_args)
 
       allow(gwt).to receive(:branch_info) do |name|
         branch_info_hash[name]
@@ -127,7 +127,7 @@ describe GitRepository do
       expect(GitWorktree).to receive(:new).twice.with(anything).and_return(gwt)
       expect(gwt).to receive(:branches).with(anything).and_return(branch_list)
       expect(gwt).to receive(:tags).with(no_args).and_return(tag_list)
-      expect(gwt).to receive(:fetch_and_merge).with(no_args)
+      expect(gwt).to receive(:pull).with(no_args)
 
       allow(gwt).to receive(:branch_info) do |name|
         branch_info_hash[name]
@@ -144,7 +144,7 @@ describe GitRepository do
       expect(GitWorktree).to receive(:new).twice.with(anything).and_return(gwt)
       expect(gwt).to receive(:branches).with(anything).and_return(branch_list)
       expect(gwt).to receive(:tags).with(no_args).and_return(tag_list)
-      expect(gwt).to receive(:fetch_and_merge).with(no_args)
+      expect(gwt).to receive(:pull).with(no_args)
 
       allow(gwt).to receive(:branch_info) do |name|
         branch_info_hash[name]
@@ -160,7 +160,7 @@ describe GitRepository do
       expect(GitWorktree).to receive(:new).twice.with(anything).and_return(gwt)
       expect(gwt).to receive(:branches).with(anything).and_return(branch_list)
       expect(gwt).to receive(:tags).with(no_args).and_return(tag_list)
-      expect(gwt).to receive(:fetch_and_merge).with(no_args)
+      expect(gwt).to receive(:pull).with(no_args)
 
       allow(gwt).to receive(:branch_info) do |name|
         branch_info_hash[name]
@@ -174,7 +174,7 @@ describe GitRepository do
 
     it "#refresh branches deleted" do
       expect(GitWorktree).to receive(:new).twice.with(anything).and_return(gwt)
-      expect(gwt).to receive(:fetch_and_merge).twice.with(no_args)
+      expect(gwt).to receive(:pull).twice.with(no_args)
       expect(gwt).to receive(:branches).twice.with(anything).and_return(branch_list)
       expect(gwt).to receive(:tags).twice.with(no_args).and_return(tag_list)
 
@@ -194,7 +194,7 @@ describe GitRepository do
 
     it "#refresh tags deleted" do
       expect(GitWorktree).to receive(:new).twice.with(anything).and_return(gwt)
-      expect(gwt).to receive(:fetch_and_merge).twice.with(no_args)
+      expect(gwt).to receive(:pull).twice.with(no_args)
       expect(gwt).to receive(:branches).twice.with(anything).and_return(branch_list)
       expect(gwt).to receive(:tags).twice.with(no_args).and_return(tag_list)
 


### PR DESCRIPTION
The code here involved a bit of an overhaul of the credentials handling inside GitWorktree, but I think it's a lot cleaner this way.  Basically, we wrap credential usage in a with block that creates the key as a Tempfile, does the operation and then deletes the key.  For user/pass, we still use the block format, but nothing actually happens.

Note that the only mechanism provided by rugged seems to be SSH keys as files, hence the use of Tempfile.  libgit2 seems to have support for SSH key in memory, but it's not exposed via rugged from what I can tell.

I think as a follow up we may want to either a) expose that ssh key in memory cred in rugged, or b) allow for IO objects in addition to filename Strings for the privatekey and publickey options.

@carbonin @NickLaMuro Please review.
