### PR TITLE
[V2V] Simplify InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -42,10 +42,6 @@ class InfraConversionJob < Job
     }
   end
 
-  def load_states
-    {}
-  end
-
   def state_settings
     @state_settings ||= {
       :running_in_automate => {

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -73,6 +73,7 @@ class InfraConversionJob < Job
   def polling_timeout
     options[:retry_interval] ||= Settings.transformation.job.retry_interval # in seconds
     return false if states[state.to_sym][:max_retries].nil?
+
     retries = "retries_#{state}".to_sym
     context[retries] = (context[retries] || 0) + 1
     context[retries] > states[state.to_sym][:max_retries]
@@ -108,7 +109,7 @@ class InfraConversionJob < Job
 
     message = "Migration Task vm=#{migration_task.source.name}, state=#{migration_task.state}, status=#{migration_task.status}"
     _log.info(prep_message(message))
-    update_attributes(:message => message)
+    update(:message => message)
     if migration_task.state == 'finished'
       self.status = migration_task.status
       queue_signal(:finish)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1088,8 +1088,6 @@
 :transformation:
   :job:
     :retry_interval: 15 # in seconds
-    :states_max_retries:
-      :running_in_automate: 8640 # 36 hours with a retry interval of 15 seconds
   :limits:
     :max_concurrent_tasks_per_ems: 10
     :max_concurrent_tasks_per_host: 10

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1086,14 +1086,13 @@
     :keep_tasks: 1.week
     :purge_window_size: 1000
 :transformation:
+  :job:
+    :retry_interval: 15 # in seconds
   :limits:
     :max_concurrent_tasks_per_ems: 10
     :max_concurrent_tasks_per_host: 10
     :cpu_limit_per_host: unlimited
     :network_limit_per_host: unlimited
-    :conversion_polling_interval: 15 # in seconds
-    :poll_conversion_max: 86400 # i.e. default 24 hours (15s per-interval)
-    :poll_post_stage_max: 25200 # i.e. default 7 hours (15s per-interval)
 :ui:
   :mark_translated_strings: false
   :url:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1088,6 +1088,8 @@
 :transformation:
   :job:
     :retry_interval: 15 # in seconds
+    :states_max_retries:
+      :running_in_automate: 8640 # 36 hours with a retry interval of 15 seconds
   :limits:
     :max_concurrent_tasks_per_ems: 10
     :max_concurrent_tasks_per_host: 10

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w(start poll_automate_state_machine finish abort_job cancel error).each do |signal|
+    %w[start poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -22,7 +22,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w(start poll_automate_state_machine).each do |signal|
+    %w[start poll_automate_state_machine].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -91,7 +91,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
 
       it 'to poll_automate_state_machine when migration_task.state is not finished' do
-        task.update!(:state => 'active')
+        task.update!(:state => 'migrate')
         Timecop.freeze(2019, 2, 6) do
           expect(job).to receive(:queue_signal).with(:poll_automate_state_machine, :deliver_on => Time.now.utc + poll_interval)
           job.signal(:poll_automate_state_machine)


### PR DESCRIPTION
In current implementation, InfraConversionJob polls two phases: `conversion` and `post_stage`. These phases are consecutive in the same Automate state machine. Moreover, the polling shouldn't change the `migration_task`, because Automate is responsible for the task update and this could interfere. This PR fusions the two phases into a single state `poll_automate_state_machine` that will only move the state machine to the `finish` state once `migration_task` state is `finished`.

This PR also extends the behavior of the state machine with a `states` method that return a hash. Each entry of the hash is a description of the state, with attributes that can be used by local methods. For example, this PR changes the implementation of `polling_timeout` to use the `max_retries` attribute of the state. In future PR, we could use the concept of `weight` to calculate a weighted percentage of progress.

For readability, this PR also moves the transitions methods to the end of the file, preventing mixing InfraConversionJob helpers and transitions.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1740659