### PR TITLE
Set service's lifecycle_state based on miq_request_task's state.

### DIFF
--- a/app/models/mixins/lifecycle_mixin.rb
+++ b/app/models/mixins/lifecycle_mixin.rb
@@ -6,9 +6,9 @@ module LifecycleMixin
   STATE_PROVISIONING = 'provisioning'.freeze
 
   def update_lifecycle_state
-    case miq_request.request_state
+    case miq_request_task.state
     when "finished"
-      lifecycle_state = miq_request.status == 'Ok' ? STATE_PROVISIONED : STATE_ERROR_PROVISIONING
+      lifecycle_state = miq_request_task.status == 'Ok' ? STATE_PROVISIONED : STATE_ERROR_PROVISIONING
       update(:lifecycle_state => lifecycle_state)
     else
       update(:lifecycle_state => STATE_PROVISIONING)

--- a/app/models/service_template_provision_task.rb
+++ b/app/models/service_template_provision_task.rb
@@ -214,10 +214,14 @@ class ServiceTemplateProvisionTask < MiqRequestTask
     return if service.nil?
 
     service.raise_provisioned_event
-    service.update_lifecycle_state if miq_request_task.nil?
+    service.update_lifecycle_state if service_template_source?
   end
 
   private
+
+  def service_template_source?
+    source_type == "ServiceTemplate"
+  end
 
   def valid_states
     super + ["provisioned"]

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -268,17 +268,15 @@ describe ServiceTemplateProvisionTask do
 
       it 'set service lifecycle_state to provisioned' do
         expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_provisioned)
-        @task_0.destination = @service
-        @request.miq_request_tasks.except(@task_0).each { |t| t.update(:state => "finished") }
-        @task_0.update_and_notify_parent(:state => "finished", :status => "Ok", :message => "Test Message")
+        @task_3.update(:destination => @service, :source_type => "ServiceTemplate", :state => "finished", :status => "Ok")
+        @task_3.task_finished
         expect(@service.provisioned?).to be true
       end
 
       it 'set service lifecycle_state to error_provisioned' do
         expect(MiqEvent).to receive(:raise_evm_event).with(@service, :service_provisioned)
-        @task_0.destination = @service
-        @request.miq_request_tasks.except(@task_0).each { |t| t.update(:state => "finished") }
-        @task_0.update_and_notify_parent(:state => "finished", :status => "Error", :message => "Test Message")
+        @task_3.update(:destination => @service, :source_type => "ServiceTemplate", :state => "finished", :status => "Error")
+        @task_3.task_finished
         expect(@service.provision_failed?).to be true
       end
     end


### PR DESCRIPTION
With bundle service, all the top and sub services are connected to the same request.
A sub service may have two ```ServiceTemplateProvisionTask```. One has ```ServiceTemplate``` as the source while the other has ```MiqRequest```.

https://bugzilla.redhat.com/show_bug.cgi?id=1743550

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, services, ivanchuk/yes, changelog/yes, blocker

<img width="1392" alt="Screen Shot 2019-08-26 at 13 18 43" src="https://user-images.githubusercontent.com/2593270/63713404-961b1c80-c80d-11e9-9766-b814f3dd1cb6.png">

