### PR TITLE
Add Settings attribute for displaying the ops/database screen

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1095,6 +1095,7 @@
     :network_limit_per_host: unlimited
 :ui:
   :mark_translated_strings: false
+  :display_ops_database: false
   :url:
 :vim_performance_states:
   :history:


### PR DESCRIPTION
As we discussed with PM in the BZ, we're hiding the screen with the possibility of re-displaying it by setting a configuartion parameter. Of course this requires a configuration parameter first. I'm not sure if I'm putting it into the right place though, cc @mzazrivec as everyone else is on PTO.

@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @lpichler 
@miq-bot add_label enhancement, ivanchuk/yes

https://bugzilla.redhat.com/show_bug.cgi?id=1744542
