### PR TITLE
Update :placeholders share example

### DIFF
--- a/spec/shared/i18n/placeholders.rb
+++ b/spec/shared/i18n/placeholders.rb
@@ -1,22 +1,35 @@
 shared_examples :placeholders do |dir|
   it "translations preserve placeholders in strings" do
     errors = {}
+    false_negatives = {}
+    incorrect_plurals = []
 
     Pathname.glob(File.join(dir, "**", "*.po")).each do |po_file|
       po = FastGettext::PoFile.new(po_file)
       locale = po_file.dirname.basename.to_s
+      false_negatives[po_file.to_s] = []
       next if locale == 'en' # There's no need to test english .po
+
       po.data.each do |original, translation|
-        next if translation.nil?
-        # Chinese translations do not have plural forms
-        original = original.split("\u0000").first if locale == 'zh_CN' && original.present?
-        placeholders = original.scan(/%{\w+}/)
-        placeholders.sort!
-        next if placeholders.empty?
-        translated_placeholders = translation.scan(/%{\w+}/)
-        translated_placeholders.sort!
-        if placeholders.uniq != translated_placeholders.uniq
-          errors.store_path(po_file.to_s, original, translation)
+        next if translation.nil? || !original.include?("%{") # Skip if string is not translated or original does not contain %{}
+
+        if %w[ja zh_CN].include?(locale) && original.include?("\u0000") # Chinese and Japanese translations do not have plural forms
+          if translation.include?("\u0000") # there should be only one translated form
+            incorrect_plurals << translation
+            next
+          end
+          singular, plural = original.split("\u0000").map { |str| str.scan(/%{\w+}/).sort.uniq }
+          translated_placeholders = translation.scan(/%{\w+}/).sort!.uniq
+          if singular != translated_placeholders && plural != translated_placeholders
+            errors.store_path(po_file.to_s, original, translation)
+          end
+          false_negatives[po_file.to_s].append(original.split("\u0000").first)
+        else
+          origin = original.scan(/%{\w+}/).sort.uniq
+          transl = translation.scan(/%{\w+}/).sort.uniq
+          if origin != transl && !false_negatives[po_file.to_s].include?(original)
+            errors.store_path(po_file.to_s, original, translation)
+          end
         end
       end
     end
@@ -31,6 +44,7 @@ shared_examples :placeholders do |dir|
       end
     end
     expect(errors).to be_empty
+    expect(incorrect_plurals).to be_empty
   end
 
   it "gettext strings do not contain interpolations" do
@@ -38,6 +52,7 @@ shared_examples :placeholders do |dir|
     Pathname.glob(File.join(dir, "**", "*.pot")).each do |pot_file|
       File.open(pot_file).each do |line|
         next unless line =~ /^.*(".*\#\{[.\w]+\}.*")$/
+
         errors.push($1)
       end
     end


### PR DESCRIPTION
Previously, we mistakenly assumed that in languages which do not use plurals, the translation would always contain placeholders matching the English singular form. For example:
```ruby
n_("%{action} initiated for %{count} %{model} from the %{product} Database",
   "%{action} initiated for %{count} %{models} from the %{product} Database", n)
```
can be translated as
```
%{product} データベースから %{count} %{models} に対する %{action} が実行されました
```
i.e. the `%{}` identifiers would match the English plural form. We need to reflect that in the tests.

Also, for languages, which do not use plurals, we'll be watching for mistakenly added plural forms

@miq-bot add_label test, ivanchuk/yes, internationalization
