### PR TITLE
[WIP] Add identifier for parent choices for vms

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5357,6 +5357,11 @@
         :description: Show Chargeback Preview for a VM
         :feature_type: view
         :identifier: vm_chargeback
+      - :name: VM Parent Choices
+        :description: Show Parent Choices for a VM
+        :feature_type: view
+        :hidden: true
+        :identifier: vm_parent_choices
     - :name: Operate
       :description: Perform Operations on VMs
       :feature_type: control


### PR DESCRIPTION
I was told the API needs an endpoint for the list of parent choices for a VM.

<sub><sup> overkill though it may be, I just work here or something </sup></sub>

related to:
https://github.com/ManageIQ/manageiq-api/pull/671

See https://github.com/ManageIQ/manageiq-api/issues/637