### PR TITLE
[V2V] Add powering_on_vm state to InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -497,10 +497,10 @@ class InfraConversionJob < Job
     destination_vm.save
 
     update_migration_task_progress(:on_exit)
-    queue_signal(:poll_automate_state_machine)
+    queue_signal(:power_on_vm)
   rescue StandardError
     update_migration_task_progress(:on_error)
-    queue_signal(:poll_automate_state_machine)
+    queue_signal(:power_on_vm)
   end
 
   def power_on_vm

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -138,7 +138,7 @@ class InfraConversionJob < Job
   end
 
   def target_vm
-    return @target_vm = source_vm if migration_phase == 'pre'
+    return @target_vm = source_vm if migration_phase == 'pre' || migration_task.canceling?
     return @target_vm = destination_vm if migration_phase == 'post'
   end
 
@@ -505,7 +505,8 @@ class InfraConversionJob < Job
 
   def power_on_vm
     update_migration_task_progress(:on_entry)
-    unless target_vm.power_state == 'on'
+
+    unless target_vm.power_state == 'on' || migration_task.options[:source_vm_power_state] != 'on'
       target_vm.start
       update_migration_task_progress(:on_exit)
       return queue_signal(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -49,8 +49,8 @@ class InfraConversionJob < Job
       :power_on_vm                          => {'restoring_vm_attributes' => 'powering_on_vm' },
       :poll_power_on_vm_complete            => {'powering_on_vm' => 'powering_on_vm'},
       :poll_automate_state_machine          => {
-        'powering_on_vm'          => 'running_in_automate',
-        'running_in_automate'     => 'running_in_automate'
+        'powering_on_vm'      => 'running_in_automate',
+        'running_in_automate' => 'running_in_automate'
       },
       :finish                               => {'*'                => 'finished'},
       :abort_job                            => {'*'                => 'aborting'},
@@ -514,7 +514,7 @@ class InfraConversionJob < Job
     update_migration_task_progress(:on_exit)
     handover_to_automate
     queue_signal(:poll_automate_state_machine)
-  rescue StandardError => error
+  rescue StandardError
     update_migration_task_progress(:on_error)
     handover_to_automate
     queue_signal(:poll_automate_state_machine)
@@ -532,7 +532,7 @@ class InfraConversionJob < Job
 
     update_migration_task_progress(:on_retry)
     queue_signal(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
-  rescue StandardError => error
+  rescue StandardError
     update_migration_task_progress(:on_error)
     handover_to_automate
     queue_signal(:poll_automate_state_machine)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -46,8 +46,10 @@ class InfraConversionJob < Job
       },
       :apply_right_sizing                   => {'waiting_for_inventory_refresh' => 'applying_right_sizing'},
       :restore_vm_attributes                => {'applying_right_sizing' => 'restoring_vm_attributes'},
+      :power_on_vm                          => {'restoring_vm_attributes' => 'powering_on_vm' },
+      :poll_power_on_vm_complete            => {'powering_on_vm' => 'powering_on_vm'},
       :poll_automate_state_machine          => {
-        'restoring_vm_attributes' => 'running_in_automate',
+        'powering_on_vm'          => 'running_in_automate',
         'running_in_automate'     => 'running_in_automate'
       },
       :finish                               => {'*'                => 'finished'},
@@ -102,6 +104,11 @@ class InfraConversionJob < Job
       :restoring_vm_attributes       => {
         :description => "Restore VM Attributes",
         :weight      => 1
+      },
+      :powering_on_vm                => {
+        :description => "Power on virtual machine",
+        :weight      => 1,
+        :max_retries => 15.minutes / state_retry_interval
       },
       :running_in_automate           => {
         :max_retries => 36.hours / state_retry_interval
@@ -490,9 +497,42 @@ class InfraConversionJob < Job
     destination_vm.save
 
     update_migration_task_progress(:on_exit)
-    handover_to_automate
     queue_signal(:poll_automate_state_machine)
   rescue StandardError
+    update_migration_task_progress(:on_error)
+    queue_signal(:poll_automate_state_machine)
+  end
+
+  def power_on_vm
+    update_migration_task_progress(:on_entry)
+    unless target_vm.power_state == 'on'
+      target_vm.start
+      update_migration_task_progress(:on_exit)
+      return queue_signal(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
+    end
+
+    update_migration_task_progress(:on_exit)
+    handover_to_automate
+    queue_signal(:poll_automate_state_machine)
+  rescue StandardError => error
+    update_migration_task_progress(:on_error)
+    handover_to_automate
+    queue_signal(:poll_automate_state_machine)
+  end
+
+  def poll_power_on_vm_complete
+    update_migration_task_progress(:on_entry)
+    return abort_conversion('Powering on VM timed out', 'error') if polling_timeout
+
+    if target_vm.power_state == 'on'
+      update_migration_task_progress(:on_exit)
+      handover_to_automate
+      return queue_signal(:poll_automate_state_machine)
+    end
+
+    update_migration_task_progress(:on_retry)
+    queue_signal(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
+  rescue StandardError => error
     update_migration_task_progress(:on_error)
     handover_to_automate
     queue_signal(:poll_automate_state_machine)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -506,7 +506,7 @@ class InfraConversionJob < Job
   def power_on_vm
     update_migration_task_progress(:on_entry)
 
-    unless target_vm.power_state == 'on' || migration_task.options[:source_vm_power_state] != 'on'
+    if migration_task.options[:source_vm_power_state] == 'on' && target_vm.power_state != 'on'
       target_vm.start
       update_migration_task_progress(:on_exit)
       return queue_signal(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -523,7 +523,7 @@ class InfraConversionJob < Job
 
   def poll_power_on_vm_complete
     update_migration_task_progress(:on_entry)
-    return abort_conversion('Powering on VM timed out', 'error') if polling_timeout
+    raise 'Powering on VM timed out' if polling_timeout
 
     if target_vm.power_state == 'on'
       update_migration_task_progress(:on_exit)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1172,7 +1172,7 @@ RSpec.describe InfraConversionJob, :v2v do
       allow(job.migration_task.source).to receive(:service).and_raise('Fake error message')
       expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
       expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_error)
-      expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+      expect(job).to receive(:queue_signal).with(:power_on_vm)
       job.signal(:restore_vm_attributes)
     end
 
@@ -1186,7 +1186,7 @@ RSpec.describe InfraConversionJob, :v2v do
         vm_vmware.update!(:retirement_warn => 7)
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-        expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+        expect(job).to receive(:queue_signal).with(:power_on_vm)
         job.signal(:restore_vm_attributes)
         vm_redhat.reload
         expect(vm_vmware.service).to be_nil

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1201,7 +1201,7 @@ RSpec.describe InfraConversionJob, :v2v do
     end
   end
 
-  context '#shutdown_vm' do
+  context '#power_on_vm' do
     before do
       job.state = 'restoring_vm_attributes'
       task.update_options(:migration_phase => 'post')
@@ -1229,7 +1229,7 @@ RSpec.describe InfraConversionJob, :v2v do
     end
   end
 
-  context '#poll_shutdown_vm_complete' do
+  context '#poll_power_on_vm_complete' do
     before do
       job.state = 'powering_on_vm'
       task.update_options(:migration_phase => 'post')

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes poll_automate_state_machine finish abort_job cancel error].each do |signal|
+    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -361,7 +361,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes poll_automate_state_machine].each do |signal|
+    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete poll_automate_state_machine].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -392,6 +392,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -418,6 +420,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -444,6 +448,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -470,6 +476,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -496,6 +504,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -522,6 +532,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -548,6 +560,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow transform_vm signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
@@ -574,6 +588,9 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow transform_vm signal'
       it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
+      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
     context 'applying_right_sizing' do
@@ -599,6 +616,9 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
+      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
     end
 
     context 'restoring_vm_attributes' do
@@ -606,6 +626,35 @@ RSpec.describe InfraConversionJob, :v2v do
         job.state = 'restoring_vm_attributes'
       end
 
+      it_behaves_like 'allows power_on_vm signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'doesn\'t allow start signal'
+      it_behaves_like 'doesn\'t allow remove_snapshots signal'
+      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
+      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
+      it_behaves_like 'doesn\'t allow run_migration_playbook signal'
+      it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
+      it_behaves_like 'doesn\'t allow shutdown_vm signal'
+      it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
+      it_behaves_like 'doesn\'t allow transform_vm signal'
+      it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
+      it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
+      it_behaves_like 'doesn\'t allow apply_right_sizing signal'
+      it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
+      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
+    end
+
+    context 'powering_on_vm' do
+      before do
+        job.state = 'powering_on_vm'
+      end
+
+      it_behaves_like 'allows poll_power_on_vm_complete signal'
       it_behaves_like 'allows poll_automate_state_machine signal'
       it_behaves_like 'allows finish signal'
       it_behaves_like 'allows abort_job signal'
@@ -625,6 +674,7 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
     end
 
     context 'running_in_automate' do
@@ -651,6 +701,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
     end
   end
 
@@ -1122,7 +1174,6 @@ RSpec.describe InfraConversionJob, :v2v do
       expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_error)
       expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
       job.signal(:restore_vm_attributes)
-      expect(task.reload.options[:workflow_runner]).to eq('automate')
     end
 
     it 'restore VM attributes' do
@@ -1146,8 +1197,68 @@ RSpec.describe InfraConversionJob, :v2v do
         expect(vm_redhat.miq_group.id).to eq(group.id)
         expect(vm_redhat.retires_on).to eq(Time.now.utc + 1.day)
         expect(vm_redhat.retirement_warn).to eq(7)
-        expect(task.reload.options[:workflow_runner]).to eq('automate')
       end
+    end
+  end
+
+  context '#shutdown_vm' do
+    before do
+      job.state = 'restoring_vm_attributes'
+      task.update_options(:migration_phase => 'post')
+      task.update!(:destination => vm_redhat)
+    end
+
+    it 'exits if VM is already on' do
+      vm_redhat.update!(:raw_power_state => 'poweredOn')
+      expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+      expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+      expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+      job.signal(:power_on_vm)
+      expect(task.reload.options[:workflow_runner]).to eq('automate')
+    end
+
+    it 'sends start request to VM if VM is off' do
+      vm_redhat.update!(:raw_power_state => 'poweredOff')
+      Timecop.freeze(2019, 2, 6) do
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job.migration_task.destination).to receive(:start)
+        expect(job).to receive(:queue_signal).with(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+        job.signal(:power_on_vm)
+      end
+    end
+  end
+
+  context '#poll_shutdown_vm_complete' do
+    before do
+      job.state = 'powering_on_vm'
+      task.update_options(:migration_phase => 'post')
+      task.update!(:destination => vm_redhat)
+    end
+
+    it 'abort_conversion when powering_on_vm times out' do
+      job.context[:retries_powering_on_vm] = 60
+      expect(job).to receive(:abort_conversion).with('Powering on VM timed out', 'error')
+      job.signal(:poll_power_on_vm_complete)
+    end
+
+    it 'retries if VM is not on' do
+      vm_redhat.update!(:raw_power_state => 'poweredOff')
+      Timecop.freeze(2019, 2, 6) do
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+        expect(job).to receive(:queue_signal).with(:poll_power_on_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+        job.signal(:poll_power_on_vm_complete)
+      end
+    end
+
+    it 'exits if VM is on' do
+      vm_redhat.update!(:raw_power_state => 'poweredOn')
+      expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+      expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+      expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+      job.signal(:poll_power_on_vm_complete)
+      expect(task.reload.options[:workflow_runner]).to eq('automate')
     end
   end
 


### PR DESCRIPTION
For IMS 1.3 we're moving state machine handling from automate into core. For ease of writing and review, we're breaking this down into (hopefully) easily digestible bits, one state at a time. Each PR will ultimately have a corresponding PR in manageiq-content that deletes the relevant bit of code from automate.

Original automate code:

- https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/poweron.rb
- https://github.com/ManageIQ/manageiq-content/blob/master/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/checkpoweredon.rb

This PR adds powering_on_vm state to the state machine. The state machine is changed to allow transition from restoring_vm_attributes.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1748100
Depends on #19149, #19150, #19154, #19177, #19200, #19216, #19222, #19230, #19238, #19240
Built on #19240