### PR TITLE
Add support to Embedded Ansible for ssh user@host:path urls

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -9,7 +9,7 @@ class GitRepository < ApplicationRecord
 
   attr_reader :git_lock
 
-  validates :url, :format => URI.regexp(%w[http https file ssh]), :allow_nil => false
+  validates :url, :format => Regexp.union(URI.regexp(%w[http https file ssh]), /\A[-\w:.]+@.*:/), :allow_nil => false
 
   default_value_for :verify_ssl, OpenSSL::SSL::VERIFY_PEER
   validates :verify_ssl, :inclusion => {:in => [OpenSSL::SSL::VERIFY_NONE, OpenSSL::SSL::VERIFY_PEER]}

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -1,10 +1,32 @@
 describe GitRepository do
-  it "no url" do
-    expect { FactoryBot.create(:git_repository, :url => nil) }.to raise_error(ActiveRecord::RecordInvalid)
-  end
+  describe "#url" do
+    it "missing" do
+      expect(FactoryBot.build(:git_repository, :url => nil)).to_not be_valid
+    end
 
-  it "invalid url" do
-    expect { FactoryBot.create(:git_repository, :url => "abc") }.to raise_error(ActiveRecord::RecordInvalid)
+    it "invalid" do
+      expect(FactoryBot.build(:git_repository, :url => "abc")).to_not be_valid
+    end
+
+    it "http" do
+      expect(FactoryBot.build(:git_repository, :url => "http://example.com/ManageIQ/manageiq.git")).to be_valid
+    end
+
+    it "https" do
+      expect(FactoryBot.build(:git_repository, :url => "https://example.com/ManageIQ/manageiq.git")).to be_valid
+    end
+
+    it "file" do
+      expect(FactoryBot.build(:git_repository, :url => "file:///home/foo/ManageIQ/manageiq")).to be_valid
+    end
+
+    it "ssh" do
+      expect(FactoryBot.build(:git_repository, :url => "ssh://example.com/ManageIQ/manageiq.git")).to be_valid
+    end
+
+    it "ssh user@host:path" do
+      expect(FactoryBot.build(:git_repository, :url => "git@example.com:ManageIQ/manageiq.git")).to be_valid
+    end
   end
 
   it "default dirname" do


### PR DESCRIPTION
@carbonin @NickLaMuro Please review.

This is using the same regex that the UI uses [1], since I couldn't find a "standard" one.

[1] https://github.com/ManageIQ/manageiq-ui-classic/blob/e737cc675ee006c11508bc23f038c3357a1fb089/app/assets/javascripts/directives/url_validation.js#L21