### PR TITLE
[V2V] Add transition for powering_on to running_migration_playbook in InfraConversionJob

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -362,7 +362,7 @@ class InfraConversionJob < Job
     return abort_conversion(error.message, 'error') if migration_phase == 'pre'
 
     handover_to_automate
-    return queue_signal(:poll_automate_state_machine)
+    queue_signal(:poll_automate_state_machine)
   end
 
   def shutdown_vm

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -327,12 +327,10 @@ class InfraConversionJob < Job
     queue_signal(:poll_automate_state_machine)
   rescue StandardError => error
     update_migration_task_progress(:on_error)
-    if migration_phase == 'pre'
-      abort_conversion(error.message, 'error')
-    else
-      handover_to_automate
-      queue_signal(:poll_automate_state_machine)
-    end
+    return abort_conversion(error.message, 'error') if migration_phase == 'pre'
+
+    handover_to_automate
+    queue_signal(:poll_automate_state_machine)
   end
 
   def poll_run_migration_playbook_complete
@@ -361,12 +359,10 @@ class InfraConversionJob < Job
     queue_signal(:poll_run_migration_playbook_complete, :deliver_on => Time.now.utc + state_retry_interval)
   rescue StandardError => error
     update_migration_task_progress(:on_error)
-    if migration_phase == 'pre'
-      abort_conversion(error.message, 'error')
-    else
-      handover_to_automate
-      return queue_signal(:poll_automate_state_machine)
-    end
+    return abort_conversion(error.message, 'error') if migration_phase == 'pre'
+
+    handover_to_automate
+    return queue_signal(:poll_automate_state_machine)
   end
 
   def shutdown_vm


### PR DESCRIPTION
For IMS 1.3 we're moving state machine handling from automate into core. For ease of writing and review, we're breaking this down into (hopefully) easily digestible bits, one state at a time. Each PR will ultimately have a corresponding PR in manageiq-content that deletes the relevant bit of code from automate.

The states to run a migration playbook have already been implemented in https://github.com/ManageIQ/manageiq/pull/19200. This PR adds conditional transitions:

- from powering_on_vm to waiting_for_ip_address, which then moves to _running_migration_playbook
- from running_migration_playbook to poll_automate_state_machine

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1748121
Depends on #19149, #19150, #19154, #19177, #19200, #19216, #19222, #19230, #19238, #19240, #19241
Built on #19241