### PR TITLE
Fix filter_passwords for hash without a value

### DIFF
--- a/lib/vmdb/settings_walker.rb
+++ b/lib/vmdb/settings_walker.rb
@@ -39,7 +39,7 @@ module Vmdb
       # @param settings (see .walk)
       def walk_passwords(settings)
         walk(settings) do |key, value, _path, owner|
-          yield(key, value, owner) if value.present? && PASSWORD_FIELDS.include?(key.to_sym)
+          yield(key, value, owner) if PASSWORD_FIELDS.include?(key.to_sym)
         end
       end
 
@@ -47,7 +47,7 @@ module Vmdb
       #
       # @param settings (see .walk)
       def mask_passwords!(settings)
-        walk_passwords(settings) { |k, _v, h| h[k] = "********" }
+        walk_passwords(settings) { |k, v, h| h[k] = "********" if v.present? }
       end
 
       # Filter out any password attributes from the settings
@@ -61,14 +61,14 @@ module Vmdb
       #
       # @param settings (see .walk)
       def decrypt_passwords!(settings)
-        walk_passwords(settings) { |k, v, h| h[k] = ManageIQ::Password.try_decrypt(v) }
+        walk_passwords(settings) { |k, v, h| h[k] = ManageIQ::Password.try_decrypt(v) if v.present? }
       end
 
       # Walks the settings and encrypts passwords it finds
       #
       # @param settings (see .walk)
       def encrypt_passwords!(settings)
-        walk_passwords(settings) { |k, v, h| h[k] = ManageIQ::Password.try_encrypt(v) }
+        walk_passwords(settings) { |k, v, h| h[k] = ManageIQ::Password.try_encrypt(v) if v.present? }
       end
     end
 

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -518,7 +518,7 @@ describe Vmdb::Settings do
 
   describe ".filter_passwords!" do
     it "removes the field from the settings" do
-      stub_settings(:password => "abcd")
+      stub_settings(:password => nil)
       filtered = described_class.filter_passwords!(Settings.to_h)
       expect(filtered.keys).to_not include(:password)
     end


### PR DESCRIPTION
Some settings that we want to filter specify a set of properties to
collect and do not have a value.  The standard password filter skips
keys that don't have values which don't work for this case.