### PR TITLE
Remove deprecated VMWare Hosts

### DIFF
--- a/db/fixtures/miq_searches.yml
+++ b/db/fixtures/miq_searches.yml
@@ -159,57 +159,6 @@
     search_type: default
     db: Vm
 - attributes:
-    name: default_Platform / ESX 3.5
-    description: Platform / ESX 3.5
-    filter: !ruby/object:MiqExpression
-      exp:
-        and:
-        - "=":
-            field: Host-vmm_vendor
-            value: vmware
-        - INCLUDES:
-            field: Host-vmm_product
-            value: ESX
-        - "=":
-            field: Host-vmm_version
-            value: 3.5.0
-    search_type: default
-    db: Host
-- attributes:
-    name: default_Platform / ESX 4.0
-    description: Platform / ESX 4.0
-    filter: !ruby/object:MiqExpression
-      exp:
-        and:
-        - "=":
-            field: Host-vmm_vendor
-            value: vmware
-        - INCLUDES:
-            field: Host-vmm_product
-            value: ESX
-        - "=":
-            field: Host-vmm_version
-            value: 4.0.0
-    search_type: default
-    db: Host
-- attributes:
-    name: default_Platform / ESX 4.1
-    description: Platform / ESX 4.1
-    filter: !ruby/object:MiqExpression
-      exp:
-        and:
-        - "=":
-            field: Host-vmm_vendor
-            value: vmware
-        - INCLUDES:
-            field: Host-vmm_product
-            value: ESX
-        - "=":
-            field: Host-vmm_version
-            value: 4.1.0
-    search_type: default
-    db: Host
-- attributes:
     name: default_Platform / ESX 5.0
     description: Platform / ESX 5.0
     filter: !ruby/object:MiqExpression


### PR DESCRIPTION
Fix and remove deprecated VMWware Hosts from selection/display.

**NOTE:** Requires this BZ fix to work: https://bugzilla.redhat.com/show_bug.cgi?id=1740309

https://bugzilla.redhat.com/show_bug.cgi?id=1740738

Screen shot showing older versions of VMWare:
![Hosts list with older ESX versions prior to code fix](https://user-images.githubusercontent.com/552686/63130661-11f4a980-bf70-11e9-9c41-18e7db2f196a.png)

Screen shot showing only recent versions listed:
![Hosts list sans deprecated ESX versions post fix](https://user-images.githubusercontent.com/552686/63130676-220c8900-bf70-11e9-85d8-886dd84b59c1.png)


