### PR TITLE
Check type of child ids in custom button set child validation 

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -8,7 +8,7 @@ class CustomButtonSet < ApplicationRecord
     return if set_data.try(:[], :button_order).nil?
 
     children = Rbac.filtered(CustomButton.where(:id => set_data[:button_order]))
-    throw(:abort) if children.pluck(:id).sort != set_data[:button_order].sort
+    throw(:abort) if children.pluck(:id).sort != set_data[:button_order].map(&:to_i).sort
   end
 
   def update_children


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/blob/master/app/models/custom_button_set.rb#L11 gets called from hereabouts: https://github.com/ManageIQ/manageiq-api/blob/master/app/controllers/api/custom_button_sets_controller.rb#L8 and the set data there can be strings: ```{:set_data=>{:button_order=>["1"], :button_icon=>"ff ff-manageiq", :button_color=>"#4727ff", :display=>true, :applies_to_class=>"Service"}}```

Unless the issue is that listing ints as strings like that is in the call is kinda silly? But it doesn't stop QE from tryin', anyway.

naming is difficult 

@miq-bot add_label bug
@miq-bot assign @jrafanie  