### PR TITLE
Service retirement request should be per region.

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -30,6 +30,7 @@ class MiqScheduleWorker::Jobs
 
   def retirement_check
     queue_work_on_each_zone(:class_name => 'RetirementManager', :method_name => 'check')
+    queue_work(:class_name => 'RetirementManager', :method_name => 'check_per_region', :zone => nil)
   end
 
   def host_authentication_check_schedule

--- a/app/models/retirement_manager.rb
+++ b/app/models/retirement_manager.rb
@@ -1,14 +1,17 @@
 class RetirementManager
   def self.check
     ems_ids = MiqServer.my_server.zone.ext_management_system_ids
-    [OrchestrationStack, Vm, Service].flat_map do |i|
+    [OrchestrationStack, Vm].flat_map do |i|
       instances = not_retired_with_ems(i, ems_ids)
       instances.each(&:retirement_check)
     end
   end
 
+  def self.check_per_region
+    Service.scheduled_to_retire.each(&:retirement_check)
+  end
+
   def self.not_retired_with_ems(model, ems_ids)
-    return model.scheduled_to_retire unless model.column_names.include?('ems_id') # Service not assigned to ems_ids
     model.scheduled_to_retire.where(:ems_id => ems_ids)
   end
   private_class_method :not_retired_with_ems

--- a/spec/models/retirement_manager_spec.rb
+++ b/spec/models/retirement_manager_spec.rb
@@ -8,10 +8,17 @@ describe RetirementManager do
       FactoryBot.create(:orchestration_stack, :retired => true)
       vm = FactoryBot.create(:vm, :retires_on => Time.zone.today + 1.day, :ems_id => ems.id)
       FactoryBot.create(:vm, :retired => true)
+
+      expect(RetirementManager.check).to match_array([orchestration_stack, vm])
+    end
+  end
+
+  describe "#check_per_region" do
+    it "with retirement date, runs retirement checks" do
       service = FactoryBot.create(:service, :retires_on => Time.zone.today + 1.day)
       FactoryBot.create(:service, :retired => true)
 
-      expect(RetirementManager.check).to match_array([orchestration_stack, vm, service])
+      expect(RetirementManager.check_per_region).to match_array([service])
     end
   end
 end


### PR DESCRIPTION
Service is not based on zone. The retirement request should not be per zone.

Fix https://github.com/ManageIQ/manageiq/issues/18558

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, changelog/yes