### PR TITLE
Fix regex for finding regex interpolations

### DIFF
--- a/spec/shared/i18n/placeholders.rb
+++ b/spec/shared/i18n/placeholders.rb
@@ -51,7 +51,7 @@ shared_examples :placeholders do |dir|
     errors = []
     Pathname.glob(File.join(dir, "**", "*.pot")).each do |pot_file|
       File.open(pot_file).each do |line|
-        next unless line =~ /^.*(".*\#\{[.\w]+\}.*")$/
+        next unless line =~ /^.+"(.*\#\{.+\})/
 
         errors.push($1)
       end


### PR DESCRIPTION
Previous regex would not find for example: `msgid "#{td[:resource]} #{td[:action]}d"`

@miq-bot add_label test, internationalization, ivanchuk/yes