### PR TITLE
[WIP] [V2V] Update the ServiceTemplateTransformationPlanTask specs

### DIFF
--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -8,8 +8,8 @@ class TransformationMappingItem < ApplicationRecord
   validate :source_cluster,      :if => -> { source.kind_of?(EmsCluster) }
   validate :destination_cluster, :if => -> { destination.kind_of?(EmsCluster) || destination.kind_of?(CloudTenant) }
 
-  #validate :source_datastore,      :if => -> { source.kind_of?(Storage) }
-  #validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
+  validate :source_datastore,      :if => -> { source.kind_of?(Storage) }
+  validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
 
   def destination_datastore
     if destination.kind_of?(Storage) # Redhat

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -12,7 +12,7 @@ class TransformationMappingItem < ApplicationRecord
   validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
 
   validate :source_network,    :if => -> { source.kind_of?(Lan) }
-  #validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
+  validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
 
   def source_network
     mappings = transformation_mapping.transformation_mapping_items.where(:source_type => "EmsCluster")
@@ -32,7 +32,7 @@ class TransformationMappingItem < ApplicationRecord
       dst_cluster_lans = mappings.collect(&:destination).collect(&:cloud_networks).flatten
     end
 
-     unless dst_cluster_lans.include?(destination)
+    unless dst_cluster_lans.include?(destination)
       errors.add(:destination, "cluster lans must include destination lan: #{destination}")
     end
   end

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -8,6 +8,32 @@ class TransformationMappingItem < ApplicationRecord
   validate :source_cluster,      :if => -> { source.kind_of?(EmsCluster) }
   validate :destination_cluster, :if => -> { destination.kind_of?(EmsCluster) || destination.kind_of?(CloudTenant) }
 
+  #validate :source_datastore,      :if => -> { source.kind_of?(Storage) }
+  #validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
+
+  def destination_datastore
+    if destination.kind_of?(Storage) # Redhat
+      mapping_items = transformation_mapping.transformation_mapping_items.where(:destination_type=> "EmsCluster")
+      dst_cluster_storages = mapping_items.collect(&:destination).collect(&:storages).flatten
+    elsif destination.kind_of?(CloudVolume) # Openstack
+      mapping_items = transformation_mapping.transformation_mapping_items.where(:destination_type => "CloudTenant")
+      dst_cluster_storages = mapping_items.collect(&:destination).collect(&:cloud_volumes).flatten
+    end
+
+    unless dst_cluster_storages.include?(destination)
+      errors.add(:destination, "cluster storages must include destination storage: #{destination}")
+    end
+  end
+
+  def source_datastore
+    mappings = transformation_mapping.transformation_mapping_items.where(:source_type => "EmsCluster")
+    storages = mappings.collect(&:source).collect(&:storages).flatten
+
+    unless storages.include?(source)
+      errors.add(:source, "cluster storages must include source storage: #{source}")
+    end
+  end
+
   VALID_SOURCE_CLUSTER_PROVIDERS = %w[vmwarews].freeze
   VALID_DESTINATION_CLUSTER_PROVIDERS = %w[rhevm openstack].freeze
 

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -12,7 +12,7 @@ class TransformationMappingItem < ApplicationRecord
   validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
 
   validate :source_network,    :if => -> { source.kind_of?(Lan) }
-  validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
+  #validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
 
   def source_network
     mappings = transformation_mapping.transformation_mapping_items.where(:source_type => "EmsCluster")

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -11,7 +11,7 @@ class TransformationMappingItem < ApplicationRecord
   validate :source_datastore,      :if => -> { source.kind_of?(Storage) }
   validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
 
-  #validate :source_network,    :if => -> { source.kind_of?(Lan) }
+  validate :source_network,    :if => -> { source.kind_of?(Lan) }
   #validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
 
   def source_network

--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -12,7 +12,7 @@ class TransformationMappingItem < ApplicationRecord
   validate :destination_datastore, :if => -> { destination.kind_of?(Storage) || destination.kind_of?(CloudVolume) }
 
   validate :source_network,    :if => -> { source.kind_of?(Lan) }
-  #validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
+  validate :destination_network, :if => -> { destination.kind_of?(Lan) || destination.kind_of?(CloudNetwork) }
 
   def source_network
     mappings = transformation_mapping.transformation_mapping_items.where(:source_type => "EmsCluster")

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -26,10 +26,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     let(:conversion_host) { FactoryBot.create(:conversion_host, :skip_validate, :resource => host) }
 
     let(:mapping) do
-      FactoryBot.create(
-        :transformation_mapping,
-        :transformation_mapping_items => [TransformationMappingItem.new(:source => src, :destination => dst)]
-      )
+      FactoryBot.create(:transformation_mapping).tap do |tm|
+        FactoryBot.create(:transformation_mapping_item,
+          :source                 => src,
+          :destination            => dst,
+          :transformation_mapping => tm
+        )
+      end
     end
 
     let(:catalog_item_options) do
@@ -256,10 +259,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     let(:dst_security_group) { FactoryBot.create(:security_group) }
 
     let(:mapping) do
-      FactoryBot.create(
-        :transformation_mapping,
-        :transformation_mapping_items => [TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster)]
-      )
+      FactoryBot.create(:transformation_mapping).tap do |tm|
+        FactoryBot.create(:transformation_mapping_item,
+          :source                 => src_cluster,
+          :destination            => dst_cluster,
+          :transformation_mapping => tm
+        )
+      end
     end
 
     let(:catalog_item_options) do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -584,8 +584,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         let(:openstack_ems) { FactoryBot.create(:ems_openstack, :api_version => 'v3', :zone => FactoryBot.create(:zone)) }
         let(:openstack_cloud_tenant) { FactoryBot.create(:cloud_tenant, :name => 'fake tenant', :ext_management_system => openstack_ems) }
         let(:openstack_cloud_volume_type) { FactoryBot.create(:cloud_volume_type) }
-        let(:openstack_cloud_network_1) { FactoryBot.create(:cloud_network) }
-        let(:openstack_cloud_network_2) { FactoryBot.create(:cloud_network) }
+        let(:openstack_cloud_networks) { FactoryBot.create_list(:cloud_network, 2, :cloud_tenant => openstack_cloud_tenant) }
         let(:openstack_flavor) { FactoryBot.create(:flavor) }
         let(:openstack_security_group) { FactoryBot.create(:security_group) }
         let(:openstack_conversion_host_vm) { FactoryBot.create(:vm_openstack, :ext_management_system => openstack_ems, :cloud_tenant => openstack_cloud_tenant) }
@@ -605,12 +604,12 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             )
             FactoryBot.create(:transformation_mapping_item,
               :source                 => src_lans.first,
-              :destination            => openstack_cloud_network_1,
+              :destination            => openstack_cloud_networks.first,
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
               :source                 => src_lans.last,
-              :destination            => openstack_cloud_network_2,
+              :destination            => openstack_cloud_networks.last,
               :transformation_mapping => tm
             )
           end
@@ -628,8 +627,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates network_mappings hash" do
             expect(task_1.network_mappings).to eq(
               [
-                { :source => src_lans.first.name, :destination => openstack_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
-                { :source => src_lans.last.name, :destination => openstack_cloud_network_2.ems_ref, :mac_address => src_nic_2.address }
+                { :source => src_lans.first.name, :destination => openstack_cloud_networks.first.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lans.last.name, :destination => openstack_cloud_networks.last.ems_ref, :mac_address => src_nic_2.address }
               ]
             )
           end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -473,8 +473,9 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
         let(:dst_hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => dst_cluster) }
         let(:dst_storages) { FactoryBot.create_list(:storage, 1, :hosts => dst_hosts) }
-        let(:dst_lan_1) { FactoryBot.create(:lan) }
-        let(:dst_lan_2) { FactoryBot.create(:lan) }
+        let(:dst_switch) { FactoryBot.create(:switch, :host => dst_hosts.first) }
+        let(:dst_lan_1) { FactoryBot.create(:lan, :switch => dst_switch) }
+        let(:dst_lan_2) { FactoryBot.create(:lan, :switch => dst_switch) }
         let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:host_redhat, :ext_management_system => dst_ems)) }
 
         let(:mapping) do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -470,15 +470,28 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:host_redhat, :ext_management_system => dst_ems)) }
 
         let(:mapping) do
-          FactoryBot.create(
-            :transformation_mapping,
-            :transformation_mapping_items => [
-              TransformationMappingItem.new(:source => src_cluster, :destination => dst_cluster),
-              TransformationMappingItem.new(:source => src_storage, :destination => dst_storage),
-              TransformationMappingItem.new(:source => src_lan_1, :destination => dst_lan_1),
-              TransformationMappingItem.new(:source => src_lan_2, :destination => dst_lan_2)
-            ]
-          )
+          FactoryBot.create(:transformation_mapping).tap do |tm|
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_cluster,
+              :destination            => dst_cluster,
+              :transformation_mapping => tm
+            )
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_storage,
+              :destination            => dst_storage,
+              :transformation_mapping => tm
+            )
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_lan_1,
+              :destination            => dst_lan_1,
+              :transformation_mapping => tm
+            )
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_lan_2,
+              :destination            => dst_lan_2,
+              :transformation_mapping => tm
+            )
+          end
         end
 
         before do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -336,8 +336,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       let(:src_host) { FactoryBot.create(:host_vmware_esx, :ems_cluster => src_cluster, :ipaddress => '10.0.0.1') }
       let(:src_storage) { FactoryBot.create(:storage, :hosts => [src_host], :name => 'stockage récent') }
       let(:src_switch) { FactoryBot.create(:switch, :ems_id => src_ems.id) }
-      let(:src_host_switch) { FactoryBot.create(:host_switch, :host => src_host, :switch => src_switch) }
       let(:src_lans) { FactoryBot.create_list(:lan, 2, :switch => src_switch) }
+      let!(:src_host_switch) { FactoryBot.create(:host_switch, :host => src_host, :switch => src_switch) }
 
       let(:src_nic_1) { FactoryBot.create(:guest_device_nic, :lan => src_lans.first) }
       let(:src_nic_2) { FactoryBot.create(:guest_device_nic, :lan => src_lans.last) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   let(:infra_conversion_job) { FactoryBot.create(:infra_conversion_job) }
+  let(:src_ems) { FactoryBot.create(:ems_vmware) }
+  let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
 
   describe '.base_model' do
     it { expect(described_class.base_model).to eq(ServiceTemplateTransformationPlanTask) }
@@ -15,9 +17,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   end
 
   context 'independent of provider' do
-    let(:src_ems) { FactoryBot.create(:ems_vmware) }
     let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
-    let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
     let(:dst_cluster) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems) }
     let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
     let(:vm) { FactoryBot.create(:vm_or_template) }
@@ -246,8 +246,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   end
 
   context 'populated request and task' do
-    let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
-    let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
     let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
     let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
 
@@ -335,10 +333,10 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     end
 
     context 'source is vmwarews' do
-      let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
       let(:src_host) { FactoryBot.create(:host_vmware_esx, :ems_cluster => src_cluster, :ipaddress => '10.0.0.1') }
       let(:src_storage) { FactoryBot.create(:storage, :hosts => [src_host], :name => 'stockage récent') }
-      let(:src_switch) { FactoryBot.create(:switch, :host => src_host) }
+      let(:src_switch) { FactoryBot.create(:switch, :ems_id => src_ems.id) }
+      let(:src_host_switch) { FactoryBot.create(:host_switch, :host => src_host, :switch => src_switch) }
       let(:src_lans) { FactoryBot.create_list(:lan, 2, :switch => src_switch) }
 
       let(:src_nic_1) { FactoryBot.create(:guest_device_nic, :lan => src_lans.first) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -338,11 +338,11 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
       let(:src_host) { FactoryBot.create(:host_vmware_esx, :ems_cluster => src_cluster, :ipaddress => '10.0.0.1') }
       let(:src_storage) { FactoryBot.create(:storage, :hosts => [src_host], :name => 'stockage récent') }
+      let(:src_switch) { FactoryBot.create(:switch, :host => src_host) }
+      let(:src_lans) { FactoryBot.create_list(:lan, 2, :switch => src_switch) }
 
-      let(:src_lan_1) { FactoryBot.create(:lan) }
-      let(:src_lan_2) { FactoryBot.create(:lan) }
-      let(:src_nic_1) { FactoryBot.create(:guest_device_nic, :lan => src_lan_1) }
-      let(:src_nic_2) { FactoryBot.create(:guest_device_nic, :lan => src_lan_2) }
+      let(:src_nic_1) { FactoryBot.create(:guest_device_nic, :lan => src_lans.first) }
+      let(:src_nic_2) { FactoryBot.create(:guest_device_nic, :lan => src_lans.last) }
 
       let(:src_disk_1) { instance_double("disk", :device_name => "Hard disk 1", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm.vmdk", :size => 17_179_869_184) }
       let(:src_disk_2) { instance_double("disk", :device_name => "Hard disk 2", :device_type => "disk", :filename => "[datastore12] test_vm/test_vm-2.vmdk", :size => 17_179_869_184) }
@@ -490,12 +490,12 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
-              :source                 => src_lan_1,
+              :source                 => src_lans.first,
               :destination            => dst_lan_1,
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
-              :source                 => src_lan_2,
+              :source                 => src_lans.last,
               :destination            => dst_lan_2,
               :transformation_mapping => tm
             )
@@ -514,8 +514,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates network_mappings hash" do
             expect(task_1.network_mappings).to eq(
               [
-                { :source => src_lan_1.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
-                { :source => src_lan_2.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address }
+                { :source => src_lans.first.name, :destination => dst_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lans.last.name, :destination => dst_lan_2.name, :mac_address => src_nic_2.address }
               ]
             )
           end
@@ -599,12 +599,12 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
-              :source                 => src_lan_1,
+              :source                 => src_lans.first,
               :destination            => dst_cloud_network_1,
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
-              :source                 => src_lan_2,
+              :source                 => src_lans.last,
               :destination            => dst_cloud_network_2,
               :transformation_mapping => tm
             )
@@ -623,8 +623,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates network_mappings hash" do
             expect(task_1.network_mappings).to eq(
               [
-                { :source => src_lan_1.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
-                { :source => src_lan_2.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address }
+                { :source => src_lans.first.name, :destination => dst_cloud_network_1.ems_ref, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lans.last.name, :destination => dst_cloud_network_2.ems_ref, :mac_address => src_nic_2.address }
               ]
             )
           end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -470,7 +470,9 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
       context 'destination is rhevm' do
         let(:dst_ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
-        let(:dst_storage) { FactoryBot.create(:storage) }
+        let(:dst_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => dst_ems) }
+        let(:dst_hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => dst_cluster) }
+        let(:dst_storages) { FactoryBot.create_list(:storage, 1, :hosts => dst_hosts) }
         let(:dst_lan_1) { FactoryBot.create(:lan) }
         let(:dst_lan_2) { FactoryBot.create(:lan) }
         let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => FactoryBot.create(:host_redhat, :ext_management_system => dst_ems)) }
@@ -484,7 +486,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             )
             FactoryBot.create(:transformation_mapping_item,
               :source                 => src_storage,
-              :destination            => dst_storage,
+              :destination            => dst_storages.first,
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
@@ -538,7 +540,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_password     => 'esx_passwd',
               :rhv_url             => "https://#{dst_ems.hostname}/ovirt-engine/api",
               :rhv_cluster         => dst_cluster.name,
-              :rhv_storage         => dst_storage.name,
+              :rhv_storage         => dst_storages.first.name,
               :rhv_password        => dst_ems.authentication_password,
               :source_disks        => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings    => task_1.network_mappings,
@@ -562,7 +564,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :transport_method    => 'ssh',
               :rhv_url             => "https://#{dst_ems.hostname}/ovirt-engine/api",
               :rhv_cluster         => dst_cluster.name,
-              :rhv_storage         => dst_storage.name,
+              :rhv_storage         => dst_storages.first.name,
               :rhv_password        => dst_ems.authentication_password,
               :source_disks        => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings    => task_1.network_mappings,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   let(:src_ems) { FactoryBot.create(:ems_vmware) }
   let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
 
+  let(:redhat_ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+  let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => redhat_ems) }
+  let(:redhat_hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => redhat_cluster) }
+  let(:redhat_storages) { FactoryBot.create_list(:storage, 1, :hosts => redhat_hosts) }
+  let(:redhat_switch) { FactoryBot.create(:switch, :host => redhat_hosts.first) }
+  let(:redhat_lans) { FactoryBot.create_list(:lan, 2, :switch => redhat_switch) }
+  let!(:redhat_host_switch) { FactoryBot.create(:host_switch, :host => redhat_hosts.first, :switch => redhat_switch) }
+
   describe '.base_model' do
     it { expect(described_class.base_model).to eq(ServiceTemplateTransformationPlanTask) }
   end
@@ -467,14 +475,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       end
 
       context 'destination is rhevm' do
-        let(:redhat_ems) { FactoryBot.create(:ems_redhat, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
-        let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => redhat_ems) }
-        let(:redhat_hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => redhat_cluster) }
-        let(:redhat_storages) { FactoryBot.create_list(:storage, 1, :hosts => redhat_hosts) }
-        let(:redhat_switch) { FactoryBot.create(:switch, :host => redhat_hosts.first) }
-        let(:redhat_lans) { FactoryBot.create_list(:lan, 2, :switch => redhat_switch) }
-        let!(:redhat_host_switch) { FactoryBot.create(:host_switch, :host => redhat_hosts.first, :switch => redhat_switch) }
-
         let(:conversion_host) {
           FactoryBot.create(
             :conversion_host,
@@ -580,6 +580,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         end
       end
 
+=begin
       context 'destination is openstack' do
         let(:dst_ems) { FactoryBot.create(:ems_openstack, :api_version => 'v3', :zone => FactoryBot.create(:zone)) }
         let(:dst_cloud_tenant) { FactoryBot.create(:cloud_tenant, :name => 'fake tenant', :ext_management_system => dst_ems) }
@@ -710,6 +711,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           end
         end
       end
+=end
     end
   end
 end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => redhat_ems) }
   let(:redhat_hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => redhat_cluster) }
   let(:redhat_storages) { FactoryBot.create_list(:storage, 1, :hosts => redhat_hosts) }
-  let(:redhat_switch) { FactoryBot.create(:switch, :host => redhat_hosts.first) }
+  let(:redhat_switch) { FactoryBot.create(:switch, :ems_id => redhat_ems.id) }
   let(:redhat_lans) { FactoryBot.create_list(:lan, 2, :switch => redhat_switch) }
   let!(:redhat_host_switch) { FactoryBot.create(:host_switch, :host => redhat_hosts.first, :switch => redhat_switch) }
 

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -472,8 +472,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         let(:redhat_hosts) { FactoryBot.create_list(:host, 1, :ems_cluster => redhat_cluster) }
         let(:redhat_storages) { FactoryBot.create_list(:storage, 1, :hosts => redhat_hosts) }
         let(:redhat_switch) { FactoryBot.create(:switch, :host => redhat_hosts.first) }
-        let(:redhat_lan_1) { FactoryBot.create(:lan, :switch => redhat_switch) }
-        let(:redhat_lan_2) { FactoryBot.create(:lan, :switch => redhat_switch) }
+        let(:redhat_lans) { FactoryBot.create_list(:lan, 2, :switch => redhat_switch) }
 
         let(:conversion_host) {
           FactoryBot.create(
@@ -496,12 +495,12 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             )
             FactoryBot.create(:transformation_mapping_item,
               :source                 => src_lans.first,
-              :destination            => redhat_lan_1,
+              :destination            => redhat_lans.first,
               :transformation_mapping => tm
             )
             FactoryBot.create(:transformation_mapping_item,
               :source                 => src_lans.last,
-              :destination            => redhat_lan_2,
+              :destination            => redhat_lans.last,
               :transformation_mapping => tm
             )
           end
@@ -519,8 +518,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates network_mappings hash" do
             expect(task_1.network_mappings).to eq(
               [
-                { :source => src_lans.first.name, :destination => redhat_lan_1.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
-                { :source => src_lans.last.name, :destination => redhat_lan_2.name, :mac_address => src_nic_2.address }
+                { :source => src_lans.first.name, :destination => redhat_lans.first.name, :mac_address => src_nic_1.address, :ip_address => '10.0.1.1' },
+                { :source => src_lans.last.name, :destination => redhat_lans.last.name, :mac_address => src_nic_2.address }
               ]
             )
           end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -579,15 +579,28 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => conversion_host_vm) }
 
         let(:mapping) do
-          FactoryBot.create(
-            :transformation_mapping,
-            :transformation_mapping_items => [
-              TransformationMappingItem.new(:source => src_cluster, :destination => dst_cloud_tenant),
-              TransformationMappingItem.new(:source => src_storage, :destination => dst_cloud_volume_type),
-              TransformationMappingItem.new(:source => src_lan_1, :destination => dst_cloud_network_1),
-              TransformationMappingItem.new(:source => src_lan_2, :destination => dst_cloud_network_2)
-            ]
-          )
+          FactoryBot.create(:transformation_mapping).tap do |tm|
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_cluster,
+              :destination            => dst_cloud_tenant,
+              :transformation_mapping => tm
+            )
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_storage,
+              :destination            => dst_cloud_volume_type,
+              :transformation_mapping => tm
+            )
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_lan_1,
+              :destination            => dst_cloud_network_1,
+              :transformation_mapping => tm
+            )
+            FactoryBot.create(:transformation_mapping_item,
+              :source                 => src_lan_2,
+              :destination            => dst_cloud_network_2,
+              :transformation_mapping => tm
+            )
+          end
         end
 
         before do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -330,8 +330,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
     context 'source is vmwarews' do
       let(:src_ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone)) }
-      let(:src_host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => src_ems, :ipaddress => '10.0.0.1') }
-      let(:src_storage) { FactoryBot.create(:storage, :ext_management_system => src_ems, :name => 'stockage récent') }
+      let(:src_host) { FactoryBot.create(:host_vmware_esx, :ems_cluster => src_cluster, :ipaddress => '10.0.0.1') }
+      let(:src_storage) { FactoryBot.create(:storage, :hosts => [src_host], :name => 'stockage récent') }
 
       let(:src_lan_1) { FactoryBot.create(:lan) }
       let(:src_lan_2) { FactoryBot.create(:lan) }

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -473,6 +473,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         let(:redhat_storages) { FactoryBot.create_list(:storage, 1, :hosts => redhat_hosts) }
         let(:redhat_switch) { FactoryBot.create(:switch, :host => redhat_hosts.first) }
         let(:redhat_lans) { FactoryBot.create_list(:lan, 2, :switch => redhat_switch) }
+        let!(:redhat_host_switch) { FactoryBot.create(:host_switch, :host => redhat_hosts.first, :switch => redhat_switch) }
 
         let(:conversion_host) {
           FactoryBot.create(

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
   context 'independent of provider' do
     let(:src_ems) { FactoryBot.create(:ems_vmware) }
     let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
-    let(:src) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
-    let(:dst) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems) }
+    let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
+    let(:dst_cluster) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems) }
     let(:host) { FactoryBot.create(:host, :ext_management_system => FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone))) }
     let(:vm) { FactoryBot.create(:vm_or_template) }
     let(:vm2)  { FactoryBot.create(:vm_or_template) }
@@ -28,8 +28,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     let(:mapping) do
       FactoryBot.create(:transformation_mapping).tap do |tm|
         FactoryBot.create(:transformation_mapping_item,
-          :source                 => src,
-          :destination            => dst,
+          :source                 => src_cluster,
+          :destination            => dst_cluster,
           :transformation_mapping => tm
         )
       end
@@ -67,7 +67,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     end
 
     describe '#transformation_destination' do
-      it { expect(task.transformation_destination(src)).to eq(dst) }
+      it { expect(task.transformation_destination(src_cluster)).to eq(dst_cluster) }
     end
 
     describe '#pre_ansible_playbook_service_template' do


### PR DESCRIPTION
The specs for the `ServiceTemplateTransformationPlanTask` need some cleanup so that we can add proper validations to the `TransformationMappingItem` model without also breaking these specs. Essentially, it does the following:

* Removes redundant partials.
* Gives the resources more explicit names to help readability.
* Uses factories instead of raw objects for TransformationMappingItem instances.
* Creates a proper environment, i.e. switches are associated with an EMS, and cloud networks are associated with a cloud tenant.

TODO: There's some kind of scoping issue with the redhat resources. I'm not sure why I cannot put them in their own context without breaking stuff.