### PR TITLE
[V2V] Add applying_right_sizing state to InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -444,15 +444,15 @@ class InfraConversionJob < Job
   def apply_right_sizing
     update_migration_task_progress(:on_entry)
 
-    %i(cpu memory).each do |item|
+    %i[cpu memory].each do |item|
       right_sizing_mode = migration_task.send("#{item}_right_sizing_mode")
       send("apply_right_sizing_#{item}", right_sizing_mode) if right_sizing_mode.present?
     end
-    
+
     update_migration_task_progress(:on_exit)
     handover_to_automate
     queue_signal(:poll_automate_state_machine)
-  rescue StandardError => error
+  rescue StandardError
     update_migration_task_progress(:on_error)
     queue_signal(:poll_automate_state_machine)
   end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -454,6 +454,7 @@ class InfraConversionJob < Job
     queue_signal(:poll_automate_state_machine)
   rescue StandardError
     update_migration_task_progress(:on_error)
+    handover_to_automate
     queue_signal(:poll_automate_state_machine)
   end
 

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -32,6 +32,8 @@ module ServiceTemplateTransformationPlan::ValidateConfigInfo
           vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
           vm_options[:osp_security_group_id] = vm_hash[:osp_security_group_id] if vm_hash[:osp_security_group_id].present?
           vm_options[:osp_flavor_id] = vm_hash[:osp_flavor_id] if vm_hash[:osp_flavor_id].present?
+          vm_options[:cpu_right_sizing_mode] = vm_hash[:cpu_right_sizing_mode] if vm_hash[:cpu_right_sizing_mode].present?
+          vm_options[:memory_right_sizing_mode] = vm_hash[:memory_right_sizing_mode] if vm_hash[:memory_right_sizing_mode].present?
           vms << {:vm => vm_obj, :options => vm_options}
         end
       end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -31,6 +31,14 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     ServiceTemplate.find_by(:id => vm_resource.options["post_ansible_playbook_service_template_id"])
   end
 
+  def cpu_right_sizing_mode
+    vm_resource.options["cpu_right_sizing_mode"]
+  end
+
+  def memory_right_sizing_mode
+    vm_resource.options["memory_right_sizing_mode"]
+  end
+
   def update_transformation_progress(progress)
     update_options(:progress => (options[:progress] || {}).merge(progress))
   end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete poll_automate_state_machine finish abort_job cancel error].each do |signal|
+    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -358,7 +358,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete poll_automate_state_machine].each do |signal|
+    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing poll_automate_state_machine].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -540,6 +540,29 @@ RSpec.describe InfraConversionJob, :v2v do
       end
 
       it_behaves_like 'allows poll_inventory_refresh_complete signal'
+      it_behaves_like 'allows apply_right_sizing signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'doesn\'t allow start signal'
+      it_behaves_like 'doesn\'t allow remove_snapshots signal'
+      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
+      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
+      it_behaves_like 'doesn\'t allow run_migration_playbook signal'
+      it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
+      it_behaves_like 'doesn\'t allow shutdown_vm signal'
+      it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
+      it_behaves_like 'doesn\'t allow transform_vm signal'
+      it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
+    end
+
+    context 'applying_right_sizing' do
+      before do
+        job.state = 'applying_right_sizing'
+      end
+
       it_behaves_like 'allows poll_automate_state_machine signal'
       it_behaves_like 'allows finish signal'
       it_behaves_like 'allows abort_job signal'
@@ -556,6 +579,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
       it_behaves_like 'doesn\'t allow transform_vm signal'
       it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
+      it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
+      it_behaves_like 'doesn\'t allow apply_right_sizing signal'
     end
 
     context 'running_in_automate' do
@@ -580,6 +605,7 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow transform_vm signal'
       it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
+      it_behaves_like 'doesn\'t allow apply_right_sizing signal'
     end
   end
 
@@ -954,37 +980,77 @@ RSpec.describe InfraConversionJob, :v2v do
         end
       end
     end
+  end
 
-    context '#poll_inventory_refresh_complete' do
-      before do
-        job.state = 'waiting_for_inventory_refresh'
-      end
+  context '#poll_inventory_refresh_complete' do
+    before do
+      job.state = 'waiting_for_inventory_refresh'
+    end
 
-      it 'abort_conversion when waiting_for_inventory_refresh times out' do
-        job.context[:retries_waiting_for_inventory_refresh] = 240
-        expect(job).to receive(:abort_conversion).with('Identify destination VM timed out', 'error')
+    it 'abort_conversion when waiting_for_inventory_refresh times out' do
+      job.context[:retries_waiting_for_inventory_refresh] = 240
+      expect(job).to receive(:abort_conversion).with('Identify destination VM timed out', 'error')
+      job.signal(:poll_inventory_refresh_complete)
+    end
+
+    it 'retry when destination VM is not in the inventory' do
+      Timecop.freeze(2019, 2, 6) do
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+        expect(job).to receive(:queue_signal).with(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
         job.signal(:poll_inventory_refresh_complete)
       end
+    end
 
-      it 'retry when destination VM is not in the inventory' do
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
-          expect(job).to receive(:queue_signal).with(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
-          job.signal(:poll_inventory_refresh_complete)
-        end
+    it 'to finish when migration_task.state is finished' do
+      allow(Vm).to receive(:find_by).with(:name => task.source.name, :ems_id => task.destination_ems.id).and_return(vm_redhat)
+      Timecop.freeze(2019, 2, 6) do
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit).and_call_original
+        expect(job).to receive(:queue_signal).with(:apply_right_sizing)
+        job.signal(:poll_inventory_refresh_complete)
+        expect(job.migration_task.destination.id).to eq(vm_redhat.id)
+      end
+    end
+  end
+
+  context '#apply_right_sizing' do
+    before do
+      job.state = 'waiting_for_inventory_refresh'
+      task.update!(:destination => vm_redhat)
+    end
+
+    context 'without right_sizing mode' do
+      before do
+        allow(job.migration_task).to receive(:cpu_right_sizing_mode).and_return(nil)
+        allow(job.migration_task).to receive(:memory_right_sizing_mode).and_return(nil)
       end
 
-      it 'to finish when migration_task.state is finished' do
-        allow(Vm).to receive(:find_by).with(:name => task.source.name, :ems_id => task.destination_ems.id).and_return(vm_redhat)
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit).and_call_original
-          expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
-          job.signal(:poll_inventory_refresh_complete)
-          expect(job.migration_task.destination.id).to eq(vm_redhat.id)
-          expect(task.reload.options[:workflow_runner]).to eq('automate')
-        end
+      it 'exits if no right-sizing is requested' do
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+        job.signal(:apply_right_sizing)
+        expect(task.reload.options[:workflow_runner]).to eq('automate')
+      end
+    end
+
+    context 'with right_sizing_mode' do
+      before do
+        allow(job.migration_task).to receive(:cpu_right_sizing_mode).and_return(:aggressive)
+        allow(job.migration_task).to receive(:memory_right_sizing_mode).and_return(:conservative)
+        allow(job.migration_task.source).to receive(:aggressive_recommended_vcpus).and_return(1)
+        allow(job.migration_task.source).to receive(:conservative_recommended_mem).and_return(1024)
+      end
+
+      it 'applies right-sizing if mode is set' do
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job.migration_task.destination).to receive(:set_number_of_cpus).with(1)
+        expect(job.migration_task.destination).to receive(:set_memory).with(1024)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+        job.signal(:apply_right_sizing)
+        expect(task.reload.options[:workflow_runner]).to eq('automate')
       end
     end
   end


### PR DESCRIPTION
For IMS 1.3 we're moving state machine handling from automate into core. For ease of writing and review, we're breaking this down into (hopefully) easily digestible bits, one state at a time. Each PR will ultimately have a corresponding PR in manageiq-content that deletes the relevant bit of code from automate.

Original automate code:
https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/applyrightsize.rb

This PR adds applying_right_sizing state to the state machine. The state machine is changed to allow transition from waiting_for_inventory_refresh.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1747927
Depends on #19149, #19150, #19154, #19177, #19200, #19216, #19222, #19230
Built on #19230