### PR TITLE
Add distributed_virtual_lans for infra_manager

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -8,6 +8,7 @@ module ManageIQ::Providers
     include AvailabilityMixin
 
     has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
+    has_many :distributed_virtual_lans, -> { distinct }, :through => :distributed_virtual_switches, :source => :lans
     has_many :host_virtual_switches, -> { distinct }, :through => :hosts
 
     has_many :host_hardwares,             :through => :hosts, :source => :hardware


### PR DESCRIPTION
Adding an association for another another fix.
required for: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/401

https://bugzilla.redhat.com/show_bug.cgi?id=1576509