### PR TITLE
Add vmdb_database chart to string extraction

### DIFF
--- a/config/locale_task_config.yaml
+++ b/config/locale_task_config.yaml
@@ -11,6 +11,10 @@ yaml_strings_to_extract:
   - title
   product/charts/layouts/*/*.yaml:
   - title
+  product/charts/miq_reports/vmdb_database.yaml:
+  - headers
+  - title
+  - name
   product/compare/*.yaml:
   - headers
   - group


### PR DESCRIPTION
@miq-bot add_label internationalization, ivanchuk/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1725095