### PR TITLE
remove already initialized warning

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -900,7 +900,9 @@ describe MiqReport do
         )
       end
 
-      let(:test_controller) do
+      let(:test_controller) { TestController.new }
+
+      before do
         class TestController
           # when this method returns true it means
           # that column is displayed
@@ -912,9 +914,9 @@ describe MiqReport do
             User.current_user.super_admin_user?
           end
         end
-
-        TestController.new
       end
+
+      after { Object.send(:remove_const, :TestController) }
 
       let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
fixes:

```
spec/models/miq_report_spec.rb:907: warning: already initialized constant DISPLAY_GTL_METHODS
```

in rspec, you can't define a class in a method - is is basically the same as globally defining it
instead you can do it in a before and then you need to remember to remove the constant (the class definition)