### PR TITLE
Add a common validate_credentials API and method for getting all provider create params

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -46,6 +46,12 @@ class ExtManagementSystem < ApplicationRecord
     !reflections.include?("parent_manager")
   end
 
+  def self.provider_create_params
+    supported_types_for_create.each_with_object({}) do |ems_type, create_params|
+      create_params[ems_type.name] = ems_type.params_for_create if ems_type.respond_to?(:params_for_create)
+    end
+  end
+
   belongs_to :provider
   has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
 


### PR DESCRIPTION
This changes validate_credentials_task from calling raw_connect with
different args for every provider to call a common validate_credentials
method that will be implemented for each provider.

It also adds a top-level method for retrieving each provider's
json-schema create params so that the UI can use data-driven-forms and
build the validate_credentials_task args generically rather than having
to have a case for each provider.

Related: https://github.com/ManageIQ/manageiq-providers-amazon/pull/551

https://github.com/ManageIQ/manageiq/issues/18818