### PR TITLE
Allow user-queued full-refreshes when streaming

### DIFF
--- a/app/models/ems_event/automate.rb
+++ b/app/models/ems_event/automate.rb
@@ -11,6 +11,8 @@ class EmsEvent
     end
 
     def refresh(*targets, sync)
+      return if ext_management_system.supports_streaming_refresh?
+
       targets = targets.flatten
       return if targets.blank?
 

--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -51,9 +51,6 @@ module EmsRefresh
       h[e] << t unless e.nil?
     end
 
-    # Drop targets on EMSs which are using streaming refresh
-    targets_by_ems.reject! { |ems, _| ems.supports_streaming_refresh? }
-
     # Queue the refreshes
     task_ids = targets_by_ems.collect do |ems, ts|
       ts = ts.collect { |t| [t.class.to_s, t.id] }.uniq

--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -94,14 +94,14 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
     self.class.delay_queue_delivery_for_vim_broker? && !MiqVimBrokerWorker.available?
   end
 
-  def deliver_queue_message(msg)
+  def deliver_queue_message(msg, &block)
     reset_poll_escalate if poll_method == :sleep_poll_escalate
 
     begin
       $_miq_worker_current_msg = msg
       Thread.current[:tracking_label] = msg.tracking_label || msg.task_id
       heartbeat_message_timeout(msg)
-      status, message, result = msg.deliver
+      status, message, result = msg.deliver(&block)
 
       if status == MiqQueue::STATUS_TIMEOUT
         begin

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -45,14 +45,6 @@ describe EmsRefresh do
       target2 = FactoryBot.create(:vm_vmware, :ext_management_system => @ems)
       queue_refresh_and_assert_queue_item(target2, [target, target2])
     end
-
-    it "with streaming refresh enabled doesn't queue a refresh" do
-      allow(@ems).to receive(:supports_streaming_refresh?).and_return(true)
-      target = @ems
-
-      described_class.queue_refresh(target)
-      expect(MiqQueue.count).to eq(0)
-    end
   end
 
   context "stopping targets unbounded growth" do


### PR DESCRIPTION
If an EMS is using streaming refresh, allow user queued full refreshes
but drop event triggered ones as these will be handled internally.

Related: https://github.com/ManageIQ/manageiq-providers-vmware/pull/451