### PR TITLE
Test that each lang catalog has properly set locale_name

### DIFF
--- a/spec/i18n/locale_name_spec.rb
+++ b/spec/i18n/locale_name_spec.rb
@@ -1,0 +1,11 @@
+describe :locale_name do
+  it "all languages have properly set locale_name" do
+    Vmdb::FastGettextHelper.find_available_locales.each do |lang|
+      FastGettext.locale = lang
+      locale_name = _('locale_name')
+      expect(locale_name).not_to eq('locale_name')
+    end
+
+    FastGettext.locale = 'en' # set the locale for runnin specs back to English
+  end
+end


### PR DESCRIPTION
So for `en` locale it would be `English`, for `es` it would be `Español`, etc.