### PR TITLE
Set 'REF' and 'IMAGE_REF' args for Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM manageiq/manageiq-pods:frontend-latest
+ARG IMAGE_REF=latest
+FROM manageiq/manageiq-pods:frontend-${IMAGE_REF}
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq
+
+## Set build ARG
+ARG REF=master
 
 ENV DATABASE_URL=postgresql://root@localhost/vmdb_production?encoding=utf8&pool=5&wait_timeout=5
 


### PR DESCRIPTION
As per [help](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact), `ARG` that's set before `FROM` is used only to substitute variables for `FROM`, so `REF` is declared separately.

Related PR: https://github.com/ManageIQ/manageiq-pods/pull/330