### PR TITLE
[MiqQueue] Format .format_full_log_msg

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -554,7 +554,23 @@ class MiqQueue < ApplicationRecord
   end
 
   def self.format_full_log_msg(msg)
-    "Message id: [#{msg.id}], #{msg.handler_type} id: [#{msg.handler_id}], Zone: [#{msg.zone}], Role: [#{msg.role}], Server: [#{msg.server_guid}], MiqTask id: [#{msg.miq_task_id}], Ident: [#{msg.queue_name}], Target id: [#{msg.target_id}], Instance id: [#{msg.instance_id}], Task id: [#{msg.task_id}], Command: [#{msg.class_name}.#{msg.method_name}], Timeout: [#{msg.msg_timeout}], Priority: [#{msg.priority}], State: [#{msg.state}], Deliver On: [#{msg.deliver_on}], Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], Args: #{ManageIQ::Password.sanitize_string(msg.args.inspect)}"
+    "Message id: [#{msg.id}], "                                     \
+    "#{msg.handler_type} id: [#{msg.handler_id}], "                 \
+    "Zone: [#{msg.zone}], "                                         \
+    "Role: [#{msg.role}], "                                         \
+    "Server: [#{msg.server_guid}], "                                \
+    "MiqTask id: [#{msg.miq_task_id}], "                            \
+    "Ident: [#{msg.queue_name}], "                                  \
+    "Target id: [#{msg.target_id}], "                               \
+    "Instance id: [#{msg.instance_id}], "                           \
+    "Task id: [#{msg.task_id}], "                                   \
+    "Command: [#{msg.class_name}.#{msg.method_name}], "             \
+    "Timeout: [#{msg.msg_timeout}], "                               \
+    "Priority: [#{msg.priority}], "                                 \
+    "State: [#{msg.state}], "                                       \
+    "Deliver On: [#{msg.deliver_on}], "                             \
+    "Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], "  \
+    "Args: #{ManageIQ::Password.sanitize_string(msg.args.inspect)}"
   end
 
   def self.format_short_log_msg(msg)


### PR DESCRIPTION
For readability, since it is really hard to see everything that is being logged in this message.


Steps for Testing/QA
--------------------

To confirm it works:

```console
$ bin/rails r "puts MiqQueue.format_full_log_msg(MiqQueue.new)"
```