### PR TITLE
Make destroying guest_devices faster

### DIFF
--- a/tools/cleanup_duplicate_host_guest_devices.rb
+++ b/tools/cleanup_duplicate_host_guest_devices.rb
@@ -6,6 +6,7 @@ opts = Optimist.options do
   opt :ems_id, "The ID of the ExtManagementSystem to reconnect VMs for", :type => :integer
   opt :ems_name, "The name of the ExtManagementSystem to reconnect VMs for", :type => :string
   opt :dry_run, "Just print out what would be done without modifying anything", :type => :boolean, :default => true
+  opt :page_size, "How many records to delete at a time", :type => :integer, :default => 100
 end
 
 if opts[:ems_id].nil? && opts[:ems_name].nil?
@@ -45,6 +46,28 @@ end
 
 return if opts[:dry_run]
 
-GuestDevice.destroy(guest_devices_to_delete) unless opts[:dry_run]
+associations = %i[has_one has_many].flat_map { |assoc| GuestDevice.reflect_on_all_associations(assoc) }
+dependents   = associations.select { |assoc| assoc.options[:dependent].present? }
+
+total_slices = (guest_devices_to_delete.count / opts[:page_size].to_f).ceil
+guest_devices_to_delete.each_slice(opts[:page_size]).with_index do |slice, index|
+  puts "Destroying slice #{index + 1} of #{total_slices}..."
+  GuestDevice.delete(slice)
+
+  dependents.each do |assoc|
+    delete_meth = assoc.options[:dependent]
+    foreign_key = assoc.join_keys.key
+
+    if %i[delete destroy].include?(delete_meth)
+      assoc.klass.where(foreign_key => slice).send("#{delete_meth}_all")
+    elsif delete_meth == :nullify
+      assoc.klass.where(foreign_key => slice).update_all(foreign_key => nil)
+    else
+      assoc.klass.where(foreign_key => slice).each(&delete_meth)
+    end
+  end
+
+  puts "Destroying slice #{index + 1} of #{total_slices}...Complete"
+end
 
 puts "Destroyed #{guest_devices_to_delete.count} duplicate Guest Devices"


### PR DESCRIPTION
GuestDevice.destroy() was extremely slow, and was doing an extra:
```
[----] D, [2019-08-30T15:59:25.111041 #6727:2ad6e77ec5b4] DEBUG -- :    (380.0ms)  SELECT "guest_devices"."id" FROM "guest_devices"
```

which was taking forever.

Switching to .delete and manually dependent destroying the guest_device
dependent records was much faster.

https://bugzilla.redhat.com/show_bug.cgi?id=1746600