### PR TITLE
Add waiting_for_inventory_refresh state to InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -399,7 +399,7 @@ class InfraConversionJob < Job
       raise migration_task.options[:virtv2v_message]
     when 'succeeded'
       update_migration_task_progress(:on_exit)
-      queue_signal(:poll_automate_state_machine)
+      queue_signal(:poll_inventory_refresh_complete)
     end
   rescue StandardError => error
     update_migration_task_progress(:on_error)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -420,8 +420,9 @@ class InfraConversionJob < Job
     end
 
     migration_task.update!(:destination => destination_vm)
-    update_migration_task_progress(:on_exit)
+    migration_task.update_options(:migration_phase => 'post')
     handover_to_automate
+    update_migration_task_progress(:on_exit)
     queue_signal(:poll_automate_state_machine)
   rescue StandardError => error
     update_migration_task_progress(:on_error)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -948,7 +948,7 @@ RSpec.describe InfraConversionJob, :v2v do
           task.update_options(:virtv2v_status => 'succeeded')
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit).and_call_original
-          expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+          expect(job).to receive(:queue_signal).with(:poll_inventory_refresh_complete)
           job.signal(:poll_transform_vm_complete)
           expect(task.reload.options[:progress][:states][job.state.to_sym]).to include(:percent => 100.0)
         end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -982,8 +982,9 @@ RSpec.describe InfraConversionJob, :v2v do
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit).and_call_original
           expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
           job.signal(:poll_inventory_refresh_complete)
-          expect(job.migration_task.destination.id).to eq(vm_redhat.id)
-          expect(task.reload.options[:workflow_runner]).to eq('automate')
+          expect(task.reload.destination.id).to eq(vm_redhat.id)
+          expect(task.options[:migration_phase]).to eq('post')
+          expect(task.options[:workflow_runner]).to eq('automate')
         end
       end
     end


### PR DESCRIPTION
For IMS 1.3 we're moving state machine handling from automate into core. For ease of writing and review, we're breaking this down into (hopefully) easily digestible bits, one state at a time. Each PR will ultimately have a corresponding PR in manageiq-content that deletes the relevant bit of code from automate.

Original automate code:
https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/checkvmininventory.rb

This PR adds waiting_for_inventory_refresh state to the state machine. The state machine is changed to allow transition from transforming_vm.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1747338
Depends on #19149, #19150, #19154, #19177, #19200, #19216, #19222