### PR TITLE
Fix the custom button set set_data hash links to the original buttons on copy

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -92,8 +92,14 @@ class CustomButtonSet < ApplicationRecord
     options.each_with_object(dup) { |(k, v), button_set| button_set.send("#{k}=", v) }.tap do |cbs|
       cbs.guid = SecureRandom.uuid
       cbs.name = "#{name}-#{cbs.guid}"
+      cbs.set_data[:button_order] = []
       cbs.save!
-      custom_buttons.each { |cb| cbs.add_member(cb.copy(:applies_to => options[:owner])) }
+      custom_buttons.each do |cb|
+        cb_copy = cb.copy(:applies_to => options[:owner])
+        cbs.add_member(cb_copy)
+        cbs.set_data[:button_order] << cb_copy.id
+        cbs.save!
+      end
     end
   end
 

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -71,7 +71,8 @@ describe CustomButtonSet do
     service_template1 = FactoryBot.create(:service_template)
     service_template2 = FactoryBot.create(:service_template)
     custom_button     = FactoryBot.create(:custom_button, :applies_to => service_template1)
-    custom_button_set = FactoryBot.create(:custom_button_set)
+    set_data          = {:applies_to_class => "ServiceTemplate", :button_order => [custom_button.id]}
+    custom_button_set = FactoryBot.create(:custom_button_set, :set_data => set_data)
 
     custom_button_set.add_member(custom_button)
     custom_button_set.deep_copy(:owner => service_template2)

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -2,10 +2,11 @@ describe ServiceTemplate do
   describe "#template_copy" do
     let(:custom_button)                  { FactoryBot.create(:custom_button, :applies_to => service_template) }
     let(:custom_button_for_service)      { FactoryBot.create(:custom_button, :applies_to_class => "Service") }
-    let(:custom_button_set)              { FactoryBot.create(:custom_button_set, :owner => service_template) }
+    let(:custom_button_set)              { FactoryBot.create(:custom_button_set, :owner => service_template, :set_data => set_data) }
     let(:service_template)               { FactoryBot.create(:service_template) }
     let(:service_template_ansible_tower) { FactoryBot.create(:service_template_ansible_tower) }
     let(:service_template_orchestration) { FactoryBot.create(:service_template_orchestration) }
+    let(:set_data)                       { {:applies_to_class => "Service", :button_order => [custom_button.id]} }
 
     def copy_template(template, name = nil)
       copy = nil
@@ -43,8 +44,15 @@ describe ServiceTemplate do
       it "with custom button set" do
         custom_button_set.add_member(custom_button)
         expect(service_template.custom_button_sets.count).to eq(1)
+        expect(service_template.custom_button_sets.first.custom_buttons.count).to eq(1)
+        expect(service_template.custom_button_sets.first.set_data).to eq(set_data)
+        expect(service_template.custom_button_sets.first.children).to eq([custom_button])
         new_service_template = copy_template(service_template, "new_template")
         expect(new_service_template.custom_button_sets.count).to eq(1)
+        expect(new_service_template.custom_button_sets.first.set_data).not_to eq(set_data)
+        expect(new_service_template.custom_button_sets.first.custom_buttons.count).to eq(1)
+        expect(new_service_template.custom_button_sets.first.children).not_to eq([custom_button])
+        expect(new_service_template.custom_button_sets.first.children).to eq(new_service_template.custom_button_sets.first.custom_buttons)
       end
 
       it "with non-copyable resource (configuration script base)" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740556

The button set copy needs to reset and then save the new button order. 

@miq-bot add_label bug, ivanchuk/yes
@miq-bot assign @bdunne
