### PR TITLE
Move relation into the base class

### DIFF
--- a/app/models/pxe_menu.rb
+++ b/app/models/pxe_menu.rb
@@ -1,5 +1,8 @@
 class PxeMenu < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :pxe_server
+  has_many :pxe_images, :dependent => :destroy
 
   def self.class_from_contents(contents)
     line = contents.to_s.each_line { |l| break l }

--- a/app/models/pxe_menu_ipxe.rb
+++ b/app/models/pxe_menu_ipxe.rb
@@ -1,6 +1,4 @@
 class PxeMenuIpxe < PxeMenu
-  has_many :pxe_images, :class_name => "PxeImageIpxe", :foreign_key => :pxe_menu_id, :dependent => :destroy
-
   def self.parse_contents(contents)
     menu_items = parse_menu(contents)
     entries = parse_labels(contents, menu_items.keys)

--- a/app/models/pxe_menu_pxelinux.rb
+++ b/app/models/pxe_menu_pxelinux.rb
@@ -1,6 +1,4 @@
 class PxeMenuPxelinux < PxeMenu
-  has_many :pxe_images, :class_name => "PxeImagePxelinux", :foreign_key => :pxe_menu_id, :dependent => :destroy
-
   def self.parse_contents(contents)
     items = []
     current_item = nil

--- a/spec/models/pxe_menu_spec.rb
+++ b/spec/models/pxe_menu_spec.rb
@@ -162,4 +162,16 @@ PXEMENU
       expect(new_pxe_menu.pxe_images.length).to eq(3)
     end
   end
+
+  describe 'destroy' do
+    let!(:pxe_image) { FactoryBot.create(:pxe_image, :pxe_menu => subject) }
+
+    it 'removes related pxe images as well' do
+      expect(PxeMenu.count).to eq(1)
+      expect(PxeImage.count).to eq(1)
+      subject.destroy
+      expect(PxeMenu.count).to eq(0)
+      expect(PxeImage.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
When one destroys PxeMenu, also related MiqImages are destroyed. This works for both subclasses of PxeMenu:

- `PxeMenuIpxe`
- `PxeMenuPxelinux`

but does not work for base class, which is annoying in rspecs. With this commit we simply move relation definition to the base class so that it now works everywhere.

Fixes https://github.com/ManageIQ/manageiq/issues/18940

@miq-bot add_label bug,ivanchuk/yes
@miq-bot assign @bdunne 

/cc @tadeboro @matejart @gberginc 
