### PR TITLE
Utility function to update PxeMenu list

### DIFF
--- a/app/models/pxe_server.rb
+++ b/app/models/pxe_server.rb
@@ -198,6 +198,16 @@ class PxeServer < ApplicationRecord
     _log.info("#{log_message}...Complete")
   end
 
+  def ensure_menu_list(menu_list)
+    current_menus = pxe_menus.map(&:file_name)
+    to_destroy = current_menus - menu_list
+    to_create = menu_list - current_menus
+    transaction do
+      pxe_menus.where(:file_name => to_destroy).destroy_all
+      to_create.each { |menu| pxe_menus << PxeMenu.create!(:file_name => menu) }
+    end
+  end
+
   def self.display_name(number = 1)
     n_('PXE Server', 'PXE Servers', number)
   end


### PR DESCRIPTION
With this commit we introduce a utility method on PxeServer model to handle PxeMenus list update. Until now, miq-api was always recreating all menus upon server update, but often we can actually just preserve exisitng menus. This method calculates what menus to add, what to preserve and what to remove, and then executes it.

Depends on: https://github.com/ManageIQ/manageiq/pull/19126
Fixes https://github.com/ManageIQ/manageiq/issues/18940

@miq-bot add_label bug,ivanchuk/yes
@miq-bot assign @agrare 