### PR TITLE
[IVANCHUK] Add human locale name for Brazilian Portuguese

### DIFF
--- a/config/human_locale_names.yaml
+++ b/config/human_locale_names.yaml
@@ -4,5 +4,5 @@ human_locale_names:
   es: Español
   fr: Français
   ja: 日本語
-  pt_BR: pt_BR
+  pt_BR: Português (Brasil)
   zh_CN: 简体中文


### PR DESCRIPTION
Master is being addressed in https://github.com/ManageIQ/manageiq/pull/19259

@add_label bug, internationalization

https://bugzilla.redhat.com/show_bug.cgi?id=1749298