### PR TITLE
Skip already reconnected object

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -248,6 +248,9 @@ module ManageIQ::Providers
                 inventory_object = inventory_objects_index.delete(index)
                 hash             = attributes_index.delete(index)
 
+                # Skip if hash is blank, which can happen when having several archived entities with the same ref
+                next unless hash
+
                 # Make the entity active again, otherwise we would be duplicating nested entities
                 hash[:deleted_on] = nil
 


### PR DESCRIPTION
The current reconnect code may try to reconnect multiple
times, because MIQ DB doesn't have constraints preventing
duplicates.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732442

