### PR TITLE
Add validating uniqueness of name of Catalog Items and Bundles

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -47,7 +47,7 @@ class ServiceTemplate < ApplicationRecord
   include_concern 'Filter'
   include_concern 'Copy'
 
-  validates :name, :presence => true
+  validates :name, :presence => true, :uniqueness => true
   belongs_to :tenant
 
   has_many   :service_templates, :through => :service_resources, :source => :resource, :source_type => 'ServiceTemplate'


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1531512

With this PR, it will not be possible to create Catalog Items and Bundles with the same name.

**Before:**
![catalog_before](https://user-images.githubusercontent.com/13417815/62929163-2e4ee580-bdba-11e9-81e7-48b8d66d7c96.png)

**After:**
![name_after](https://user-images.githubusercontent.com/13417815/62928026-0199ce80-bdb8-11e9-8e59-dc1fe8dc6c26.png)
