### PR TITLE
[GitRepository] Broadcast delete of repo_dir

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -16,9 +16,14 @@ class GitRepository < ApplicationRecord
 
   has_many :git_branches, :dependent => :destroy
   has_many :git_tags, :dependent => :destroy
-  after_destroy :delete_repo_dir # TODO: Need to distribute this to all systems
+  after_destroy :broadcast_repo_dir_delete
 
   INFO_KEYS = %w(commit_sha commit_message commit_time name).freeze
+
+  def self.delete_repo_dir(id, directory_name)
+    _log.info("Deleting GitRepository[#{id}] in #{directory_name} for MiqServer[#{MiqServer.my_server.id}]...")
+    FileUtils.rm_rf(directory_name)
+  end
 
   def refresh
     update_repo
@@ -229,7 +234,11 @@ class GitRepository < ApplicationRecord
     params
   end
 
-  def delete_repo_dir
-    FileUtils.rm_rf(directory_name)
+  def broadcast_repo_dir_delete
+    MiqQueue.broadcast(
+      :class_name  => self.class.name,
+      :method_name => "delete_repo_dir",
+      :args        => [id, directory_name]
+    )
   end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -383,6 +383,9 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
         expect(Notification).to receive(:create!).with(notification_args('deletion', {}))
         record.delete_in_provider
 
+        # Run most recent queue item (`GitRepository#broadcast_repo_dir_delete`)
+        MiqQueue.get.deliver
+
         expect { record.reload }.to raise_error ActiveRecord::RecordNotFound
 
         expect(git_repo_dir).to_not exist


### PR DESCRIPTION
Built on top of https://github.com/ManageIQ/manageiq/pull/19122

Updates `GitRepository#destroy` to send `FileUtils.rm_rf` calls to the queue so it can be performed on all servers.  The jobs should be idempotent and able to work even after the record is removed from the database.


Links
-----

* Addresses the rest of RFE TODO: https://github.com/ManageIQ/manageiq-design/issues/45#issuecomment-514372257