### PR TITLE
Fixed MiqSearch.seed  when search name was changed and corrected typo miq_search.yml

### DIFF
--- a/app/models/miq_search.rb
+++ b/app/models/miq_search.rb
@@ -93,10 +93,10 @@ class MiqSearch < ApplicationRecord
       name  = attrs['name']
       db    = attrs['db']
 
-      rec = searches["#{name}-#{db}"]
+      rec = searches.delete("#{name}-#{db}")
       if rec.nil?
         _log.info("Creating [#{name}]")
-        searches["#{name}-#{db}"] = create!(attrs)
+        create!(attrs)
       else
         # Avoid undoing user changes made to enable/disable default searches which is held in the search_key column
         attrs.delete('search_key')
@@ -108,6 +108,10 @@ class MiqSearch < ApplicationRecord
 
         rec.save! if rec.changed?
       end
+    end
+    if searches.any?
+      _log.warn("Deleting the following MiqSearch(es) as they no longer exist: #{searches.keys.sort.collect(&:inspect).join(", ")}")
+      MiqSearch.destroy(searches.values.map(&:id))
     end
   end
 

--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -346,8 +346,8 @@
     search_type: default
     db: Host
 - attributes:
-    name: default_Status / Orhaned
-    description: Status / Orhaned
+    name: default_Status / Orphaned
+    description: Status / Orphaned
     filter: !ruby/object:MiqExpression
       exp:
         "=":


### PR DESCRIPTION
**ISSUE:** If name of search changed in ```db/fixtures/miq_search.yml``` than second record created in addition to the old one

**FIX**:  change ```MiqSearch.seed``` to destroy records representing default searches which we are not supplying anymore

This PR also fixed typo in ```db/fixtures/miq_search.yml```, which was introduced in https://github.com/ManageIQ/manageiq/pull/17815
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740309

@miq-bot add-label bug, core, changelog/yes, hammer/yes, ivanchuk/yes