### PR TITLE
[Hammer] Revert "Fix sporadic failure now that distinct remembers the order"

### DIFF
--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2307,7 +2307,7 @@ describe Rbac::Filterer do
                                   :order            => :updated_on)
 
         expect(attrs[:auth_count]).to eq(3)
-        expect(recs.map(&:id)).to eq(vms.sort_by(&:updated_on).reverse.map(&:id))
+        expect(recs.map(&:id)).to eq(vms.map(&:id))
       end
     end
   end


### PR DESCRIPTION
This reverts commit f3201ee66c480dff8f837dbf8d916348a754e744.

This covered up an issue and worked 99% of the time.
After merging #18928 this is no longer needed.
