### PR TITLE
[EmbeddedAnsible] TODO Cleanup

### DIFF
--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job/status_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job/status_spec.rb
@@ -31,18 +31,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job::Sta
     expect(status.normalized_status).to eq(['failed', 'Stack creation failed'])
   end
 
-  # TODO:  remove or implement?  Is canceling something we can handle?
-  #
-  # it 'parses Canceled' do
-  #   status = described_class.new('Canceled', nil)
-  #   expect(status.completed?).to   be_truthy
-  #   expect(status.succeeded?).to   be_falsey
-  #   expect(status.canceled?).to    be_truthy
-  #   expect(status.deleted?).to     be_falsey
-  #   expect(status.rolled_back?).to be_falsey
-  #   expect(status.normalized_status).to eq(['create_canceled', 'Job launching was canceled'])
-  # end
-
   it 'parses transient status' do
     miq_task.state  = MiqTask::STATE_ACTIVE
     miq_task.status = MiqTask::STATUS_UNKNOWN

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -144,53 +144,36 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
       end
     end
 
-    # TODO:  Punting for now need some more time to get this tested properly,
-    #        but don't have the current mental capacity to figure the right way
-    #        to set this up in a time crunch.
+    describe "#raw_stdout_via_worker" do
+      before do
+        EvmSpecHelper.create_guid_miq_server_zone
+        allow(described_class).to receive(:find).and_return(job)
 
-    # describe "#raw_stdout" do
-    #   subject { described_class.create_job(playbook, {}) }
+        allow(MiqTask).to receive(:wait_for_taskid) do
+          request = MiqQueue.find_by(:class_name => described_class.name)
+          request.update(:state => MiqQueue::STATE_DEQUEUE)
+          request.delivered(*request.deliver)
+        end
+      end
 
-    #   it "gets the standard output of the job" do
-    #     expect(subject.raw_stdout("html")).to eq("<html><body>job stdout</body></html>")
-    #   end
+      it "gets stdout from the job" do
+        expect(job).to receive(:raw_stdout).and_return("A stdout from the job")
+        taskid = job.raw_stdout_via_worker("user")
+        MiqTask.wait_for_taskid(taskid)
+        expect(MiqTask.find(taskid)).to have_attributes(
+          :task_results => "A stdout from the job",
+          :status       => "Ok"
+        )
+      end
 
-    #   it "catches errors from provider" do
-    #     expect(connection.api.jobs).to receive(:find).and_raise("bad happened")
-    #     expect { subject.raw_stdout("html") }.to raise_error(MiqException::MiqOrchestrationStatusError)
-    #   end
-    # end
-    #
-    # describe "#raw_stdout_via_worker" do
-    #   before do
-    #     EvmSpecHelper.create_guid_miq_server_zone
-    #     allow(described_class).to receive(:find).and_return(job)
-
-    #     allow(MiqTask).to receive(:wait_for_taskid) do
-    #       request = MiqQueue.find_by(:class_name => described_class.name)
-    #       request.update(:state => MiqQueue::STATE_DEQUEUE)
-    #       request.delivered(*request.deliver)
-    #     end
-    #   end
-
-    #  it "gets stdout from the job" do
-    #    expect(job).to receive(:raw_stdout).and_return("A stdout from the job")
-    #    taskid = job.raw_stdout_via_worker("user")
-    #    MiqTask.wait_for_taskid(taskid)
-    #    expect(MiqTask.find(taskid)).to have_attributes(
-    #      :task_results => "A stdout from the job",
-    #      :status       => "Ok"
-    #    )
-    #  end
-
-    #   it "returns the error message" do
-    #     expect(job).to receive(:raw_stdout).and_throw("Failed to get stdout from the job")
-    #     taskid = job.raw_stdout_via_worker("user")
-    #     MiqTask.wait_for_taskid(taskid)
-    #     expect(MiqTask.find(taskid).message).to include("Failed to get stdout from the job")
-    #     expect(MiqTask.find(taskid).status).to eq("Error")
-    #   end
-    # end
+      it "returns the error message" do
+        expect(job).to receive(:raw_stdout).and_throw("Failed to get stdout from the job")
+        taskid = job.raw_stdout_via_worker("user")
+        MiqTask.wait_for_taskid(taskid)
+        expect(MiqTask.find(taskid).message).to include("Failed to get stdout from the job")
+        expect(MiqTask.find(taskid).status).to eq("Error")
+      end
+    end
   end
 
   context "when embedded_ansible role is disabled" do


### PR DESCRIPTION
Removes a bunch of TODO comments from the ~~`app/` and~~ `spec/` directories that I felt were not relevant.

Of the remaining ones:

- One is removed here:  https://github.com/ManageIQ/manageiq/pull/19274
- One is still valid: should be handled: https://github.com/ManageIQ/manageiq/blob/2d001e04/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb#L203 

The second one is something that needs further thought and discussion on the best way to move forward (service class possibly), so don't want to tackle that in this PR.

Edit:  Per the PR review, the ones we did remove from the `app/` dir should have some more discussion, so removed those for the time being.