### PR TITLE
DialogFieldDropDown - Don't add_nil_option to values for multiselects

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -22,6 +22,10 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     [[nil, N_("<None>")]]
   end
 
+  def multiselect?
+    force_multi_value
+  end
+
   def refresh_json_value(checked_value)
     self.default_value = nil
     @raw_values = nil

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -117,9 +117,13 @@ class DialogFieldSortedItem < DialogField
     @raw_values ||= dynamic ? values_from_automate : static_raw_values
     reject_extraneous_nil_values unless dynamic?
     @raw_values = sort_data(@raw_values)
-    add_nil_option unless dynamic?
+    add_nil_option unless dynamic? || multiselect?
     determine_selected_value
     @raw_values
+  end
+
+  def multiselect?
+    false
   end
 
   def reject_extraneous_nil_values

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -386,7 +386,7 @@ describe DialogFieldDropDownList do
           end
 
           it "returns the raw values without a nil option" do
-            expect(dialog_field.values).to eq([%w(potato potato)])
+            expect(dialog_field.values).to eq([%w[potato potato]])
           end
         end
 
@@ -396,7 +396,7 @@ describe DialogFieldDropDownList do
           end
 
           it "returns the raw values with a nil option" do
-            expect(dialog_field.values).to eq([[nil, "<None>"], %w(potato potato)])
+            expect(dialog_field.values).to eq([[nil, "<None>"], %w[potato potato]])
           end
         end
       end
@@ -454,7 +454,7 @@ describe DialogFieldDropDownList do
           end
 
           it "returns the values" do
-            expect(dialog_field.values).to eq([%w(original values)])
+            expect(dialog_field.values).to eq([%w[original values]])
           end
         end
 
@@ -464,7 +464,7 @@ describe DialogFieldDropDownList do
           end
 
           it "returns the values including nil" do
-            expect(dialog_field.values).to eq([[nil, "<None>"], %w(original values)])
+            expect(dialog_field.values).to eq([[nil, "<None>"], %w[original values]])
           end
         end
       end

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -380,8 +380,24 @@ describe DialogFieldDropDownList do
           dialog_field.instance_variable_set(:@raw_values, [%w(potato potato)])
         end
 
-        it "returns the raw values with a nil option" do
-          expect(dialog_field.values).to eq([[nil, "<None>"], %w(potato potato)])
+        context 'and this is a multiselect' do
+          before do
+            dialog_field.force_multi_value = true
+          end
+
+          it "returns the raw values without a nil option" do
+            expect(dialog_field.values).to eq([%w(potato potato)])
+          end
+        end
+
+        context 'and this is a single select' do
+          before do
+            dialog_field.force_multi_value = false
+          end
+
+          it "returns the raw values with a nil option" do
+            expect(dialog_field.values).to eq([[nil, "<None>"], %w(potato potato)])
+          end
         end
       end
 
@@ -432,8 +448,24 @@ describe DialogFieldDropDownList do
           dialog_field.values = [%w(original values)]
         end
 
-        it "returns the values" do
-          expect(dialog_field.values).to eq([[nil, "<None>"], %w(original values)])
+        context 'and this is a multiselect' do
+          before do
+            dialog_field.force_multi_value = true
+          end
+
+          it "returns the values" do
+            expect(dialog_field.values).to eq([%w(original values)])
+          end
+        end
+
+        context 'and this is a single select' do
+          before do
+            dialog_field.force_multi_value = false
+          end
+
+          it "returns the values including nil" do
+            expect(dialog_field.values).to eq([[nil, "<None>"], %w(original values)])
+          end
         end
       end
     end


### PR DESCRIPTION
We're doing `add_nil_option` when computing field `.values`.
This probably makes sense for all the other sorted items,
but multiselects already have an implicit "Nothing selected" option.

And adding "<None>" to `.values` just means it will get shown as another option in the multiselect,
allowing the user to select "<None>, One, Two" :).

=> Explicitly not adding nil for multiselects.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740823

Cc @eclarizio WDYT?