### PR TITLE
Add a named scope to retrieve the default dashboard (MiqWidgetSet)

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -5,6 +5,10 @@ class MiqWidgetSet < ApplicationRecord
 
   WIDGET_DIR =  File.expand_path(File.join(Rails.root, "product/dashboard/dashboards"))
 
+  def self.default_dashboard
+    find_by(:name => 'default', :read_only => true)
+  end
+
   def self.with_users
     where.not(:userid => nil)
   end


### PR DESCRIPTION
I really hope that the `default` here is not a reserved word or something related to the default scope. We're queriying this quite often from one part of the UI, so I'd like to move it here.

@miq-bot add_reviewer @lpichler 
@miq-bot add_reviewer @kbrock 
@miq-bot add_label enhancement, hammer/no, ivanchuk/no