### PR TITLE
Successive automation task runs shouldn't change the original params

### DIFF
--- a/app/models/automation_request.rb
+++ b/app/models/automation_request.rb
@@ -29,31 +29,17 @@ class AutomationRequest < MiqRequest
     options[:schedule_type] = parameters['schedule_time'].present? ? "schedule" : "immediately"
     options[:schedule_time] = parameters['schedule_time'].to_i.days.from_now if parameters['schedule_time']
 
-    object_parameters = parse_out_objects(parameters)
-    attrs = MiqRequestWorkflow.parse_ws_string(parameters)
-    attrs.merge!(object_parameters)
-
-    attrs[:userid]     = user.userid
     options[:user_id]  = user.id
-    options[:attrs]    = attrs
+    options[:attrs]    = build_attrs(parameters, user)
     options[:miq_zone] = zone(options) if options[:attrs].key?(:miq_zone)
 
     create_request(options, user, auto_approve)
   end
 
   def self.create_from_scheduled_task(user, uri_parts, parameters)
-    [:namespace, :class_name].each { |key| uri_parts.delete(key) if uri_parts.key?(key) }
-    approval = {'auto_approve' => true}
-    uri_parts.stringify_keys!
-    parameters.stringify_keys!
-    create_from_ws("1.1", user, uri_parts, parameters, approval)
-  end
-
-  def self.parse_out_objects(parameters)
-    object_hash = parameters.select { |key, _v| key.to_s.include?(MiqAeEngine::MiqAeObject::CLASS_SEPARATOR) }
-    object_hash.each do |key, _v|
-      parameters.delete(key)
-    end
+    parameters = parameters.stringify_keys
+    uri_parts = uri_parts.except(:namespace, :class_name).stringify_keys!
+    create_from_ws("1.1", user, uri_parts, parameters, 'auto_approve' => true)
   end
 
   def self.zone(options)
@@ -79,4 +65,14 @@ class AutomationRequest < MiqRequest
   def log_request_success(_requester_id, _mode)
     # currently we do not log successful automation requests
   end
+
+  def self.build_attrs(parameters, user)
+    parameters = parameters.dup
+    object_hash = parameters.select { |key, _v| key.to_s.include?(MiqAeEngine::MiqAeObject::CLASS_SEPARATOR) }
+    parameters.extract!(*object_hash.keys)
+    MiqRequestWorkflow.parse_ws_string(parameters).merge!(object_hash).tap do |attrs|
+      attrs[:userid] = user.userid
+    end
+  end
+  private_class_method :build_attrs
 end

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -20,18 +20,6 @@ describe AutomationRequest do
     expect(AutomationRequest.request_task_class).to eq(AutomationTask)
   end
 
-  context ".parse_out_objects" do
-    it "isolates objects including the '::' class separator" do
-      object_parameters = {'VmOrTemplate::vm' => 10, 'var2' => @ae_var2.to_s, 'var3' => @ae_var3.to_s}
-      non_object_parameters = {'var2' => @ae_var2.to_s, 'var3' => @ae_var3.to_s}
-      object_hash = AutomationRequest.parse_out_objects(object_parameters)
-      non_object_hash = AutomationRequest.parse_out_objects(non_object_parameters)
-      expect(object_hash).to eq 'VmOrTemplate::vm' => 10
-      expect(non_object_hash).to be_a Hash
-      expect(non_object_hash).to be_empty
-    end
-  end
-
   context ".create_from_ws" do
     it "with empty requester string" do
       ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @parameters, {})
@@ -51,6 +39,13 @@ describe AutomationRequest do
       expect(ar.options[:attrs][:userid]).to eq(admin.userid)
       expect(ar.options[:schedule_type]).to eq("immediately")
       expect(ar.options[:schedule_time]).to eq(nil)
+      expect(ar.options[:attrs].keys).to eq([:var1, :var2, :var3, :userid])
+    end
+
+    it "with object in parameters" do
+      parameters = {'var1' => @ae_var1.to_s, 'var2' => @ae_var2.to_s, 'var3' => @ae_var3.to_s, 'VmOrTemplate::vm' => 10}
+      ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, parameters, {})
+      expect(ar.options[:attrs].keys).to include("VmOrTemplate::vm")
     end
 
     it "creates request with schedule" do
@@ -65,6 +60,7 @@ describe AutomationRequest do
       @object_parameters = {'VmOrTemplate::vm' => 10, 'var2' => @ae_var2.to_s, 'var3' => @ae_var3.to_s}
       ar = AutomationRequest.create_from_ws(@version, admin, @uri_parts, @object_parameters, {})
       expect(ar.options[:attrs]).to include("VmOrTemplate::vm" => 10, :var2 => @ae_var2.to_s)
+      expect(@object_parameters).to include("VmOrTemplate::vm" => 10)
     end
 
     it "does not allow overriding userid who is NOT in the database" do

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -566,6 +566,7 @@ describe MiqSchedule do
 
     context "valid action_automation_request" do
       let(:admin) { FactoryBot.create(:user_miq_request_approver) }
+      let(:ems)   { FactoryBot.create(:ext_management_system) }
       let(:automate_sched) do
         MiqSchedule.create(:name          => "test_method", :resource_type => "AutomationRequest",
                            :userid        => admin.userid, :enabled => true,
@@ -575,7 +576,8 @@ describe MiqSchedule do
                            :filter        => {:uri_parts  => {:namespace => 'ss',
                                                               :instance  => 'vv',
                                                               :message   => 'mm'},
-                                              :parameters => {"param" => "8"}})
+                                              :parameters => {"param"                                      => "8",
+                                                              "ExtManagementSystem::ext_management_system" => ems.id}})
       end
 
       it "should create a request from a scheduled task" do
@@ -587,6 +589,7 @@ describe MiqSchedule do
         FactoryBot.create(:user_admin, :userid => 'admin')
         automate_sched.action_automation_request(AutomationRequest, '')
         expect(AutomationRequest.where(:description => "Automation Task", :userid => admin.userid).count).to eq(1)
+        expect(automate_sched.filter[:parameters].keys).to include("ExtManagementSystem::ext_management_system")
       end
     end
 


### PR DESCRIPTION
Params get removed and re-added here: https://github.com/ManageIQ/manageiq/pull/12722/files#diff-e3295c427cec18ad642950055ae49a3bR53 and on the second run of an automation task that's scheduled, we've lost the relevant attributes. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1713072