### PR TITLE
[MiqQueue] Add MiqQueue.broadcast

### DIFF
--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -61,11 +61,13 @@ module EvmSpecHelper
     instance.instance_variable_set(ivar, nil)
   end
 
+  def self.stub_as_local_server(server)
+    allow(MiqServer).to receive(:my_guid).and_return(server.guid)
+    MiqServer.my_server_clear_cache
+  end
+
   def self.local_miq_server(attrs = {})
-    remote_miq_server(attrs).tap do |server|
-      allow(MiqServer).to receive(:my_guid).and_return(server.guid)
-      MiqServer.my_server_clear_cache
-    end
+    remote_miq_server(attrs).tap { |server| stub_as_local_server(server) }
   end
 
   def self.local_guid_miq_server_zone


### PR DESCRIPTION
Adds a helper method to `MiqQueue` to enable broadcasting a job to all servers.  Allows filtering servers to broadcast to by zone.

Will be followed up by a PR to handle broadcasting filesystem deletes for `GitRepository` records.


Links
-----

* Addresses part of RFE TODO:  https://github.com/ManageIQ/manageiq-design/issues/45#issuecomment-514372257