### PR TITLE
Make automation request scheduling granular

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -26,8 +26,7 @@ class AutomationRequest < MiqRequest
     options[:namespace]     = (options.delete(:namespace) || DEFAULT_NAMESPACE).strip.gsub(/(^\/|\/$)/, "")  # Strip blanks and slashes from beginning and end of string
     options[:class_name]    = (options.delete(:class) || DEFAULT_CLASS).strip.gsub(/(^\/|\/$)/, "")
     options[:instance_name] = (options.delete(:instance) || DEFAULT_INSTANCE).strip
-    options[:schedule_type] = parameters['schedule_time'].present? ? "schedule" : "immediately"
-    options[:schedule_time] = parameters['schedule_time'].to_i.days.from_now if parameters['schedule_time']
+    options.merge!(parse_schedule_options(parameters.select { |key, _v| key.to_s.include?('schedule') }))
 
     options[:user_id]  = user.id
     options[:attrs]    = build_attrs(parameters, user)
@@ -75,4 +74,15 @@ class AutomationRequest < MiqRequest
     end
   end
   private_class_method :build_attrs
+
+  def self.parse_schedule_options(parameters)
+    {:schedule_type => "schedule"}.tap do |hash|
+      if parameters['schedule_time']
+        hash[:schedule_time] = Time.zone.parse(parameters['schedule_time'])
+      else
+        hash[:schedule_type] = "immediately"
+      end
+    end
+  end
+  private_class_method :parse_schedule_options
 end

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -48,12 +48,20 @@ describe AutomationRequest do
       expect(ar.options[:attrs].keys).to include("VmOrTemplate::vm")
     end
 
-    it "creates request with schedule" do
-      @parameters['schedule_time'] = "10"
-      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
+    context "with schedule" do
+      it "with schedule_time param" do
+        @parameters['schedule_time'] = "2019-08-14 17:41:06 UTC"
+        ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
 
-      expect(ar.options[:schedule_type]).to eq("schedule")
-      expect(ar.options[:schedule_time]).to be_within(1.second).of 10.days.from_now
+        expect(ar.options[:schedule_type]).to eq("schedule")
+        expect(ar.options[:schedule_time]).to be_within(1.second).of Time.zone.parse("2019-08-14 17:41:06 UTC")
+      end
+
+      it "immediately" do
+        ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
+
+        expect(ar.options[:schedule_type]).to eq("immediately")
+      end
     end
 
     it 'does not downcase and stringify objects in the parameters hash' do


### PR DESCRIPTION
So we're no longer restricted to days. 

@miq-bot add_label bug

    schedule_time - Date/DateTime value in UTC 



<sub><sup> time zones are horrible and i hate them</sup></sub>


<sub><sup> also it's totally worth a penny, c'mon you lot </sup></sub>

<sub><sup> job security is putting the bugs back in </sup></sub>