### PR TITLE
Remove an unreachable statement

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -360,7 +360,6 @@ class MiqWorker < ApplicationRecord
   def self.containerized_worker?
     # un-rearch containers until further notice
     return false
-    MiqEnvironment::Command.is_podified? && supports_container?
   end
 
   def containerized_worker?


### PR DESCRIPTION
This comments out a currently unreachable statement in `MiqWorker`. This is just to silence "statement not reached" warnings.