### PR TITLE
[WIP] [V2V] Add state machine support for collapse snapshots

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -53,13 +53,17 @@ class InfraConversionJob < Job
   # doesn't work if the VM has snapshots. This is a limitation of CBT.
   #
   def collapse_snapshots
+    message = 'Collapsing Snapshots'
+
     if migration_task.source.supports_remove_all_snapshots?
-      _log.info(prep_message('Collapsing snapshots'))
+      update_attributes(:message => message)
+      _log.info(prep_message(message))
       migration_task.source.remove_all_snapshots
     end
 
     signal = warm_migration? ? :warm_migration_sync : :run_pre_migration_playbook
 
+    update_attributes(:message => message, :status => status)
     queue_signal(signal)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -53,9 +53,9 @@ class InfraConversionJob < Job
   # doesn't work if the VM has snapshots. This is a limitation of CBT.
   #
   def collapse_snapshots
-    if vm.supports_remove_all_snapshots?
+    if migration_task.source.supports_remove_all_snapshots?
       _log.info(prep_message('Collapsing snapshots'))
-      vm.remove_all_snapshots
+      migration_task.source.remove_all_snapshots
     end
 
     signal = warm_migration? ? :warm_migration_sync : :run_pre_migration_playbook

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -58,11 +58,7 @@ class InfraConversionJob < Job
       vm.remove_all_snapshots
     end
 
-    if warm_migration?
-      signal = :warm_migration_sync
-    else
-      signal = :run_pre_migration_playbook
-    end
+    signal = warm_migration? ? :warm_migration_sync : :run_pre_migration_playbook
 
     queue_signal(signal)
   end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -22,6 +22,7 @@ class InfraConversionJob < Job
   #                                                    :finish             v
   #                                                                    finished
   #
+  # TODO: Update this diagram after we've settled on the updated state transitions.
 
   alias_method :initializing, :dispatch_start
   alias_method :finish,       :process_finished

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -38,7 +38,7 @@ class InfraConversionJob < Job
     {
       :initializing       => {'initialize'           => 'waiting_to_start'},
       :start              => {'waiting_to_start'     => 'ready'},
-      :collapse_snapshots => {'ready'                => 'collapsing_snapshots'},
+      :collapse_snapshots => {'ready'                => 'collapsing_snapshots', 'collapsing_snapshots' => 'collapsing_snapshots'},
       :poll_conversion    => {'collapsing_snapshots' => 'running', 'running' => 'running' },
       :start_post_stage   => {'running'              => 'post_conversion'},
       :poll_post_stage    => {'post_conversion'      => 'post_conversion'},
@@ -58,10 +58,10 @@ class InfraConversionJob < Job
 
     if migration_task.source.supports_remove_all_snapshots?
       _log.info(prep_message(message))
-      migration_task.source.remove_all_snapshots
+      migration_task.source.remove_all_snapshots_queue(migration_task.userid)
     end
 
-    # handover_to_automate # Depends on Fabien's PR
+    # handover_to_automate # Depends on Fabien's PR https://github.com/ManageIQ/manageiq/pull/19149
     queue_signal(:poll_conversion)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -61,7 +61,7 @@ class InfraConversionJob < Job
       migration_task.source.remove_all_snapshots_queue(migration_task.userid)
     end
 
-    # handover_to_automate # Depends on Fabien's PR https://github.com/ManageIQ/manageiq/pull/19149
+    handover_to_automate
     queue_signal(:poll_conversion)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -53,7 +53,7 @@ class InfraConversionJob < Job
   # doesn't work if the VM has snapshots. This is a limitation of CBT.
   #
   def collapse_snapshots
-    if vm.supports_feature?(:remove_all_snapshots)
+    if vm.supports_remove_all_snapshots?
       _log.info(prep_message('Collapsing snapshots'))
       vm.remove_all_snapshots
     end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -37,8 +37,8 @@ class InfraConversionJob < Job
 
     {
       :initializing       => {'initialize'       => 'waiting_to_start'},
-      :start              => {'waiting_to_start' => 'running'},
-      :collapse_snapshots => {'waiting_to_start' => 'collapsing_snapshots'},
+      :start              => {'waiting_to_start' => 'ready'},
+      :collapse_snapshots => {'ready'            => 'collapsing_snapshots'},
       :poll_conversion    => {'running'          => 'running'},
       :start_post_stage   => {'running'          => 'post_conversion'},
       :poll_post_stage    => {'post_conversion'  => 'post_conversion'},
@@ -53,17 +53,16 @@ class InfraConversionJob < Job
   # doesn't work if the VM has snapshots. This is a limitation of CBT.
   #
   def collapse_snapshots
-    message = 'Collapsing Snapshots'
+    message = 'Collapse Snapshots'
 
     if migration_task.source.supports_remove_all_snapshots?
-      update(:message => message)
       _log.info(prep_message(message))
       migration_task.source.remove_all_snapshots
     end
 
     signal = warm_migration? ? :warm_migration_sync : :run_pre_migration_playbook
 
-    update(:message => message, :status => status)
+    update(:message => message)
     queue_signal(signal)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -56,14 +56,14 @@ class InfraConversionJob < Job
     message = 'Collapsing Snapshots'
 
     if migration_task.source.supports_remove_all_snapshots?
-      update_attributes(:message => message)
+      update(:message => message)
       _log.info(prep_message(message))
       migration_task.source.remove_all_snapshots
     end
 
     signal = warm_migration? ? :warm_migration_sync : :run_pre_migration_playbook
 
-    update_attributes(:message => message, :status => status)
+    update(:message => message, :status => status)
     queue_signal(signal)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -39,7 +39,7 @@ class InfraConversionJob < Job
       :initializing       => {'initialize'           => 'waiting_to_start'},
       :start              => {'waiting_to_start'     => 'ready'},
       :collapse_snapshots => {'ready'                => 'collapsing_snapshots'},
-      :poll_conversion    => {'collapsing_snapshots' =>'running', 'running' => 'running' },
+      :poll_conversion    => {'collapsing_snapshots' => 'running', 'running' => 'running' },
       :start_post_stage   => {'running'              => 'post_conversion'},
       :poll_post_stage    => {'post_conversion'      => 'post_conversion'},
       :finish             => {'*'                    => 'finished'},
@@ -61,6 +61,7 @@ class InfraConversionJob < Job
       migration_task.source.remove_all_snapshots
     end
 
+    # handover_to_automate # Depends on Fabien's PR
     queue_signal(:poll_conversion)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -59,7 +59,9 @@ class InfraConversionJob < Job
 
     if migration_task.source.supports_remove_all_snapshots?
       _log.info(prep_message(message))
-      migration_task.source.remove_all_snapshots_queue(migration_task.userid)
+      task_id = migration_task.source.remove_all_snapshots_queue(migration_task.userid)
+      queue_signal(:collapsing_snapshots)
+      MiqTask.wait_for_taskid(task_id)
     end
 
     handover_to_automate

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w(start collapse_snapshots poll_conversion start_post_stage poll_post_stage finish abort_job cancel error).each do |signal|
+    %w[start collapse_snapshots poll_conversion start_post_stage poll_post_stage finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -22,7 +22,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w(start collapse_snapshots poll_conversion start_post_stage poll_post_stage).each do |signal|
+    %w[start collapse_snapshots poll_conversion start_post_stage poll_post_stage].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w(start poll_conversion start_post_stage poll_post_stage finish abort_job cancel error).each do |signal|
+    %w(start collapse_snapshots poll_conversion start_post_stage poll_post_stage finish abort_job cancel error).each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -22,7 +22,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w(start poll_conversion start_post_stage poll_post_stage).each do |signal|
+    %w(start collapse_snapshots poll_conversion start_post_stage poll_post_stage).each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -39,7 +39,7 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows abort_job signal'
       it_behaves_like 'allows cancel signal'
       it_behaves_like 'allows error signal'
-      it_behaves_like 'allows collapse_snapshot signal'
+      it_behaves_like 'allows collapse_snapshots signal'
 
       it_behaves_like 'doesn\'t allow poll_conversion signal'
       it_behaves_like 'doesn\'t allow start_post_stage signal'

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
     context 'collapsing_snapshots' do
       before do
-        job.state = 'ready'
+        job.state = 'collapsing_snapshots'
       end
 
       it_behaves_like 'allows collapse_snapshots signal'

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -39,11 +39,26 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows abort_job signal'
       it_behaves_like 'allows cancel signal'
       it_behaves_like 'allows error signal'
-      it_behaves_like 'allows collapse_snapshots signal'
 
       it_behaves_like 'doesn\'t allow poll_conversion signal'
       it_behaves_like 'doesn\'t allow start_post_stage signal'
       it_behaves_like 'doesn\'t allow poll_post_stage signal'
+    end
+
+    context 'ready' do
+      before do
+        job.state = 'ready'
+      end
+
+      it_behaves_like 'allows collapse_snapshots signal'
+    end
+
+    context 'collapsing_snapshots' do
+      before do
+        job.state = 'ready'
+      end
+
+      it_behaves_like 'allows collapse_snapshots signal'
     end
 
     context 'running' do
@@ -96,41 +111,22 @@ RSpec.describe InfraConversionJob, :v2v do
     end
 
     context "#collapse_snapshots" do
-      it 'to collapse snapshots when signaled :collapse_snapshots if warm migration' do
-        allow(job).to receive(:warm_migration?).and_return(true)
-        job.state = 'waiting_to_start'
-
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:queue_signal).with(:warm_migration_sync)
-          job.signal(:collapse_snapshots)
-        end
-      end
-
-      it 'to collapse snapshots when signaled :collapse_snapshots if not a warm migration' do
-        allow(job).to receive(:warm_migration?).and_return(false)
-        job.state = 'waiting_to_start'
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:queue_signal).with(:run_pre_migration_playbook)
-          job.signal(:collapse_snapshots)
-        end
-      end
-
       it 'calls remove_all_snapshots if supported' do
         allow(vm).to receive(:supports_remove_all_snapshots?).and_return(true)
 
-        job.state = 'waiting_to_start'
+        job.state = 'ready'
 
         Timecop.freeze(2019, 2, 6) do
-          expect(vm).to receive(:remove_all_snapshots)
+          expect(vm).to receive(:remove_all_snapshots_queue)
           job.signal(:collapse_snapshots)
         end
       end
 
       it 'does not call remove_all_snapshots if not supported' do
-        job.state = 'waiting_to_start'
+        job.state = 'ready'
 
         Timecop.freeze(2019, 2, 6) do
-          expect(vm).to_not receive(:remove_all_snapshots)
+          expect(vm).to_not receive(:remove_all_snapshots_queue)
           job.signal(:collapse_snapshots)
         end
       end


### PR DESCRIPTION
For IMS 1.3 we're moving state machine handling from automate into core. For ease of writing and review, we're breaking this down into (hopefully) easily digestible bits, one state at a time. Each PR will ultimately have a corresponding PR in manageiq-content that deletes the relevant bit of code from automate.

Original automate code: https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/collapsesnapshots.rb

Since this is the first thing that needs to happen, we're starting with snapshot collapse, i.e. deletion.

WIP for now until I get specs added and task information updated for the sake of the UI team.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1740881
Depends on: https://bugzilla.redhat.com/show_bug.cgi?id=1741179

Will also need https://github.com/ManageIQ/manageiq/pull/19149