### PR TITLE
Remove Ansible::Content requirements.yml location shim

### DIFF
--- a/lib/ansible/content.rb
+++ b/lib/ansible/content.rb
@@ -31,12 +31,7 @@ module Ansible
     end
 
     def requirements_file
-      @requirements_file ||= begin
-        local_file     = path.join('requirements.yml')
-        roles_dir_file = roles_dir.join('requirements.yml')
-
-        roles_dir_file.exist? ? roles_dir_file : local_file
-      end
+      @requirements_file ||= roles_dir.join('requirements.yml')
     end
   end
 end

--- a/spec/lib/ansible/content_spec.rb
+++ b/spec/lib/ansible/content_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe Ansible::Content do
   let(:content_dir)        { Pathname.new(Dir.mktmpdir) }
   let(:roles_dir)          { content_dir.join("roles") }
-  let(:local_requirements) { content_dir.join("requirements.yml") }
   let(:roles_requirements) { content_dir.join("roles", "requirements.yml") }
 
   subject { described_class.new(content_dir) }
@@ -11,19 +10,6 @@ RSpec.describe Ansible::Content do
   describe "#fetch_galaxy_roles" do
     it "doesn't run anything if there is no requirements file" do
       expect(AwesomeSpawn).not_to receive(:run!)
-
-      subject.fetch_galaxy_roles
-    end
-
-    it "runs ansible-galaxy using the local requirements file" do
-      FileUtils.touch(local_requirements)
-
-      expected_params = [
-        "install",
-        :roles_path= => roles_dir,
-        :role_file=  => local_requirements
-      ]
-      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
 
       subject.fetch_galaxy_roles
     end
@@ -42,28 +28,14 @@ RSpec.describe Ansible::Content do
       subject.fetch_galaxy_roles
     end
 
-    it "prefers the roles requirements file" do
+    it "works with a string path" do
       FileUtils.mkdir(roles_dir)
       FileUtils.touch(roles_requirements)
-      FileUtils.touch(local_requirements)
 
       expected_params = [
         "install",
         :roles_path= => roles_dir,
         :role_file=  => roles_requirements
-      ]
-      expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
-
-      subject.fetch_galaxy_roles
-    end
-
-    it "works with a string path" do
-      FileUtils.touch(local_requirements)
-
-      expected_params = [
-        "install",
-        :roles_path= => roles_dir,
-        :role_file=  => local_requirements
       ]
       expect(AwesomeSpawn).to receive(:run!).with("ansible-galaxy", :params => expected_params)
 


### PR DESCRIPTION
@carbonin Please review.
cc @agrare @NickLaMuro 

Depends on ManageIQ/manageiq-providers-lenovo#276 and ManageIQ/manageiq-providers-nuage#185

As per https://github.com/ManageIQ/manageiq/pull/19079#discussion_r309780769
