### PR TITLE
BigDecimal.new deprecated in v1.3.3 which ruby 2.5 uses

### DIFF
--- a/app/models/chargeback_rate_detail_measure.rb
+++ b/app/models/chargeback_rate_detail_measure.rb
@@ -14,7 +14,7 @@ class ChargebackRateDetailMeasure < ApplicationRecord
   def adjust(from_unit, to_unit)
     return 1 if from_unit == to_unit
     jumps = units.index(to_unit) - units.index(from_unit)
-    BigDecimal.new(step)**jumps
+    BigDecimal(step)**jumps
   end
 
   private def units_same_length


### PR DESCRIPTION
it's bundled with Ruby 2.5.0.rc1, see https://github.com/ruby/bigdecimal/pull/125