### PR TITLE
[WIP] custom button set copy refactor

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -230,7 +230,12 @@ class CustomButton < ApplicationRecord
 
   def copy(options = {})
     options[:guid] = SecureRandom.uuid
-    options.each_with_object(dup) { |(k, v), button| button.send("#{k}=", v) }.tap(&:save!)
+    options.each_with_object(dup) do |(k, v), button| 
+      button.send("#{k}=", v)
+      button.name = button.name + " #{options[:guid]}"
+      button.description = button.description + " #{options[:guid]}"
+      button.save!
+    end
   end
 
   def self.display_name(number = 1)

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -474,6 +474,13 @@ class ServiceTemplate < ApplicationRecord
     zone&.name if atomic?
   end
 
+  def set_button_order(custom_button)
+    options[:button_order] ||= []
+    options[:button_order] << "cb-#{custom_button.id}"
+    save!
+  end
+
+
   private
 
   def update_service_resources(config_info, auth_user = nil)

--- a/app/models/service_template/copy.rb
+++ b/app/models/service_template/copy.rb
@@ -31,7 +31,7 @@ module ServiceTemplate::Copy
   end
 
   def custom_button_set_copy(custom_button_set, template)
-    new_cbs = custom_button_set.deep_copy(:owner => template)
+    new_cbs = custom_button_set.deep_copy
     template[:options][:button_order] << "cbg-#{new_cbs.id}"
   end
 

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -27,7 +27,7 @@ describe CustomButtonSet do
     let(:miq_expression)    { MiqExpression.new('EQUAL' => {'field' => 'Vm-name', 'value' => "vm_1"}) }
     let(:custom_button_2)   { FactoryBot.create(:custom_button, :applies_to => vm_1, :visibility_expression => miq_expression) }
     let(:set_data)          { {:applies_to_class => "Vm", :button_order => [custom_button_1.id, custom_button_2.id]} }
-    let(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "set_1", :set_data => set_data) }
+    let(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "set_1", :set_data => set_data, :owner => vm_1) }
 
     before do
       [custom_button_1, custom_button_2].each { |x| custom_button_set.add_member(x) }
@@ -47,7 +47,7 @@ describe CustomButtonSet do
       let(:custom_button_3)        { FactoryBot.create(:custom_button, :applies_to => vm_1, :visibility_expression => miq_expression) }
       let(:custom_button_4)        { FactoryBot.create(:custom_button, :applies_to => vm_1, :visibility_expression => miq_expression) }
       let(:set_data)               { {:applies_to_class => "Vm", :button_order => [custom_button_4.id, custom_button_2.id, custom_button_1.id, custom_button_3.id]} }
-      let(:custom_button_set)      { FactoryBot.create(:custom_button_set, :name => "set_1", :set_data => set_data) }
+      let(:custom_button_set)      { FactoryBot.create(:custom_button_set, :name => "set_1", :set_data => set_data, :owner => vm_1) }
 
       before do
         [custom_button_3, custom_button_4].each { |x| custom_button_set.add_member(x) }
@@ -72,10 +72,10 @@ describe CustomButtonSet do
     service_template2 = FactoryBot.create(:service_template)
     custom_button     = FactoryBot.create(:custom_button, :applies_to => service_template1)
     set_data          = {:applies_to_class => "ServiceTemplate", :button_order => [custom_button.id]}
-    custom_button_set = FactoryBot.create(:custom_button_set, :set_data => set_data)
+    custom_button_set = FactoryBot.create(:custom_button_set, :set_data => set_data, :owner => service_template2)
 
     custom_button_set.add_member(custom_button)
-    custom_button_set.deep_copy(:owner => service_template2)
+    custom_button_set.deep_copy
 
     expect(CustomButton.count).to eq(2)
     expect(CustomButtonSet.count).to eq(2)


### PR DESCRIPTION
Noticed a couple of things on the custom button set copy. 

1) the custom button set owner should exist, which means we don't need to pass it in as an option for copying the button set
2) the update button_order only happens for service templates and so should probably be a method on service templates? 


I like this better than https://github.com/ManageIQ/manageiq/pull/19175.
