### PR TITLE
Add copying tag as optional choice

### DIFF
--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -1,7 +1,7 @@
 module ServiceTemplate::Copy
   extend ActiveSupport::Concern
 
-  def template_copy(new_name = "Copy of " + name + Time.zone.now.to_s)
+  def template_copy(new_name = "Copy of " + name + Time.zone.now.to_s, copy_tags: false)
     if template_valid? && type != 'ServiceTemplateAnsiblePlaybook'
       ActiveRecord::Base.transaction do
         dup.tap do |template|
@@ -10,7 +10,7 @@ module ServiceTemplate::Copy
           resource_action_copy(template)
           additional_tenant_copy(template)
           picture_copy(template) if picture
-
+          tags_copy(template) if copy_tags
           direct_custom_buttons.each { |custom_button| custom_button_copy(custom_button, template) }
           custom_button_sets.each { |custom_button_set| custom_button_set_copy(custom_button_set, template) }
           template.save!
@@ -44,5 +44,9 @@ module ServiceTemplate::Copy
 
   def resource_action_copy(template)
     template.resource_actions << resource_actions.collect(&:dup)
+  end
+
+  def tags_copy(template)
+    template.tags << tags.dup
   end
 end

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -210,5 +210,28 @@ describe ServiceTemplate do
         expect(new_template.additional_tenants.count).to eq(2)
       end
     end
+
+    context "tags" do
+      it "does not duplicate tags by default" do
+        service_template.tags << FactoryBot.create(:tag)
+        expect(service_template.tags.count).to eq(1)
+
+        new_template = service_template.template_copy
+
+        expect(new_template.tags.count).to be_zero
+      end
+
+      it "duplicates tags" do
+        service_template.tags << [
+          FactoryBot.create(:tag),
+          FactoryBot.create(:tag)
+        ]
+        expect(service_template.tags.count).to eq(2)
+
+        new_template = service_template.template_copy(:copy_tags => true)
+
+        expect(new_template.tags).to match_array(service_template.tags)
+      end
+    end
   end
 end


### PR DESCRIPTION
When service template is copied, tags might also need to be copied as well. This change adds an optional filed to allow tags to be copied as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1740399