### PR TITLE
Remove user roles for Host Discover and Add

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1246,9 +1246,6 @@
       :description: Check Compliance of Last Known Configuration for Hosts / Nodes
       :feature_type: control
       :identifier: host_check_compliance
-    - :name: Discover
-      :feature_type: control
-      :identifier: host_discover
     - :name: Manage Policies
       :description: Manage Policies for Hosts / Nodes
       :feature_type: control
@@ -1306,10 +1303,6 @@
     :feature_type: admin
     :identifier: host_admin
     :children:
-    - :name: Add
-      :description: Add a Host / Node
-      :feature_type: admin
-      :identifier: host_new
     - :name: Remove
       :description: Remove Hosts / Nodes
       :feature_type: admin

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -396,9 +396,7 @@
   - physical_server_view
   - physical_storage_view
   - physical_infra_topology_view
-  - host_new
   - host_compare
-  - host_discover
   - host_drift
   - host_edit
   - host_refresh


### PR DESCRIPTION
Removes related user roles for discovering and adding Hosts.

Related PRs:
https://github.com/ManageIQ/manageiq-ui-classic/pull/5963
https://github.com/ManageIQ/manageiq/pull/19107

@miq-bot add_labels bug, ui, cleanup

https://bugzilla.redhat.com/show_bug.cgi?id=1733294