### PR TITLE
Set tenant from group in Authentification(KeyPairs) model

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -36,6 +36,8 @@ class Authentication < ApplicationRecord
   before_save :set_credentials_changed_on
   after_save :after_authentication_changed
 
+  before_validation :set_tenant_from_group
+
   serialize :options
 
   include OwnershipMixin
@@ -151,6 +153,10 @@ class Authentication < ApplicationRecord
   end
 
   private
+
+  def set_tenant_from_group
+    self.tenant_id = miq_group.tenant_id if miq_group
+  end
 
   def set_credentials_changed_on
     return unless @auth_changed

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,4 +1,17 @@
 describe Authentication do
+  describe ".set_ownership" do
+    let!(:authentication) { FactoryBot.create(:authentication) }
+    let(:tenant) { FactoryBot.create(:tenant) }
+    let!(:group) { FactoryBot.create(:miq_group, :tenant => tenant) }
+
+    it "sets tenant from group" do
+      expect(authentication.tenant).to be_nil
+      authentication.class.set_ownership([authentication.id], :group => group)
+
+      expect(authentication.reload.tenant.id).to eq(tenant.id)
+    end
+  end
+
   describe ".encrypted_columns" do
     it "returns the encrypted columns" do
       expected = %w(password password_encrypted auth_key auth_key_encrypted service_account service_account_encrypted auth_key_password auth_key_password_encrypted become_password become_password_encrypted)


### PR DESCRIPTION
We have `OwnershipMixin` on model `Authentification` but there is no way how set tenant 
according to group. 

So I put method for it to `before_validation` as we have it other models with  `OwnershipMixin`. For example:  [VmOrTemplate](https://github.com/ManageIQ/manageiq/blob/710fecf2a6835376f19101873319ed324860a7b1/app/models/vm_or_template.rb#L194),...

Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1741635


@miq-bot add_label Ivanchuk/yes, hammer/yes, bug

fyi @andyvesel 

@miq-bot assign @gtanzillo 

