### PR TITLE
Add check for nil group to system_context_requester

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -257,6 +257,10 @@ module RetirementMixin
       $log.info("System context defaulting to admin user because owner of #{name} (#{self.class}) not set or owner no longer found in database.")
       return User.super_admin
     end
+    if evm_owner.current_group.nil?
+      $log.info("System context defaulting to admin user because owner of #{name} (#{self.class}) was found but lacks a group.")
+      return User.super_admin
+    end
     $log.info("Setting retirement requester of #{name} to #{evm_owner_id}.")
     evm_owner
   end

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -34,6 +34,25 @@ describe "VM Retirement Management" do
       end
     end
 
+    context "with user lacking group" do
+      let(:user1) { FactoryBot.create(:user) }
+      let(:vm_with_owner_no_group) { FactoryBot.create(:vm, :evm_owner => user1, :host => FactoryBot.create(:host)) }
+
+      it "uses user as requester" do
+        vm_with_owner_no_group.update(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
+
+        expect(vm_with_owner.retirement_last_warn).to be_nil
+        allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'success', MiqAeEngine::MiqAeWorkspaceRuntime.new])
+        vm_with_owner_no_group.retirement_check
+        status, message, result = MiqQueue.first.deliver
+        MiqQueue.first.delivered(status, message, result)
+
+        expect(vm_with_owner_no_group.retirement_last_warn).not_to be_nil
+        # the next test is only nil because we're not creating a true super admin in these specs
+        expect(vm_with_owner_no_group.retirement_requester).to eq(nil)
+      end
+    end
+
     context "without user" do
       before do
         user.destroy


### PR DESCRIPTION
System retirement breaks currently if a user's groups get deleted. 


https://bugzilla.redhat.com/show_bug.cgi?id=1750990


<sub><sup>given the situation we're in here...</sup></sub>