### PR TITLE
Do not  attempt to calculate backlog unless subscription status is "replicating"

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -100,10 +100,16 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def backlog
-    connection.xlog_location_diff(remote_region_lsn, subscription_attributes["remote_replication_lsn"])
-  rescue PG::Error => e
-    _log.error(e.message)
-    nil
+    if status != "replicating"
+      _log.error("Is `#{dbname}` running on host `#{host}` and accepting TCP/IP connections on port #{port} ?")
+      return nil
+    end
+    begin
+      connection.xlog_location_diff(remote_region_lsn, subscription_attributes["remote_replication_lsn"])
+    rescue PG::Error => e
+      _log.error(e.message)
+      nil
+    end
   end
 
   def sync_tables

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -468,6 +468,13 @@ describe PglogicalSubscription do
 
       expect(described_class.first.backlog).to be nil
     end
+
+    it 'does not attempt to calculate backlog and returns nil unless subscription status is "replicating"' do
+      allow(described_class).to receive(:subscription_status).and_return("down")
+
+      expect(remote_connection).not_to receive(:xlog_location)
+      expect(described_class.first.backlog).to be nil
+    end
   end
 
   private


### PR DESCRIPTION
**ISSUE:** There are some situation when invoking ```PglogicalSubscription#backlog``` causing UI screen to timeout

**FIX:** Do not attempt to calculate backlog unless subscription status is "replicating"
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1741240

@miq-bot add-label bug, core, changelog/yes, ivanchuk/yes