### PR TITLE
[Ansible::Runner]  Handle edge cases from poor `stdout` data from `ansible-runner`

### DIFF
--- a/lib/ansible/runner/response.rb
+++ b/lib/ansible/runner/response.rb
@@ -60,7 +60,8 @@ module Ansible
           # https://github.com/ansible/ansible-runner/issues/89#issuecomment-404236832 , so it fails early if there is
           # a non json line
           begin
-            parsed_stdout << JSON.parse(line)
+            data = JSON.parse(line)
+            parsed_stdout << data if data.kind_of?(Hash)
           rescue => e
             _log.warn("Couldn't parse JSON from: #{e}")
           end

--- a/spec/lib/ansible/runner/response_spec.rb
+++ b/spec/lib/ansible/runner/response_spec.rb
@@ -1,14 +1,23 @@
 describe Ansible::Runner::Response do
   subject { described_class.new(:base_dir => base_dir) }
 
-  let(:base_dir)     { File.expand_path("../../..", stdout_file.path) } # triggers stdout_file
+  let(:base_dir)     { File.expand_path("../../../..", job_events.first.path) } # triggers job_events
   let(:runner_dir)   { Dir.mktmpdir("runner_run") } # same as base_dir
-  let(:stdout_file)  { File.open(stdout_filename, "w") { |f| f.write(stdout_lines); f } }
-  let(:stdout_lines) { "" }
+  let(:stdout_lines) { "\n" }
 
-  let(:stdout_filename) do
-    File.join(runner_dir, "artifacts", "result", "stdout").tap do |filename|
-      FileUtils.mkdir_p(File.dirname(filename))
+  let(:job_events) do
+    stdout_lines.lines.map.with_index do |line, index|
+      filename = File.join(job_events_dir, "#{index + 1}-#{SecureRandom.uuid}.json")
+      File.open(filename, "w") do |file|
+        file.write(line)
+        file
+      end
+    end
+  end
+
+  let(:job_events_dir) do
+    File.join(runner_dir, "artifacts", "result", "job_events").tap do |dir|
+      FileUtils.mkdir_p(dir)
     end
   end
 
@@ -21,17 +30,6 @@ describe Ansible::Runner::Response do
     LINES
   end
 
-  let(:bad_mixed_stdout) do
-    <<~LINES
-      {"uuid": "d737fa4a", "counter": 1, "stdout": "", "start_line": 0, "end_line": 0}
-      {"uuid": "080027c4", "counter": 2, "stdout": "\\r\\nPLAY [List Variables] **********************************************************", "start_line": 0, "end_line": 2}
-      PLAY [List Variables] **********************************************************
-      {"uuid": "080027c4", "counter": 3, "stdout": "\\r\\nTASK [Gathering Facts] *********************************************************", "start_line": 2, "end_line": 4}
-      TASK [Gathering Facts] *********************************************************
-      {"uuid": "7f4409f5", "counter": 4, "stdout": "", "start_line": 4, "end_line": 4}
-    LINES
-  end
-
   after do
     FileUtils.rm_rf(runner_dir) if Dir.exist?(runner_dir)
   end
@@ -39,7 +37,9 @@ describe Ansible::Runner::Response do
   describe "#stdout" do
     context "with no stdout file" do
       it "returns an empty string" do
-        FileUtils.rm_rf(stdout_file.path)
+        subject
+        FileUtils.rm_rf(Dir.glob(File.join(job_events_dir, "*.json")))
+
         expect(subject.stdout).to eq("")
       end
     end
@@ -51,41 +51,20 @@ describe Ansible::Runner::Response do
         expect(subject.stdout).to eq(good_stdout)
       end
     end
-
-    context "with invalid stdout (mixed JSON and non-JSON lines)" do
-      let(:stdout_lines) { bad_mixed_stdout }
-
-      it "returns the valid content" do
-        expect(subject.stdout).to eq(good_stdout)
-      end
-    end
   end
 
   describe "#parsed_stdout" do
     context "with no stdout file" do
       it "returns an empty array" do
-        FileUtils.rm_rf(stdout_file.path)
+        subject
+        FileUtils.rm_rf(Dir.glob(File.join(job_events_dir, "*.json")))
+
         expect(subject.parsed_stdout).to eq([])
       end
     end
 
     context "with valid stdout (1 JSON object per line)" do
       let(:stdout_lines) { good_stdout }
-
-      it "returns an array of only hashes" do
-        expect(subject.parsed_stdout.all? { |line| line.kind_of?(Hash) }).to be_truthy
-      end
-
-      it "includes the expected 'stdout' keys" do
-        expect(subject.parsed_stdout[0]['stdout']).to eq("")
-        expect(subject.parsed_stdout[1]['stdout']).to eq("\r\nPLAY [List Variables] **********************************************************")
-        expect(subject.parsed_stdout[2]['stdout']).to eq("\r\nTASK [Gathering Facts] *********************************************************")
-        expect(subject.parsed_stdout[3]['stdout']).to eq("")
-      end
-    end
-
-    context "with invalid stdout (mixed JSON and non-JSON lines)" do
-      let(:stdout_lines) { bad_mixed_stdout }
 
       it "returns an array of only hashes" do
         expect(subject.parsed_stdout.all? { |line| line.kind_of?(Hash) }).to be_truthy

--- a/spec/lib/ansible/runner/response_spec.rb
+++ b/spec/lib/ansible/runner/response_spec.rb
@@ -1,0 +1,73 @@
+describe Ansible::Runner::Response do
+  subject { described_class.new(:base_dir => base_dir) }
+
+  let(:base_dir)     { File.expand_path("../../..", stdout_file.path) } # triggers stdout_file
+  let(:runner_dir)   { Dir.mktmpdir("runner_run") } # same as base_dir
+  let(:stdout_file)  { File.open(stdout_filename, "w") { |f| f.write(stdout_lines); f } }
+  let(:stdout_lines) { "" }
+
+  let(:stdout_filename) do
+    File.join(runner_dir, "artifacts", "result", "stdout").tap do |filename|
+      FileUtils.mkdir_p(File.dirname(filename))
+    end
+  end
+
+  after do
+    FileUtils.rm_rf(runner_dir) if Dir.exist?(runner_dir)
+  end
+
+  describe "#parsed_stdout" do
+    context "with no stdout file" do
+      it "returns an empty array" do
+        FileUtils.rm_rf(stdout_file.path)
+        expect(subject.parsed_stdout).to eq([])
+      end
+    end
+
+    context "with valid stdout (1 JSON object per line)" do
+      let(:stdout_lines) do
+        <<~LINES
+          {"uuid": "d737fa4a", "counter": 1, "stdout": "", "start_line": 0, "end_line": 0}
+          {"uuid": "080027c4", "counter": 2, "stdout": "\\r\\nPLAY [List Variables] **********************************************************", "start_line": 0, "end_line": 2}
+          {"uuid": "080027c4", "counter": 3, "stdout": "\\r\\nTASK [Gathering Facts] *********************************************************", "start_line": 2, "end_line": 4}
+          {"uuid": "7f4409f5", "counter": 4, "stdout": "", "start_line": 4, "end_line": 4}
+        LINES
+      end
+
+      it "returns an array of only hashes" do
+        expect(subject.parsed_stdout.all? { |line| line.kind_of?(Hash) }).to be_truthy
+      end
+
+      it "includes the expected 'stdout' keys" do
+        expect(subject.parsed_stdout[0]['stdout']).to eq("")
+        expect(subject.parsed_stdout[1]['stdout']).to eq("\r\nPLAY [List Variables] **********************************************************")
+        expect(subject.parsed_stdout[2]['stdout']).to eq("\r\nTASK [Gathering Facts] *********************************************************")
+        expect(subject.parsed_stdout[3]['stdout']).to eq("")
+      end
+    end
+
+    context "with invalid stdout (mixed JSON and non-JSON lines)" do
+      let(:stdout_lines) do
+        <<~LINES
+          {"uuid": "d737fa4a", "counter": 1, "stdout": "", "start_line": 0, "end_line": 0}
+          {"uuid": "080027c4", "counter": 2, "stdout": "\\r\\nPLAY [List Variables] **********************************************************", "start_line": 0, "end_line": 2}
+          PLAY [List Variables] **********************************************************
+          {"uuid": "080027c4", "counter": 3, "stdout": "\\r\\nTASK [Gathering Facts] *********************************************************", "start_line": 2, "end_line": 4}
+          TASK [Gathering Facts] *********************************************************
+          {"uuid": "7f4409f5", "counter": 4, "stdout": "", "start_line": 4, "end_line": 4}
+        LINES
+      end
+
+      it "returns an array of only hashes" do
+        expect(subject.parsed_stdout.all? { |line| line.kind_of?(Hash) }).to be_truthy
+      end
+
+      it "includes the expected 'stdout' keys" do
+        expect(subject.parsed_stdout[0]['stdout']).to eq("")
+        expect(subject.parsed_stdout[1]['stdout']).to eq("\r\nPLAY [List Variables] **********************************************************")
+        expect(subject.parsed_stdout[2]['stdout']).to eq("\r\nTASK [Gathering Facts] *********************************************************")
+        expect(subject.parsed_stdout[3]['stdout']).to eq("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first pass at trying to address the issue described here:

https://bugzilla.redhat.com/show_bug.cgi?id=1739015

Over all it is adding different types of guards to get around some of the bugs in `ansible-runner`'s generated output.  The commit's go in more detail, but the 3 changes in short are:

- Commit 1: Avoid adding the the result of `Ansible::Runner::Response.parsed_output` anything that isn't a `Hash` (prevents errors, but data is left out)
- Commit 2: Use the `artifacts/result/job_events/*.json` files instead of `stdout`
- Commit 3: Still use `artifacts/result/stdout`, but don't read bad lines (non-JSON ones)

Commit 1 is a independent change of 2 & 3, but for the most part 2 & 3 are mutually exclusive, unless we decide to use one as a fallback for the other.  However, that option adds a bit of extra logic that I didn't want to code up in a first pass.


TODO:
-----

* [x] Add some specs
* [ ] Look into what might be fixable in `ansible-runner`


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1739015
* Example "bad data": https://gist.github.com/NickLaMuro/92e81799272c8bd439adf51ab61d41b1#file-artifact-dash-result-dash-stdout-L2562
* Open issue for `ansible-runner`: https://github.com/ansible/ansible-runner/issues/89