### PR TITLE
[V2V] Allow active InfraConversionJob to be throttled

### DIFF
--- a/app/models/job_proxy_dispatcher.rb
+++ b/app/models/job_proxy_dispatcher.rb
@@ -202,7 +202,7 @@ class JobProxyDispatcher
   end
 
   def self.waiting?
-    Job.where(:state => 'waiting_to_start').exists?
+    Job.where(:state => 'waiting_to_start').exists? || InfraConversionJob.where.not(:state => ['finished', 'waiting_to_start']).exists?
   end
 
   def pending_jobs(job_class = VmScan)


### PR DESCRIPTION
The `JobProxyDispatcher.dispatch` is called only if `JobProxyDispatcher.waiting?` returns `true`. With existing implementation, it means that there is a Job in state `waiting_to_start`. However, the `dispatch` method calls the `InfraConversionThrottler.apply_limits` method that we need to run every 15 seconds as long as at least 1 InfraConversionJob is active, i.e. not in `finished` or `waiting_to_start` state.

This PR extends the check to include verification that active InfraConversionJob exists.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1690851