### PR TITLE
Let `pxe_menu.pxe_images` use correct subclass

### DIFF
--- a/app/models/pxe_menu_ipxe.rb
+++ b/app/models/pxe_menu_ipxe.rb
@@ -1,4 +1,10 @@
 class PxeMenuIpxe < PxeMenu
+  has_many :pxe_images,
+           :class_name  => "PxeImageIpxe",
+           :foreign_key => :pxe_menu_id,
+           :dependent   => :destroy,
+           :inverse_of  => :pxe_menu
+
   def self.parse_contents(contents)
     menu_items = parse_menu(contents)
     entries = parse_labels(contents, menu_items.keys)

--- a/app/models/pxe_menu_pxelinux.rb
+++ b/app/models/pxe_menu_pxelinux.rb
@@ -1,4 +1,10 @@
 class PxeMenuPxelinux < PxeMenu
+  has_many :pxe_images,
+           :class_name  => "PxeImagePxelinux",
+           :foreign_key => :pxe_menu_id,
+           :dependent   => :destroy,
+           :inverse_of  => :pxe_menu
+
   def self.parse_contents(contents)
     items = []
     current_item = nil

--- a/spec/models/pxe_menu_spec.rb
+++ b/spec/models/pxe_menu_spec.rb
@@ -132,34 +132,52 @@ PXEMENU
   context "#synchronize" do
     before do
       @pxe_server = FactoryBot.create(:pxe_server)
-      allow(@pxe_server).to receive_messages(:read_file => @contents_ipxe)
     end
 
-    it "on typed menu" do
-      pxe_menu = FactoryBot.create(:pxe_menu_ipxe, :pxe_server => @pxe_server)
-      pxe_menu.synchronize
+    context "ipxe" do
+      before { allow(@pxe_server).to receive_messages(:read_file => @contents_ipxe) }
 
-      new_pxe_menu = PxeMenu.find(pxe_menu.id)
-      expect(new_pxe_menu).to be_kind_of(PxeMenuIpxe)
-      expect(new_pxe_menu.pxe_images.length).to eq(3)
+      it "on typed menu" do
+        pxe_menu = FactoryBot.create(:pxe_menu_ipxe, :pxe_server => @pxe_server)
+        pxe_menu.synchronize
+
+        new_pxe_menu = PxeMenu.find(pxe_menu.id)
+        expect(new_pxe_menu).to be_kind_of(PxeMenuIpxe)
+        expect(new_pxe_menu.pxe_images.length).to eq(3)
+        expect(new_pxe_menu.pxe_images.first.type).to eq('PxeImageIpxe')
+      end
+
+      it "on untyped menu" do
+        pxe_menu = FactoryBot.create(:pxe_menu, :pxe_server => @pxe_server)
+        pxe_menu.synchronize
+
+        new_pxe_menu = PxeMenu.find(pxe_menu.id)
+        expect(new_pxe_menu).to be_kind_of(PxeMenuIpxe)
+        expect(new_pxe_menu.pxe_images.length).to eq(3)
+      end
+
+      it "on typed menu switching to a different type" do
+        pxe_menu = FactoryBot.create(:pxe_menu_pxelinux, :contents => @contents_pxelinux, :pxe_server => @pxe_server)
+        pxe_menu.synchronize
+
+        new_pxe_menu = PxeMenu.find(pxe_menu.id)
+        expect(new_pxe_menu).to be_kind_of(PxeMenuIpxe)
+        expect(new_pxe_menu.pxe_images.length).to eq(3)
+      end
     end
 
-    it "on untyped menu" do
-      pxe_menu = FactoryBot.create(:pxe_menu, :pxe_server => @pxe_server)
-      pxe_menu.synchronize
+    context "pxelinux" do
+      before { allow(@pxe_server).to receive_messages(:read_file => @contents_pxelinux) }
 
-      new_pxe_menu = PxeMenu.find(pxe_menu.id)
-      expect(new_pxe_menu).to be_kind_of(PxeMenuIpxe)
-      expect(new_pxe_menu.pxe_images.length).to eq(3)
-    end
+      it "on typed menu" do
+        pxe_menu = FactoryBot.create(:pxe_menu_pxelinux, :pxe_server => @pxe_server)
+        pxe_menu.synchronize
 
-    it "on typed menu switching to a different type" do
-      pxe_menu = FactoryBot.create(:pxe_menu_pxelinux, :contents => @contents_pxelinux, :pxe_server => @pxe_server)
-      pxe_menu.synchronize
-
-      new_pxe_menu = PxeMenu.find(pxe_menu.id)
-      expect(new_pxe_menu).to be_kind_of(PxeMenuIpxe)
-      expect(new_pxe_menu.pxe_images.length).to eq(3)
+        new_pxe_menu = PxeMenu.find(pxe_menu.id)
+        expect(new_pxe_menu).to be_kind_of(PxeMenuPxelinux)
+        expect(new_pxe_menu.pxe_images.length).to eq(10)
+        expect(new_pxe_menu.pxe_images.first.type).to eq('PxeImagePxelinux')
+      end
     end
   end
 


### PR DESCRIPTION
With recent update we moved the `has_many` relation from child classes (PxeMenuIpxe, PxeMenuPxelinux) to the base class (PxeMenu). But it doesn't fully work as intended because in the inventorying code we do something like:

```
menu.pxe_images.build(...)
```

So currently we are never populating the `type` field of the pxe_images, hence STI won't work, hence some strange "methods undefined" errors would appear as described in the BZ.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1748035
Caused by https://github.com/ManageIQ/manageiq/pull/19126

@miq-bot add_label bug, ivanchuk/yes
@miq-bot assign @agrare 
