### PR TITLE
[EmbeddedAnsible] Add parameter support for jobs

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -22,6 +22,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
         :authentications       => collect_authentications(template.manager, options),
         :job_template          => template_ref).tap do |stack|
       stack.send(:update_with_provider_object, raw_create_stack(template, options))
+      stack.create_parameters(template, options)
     end
   end
 
@@ -87,6 +88,16 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
 
   def retireable?
     false
+  end
+
+  def create_parameters(template, options)
+    external = options[:extra_vars]
+
+    self.parameters = template.variables.merge(external || {}).collect do |key, val|
+      OrchestrationStackParameter.new(:name => key, :value => val, :ems_ref => "#{template.id}_#{key}")
+    end
+
+    save!
   end
 
   private

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -79,7 +79,8 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
             :credential         => machine_credential.id,
             :cloud_credential   => cloud_credential.id,
             :network_credential => network_credential.id,
-            :vault_credential   => vault_credential.id
+            :vault_credential   => vault_credential.id,
+            :extra_vars         => { "param1" => "val1", "param2" => "val2" }
           }
         end
 
@@ -146,14 +147,9 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
             :name              => "play2"
           )
 
-          # TODO/FIXME:  This needs to be implemented.
-          #
-          # The following are implemented in AnsibleTower::Job but not here:
-          #
-          #   - update_parameters
-          #
-          # expect(subject.parameters.first).to have_attributes(:name => "param1", :value => "val1")
-          #
+          expect(subject.parameters[0]).to have_attributes(:name => "instance_ids", :value => '["i-3434"]')
+          expect(subject.parameters[1]).to have_attributes(:name => "param1", :value => "val1")
+          expect(subject.parameters[2]).to have_attributes(:name => "param2", :value => "val2")
         end
 
         # TODO:  This is should be irrelevant now, right?


### PR DESCRIPTION
Saves the params for each key/val as a `OrchestrationStackParameter` record, similar as to what was done in `manageiq-providers-ansible_tower`.

This was something that we didn't get to for the `ivanchuk` release.


Links
-----

* Similar work done in previous merged PR:
  - https://github.com/ManageIQ/manageiq/pull/19232
  - https://github.com/ManageIQ/manageiq/pull/19247