### PR TITLE
Add Auth KeyPair Ownership feature

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -864,6 +864,10 @@
       :description: Edit Tags of Key Pairs
       :feature_type: control
       :identifier: auth_key_pair_cloud_tag
+    - :name: Set Ownership
+      :description: Set Ownership of Keys Pairs
+      :feature_type: control
+      :identifier: auth_key_pair_ownership
   - :name: Modify
     :description: Modify Key Pairs
     :feature_type: admin


### PR DESCRIPTION
This feature is needed for adding Set Ownership screen. It should be backported to Hammer.

Links [Optional]
----------------
https://github.com/ManageIQ/manageiq-ui-classic/pull/5967
https://github.com/ManageIQ/manageiq-ui-classic/pull/5973
https://bugzilla.redhat.com/show_bug.cgi?id=1589766
https://bugzilla.redhat.com/show_bug.cgi?id=1730066

