### PR TITLE
Improve references

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -81,7 +81,11 @@ module MiqReport::Generator
   end
 
   def get_include_for_find
-    include_as_hash(include.presence || invent_report_includes).deep_merge(include_for_find || {}).presence
+    get_include.deep_merge(include_for_find || {}).presence
+  end
+
+  def get_include
+    include_as_hash(include.presence || invent_report_includes)
   end
 
   def invent_includes

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -250,18 +250,15 @@ module MiqReport::Generator
   def generate_daily_metric_rollup_results(options = {})
     unless conditions.nil?
       conditions.preprocess_options = {:vim_performance_daily_adhoc => (time_profile && time_profile.rollup_daily_metrics)}
-      exp_sql, exp_includes = conditions.to_sql
-      # only_cols += conditions.columns_for_sql # Add cols references in expression to ensure they are present for evaluation
     end
 
     time_range = Metric::Helper.time_range_from_offset(interval, db_options[:start_offset], db_options[:end_offset], tz)
     results = Metric::Helper.find_for_interval_name('daily', time_profile || tz, db_klass)
-                            .where(where_clause).where(exp_sql)
+                            .where(where_clause)
                             .where(options[:where_clause])
                             .where(:timestamp => time_range)
                             .includes(get_include_for_find)
                             .references(db_klass.includes_to_references(get_include))
-                            .includes(exp_includes || [])
                             .limit(options[:limit])
     results = Rbac.filtered(results, :class        => db,
                                      :filter       => conditions,
@@ -274,18 +271,14 @@ module MiqReport::Generator
   def generate_interval_metric_results(options = {})
     time_range = Metric::Helper.time_range_from_offset(interval, db_options[:start_offset], db_options[:end_offset])
 
-    # Only build where clause from expression for hourly report. It will not work properly for daily because many values are rolled up from hourly.
-    exp_sql, exp_includes = conditions.to_sql(tz) unless conditions.nil? || db_klass.respond_to?(:instances_are_derived?)
-
     results = db_klass.with_interval_and_time_range(interval, time_range)
                       .where(where_clause)
                       .where(options[:where_clause])
-                      .where(exp_sql)
                       .includes(get_include_for_find)
                       .references(db_klass.includes_to_references(get_include))
-                      .includes(exp_includes || [])
                       .limit(options[:limit])
 
+    # Rbac will only add miq_expression for hourly report. It will not work properly for daily because many values are rolled up from hourly.
     results = Rbac.filtered(results, :class        => db,
                                      :filter       => conditions,
                                      :userid       => options[:userid],

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -255,14 +255,12 @@ module MiqReport::Generator
     end
 
     time_range = Metric::Helper.time_range_from_offset(interval, db_options[:start_offset], db_options[:end_offset], tz)
-    # TODO: add .select(only_cols)
-    db_includes = get_include_for_find
     results = Metric::Helper.find_for_interval_name('daily', time_profile || tz, db_klass)
                             .where(where_clause).where(exp_sql)
                             .where(options[:where_clause])
                             .where(:timestamp => time_range)
-                            .includes(db_includes)
-                            .references(db_klass.includes_to_references(db_includes))
+                            .includes(get_include_for_find)
+                            .references(db_klass.includes_to_references(get_include))
                             .includes(exp_includes || [])
                             .limit(options[:limit])
     results = Rbac.filtered(results, :class        => db,
@@ -284,6 +282,7 @@ module MiqReport::Generator
                       .where(options[:where_clause])
                       .where(exp_sql)
                       .includes(get_include_for_find)
+                      .references(db_klass.includes_to_references(get_include))
                       .includes(exp_includes || [])
                       .limit(options[:limit])
 
@@ -316,6 +315,7 @@ module MiqReport::Generator
       :targets          => targets,
       :filter           => conditions,
       :include_for_find => get_include_for_find,
+      :references       => get_include,
       :where_clause     => where_clause,
       :skip_counts      => true
     )

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -93,6 +93,7 @@ module MiqReport::Search
     search_options = options.merge(:class            => db,
                                    :conditions       => conditions,
                                    :include_for_find => includes,
+                                   :references       => get_include,
                                    :skip_references  => skip_references
                                   )
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order

--- a/app/models/vim_performance_analysis.rb
+++ b/app/models/vim_performance_analysis.rb
@@ -66,6 +66,7 @@ module VimPerformanceAnalysis
         search_options = {
           :class            => topts[:compute_type].to_s,
           :include_for_find => includes,
+          :references       => includes,
           :userid           => @options[:userid],
           :miq_group_id     => @options[:miq_group_id],
         }

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -260,7 +260,6 @@ module Rbac
 
       exp_sql, exp_includes, exp_attrs = search_filter.to_sql(tz) if search_filter && !klass.try(:instances_are_derived?)
       attrs[:apply_limit_in_sql] = (exp_attrs.nil? || exp_attrs[:supported_by_sql]) && user_filters["belongsto"].blank?
-      skip_references            = skip_references?(scope, options, attrs, exp_sql, exp_includes)
 
       # for belongs_to filters, scope_targets uses scope to make queries. want to remove limits for those.
       # if you note, the limits are put back into scope a few lines down from here
@@ -270,7 +269,7 @@ module Rbac
               .includes(include_for_find).includes(exp_includes)
               .order(order)
 
-      scope = include_references(scope, klass, references, exp_includes, skip_references)
+      scope = include_references(scope, klass, references, exp_includes)
       scope = scope.limit(limit).offset(offset) if attrs[:apply_limit_in_sql]
 
       if inline_view?(options, scope)
@@ -362,63 +361,8 @@ module Rbac
       end
     end
 
-    # This is a very primitive way of determining whether we want to skip
-    # adding references to the query.
-    #
-    # For now, basically it checks if the caller has not provided :extra_cols,
-    # or if the MiqExpression can't apply the limit in SQL.  If both of those
-    # are true, then we don't add `.references` to the scope.
-    #
-    # Also, if for whatever reason we are passed a
-    # `ActiveRecord::NullRelation`, make sure that we don't skip references.
-    # This will cause the EXPLAIN to blow up since `.to_sql` gets changed to
-    # always return `""`... even though at the end of the day, we will always
-    # get back zero records from the query.
-    #
-    # If still invalid, there is an EXPLAIN check in #include_references that
-    # will make sure the query is valid and if not, will include the references
-    # as done previously.
-    def skip_references?(scope, options, attrs, exp_sql, exp_includes)
-      return false if scope.singleton_class.included_modules.include?(ActiveRecord::NullRelation)
-      options[:skip_references] ||
-      (options[:extra_cols].blank? &&
-        !options.key?(:references) &&
-        (!attrs[:apply_limit_in_sql] && (exp_sql.nil? || exp_includes.nil?)))
-    end
-
-    def include_references(scope, klass, include_for_find, exp_includes, skip)
-      if skip
-        # If we are in a transaction, we don't want to polute that
-        # transaction with a failed EXPLAIN.  We use a SQL SAVEPOINT (which is
-        # created via `transaction(:requires_new => true)`) to prevent that
-        # from being an issue (happens in tests with transactional fixtures)
-        #
-        # See https://stackoverflow.com/a/31146267/3574689
-        valid_skip = MiqDatabase.transaction(:requires_new => true) do
-          begin
-            ActiveRecord::Base.connection.explain(scope.to_sql)
-          rescue ActiveRecord::StatementInvalid => e
-            unless Rails.env.production?
-              warn "There was an issue with the Rbac filter without references!"
-              warn "Consider trying to fix this edge case in Rbac::Filterer!  Error Below:"
-              warn e.message
-              warn e.backtrace
-            end
-            # returns nil
-            raise ActiveRecord::Rollback
-          end
-        end
-        # If the result of the transaction is non-nil, then the block was
-        # successful and didn't trigger the ActiveRecord::Rollback, so we can
-        # return the scope as is.
-        return scope if valid_skip
-      end
-
-      ref_includes = Hash(include_for_find).merge(Hash(exp_includes))
-      unless polymorphic_include?(klass, ref_includes)
-        scope = scope.references(klass.includes_to_references(include_for_find)).references(klass.includes_to_references(exp_includes))
-      end
-      scope
+    def include_references(scope, klass, include_for_find, exp_includes)
+      scope.references(klass.includes_to_references(include_for_find)).references(klass.includes_to_references(exp_includes))
     end
 
     # @param includes [Array, Hash]
@@ -433,13 +377,6 @@ module Rbac
         end
       end
       scope
-    end
-
-    def polymorphic_include?(target_klass, includes)
-      includes.keys.any? do |incld|
-        reflection = target_klass.reflect_on_association(incld)
-        reflection && reflection.polymorphic?
-      end
     end
 
     def filtered(objects, options = {})


### PR DESCRIPTION
### Overview

- [x] use static `references()` properly. #19295 <== better description of the problem
- [x] Use dynamic `references()` properly #19318
- [ ] Use `references()` sparingly. <== **This PR**

### Use references properly

We pass a hash of relations to `include()`. We pass that same parameter to `references()`. But, we should pass an array of table names [rails references docs]. This is undefined behavior. Rails currently puts all tables into the primary query.

Change `references(hash)` to `references(array)`. It also introduces a method that converts a hash of relations into an array of table names.

### Use references sparingly.

Reports reference tables in 2 ways:

1. `include:` the models/columns that are in the `SELECT` clause.
2. `include_for_find:`. the models that are used by the ruby view code.

Only the `include` portion needs to actually be in the primary query.

Introduce option `references` to `Rbac` to allow the caller to distinguish between the 2 scenarios. If `references` is not passed into `Rbac`, the code assumes the existing behavior and adds the tables to the `references()`.

[rails references docs]: https://apidock.com/rails/ActiveRecord/QueryMethods/references

This is a remake of #18848 and attempting to address performance issues on both the vm and services page
