### PR TITLE
[Ansible::Runner::Response] Fix ident for stdout

### DIFF
--- a/lib/ansible/runner/response.rb
+++ b/lib/ansible/runner/response.rb
@@ -100,7 +100,7 @@ module Ansible
           # `File.basename` calls are done in a `.sort_by!` up front so they
           # aren't triggered for each block call in a traditional `.sort!`.
           #
-          job_event_files = Dir.glob(File.join(base_dir, "artifacts", "result", "job_events", "*.json"))
+          job_event_files = Dir.glob(File.join(base_dir, "artifacts", ident, "job_events", "*.json"))
                                .sort_by! { |fname| fname.match(%r{job_events/(\d+)})[1].to_i }
 
           # Read each file and added it to the `stdout` string.


### PR DESCRIPTION
I made an oopsie....

Basically I hard coded in the "result" directory for the `Ansible::Runner::Response`, when it should have made use of the instance variable `ident` for that.

This fixes that.


Links
-----

* Where the shame began... https://github.com/ManageIQ/manageiq/pull/19147