### PR TITLE
Delete dynamic list type from DialogField as it no longer exists

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -57,7 +57,6 @@ class DialogField < ApplicationRecord
     :dialog_field_button,
     :dialog_field_tag_control,
     :dialog_field_radio_button,
-    :dialog_field_dynamic_list,
     # Enable when UI support is available
     # #:dialog_field_list_view      # Future
   ]


### PR DESCRIPTION
There's an [ancient migration](https://github.com/ManageIQ/manageiq-schema/blob/6a8940dc146d4bc8cbde61112936e1edd242aaaf/db/migrate/20150331104323_change_dialog_field_dynamic_lists_to_dialog_field_drop_down_list_with_dynamic_flag.rb) for removing these from our DB, so dropping it from the model as well.

@miq-bot add_reviewer @d-m-u 
@miq-bot add_label ivanchuk/no, cleanup, automation/automate