### PR TITLE
Refactor the auth_changed variable in Authentication model

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,6 +1,6 @@
 class AuthToken < Authentication
   after_update :after_authentication_changed,
-    :if => Proc.new{ |auth| auth.saved_change_to_auth_key? }
+    :if => proc { |auth| auth.saved_change_to_auth_key? }
 
   def self.display_name(number = 1)
     n_('Authentication Token', 'Authentication Tokens', number)

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,8 +1,6 @@
 class AuthToken < Authentication
-  def auth_key=(val)
-    auth_changed = true if auth_key && (val != auth_key)
-    super(val)
-  end
+  after_update :after_authentication_changed,
+    :if => Proc.new{ |auth| auth.saved_change_to_auth_key? }
 
   def self.display_name(number = 1)
     n_('Authentication Token', 'Authentication Tokens', number)

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,7 +1,4 @@
 class AuthToken < Authentication
-  after_update :after_authentication_changed,
-    :if => proc { |auth| auth.saved_change_to_auth_key? }
-
   def self.display_name(number = 1)
     n_('Authentication Token', 'Authentication Tokens', number)
   end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,6 +1,6 @@
 class AuthToken < Authentication
   def auth_key=(val)
-    @auth_changed = true if val != auth_key
+    auth_changed = true if val != auth_key
     super(val)
   end
 

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,6 +1,6 @@
 class AuthToken < Authentication
   def auth_key=(val)
-    auth_changed = true if val != auth_key
+    auth_changed = true if auth_key && (val != auth_key)
     super(val)
   end
 

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -1,6 +1,6 @@
 class AuthUseridPassword < Authentication
   after_update :after_authentication_changed,
-    :if => proc { |auth| auth.saved_change_to_userid? || auth.saved_changed_to_password? }
+    :if => proc { |auth| auth.saved_change_to_userid? || auth.saved_change_to_password? }
 
   def self.display_name(number = 1)
     n_('Password', 'Passwords', number)

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -2,16 +2,6 @@ class AuthUseridPassword < Authentication
   after_update :after_authentication_changed,
     :if => Proc.new{ |auth| auth.saved_change_to_userid || auth.saved_changed_to_password? }
 
-  def password=(val)
-    auth_changed = true if password && (val != password)
-    super(val)
-  end
-
-  def userid=(val)
-    auth_changed = true if userid && (val != userid)
-    super(val)
-  end
-
   def self.display_name(number = 1)
     n_('Password', 'Passwords', number)
   end

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -1,6 +1,6 @@
 class AuthUseridPassword < Authentication
   after_update :after_authentication_changed,
-    :if => proc { |auth| auth.saved_change_to_userid || auth.saved_changed_to_password? }
+    :if => proc { |auth| auth.saved_change_to_userid? || auth.saved_changed_to_password? }
 
   def self.display_name(number = 1)
     n_('Password', 'Passwords', number)

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -1,4 +1,7 @@
 class AuthUseridPassword < Authentication
+  after_update :after_authentication_changed,
+    :if => Proc.new{ |auth| auth.saved_change_to_userid || auth.saved_changed_to_password? }
+
   def password=(val)
     auth_changed = true if password && (val != password)
     super(val)

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -1,11 +1,11 @@
 class AuthUseridPassword < Authentication
   def password=(val)
-    @auth_changed = true if val != password
+    auth_changed = true if password && (val != password)
     super(val)
   end
 
   def userid=(val)
-    @auth_changed = true if val != userid
+    auth_changed = true if userid && (val != userid)
     super(val)
   end
 

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -1,7 +1,4 @@
 class AuthUseridPassword < Authentication
-  after_update :after_authentication_changed,
-    :if => proc { |auth| auth.saved_change_to_userid? || auth.saved_change_to_password? }
-
   def self.display_name(number = 1)
     n_('Password', 'Passwords', number)
   end

--- a/app/models/auth_userid_password.rb
+++ b/app/models/auth_userid_password.rb
@@ -1,6 +1,6 @@
 class AuthUseridPassword < Authentication
   after_update :after_authentication_changed,
-    :if => Proc.new{ |auth| auth.saved_change_to_userid || auth.saved_changed_to_password? }
+    :if => proc { |auth| auth.saved_change_to_userid || auth.saved_changed_to_password? }
 
   def self.display_name(number = 1)
     n_('Password', 'Passwords', number)

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,9 +1,12 @@
 class Authentication < ApplicationRecord
   acts_as_miq_taggable
   include_concern 'ImportExport'
-  include YAMLImportExportMixin
 
+  include YAMLImportExportMixin
   include NewWithTypeStiMixin
+
+  attr_accessor :auth_changed
+
   def self.new(*args, &block)
     if self == Authentication
       AuthUseridPassword.new(*args, &block)
@@ -32,10 +35,6 @@ class Authentication < ApplicationRecord
            :through => :authentication_orchestration_stacks
 
   has_many :configuration_script_sources
-
-  after_initialize do
-    @auth_changed = false
-  end
 
   before_save :set_credentials_changed_on
   after_save :after_authentication_changed

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -2,8 +2,11 @@ class Authentication < ApplicationRecord
   acts_as_miq_taggable
   include_concern 'ImportExport'
 
-  include YAMLImportExportMixin
   include NewWithTypeStiMixin
+  include OwnershipMixin
+  include PasswordMixin
+  include TenancyMixin
+  include YAMLImportExportMixin
 
   def self.new(*args, &block)
     if self == Authentication
@@ -13,7 +16,6 @@ class Authentication < ApplicationRecord
     end
   end
 
-  include PasswordMixin
   encrypt_column :auth_key
   encrypt_column :auth_key_password
   encrypt_column :become_password
@@ -37,9 +39,6 @@ class Authentication < ApplicationRecord
   after_update :after_authentication_changed
 
   serialize :options
-
-  include OwnershipMixin
-  include TenancyMixin
 
   belongs_to :tenant
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -33,6 +33,10 @@ class Authentication < ApplicationRecord
 
   has_many :configuration_script_sources
 
+  after_initialize do
+    @auth_changed = false
+  end
+
   before_save :set_credentials_changed_on
   after_save :after_authentication_changed
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -152,6 +152,8 @@ class Authentication < ApplicationRecord
   private
 
   def after_authentication_changed
+    return unless saved_change_to_userid? || saved_change_to_password? || saved_change_to_auth_key?
+
     _log.info("[#{resource_type}] [#{resource_id}], previously valid on: [#{last_valid_on}]")
 
     raise_event(:changed)

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -156,19 +156,19 @@ class Authentication < ApplicationRecord
   private
 
   def set_credentials_changed_on
-    return unless @auth_changed
+    return unless auth_changed
     self.credentials_changed_on = Time.now.utc
   end
 
   def after_authentication_changed
-    return unless @auth_changed
+    return unless auth_changed
     _log.info("[#{resource_type}] [#{resource_id}], previously valid on: [#{last_valid_on}]")
 
     raise_event(:changed)
 
     # Async validate the credentials
     resource.authentication_check_types_queue(authentication_type) if resource
-    @auth_changed = false
+    auth_changed = false
   end
 
   def event_prefix

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -151,10 +151,6 @@ class Authentication < ApplicationRecord
 
   private
 
-  def set_tenant_from_group
-    self.tenant_id = miq_group.tenant_id if miq_group
-  end
-
   def after_authentication_changed
     _log.info("[#{resource_type}] [#{resource_id}], previously valid on: [#{last_valid_on}]")
 

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -102,8 +102,9 @@ describe AuthenticationMixin do
     end
 
     it "should be triggered for kubernetes" do
-      auth = AuthToken.new(:name => "bearer", :auth_key => "valid-token")
-      FactoryBot.create(:ems_kubernetes, :authentications => [auth])
+      auths = FactoryBot.create_list(:auth_token, 1, :name => "bearer")
+      auths.first.auth_key = "valid_token" # Assign this afterwards to force an update callback
+      FactoryBot.create(:ems_kubernetes, :authentications => auths)
 
       expect(MiqQueue.count).to eq(2)
       expect(MiqQueue.find_by(:method_name => 'raise_evm_event')).not_to be_nil
@@ -111,8 +112,9 @@ describe AuthenticationMixin do
     end
 
     it "should be triggered for openshift" do
-      auth = AuthToken.new(:name => "bearer", :auth_key => "valid-token")
-      FactoryBot.create(:ems_openshift, :authentications => [auth])
+      auths = FactoryBot.create_list(:auth_token, 1)
+      auths.first.auth_key = "valid_token" # Assign this afterwards to force an update callback
+      FactoryBot.create(:ems_openshift, :authentications => auths)
 
       expect(MiqQueue.count).to eq(2)
       expect(MiqQueue.find_by(:method_name => 'raise_evm_event')).not_to be_nil


### PR DESCRIPTION
If you enable rspec warnings and run the specs you will see this:

`warning: instance variable @auth_changed not initialized`

This PR fixes that.

Update: some rather significant changes since the first pass, instead of using an accessor this PR instead now relies on update callbacks for specific fields, i.e. "The Rails Way".