### PR TITLE
[V2V] Removed a duplicate variable for ems_openstack from transformation_mapping_item_spec.

### DIFF
--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe TransformationMappingItem, :v2v do
   # Datastore Validation
   # ---------------------------------------------------------------------------
   context "datastore validation" do
-    let(:ems_ops) { FactoryBot.create(:ems_openstack) }
-    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_ops) }
+    # let(:ems_ops) { FactoryBot.create(:ems_openstack) }
+    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_openstack) }
 
     context "source vmware datastore" do
       let(:src_vmware_host) { FactoryBot.create(:host_vmware, :ems_cluster => vmware_cluster) }
@@ -105,8 +105,8 @@ RSpec.describe TransformationMappingItem, :v2v do
   # Network Validation
   # ---------------------------------------------------------------------------
   context "Network validation" do
-    let(:ems_ops) { FactoryBot.create(:ems_openstack) }
-    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_ops) }
+    # let(:ems_ops) { FactoryBot.create(:ems_openstack) }
+    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_openstack) }
 
     # source network
     context "source vmware network" do

--- a/spec/models/transformation_mapping_item_spec.rb
+++ b/spec/models/transformation_mapping_item_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe TransformationMappingItem, :v2v do
   # Datastore Validation
   # ---------------------------------------------------------------------------
   context "datastore validation" do
-    # let(:ems_ops) { FactoryBot.create(:ems_openstack) }
     let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_openstack) }
 
     context "source vmware datastore" do
@@ -105,7 +104,6 @@ RSpec.describe TransformationMappingItem, :v2v do
   # Network Validation
   # ---------------------------------------------------------------------------
   context "Network validation" do
-    # let(:ems_ops) { FactoryBot.create(:ems_openstack) }
     let(:cloud_tenant) { FactoryBot.create(:cloud_tenant_openstack, :ext_management_system => ems_openstack) }
 
     # source network


### PR DESCRIPTION
A minor left over from [[V2V] Lan validation in Transformation Mapping](https://github.com/ManageIQ/manageiq/pull/19220)