### PR TITLE
Show saved currency value consistently

### DIFF
--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -191,7 +191,7 @@ class ChargebackRateDetail < ApplicationRecord
   # New method created in order to show the rates in a easier to understand way
   def show_rates
     hr = ChargebackRateDetail::PER_TIME_MAP[per_time.to_sym]
-    rate_display = "#{detail_currency.code} / #{hr}"
+    rate_display = "#{detail_currency.symbol} [#{detail_currency.full_name}] / #{hr}"
     rate_display_unit = "#{rate_display} / #{per_unit_display}"
     per_unit.nil? ? rate_display : rate_display_unit
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -275,10 +275,10 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
     cbc = FactoryBot.create(:chargeback_rate_detail_currency, :code => "EUR")
 
     cbd = FactoryBot.build(:chargeback_rate_detail_fixed_compute_cost, :detail_currency => cbc)
-    expect(cbd.show_rates).to eq("EUR / Day")
+    expect(cbd.show_rates).to eq("€ [Euro] / Day")
 
     cbd = FactoryBot.build(:chargeback_rate_detail_memory_allocated, :detail_currency => cbc)
-    expect(cbd.show_rates).to eq("EUR / Day / MB")
+    expect(cbd.show_rates).to eq("€ [Euro] / Day / MB")
   end
 
   context "tier set correctness" do


### PR DESCRIPTION
Show selected currency value consistent with value that was selected in a drop down on edit screen

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1740411

before
![before2](https://user-images.githubusercontent.com/3450808/63738998-b7095f00-c859-11e9-903c-7ebdb6bacbe8.png)

after
![after2](https://user-images.githubusercontent.com/3450808/63738991-abb63380-c859-11e9-9fae-ca3f58e3f41e.png)
