### PR TITLE
[EmbeddedAnsible] Force embedded_ansible role for workflow

### DIFF
--- a/app/models/manageiq/providers/ansible_playbook_workflow.rb
+++ b/app/models/manageiq/providers/ansible_playbook_workflow.rb
@@ -1,4 +1,10 @@
 class ManageIQ::Providers::AnsiblePlaybookWorkflow < ManageIQ::Providers::AnsibleRunnerWorkflow
+  def self.create_job(*args, **kwargs)
+    role_or_playbook_options = args[2]
+    args[2] = role_or_playbook_options.merge(:role => "embedded_ansible")
+    super(*args, **kwargs)
+  end
+
   def execution_type
     "playbook"
   end


### PR DESCRIPTION
The `queue_signal` method in `AnsibleRunnerWorkflow` forces the "ems_operations" role when it schedules a queue item, but this class (which inherits from `AnsibleRunnerWorkflow`) is getting assigned this job from a wrapper job that requires the `embedded_ansible` role.  In addition, the previous job queue an job that is locked to the existing server guid, so it is possible for that server to take the first job, but not the second when it doesn't have both an "embedded_ansible" and "ems_operations" role.

When a server exists that only has the "embedded_ansible" role, it is possible to get into a state where a playbook can be scheduled, but then is never ran because no server matches.  This fix simply always uses the "embedded_ansible" role for everything, but tries to only modify the lower level classes to achieve that.


Alternative Solution
--------------------

There is a "cleaner" solution for this that would instead modify the `AnsibleRunnerWorkflow#queue_signal`:

* https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/ansible_runner_workflow.rb#L95

to instead just default to "embedded_ansible" instead of "ems_operations".  However, since I am not confident that this is only use for "embedded ansible", I favored this method.  While much uglier, it felt a bit safer at this stage in the game.  I would agree that we should probably not go with this solution long term, but for a quick fix, I would argue this is a bit safer.


Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1742839


Steps for Testing/QA
--------------------

Provided replication steps in the BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1742839#c7


And this can be easily replicated on a single appliance.