### PR TITLE
Support addition for time as well as comparison

### DIFF
--- a/config/initializers/add_active_support_duration_to_eo_time.rb
+++ b/config/initializers/add_active_support_duration_to_eo_time.rb
@@ -1,0 +1,9 @@
+module AddActiveSupportDurationToEoTime
+  def inc(t, dir = 1)
+    t = t.to_i if t.kind_of?(ActiveSupport::Duration)
+    super(t, dir)
+  end
+end
+
+require 'et-orbi'
+EtOrbi::EoTime.prepend(AddActiveSupportDurationToEoTime)


### PR DESCRIPTION
Master is broken because we can compare time objects thanks to https://github.com/ManageIQ/manageiq/pull/19165 and https://github.com/ManageIQ/manageiq/pull/19153 but not add them. 

This fixes the failure @simaishi ran into yesterday on 5.11.

@miq-bot assign @bdunne 
Lose a patch, gain a patch? Silly me for thinking that only the comparison was necessary...

## Testing:
with this line: 
```ruby
2.5.5 :001 > eot = EtOrbi::EoTime.new(0, 'Europe/Moscow') + 1.hour
 => #<EtOrbi::EoTime:0x00007f9b4e86ac90 @seconds=3600.0, @zone=#<TZInfo::DataTimezone: Europe/Moscow>, @time=nil> 
```

without:
```ruby
2.5.5 :001 > eot = EtOrbi::EoTime.new(0, 'Europe/Moscow')2.5.5 :001 > eot = EtOrbi::EoTime.new(0, 'Europe/Moscow') ...
2.5.5 :002 > eot + 1.hour
Traceback (most recent call last):
       15: from bin/rails:4:in `<main>'
       14: from bin/rails:4:in `require'
       13: from railties (5.1.7) lib/rails/commands.rb:16:in `<top (required)>'
       12: from railties (5.1.7) lib/rails/command.rb:44:in `invoke'
       11: from railties (5.1.7) lib/rails/command/base.rb:63:in `perform'
       10: from thor (0.19.4) lib/thor.rb:369:in `dispatch'
        9: from thor (0.19.4) lib/thor/invocation.rb:126:in `invoke_command'
        8: from thor (0.19.4) lib/thor/command.rb:27:in `run'
        7: from railties (5.1.7) lib/rails/commands/console/console_command.rb:97:in `perform'
        6: from railties (5.1.7) lib/rails/commands/console/console_command.rb:17:in `start'
        5: from railties (5.1.7) lib/rails/commands/console/console_command.rb:62:in `start'
        4: from (irb):2
        3: from et-orbi (1.2.2) lib/et-orbi/time.rb:236:in `+'
        2: from config/initializers/convert_eo_time_to_time.rb:4:in `inc'
        1: from et-orbi (1.2.2) lib/et-orbi/time.rb:314:in `inc'
ArgumentError (Cannot call add or subtract ActiveSupport::Duration to EoTime instance)
```
