### PR TITLE
Update the button order on copy

### DIFF
--- a/app/models/custom_button_set.rb
+++ b/app/models/custom_button_set.rb
@@ -93,11 +93,15 @@ class CustomButtonSet < ApplicationRecord
       cbs.guid = SecureRandom.uuid
       cbs.name = "#{name}-#{cbs.guid}"
       cbs.set_data[:button_order] = []
+      cbs.set_data[:applies_to_id] = options[:owner].id
       cbs.save!
       custom_buttons.each do |cb|
         cb_copy = cb.copy(:applies_to => options[:owner])
         cbs.add_member(cb_copy)
+        options[:owner][:options][:button_order] ||= []
+        options[:owner][:options][:button_order] << "cb-#{cb_copy.id}"
         cbs.set_data[:button_order] << cb_copy.id
+        options[:owner].save!
         cbs.save!
       end
     end

--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -5,7 +5,7 @@ module ServiceTemplate::Copy
     if template_valid? && type != 'ServiceTemplateAnsiblePlaybook'
       ActiveRecord::Base.transaction do
         dup.tap do |template|
-          template.update_attributes(:name => new_name, :display => false)
+          template.update!(:name => new_name, :display => false, :options => {:button_order => []})
           service_resources.each { |service_resource| resource_copy(service_resource, template) }
           resource_action_copy(template)
           additional_tenant_copy(template)
@@ -26,11 +26,13 @@ module ServiceTemplate::Copy
   end
 
   def custom_button_copy(custom_button, template)
-    custom_button.copy(:applies_to => template)
+    new_cb = custom_button.copy(:applies_to => template)
+    template[:options][:button_order] << "cb-#{new_cb.id}"
   end
 
   def custom_button_set_copy(custom_button_set, template)
-    custom_button_set.deep_copy(:owner => template)
+    new_cbs = custom_button_set.deep_copy(:owner => template)
+    template[:options][:button_order] << "cbg-#{new_cbs.id}"
   end
 
   def picture_copy(template)

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -6,7 +6,7 @@ describe ServiceTemplate do
     let(:service_template)               { FactoryBot.create(:service_template) }
     let(:service_template_ansible_tower) { FactoryBot.create(:service_template_ansible_tower) }
     let(:service_template_orchestration) { FactoryBot.create(:service_template_orchestration) }
-    let(:set_data)                       { {:applies_to_class => "Service", :button_order => [custom_button.id]} }
+    let(:set_data)                       { {:applies_to_class => "Service", :button_order => [custom_button.id], :applies_to_id => service_template.id} }
 
     def copy_template(template, name = nil)
       copy = nil
@@ -42,17 +42,22 @@ describe ServiceTemplate do
       end
 
       it "with custom button set" do
+        service_template.update!(:options => {:button_order => ["cbg-#{custom_button_set.id}"]})
         custom_button_set.add_member(custom_button)
         expect(service_template.custom_button_sets.count).to eq(1)
         expect(service_template.custom_button_sets.first.custom_buttons.count).to eq(1)
         expect(service_template.custom_button_sets.first.set_data).to eq(set_data)
         expect(service_template.custom_button_sets.first.children).to eq([custom_button])
         new_service_template = copy_template(service_template, "new_template")
+        new_button_group = new_service_template.custom_button_sets.first
+        new_button = new_service_template.custom_button_sets.first.custom_buttons.first
         expect(new_service_template.custom_button_sets.count).to eq(1)
-        expect(new_service_template.custom_button_sets.first.set_data).not_to eq(set_data)
-        expect(new_service_template.custom_button_sets.first.custom_buttons.count).to eq(1)
-        expect(new_service_template.custom_button_sets.first.children).not_to eq([custom_button])
-        expect(new_service_template.custom_button_sets.first.children).to eq(new_service_template.custom_button_sets.first.custom_buttons)
+        expect(new_button_group.set_data).not_to eq(set_data)
+        expect(new_button_group.set_data[:applies_to_id]).not_to eq(service_template.custom_button_sets.first.set_data[:applies_to_id])
+        expect(new_button_group.custom_buttons.count).to eq(1)
+        expect(new_service_template[:options][:button_order]).to contain_exactly("cbg-#{new_button_group.id}", "cb-#{new_button.id}")
+        expect(new_button_group.children).not_to eq([custom_button])
+        expect(new_button_group.children).to eq(new_button_group.custom_buttons)
       end
 
       it "with non-copyable resource (configuration script base)" do


### PR DESCRIPTION
The service template copy should update the button order that stored in the options hash.

@h-kataria please review

Fixes the last remaining issue with https://bugzilla.redhat.com/show_bug.cgi?id=1740556