### PR TITLE
Removed advanced config option to switch between "puma" and "thin"

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -38,7 +38,7 @@ module MiqWebServerWorkerMixin
     end
 
     def rails_server
-      ::Settings.server.rails_server
+      "puma"
     end
 
     def all_ports_in_use

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1014,7 +1014,6 @@
   :prefetch_max_per_worker_dequeue: 100
   :prefetch_min_per_worker_dequeue: 10
   :prefetch_stale_threshold: 30.seconds
-  :rails_server: puma
   :role: database_operations,event,reporting,scheduler,smartstate,ems_operations,ems_inventory,user_interface,remote_console,web_services,automate
   :server_dequeue_frequency: 5.seconds
   :server_log_frequency: 5.minutes


### PR DESCRIPTION
Removed advanced config option to switch between "puma" and "thin"

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1752870

@miq-bot add-label core, technical debt