### PR TITLE
Load balancers can't be retired so the setting can go away

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -136,7 +136,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
     # Schedule - Check for retired items and start retirement
     # TODO: remove redundant settings in follow-up pr
-    every = [worker_settings[:service_retired_interval], worker_settings[:vm_retired_interval], worker_settings[:orchestration_stack_retired_interval], worker_settings[:load_balancer_retired_interval]].min
+    every = [worker_settings[:service_retired_interval], worker_settings[:vm_retired_interval], worker_settings[:orchestration_stack_retired_interval]].min
     scheduler.schedule_every(every, :first_in => every) do
       enqueue(:retirement_check)
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1224,7 +1224,6 @@
       :job_proxy_dispatcher_stale_message_check_interval: 60.seconds
       :job_proxy_dispatcher_stale_message_timeout: 2.minutes
       :job_timeout_interval: 60.seconds
-      :load_balancer_retired_interval: 10.minutes
       :log_active_configuration_interval: 1.days
       :log_database_statistics_interval: 1.days
       :memory_threshold: 500.megabytes


### PR DESCRIPTION
Load balancer retirement was never implemented and so it got nixed in https://github.com/ManageIQ/manageiq/pull/18443 so we don't need the setting for it, I think. 

@miq-bot assign @bdunne 
🎉 
