### PR TITLE
Use find_by to skip exceptions in Export of schedules

### DIFF
--- a/app/models/miq_schedule/import_export.rb
+++ b/app/models/miq_schedule/import_export.rb
@@ -79,7 +79,7 @@ module MiqSchedule::ImportExport
         filter =
           if miq_schedule["resource_type"] == "MiqReport" || miq_schedule["resource_type"] == "MiqWidget"
             resource = miq_schedule["resource_type"].safe_constantize.find_by(:name => filter_resource_name)
-            raise "Unable to find  #{filter_resource_name}" unless resource
+            raise "Unable to find resource used in filter #{filter_resource_name}. Please add/update :filter_resource_name attribute in yaml of #{miq_schedule["resource_type"]}" unless resource
 
             MiqExpression.new("=" => {"field" => "#{miq_schedule["resource_type"]}-id", "value" => resource.id})
           else

--- a/app/models/miq_schedule/import_export.rb
+++ b/app/models/miq_schedule/import_export.rb
@@ -4,25 +4,25 @@ module MiqSchedule::ImportExport
   SKIPPED_ATTRIBUTES = %w[id created_on updated_at last_run_on zone_id].freeze
 
   def handle_attributes_for_miq_report(export_attributes)
-    export_attributes['sched_action'][:options][:miq_group_description] = MiqGroup.find(export_attributes['sched_action'][:options][:miq_group_id])&.description
+    export_attributes['sched_action'][:options][:miq_group_description] = MiqGroup.find_by(:id => export_attributes['sched_action'][:options][:miq_group_id])&.description
     export_attributes
   end
 
   def handle_attributes(export_attributes)
     if export_attributes['resource_type'] == 'MiqReport' || export_attributes['resource_type'] == 'MiqWidget'
       filter_record_id = export_attributes['filter'].exp["="]["value"]
-      resource = export_attributes["resource_type"].safe_constantize.find(filter_record_id)
-      export_attributes["filter_resource_name"] = export_attributes["resource_type"] == "MiqReport" ? resource.name : resource.description
+      resource = export_attributes["resource_type"].safe_constantize.find_by(:id => filter_record_id)
+      export_attributes["filter_resource_name"] = export_attributes["resource_type"] == "MiqReport" ? resource.name : resource.description if resource
     elsif export_attributes["filter"]&.kind_of?(MiqExpression)
       export_attributes['filter'] = MiqExpression.new(export_attributes['filter'].exp)
     end
 
-    export_attributes['MiqSearchContent'] = MiqSearch.find(export_attributes['miq_search_id']).export_to_array if export_attributes['miq_search_id']
+    export_attributes['MiqSearchContent'] = MiqSearch.find_by(:id => export_attributes['miq_search_id']).export_to_array if export_attributes['miq_search_id']
 
-    export_attributes['FileDepotContent'] = FileDepot.find(export_attributes['file_depot_id']).export_to_array if export_attributes['file_depot_id']
+    export_attributes['FileDepotContent'] = FileDepot.find_by(:id => export_attributes['file_depot_id']).export_to_array if export_attributes['file_depot_id']
 
     if export_attributes['resource_id']
-      schedule_resource = export_attributes["resource_type"].safe_constantize.find(export_attributes['resource_id'])
+      schedule_resource = export_attributes["resource_type"].safe_constantize.find_by(:id => export_attributes['resource_id'])
       export_attributes['resource_name'] = schedule_resource&.name
     end
 

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -34,6 +34,19 @@ describe MiqSchedule do
         expect(miq_schedule_array['sched_action'][:options]).to eq(options.merge(:miq_group_description => miq_group.description))
         expect(miq_schedule_array['filter_resource_name']).to eq(miq_report.name)
       end
+
+      context "filter resource doesn't exists" do
+        let(:miq_expression) { MiqExpression.new("=" => {"field" => "MiqReport-id", "value" => 999_999_999}) }
+
+        it "exports to array" do
+          expect do
+            miq_schedule_array = MiqSchedule.export_to_array([miq_schedule.id], MiqSchedule).first["MiqSchedule"]
+            expect(miq_schedule_array.slice(*MiqSchedule::ImportExport::SKIPPED_ATTRIBUTES)).to be_empty
+            expect(miq_schedule_array['sched_action'][:options]).to eq(options.merge(:miq_group_description => miq_group.description))
+            expect(miq_schedule_array['filter_resource_name']).to be_nil
+          end.not_to raise_error
+        end
+      end
     end
 
     context "SmartState" do


### PR DESCRIPTION
we don't need to skip export process when don't have already resource in DB.
And I also improved error message.


@miq-bot add-label bug
@miq-bot add-label ivanchuk/yes


@miq-bot assign @gtanzillo 

## Links
related to https://bugzilla.redhat.com/show_bug.cgi?id=1560090
