### PR TITLE
Set default playbook service timeout to 100 minutes

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb
@@ -1,5 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScript
   FRIENDLY_NAME = "Embedded Ansible Job Template".freeze
+  DEFAULT_EXECUTION_TTL = 100.minutes # automate state machine aborts after 100 retries at a minite interval
 
   include ManageIQ::Providers::EmbeddedAnsible::CrudCommon
 
@@ -41,8 +42,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScri
     credentials = collect_credentials(vars)
 
     kwargs = {:become_enabled => vars[:become_enabled]}
-    kwargs[:timeout]   = vars[:execution_ttl].to_i.minutes if vars[:execution_ttl].present?
-    kwargs[:verbosity] = vars[:verbosity].to_i             if vars[:verbosity].present?
+    kwargs[:timeout]   = vars[:execution_ttl].present? ? vars[:execution_ttl].to_i.minutes : DEFAULT_EXECUTION_TTL
+    kwargs[:verbosity] = vars[:verbosity].to_i if vars[:verbosity].present?
 
     workflow.create_job({}, extra_vars, playbook_vars, vars[:hosts], credentials, kwargs).tap do |job|
       job.signal(:start)

--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < ::Job
-  DEFAULT_EXECUTION_TTL = 10 # minutes
+  DEFAULT_EXECUTION_TTL = 100 # minutes
 
   # options are job table columns, including options column which is the playbook context info
   def self.create_job(options)

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_spec.rb
@@ -46,7 +46,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationS
       expect(job.options[:extra_vars]).to eq(:instance_ids => ["i-3434"])
       expect(job.options[:configuration_script_source_id]).to eq(ansible_script_source.id)
       expect(job.options[:playbook_relative_path]).to eq(playbook.name)
-      expect(job.options[:timeout]).to eq(1.hour)
+      expect(job.options[:timeout]).to eq(100.minutes)
       expect(job.options[:verbosity]).to eq(0)
     end
 


### PR DESCRIPTION
Automate has its own timeout. This Ansible runner timeout does not play nice with automate timeout.

https://bugzilla.redhat.com/show_bug.cgi?id=1750370

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, Ivanchuk/yes, changelog/yes, blocker

cc @Fryguy @NickLaMuro 