### PR TITLE
Some FactoryBot list refactoring

### DIFF
--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -280,14 +280,12 @@ describe GenericObjectDefinition do
     end
 
     it 'finds by associations' do
-      vm = []
-      3.times { vm << FactoryBot.create(:vm_vmware) }
-
+      vms = FactoryBot.create_list(:vm_vmware, 3)
       definition.add_property_association(:vms, 'vm')
-      @g1.vms = [vm[0], vm[1], vm[2]]
+      @g1.vms = vms
       @g1.save!
 
-      @options = {:vms => [vm[0].id, vm[1].id]}
+      @options = {:vms => [vms[0].id, vms[1].id]}
       expect(subject.size).to eq(1)
       expect(subject.first).to eq(@g1)
     end

--- a/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_workflow_spec.rb
@@ -123,22 +123,17 @@ RSpec.describe ManageIQ::Providers::CloudManager::ProvisionWorkflow do
       FactoryBot.create(:classification_cost_center_with_tags)
       admin.current_group.entitlement = Entitlement.create!(:filters => {'managed'   => [['/managed/cc/001']],
                                                                          'belongsto' => []})
-      2.times do |i|
-        kp = ManageIQ::Providers::CloudManager::AuthKeyPair.create(:name => "auth_#{i}")
-        ems.key_pairs << kp
-      end
-      2.times { FactoryBot.create(:availability_zone, :ems_id => ems.id) }
-      2.times do
-        FactoryBot.create(:security_group, :name                  => "sgb_1",
-                                            :ext_management_system => ems.network_manager)
-      end
-      ems.flavors << FactoryBot.create(:flavor, :name => "t1.micro", :supports_32_bit => true,
-                                        :supports_64_bit => true)
-      ems.flavors << FactoryBot.create(:flavor, :name => "m1.large", :supports_32_bit => false,
-                                        :supports_64_bit => true)
+      FactoryBot.create_list(:availability_zone, 2, :ems_id => ems.id)
+      FactoryBot.create_list(:security_group, 2, :name => "sgb_1", :ext_management_system => ems.network_manager)
+
+      ems.key_pairs = FactoryBot.create_list(:auth_key_pair_cloud, 2)
+      ems.flavors << FactoryBot.create(:flavor, :name => "t1.micro", :supports_32_bit => true, :supports_64_bit => true)
+      ems.flavors << FactoryBot.create(:flavor, :name => "m1.large", :supports_32_bit => false, :supports_64_bit => true)
+
       tagged_key_pair = ems.key_pairs.first
       tagged_zone = ems.availability_zones.first
       tagged_flavor = ems.flavors.first
+
       Classification.classify(tagged_zone, 'cc', '001')
       Classification.classify(tagged_flavor, 'cc', '001')
       Classification.classify(tagged_key_pair, 'cc', '001')

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -33,15 +33,9 @@ describe Metric do
 
     context "with enabled and disabled targets" do
       before do
-        storages = []
-        2.times { storages << FactoryBot.create(:storage_target_vmware) }
-
-        @vmware_clusters = []
-        2.times do
-          cluster = FactoryBot.create(:cluster_target)
-          @vmware_clusters << cluster
-          @ems_vmware.ems_clusters << cluster
-        end
+        storages = FactoryBot.create_list(:storage_target_vmware, 2)
+        @vmware_clusters = FactoryBot.create_list(:cluster_target, 2)
+        @ems_vmware.ems_clusters = @vmware_clusters
 
         6.times do |n|
           host = FactoryBot.create(:host_target_vmware, :ext_management_system => @ems_vmware)
@@ -1028,13 +1022,10 @@ describe Metric do
       before do
         @availability_zone = FactoryBot.create(:availability_zone_target)
         @ems_openstack.availability_zones << @availability_zone
-        @vms_in_az = []
-        2.times { @vms_in_az << FactoryBot.create(:vm_openstack, :ems_id => @ems_openstack.id) }
+        @vms_in_az = FactoryBot.create_list(:vm_openstack, 2, :ems_id => @ems_openstack.id)
         @availability_zone.vms = @vms_in_az
         @availability_zone.vms.push(FactoryBot.create(:vm_openstack, :ems_id => nil))
-
-        @vms_not_in_az = []
-        3.times { @vms_not_in_az << FactoryBot.create(:vm_openstack, :ems_id => @ems_openstack.id) }
+        @vms_not_in_az = FactoryBot.create_list(:vm_openstack, 3, :ems_id => @ems_openstack.id)
 
         MiqQueue.delete_all
       end

--- a/spec/models/miq_widget/report_content_spec.rb
+++ b/spec/models/miq_widget/report_content_spec.rb
@@ -26,7 +26,7 @@ describe MiqWidget, "::ReportContent" do
     EvmSpecHelper.create_guid_miq_server_zone
     @admin       = FactoryBot.create(:user_admin)
     @admin_group = @admin.current_group
-    vm_count.times { FactoryBot.create(:vm_vmware) }
+    FactoryBot.create_list(:vm_vmware, vm_count)
   end
 
   it "#generate_one_content_for_user" do

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -45,9 +45,8 @@ describe Zone do
     end
 
     it "returns the set of ems_clouds" do
-      ems_clouds = []
-      2.times { ems_clouds << FactoryBot.create(:ems_openstack, :zone => @zone) }
-      2.times { ems_clouds << FactoryBot.create(:ems_amazon, :zone => @zone) }
+      ems_clouds = FactoryBot.create_list(:ems_openstack, 2, :zone => @zone)
+      ems_clouds += FactoryBot.create_list(:ems_amazon, 2, :zone => @zone)
       ems_infra = FactoryBot.create(:ems_vmware, :zone => @zone)
 
       zone_clouds = @zone.ems_clouds
@@ -58,9 +57,7 @@ describe Zone do
 
     it "returns the set of availability_zones" do
       openstack = FactoryBot.create(:ems_openstack, :zone => @zone)
-      azs = []
-      3.times { azs << FactoryBot.create(:availability_zone, :ems_id => openstack.id) }
-
+      azs = FactoryBot.create_list(:availability_zone, 3, :ems_id => openstack.id)
       expect(@zone.availability_zones).to match_array(azs)
     end
   end


### PR DESCRIPTION
At the moment some of our specs are using `x.times{ some_array << FactoryBot.create }`. In fact, the FactoryBot class has a `create_list` method we can use instead that makes life easier in general, and is less code.

So, I went through and found the relevant cases in the specs and updated them. In one case (auth_key_pair) I also replaced a literal model with a factory.