### PR TITLE
Handle cases where an EmbeddedAnsible job may not have stdout

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -108,7 +108,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
   end
 
   def raw_stdout_json
-    miq_task.context_data[:ansible_runner_stdout]
+    miq_task.try(&:context_data).try(:[], :ansible_runner_stdout) || []
   end
 
   def raw_stdout_txt
@@ -116,6 +116,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
   end
 
   def raw_stdout_html
-    TerminalToHtml.render(raw_stdout_txt)
+    text = raw_stdout_txt
+    text = _("No output available") if text.blank?
+    TerminalToHtml.render(text)
   end
 end

--- a/lib/terminal_to_html.rb
+++ b/lib/terminal_to_html.rb
@@ -9,7 +9,7 @@ class TerminalToHtml
   end
 
   def self.wrap_html_container(rendered)
-    stylesheet = File.read(File.join(Gem.latest_spec_for("terminal").full_gem_path, "/app/assets/stylesheets/terminal.css"))
+    stylesheet = File.read(File.join(Bundler.environment.specs["terminal"].first.full_gem_path, "/app/assets/stylesheets/terminal.css"))
     <<~EOHTML
       <div>
       <style scoped>


### PR DESCRIPTION
Old jobs before the new embedded ansible code will not have the stdout
in the database. In addition, there are timing issues where stdout may
not yet be populated. This commit defensively handles all of these
cases.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1735114

@NickLaMuro @carbonin Please review.