### PR TITLE
[V2V] Remove .py extension from calls to virt-v2v-wrapper

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -158,7 +158,7 @@ class ConversionHost < ApplicationRecord
     raise "Could not apply the limits in '#{path}' on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
-  # Run the virt-v2v-wrapper.py script on the remote host and return a hash
+  # Run the virt-v2v-wrapper script on the remote host and return a hash
   # result from the parsed JSON output.
   #
   # Certain sensitive fields are filtered in the error messages to prevent
@@ -167,12 +167,12 @@ class ConversionHost < ApplicationRecord
   def run_conversion(conversion_options)
     ignore = %w[password fingerprint key]
     filtered_options = conversion_options.clone.tap { |h| h.each { |k, _v| h[k] = "__FILTERED__" if ignore.any? { |i| k.to_s.end_with?(i) } } }
-    result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper.py', nil, nil, conversion_options.to_json) }
+    result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper', nil, nil, conversion_options.to_json) }
     JSON.parse(result)
   rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
     raise "Failed to connect and run conversion using options #{filtered_options} with [#{err.class}: #{err}]"
   rescue JSON::ParserError
-    raise "Could not parse result data after running virt-v2v-wrapper.py using options: #{filtered_options}. Result was: #{result}."
+    raise "Could not parse result data after running virt-v2v-wrapper using options: #{filtered_options}. Result was: #{result}."
   rescue StandardError => err
     raise "Starting conversion failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -500,7 +500,7 @@ RSpec.describe ConversionHost, :v2v do
 
     it "works as expected if the connection is successful but the JSON is invalid" do
       allow(conversion_host).to receive(:connect_ssh).and_return('bogus')
-      expected_message = "Could not parse result data after running virt-v2v-wrapper.py using "\
+      expected_message = "Could not parse result data after running virt-v2v-wrapper using "\
         "options: #{filtered_options}. Result was: bogus."
       expect { conversion_host.run_conversion(conversion_options) }.to raise_error(expected_message)
     end


### PR DESCRIPTION
Over time, virt-v2v-wrapper has evolved and will continue to evolve. To prepare for that, it has been renamed from virt-v2v-wrapper.py to virt-v2v-wrapper. The name with .py extension still exist for backward compatibility, but it might be removed later.

This PR changes calls to virt-v2v-wrapper to remove the .py extension.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1744949