### PR TITLE
Open URL: expand to "Provider"

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -1,6 +1,7 @@
 class ExtManagementSystem < ApplicationRecord
   include CustomActionsMixin
   include SupportsFeatureMixin
+  include ExternalUrlMixin
 
   def self.with_tenant(tenant_id)
     tenant = Tenant.find(tenant_id)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -6,7 +6,6 @@ class Provider < ApplicationRecord
   include SupportsFeatureMixin
   include TenancyMixin
   include UuidMixin
-  include ExternalUrlMixin
 
   belongs_to :tenant
   belongs_to :zone


### PR DESCRIPTION
To make "Provider" work one needs to modify "ExtManagementSystem".

Partial fix for:
https://bugzilla.redhat.com/show_bug.cgi?id=1550002

The Mixin was included in the "Provider" but what where it is really needed is the "ExtManagementSystem".

### Testing:
To be tested according to https://github.com/ManageIQ/guides/blob/master/automate_url_open.md together with: https://github.com/ManageIQ/manageiq-ui-classic/pull/6040 (test the "Provider" usecase).