### PR TITLE
Introduce product feature for viewing automate namespaces

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -2269,6 +2269,10 @@
     :hidden: true
     :identifier: miq_ae_namespace
     :children:
+    - :name: View
+      :description: View
+      :feature_type: view
+      :identifier: miq_ae_namespace_view
     - :name: Modify
       :description: Modify Namespace
       :feature_type: admin


### PR DESCRIPTION
Somehow this was missing from the product features list. If we want an API endpoint that can display automate namespaces, this is probably necessary. Of course I'm no automate expert so I'm not sure about this, so summoning @gmcculloug @d-m-u to clarify this.

Also it's an open question to what roles should I append this feature and/or if we need to change something in the UI if we have this feature cc @martinpovolny 

@miq-bot add_label enhancement, automate, rbac, hammer/no, ivanchuk/no, changelog/yes
@miq-bot add_reviewer @d-m-u 
@miq-bot add_reviewer @kbrock 
@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @martinpovolny 