### PR TITLE
Allow error messages in ServiceTemplate.validate_order

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -90,6 +90,9 @@ class ServiceTemplate < ApplicationRecord
     unsupported_reason_add(:order, 'Service template does not belong to a service catalog') unless service_template_catalog
     unsupported_reason_add(:order, 'Service template is not configured to be displayed') unless display
   end
+  alias orderable?     supports_order?
+  alias validate_order supports_order?
+
 
   def self.with_tenant(tenant_id)
     tenant = Tenant.find(tenant_id)
@@ -355,11 +358,6 @@ class ServiceTemplate < ApplicationRecord
     end.try(:resource).try(:validate_template) || {:valid => true, :message => nil}
   end
 
-  def validate_order
-    supports_order?
-  end
-  alias orderable? validate_order
-
   def provision_action
     resource_actions.find_by(:action => "Provision")
   end
@@ -432,7 +430,7 @@ class ServiceTemplate < ApplicationRecord
 
       errors = workflow.validate_dialog
       errors << unsupported_reason(:order)
-      return {:errors => errors} unless errors.compact.blank?
+      return {:errors => errors} if errors.compact.present?
 
       schedule = MiqSchedule.create!(
         :name         => "Order #{self.class.name} #{id} at #{time}",

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -353,7 +353,10 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def validate_order
-    service_template_catalog && display
+    errors = []
+    errors << 'Service template does not belong to a service catalog' unless service_template_catalog
+    errors << 'Service template is not configured to be displayed' unless display
+    errors
   end
   alias orderable? validate_order
 
@@ -427,7 +430,8 @@ class ServiceTemplate < ApplicationRecord
       require 'time'
       time = Time.parse(schedule_time).utc
 
-      errors = workflow.validate_dialog
+      errors = validate_order
+      errors += workflow.validate_dialog
       return {:errors => errors} unless errors.blank?
 
       schedule = MiqSchedule.create!(

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -354,7 +354,6 @@ class ServiceTemplate < ApplicationRecord
 
   def validate_order(with_errors = false)
     errors = []
-    errors << 'Service ordering via API is not allowed' unless Settings.product.allow_api_service_ordering
     errors << 'Service template does not belong to a service catalog' unless service_template_catalog
     errors << 'Service template is not configured to be displayed' unless display
     with_errors ? errors : errors.blank?

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -358,7 +358,10 @@ class ServiceTemplate < ApplicationRecord
     errors << 'Service template is not configured to be displayed' unless display
     errors
   end
-  alias orderable? validate_order
+
+  def orderable?
+    validate_order.blank?
+  end
 
   def provision_action
     resource_actions.find_by(:action => "Provision")

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -357,8 +357,6 @@ class ServiceTemplate < ApplicationRecord
     errors << 'Service ordering via API is not allowed' unless Settings.product.allow_api_service_ordering
     errors << 'Service template does not belong to a service catalog' unless service_template_catalog
     errors << 'Service template is not configured to be displayed' unless display
-    errors
-
     with_errors ? errors : errors.blank?
   end
   alias orderable? validate_order

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -26,8 +26,6 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   def validate_order(with_errors = false)
     errors = []
     errors << 'All VMs of the migration plan have already been successfully migrated' if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.blank?
-    errors
-
     with_errors ? errors : errors.blank?
   end
   alias orderable? validate_order

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -28,7 +28,6 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     errors << 'All VMs of the migration plan have already been successfully migrated' if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.blank?
     errors
   end
-  alias orderable? validate_order
 
   def self.default_provisioning_entry_point(_service_type)
     '/Transformation/StateMachines/VMTransformation/Transformation'

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -24,8 +24,9 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   end
 
   def validate_order
-    # Service template should not be orderable if all VMs have already been migrated
-    vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.present?
+    errors = []
+    errors << 'All VMs of the migration plan have already been successfully migrated' if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.blank?
+    errors
   end
   alias orderable? validate_order
 

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -1,6 +1,12 @@
 class ServiceTemplateTransformationPlan < ServiceTemplate
   include_concern 'ValidateConfigInfo'
   virtual_has_one :transformation_mapping
+
+  supports :order do
+    unmigrated_vms = vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }
+    unsupported_reason_add(:order, 'All VMs of the migration plan have already been successfully migrated') if unmigrated_vms.blank?
+  end
+
   def request_class
     ServiceTemplateTransformationPlanRequest
   end
@@ -22,13 +28,6 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   def transformation_mapping_resource
     service_resources.where(:resource_type => 'TransformationMapping')
   end
-
-  def validate_order(with_errors = false)
-    errors = []
-    errors << 'All VMs of the migration plan have already been successfully migrated' if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.blank?
-    with_errors ? errors : errors.blank?
-  end
-  alias orderable? validate_order
 
   def self.default_provisioning_entry_point(_service_type)
     '/Transformation/StateMachines/VMTransformation/Transformation'

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -23,11 +23,14 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     service_resources.where(:resource_type => 'TransformationMapping')
   end
 
-  def validate_order
+  def validate_order(with_errors = false)
     errors = []
     errors << 'All VMs of the migration plan have already been successfully migrated' if vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }.blank?
     errors
+
+    with_errors ? errors : errors.blank?
   end
+  alias orderable? validate_order
 
   def self.default_provisioning_entry_point(_service_type)
     '/Transformation/StateMachines/VMTransformation/Transformation'

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -6,6 +6,8 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
     unmigrated_vms = vm_resources.reject { |res| res.resource.is_tagged_with?('transformation_status/migrated', :ns => '/managed') }
     unsupported_reason_add(:order, 'All VMs of the migration plan have already been successfully migrated') if unmigrated_vms.blank?
   end
+  alias orderable?     supports_order?
+  alias validate_order supports_order?
 
   def request_class
     ServiceTemplateTransformationPlanRequest

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -915,7 +915,8 @@ describe ServiceTemplate do
   context "#order" do
     let(:user) { FactoryBot.create(:user) }
     let(:resource_action) { FactoryBot.create(:resource_action, :action => "Provision") }
-    let(:service_template) { FactoryBot.create(:service_template, :resource_actions => [resource_action]) }
+    let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
+    let(:service_template) { FactoryBot.create(:service_template, :resource_actions => [resource_action], :service_template_catalog => service_template_catalog, :display => true) }
     let(:resource_action_options) { {:target => service_template, :initiator => 'control', :submit_workflow => true} }
     let(:miq_request) { FactoryBot.create(:service_template_provision_request) }
     let!(:resource_action_workflow) { ResourceActionWorkflow.new({}, user, resource_action, resource_action_options) }

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1116,9 +1116,19 @@ describe ServiceTemplate do
   end
 
   context "#supports_order?" do
-    it "returns the expected boolean value" do
-      st = FactoryBot.create(:service_template)
-      expect(st.supports_order?).to eql(true)
+    context 'when service_template cannot be displayed' do
+      it "returns the expected boolean value" do
+        st = FactoryBot.create(:service_template, :service_template_catalog => FactoryBot.create(:service_template_catalog), :display => false)
+        expect(st.supports_order?).to eql(false)
+        expect(st.unsupported_reason(:order)).to eq('Service template is not configured to be displayed')
+      end
+    end
+
+    context 'when service_template can be displayed' do
+      it "returns the expected boolean value" do
+        st = FactoryBot.create(:service_template, :service_template_catalog => FactoryBot.create(:service_template_catalog), :display => true)
+        expect(st.supports_order?).to eql(true)
+      end
     end
   end
 end

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -108,14 +108,14 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
 
     it 'allows a plan to be ordered if all VMs have not been migrated' do
       expect(service_template.validate_order).to eq([])
-      expect(service_template.orderable?).to eq([]) # alias
+      expect(service_template.orderable?).to be_truthy
     end
 
     it 'denies a plan from bring ordered if all VMs have been migrated' do
       vm1.tag_add('transformation_status/migrated', :ns => '/managed')
       vm2.tag_add('transformation_status/migrated', :ns => '/managed')
       expect(service_template.validate_order).to eq(['All VMs of the migration plan have already been successfully migrated'])
-      expect(service_template.orderable?).to eq(['All VMs of the migration plan have already been successfully migrated']) # alias
+      expect(service_template.orderable?).to be_falsey
     end
   end
 

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -107,15 +107,16 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     let(:service_template) { described_class.create_catalog_item(catalog_item_options) }
 
     it 'allows a plan to be ordered if all VMs have not been migrated' do
-      expect(service_template.validate_order(true)).to eq([]) # with errors array
-      expect(service_template.orderable?).to be_truthy # alias with boolean
+      expect(service_template.validate_order).to eql(true)
+      expect(service_template.orderable?).to eql(true) # alias
     end
 
     it 'denies a plan from bring ordered if all VMs have been migrated' do
       vm1.tag_add('transformation_status/migrated', :ns => '/managed')
       vm2.tag_add('transformation_status/migrated', :ns => '/managed')
-      expect(service_template.validate_order(true)).to eq(['All VMs of the migration plan have already been successfully migrated']) # with errors array
-      expect(service_template.orderable?).to be_falsey # alias with boolean
+      expect(service_template.validate_order).to eql(false)
+      expect(service_template.orderable?).to eql(false) # alias
+      expect(service_template.unsupported_reason(:order)).to eq('All VMs of the migration plan have already been successfully migrated')
     end
   end
 

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -107,15 +107,15 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     let(:service_template) { described_class.create_catalog_item(catalog_item_options) }
 
     it 'allows a plan to be ordered if all VMs have not been migrated' do
-      expect(service_template.validate_order).to eq([])
-      expect(service_template.orderable?).to be_truthy
+      expect(service_template.validate_order(true)).to eq([]) # with errors array
+      expect(service_template.orderable?).to be_truthy # alias with boolean
     end
 
     it 'denies a plan from bring ordered if all VMs have been migrated' do
       vm1.tag_add('transformation_status/migrated', :ns => '/managed')
       vm2.tag_add('transformation_status/migrated', :ns => '/managed')
-      expect(service_template.validate_order).to eq(['All VMs of the migration plan have already been successfully migrated'])
-      expect(service_template.orderable?).to be_falsey
+      expect(service_template.validate_order(true)).to eq(['All VMs of the migration plan have already been successfully migrated']) # with errors array
+      expect(service_template.orderable?).to be_falsey # alias with boolean
     end
   end
 

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -107,15 +107,15 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     let(:service_template) { described_class.create_catalog_item(catalog_item_options) }
 
     it 'allows a plan to be ordered if all VMs have not been migrated' do
-      expect(service_template.validate_order).to be_truthy
-      expect(service_template.orderable?).to be_truthy # alias
+      expect(service_template.validate_order).to eq([])
+      expect(service_template.orderable?).to eq([]) # alias
     end
 
     it 'denies a plan from bring ordered if all VMs have been migrated' do
       vm1.tag_add('transformation_status/migrated', :ns => '/managed')
       vm2.tag_add('transformation_status/migrated', :ns => '/managed')
-      expect(service_template.validate_order).to be_falsey
-      expect(service_template.orderable?).to be_falsey # alias
+      expect(service_template.validate_order).to eq(['All VMs of the migration plan have already been successfully migrated'])
+      expect(service_template.orderable?).to eq(['All VMs of the migration plan have already been successfully migrated']) # alias
     end
   end
 


### PR DESCRIPTION
For V2V, we want to return a meaningful message to the user when the service isn't orderable.
In current implementation, the `ServiceTemplate.validate_order` method only returns a boolean.

This PR makes it return explicit error messages. The error messages are aggregated with the `workflow.validate_dialog` error messages, so the user has more information why the service template order has failed.

This requires a follow-up PR in ManageIQ/manageiq-api, because it expects a boolean, and also to add the error messages to the response.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1744197
Depends on #19203