### PR TITLE
Set result_format to ignore for enabled open_url.

### DIFF
--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -28,13 +28,17 @@ class ResourceAction < ApplicationRecord
     else
       override_values = {:object_type => target.class.base_class.name, :object_id => target.id}
     end
+
+    attrs = (ae_attributes || {}).merge(override_attrs || {})
+    attrs["result_format"] = 'ignore' if resource&.options&.dig(:open_url)
+
     {
       :namespace        => ae_namespace,
       :class_name       => ae_class,
       :instance_name    => ae_instance,
       :automate_message => ae_message,
       :open_url_task_id => open_url_task_id,
-      :attrs            => (ae_attributes || {}).merge(override_attrs || {}),
+      :attrs            => attrs,
     }.merge(override_values).tap do |args|
       args[:user_id] ||= user.id
       args[:miq_group_id] ||= user.current_group.id

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -107,4 +107,20 @@ describe ResourceAction do
       expect(ra.ae_uri).to eq("#{ra.ae_path}?FOO1=BAR1&FOO2=BAR2#CREATE")
     end
   end
+
+  context "#automate_queue_hash" do
+    let(:button) { FactoryBot.create(:custom_button, :options => {:open_url => true}, :applies_to_class => "Vm") }
+    let(:ra)     { FactoryBot.create(:resource_action, :resource => button) }
+    let(:user)   { FactoryBot.create(:user_with_group) }
+    let(:target) { FactoryBot.create(:vm_vmware) }
+
+    it "adds result_format for open_url" do
+      expect(ra.automate_queue_hash(target, {}, user)).to include(:attrs => {"result_format"=>"ignore"})
+    end
+
+    it "does not add result_format for not open_url" do
+      button.options[:open_url] = false
+      expect(ra.automate_queue_hash(target, {}, user)).not_to include(:attrs => {"result_format"=>"ignore"})
+    end
+  end
 end


### PR DESCRIPTION
Automate won't return back workspace object if result_format is ignore.

Custom button calls MiqTask.generic_action_with_callback which sets up a queue callback.
MiqAeEngine.deliver always returns a workspace handle which references the custom button target object after processing the automate method.
The workspace handle is returned as the result to the queue callback and got saved into miq_task.task_results by calling YAML.dump.

When custom button's target is a generic object, YMAL.dump would fail as method encode_with is not exposed to generic object.
Since open_url really does not care about return value from the automate method, result_format = ignore is sent to automate to not sending back the
workspace as the return value.

Depends on https://github.com/ManageIQ/manageiq-automation_engine/pull/354.

Reported by https://github.com/ManageIQ/manageiq-ui-classic/pull/6040#issuecomment-522771465.
https://bugzilla.redhat.com/show_bug.cgi?id=1550002

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, Ivanchuk/yes, changelog/yes
cc @mkanoor @martinpovolny 