### PR TITLE
Fix inverse_of for DistributedVirtualSwitch

### DIFF
--- a/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/infra_manager/distributed_virtual_switch.rb
@@ -1,3 +1,3 @@
 class ManageIQ::Providers::InfraManager::DistributedVirtualSwitch < ::Switch
-  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :distributed_virtual_switch
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :distributed_virtual_switches, :class_name => "ManageIQ::Providers::InfraManager"
 end


### PR DESCRIPTION
This caused the graph refresh fail for ovirt.

required for: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/401