### PR TITLE
Workflow cloud_tenant fix

### DIFF
--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -340,7 +340,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
     end
 
     # Only select the colums we need
-    vms = vms.select(:id, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
+    vms = vms.select(:id, :type, :name, :guid, :uid_ems, :ems_id, :cloud_tenant_id)
 
     allowed_templates_list = source_vm_rbac_filter(vms, condition, VM_OR_TEMPLATE_EXTRA_COLS).to_a
     @allowed_templates_filter = filter_id


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746931
Introduced https://github.com/ManageIQ/manageiq/pull/18353

This did not bring back the `type` column so all classes were `VmOrType`.
Since the `cloud_tenant` method is introduced in a subclass, it was missing.
Now that we are instantiating the correct class (with help from `type`) all is well.

```
[----] F, [2019-08-29T09:40:01.670066 #3373:2adf69a8c12c] FATAL -- : Error caught:
[NoMethodError] undefined method `cloud_tenant' for #<VmOrTemplate:0x000055bee25ff310>
Did you mean?  cloud_tenant_id
gems/activemodel-5.1.7/lib/active_model/attribute_methods.rb:432:in `method_missing'
app/models/miq_provision_virt_workflow.rb:1049:in `create_hash_struct_from_vm_or_template'
```
