### PR TITLE
eliminate useless spec

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -358,11 +358,6 @@ FactoryBot.define do
 
   # Leaf classes for automation_manager
 
-  factory :automation_manager_ansible_tower,
-          :aliases => ["manageiq/providers/ansible_tower/automation_manager"],
-          :class   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
-          :parent  => :external_automation_manager
-
   factory :embedded_automation_manager_ansible,
           :aliases => ["manageiq/providers/embedded_ansible/automation_manager"],
           :class   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
@@ -1,6 +1,4 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
-  it_behaves_like 'ansible automation_manager'
-
   context 'catalog types' do
     let(:ems) { FactoryBot.create(:embedded_automation_manager) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 # include the manageiq-gems-pending matchers
 Dir[ManageIQ::Gems::Pending.root.join("spec/support/custom_matchers/*.rb")].each { |f| require f }
-Dir[ManageIQ::Providers::AnsibleTower::Engine.root.join("spec/support/ansible_shared/**/*.rb")].each { |f| require f }
 # include the manageiq-password matchers
 require "manageiq/password/rspec_matchers"
 


### PR DESCRIPTION
The `shared_example` is purely (external) Tower implementation.  

---

I doubt those specs are applicable to the new runner-implementation of embedded Ansible. I can take a look later.