### PR TITLE
Add .jsx to file glob of files to extract strings from

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -228,7 +228,7 @@ namespace :locale do
       end
 
       def files_to_translate
-        Dir.glob("#{@engine_root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js}")
+        Dir.glob("#{@engine_root}/{app,db,lib,config,locale}/**/*.{rb,erb,haml,slim,rhtml,js,jsx}")
       end
 
       def text_domain


### PR DESCRIPTION
This is to support string extraction from `.jsx` files as well.

@martinpovolny 

@miq-bot add_label internationalization, ivanchuk/yes