### PR TITLE
[HAMMER] log_backtrace won't print backtrace for MiqException errors

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -11,6 +11,6 @@ class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
 
   def self.raw_connect(base_url, username, password, verify_ssl)
     return super if MiqRegion.my_region.role_active?('embedded_ansible')
-    raise StandardError, 'Embedded ansible is disabled'
+    raise MiqException::Error, 'Embedded ansible is disabled'
   end
 end


### PR DESCRIPTION
See: https://github.com/ManageIQ/manageiq-gems-pending/blob/hammer/lib/gems/pending/util/vmdb-logger.rb#L106

This will still print as an ERROR level but the backtrace will not be printed to the log as this is a known
error condition where the backtrace is not needed.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1729166

Note, embedded ansible was converted to use runner starting in ivanchuk, therefore this is a hammer only change.

See: https://github.com/ManageIQ/manageiq/pull/18687