### PR TITLE
Update service dialog options when reconfigure finishes well.

### DIFF
--- a/app/models/service_reconfigure_task.rb
+++ b/app/models/service_reconfigure_task.rb
@@ -60,6 +60,9 @@ class ServiceReconfigureTask < MiqRequestTask
     return if miq_request.state == 'finished'
 
     if ae_result == 'ok'
+      source.options[:dialog] = source.options[:dialog].merge(options[:dialog]) if options[:dialog]
+      source.save!
+
       update_and_notify_parent(:state   => "finished",
                                :status  => "Ok",
                                :message => "#{request_class::TASK_DESCRIPTION} completed")

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -44,6 +44,20 @@ describe ServiceReconfigureTask do
         :message => 'Service Reconfigure failed')
       task.after_ae_delivery('error')
     end
+
+    it "updates service's dialog options if reconfigure passes" do
+      service.update(:options => {:dialog => {:var1 => "value"}})
+      task.options[:dialog] = {:var1 => "new_value"}
+      task.after_ae_delivery('ok')
+      expect(service.options[:dialog]).to include(:var1 => "new_value")
+    end
+
+    it "does not update service's dialog options if reconfigure fails" do
+      service.update(:options => {:dialog => {:var1 => "value"}})
+      task.options[:dialog] = {:var1 => "new_value"}
+      task.after_ae_delivery('error')
+      expect(service.options[:dialog]).to include(:var1 => "value")
+    end
   end
 
   describe "#after_request_task_create" do


### PR DESCRIPTION
Save the reconfigure dialog options into service.options[:dialog] if it finishes successfully.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1733263

@miq-bot assign @tinaafitz 
@miq-bot add_label services, bug, hammer/yes, Ivanchuk/yes, changelog/yes

cc @bzwei 