### PR TITLE
Service display has been renamed to visible.

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -64,6 +64,7 @@ class Service < ApplicationRecord
   include CiFeatureMixin
   include CustomActionsMixin
   include CustomAttributeMixin
+  include DeprecationMixin
   include ExternalUrlMixin
   include LifecycleMixin
   include Metric::CiMixin
@@ -108,6 +109,7 @@ class Service < ApplicationRecord
   alias parent_service parent
   alias_attribute :service, :parent
   virtual_belongs_to :service
+  deprecate_attribute :display, :visible
 
   def power_states
     vms.map(&:power_state)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -205,14 +205,18 @@ class ServiceTemplate < ApplicationRecord
 
   def create_service(service_task, parent_svc = nil)
     nh = attributes.dup
+
+    # Service#display was renamed to #visible in https://github.com/ManageIQ/manageiq-schema/pull/410
+    nh['visible'] = nh.delete('display') if nh.key?('display')
+
     nh['options'][:dialog] = service_task.options[:dialog]
     (nh.keys - Service.column_names + %w(created_at guid service_template_id updated_at id type prov_type)).each { |key| nh.delete(key) }
 
     # Hide child services by default
-    nh['display'] = false if parent_svc
+    nh['visible'] = false if parent_svc
 
-    # If display is nil, set it to false
-    nh['display'] ||= false
+    # If visible is nil, set it to false
+    nh['visible'] ||= false
 
     # convert template class name to service class name by naming convention
     nh['type'] = self.class.name.sub('Template', '')


### PR DESCRIPTION
To avoid name conflict with Kernel#display method.

Depends on https://github.com/ManageIQ/manageiq-schema/pull/410.
https://bugzilla.redhat.com/show_bug.cgi?id=1737559

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, ivanchuk/no, changelog/yes