### PR TITLE
Run ansible-runner with PYTHONPATH set to access additional modules

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -206,7 +206,7 @@ module Ansible
         end
         command_line_hash.merge!(cred_command_line)
 
-        env_vars_hash   = env_vars.merge(cred_env_vars)
+        env_vars_hash   = env_vars.merge(cred_env_vars).merge(python_env)
         extra_vars_hash = extra_vars.merge(cred_extra_vars)
 
         create_hosts_file(base_dir, hosts)
@@ -298,6 +298,19 @@ module Ansible
 
         playbook_dir = File.dirname(playbook_or_role_args[:playbook])
         Ansible::Content.new(playbook_dir).fetch_galaxy_roles
+      end
+
+      def python_env
+        python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/"
+        python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages/"
+
+        if File.exist?(python3_modules_path)
+          { "PYTHONPATH" => python3_modules_path }
+        elsif File.exist?(python2_modules_path)
+          { "PYTHONPATH" => python2_modules_path }
+        else
+          {}
+        end
       end
 
       def credentials_info(credentials, base_dir)

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -87,6 +87,38 @@ describe Ansible::Runner do
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
     end
 
+    it "sets PYTHONPATH correctly with python3 modules installed " do
+      python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages/"
+      python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/"
+
+      allow(File).to receive(:exist?).with(python2_modules_path).and_return(false)
+      allow(File).to receive(:exist?).with(python3_modules_path).and_return(true)
+
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+
+        expect(options[:env]["PYTHONPATH"]).to eq(python3_modules_path)
+      end.and_return(result)
+
+      described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
+    end
+
+    it "sets PYTHONPATH correctly with python2 modules installed " do
+      python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages/"
+      python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/"
+
+      allow(File).to receive(:exist?).with(python2_modules_path).and_return(true)
+      allow(File).to receive(:exist?).with(python3_modules_path).and_return(false)
+
+      expect(AwesomeSpawn).to receive(:run) do |command, options|
+        expect(command).to eq("ansible-runner")
+
+        expect(options[:env]["PYTHONPATH"]).to eq(python2_modules_path)
+      end.and_return(result)
+
+      described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)
+    end
+
     context "with special characters" do
       let(:env_vars)   { {"ENV1" => "pa$%w0rd!'"} }
       let(:extra_vars) { {"name" => "john's server"} }


### PR DESCRIPTION
On the appliance we will install all the modules that were previously used by awx to utilize the cloud credential roles out of the box.

In addition to this fix, we will need to install the modules on the appliance at build time which is done in ~~https://github.com/ManageIQ/manageiq-appliance-build/pull/340~~ https://github.com/ManageIQ/manageiq-appliance-build/pull/341

https://bugzilla.redhat.com/show_bug.cgi?id=1734129