### PR TITLE
When this is called from rake evm:db:backup:local MiqEvent is not defined

### DIFF
--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -37,7 +37,7 @@ class EvmDatabaseOps
     else
       msg = "Destination location: [#{database_opts[:local_file]}], does not have enough free disk space: [#{free_space} bytes] for database of size: [#{db_size} bytes]"
       _log.warn(msg)
-      MiqEvent.raise_evm_event_queue(MiqServer.my_server, "evm_server_db_backup_low_space", :event_details => msg)
+      defined?(::MiqEvent) && MiqEvent.raise_evm_event_queue(MiqServer.my_server, "evm_server_db_backup_low_space", :event_details => msg)
       raise MiqException::MiqDatabaseBackupInsufficientSpace, msg
     end
   end


### PR DESCRIPTION
This rake task is called from appliance console database backup.

Does not fix the BZ, but discovered while trying to reproduce https://bugzilla.redhat.com/show_bug.cgi?id=1741481
```
[root@localhost vmdb]# rake evm:db:backup:local -- --local-file /tmp/test.dump
#<Thread:0x00005584e8730ec0@/opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/miq_file_storage.rb:275 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	2: from /opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/miq_file_storage.rb:277:in `block in handle_io_block'
	1: from /var/www/miq/vmdb/lib/evm_database_ops.rb:173:in `block (2 levels) in with_file_storage'
/var/www/miq/vmdb/lib/evm_database_ops.rb:40:in `validate_free_space': uninitialized constant EvmDatabaseOps::MiqEvent (NameError)
rake aborted!
NoMethodError: undefined method `path' for nil:NilClass
/opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/mount/miq_generic_mount_session.rb:493:in `source_for_log'
/opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/mount/miq_generic_mount_session.rb:265:in `rescue in add'
/opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/mount/miq_generic_mount_session.rb:261:in `add'
/var/www/miq/vmdb/lib/evm_database_ops.rb:160:in `block in with_file_storage'
/opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/miq_file_storage.rb:31:in `with_interface_class'
/var/www/miq/vmdb/lib/evm_database_ops.rb:133:in `with_file_storage'
/var/www/miq/vmdb/lib/evm_database_ops.rb:57:in `backup'
/var/www/miq/vmdb/lib/tasks/evm_dba.rake:204:in `block (4 levels) in <top (required)>'
/opt/rh/cfme-gemset/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'

Caused by:
NameError: uninitialized constant EvmDatabaseOps::MiqEvent
/var/www/miq/vmdb/lib/evm_database_ops.rb:40:in `validate_free_space'
/var/www/miq/vmdb/lib/evm_database_ops.rb:173:in `block (2 levels) in with_file_storage'
/opt/rh/cfme-gemset/bundler/gems/cfme-gems-pending-184554806463/lib/gems/pending/util/miq_file_storage.rb:277:in `block in handle_io_block'
Tasks: TOP => evm:db:backup:local
(See full trace by running task with --trace)
```
