### PR TITLE
[ServiceAnsible*] Ensure filtering out token data in logs

### DIFF
--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -47,7 +47,7 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     opts[:hosts] = hosts_array(opts.delete(:hosts))
 
     _log.info("Launching Ansible job with options:")
-    $log.log_hashes(opts)
+    $log.log_hashes(opts, :filter => ["api_token", "token"])
     new_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create_job(jt, decrypt_options(opts))
     update_job_for_playbook(action, new_job, opts[:hosts])
 

--- a/app/models/service_ansible_tower.rb
+++ b/app/models/service_ansible_tower.rb
@@ -17,7 +17,7 @@ class ServiceAnsibleTower < Service
       }
     )
     _log.info("Launching Ansible Tower job with options:")
-    $log.log_hashes(options)
+    $log.log_hashes(options, :filter => ["api_token", "token"])
     @job = job_class.create_job(job_template, options)
     add_resource(@job)
     @job


### PR DESCRIPTION
I noticed that we are logging auth tokens for the API when kicking off an `ansible-runner` task:

```
[----] I, [2019-08-12T18:40:31.034305 #11491:2ad3b38865c4]  INFO -- : Q-task_id([r1_service_template_provision_task_1]) MIQ(ServiceAnsiblePlaybook#launch_ansible_job) Launching Ansible job with options:
[----] I, [2019-08-12T18:40:31.035078 #11491:2ad3b38865c4]  INFO -- : Q-task_id([r1_service_template_provision_task_1])
---
become_enabled: false
execution_ttl: ''
extra_vars:
  manageiq:
    service: services/1
    action: Provision
    api_url: https://10.0.2.15
    api_token: 96bfa629097271a9b2efa6d9eb17e037
    user: users/1
    group: groups/2
    X_MIQ_Group: EvmGroup-super_administrator
    request_task: requests/1/request_tasks/1
    request: requests/1
  manageiq_connection:
    url: https://10.0.2.15
    token: 96bfa629097271a9b2efa6d9eb17e037
    X_MIQ_Group: EvmGroup-super_administrator
verbosity: '0'
credential: 1
hosts:
- localhost
```

(don't worry, the above is just from a temp VM...)

This isn't a good idea, and a security risk, so I made used of the `:filter` option in `ManageIQ::Loggers`:

https://github.com/ManageIQ/manageiq-loggers/blob/ef147e4e/lib/manageiq/loggers/base.rb#L80

And that should convert all the token values in the above to `[FILTERED]`.  Will report back with screenshots after having tested on aforementioned VM...