### PR TITLE
Allow users to specify a proxy for git repositories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,13 +71,13 @@ gem "rest-client",                    "~>2.0.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.2.2",       :require => false
-gem "rugged",                         "~>0.27.0",      :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
 gem "sys-filesystem",                 "~>1.2.0"
 gem "terminal",                                        :require => false
 
 # Modified gems (forked on Github)
+gem "rugged",                         "=0.28.2", :require => false,   :git => "https://github.com/ManageIQ/rugged.git", :tag => "v0.28.2-1", :submodules => true
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -236,7 +236,16 @@ class GitRepository < ApplicationRecord
   end
 
   def proxy_url?
-    !!Settings.git_repository_proxy.host && %w[http https].include?(Settings.git_repository_proxy.scheme)
+    return false unless !!Settings.git_repository_proxy.host
+    return false unless %w[http https].include?(Settings.git_repository_proxy.scheme)
+
+    repo_url_scheme = begin
+                        URI.parse(url).scheme
+                      rescue URI::InvalidURIError
+                        # url is not a parsable URI, such as git@github.com:ManageIQ/manageiq.git
+                        nil
+                      end
+    %w[http https].include?(repo_url_scheme)
   end
 
   def proxy_url

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -231,7 +231,18 @@ class GitRepository < ApplicationRecord
         params[:password] = auth.password
       end
     end
+    params[:proxy_url] = proxy_url if proxy_url?
     params
+  end
+
+  def proxy_url?
+    !!Settings.git_repository_proxy.host
+  end
+
+  def proxy_url
+    uri_opts = Settings.git_repository_proxy.to_h.slice(:host, :port, :scheme, :path)
+    uri_opts[:path] ||= "/"
+    URI::Generic.build(uri_opts).to_s
   end
 
   def broadcast_repo_dir_delete

--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -236,7 +236,7 @@ class GitRepository < ApplicationRecord
   end
 
   def proxy_url?
-    !!Settings.git_repository_proxy.host
+    !!Settings.git_repository_proxy.host && %w[http https].include?(Settings.git_repository_proxy.scheme)
   end
 
   def proxy_url

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -840,6 +840,7 @@
   :port:
   :user:
   :scheme:
+  :path:
 :help_menu:
   :documentation:
     :type: default

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -834,6 +834,12 @@
     - MoveIntoResourcePool
     :VmSuspendedEvent:
     - SuspendVM_Task
+:git_repository_proxy:
+  :host:
+  :password:
+  :port:
+  :user:
+  :scheme:
 :help_menu:
   :documentation:
     :type: default
@@ -863,12 +869,6 @@
     :user:
     :scheme:
   :gce:
-    :host:
-    :password:
-    :port:
-    :user:
-    :scheme:
-  :embedded_ansible:
     :host:
     :password:
     :port:

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -109,6 +109,24 @@ describe GitRepository do
         repo.refresh
       end
 
+      it "doesn't send the proxy settings if the scheme is not http or https" do
+        proxy_settings = {
+          :git_repository_proxy => {
+            :host   => "example.com",
+            :port   => "12345",
+            :scheme => "socks5"
+          }
+        }
+        stub_settings(proxy_settings)
+        expect(GitWorktree).to receive(:new) do |options|
+          expect(options[:proxy_url]).to be_nil
+        end.twice.and_return(gwt)
+
+        expect(gwt).to receive(:pull).with(no_args)
+
+        repo.refresh
+      end
+
       context "self signed certifcate" do
         let(:verify_ssl) { OpenSSL::SSL::VERIFY_NONE }
 

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -109,7 +109,7 @@ describe GitRepository do
         repo.refresh
       end
 
-      it "doesn't send the proxy settings if the scheme is not http or https" do
+      it "doesn't send the proxy settings if the proxy scheme is not http or https" do
         proxy_settings = {
           :git_repository_proxy => {
             :host   => "example.com",
@@ -124,6 +124,25 @@ describe GitRepository do
 
         expect(gwt).to receive(:pull).with(no_args)
 
+        repo.refresh
+      end
+
+      it "doesn't send the proxy settings if the repo scheme is not http or https" do
+        proxy_settings = {
+          :git_repository_proxy => {
+            :host   => "example.com",
+            :port   => "3128",
+            :scheme => "http"
+          }
+        }
+        stub_settings(proxy_settings)
+        expect(GitWorktree).to receive(:new) do |options|
+          expect(options[:proxy_url]).to be_nil
+        end.twice.and_return(gwt)
+
+        expect(gwt).to receive(:pull).with(no_args)
+
+        repo.update!(:url => "git@example.com:ManageIQ/manageiq.git")
         repo.refresh
       end
 

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -93,6 +93,22 @@ describe GitRepository do
         expect(repo.default_authentication.password).to eq(password)
       end
 
+      it "sends the proxy settings to the worktree instance" do
+        proxy_settings = {
+          :git_repository_proxy => {
+            :host   => "example.com",
+            :port   => "80",
+            :scheme => "http",
+            :path   => "/proxy"
+          }
+        }
+        stub_settings(proxy_settings)
+        expect(GitWorktree).to receive(:new).with(hash_including(:proxy_url => "http://example.com:80/proxy")).twice.times.and_return(gwt)
+        expect(gwt).to receive(:pull).with(no_args)
+
+        repo.refresh
+      end
+
       context "self signed certifcate" do
         let(:verify_ssl) { OpenSSL::SSL::VERIFY_NONE }
 


### PR DESCRIPTION
This PR uses my changes to rugged (https://github.com/libgit2/rugged/pull/808) to allow users to configure a git repository proxy url.

This also builds on https://github.com/ManageIQ/manageiq-schema/pull/406 which moved the embedded ansible proxy options to a top level setting so it could apply to all git repositories. We did this because it made it much easier to get the proxy options to the worktree instance from the GitRepository model. Without the settings change we would have to make the proxy settings conditional on whether or not the git repository instance existed because it was part of an embedded ansible configuration script source.

Plus automate domains get proxy support for free :smile: 

TODO:

- [x] Add more worktree specs
- [x] Add git repository specs
- [x] Test this for real