### PR TITLE
Add order option to SupportsFeatureMixin module

### DIFF
--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -99,6 +99,7 @@ module SupportsFeatureMixin
     :migrate                             => 'Migration',
     :capture                             => 'Capture of Capacity & Utilization Metrics',
     :openscap_scan                       => 'OpenSCAP security scan',
+    :order                               => 'Service Order',
     :provisioning                        => 'Provisioning',
     :publish                             => 'Publishing',
     :quick_stats                         => 'Quick Stats',

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -1,4 +1,6 @@
 class ServiceTemplate < ApplicationRecord
+  include SupportsFeatureMixin
+
   DEFAULT_PROCESS_DELAY_BETWEEN_GROUPS = 120
 
   GENERIC_ITEM_SUBTYPES = {
@@ -83,6 +85,8 @@ class ServiceTemplate < ApplicationRecord
   scope :with_existent_service_template_catalog_id, ->         { where.not(:service_template_catalog_id => nil) }
   scope :displayed,                                 ->         { where(:display => true) }
   scope :public_service_templates,                  ->         { where(:internal => [false, nil]) }
+
+  supports :order
 
   def self.with_tenant(tenant_id)
     tenant = Tenant.find(tenant_id)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1113,6 +1113,13 @@ describe ServiceTemplate do
       end
     end
   end
+
+  context "#supports_order?" do
+    it "returns the expected boolean value" do
+      st = FactoryBot.create(:service_template)
+      expect(st.supports_order?).to eql(true)
+    end
+  end
 end
 
 def add_and_save_service(p, c)


### PR DESCRIPTION
This is a followup (or prequel?) to https://github.com/ManageIQ/manageiq/pull/19186 that would allow the ability to set whether or not a given service is actually orderable.

At the moment there's only `ServiceTemplate.validate_order` which returns a simple boolean. This allows for more flexibility for subclasses/providers that can hook into it and provide custom messages if/when it's not supported.

Update: This also explicitly includes the `SupportsFeatureMixin` into the `ServiceTemplate` class, and adds a default `supports :order` to it.