### PR TITLE
[V2V] Skip the infra conversion job if it's already in a running state

### DIFF
--- a/app/models/job/state_machine.rb
+++ b/app/models/job/state_machine.rb
@@ -33,7 +33,7 @@ module Job::StateMachine
       save
       send(signal, *args) if respond_to?(signal)
     else
-      raise _("%{signal} is not permitted at state %{state}") % {:signal => signal, :state => state}
+      raise _("%{signal} is not permitted at state %{state} for job ID %{id}") % {:signal => signal, :state => state, :id => id}
     end
   end
 end

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -11,6 +11,7 @@ class InfraConversionThrottler
       slots = (ems.miq_custom_get('MaxTransformationRunners') || Settings.transformation.limits.max_concurrent_tasks_per_ems).to_i - running
 
       jobs.each do |job|
+        next if job.state == 'running'
         vm_name = job.migration_task.source.name
 
         preflight_check = job.migration_task.preflight_check


### PR DESCRIPTION
There appears to be a race condition where a job can already be in a running state by the time we try to start it. The result is that we see this in the log:

`start is not permitted at state running`

This PR just skips the job if it's already in a running state. I've also added the job ID to the error message for easier debugging.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1724040