### PR TITLE
Add VmOrTemplate.remove_all_snapshots_queue

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -152,7 +152,7 @@ module VmOrTemplate::Operations::Snapshot
 
   def remove_all_snapshots_queue(userid)
     task_opts = {
-      :name => "Removing all snapshots for #{name}",
+      :name   => "Removing all snapshots for #{name}",
       :userid => userid
     }
 

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -150,16 +150,22 @@ module VmOrTemplate::Operations::Snapshot
     raw_remove_all_snapshots
   end
 
-  def remove_all_snapshots_queue(task_id = nil)
-    MiqQueue.put_unless_exists(
+  def remove_all_snapshots_queue(userid)
+    task_opts = {
+      :name => "Removing all snapshots for #{name}",
+      :userid => userid
+    }
+
+    queue_opts = {
       :class_name  => self.class.name,
-      :instance_id => id,
       :method_name => 'remove_all_snapshots',
-      :args        => [],
-      :role        => "ems_operations",
-      :zone        => my_zone,
-      :task_id     => task_id
-    )
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
   def raw_revert_to_snapshot(snapshot_id)

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -150,6 +150,18 @@ module VmOrTemplate::Operations::Snapshot
     raw_remove_all_snapshots
   end
 
+  def remove_all_snapshots_queue(task_id = nil)
+    MiqQueue.put_unless_exists(
+      :class_name  => self.class.name,
+      :instance_id => id,
+      :method_name => 'remove_all_snapshots',
+      :args        => [],
+      :role        => "ems_operations",
+      :zone        => my_zone,
+      :task_id     => task_id
+    )
+  end
+
   def raw_revert_to_snapshot(snapshot_id)
     raise MiqException::MiqVmError, unsupported_reason(:revert_to_snapshot) unless supports_revert_to_snapshot?
     snapshot = snapshots.find_by(:id => snapshot_id)


### PR DESCRIPTION
In existing implementation, it's possible to queue a single snapshot removal via `VmOrTemplate.remove_snapshot_queue`. However, this is not possible to queue the removal of all snapshots, while it's probably going to take longer.

This PR introduces `VmOrTemplate.remove_all_snapshots_queue`.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1741326