### PR TITLE
[HAMMER]Do not calculate backlog when subscription not active

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -108,10 +108,16 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def backlog
-    connection.xlog_location_diff(remote_node_lsn, remote_replication_lsn)
-  rescue PG::Error => e
-    _log.error(e.message)
-    nil
+    if status != "replicating"
+      _log.error("Please check that database `#{dbname}` is running on host `#{host}` and accepting TCP/IP connections on port #{port}")
+      return nil
+    end
+    begin
+      connection.xlog_location_diff(remote_node_lsn, remote_replication_lsn)
+    rescue PG::Error => e
+      _log.error(e.message)
+      nil
+    end
   end
 
   # translate the output from the pglogical stored proc to our object columns

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -109,7 +109,7 @@ class PglogicalSubscription < ActsAsArModel
 
   def backlog
     if status != "replicating"
-      _log.error("Please check that database `#{dbname}` is running on host `#{host}` and accepting TCP/IP connections on port #{port}")
+      _log.error("Is `#{dbname}` running on host `#{host}` and accepting TCP/IP connections on port #{port} ?")
       return nil
     end
     begin

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -496,5 +496,12 @@ describe PglogicalSubscription do
 
       expect(described_class.first.backlog).to be nil
     end
+
+    it 'does not attempt to calculate backlog and returns nil unless subscription status is "replicating"' do
+      allow(described_class).to receive(:status).and_return("down")
+
+      expect(remote_connection).not_to receive(:xlog_location)
+      expect(described_class.first.backlog).to be nil
+    end
   end
 end


### PR DESCRIPTION
Do not attempt to calculate backlog unless subscription status is "replicating"

It is ```hammer``` specific PR to backport https://github.com/ManageIQ/manageiq/pull/19234

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749052

@miq-bot add-label bug, core

\cc @gtanzillo 
