### PR TITLE
Update rufus-scheduler to 3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,9 @@ gem "sqlite3",                        "~>1.3.0",       :require => false
 gem "sys-filesystem",                 "~>1.2.0"
 gem "terminal",                                        :require => false
 
+# temporary inclusion till we can get ConvertTimeToEoTime patch into upstream
+gem "et-orbi"
+
 # Modified gems (forked on Github)
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -77,9 +77,6 @@ gem "sqlite3",                        "~>1.3.0",       :require => false
 gem "sys-filesystem",                 "~>1.2.0"
 gem "terminal",                                        :require => false
 
-# temporary inclusion till we can get ConvertTimeToEoTime patch into upstream
-gem "et-orbi"
-
 # Modified gems (forked on Github)
 gem "ruport",                         "=1.7.0",                       :git => "https://github.com/ManageIQ/ruport.git", :tag => "v1.7.0-3"
 
@@ -194,9 +191,11 @@ group :graphql_api, :manageiq_default do
 end
 
 group :scheduler, :manageiq_default do
-  # Modified gems (forked on Github)
-  gem "rufus-scheduler", "=3.1.10.2", :git => "https://github.com/ManageIQ/rufus-scheduler.git", :require => false, :tag => "v3.1.10-2"
+  gem "rufus-scheduler"
 end
+# rufus has et-orbi dependency
+# this is temporary inclusion till we can get ConvertTimeToEoTime patch into upstream:
+gem "et-orbi"
 
 group :seed, :manageiq_default do
   manageiq_plugin "manageiq-content"

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -77,15 +77,19 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Log current system configuration
     every = worker_settings[:log_active_configuration_interval]
 
-    scheduler.schedule_every(every, :tags => [:vmdb_appliance_log_config, schedule_category]) do
-      enqueue(:vmdb_appliance_log_config)
-    end
+    scheduler.schedule_every(
+      every,
+      :first_in => every,
+      :tags     => [:vmdb_appliance_log_config, schedule_category]
+    ) { enqueue(:vmdb_appliance_log_config) }
 
     # Schedule - Log current database statistics and bloat
     every = worker_settings[:log_database_statistics_interval]
-    scheduler.schedule_every(every, :tags => [:log_all_database_statistics, schedule_category]) do
-      enqueue(:vmdb_database_log_all_database_statistics)
-    end
+    scheduler.schedule_every(
+      every,
+      :first_in => every,
+      :tags     => [:log_all_database_statistics, schedule_category]
+    ) { enqueue(:vmdb_database_log_all_database_statistics) }
 
     # Schedule - Update Server Statistics
     every = worker_settings[:server_stats_interval]

--- a/config/initializers/convert_time_to_eo.rb
+++ b/config/initializers/convert_time_to_eo.rb
@@ -1,0 +1,12 @@
+# temporary hack for when/if we can get patch accepted upscream
+# et-orbi doesn't support comparisons of EoTime in the scheduler with user provided Time objects
+# see https://github.com/ManageIQ/manageiq/pull/19153#issuecomment-521719495
+module ConvertTimeToEoTime
+  def ==(*args)
+    o = EtOrbi.make_time(args.first) if args.first.kind_of?(Time) || args.first.kind_of?(DateTime)
+    super(o)
+  end
+end
+
+require 'et-orbi'
+EtOrbi::EoTime.prepend(ConvertTimeToEoTime)

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -29,7 +29,7 @@ describe MiqScheduleWorker::Jobs do
         schedule_id = 123
         scheduler = Rufus::Scheduler.new
         block = -> { "some work" }
-        rufus_job = Rufus::Scheduler::EveryJob.new(scheduler, 1.hour, {}, block)
+        rufus_job = Rufus::Scheduler::EveryJob.new(scheduler, 1.hour.to_i, {}, block)
 
         expect(MiqSchedule).to receive(:queue_scheduled_work).with(schedule_id, rufus_job.job_id, 1.hour.from_now.to_i, {})
 

--- a/spec/models/miq_schedule_worker/scheduler_spec.rb
+++ b/spec/models/miq_schedule_worker/scheduler_spec.rb
@@ -72,7 +72,7 @@ describe MiqScheduleWorker::Scheduler do
       scheduler.schedule_cron("0 0 * * *", :tags => [:a, :b], &work)
       job = rufus_scheduler.jobs.first
 
-      expect(job.frequency).to eq(1.day)
+      expect(job.rough_frequency).to eq(1.day.to_i)
       expect(job.tags).to match_array(%w(a b))
       expect(job.callable).to eq(work)
     end


### PR DESCRIPTION
We're using rufus-scheduler 3.1.10.2 and 3.7 is currently in the works.  

To get to 3.6, there are three changes necessary:
1) job ```frequency``` was replaced by ```rough_frequency``` (https://github.com/jmettraux/rufus-scheduler/commit/ba25015f9442a7cdc0040a453dccdf778204ff87#diff-5d7d9fcb70b7c4ad09e1fa4b2cd82591)
2) a couple of our runner specs needed updated arguments to not break tagging

 we need the patch, darn it:
3) https://github.com/floraison/et-orbi/blob/master/lib/et-orbi/time.rb#L208 pretty much just needs to be replaced with: ```o = EtOrbi.make_time(o)```

updated to of course include the requisite picture of a ```rufous``` in all its glory: 
<img width="390" alt="Screen Shot 2019-08-14 at 5 13 29 PM" src="https://user-images.githubusercontent.com/16326669/63056828-df3aaa80-beb6-11e9-911c-f94a1a9a7152.png">


@miq-bot assign @jrafanie 