### PR TITLE
Fix:  rspec expectation in miq_report_spec when replacing update_attributes with update!

### DIFF
--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -850,9 +850,9 @@ describe MiqReport do
   context "support for saving attributes which are not present in the model" do
     let(:report) { FactoryBot.create(:miq_report) }
 
-    it "does not raise error when result of #export_to_array used for mass update" do
-      report_hash = report.export_to_array[0].values.first
-      expect { MiqReport.new.update_attributes(report_hash) }.not_to raise_error
+    it "does not raise error when result of #export_to_array (with report's menu_name removed) used for updating another report" do
+      report_hash = report.export_to_array[0].values.first.except("menu_name")
+      expect { FactoryBot.create(:miq_report).update!(report_hash) }.not_to raise_error
     end
 
     describe "#userid=" do


### PR DESCRIPTION
**ISSUE:** ```update_attributes``` does not raise error if update failed and expectation was always successful

@miq-bot add-label changelog/no, technical debt