### PR TITLE
Do not raise error in MiqExpression#to_sql if (:token) present as one of operators

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -285,7 +285,7 @@ class MiqExpression
 
   def to_sql(tz = nil)
     tz ||= "UTC"
-    @pexp, attrs = preprocess_for_sql(@exp.deep_clone)
+    @pexp, attrs = preprocess_for_sql(@exp.deep_clone.except!(:token))
     sql = to_arel(@pexp, tz).to_sql if @pexp.present?
     incl = includes_for_sql unless sql.blank?
     [sql, incl, attrs]

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -285,13 +285,14 @@ class MiqExpression
 
   def to_sql(tz = nil)
     tz ||= "UTC"
-    @pexp, attrs = preprocess_for_sql(@exp.deep_clone.except!(:token))
+    @pexp, attrs = preprocess_for_sql(@exp.deep_clone)
     sql = to_arel(@pexp, tz).to_sql if @pexp.present?
     incl = includes_for_sql unless sql.blank?
     [sql, incl, attrs]
   end
 
   def preprocess_for_sql(exp, attrs = nil)
+    exp.delete(:token)
     attrs ||= {:supported_by_sql => true}
     operator = exp.keys.first
     case operator.downcase

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -242,6 +242,21 @@ describe MiqExpression do
   end
 
   describe "#to_sql" do
+    it "returns nil if SQL generation for that expression is not supported" do
+      sql, * = MiqExpression.new("=" => {"field" => "Service-custom_1", "value" => ""}).to_sql
+      expect(sql).to be_nil
+    end
+
+    it "does not raise error and returns nil if SQL generation for expression is not supported and 'token' key present in expression's Hash" do
+      sql, * = MiqExpression.new("=" => {"field" => "Service-custom_1", "value" => ""}, :token => 1).to_sql
+      expect(sql).to be_nil
+    end
+
+    it "generates the SQL for an = expression if SQL generation for expression supported and 'token' key present in expression's Hash" do
+      sql, * = MiqExpression.new("=" => {"field" => "Vm-name", "value" => "foo"}, :token => 1).to_sql
+      expect(sql).to eq("\"vms\".\"name\" = 'foo'")
+    end
+
     it "generates the SQL for an EQUAL expression" do
       sql, * = MiqExpression.new("EQUAL" => {"field" => "Vm-name", "value" => "foo"}).to_sql
       expect(sql).to eq("\"vms\".\"name\" = 'foo'")


### PR DESCRIPTION
**ISSUE**: Sometimes ```:token``` key (used in automate) is not removed from ```MiqExpression```'s ```Hash``` before saving or attempting to execute. 
This will trigger below  Error if another entry in MiqExpression does not support SQL generation:
````
[----] F, [2019-08-15T11:46:54.428352 #10513:3fecc1715820] FATAL -- : Error caught: [RuntimeError] operator 'token' is not supported
/Users/yrudman/work/rh/manageiq/lib/miq_expression.rb:1437:in `to_arel'
/Users/yrudman/work/rh/manageiq/lib/miq_expression.rb:289:in `to_sql'
/Users/yrudman/work/rh/manageiq/lib/rbac/filterer.rb:257:in `search'
/Users/yrudman/work/rh/manageiq/lib/rbac/filterer.rb:146:in `search'
/Users/yrudman/work/rh/manageiq/lib/rbac.rb:3:in `search'
/Users/yrudman/work/rh/manageiq/app/models/miq_report/search.rb:117:in `paged_view_search'
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/application_controller.rb:1325:in `get_view'
/Users/yrudman/work/rh/manageiq-ui-classic/app/controllers/application_controller.rb:422:in `report_data'
````
**Note:** if another entry in ```MiqExpression``` does support SQL generation than no Error; it may explain why this bug was not found before.

**FIX**: remove ```:token``` from MiqExpression's Hash before attempting to generate SQL

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741243

There is another PR https://github.com/ManageIQ/manageiq/pull/17215 on the same topic, but apparently it did not solve issue for all situations.

@miq-bot add-label changelog/no, bug, core, hammer/yes, ivanchuk/yes