### PR TITLE
Add export/import of schedules to rake task

### DIFF
--- a/lib/task_helpers/exports/schedules.rb
+++ b/lib/task_helpers/exports/schedules.rb
@@ -1,0 +1,16 @@
+module TaskHelpers
+  class Exports
+    class Schedules
+      def export(options = {})
+        export_dir = options[:directory]
+
+        schedules = options[:all] ? MiqSchedule.all : MiqSchedule.where(:userid => 'system', :prod_default => 'system')
+
+        schedules.each do |schedule|
+          filename = Exports.safe_filename(schedule.name, options[:keep_spaces])
+          File.write("#{export_dir}/#{filename}.yaml", MiqSchedule.export_to_yaml([schedule], MiqSchedule))
+        end
+      end
+    end
+  end
+end

--- a/lib/task_helpers/imports/schedules.rb
+++ b/lib/task_helpers/imports/schedules.rb
@@ -1,0 +1,20 @@
+module TaskHelpers
+  class Imports
+    class Schedules
+      def import(options = {})
+        return unless options[:source]
+
+        glob = File.file?(options[:source]) ? options[:source] : "#{options[:source]}/*.yaml"
+        Dir.glob(glob) do |filename|
+          $log.info("Importing Schedules from: #{filename}")
+
+          begin
+            MiqSchedule.import(File.open(filename, 'r'))
+          rescue StandardError => err
+            warn("Error importing #{filename} : #{err.message}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/evm_export_import.rake
+++ b/lib/tasks/evm_export_import.rake
@@ -123,6 +123,14 @@ namespace :evm do
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end
+
+    desc 'Exports all schedules to individual YAML files'
+    task :schedules => :environment do
+      options = TaskHelpers::Exports.parse_options
+      TaskHelpers::Exports::Schedules.new.export(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
   end
 
   namespace :import do
@@ -232,6 +240,14 @@ namespace :evm do
     task :generic_object_definitions => :environment do
       options = TaskHelpers::Imports.parse_options
       TaskHelpers::Imports::GenericObjectDefinitions.new.import(options)
+
+      exit # exit so that parameters to the first rake task are not run as rake tasks
+    end
+
+    desc 'Import all schedule definitions from individual YAML files'
+    task :schedules => :environment do
+      options = TaskHelpers::Imports.parse_options
+      TaskHelpers::Imports::Schedules.new.import(options)
 
       exit # exit so that parameters to the first rake task are not run as rake tasks
     end


### PR DESCRIPTION
This allows to export/import all schedules.

Usage:

```
Export:
rake evm:export:schedules -- --directory=./my_dir

Import:
rake evm:import:schedules -- --source=./my_dir
```

Links 
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1560090#c17

@miq-bot assign @gtanzillo 
@miq-bot add-label ivanchuk/yes
@miq-bot add-label  enhancement
