### PR TITLE
[V2V] Manage handover between core and automate

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -50,8 +50,13 @@ class InfraConversionJob < Job
     # valid states: %w(migrated pending finished active queued)
   end
 
+  def handover_to_automate
+    migration_task.update_options(:workflow_runner => 'automate')
+  end
+
   def start
     migration_task.update!(:state => 'migrate')
+    handover_to_automate
     queue_signal(:poll_conversion)
   end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -50,6 +50,8 @@ class InfraConversionJob < Job
     # valid states: %w(migrated pending finished active queued)
   end
 
+  # Temporary method to allow switching from InfraConversionJob to Automate.
+  # In Automate, another method waits for workflow_runner to be 'automate'.
   def handover_to_automate
     migration_task.update_options(:workflow_runner => 'automate')
   end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe InfraConversionJob, :v2v do
         expect(job).to receive(:queue_signal).with(:poll_conversion)
         job.signal(:start)
         expect(task.state).to eq('migrate')
+        expect(task.options[:workflow_runner]).to eq('automate')
       end
     end
 


### PR DESCRIPTION
In order to port code to core model, we need a way to handover the migration to Automate on another criteria that the task state. This allows to keep the task in state 'migrate', while implementing some logic in InfraConversionJob.

This PR adds a method to set the `:workflow_runner` option on the migration task. Automate will wait for this option to be `automate` before continuing its state machine.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1741179
Built on #19146