### PR TITLE
[WIP][POC] Add MiqQueueLogFilterer for MiqQueue

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -570,11 +570,15 @@ class MiqQueue < ApplicationRecord
     "State: [#{msg.state}], "                                       \
     "Deliver On: [#{msg.deliver_on}], "                             \
     "Data: [#{msg.data.nil? ? "" : "#{msg.data.length} bytes"}], "  \
-    "Args: #{ManageIQ::Password.sanitize_string(msg.args.inspect)}"
+    "Args: #{ManageIQ::Password.sanitize_string(inspectable_args(msg))}"
   end
 
   def self.format_short_log_msg(msg)
     "Message id: [#{msg.id}]"
+  end
+
+  def self.inspectable_args(msg)
+    MiqQueueLogFilterer.inspect_args_for(msg)
   end
 
   def get_worker

--- a/lib/miq_queue_log_filterer.rb
+++ b/lib/miq_queue_log_filterer.rb
@@ -1,0 +1,30 @@
+class MiqQueueLogFilterer
+  class << self
+    attr_reader :filter_registry
+
+    # rubocop:disable Naming/MemoizedInstanceVariableName
+    def initialize_filter_registry
+      @filter_registry ||= {}
+    end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
+
+    def register_filter(class_name, method_name, filter_method)
+      filter_registry[class_name] ||= {}
+      filter_registry[class_name][method_name] = filter_method
+    end
+
+    def inspect_args_for(queue_msg)
+      klass  = queue_msg.class_name
+      method = queue_msg.method_name
+      args   = queue_msg.args
+
+      if filter_registry.fetch(klass, {})[method]
+        klass.constantize.send("filter_args_for_#{method}", args).inspect
+      else
+        args.inspect
+      end
+    end
+  end
+
+  initialize_filter_registry
+end

--- a/spec/lib/miq_queue_log_filterer_spec.rb
+++ b/spec/lib/miq_queue_log_filterer_spec.rb
@@ -1,0 +1,63 @@
+describe MiqQueueLogFilterer do
+  # Allow for adding to the registery in the specs without messing this up
+  # elsewhere in the suite.
+  around do |example|
+    old_filter_registry = described_class.filter_registry.dup
+
+    example.run
+
+    described_class.instance_variable_set(:@filter_registry, old_filter_registry)
+  end
+
+  describe ".register_filter" do
+    it "adds a filter_method for a given class_name and method_name" do
+      class_name    = "Foo"
+      method_name   = "bar"
+      filter_method = "filter_args_for_bar"
+
+      expect(described_class.filter_registry[class_name]).to be_nil
+
+      described_class.register_filter(class_name, method_name, filter_method)
+
+      expect(described_class.filter_registry[class_name]).to eq("bar" => "filter_args_for_bar")
+    end
+  end
+
+  describe ".inspect_args_for" do
+    let(:msg_args)  { ["some", "args"] }
+    let(:queue_msg) { MiqQueue.new(:class_name => "Foo", :method_name => "bar", :args => msg_args) }
+    let(:foo_klass) do
+      Class.new do
+        def self.filter_args_for_bar(_args)
+          "[FILTERED]"
+        end
+      end
+    end
+
+    before do
+      Object.const_set(:Foo, foo_klass)
+    end
+
+    after do
+      Object.send(:remove_const, :Foo)
+    end
+
+    context "without a filter" do
+      it "returns the raw args" do
+        result = described_class.inspect_args_for(queue_msg)
+        expect(result).to eq('["some", "args"]')
+      end
+    end
+
+    context "with a filter registered" do
+      before do
+        described_class.register_filter("Foo", "bar", "filter_args_for_bar")
+      end
+
+      it "returns the raw args" do
+        result = described_class.inspect_args_for(queue_msg)
+        expect(result).to eq('"[FILTERED]"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a helper class for MiqQueue that is in charge of filtering out arguments that potentially contain sensitive from being logged by `MiqQueue.format_full_log_msg`.

This currently requires hard-coding the methods that need to be filtered on, but ideally this could be expanded on in the future to pluggable instead of requiring core to be controlling this data.

Still very much a `[WIP]`, but getting this out there so we can start a discussion on if this will work in the short term.


Cons
----

- ~~Requires the use of `.constantize`, which I could see being an issue potentially with autoloading~~
- ~~`.respond_to?` is not the fastest method in the world, and if this is done for every queue message (both on `.put` and `deliver`), this could add some slowness~~

I think I have eliminated both of these cons by refactoring this a bit.  Still not "great" by any means, but definitely better by it being a hash lookup.

Push up the old implementation for comparison here (used a permalink for posterity):

https://github.com/ManageIQ/manageiq/compare/73856f74...NickLaMuro:configurable_args_filter_for_miq_queue_old


Links
-----

* Partially addresses:  https://bugzilla.redhat.com/show_bug.cgi?id=1752033