### PR TITLE
Fixed typo in warning log

### DIFF
--- a/app/models/miq_schedule_worker/scheduler.rb
+++ b/app/models/miq_schedule_worker/scheduler.rb
@@ -15,7 +15,7 @@ class MiqScheduleWorker
 
     def schedule_every(duration = nil, callable = nil, opts = {}, &block)
       if duration.blank?
-        logger.warn("Duration is empty, scheduling ingnored. Called from: #{block}.")
+        logger.warn("Duration is empty, scheduling ignored. Called from: #{block}.")
         return
       end
 

--- a/spec/models/miq_schedule_worker/scheduler_spec.rb
+++ b/spec/models/miq_schedule_worker/scheduler_spec.rb
@@ -50,7 +50,7 @@ describe MiqScheduleWorker::Scheduler do
 
     context "with different parmeters" do
       it "interprets first arg nil as trigger to skip scheduling" do
-        expect(logger).to receive(:warn).once.with(/Duration is empty, scheduling ingnored/)
+        expect(logger).to receive(:warn).once.with(/Duration is empty, scheduling ignored/)
         scheduler.schedule_every(nil) {}
       end
 


### PR DESCRIPTION
Fixing typo in warning message to the log.
Follow-up to https://github.com/ManageIQ/manageiq/pull/19105 

 Failing BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1736749


@miq-bot add-label changelog/no,  bug, core, hammer/yes,  ivanchuk/yes 