### PR TITLE
[V2V] Lan validation in Transformation Mapping

### DIFF
--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -53,12 +53,6 @@ RSpec.describe TransformationMappingItem, :v2v do
   # Datastore Validation
   # ---------------------------------------------------------------------------
   context "datastore validation" do
-    let(:ems_vmware) { FactoryBot.create(:ems_vmware) }
-    let(:vmware_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
-
-    let(:ems_redhat) { FactoryBot.create(:ems_redhat) }
-    let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
-
     let(:ems_ops) { FactoryBot.create(:ems_openstack) }
     let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_ops) }
 
@@ -111,19 +105,13 @@ RSpec.describe TransformationMappingItem, :v2v do
   # Network Validation
   # ---------------------------------------------------------------------------
   context "Network validation" do
-    let(:ems_vmware) { FactoryBot.create(:ems_vmware) }
-    let(:vmware_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
-
-    let(:ems_redhat) { FactoryBot.create(:ems_redhat) }
-    let(:redhat_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems_redhat) }
-
     let(:ems_ops) { FactoryBot.create(:ems_openstack) }
     let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_ops) }
 
     # source network
     context "source vmware network" do
       let(:src_vmware_host) { FactoryBot.create(:host_vmware, :ems_cluster => vmware_cluster) }
-      let(:src_switch) { FactoryBot.create(:switch, :host => src_vmware_host) }
+      let(:src_switch) { FactoryBot.create(:switch, :hosts => [src_vmware_host]) }
       let(:src_lan) { FactoryBot.create(:lan, :switch => src_switch) }
 
       context "destination openstack" do
@@ -135,14 +123,6 @@ RSpec.describe TransformationMappingItem, :v2v do
         let(:valid_source) { FactoryBot.create(:transformation_mapping_item, :source => src_lan, :destination => dst_cloud_network, :transformation_mapping_id => ops_mapping.id) }
         let(:invalid_source) { FactoryBot.build(:transformation_mapping_item, :source => dst_cloud_network, :destination => src_lan, :transformation_mapping_id => ops_mapping.id) }
 
-        before do
-          src_switch.lans << [src_lan]
-          src_vmware_host.switches << [src_switch]
-          vmware_cluster.hosts << [src_vmware_host]
-
-          cloud_tenant.cloud_networks << [dst_cloud_network]
-        end
-
         it "valid source" do
           expect(valid_source.valid?).to be(true)
         end
@@ -153,7 +133,7 @@ RSpec.describe TransformationMappingItem, :v2v do
 
       context "destination red hat" do
         let(:dst_rh_host) { FactoryBot.create(:host_redhat, :ems_cluster => redhat_cluster) }
-        let(:dst_rh_switch) { FactoryBot.create(:switch, :host => dst_rh_host) }
+        let(:dst_rh_switch) { FactoryBot.create(:switch, :hosts => [dst_rh_host]) }
         let(:dst_rh_lan) { FactoryBot.create(:lan, :switch=> dst_rh_switch) }
 
         let(:tmi_cluster) { FactoryBot.create(:transformation_mapping_item, :source => vmware_cluster, :destination => redhat_cluster) }
@@ -163,16 +143,6 @@ RSpec.describe TransformationMappingItem, :v2v do
         context "source validation" do
           let(:valid_lan) { FactoryBot.create(:transformation_mapping_item, :source => src_lan, :destination => dst_rh_lan, :transformation_mapping_id => rh_mapping.id) }
           let(:invalid_lan) { FactoryBot.build(:transformation_mapping_item, :source => dst_rh_lan, :destination => src_lan, :transformation_mapping_id => rh_mapping.id) }
-
-          before do
-            src_switch.lans << [src_lan]
-            src_vmware_host.switches << [src_switch]
-            vmware_cluster.hosts << [src_vmware_host]
-
-            dst_rh_switch.lans << [dst_rh_lan]
-            dst_rh_host.switches << [dst_rh_switch]
-            redhat_cluster.hosts << [dst_rh_host]
-          end
 
           it "valid rhev lan" do
             expect(valid_lan.valid?).to be(true)

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -135,13 +135,13 @@ RSpec.describe TransformationMappingItem, :v2v do
         let(:valid_source) { FactoryBot.create(:transformation_mapping_item, :source => src_lan, :destination => dst_cloud_network, :transformation_mapping_id => ops_mapping.id) }
         let(:invalid_source) { FactoryBot.build(:transformation_mapping_item, :source => dst_cloud_network, :destination => src_lan, :transformation_mapping_id => ops_mapping.id) }
 
-          before do
-            src_switch.lans << [src_lan]
-            src_vmware_host.switches << [src_switch]
-            vmware_cluster.hosts << [src_vmware_host]
+        before do
+          src_switch.lans << [src_lan]
+          src_vmware_host.switches << [src_switch]
+          vmware_cluster.hosts << [src_vmware_host]
 
-            cloud_tenant.cloud_networks << [dst_cloud_network]
-          end
+          cloud_tenant.cloud_networks << [dst_cloud_network]
+        end
 
         it "valid source" do
           expect(valid_source.valid?).to be(true)

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -12,8 +12,11 @@ RSpec.describe TransformationMapping, :v2v do
   let(:src_storages_vmware) { FactoryBot.create_list(:storage, 1, :hosts => src_hosts_vmware) }
   let(:dst_storages_redhat) { FactoryBot.create_list(:storage, 1, :hosts => dst_hosts_redhat) }
 
-  let(:src_lan_vmware) { FactoryBot.create(:lan) }
-  let(:dst_lan_redhat) { FactoryBot.create(:lan) }
+  let(:src_switches_vmware) { FactoryBot.create_list(:switch, 1, :hosts => src_hosts_vmware) }
+  let(:dst_switches_redhat) { FactoryBot.create_list(:switch, 1, :hosts => dst_hosts_redhat) }
+
+  let(:src_lans_vmware) { FactoryBot.create_list(:lan, 1, :switch => src_switches_vmware.first) }
+  let(:dst_lans_redhat) { FactoryBot.create_list(:lan, 1, :switch => dst_switches_redhat.first) }
 
   let(:dst_cloud_tenant_openstack) { FactoryBot.create(:cloud_tenant, :ext_management_system => dst_ems_openstack) }
 
@@ -30,8 +33,8 @@ RSpec.describe TransformationMapping, :v2v do
         :transformation_mapping => tm
       )
       FactoryBot.create(:transformation_mapping_item,
-        :source                 => src_lan_vmware,
-        :destination            => dst_lan_redhat,
+        :source                 => src_lans_vmware.first,
+        :destination            => dst_lans_redhat.first,
         :transformation_mapping => tm
       )
     end
@@ -69,7 +72,7 @@ RSpec.describe TransformationMapping, :v2v do
   end
 
   context '#search_vms_and_validate' do
-    let(:nics) { FactoryBot.create_list(:guest_device_nic, 1, :lan => src_lan_vmware) }
+    let(:nics) { FactoryBot.create_list(:guest_device_nic, 1, :lan => src_lans_vmware.first) }
     let(:hardware) { FactoryBot.create(:hardware, :guest_devices => nics) }
 
     let!(:vm) do


### PR DESCRIPTION
This PR validates that the source and target networks (lans) are associated with the parent EmsCluster. 

**Target Lans**
**RHV:** Class Lan, Filters: Must belong to target cluster
**OSP:** Class CloudNetwork, Filters: Must belong to target CloudTenant's ExtManagementSystem

**Source Lans**
**VMW:** Class Lan, Filters: Must belong to one of the source clusters

https://trello.com/c/1x31IdD0/241-spike-mapping-and-plan-api-validation-of-input
https://bugzilla.redhat.com/show_bug.cgi?id=1713443