### PR TITLE
Add an EmsFolder#vm_folder? method indicating if a folder can have vm children

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -118,6 +118,11 @@ class EmsFolder < ApplicationRecord
     detect_ancestor(:of_type => "EmsFolder") { |a| a.kind_of?(Datacenter) }
   end
 
+  # Indicates if the folder is able to have child VMs
+  def vm_folder?
+    path.any? { |folder| folder.name == "vm" && folder.hidden? }
+  end
+
   # TODO: refactor by vendor/hypervisor (currently, this assumes VMware)
   def register_host(host)
     host = Host.extract_objects(host)

--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -3,28 +3,70 @@ describe EmsFolder do
     before do
       @root = FactoryBot.create(:ems_folder, :name => "root")
 
-      @dc   = FactoryBot.create(:ems_folder, :name => "dc")
+      @dc   = FactoryBot.create(:datacenter, :name => "dc")
       @dc.parent = @root
 
+      @vm = FactoryBot.create(:ems_folder, :name => "vm", :hidden => true)
+      @vm.parent = @dc
+
+      @host = FactoryBot.create(:ems_folder, :name => "host", :hidden => true)
+      @host.parent = @dc
+
       @sib1 = FactoryBot.create(:ems_folder, :name => "sib1")
-      @sib1.parent = @dc
+      @sib1.parent = @vm
 
       @sib2 = FactoryBot.create(:ems_folder, :name => "sib2")
-      @sib2.parent = @dc
+      @sib2.parent = @vm
 
       @leaf = FactoryBot.create(:ems_folder, :name => "leaf")
       @leaf.parent = @sib2
+
+      @yellow = FactoryBot.create(:ems_folder, :name => "prod_cluster")
+      @yellow.parent = @host
     end
 
     it "calling child_folder_paths" do
       expected = {
-        @root.id => "root",
-        @dc.id   => "root/dc",
-        @sib1.id => "root/dc/sib1",
-        @sib2.id => "root/dc/sib2",
-        @leaf.id => "root/dc/sib2/leaf"
+        @root.id   => "root",
+        @dc.id     => "root/dc",
+        @vm.id     => "root/dc/vm",
+        @host.id   => "root/dc/host",
+        @sib1.id   => "root/dc/vm/sib1",
+        @sib2.id   => "root/dc/vm/sib2",
+        @leaf.id   => "root/dc/vm/sib2/leaf",
+        @yellow.id => "root/dc/host/prod_cluster"
       }
       expect(@root.child_folder_paths).to eq(expected)
+    end
+
+    context "#vm_folder?" do
+      it "returns false for a yellow folder" do
+        expect(@yellow.vm_folder?).to be_falsy
+      end
+
+      it "returns false for the hidden host folder" do
+        expect(@host.vm_folder?).to be_falsy
+      end
+
+      it "returns false for the datacenter" do
+        expect(@dc.vm_folder?).to be_falsy
+      end
+
+      it "return false for folders above the datacenter" do
+        expect(@root.vm_folder?).to be_falsy
+      end
+
+      it "returns true for the hidden vm folder" do
+        expect(@vm.vm_folder?).to be_truthy
+      end
+
+      it "returns true for a child folder of the vm folder" do
+        expect(@sib1.vm_folder?).to be_truthy
+      end
+
+      it "returns true for a leaf folder of the vm folder" do
+        expect(@leaf.vm_folder?).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
Add a `EmsFolder#vm_folder?` method returning if a folder is able to
have child vms.

This checks if the folder is or has as an ancestor the hidden "vm"
folder.  All other folders are considered "yellow" and are unable to
have vms as children.

Fixes https://github.com/ManageIQ/manageiq/issues/19104