### PR TITLE
Handle orphaned worker classes in kill_all_workers

### DIFF
--- a/app/models/miq_server/worker_management/monitor/kill.rb
+++ b/app/models/miq_server/worker_management/monitor/kill.rb
@@ -4,13 +4,36 @@ module MiqServer::WorkerManagement::Monitor::Kill
   def kill_all_workers
     return unless self.is_local?
 
-    killed_workers = []
-    miq_workers.each do |w|
-      if MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
-        w.kill
-        worker_delete(w.pid)
-        killed_workers << w
+    remove_unknown_workers
+    remove_workers
+  end
+
+  private
+
+  def remove_unknown_workers
+    # We try, but forget to write migrations to delete orphaned worker class rows, causing this method
+    # to blow up and cause the server to continually fail to start.
+    # This is called very early from evm_application and ensures we attempt to call MiqWorker#kill
+    # to remove the problematic rows, and their in flight queue messages.
+    bad_workers = miq_workers.where.not(:type => MiqWorker.descendants.map(&:name))
+    if bad_workers.size.positive?
+      begin
+        MiqWorker.inheritance_column = "__disabled"
+        remove_workers(bad_workers)
+      ensure
+        MiqWorker.inheritance_column = "type"
       end
+    end
+  end
+
+  def remove_workers(workers = miq_workers)
+    killed_workers = []
+
+    workers.each do |w|
+      w.kill_process if MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
+      w.destroy
+      worker_delete(w.pid)
+      killed_workers << w
     end
     miq_workers.delete(*killed_workers) unless killed_workers.empty?
   end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -451,6 +451,11 @@ class MiqWorker < ApplicationRecord
   alias_method :restart, :stop
 
   def kill
+    kill_process
+    destroy
+  end
+
+  def kill_process
     unless pid.nil?
       begin
         _log.info("Killing worker: ID [#{id}], PID [#{pid}], GUID [#{guid}], status [#{status}]")
@@ -465,8 +470,6 @@ class MiqWorker < ApplicationRecord
         _log.warn("Worker ID [#{id}] PID [#{pid}] GUID [#{guid}] has been killed, but with the following error: #{err}")
       end
     end
-
-    destroy
   end
 
   def is_current?

--- a/spec/models/miq_server/worker_management/monitor/kill_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kill_spec.rb
@@ -1,0 +1,57 @@
+describe MiqServer::WorkerManagement::Monitor::Kill do
+  context "#kill_all_workers" do
+    let(:server)   { EvmSpecHelper.create_guid_miq_server_zone.second }
+    let(:is_local) { true }
+    let(:worker)   do
+      FactoryBot.create(:miq_generic_worker, :pid => 1234, :status => MiqWorker::STATUS_STARTING, :miq_server => server).tap do |w|
+        MiqWorker.where(:id => w.id).update_all(:type => "NonExistingClass")
+      end
+    end
+
+    before do
+      server.setup_drb_variables
+      server.worker_add(worker.pid)
+      allow(server).to receive(:is_local?).and_return(is_local)
+    end
+
+    def assert_worker_record_deleted_and_not_monitored
+      expect(MiqWorker.count).to eq(0)
+      expect(server.reload.miq_workers.count).to eq(0)
+      expect(server.instance_variable_get(:@workers).keys.length).to eq(0)
+    end
+
+    context "local" do
+      it "stopped worker is removed" do
+        MiqWorker.all.update_all(:status => MiqWorker::STATUS_STOPPED)
+        expect(Process).to_not receive(:kill)
+
+        server.kill_all_workers
+
+        assert_worker_record_deleted_and_not_monitored
+      end
+
+      it "started worker is killed and removed" do
+        MiqWorker.all.update_all(:status => MiqWorker::STATUS_STARTED)
+        expect(Process).to receive(:kill).with(9, worker.pid)
+
+        server.kill_all_workers
+
+        assert_worker_record_deleted_and_not_monitored
+      end
+    end
+
+    context "remote" do
+      let(:is_local) { false }
+
+      it "starting worker untouched" do
+        expect(Process).to_not receive(:kill)
+
+        server.kill_all_workers
+
+        expect(MiqWorker.count).to eq(1)
+        expect(server.reload.miq_workers.count).to eq(1)
+        expect(server.instance_variable_get(:@workers).keys).to eq([worker.pid])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This entrypoint needs to expect orphaned worker classes.

This safety mechanism allows us to attempt to "kill" the orphaned worker class's miq_workers row.  It's possible there is some extra logic in the subclasses' kill method that we won't be running, such as killing a pid file, but this should be enough to get around this problem of forgetting to write a migration to kill these rows.

Note, evm_application.rb is the first caller to MiqServer#miq_workers in the server startup.  It happens before the process is even spawned from the rake task.

See here: https://github.com/ManageIQ/manageiq/blob/62ff81fc4a0e8d6e6330fa3216c2f72c7b70de92/lib/tasks/evm_application.rb#L21

Additionally, by splitting the MiqWorker#kill method into kill_process and destroy, can only try to kill_process on starting/started workers while still removing the rows for others.