### PR TITLE
Don't require support/fake_ansible_repo

### DIFF
--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -1,5 +1,3 @@
-require 'support/fake_ansible_repo'
-
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource do
   context "with a local repo" do
     let(:manager) do


### PR DESCRIPTION
This causes provider tests to fail with:
```
An error occurred while loading ./spec/manageiq/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb.
Failure/Error: require 'support/fake_ansible_repo'
```