### PR TITLE
[V2V] Update Transformation Task in InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -78,7 +78,7 @@ class InfraConversionJob < Job
 
   def on_entry(state_hash, _)
     state_hash ||= { :state => 'active', :status => 'Ok', :message => states[state.to_sym].description }
-    if context[:retries][state.to_sym].to_i.zero?
+    if context["retries_#{state}".to_sym].to_i.zero?
       state_hash[:started_on] = Time.now.utc
       state_hash[:percent] = 0.0
     end
@@ -87,7 +87,7 @@ class InfraConversionJob < Job
 
   def on_retry(state_hash, state_progress = nil)
     if state_progress.nil?
-      state_hash[:percent] = context[:retries][state.to_sym].to_f / states[state.to_sym][:max_retries].to_f * 100.0
+      state_hash[:percent] = context["retries#{state}".to_sym].to_f / states[state.to_sym][:max_retries].to_f * 100.0
     else
       state_hash.merge!(state_progress)
     end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -42,14 +42,6 @@ class InfraConversionJob < Job
     }
   end
 
-  def state_settings
-    @state_settings ||= {
-      :running_in_automate => {
-        :max_retries => 8640 # 36 hours with a retry interval of 15 seconds
-      }
-    }
-  end
-
   # Example state:
   #   :state_name => {
   #     :description => 'State description',

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe InfraConversionJob, :v2v do
             :percent    => 25.0,
             :updated_on => Time.now.utc
           }
-          expect(job.on_retry(state_hash, {:percent => 25.0})).to eq(state_hash.merge(state_hash_diff))
+          expect(job.on_retry(state_hash, :percent => 25.0)).to eq(state_hash.merge(state_hash_diff))
         end
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe InfraConversionJob, :v2v do
             }
           }
           task.update_options(:progress => progress)
-          job.update_migration_task_progress(:on_retry, { :percent => 30 })
+          job.update_migration_task_progress(:on_retry, :percent => 30)
           expect(task.reload.options[:progress]).to eq(
             :current_state => 'running_in_automate',
             :percent       => 10.0,
@@ -189,7 +189,7 @@ RSpec.describe InfraConversionJob, :v2v do
           )
         end
       end
- 
+
       it 'updates the task progress hash on exit' do
         job.context[:retries_running_in_automate] = 1728
         Timecop.freeze(2019, 2, 6) do
@@ -223,7 +223,7 @@ RSpec.describe InfraConversionJob, :v2v do
           )
         end
       end
- 
+
       it 'updates the task progress hash on error' do
         job.context[:retries_running_in_automate] = 1728
         Timecop.freeze(2019, 2, 6) do

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -122,18 +122,19 @@ RSpec.describe InfraConversionJob, :v2v do
         job.context[:retries_running_in_automate] = 1728
         Timecop.freeze(2019, 2, 6) do
           task.update_options(:progress => {
-            :current_state => 'running_in_automate',
-            :percent       => 10.0,
-            :states        => {
-              :running_in_automate => {
-                :state      => 'active',
-                :status     => 'Ok',
-                :started_on => Time.now.utc - 1.minute,
-                :percent    => 10.0,
-                :updated_on => Time.now.utc - 30.seconds
-              }
-            }
-          })
+                                :current_state => 'running_in_automate',
+                                :percent       => 10.0,
+                                :states        => {
+                                  :running_in_automate => {
+                                    :state      => 'active',
+                                    :status     => 'Ok',
+                                    :started_on => Time.now.utc - 1.minute,
+                                    :percent    => 10.0,
+                                    :updated_on => Time.now.utc - 30.seconds
+                                  }
+                                }
+                              }
+          )
           job.update_migration_task_progress(:on_retry, nil)
           expect(task.reload.options[:progress]).to eq(
             :current_state => 'running_in_automate',

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -12,6 +12,246 @@ RSpec.describe InfraConversionJob, :v2v do
     end
   end
 
+  context 'state hash methods' do
+    before do
+      job.state = 'running_in_automate'
+      job.context[:retries_running_in_automate] = 1728
+    end
+
+    context '.on_entry' do
+      it 'initializes the state hash if it did not exist' do
+        Timecop.freeze(2019, 2, 6) do
+          expect(job.on_entry(nil, nil)).to eq(
+            :state      => 'active',
+            :status     => 'Ok',
+            :started_on => Time.now.utc,
+            :percent    => 0.0
+          )
+        end
+      end
+    end
+
+    context '.on_retry' do
+      it 'uses ad-hoc percentage if no progress is provided' do
+        Timecop.freeze(2019, 2, 6) do
+          state_hash = {
+            :state      => 'active',
+            :status     => 'Ok',
+            :started_on => Time.now.utc - 1.minute,
+            :percent    => 10.0
+          }
+          expect(job.on_retry(state_hash, nil)).to eq(state_hash.merge(
+            :percent    => 20.0,
+            :updated_on => Time.now.utc
+          ))
+        end
+      end
+
+      it 'uses percentage from progress hash' do
+        Timecop.freeze(2019, 2, 6) do
+          state_hash = {
+            :state      => 'active',
+            :status     => 'Ok',
+            :started_on => Time.now.utc - 1.minute,
+            :percent    => 10.0
+          }
+          expect(job.on_retry(state_hash, {:percent => 25.0})).to eq(state_hash.merge(
+            :percent    => 25.0,
+            :updated_on => Time.now.utc
+          ))
+        end
+      end
+    end
+
+    context '.on_exit' do
+      it 'uses percentage from progress hash' do
+        Timecop.freeze(2019, 2, 6) do
+          state_hash = {
+            :state      => 'active',
+            :status     => 'Ok',
+            :started_on => Time.now.utc - 1.minute,
+            :percent    => 80.0
+          }
+          expect(job.on_exit(state_hash, nil)).to eq(state_hash.merge(
+            :state      => 'finished',
+            :percent    => 100.0,
+            :updated_on => Time.now.utc
+          ))
+        end
+      end
+    end
+
+    context '.on_error' do
+      it 'uses percentage from progress hash' do
+        Timecop.freeze(2019, 2, 6) do
+          state_hash = {
+            :state      => 'active',
+            :status     => 'Ok',
+            :started_on => Time.now.utc - 1.minute,
+            :percent    => 80.0
+          }
+          expect(job.on_error(state_hash, nil)).to eq(state_hash.merge(
+            :state      => 'finished',
+            :status     => 'Error',
+            :updated_on => Time.now.utc
+          ))
+        end
+      end
+    end
+
+    context '.update_migration_task_progress' do
+      it 'initializes the progress hash on entry if it does not exist' do
+        Timecop.freeze(2019, 2, 6) do
+          job.update_migration_task_progress(:on_entry, nil)
+          expect(task.reload.options[:progress]).to eq(
+            :current_state => 'running_in_automate',
+            :percent       => 0.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc,
+                :percent    => 0.0
+              }
+            }
+          )
+        end
+      end
+
+      it 'updates the task progress hash on retry without a state progress hash' do
+        job.context[:retries_running_in_automate] = 1728
+        Timecop.freeze(2019, 2, 6) do
+          task.update_options(:progress => {
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 10.0,
+                :updated_on => Time.now.utc - 30.seconds
+              }
+            }
+          })
+          job.update_migration_task_progress(:on_retry, nil)
+          expect(task.reload.options[:progress]).to eq(
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 20.0,
+                :updated_on => Time.now.utc
+              }
+            }
+          )
+        end
+      end
+
+      it 'updates the task progress hash on retry with a state progress hash' do
+        job.context[:retries_running_in_automate] = 1728
+        Timecop.freeze(2019, 2, 6) do
+          task.update_options(:progress => {
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 10.0,
+                :updated_on => Time.now.utc - 30.seconds
+              }
+            }
+          })
+          job.update_migration_task_progress(:on_retry, { :percent => 30 })
+          expect(task.reload.options[:progress]).to eq(
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 30.0,
+                :updated_on => Time.now.utc
+              }
+            }
+          )
+        end
+      end
+ 
+      it 'updates the task progress hash on exit' do
+        job.context[:retries_running_in_automate] = 1728
+        Timecop.freeze(2019, 2, 6) do
+          task.update_options(:progress => {
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 10.0,
+                :updated_on => Time.now.utc - 30.seconds
+              }
+            }
+          })
+          job.update_migration_task_progress(:on_exit, nil)
+          expect(task.reload.options[:progress]).to eq(
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'finished',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 100.0,
+                :updated_on => Time.now.utc
+              }
+            }
+          )
+        end
+      end
+ 
+      it 'updates the task progress hash on error' do
+        job.context[:retries_running_in_automate] = 1728
+        Timecop.freeze(2019, 2, 6) do
+          task.update_options(:progress => {
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'active',
+                :status     => 'Ok',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 10.0,
+                :updated_on => Time.now.utc - 30.seconds
+              }
+            }
+          })
+          job.update_migration_task_progress(:on_error, nil)
+          expect(task.reload.options[:progress]).to eq(
+            :current_state => 'running_in_automate',
+            :percent       => 10.0,
+            :states        => {
+              :running_in_automate => {
+                :state      => 'finished',
+                :status     => 'Error',
+                :started_on => Time.now.utc - 1.minute,
+                :percent    => 10.0,
+                :updated_on => Time.now.utc
+              }
+            }
+          )
+        end
+      end
+    end
+  end
+
   context 'state transitions' do
     %w[start poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
@@ -73,7 +313,7 @@ RSpec.describe InfraConversionJob, :v2v do
     end
   end
 
-  context 'operations' do
+  context 'transition methods' do
     let(:poll_interval) { Settings.transformation.job.retry_interval }
 
     context '#start' do


### PR DESCRIPTION
We want to port the `WeightedUpdateStatus` method to InfraConversionJob. The goal of the method is to update the ServiceTemplateTransformationPlanTask at each transition, so that the UI can display the information.

This PR introduces a new hash, `states`, that stores information about the states: `description`, `weight` and `max_retries`. These fields are used to update the task. Currently, only `polling_timeout` leverages this new hash. It has been changed to use `max_retries`.

We consider that a state has 4 hooks:

- `on_entry` - the state starts running, including retries
- `on_retry` - the state exits and the transition doesn't change the state
- `on_exit` - the state exits and the transition changes the state
- `on_error` - the state has failed

The `update_migration_task_progress` method generates a state hash with: `state`, `status`, `message`, `percent`, `started_on` and `updated_on`. Each hook can alter one or more attributes of the state hash. The state hash is then used to update the migration task progress.

This PR also simplifies `poll_conversion` and `poll_post_stage` method that shouldn't interfere with Automate methods. They are meant to only monitor virt-v2v and post-migration phases of the migration task. These methods will be updated when we port `VMTransform`, `VMCheckTransformed` methods, as well as the methods in `PostTransform`.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1740659
Built on #19149, #19164