### PR TITLE
Move preflight check before conversion host assignment

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -51,8 +51,6 @@ class InfraConversionJob < Job
   end
 
   def start
-    message = "Preflight check is ok. A conversion host has been assigned. Starting."
-    _log.info(prep_message(message))
     migration_task.update!(:state => 'migrate')
     queue_signal(:poll_conversion)
   end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -51,18 +51,9 @@ class InfraConversionJob < Job
   end
 
   def start
-    # TransformationCleanup 3 things:
-    #  - kill v2v: ignored because no converion_host is there yet in the original automate-based logic
-    #  - power_on: ignored
-    #  - check_power_on: ignore
-
-    migration_task.preflight_check
-    _log.info(prep_message("Preflight check passed, task.state=#{migration_task.state}. continue ..."))
+    message = "Preflight check is ok. A conversion host has been assigned."
+    _log.info(prep_message(message))
     queue_signal(:poll_conversion)
-  rescue => error
-    message = prep_message("Preflight check has failed: #{error}")
-    _log.info(message)
-    abort_conversion(message, 'error')
   end
 
   def abort_conversion(message, status)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -51,8 +51,9 @@ class InfraConversionJob < Job
   end
 
   def start
-    message = "Preflight check is ok. A conversion host has been assigned."
+    message = "Preflight check is ok. A conversion host has been assigned. Starting."
     _log.info(prep_message(message))
+    migration_task.update!(:state => 'migrate')
     queue_signal(:poll_conversion)
   end
 

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -56,7 +56,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     destination_cluster
     virtv2v_disks
     network_mappings
-    update_attributes(:state => 'migrate')
     { :status => 'Ok', :message => 'Preflight check is successful' }
   rescue StandardError => error
     { :status => 'Error', :message => error.message }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -57,9 +57,9 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     virtv2v_disks
     network_mappings
     update_attributes(:state => 'migrate')
-    return { :status => 'Ok', :message => 'Preflight check is successful' }
-  rescue => err
-    return { :status => 'Error', :message => err.message }
+    { :status => 'Ok', :message => 'Preflight check is successful' }
+  rescue StandardError => error
+    { :status => 'Error', :message => error.message }
   end
 
   def source_cluster

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -57,6 +57,9 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     virtv2v_disks
     network_mappings
     update_attributes(:state => 'migrate')
+    return { :status => 'Ok', :message => 'Preflight check is successful' }
+  rescue => err
+    return { :status => 'Error', :message => err.message }
   end
 
   def source_cluster

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -15,7 +15,7 @@ class InfraConversionThrottler
 
         preflight_check = job.migration_task.preflight_check
         if preflight_check[:status] == 'Error'
-          _log.info("Preflight check for #{vm_name} has failed. Discarding.")
+          _log.error("Preflight check for #{vm_name} has failed. Discarding.")
           job.abort_conversion(preflight_check[:message], 'error')
           next
         end

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -10,22 +10,21 @@ class InfraConversionThrottler
       _log.debug("-- Currently running jobs in EMS: #{running}")
       slots = (ems.miq_custom_get('MaxTransformationRunners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
 
-      if slots <= 0
-        _log.debug("-- No available slot in EMS. Stopping.")
-        next
-      end
-      _log.debug("-- Available slots in EMS: #{slots}")
-
       jobs.each do |job|
         vm_name = job.migration_task.source.name
 
         preflight_check = job.migration_task.preflight_check
         if preflight_check[:status] == 'Error'
-          _log.info("Preflight check for #{vm_name} has failed. Discarding...")
+          _log.info("Preflight check for #{vm_name} has failed. Discarding.")
           job.abort_conversion(preflight_check[:message], 'error')
           next
         end
 
+        if slots <= 0
+          _log.debug("-- No available slot in EMS. Skipping.")
+          next
+        end
+        _log.debug("-- Available slots in EMS: #{slots}")
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
         eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.count }

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -17,6 +17,12 @@ class InfraConversionThrottler
       _log.debug("-- Available slots in EMS: #{slots}")
 
       jobs.each do |job|
+        preflight_check = job.migration_task.preflight_check
+        if preflight_check[:status] == 'Error'
+          job.abort_conversion(preflight_check[:message], 'error')
+          next
+        end
+
         vm_name = job.migration_task.source.name
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -41,7 +41,7 @@ class InfraConversionThrottler
 
         eligible_host = eligible_hosts.first
         _log.debug("-- Associating  #{eligible_host.name} to the task for '#{vm_name}'.")
-        job.migration_task.update!(:conversion_host => eligible_host, :state => 'migrate')
+        job.migration_task.update!(:conversion_host => eligible_host)
         job.migration_task.update_options(:conversion_host_name => eligible_host.name)
 
         _log.debug("-- Queuing :start signal for the job for '#{vm_name}': current state is '#{job.state}'.")

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe InfraConversionThrottler, :v2v do
       expect(job_waiting).to receive(:queue_signal).with(:start)
       described_class.start_conversions
       expect(task_waiting.conversion_host.id).to eq(conversion_host2.id)
-      expect(task_waiting.state).to eq('migrate')
       expect(task_waiting.options[:conversion_host_name]).to eq(conversion_host2.name)
     end
   end

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
 
     before do
       allow(task_waiting).to receive(:destination_ems).and_return(ems)
+      allow(task_waiting).to receive(:preflight_check).and_return(:status => 'Ok', :message => 'Preflight check is successful')
       allow(job_waiting).to receive(:migration_task).and_return(task_waiting)
       allow(described_class).to receive(:pending_conversion_jobs).and_return(ems => [job_waiting])
       allow(ems).to receive(:conversion_hosts).and_return([conversion_host1, conversion_host2])
@@ -27,6 +28,12 @@ RSpec.describe InfraConversionThrottler, :v2v do
       allow(conversion_host2).to receive(:check_ssh_connection).and_return(true)
       allow(conversion_host1).to receive(:authentication_check).and_return([true, 'passed'])
       allow(conversion_host2).to receive(:authentication_check).and_return([true, 'passed'])
+    end
+
+    it 'will abort conversion job if task fails preflight check' do
+      allow(task_waiting).to receive(:preflight_check).and_return(:status => 'Error', :message => 'Fake error message')
+      expect(job_waiting).to receive(:abort_conversion).with('Fake error message', 'error')
+      described_class.start_conversions
     end
 
     it 'will not start a job when ems limit hit' do
@@ -51,6 +58,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
       expect(job_waiting).to receive(:queue_signal).with(:start)
       described_class.start_conversions
       expect(task_waiting.conversion_host.id).to eq(conversion_host2.id)
+      expect(task_waiting.state).to eq('migrate')
       expect(task_waiting.options[:conversion_host_name]).to eq(conversion_host2.name)
     end
   end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe InfraConversionJob, :v2v do
       it 'to poll_conversion when preflight_check passes' do
         expect(job).to receive(:queue_signal).with(:poll_conversion)
         job.signal(:start)
+        expect(task.state).to eq('migrate')
       end
     end
 

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -87,14 +87,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
     context '#start' do
       it 'to poll_conversion when preflight_check passes' do
-        expect(task).to receive(:preflight_check)
         expect(job).to receive(:queue_signal).with(:poll_conversion)
-        job.signal(:start)
-      end
-
-      it 'to abort_conversion when preflight_check failed' do
-        expect(task).to receive(:preflight_check).and_raise
-        expect(job).to receive(:abort_conversion)
         job.signal(:start)
       end
     end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "passes preflight check regardless of power_state" do
           src_vm_1.send(:power_state=, 'anything')
-          expect { task_1.preflight_check }.not_to raise_error
+          expect(task_1.preflight_check).to eq(:status => 'Ok', :message => 'Preflight check is successful')
         end
 
         context "transport method is vddk" do
@@ -598,7 +598,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "fails preflight check if src is power off" do
           src_vm_1.send(:power_state=, 'off')
-          expect { task_1.preflight_check }.to raise_error('OSP destination and source power_state is off')
+          expect(task_1.preflight_check).to eq(:status => 'Error', :message => 'OSP destination and source power_state is off')
         end
 
         context "transport method is vddk" do


### PR DESCRIPTION
When a migration plan is run, a ServiceTemplateTransformationPlanTask and an InfraConversionJob are created per VM in the plan. The InfraConversionJob is responsible for monitoring the process via a state machine.

With the current state machine, the first thing that happens is that a conversion host is assigned to the Task. Then, the task is 'starts' which means that it runs the ServiceTemplateTransformationPlanTask.preflight_check method.

This has two effects:

1. We need a conversion host to run the checks. This means that in a large plan, it may happen really late because the number of conversion slots is limited.

2. The UI doesn't report the correct total storage to migrate, because the virtv2v_disks array is only populated during preflight_check. This means that migrations waiting for a conversion host are not reported.

This PR moves the preflight check in InfraConversionThrottler that will discard invalid tasks. This way the job transitions directly from `waiting_to_start` to `aborting` and the task is cancelled.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1726939