### PR TITLE
Fix references pass 1

### DIFF
--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -45,7 +45,7 @@ class Flavor < ApplicationRecord
 
   def self.tenant_joins_clause(scope)
     scope.includes(:cloud_tenants => "source_tenant", :ext_management_system => {})
-         .references(:cloud_tenants => "source_tenant", :ext_management_system => {})
+         .references(:cloud_tenants, :tenants, :ext_management_system)
   end
 
   def self.create_flavor_queue(userid, ext_management_system, options = {})

--- a/app/models/mixins/cloud_tenancy_mixin.rb
+++ b/app/models/mixins/cloud_tenancy_mixin.rb
@@ -1,11 +1,6 @@
 module CloudTenancyMixin
   extend ActiveSupport::Concern
 
-  QUERY_REFERENCES = {
-    :cloud_tenant          => "source_tenant",
-    :ext_management_system => {}
-  }.freeze
-
   module ClassMethods
     include TenancyCommonMixin
 
@@ -18,8 +13,8 @@ module CloudTenancyMixin
     end
 
     def tenant_joins_clause(scope)
-      scope.includes(QUERY_REFERENCES)
-           .references(QUERY_REFERENCES) # needed for the where to work
+      scope.includes(:cloud_tenant => "source_tenant", :ext_management_system => {})
+           .references(:cloud_tenants, :tenants, :ext_management_systems) # needed for the where to work
     end
   end
 end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -100,7 +100,7 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def self.with_additional_tenants
-    includes(:service_template_tenants => :tenant)
+    references(table_name, :tenants).includes(:service_template_tenants => :tenant)
   end
 
   def self.catalog_item_types

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -49,7 +49,7 @@ describe ContainerGroup do
     it "preloads the conditions" do
       condition_other
       cr = condition_ready
-      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status => {}).find_by(:id => container_group.id)
+      cg = ContainerGroup.includes(:ready_condition_status).references(:ready_condition_status).find_by(:id => container_group.id)
 
       expect { expect(cg.ready_condition).to eq(cr) }.to match_query_limit_of(0)
     end

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -34,7 +34,7 @@ describe MetricRollup do
       # TODO: that causes the error "ActiveRecord::ConfigurationError: nil"
       # TODO: instead of the expected "ActiveRecord::EagerLoadPolymorphicError" error.
       expect do
-        Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table => {}).to_a
+        Tagging.includes(:taggable => {}).where('bogus_table.column = 1').references(:bogus_table).to_a
       end.to raise_error ActiveRecord::EagerLoadPolymorphicError
     end
   end


### PR DESCRIPTION
extracted from #19127  

Background
------------

### Rails 1.0-3.x

Rails 1.0-3.x used `includes()` to preloading associations. It simply added all model's tables to a single query.

### Rails 4.0

When there are `has_many` tables, too much duplicate data comes back. So Rails 4.0 defaulted to performing multiple queries, but [[introduced]](https://github.com/rails/rails/commit/4c4760a619e9bddf14e65dd7f0d5bbc3f9ca320e) `references()` to fall back in the default behavior. Also of note, 3 months later [`to_s`](https://github.com/rails/rails/commit/8c2c60511bea) was introduced, further cementing that it is expecting a list of table names.

### Miq migrates to Rails 4.0

When we transitioned from Rails 3.0 to 4.0, we did not have a good handle on the tables that were in our queries. Nor did we understand the finer points to `references()`. We told Rbac that we referenced every table in the query. Which makes sense as a quick transition plan. 9a000fb739946dfa and followup 4503b6c07a53ee.

When we introduced this, we passed the same value to `includes()` as we passed to `references()`.

Analysis of current implementation
----------------------------------

### Why does it work?

`includes()` takes an array or hash of relation names, and `references()` takes an array of table names. This is always the way it has worked.

So we've been doing it wrong. We pass a hash of relation names to `references()` and Rails calls `to_s` on the hash and adds it as a table name.

It turns out, that if Rails doesn't recognize the table name in the `references()` list, it will add all tables from the `includes()` hash. We could just pass `references("x")` and it would work the same way.

### So is it working?

Yes and no.

- If by working you mean the queries run, then Yes.
- If by working you mean that our application works for larger customers and performs well, then Not so much.
- If by working you mean that we are not passing incorrect parameters that rely upon undocumented behavior to work, then No.
- If by working you mean that we are hoping that undocumented internals never change, then...

### Is it really that slow?

First off, Rails 4.0 defaulted to avoiding this behavior in 2013 because it was too slow.

We have problems with our queries joining to too many compliances or tags. We've gone in and removed joins from a number of compliances views recently.

We introduced code to try and skip references that we can safely determine are not necessary. #17141 - that gave us some huge wins.

### Did virtual attributes recently make it slower?

Before ManageIQ/activerecord-virtual_attributes#16, `references()` of virtual relations were ignored. They were just treated as `includes()`.
After that PR, the `references()` are actually respected. It was not a knowing change, but our code was simplified by passing the references and includes to rails itself. And no surprise, rails actually respects the values passed in.

Since `references()` currently is set to include every `includes()` table, and we are now respecting this request, we add even more tables to the joins. This exasperates the problem even more.


What is the suggested Plan?
---

- Correctly pass table names into references. **<== this PR**
- Change Rbac from passing relations to passing table names into references. #19318
- Only pass the table names to `references` that we actually reference #19127 


Related to ManageIQ/activerecord-virtual_attributes#42