### PR TITLE
[V2V] Add running_migration_playbook state to InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -59,12 +59,12 @@ class InfraConversionJob < Job
   #   }
   def state_settings
     @state_settings ||= {
-      :removing_snapshots  => {
+      :removing_snapshots         => {
         :description => 'Remove snapshosts',
         :weight      => 5,
         :max_retries => 4.hours / state_retry_interval
       },
-      :waiting_for_ip_address   => {
+      :waiting_for_ip_address     => {
         :description => 'Waiting for VM IP address',
         :weight      => 1,
         :max_retries => 1.hour / state_retry_interval
@@ -74,7 +74,7 @@ class InfraConversionJob < Job
         :weight      => 10,
         :max_retries => 6.hours / state_retry_interval
       },
-      :running_in_automate      => {
+      :running_in_automate        => {
         :max_retries => 36.hours / state_retry_interval
       }
     }

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1,26 +1,82 @@
 RSpec.describe InfraConversionJob, :v2v do
-  let(:user)               { FactoryBot.create(:user) }
-  let(:zone)               { FactoryBot.create(:zone) }
-  let(:ems_vmware)         { FactoryBot.create(:ems_vmware, :zone => zone) }
-  let(:ems_cluster_vmware) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
-  let(:host_vmware)        { FactoryBot.create(:host, :ext_management_system => ems_vmware, :ems_cluster => ems_cluster_vmware) }
-  let(:vm_vmware)          { FactoryBot.create(:vm_vmware, :ext_management_system => ems_vmware, :ems_cluster => ems_cluster_vmware, :host => host_vmware, :evm_owner => user) }
-  let(:ems_redhat)         { FactoryBot.create(:ems_redhat, :zone => zone) }
-  let(:ems_cluster_redhat) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
-  let(:host_redhat)        { FactoryBot.create(:host, :ext_management_system => ems_redhat, :ems_cluster => ems_cluster_redhat) }
-  let(:vm_redhat)  { FactoryBot.create(:vm_vmware, :ext_management_system => ems_redhat, :ems_cluster => ems_cluster_redhat, :host => host_redhat, :evm_owner => user) }
-  let(:request)    { FactoryBot.create(:service_template_transformation_plan_request) }
-  let(:task)       { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :source => vm_vmware, :userid => user.id) }
-  let(:options)    { {:target_class => task.class.name, :target_id => task.id} }
-  let(:job)        { described_class.create_job(options) }
+  let(:user)                  { FactoryBot.create(:user_with_group) }
+  let(:zone)                  { FactoryBot.create(:zone) }
+
+  let(:ems_vmware)            { FactoryBot.create(:ems_vmware, :zone => zone) }
+  let(:ems_cluster_vmware)    { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
+  let(:host_vmware)           { FactoryBot.create(:host, :ext_management_system => ems_vmware, :ems_cluster => ems_cluster_vmware) }
+  let(:lan_vmware)            { FactoryBot.create(:lan) }
+  let(:network_vmware)        { FactoryBot.create(:network, :ipaddress => nil) }
+  let(:nic_vmware)            { FactoryBot.create(:guest_device_nic, :lan => lan_vmware, :network => network_vmware) }
+  let(:hardware_vmware)       { FactoryBot.create(:hardware, :nics => [nic_vmware], :networks => [network_vmware]) }
+  let(:vm_vmware) do
+    FactoryBot.create(:vm_vmware,
+                      :ext_management_system => ems_vmware,
+                      :ems_cluster => ems_cluster_vmware,
+                      :host => host_vmware,
+                      :hardware => hardware_vmware,
+                      :evm_owner => user)
+  end
+
+  let(:ems_redhat)            { FactoryBot.create(:ems_redhat, :zone => zone) }
+  let(:ems_cluster_redhat)    { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
+  let(:host_redhat)           { FactoryBot.create(:host, :ext_management_system => ems_redhat, :ems_cluster => ems_cluster_redhat) }
+  let(:vm_redhat)             { FactoryBot.create(:vm_vmware, :ext_management_system => ems_redhat, :ems_cluster => ems_cluster_redhat, :host => host_redhat, :evm_owner => user) }
+
+  let(:embedded_ansible_auth) { FactoryBot.create(:embedded_ansible_credential) }
+  let(:embedded_ansible_catalog_item_options) do
+    {
+      :name                        => 'Test Migration Playbook',
+      :description                 => 'Migration Playbook for testing purpose',
+      :config_info                 => {
+        :provision => {
+          :credential_id         => embedded_ansible_auth.id,
+          :hosts                 => 'localhost',
+        },
+      }
+    }
+  end
+  let(:embedded_ansible_service_template)     { ServiceTemplateAnsiblePlaybook.create_catalog_item(embedded_ansible_catalog_item_options, nil) }
+  let(:embedded_ansible_service_request)      { FactoryBot.create(:service_template_provision_request, :source => embedded_ansible_service_template, :approval_state => 'approved', :requester => user) }
+
+  let(:transformation_mapping) do
+    FactoryBot.create(:transformation_mapping).tap do |tm|
+      FactoryBot.create(:transformation_mapping_item,
+                        :source                 => ems_cluster_vmware,
+                        :destination            => ems_cluster_redhat,
+                        :transformation_mapping => tm)
+    end
+  end
+
+  let(:transformation_plan_catalog_item_options) do
+    {
+      :name        => 'Test Transformation Plan',
+      :description => 'Transformation Plan for testing purpose',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping.id,
+        :pre_service_id            => embedded_ansible_service_template.id,
+        :post_service_id           => embedded_ansible_service_template.id,
+        :actions                   => [
+          {:vm_id => vm_vmware.id.to_s, :pre_service => true, :post_service => true},
+        ],
+      }
+    }
+  end
+  let(:transformation_plan) { ServiceTemplateTransformationPlan.create_catalog_item(transformation_plan_catalog_item_options) }
+
+  let(:request)     { FactoryBot.create(:service_template_transformation_plan_request, :source => transformation_plan) }
+  let(:task)        { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :source => vm_vmware, :userid => user.id) }
+  let(:job_options) { {:target_class => task.class.name, :target_id => task.id} }
+  let(:job)         { described_class.create_job(job_options) }
 
   before do
-    allow(MiqServer). to receive(:my_zone).and_return(zone.name)
+    allow(MiqServer).to receive(:my_zone).and_return(zone.name)
+    allow(ServiceTemplateProvisionRequest).to receive(:destination)
   end
 
   context '.create_job' do
     it 'leaves job waiting to start' do
-      job = described_class.create_job(options)
+      job = described_class.create_job(job_options)
       expect(job.state).to eq('waiting_to_start')
     end
   end
@@ -404,40 +460,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
     end
 
-    context 'waiting_for_ip_address' do
-      before do
-        job.state = 'waiting_for_ip_address'
-      end
-
-      it_behaves_like 'allows wait_for_ip_address signal'
-      it_behaves_like 'allows run_migration_playbook signal'
-      it_behaves_like 'allows finish signal'
-      it_behaves_like 'allows abort_job signal'
-      it_behaves_like 'allows cancel signal'
-      it_behaves_like 'allows error signal'
-
-      it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow collapse_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
-    end
-
-    context 'running_migration_playbook' do
-      before do
-        job.state = 'running_migration_playbook'
-      end
-
-      it_behaves_like 'allows run_migration_playbook signal'
-      it_behaves_like 'allows poll_automate_state_machine signal'
-      it_behaves_like 'allows finish signal'
-      it_behaves_like 'allows abort_job signal'
-      it_behaves_like 'allows cancel signal'
-      it_behaves_like 'allows error signal'
-
-      it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow collapse_snapshots signal'
-      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
-    end
-
     context 'running_in_automate' do
       before do
         job.state = 'running_in_automate'
@@ -452,6 +474,9 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow remove_snapshots signal'
       it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
+      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
+      it_behaves_like 'doesn\'t allow run_migration_playbook signal'
+      it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
     end
   end
 
@@ -530,7 +555,6 @@ RSpec.describe InfraConversionJob, :v2v do
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
         expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
         job.signal(:poll_remove_snapshots_complete)
-        expect(task.reload.options[:workflow_runner]).to eq('automate')
       end
 
       it 'fails if async task is finished and its status is Error' do
@@ -544,25 +568,131 @@ RSpec.describe InfraConversionJob, :v2v do
 
     context '#wait_for_ip_address' do
       before do
+        task.update_options(:migration_phase => 'pre')
         job.state = 'waiting_for_ip_address'
       end
 
       it 'abort_conversion when waiting_on_ip_address times out' do
-        job.context[:retries_waiting_on_ipaddress] = 240
+        job.context[:retries_waiting_for_ip_address] = 240
         expect(job).to receive(:abort_conversion).with('Waiting for IP address timed out', 'error')
+        job.signal(:wait_for_ip_address)
+      end
+
+      it 'exits if VM is powered off' do
+        vm_vmware.update!(:raw_power_state => 'poweredOff')
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:run_migration_playbook)
+        job.signal(:wait_for_ip_address)
+      end
+
+      it 'exits if VM is powered on has an IP address' do
+        vm_vmware.update!(:raw_power_state => 'poweredOn')
+        network_vmware.update!(:ipaddress => '10.0.0.1')
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:run_migration_playbook)
+        job.signal(:wait_for_ip_address)
+      end
+
+      it 'retries if VM is powered on and does not have an IP address' do
+        vm_vmware.update!(:raw_power_state => 'poweredOn')
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+        expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
         job.signal(:wait_for_ip_address)
       end
     end
 
     context '#run_migration_playbook' do
       before do
+        task.update_options(:migration_phase => 'pre')
+        job.state = 'waiting_for_ip_address'
+      end
+
+      context 'without a service template matching the embedded ansible service template id' do
+        it 'does not request service template provisioning' do
+          embedded_ansible_service_template.delete
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+          expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+          job.signal(:run_migration_playbook)
+          expect(task.reload.options[:workflow_runner]).to eq('automate')
+        end
+      end
+
+      context 'with a service template matching the embedded ansible service template id' do
+        it 'creates a service template provision request' do
+          Timecop.freeze(2019, 2, 6) do
+            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+            expect(job).to receive(:queue_signal).with(:poll_run_migration_playbook_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+            job.signal(:run_migration_playbook)
+            service_request = ServiceTemplateProvisionRequest.find(job.context[:pre_migration_playbook_service_request_id])
+            expect(service_request).to have_attributes(
+              :description => "Provisioning Service [#{embedded_ansible_service_template.name}] from [#{embedded_ansible_service_template.name}]",
+              :state       => 'pending',
+              :status      => 'Ok',
+              :userid      => user.userid
+            )
+          end
+        end
+      end
+    end
+
+    context '#poll_run_migration_playbook_complete' do
+      before do
+        task.update_options(:migration_phase => 'pre')
         job.state = 'running_migration_playbook'
+        job.context[:pre_migration_playbook_service_request_id] = embedded_ansible_service_request.id
+        embedded_ansible_job = FactoryBot.create(:embedded_ansible_job)
+        embedded_ansible_service = FactoryBot.create(:service_ansible_playbook)
+        embedded_ansible_service_request_task = FactoryBot.create(:service_template_provision_task, :miq_request => embedded_ansible_service_request, :destination => embedded_ansible_service, :userid => user.id)
+        embedded_ansible_service_resource = FactoryBot.create(:service_resource, :resource => embedded_ansible_job, :service => embedded_ansible_service)
       end
 
       it 'abort_conversion when running_migration_playbook times out' do
         job.context[:retries_running_migration_playbook] = 1440
         expect(job).to receive(:abort_conversion).with('Running migration playbook timed out', 'error')
-        job.signal(:run_migration_playbook)
+        job.signal(:poll_run_migration_playbook_complete)
+      end
+
+      it 'retries if service request is not finished' do
+        embedded_ansible_service_request.update!(:request_state => 'active')
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+          expect(job).to receive(:queue_signal).with(:poll_run_migration_playbook_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+          job.signal(:poll_run_migration_playbook_complete)
+        end
+      end
+
+      it 'exits if service request is finished and its status is Ok' do
+        embedded_ansible_service_request.update!(:request_state => 'finished', :status => 'Ok')
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+        job.signal(:poll_run_migration_playbook_complete)
+        expect(task.reload.options[:workflow_runner]).to eq('automate')
+      end
+
+      it 'fails if service request is finished and migration_phase is "pre" and its status is Error' do
+        embedded_ansible_service_request.update!(:state => 'finished', :status => 'Error')
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_error)
+        expect(job).to receive(:abort_conversion).with('Ansible playbook has failed (migration_phase=pre)', 'error')
+        job.signal(:poll_run_migration_playbook_complete)
+      end
+
+      it 'exits if service request is finished and migration_phase is "post" and its status is Error' do
+        task.update_options(:migration_phase => 'post')
+        job.context[:post_migration_playbook_service_request_id] = embedded_ansible_service_request.id
+        embedded_ansible_service_request.update!(:state => 'finished', :status => 'Error', :message => 'Fake error message')
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+        job.signal(:poll_run_migration_playbook_complete)
+        expect(task.reload.options[:workflow_runner]).to eq('automate')
       end
     end
 

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe InfraConversionJob, :v2v do
   let(:vm_vmware) do
     FactoryBot.create(:vm_vmware,
                       :ext_management_system => ems_vmware,
-                      :ems_cluster => ems_cluster_vmware,
-                      :host => host_vmware,
-                      :hardware => hardware_vmware,
-                      :evm_owner => user)
+                      :ems_cluster           => ems_cluster_vmware,
+                      :host                  => host_vmware,
+                      :hardware              => hardware_vmware,
+                      :evm_owner             => user)
   end
 
   let(:ems_redhat)            { FactoryBot.create(:ems_redhat, :zone => zone) }
@@ -26,18 +26,18 @@ RSpec.describe InfraConversionJob, :v2v do
   let(:embedded_ansible_auth) { FactoryBot.create(:embedded_ansible_credential) }
   let(:embedded_ansible_catalog_item_options) do
     {
-      :name                        => 'Test Migration Playbook',
-      :description                 => 'Migration Playbook for testing purpose',
-      :config_info                 => {
+      :name        => 'Test Migration Playbook',
+      :description => 'Migration Playbook for testing purpose',
+      :config_info => {
         :provision => {
-          :credential_id         => embedded_ansible_auth.id,
-          :hosts                 => 'localhost',
+          :credential_id => embedded_ansible_auth.id,
+          :hosts         => 'localhost',
         },
       }
     }
   end
-  let(:embedded_ansible_service_template)     { ServiceTemplateAnsiblePlaybook.create_catalog_item(embedded_ansible_catalog_item_options, nil) }
-  let(:embedded_ansible_service_request)      { FactoryBot.create(:service_template_provision_request, :source => embedded_ansible_service_template, :approval_state => 'approved', :requester => user) }
+  let(:embedded_ansible_service_template) { ServiceTemplateAnsiblePlaybook.create_catalog_item(embedded_ansible_catalog_item_options, nil) }
+  let(:embedded_ansible_service_request)  { FactoryBot.create(:service_template_provision_request, :source => embedded_ansible_service_template, :approval_state => 'approved', :requester => user) }
 
   let(:transformation_mapping) do
     FactoryBot.create(:transformation_mapping).tap do |tm|
@@ -645,10 +645,9 @@ RSpec.describe InfraConversionJob, :v2v do
         task.update_options(:migration_phase => 'pre')
         job.state = 'running_migration_playbook'
         job.context[:pre_migration_playbook_service_request_id] = embedded_ansible_service_request.id
-        embedded_ansible_job = FactoryBot.create(:embedded_ansible_job)
         embedded_ansible_service = FactoryBot.create(:service_ansible_playbook)
-        embedded_ansible_service_request_task = FactoryBot.create(:service_template_provision_task, :miq_request => embedded_ansible_service_request, :destination => embedded_ansible_service, :userid => user.id)
-        embedded_ansible_service_resource = FactoryBot.create(:service_resource, :resource => embedded_ansible_job, :service => embedded_ansible_service)
+        FactoryBot.create(:service_template_provision_task, :miq_request => embedded_ansible_service_request, :destination => embedded_ansible_service, :userid => user.id)
+        FactoryBot.create(:service_resource, :resource => FactoryBot.create(:embedded_ansible_job), :service => embedded_ansible_service)
       end
 
       it 'abort_conversion when running_migration_playbook times out' do


### PR DESCRIPTION
For IMS 1.3 we're moving state machine handling from automate into core. For ease of writing and review, we're breaking this down into (hopefully) easily digestible bits, one state at a time. Each PR will ultimately have a corresponding PR in manageiq-content that deletes the relevant bit of code from automate.

Original automate code:
https://github.com/ManageIQ/manageiq-content/tree/master/content/automate/ManageIQ/Transformation/Ansible.class/__methods__

This PR adds two states to the state machine: `waiting_for_ip_address` and `running_migration_playbook`. The state machine is changed to allow transition from `collapsing_snapshots`, so it only handles the pre-migration playbook. Another PR will add support for post-migration playbook.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1745233
Depends on #19149, #19150, #19154, #19177
Built on #19177