### PR TITLE
Load whole enviroment in FixAuth tool

### DIFF
--- a/tools/fix_auth.rb
+++ b/tools/fix_auth.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require File.expand_path('../config/environment', __dir__)
 
 # usage: ruby fix_auth -h
 #
@@ -12,8 +11,6 @@ if __FILE__ == $PROGRAM_NAME
   $LOAD_PATH.push(File.expand_path(File.join(__dir__, %w(.. lib))))
 end
 
-require 'active_support/all'
-require 'active_support/concern'
 # this gets around a bug if a user mistakingly
 # serializes a drb object into a configuration hash
 require 'drb'


### PR DESCRIPTION
error:

```
	37: from ./tools/fix_auth.rb:28:in `<main>'
	36: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/cli.rb:43:in `run'
	35: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/cli.rb:39:in `run'
	34: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/fix_auth.rb:100:in `run'
	33: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/fix_auth.rb:70:in `fix_database_passwords'
	32: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/fix_auth.rb:70:in `each'
	31: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/fix_auth.rb:71:in `block in fix_database_passwords'
	30: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/auth_model.rb:91:in `run'
	29: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activerecord-5.1.7/lib/active_record/relation/delegation.rb:39:in `each'
	28: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/activerecord-5.1.7/lib/active_record/relation/delegation.rb:39:in `each'
	27: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/auth_model.rb:93:in `block in run'
	26: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/auth_model.rb:48:in `fix_passwords'
	25: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/auth_model.rb:48:in `each'
	24: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/auth_model.rb:50:in `block in fix_passwords'
	23: from /Users/lpichler/projects/manageiq/manageiq/tools/fix_auth/auth_config_model.rb:36:in `recrypt'
	22: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych.rb:264:in `load'
	21: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/nodes/node.rb:50:in `to_ruby'
	20: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
	19: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
	18: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
	17: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:311:in `visit_Psych_Nodes_Document'
	16: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
	15: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
	14: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
	13: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:162:in `visit_Psych_Nodes_Mapping'
	12: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `revive_hash'
	11: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each_slice'
	10: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:336:in `each'
	 9: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:338:in `block in revive_hash'
	 8: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:32:in `accept'
	 7: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/visitor.rb:6:in `accept'
	 6: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/visitor.rb:16:in `visit'
	 5: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:208:in `visit_Psych_Nodes_Mapping'
	 4: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/visitors/to_ruby.rb:391:in `resolve_class'
	 3: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/class_loader.rb:28:in `load'
	 2: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/class_loader.rb:46:in `find'
	 1: from /Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/class_loader.rb:54:in `resolve'
/Users/lpichler/.rbenv/versions/2.5.3/lib/ruby/2.5.0/psych/class_loader.rb:54:in `path2class': undefined class/module MiqAeMethodService:: (ArgumentError)
```