### PR TITLE
Finish VM Task to error state when EMS paused

### DIFF
--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -201,8 +201,13 @@ module ProcessTasksMixin
       return instances, tasks
     end
 
-    # default: validate retirement, can be overridden
+    # default: validate retirement and maintenance zone, can be overridden
     def validate_task(task, instance, options)
+      if instance.try(:ext_management_system)&.zone == Zone.maintenance_zone
+        task.error("#{instance.ext_management_system.name} is paused")
+        return false
+      end
+
       return true unless options[:task] == "retire_now" && instance.retired?
       task.error("#{instance.name} is already retired")
       false

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -341,4 +341,31 @@ describe ProcessTasksMixin do
       end
     end
   end
+
+  describe '.validate_task' do
+    let(:ext_management_system) { double("ExtManagementSystem") }
+    let(:instance) { double("Target") }
+    let(:task) { double("Task") }
+    before do
+      Zone.seed
+
+      allow(instance).to receive(:ext_management_system).and_return(ext_management_system)
+    end
+
+    it 'validates task when EMS not paused' do
+      allow(ext_management_system).to receive_messages(:name => 'My provider',
+                                                       :zone => Zone.default_zone)
+
+      expect(task).not_to receive(:error).with("#{ext_management_system.name} is paused")
+      test_class.send(:validate_task, task, instance, {})
+    end
+
+    it 'marks task as invalid when EMS paused' do
+      allow(ext_management_system).to receive_messages(:name => 'My provider',
+                                                       :zone => Zone.maintenance_zone)
+
+      expect(task).to receive(:error).with("#{ext_management_system.name} is paused")
+      test_class.send(:validate_task, task, instance, {})
+    end
+  end
 end

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -114,7 +114,9 @@ describe Vm do
 
   context "#invoke_tasks_local" do
     before do
+      Zone.seed
       EvmSpecHelper.create_guid_miq_server_zone
+
       @host = FactoryBot.create(:host)
       @vm = FactoryBot.create(:vm_vmware, :host => @host)
     end


### PR DESCRIPTION
When ExtManagementSystem is paused, it's not possible to perform VM operations)

For example Power on/off operations created Task (`MiqTask`) in status 'Queued' and never finished it after resuming provider.

Now it switches task to Finished:Error 

Fixes **BZ** https://bugzilla.redhat.com/show_bug.cgi?id=1740285
