### PR TITLE
Make description unique for tenant groups in MiqGroup

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -234,7 +234,7 @@ class MiqGroup < ApplicationRecord
   end
 
   def self.create_tenant_group(tenant)
-    tenant_full_name = (tenant.ancestors.map(&:name) + [tenant.name]).join("/")
+    tenant_full_name = (tenant.ancestors.map(&:name) + [tenant.name] + [tenant.id.to_s]).join("/")
 
     create_with(
       :description => "Tenant #{tenant_full_name} access"


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq/pull/17197 we distinguish case sensitive for column `description` in groups and there is no such validation for `Tenant#name`.

When we create tenant then we are also creating so called _tenant_ group and this group has generated description - base on related tenant name. 

**Issue:**
**A.** create tenant with name = foo and description =foo
=> tenant (with name=foo and description =foo) is created 
=> also related tenant group has been created with description (Tenant foo access ) 
**B.** create tenant with name = FOO and description =foo
=> tenant is not created because when default group is created it will generate description which was created in point 1 and it will fails [on validation.](https://github.com/lpichler/manageiq/commit/db23d6329508714417426929cddc2a11e76cb620)

## What we can do ?
1. Make description for tenant group unique this PR.
2. Revert  https://github.com/ManageIQ/manageiq/pull/17197
3. Add similar validation for `Tenant#name`. (but in this case what to do with already created tenants with duplicated names "FOO", "Foo" ?)



Links
-----
* https://github.com/ManageIQ/manageiq/pull/17197 (https://bugzilla.redhat.com/show_bug.cgi?id=1537171)


cc @kbrock @Hyperkid123 

WIP: Need to know whether this is good approach.


