### PR TITLE
Cleanup the temporary checkout created by Embedded Ansible runs

### DIFF
--- a/app/models/manageiq/providers/ansible_playbook_workflow.rb
+++ b/app/models/manageiq/providers/ansible_playbook_workflow.rb
@@ -9,4 +9,17 @@ class ManageIQ::Providers::AnsiblePlaybookWorkflow < ManageIQ::Providers::Ansibl
 
     Ansible::Runner.run_async(env_vars, extra_vars, playbook_path, kwargs)
   end
+
+  private
+
+  def verify_options
+    if !options[:playbook_path] && !(options[:configuration_script_source_id] && options[:playbook_relative_path])
+      raise ArgumentError, "must pass :playbook_path or a :configuration_script_source_id, :playbook_relative_path pair"
+    end
+  end
+
+  def adjust_options_for_git_checkout_tempdir!
+    options[:playbook_path] = File.join(options[:git_checkout_tempdir], options[:playbook_relative_path])
+    save!
+  end
 end

--- a/app/models/manageiq/providers/ansible_role_workflow.rb
+++ b/app/models/manageiq/providers/ansible_role_workflow.rb
@@ -9,4 +9,21 @@ class ManageIQ::Providers::AnsibleRoleWorkflow < ManageIQ::Providers::AnsibleRun
 
     Ansible::Runner.run_role_async(env_vars, extra_vars, role_name, :roles_path => roles_path, :role_skip_facts => role_skip_facts)
   end
+
+  private
+
+  def verify_options
+    unless options[:role_name]
+      raise ArgumentError, "must pass :role_name"
+    end
+
+    if !!options[:configuration_script_source_id] ^ !!options[:roles_relative_path]
+      raise ArgumentError, "cannot pass half of a :configuration_script_source_id, :roles_relative_path pair"
+    end
+  end
+
+  def adjust_options_for_git_checkout_tempdir!
+    options[:roles_path] = File.join(options[:git_checkout_tempdir], options[:roles_relative_path])
+    save!
+  end
 end

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
@@ -33,8 +33,10 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
 
     extra_vars = merge_extra_vars(vars[:extra_vars])
 
-    checkout_dir  = checkout_git_repository # TODO: what will cleanup this dir?
-    playbook_vars = { :playbook_path => File.join(checkout_dir, parent.name) }
+    playbook_vars = {
+      :configuration_script_source_id => parent.configuration_script_source_id,
+      :playbook_relative_path         => parent.name
+    }
 
     credentials = collect_credentials(vars)
 
@@ -65,11 +67,5 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
       :network_credential,
       :vault_credential
     ).compact
-  end
-
-  def checkout_git_repository
-    Dir.mktmpdir("ansible-playbook-repo").tap do |dir|
-      parent.configuration_script_source.checkout_git_repository(dir)
-    end
   end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -38,17 +38,14 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
   context "#run" do
     let(:cs) { manager.configuration_scripts.first }
 
-    before do
-      expect(cs.parent.configuration_script_source).to receive(:checkout_git_repository)
-    end
-
     it "launches the referenced ansible job template" do
       job = cs.run
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:env_vars]).to eq({})
       expect(job.options[:extra_vars]).to eq(:instance_ids => ["i-3434"])
-      expect(File.basename(job.options[:playbook_path])).to eq(playbook.name)
+      expect(job.options[:configuration_script_source_id]).to eq(ansible_script_source.id)
+      expect(job.options[:playbook_relative_path]).to eq(playbook.name)
       expect(job.options[:timeout]).to eq(1.hour)
       expect(job.options[:verbosity]).to eq(0)
     end


### PR DESCRIPTION
This moves the knowledge of creation and destruction of the temporary
directory into the AnsibleRunnerWorkflow.  AnsibleRunnerWorkflow now
supports both a direct playbook_path (for on-disk playbooks) or a
configuration_script_source_id + playbook_relative_path pair of options.
If that pair is present, then the workflow knows it must checkout the
git repository contents first, and then later clean it up.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741631

@carbonin @NickLaMuro Please review.