### PR TITLE
Vm migrate task request_type should have a default value

### DIFF
--- a/app/models/vm_migrate_task.rb
+++ b/app/models/vm_migrate_task.rb
@@ -2,6 +2,7 @@ class VmMigrateTask < MiqRequestTask
   alias_attribute :vm, :source
 
   validate :validate_request_type, :validate_state
+  default_value_for :request_type, "vm_migrate"
 
   AUTOMATE_DRIVES = true
 


### PR DESCRIPTION
Otherwise we're running update_attributes here: https://github.com/ManageIQ/manageiq/blob/master/spec/models/vm_migrate_task_spec.rb#L7 on an invalid subject and that feels wrong. 

@miq-bot add_reviewer @lfu 
@miq-bot assign @tinaafitz 
@miq-bot add_label bug 
