### PR TITLE
Deprecate find_by_* methods

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -160,7 +160,7 @@ module Authenticator
 
     def authenticate_with_http_basic(username, password, request = nil, options = {})
       options[:require_user] ||= false
-      user, username = find_by_principalname(username)
+      user, username = lookup_by_principalname(username)
       result = nil
       begin
         result = user && authenticate(username, password, request, options)
@@ -175,7 +175,7 @@ module Authenticator
     end
 
     # FIXME: LDAP
-    def find_by_principalname(username)
+    def lookup_by_principalname(username)
       unless (user = case_insensitive_find_by_userid(username))
         if username.include?('\\')
           parts = username.split('\\')
@@ -188,6 +188,9 @@ module Authenticator
       end
       [user, username]
     end
+
+    alias find_by_principalname lookup_by_principalname
+    Vmdb::Deprecation.deprecate_methods(self, :find_by_principalname => :lookup_by_principalname)
 
     private
 
@@ -210,7 +213,7 @@ module Authenticator
     end
 
     def case_insensitive_find_by_userid(username)
-      user =  User.find_by_userid(username)
+      user =  User.lookup_by_userid(username)
       user || User.in_my_region.where('lower(userid) = ?', username.downcase).order(:lastlogon).last
     end
 

--- a/app/models/chargeback_vm.rb
+++ b/app/models/chargeback_vm.rb
@@ -162,7 +162,7 @@ class ChargebackVm < Chargeback
         if @options[:entity_id]
           Vm.where(:id => @options[:entity_id])
         elsif @options[:owner]
-          user = User.find_by_userid(@options[:owner])
+          user = User.lookup_by_userid(@options[:owner])
           if user.nil?
             _log.error("Unable to find user '#{@options[:owner]}'. Calculating chargeback costs aborted.")
             raise MiqException::Error, _("Unable to find user '%{name}'") % {:name => @options[:owner]}

--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -223,7 +223,7 @@ class CustomButton < ApplicationRecord
   end
 
   def self.get_user(user)
-    user = User.find_by_userid(user) if user.kind_of?(String)
+    user = User.lookup_by_userid(user) if user.kind_of?(String)
     raise _("Unable to find user '%{user}'") % {:user => user} if user.nil?
     user
   end

--- a/app/models/dialog_field_importer.rb
+++ b/app/models/dialog_field_importer.rb
@@ -57,6 +57,6 @@ class DialogFieldImporter
       cat = Category.find_by(:id => opts[:category_id])
       return cat if cat.try(:name) == opts[:category_name]
     end
-    Category.find_by_name(opts[:category_name])
+    Category.lookup_by_name(opts[:category_name])
   end
 end

--- a/app/models/miq_ae_field.rb
+++ b/app/models/miq_ae_field.rb
@@ -56,9 +56,12 @@ class MiqAeField < ApplicationRecord
     DEFAULTS[key.to_sym]
   end
 
-  def self.find_by_name(name)
+  def self.lookup_by_name(name)
     where("lower(name) = ?", name.downcase).first
   end
+
+  singleton_class.send(:alias_method, :find_by_name, :lookup_by_name)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_name => :lookup_by_name)
 
   def default_value=(value)
     set_default_value(value)

--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -11,9 +11,12 @@ class MiqAeInstance < ApplicationRecord
   validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ . - characters")
 
-  def self.find_by_name(name)
+  def self.lookup_by_name(name)
     where("lower(name) = ?", name.downcase).first
   end
+
+  singleton_class.send(:alias_method, :find_by_name, :lookup_by_name)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_name => :lookup_by_name)
 
   def get_field_attribute(field, validate, attribute)
     if validate

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -125,10 +125,13 @@ class MiqAeMethod < ApplicationRecord
     MiqAeDatastore.get_homonymic_across_domains(user, ::MiqAeMethod, fqname, enabled)
   end
 
-  def self.find_by_class_id_and_name(class_id, name)
+  def self.lookup_by_class_id_and_name(class_id, name)
     ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(name)
     ::MiqAeMethod.where(ae_method_filter).where(:class_id => class_id).first
   end
+
+  singleton_class.send(:alias_method, :find_by_class_id_and_name, :lookup_by_class_id_and_name)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_class_id_and_name => :lookup_by_class_id_and_name)
 
   def self.display_name(number = 1)
     n_('Automate Method', 'Automate Methods', number)

--- a/app/models/miq_approval.rb
+++ b/app/models/miq_approval.rb
@@ -38,7 +38,7 @@ class MiqApproval < ApplicationRecord
   end
 
   def authorized?(userid)
-    user = userid.kind_of?(User) ? userid : User.find_by_userid(userid)
+    user = userid.kind_of?(User) ? userid : User.lookup_by_userid(userid)
     return false unless user
 
     return true if user.role_allows?(:identifier => "miq_request_approval") || (approver.kind_of?(User) && approver == user)
@@ -62,7 +62,7 @@ class MiqApproval < ApplicationRecord
   end
 
   def user_validate(userid)
-    user = userid.kind_of?(User) ? userid : User.find_by_userid(userid)
+    user = userid.kind_of?(User) ? userid : User.lookup_by_userid(userid)
     raise "not authorized" unless authorized?(user)
     user
   end

--- a/app/models/miq_compare.rb
+++ b/app/models/miq_compare.rb
@@ -214,7 +214,7 @@ class MiqCompare
       elsif section == :categories
         column = column.to_s
         section = "#{TAG_PREFIX}#{column}".to_sym
-        c = Classification.find_by_name(column)
+        c = Classification.lookup_by_name(column)
         section_header = (c.nil? || c.description.blank?) ? column.titleize : c.description
         column = nil # columns will be filled in dynamically when we fetch the section data
         key = nil
@@ -252,7 +252,7 @@ class MiqCompare
         @results.each_value { |result| result[section].delete_if { |k, _v| !columns.include?(k) && k.to_s[0, 1] != '_' } }
 
         # Get all of the tag headers
-        cat = Classification.find_by_name(self.class.section_to_tag(section))
+        cat = Classification.lookup_by_name(self.class.section_to_tag(section))
         columns.collect! { |c| {:name => c, :header => cat.find_entry_by_name(c.to_s).description} }
 
         columns.sort! { |x, y| x[:header].to_s.downcase <=> y[:header].to_s.downcase }
@@ -303,7 +303,7 @@ class MiqCompare
       # Get the tag entry name and description from the source
       new_columns = case @mode
                     when :compare
-                      Classification.find_by_name(tag_name).entries.collect { |e| [e.name, e.description] if rec.is_tagged_with?(e.tag.name, :ns => "*") }
+                      Classification.lookup_by_name(tag_name).entries.collect { |e| [e.name, e.description] if rec.is_tagged_with?(e.tag.name, :ns => "*") }
                     when :drift
                       rec.tags.to_miq_a.collect { |tag| [tag.entry_name, tag.entry_description] if tag.category_name == tag_name }
                     end

--- a/app/models/miq_provision/tagging.rb
+++ b/app/models/miq_provision/tagging.rb
@@ -6,7 +6,7 @@ module MiqProvision::Tagging
 
   def allowed_tags_by_category(category_name)
     user_tags = get_user_managed_filters
-    category = Classification.find_by_name(category_name)
+    category = Classification.lookup_by_name(category_name)
     raise MiqException::MiqProvisionError, "unknown category, '#{category_name}'" if category.nil?
     category.entries.each_with_object({}) do |entry, h|
       if user_tags.blank? || user_tags.include?(entry.to_tag)

--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -43,7 +43,7 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
 
   # NOTE: for services, the requester is the owner
   def owner_options(service_task)
-    user = User.find_by_userid(service_task.userid)
+    user = User.lookup_by_userid(service_task.userid)
     return {} if user.nil?
 
     {

--- a/app/models/miq_provision_virt_workflow.rb
+++ b/app/models/miq_provision_virt_workflow.rb
@@ -212,7 +212,7 @@ class MiqProvisionVirtWorkflow < MiqProvisionWorkflow
   def allowed_cat_entries(options)
     rails_logger('allowed_cat_entries', 0)
     @values["#{options[:prov_field_name]}_category".to_sym] = options[:category]
-    cat = Classification.find_by_name(options[:category].to_s)
+    cat = Classification.lookup_by_name(options[:category].to_s)
     result = cat ? cat.entries.each_with_object({}) { |e, h| h[e.name] = e.description } : {}
     rails_logger('allowed_cat_entries', 1)
     result

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -517,7 +517,7 @@ module MiqReport::Generator
             if tag == "_none_"
               tags2desc[tag] = "[None]"
             else
-              entry = Classification.find_by_name([performance[:group_by_category], tag].join("/"))
+              entry = Classification.lookup_by_name([performance[:group_by_category], tag].join("/"))
               tags2desc[tag] = entry.nil? ? tag.titleize : entry.description
             end
           end

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -177,7 +177,7 @@ module MiqReport::Generator
       User.with_user(options[:user]) { _generate_table(options) }
     elsif options[:userid]
       userid = MiqReportResult.parse_userid(options[:userid])
-      user = User.find_by_userid(userid)
+      user = User.lookup_by_userid(userid)
       User.with_user(user, userid) { _generate_table(options) }
     else
       _generate_table(options)
@@ -354,7 +354,7 @@ module MiqReport::Generator
 
     curr_tz = Time.zone # Save current time zone setting
     userid = options[:userid].split("|").first if options[:userid]
-    user = User.find_by_userid(userid) if userid
+    user = User.lookup_by_userid(userid) if userid
 
     # TODO: user is nil from MiqWidget#generate_report_result due to passing the username as the second part of :userid, such as widget_id_735|admin...
     # Looks like widget generation for a user doesn't expect multiple timezones, could be an issue with MiqGroups.

--- a/app/models/miq_report/generator/trend.rb
+++ b/app/models/miq_report/generator/trend.rb
@@ -50,8 +50,8 @@ module MiqReport::Generator::Trend
     build_apply_time_profile(results)
     results = db_klass.build(results, db_options)
 
-     if conditions
-      tz = User.find_by_userid(options[:userid]).get_timezone if options[:userid]
+    if conditions
+      tz = User.lookup_by_userid(options[:userid]).get_timezone if options[:userid]
       results = results.reject { |obj| conditions.lenient_evaluate(obj, tz) }
     end
     results = results[0...options[:limit]] if options[:limit]

--- a/app/models/miq_report/import_export.rb
+++ b/app/models/miq_report/import_export.rb
@@ -35,13 +35,13 @@ module MiqReport::ImportExport
       report[:db_options] ||= report["db_options"]
       report[:db_options].deep_symbolize_keys! if report[:db_options]
 
-      user = options[:user] || User.find_by_userid(options[:userid])
+      user = options[:user] || User.lookup_by_userid(options[:userid])
 
       if options[:preserve_owner]
         userid = report.delete("userid")
         group_description = report.delete("group_description")
 
-        report_user = userid.present? ? User.find_by_userid(userid) : User.find_by(:id => report["user_id"])
+        report_user = userid.present? ? User.lookup_by_userid(userid) : User.find_by(:id => report["user_id"])
         if report_user.nil?
           _log.warn("User '#{userid.presence || report["user_id"]}' for imported report '#{report["name"]}' was not found")
           report.delete("user_id")

--- a/app/models/miq_report/notification.rb
+++ b/app/models/miq_report/notification.rb
@@ -3,7 +3,7 @@ module MiqReport::Notification
     userid = options[:userid]
     url = options[:email_url_prefix]
 
-    user = User.find_by_userid(userid)
+    user = User.lookup_by_userid(userid)
     from = options[:email] && !options[:email][:from].blank? ? options[:email][:from] : ::Settings.smtp.from
     to   = options[:email] ? options[:email][:to] : user.try(:email)
 

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -32,7 +32,7 @@ class MiqReportResult < ApplicationRecord
   before_save do
     user_info = userid.to_s.split("|")
     if user_info.length == 1
-      user = User.find_by_userid(user_info.first)
+      user = User.lookup_by_userid(user_info.first)
       self.miq_group_id ||= user.current_group_id unless user.nil?
     end
   end
@@ -276,7 +276,7 @@ class MiqReportResult < ApplicationRecord
     task = MiqTask.find_by(:id => taskid)
     task.update_status("Active", "Ok", "Generating report result [#{result_type}]") if task
 
-    user = options[:user] || User.find_by_userid(options[:userid])
+    user = options[:user] || User.lookup_by_userid(options[:userid])
     raise _("Unable to find user with userid 'options[:userid]'") if user.nil?
 
     rpt = report_results
@@ -401,7 +401,7 @@ class MiqReportResult < ApplicationRecord
   end
 
   def user_timezone
-    user = userid.include?("|") ? nil : User.find_by_userid(userid)
+    user = userid.include?("|") ? nil : User.lookup_by_userid(userid)
     user ? user.get_timezone : MiqServer.my_server.server_timezone
   end
 end

--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -752,7 +752,7 @@ class MiqRequestWorkflow
     values[:requester_group] ||= @requester.current_group.description
     email = values[:owner_email]
     if email.present? && values[:owner_group].blank?
-      values[:owner_group] = User.find_by_lower_email(email, @requester).try(:miq_group_description)
+      values[:owner_group] = User.lookup_by_lower_email(email, @requester).try(:miq_group_description)
     end
   end
 

--- a/app/models/miq_request_workflow/dialog_field_validation.rb
+++ b/app/models/miq_request_workflow/dialog_field_validation.rb
@@ -8,7 +8,11 @@ module MiqRequestWorkflow::DialogFieldValidation
     required_tags = fld[:required_tags].to_miq_a.collect(&:to_sym)
     missing_tags = required_tags - selected_tags_categories
     missing_categories_names = missing_tags.collect do |category|
-      Classification.find_by_name(category.to_s).description rescue nil
+      begin
+        Classification.lookup_by_name(category.to_s).description
+      rescue StandardError
+        nil
+      end
     end.compact
 
     return nil if missing_categories_names.blank?

--- a/app/models/miq_schedule.rb
+++ b/app/models/miq_schedule.rb
@@ -232,7 +232,7 @@ class MiqSchedule < ApplicationRecord
 
   def action_automation_request(_klass, _at)
     parameters = filter[:parameters]
-    user = User.find_by_userid(userid)
+    user = User.lookup_by_userid(userid)
     AutomationRequest.create_from_scheduled_task(user, filter[:uri_parts], parameters)
   end
 

--- a/app/models/mixins/filterable_mixin.rb
+++ b/app/models/mixins/filterable_mixin.rb
@@ -2,7 +2,7 @@ module FilterableMixin
   extend ActiveSupport::Concern
 
   def authorized_for_user?(userid)
-    user     = User.find_by_userid(userid)
+    user     = User.lookup_by_userid(userid)
     mfilters = user ? user.get_managed_filters : []
     bfilters = user ? user.get_belongsto_filters : []
     db       = self.class

--- a/app/models/mixins/miq_provision_mixin.rb
+++ b/app/models/mixins/miq_provision_mixin.rb
@@ -55,7 +55,7 @@ module MiqProvisionMixin
     @owner ||= begin
       email = get_option(:owner_email).try(:downcase)
       return if email.blank?
-      User.find_by_lower_email(email, get_user).tap do |owner|
+      User.lookup_by_lower_email(email, get_user).tap do |owner|
         owner.current_group_by_description = get_option(:owner_group) if owner
       end
     end

--- a/app/models/mixins/miq_request_mixin.rb
+++ b/app/models/mixins/miq_request_mixin.rb
@@ -85,7 +85,7 @@ module MiqRequestMixin
   end
 
   def add_tag(category, tag_name)
-    cat = Classification.find_by_name(category.to_s)
+    cat = Classification.lookup_by_name(category.to_s)
     return if cat.nil?
     tag = cat.children.detect { |t| t.name.casecmp(tag_name.to_s) == 0 }
     return if tag.nil?
@@ -139,10 +139,10 @@ module MiqRequestMixin
       next unless tag_name.starts_with?(ns)
       tag_path = tag_name.split('/')[2..-1].join('/')
       parts = tag_path.split('/')
-      cat = Classification.find_by_name(parts.first)
+      cat = Classification.lookup_by_name(parts.first)
       next if cat.show? == false
       cat_descript = cat.description
-      tag_descript = Classification.find_by_name(tag_path).description
+      tag_descript = Classification.lookup_by_name(tag_path).description
       ws_tag_data << {:category => parts.first, :category_display_name => cat_descript,
                       :tag_name => parts.last,  :tag_display_name => tag_descript,
                       :tag_path =>  File.join(ns, tag_path), :display_name => "#{cat_descript}: #{tag_descript}"}

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -76,7 +76,7 @@ module PerEmsWorkerMixin
 
     def stop_worker_for_ems(ems_or_queue_name)
       wpid = nil
-      find_by_queue_name(queue_name_for_ems(ems_or_queue_name).to_s).each do |w|
+      lookup_by_queue_name(queue_name_for_ems(ems_or_queue_name).to_s).each do |w|
         next unless w.status == MiqWorker::STATUS_STARTED
         wpid = w.pid
         w.stop
@@ -89,13 +89,19 @@ module PerEmsWorkerMixin
       start_worker_for_ems(ems)
     end
 
-    def find_by_ems(ems)
-      find_by_queue_name(queue_name_for_ems(ems))
+    def lookup_by_ems(ems)
+      lookup_by_queue_name(queue_name_for_ems(ems))
     end
 
-    def find_by_queue_name(queue_name)
+    alias find_by_ems lookup_by_ems
+    Vmdb::Deprecation.deprecate_methods(self, :find_by_ems => :lookup_by_ems)
+
+    def lookup_by_queue_name(queue_name)
       server_scope.where(:queue_name => queue_name).order("started_on DESC")
     end
+
+    alias find_by_queue_name lookup_by_queue_name
+    Vmdb::Deprecation.deprecate_methods(self, :find_by_queue_name => :lookup_by_queue_name)
 
     def queue_name_for_ems(ems)
       return ems unless ems.kind_of?(ExtManagementSystem)

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -22,11 +22,14 @@ class PglogicalSubscription < ActsAsArModel
     end
   end
 
-  def self.find_by_id(to_find)
+  def self.lookup_by_id(to_find)
     find(to_find)
   rescue ActiveRecord::RecordNotFound
     nil
   end
+
+  singleton_class.send(:alias_method, :find_by_id, :lookup_by_id)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_id => :lookup_by_id)
 
   def save!(reload_failover_monitor = true)
     assert_different_region!

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -122,9 +122,12 @@ class Tag < ApplicationRecord
     where(:name => fq_tag_names)
   end
 
-  def self.find_by_classification_name(name)
+  def self.lookup_by_classification_name(name)
     in_region(my_region_number).find_by(:name => Classification.name2tag(name))
   end
+
+  singleton_class.send(:alias_method, :find_by_classification_name, :lookup_by_classification_name)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_classification_name => :lookup_by_classification_name)
 
   def ==(comparison_object)
     super || name.downcase == comparison_object.to_s.downcase

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,24 +81,36 @@ class User < ApplicationRecord
     {table_name => {:id => users_ids}}
   end
 
-  def self.find_by_userid(userid)
+  def self.lookup_by_userid(userid)
     in_my_region.find_by(:userid => userid)
   end
 
-  def self.find_by_userid!(userid)
+  singleton_class.send(:alias_method, :find_by_userid, :lookup_by_userid)
+  Vmdb::Deprecation.deprecate_methods(self, :find_by_userid => :lookup_by_userid)
+
+  def self.lookup_by_userid!(userid)
     in_my_region.find_by!(:userid => userid)
   end
 
-  def self.find_by_email(email)
+  singleton_class.send(:alias_method, :find_by_userid!, :lookup_by_userid!)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_userid! => :lookup_by_userid!)
+
+  def self.lookup_by_email(email)
     in_my_region.find_by(:email => email)
   end
 
+  singleton_class.send(:alias_method, :find_by_email, :lookup_by_email)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_email => :lookup_by_email)
+
   # find a user by lowercase email
   # often we have the most probably user object onhand. so use that if possible
-  def self.find_by_lower_email(email, cache = [])
+  def self.lookup_by_lower_email(email, cache = [])
     email = email.downcase
     Array.wrap(cache).detect { |u| u.email.try(:downcase) == email } || find_by(['lower(email) = ?', email])
   end
+
+  singleton_class.send(:alias_method, :find_by_lower_email, :lookup_by_lower_email)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_lower_email => :lookup_by_lower_email)
 
   virtual_column :ldap_group, :type => :string, :uses => :current_group
   # FIXME: amazon_group too?
@@ -309,7 +321,7 @@ class User < ApplicationRecord
   end
 
   def self.current_user
-    Thread.current[:user] ||= find_by_userid(current_userid)
+    Thread.current[:user] ||= lookup_by_userid(current_userid)
   end
 
   # parallel to MiqGroup.with_groups - only show users with these groups

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -634,7 +634,7 @@ class VmOrTemplate < ApplicationRecord
   end
 
   # TODO: Vmware specific
-  def self.find_by_full_location(path)
+  def self.lookup_by_full_location(path)
     return nil if path.blank?
     vm_hash = {}
     begin
@@ -648,6 +648,9 @@ class VmOrTemplate < ApplicationRecord
     return nil unless store
     VmOrTemplate.find_by(:location => vm_hash[:location], :storage_id => store.id)
   end
+
+  singleton_class.send(:alias_method, :find_by_full_location, :lookup_by_full_location)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_full_location => :lookup_by_full_location)
 
   def self.repository_parse_path(path)
     path.gsub!(/\\/, "/")
@@ -1286,7 +1289,7 @@ class VmOrTemplate < ApplicationRecord
 
   # TODO: Vmware specific
   # Finds a Vm by a full path of the Storage and location
-  def self.find_by_path(path)
+  def self.lookup_by_path(path)
     begin
       storage_id, location = parse_path(path)
     rescue
@@ -1295,6 +1298,9 @@ class VmOrTemplate < ApplicationRecord
     end
     VmOrTemplate.find_by(:storage_id => storage_id, :location => location)
   end
+
+  singleton_class.send(:alias_method, :find_by_path, :lookup_by_path)
+  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_path => :lookup_by_path)
 
   def state
     (power_state || "unknown").downcase

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -1406,7 +1406,7 @@ class VmOrTemplate < ApplicationRecord
 
   def self.folder_category(folder_type)
     cat_name = "folder_path_#{folder_type}"
-    cat = Classification.find_by_name(cat_name)
+    cat = Classification.lookup_by_name(cat_name)
     unless cat
       cat = Classification.is_category.new(
         :name         => cat_name,

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -579,7 +579,7 @@ class MiqExpression
     end
     if val_is_a_tag
       if col
-        classification = options[:classification] || Classification.find_by_name(col) # rubocop:disable Rails/DynamicFindBy
+        classification = options[:classification] || Classification.lookup_by_name(col)
         ret << (classification ? classification.description : col)
       end
     else
@@ -1079,7 +1079,7 @@ class MiqExpression
 
     if ns == "managed"
       cat = field.split("-").last
-      catobj = Classification.find_by_name(cat) # rubocop:disable Rails/DynamicFindBy
+      catobj = Classification.lookup_by_name(cat)
       return catobj ? catobj.entries.collect { |e| [e.description, e.name] } : []
     elsif ns == "user_tag" || ns == "user"
       cat = field.split("-").last

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -296,8 +296,8 @@ class MiqLdap
       return "#{username}@#{@user_suffix}"
     when "mail"
       username = "#{username}@#{@user_suffix}" unless @user_suffix.blank? || upn?(username)
-      dbuser = User.find_by_email(username.downcase)
-      dbuser ||= User.find_by_userid(username.downcase)
+      dbuser = User.lookup_by_email(username.downcase)
+      dbuser ||= User.lookup_by_userid(username.downcase)
       return dbuser.userid if dbuser && dbuser.userid
 
       return username

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -693,7 +693,7 @@ module Rbac
     end
 
     def lookup_user_group(user, userid, miq_group, miq_group_id)
-      user ||= (userid && User.find_by_userid(userid)) || User.current_user
+      user ||= (userid && User.lookup_by_userid(userid)) || User.current_user
       miq_group_id ||= miq_group.try!(:id)
       return [user, user.current_group] if user && user.current_group_id.to_s == miq_group_id.to_s
 

--- a/lib/task_helpers/imports/tags.rb
+++ b/lib/task_helpers/imports/tags.rb
@@ -59,7 +59,7 @@ module TaskHelpers
         tag_category["name"] = tag_category["name"].to_s
         tag_category.delete("parent_id")
 
-        classification = Classification.find_by_name(tag_category['name'], REGION_NUMBER, ns)
+        classification = Classification.lookup_by_name(tag_category['name'], REGION_NUMBER, ns)
 
         entries = tag_category.delete('entries')
 

--- a/lib/tasks/evm_automate.rake
+++ b/lib/tasks/evm_automate.rake
@@ -27,7 +27,7 @@ module EvmAutomate
     if ns.nil?
       MiqAeClass.all.sort_by(&:fqname).each { |c| puts "#{c.fqname}," }
     else
-      class_list = MiqAeNamespace.find_by_fqname(ns).ae_classes.collect(&:fqname).join(", ")
+      class_list = MiqAeNamespace.lookup_by_fqname(ns).ae_classes.collect(&:fqname).join(", ")
       puts class_list
     end
   end

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -264,8 +264,8 @@ describe MiqLdap do
     it "searches for username when user_type is mail even when username is UPN" do
       @opts[:user_type] = 'mail'
       ldap = MiqLdap.new(@opts)
-      expect(User).to receive(:find_by_email)
-      expect(User).to receive(:find_by_userid)
+      expect(User).to receive(:lookup_by_email)
+      expect(User).to receive(:lookup_by_userid)
       expect(ldap.fqusername('myuserid@mycompany.com')).to eq('myuserid@mycompany.com')
     end
   end

--- a/spec/lib/task_helpers/imports/tags_spec.rb
+++ b/spec/lib/task_helpers/imports/tags_spec.rb
@@ -55,7 +55,7 @@ describe TaskHelpers::Imports::Tags do
         assert_test_tag_two_present
         expect(Tag.exists?(tag_two_cat)).to be_falsey
         expect(parent.find_entry_by_name('london').description).to eq('London Town')
-        tag_cat = Classification.find_by_name(tag_two_name)
+        tag_cat = Classification.lookup_by_name(tag_two_name)
         expect(tag_cat.description).to eq(tag_two_desc)
       end
     end
@@ -91,7 +91,7 @@ describe TaskHelpers::Imports::Tags do
   end
 
   def assert_test_tag_one_present
-    tag_cat = Classification.find_by_name(tag_one_name)
+    tag_cat = Classification.lookup_by_name(tag_one_name)
     expect(tag_cat).to_not be_nil
     expect(tag_cat.tag).to_not be_nil
     expect(File.split(tag_cat.tag.name).last).to_not be_nil
@@ -101,7 +101,7 @@ describe TaskHelpers::Imports::Tags do
   end
 
   def assert_test_tag_two_present
-    tag_cat = Classification.find_by_name(tag_two_name)
+    tag_cat = Classification.lookup_by_name(tag_two_name)
     expect(tag_cat).to_not be_nil
     expect(tag_cat.tag).to_not be_nil
     expect(File.split(tag_cat.tag.name).last).to_not be_nil

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -19,6 +19,12 @@ describe Authenticator::Database do
     end
   end
 
+  describe '#lookup_by_principalname' do
+    it "finds existing users" do
+      expect(subject.lookup_by_principalname('alice').first).to eq(alice)
+    end
+  end
+
   describe '#authenticate' do
     def authenticate
       subject.authenticate(username, password)

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -198,7 +198,7 @@ describe Authenticator::Httpd do
         it "immediately completes the task" do
           task_id = authenticate
           task = MiqTask.find(task_id)
-          expect(User.find_by_userid(task.userid)).to eq(alice)
+          expect(User.lookup_by_userid(task.userid)).to eq(alice)
         end
       end
     end
@@ -394,7 +394,7 @@ describe Authenticator::Httpd do
         it "immediately completes the task" do
           task_id = authenticate
           task = MiqTask.find(task_id)
-          user = User.find_by_userid(task.userid)
+          user = User.lookup_by_userid(task.userid)
           expect(user.name).to eq('Bob Builderson')
           expect(user.email).to eq('bob@example.com')
         end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -275,7 +275,7 @@ describe Authenticator::Ldap do
         it "immediately completes the task" do
           task_id = authenticate
           task = MiqTask.find(task_id)
-          expect(User.find_by_userid(task.userid)).to eq(alice)
+          expect(User.lookup_by_userid(task.userid)).to eq(alice)
         end
 
         context "new user creation" do
@@ -446,7 +446,7 @@ describe Authenticator::Ldap do
         it "immediately completes the task" do
           task_id = authenticate
           task = MiqTask.find(task_id)
-          user = User.find_by_userid(task.userid)
+          user = User.lookup_by_userid(task.userid)
           expect(user.name).to eq('Bob Builderson')
           expect(user.email).to eq('bob@example.com')
         end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -42,7 +42,7 @@ describe Classification do
     let(:host2) { FactoryBot.create(:host, :name => "HOST2") }
     let(:host3) do
       FactoryBot.create(:host, :name => "HOST3").tap do |host|
-        Classification.find_by_name("test_category").entries.each { |ent| ent.assign_entry_to(host) }
+        Classification.lookup_by_name("test_category").entries.each { |ent| ent.assign_entry_to(host) }
       end
     end
     let(:sti_inst) { FactoryBot.create(:template_vmware) }
@@ -63,7 +63,7 @@ describe Classification do
 
     context "#destroy" do
       it "a category deletes all entries" do
-        cat = Classification.find_by_name("test_category")
+        cat = Classification.lookup_by_name("test_category")
         expect(cat).to_not be_nil
         entries = cat.entries
         expect(entries.length).to eq(2)
@@ -73,7 +73,7 @@ describe Classification do
       end
 
       it "a category deletes assignments referenced by its entries" do
-        cat = Classification.find_by_name("test_category")
+        cat = Classification.lookup_by_name("test_category")
         assignment_tag = "/chargeback_rate/assigned_to/vm/tag/managed/test_category/test_entry"
 
         Tag.create!(:name => assignment_tag)
@@ -85,7 +85,7 @@ describe Classification do
       end
 
       it "a category does not delete assignments that are close but do not match its tag" do
-        cat = Classification.find_by_name("test_category")
+        cat = Classification.lookup_by_name("test_category")
         assignment_tag = "/chargeback_rate/assigned_to/vm/tag/managed/test_category/test_entry"
         another_tag1 = Tag.create(:name => "/policy_set/assigned_to/vm/tag/managed/test_category/test_entry1")
         another_tag2 = Tag.create(:name => "/chargeback_rate/assigned_to/vm/tag/managed/test_category1/test_entry")
@@ -100,7 +100,7 @@ describe Classification do
       end
 
       it "an entry deletes assignments where its tag is referenced" do
-        cat = Classification.find_by_name("test_category")
+        cat = Classification.lookup_by_name("test_category")
         ent = cat.entries.find { |e| e.name == "test_entry" }
         assignment_tag = "/chargeback_rate/assigned_to/vm/tag/managed/test_category/test_entry"
 
@@ -114,14 +114,14 @@ describe Classification do
     end
 
     it "should test setup data" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       expect(cat).to_not be_nil
       expect(cat.tag).to_not be_nil
       expect(File.split(cat.tag.name).last).to_not be_nil
     end
 
     it "should test add entry" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       ent = FactoryBot.create(:classification_tag, :name => "test_add_entry", :parent => cat)
 
       expect(ent).to be_valid
@@ -130,7 +130,7 @@ describe Classification do
     end
 
     it "should test add entry directly (without calling add_entry)" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       ent = cat.children.new(:name => "test_add_entry_1")
       ent.save(:validate => false)
 
@@ -151,7 +151,7 @@ describe Classification do
     end
 
     it "should test update category" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       cat.name = "test_update_entry"
 
       expect(cat).to      be_valid
@@ -159,7 +159,7 @@ describe Classification do
     end
 
     it "should test add duplicate entry" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       ent = FactoryBot.create(:classification_tag, :name => "test_add_dup_entry", :parent => cat)
 
       expect(ent).to be_valid
@@ -169,7 +169,7 @@ describe Classification do
     end
 
     it "should test update entry" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       ent = cat.entries[0]
       ent.name = "test_update_entry"
 
@@ -178,7 +178,7 @@ describe Classification do
     end
 
     it "should test update entry to duplicate" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
       ent = cat.entries[0]
       ent.name = cat.entries[1].name
 
@@ -212,7 +212,7 @@ describe Classification do
     end
 
     it "should test assign single entry to" do
-      cat = Classification.find_by_name "test_single_value_category"
+      cat = Classification.lookup_by_name "test_single_value_category"
       ent1 = cat.entries[0]
       ent2 = cat.entries[1]
 
@@ -227,7 +227,7 @@ describe Classification do
     end
 
     it "should test assign multi entry to" do
-      cat = Classification.find_by_name "test_multi_value_category"
+      cat = Classification.lookup_by_name "test_multi_value_category"
       ent1 = cat.entries[0]
       ent2 = cat.entries[1]
 
@@ -247,11 +247,11 @@ describe Classification do
     end
 
     it "find with multiple tags" do
-      cat1 = Classification.find_by_name "test_single_value_category"
+      cat1 = Classification.lookup_by_name "test_single_value_category"
       ent11 = cat1.entries[0]
       ent12 = cat1.entries[1]
 
-      cat2 = Classification.find_by_name "test_multi_value_category"
+      cat2 = Classification.lookup_by_name "test_multi_value_category"
       ent21 = cat2.entries[0]
       ent22 = cat2.entries[1]
 
@@ -270,7 +270,7 @@ describe Classification do
     end
 
     it "finds tagged items with order clause" do
-      cat1 = Classification.find_by_name "test_single_value_category"
+      cat1 = Classification.lookup_by_name "test_single_value_category"
       ent11 = cat1.entries[0]
 
       ent11.assign_entry_to(host1)
@@ -285,16 +285,16 @@ describe Classification do
       expect(any_tagged_with(Host.order(Host.arel_table[:name].lower), ent11.name, ent11.parent.name)).to eq([host1])
     end
 
-    it "should test find by entry" do
-      cat = Classification.find_by_name "test_multi_value_category"
+    it "should test lookup by entry" do
+      cat = Classification.lookup_by_name "test_multi_value_category"
       ent1 = cat.entries[0]
 
       ent1.assign_entry_to(host2)
-      expect(ent1.find_by_entry("Host")[0].name).to eq(host2.name)
+      expect(ent1.lookup_by_entry("Host")[0].name).to eq(host2.name)
     end
 
     it "should test remove entry from" do
-      cat = Classification.find_by_name "test_multi_value_category"
+      cat = Classification.lookup_by_name "test_multi_value_category"
       ent1 = cat.entries[0]
       ent2 = cat.entries[1]
 
@@ -312,7 +312,7 @@ describe Classification do
     end
 
     it "should test to_tag" do
-      cat = Classification.find_by_name("test_category")
+      cat = Classification.lookup_by_name("test_category")
 
       expect(cat).to_not be_nil
       expect(cat.entries.length).to eq(2)
@@ -320,7 +320,7 @@ describe Classification do
     end
 
     it "should test assign single entry to an STI instance" do
-      cat = Classification.find_by_name "test_single_value_category"
+      cat = Classification.lookup_by_name "test_single_value_category"
       ent1 = cat.entries[0]
       ent2 = cat.entries[1]
 
@@ -333,15 +333,15 @@ describe Classification do
     end
 
     it "should test find by entry for an STI instance" do
-      cat = Classification.find_by_name "test_multi_value_category"
+      cat = Classification.lookup_by_name "test_multi_value_category"
       ent1 = cat.entries[0]
 
       ent1.assign_entry_to(sti_inst)
-      expect(ent1.find_by_entry("MiqTemplate")[0]).to eq(sti_inst)
+      expect(ent1.lookup_by_entry("MiqTemplate")[0]).to eq(sti_inst)
     end
 
     it "should test remove entry from an STI instance" do
-      cat = Classification.find_by_name "test_multi_value_category"
+      cat = Classification.lookup_by_name "test_multi_value_category"
       ent1 = cat.entries[0]
       ent2 = cat.entries[1]
 
@@ -360,11 +360,11 @@ describe Classification do
         targets = [host1, host2, host3]
         @options[:object_ids] = targets.collect(&:id)
 
-        cat = Classification.find_by_name("test_category")
+        cat = Classification.lookup_by_name("test_category")
         @dels = cat.entries.collect
         @options[:delete_ids] = @dels.collect(&:id)
 
-        cat = Classification.find_by_name("test_multi_value_category")
+        cat = Classification.lookup_by_name("test_multi_value_category")
         @adds = cat.entries.collect
         @options[:add_ids] = @adds.collect(&:id)
       end
@@ -389,12 +389,12 @@ describe Classification do
 
     context "#category" do
       it "for tag" do
-        tag = Classification.find_by_name("test_category").children.first
+        tag = Classification.lookup_by_name("test_category").children.first
         expect(tag.category).to eq("test_category")
       end
 
       it "for category" do
-        expect(Classification.find_by_name("test_category").category).to be_nil
+        expect(Classification.lookup_by_name("test_category").category).to be_nil
       end
     end
   end
@@ -489,25 +489,25 @@ describe Classification do
     end
 
     it "finds in region" do
-      local = Classification.find_by_name("test_category1", my_region_number)
+      local = Classification.lookup_by_name("test_category1", my_region_number)
       expect(local).to eq(@local)
-      remote = Classification.find_by_name("test_category2", other_region)
+      remote = Classification.lookup_by_name("test_category2", other_region)
       expect(remote).to eq(@remote)
     end
 
     it "filters out wrong region" do
-      expect(Classification.find_by_name("test_category1", other_region)).to be_nil
-      expect(Classification.find_by_name("test_category2", my_region_number)).to be_nil
+      expect(Classification.lookup_by_name("test_category1", other_region)).to be_nil
+      expect(Classification.lookup_by_name("test_category2", my_region_number)).to be_nil
     end
 
     it "finds in all regions" do
-      expect(Classification.find_by_name("test_category1", nil)).to eq(@local)
-      expect(Classification.find_by_name("test_category2", nil)).to eq(@remote)
+      expect(Classification.lookup_by_name("test_category1", nil)).to eq(@local)
+      expect(Classification.lookup_by_name("test_category2", nil)).to eq(@remote)
     end
 
     it "finds in my region" do
-      expect(Classification.find_by_name("test_category1")).to eq(@local)
-      expect(Classification.find_by_name("test_category2")).to be_nil
+      expect(Classification.lookup_by_name("test_category1")).to eq(@local)
+      expect(Classification.lookup_by_name("test_category2")).to be_nil
     end
   end
 
@@ -524,17 +524,17 @@ describe Classification do
     end
 
     it "finds in region" do
-      expect(Classification.find_by_names(%w(test_category1 test_category2), my_region_number)).to eq([@local])
-      expect(Classification.find_by_names(%w(test_category1 test_category2), other_region)).to eq([@remote])
+      expect(Classification.lookup_by_names(%w[test_category1 test_category2], my_region_number)).to eq([@local])
+      expect(Classification.lookup_by_names(%w[test_category1 test_category2], other_region)).to eq([@remote])
     end
 
     it "finds in all regions" do
-      expect(Classification.find_by_names(%w(test_category1 test_category2), nil)).to match_array([@local, @remote])
+      expect(Classification.lookup_by_names(%w[test_category1 test_category2], nil)).to match_array([@local, @remote])
     end
 
     it "finds in my region" do
-      Classification.find_by_name(%w(test_category1 test_category2))
-      expect(Classification.find_by_names(%w(test_category1 test_category2))).to eq([@local])
+      Classification.lookup_by_name(%w[test_category1 test_category2])
+      expect(Classification.lookup_by_names(%w[test_category1 test_category2])).to eq([@local])
     end
   end
 

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -78,7 +78,7 @@ describe MiqAeClass do
 
   context "cross domain instances" do
     def set_priority(name, value)
-      ns = MiqAeNamespace.find_by_fqname(name)
+      ns = MiqAeNamespace.lookup_by_fqname(name)
       ns.update!(:priority => value)
     end
 
@@ -335,8 +335,8 @@ describe MiqAeClass do
       create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
       ns_fqnames = %w(FRED FRED/A FRED/A/B FRED/A/B/C FREDDY FREDDY/C FREDDY/C/D FREDDY/C/D/E)
       class_fqnames = %w(/FRED/A/B/C/CLASS1 /FREDDY/C/D/E/CLASS2)
-      ids = ns_fqnames.collect { |ns| "MiqAeNamespace::#{MiqAeNamespace.find_by_fqname(ns, false).id}" }
-      ids += class_fqnames.collect { |cls| "MiqAeClass::#{MiqAeClass.find_by_fqname(cls).id}" }
+      ids = ns_fqnames.collect { |ns| "MiqAeNamespace::#{MiqAeNamespace.lookup_by_fqname(ns, false).id}" }
+      ids += class_fqnames.collect { |cls| "MiqAeClass::#{MiqAeClass.lookup_by_fqname(cls).id}" }
       expect(MiqAeClass.waypoint_ids_for_state_machines).to match_array(ids)
     end
 

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -45,6 +45,13 @@ describe MiqAeField do
       @user = FactoryBot.create(:user_with_group)
     end
 
+    it "looks up by name" do
+      field_name = "TEST"
+      field = @c1.ae_fields.create(:name => field_name)
+
+      expect(MiqAeField.lookup_by_name(field_name)).to eq(field)
+    end
+
     it "should enforce necessary parameters upon create" do
       expect { @c1.ae_fields.new.save! }.to raise_error(ActiveRecord::RecordInvalid)
       # remove the invalid unsaved record in the association by clearing it

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -19,6 +19,13 @@ describe MiqAeInstance do
       i1.destroy
     end
 
+    it "should lookup instance by name" do
+      iname = "instance"
+      instance = @c1.ae_instances.create(:name => iname)
+
+      expect(MiqAeInstance.lookup_by_name(iname)).to eq(instance)
+    end
+
     it "should set the updated_by field on save" do
       i1 = @c1.ae_instances.create(:name => "instance1")
       expect(i1.updated_by).to eq('system')

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -24,6 +24,20 @@ describe MiqAeMethod do
     expect(f1.editable?(user)).to be_truthy
   end
 
+  it "should lookup method" do
+    n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    f1 = FactoryBot.create(:miq_ae_method,
+                           :class_id => c1.id,
+                           :name     => "foo_method",
+                           :scope    => "instance",
+                           :language => "ruby",
+                           :location => "inline")
+    expect(f1.editable?(user)).to be_falsey
+
+    expect(MiqAeMethod.lookup_by_class_id_and_name(c1.id, "foo_method")).to eq(f1)
+  end
+
   context "#copy" do
     let(:d2) { FactoryBot.create(:miq_ae_domain, :name => "domain2", :priority => 2) }
     let(:ns1) { FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => @d1.id) }

--- a/spec/models/miq_ae_namespace_spec.rb
+++ b/spec/models/miq_ae_namespace_spec.rb
@@ -69,22 +69,22 @@ describe MiqAeNamespace do
     expect(n1).not_to be_nil
     expect(n1.save!).to be_truthy
 
-    n2 = MiqAeNamespace.find_by_fqname("SYSTEM/test")
+    n2 = MiqAeNamespace.lookup_by_fqname("SYSTEM/test")
     expect(n2).not_to be_nil
     expect(n2).to eq(n1)
 
-    n2 = MiqAeNamespace.find_by_fqname("system")
+    n2 = MiqAeNamespace.lookup_by_fqname("system")
     expect(n2).not_to be_nil
     expect(n2).to eq(n1.parent)
 
-    expect(MiqAeNamespace.find_by_fqname("TEST")).to be_nil
+    expect(MiqAeNamespace.lookup_by_fqname("TEST")).to be_nil
   end
 
   it "should set the updated_by field on save" do
     n1 = MiqAeNamespace.find_or_create_by_fqname("foo/bar")
     expect(n1.updated_by).to eq('system')
 
-    n2 = MiqAeNamespace.find_by_fqname("foo")
+    n2 = MiqAeNamespace.lookup_by_fqname("foo")
     expect(n2.updated_by).to eq('system')
   end
 
@@ -110,12 +110,13 @@ describe MiqAeNamespace do
 
   it 'find_by_fqname works with and without leading slash' do
     n1 = MiqAeNamespace.find_or_create_by_fqname("foo/bar")
-    MiqAeNamespace.find_by_fqname('/foo/bar').id == n1.id
+
+    expect(MiqAeNamespace.lookup_by_fqname('/foo/bar').id).to eq(n1.id)
   end
 
   it 'empty namespace string should return nil' do
-    expect(MiqAeNamespace.find_by_fqname(nil)).to be_nil
-    expect(MiqAeNamespace.find_by_fqname('')).to be_nil
+    expect(MiqAeNamespace.lookup_by_fqname(nil)).to be_nil
+    expect(MiqAeNamespace.lookup_by_fqname('')).to be_nil
   end
 
   it "#domain" do

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -43,7 +43,7 @@ describe MiqProvisionWorkflow do
             "1.0", admin, "template", "target", false, "cc|001|environment|test", "")
           expect(request).to be_a_kind_of(MiqRequest)
 
-          expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
+          expect(request.options[:vm_tags]).to eq([Classification.lookup_by_name("cc/001").id])
         end
 
         it "should set tags" do
@@ -53,7 +53,7 @@ describe MiqProvisionWorkflow do
             {'cc' => '001', 'environment' => 'test'}, nil, nil, nil)
           expect(request).to be_a_kind_of(MiqRequest)
 
-          expect(request.options[:vm_tags]).to eq([Classification.find_by_name("cc/001").id])
+          expect(request.options[:vm_tags]).to eq([Classification.lookup_by_name("cc/001").id])
         end
 
         it "should encrypt fields" do

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -130,7 +130,7 @@ describe AssignmentMixin do
   # @param value    [String] value e.g.: "test"
   # @return [ClassificationTag] classification tag. `.tag()` is an available method
   def ctag(category = "environment", value = "test")
-    env = Classification.find_by_name(category) ||
+    env = Classification.lookup_by_name(category) ||
           FactoryBot.create(:classification, :name => category, :single_value => 1)
     FactoryBot.create(:classification_tag, :name => value, :parent => env)
   end

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -15,6 +15,10 @@ describe PerEmsWorkerMixin do
     expect(@worker_class.queue_name_for_ems(@ems)).to eq(@ems_queue_name)
   end
 
+  it ".lookup_by_ems" do
+    expect(@worker_class.lookup_by_ems(@ems).first).to eq(@worker_record)
+  end
+
   it ".all_valid_ems_in_zone" do
     expect(@worker_class.all_valid_ems_in_zone).to be_empty
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -171,17 +171,17 @@ describe PglogicalSubscription do
     end
   end
 
-  describe ".find_by_id" do
+  describe ".lookup_by_id" do
     it "returns the specified record with records" do
       with_records
       expected = expected_attrs.first
-      rec = described_class.find_by_id(expected["id"])
+      rec = described_class.lookup_by_id(expected["id"])
       expect(rec.attributes).to eq(expected)
     end
 
     it "returns nil without records" do
       with_no_records
-      expect(described_class.find_by_id("some_subscription")).to be_nil
+      expect(described_class.lookup_by_id("some_subscription")).to be_nil
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -81,7 +81,7 @@ describe Tag do
       FactoryBot.create(:classification_department_with_tags)
 
       @tag            = Tag.find_by(:name => "/managed/department/finance")
-      @category       = Classification.find_by_name("department")
+      @category       = Classification.lookup_by_name("department")
       @classification = @tag.classification
     end
 
@@ -125,13 +125,13 @@ describe Tag do
       FactoryBot.create(:classification_tag,      :name => "another_test_entry", :parent => parent)
     end
 
-    it "finds tag by name" do
-      expect(Tag.find_by_classification_name("test_category")).not_to be_nil
-      expect(Tag.find_by_classification_name("test_category").name).to eq(parent_ns)
+    it "looks up tag by name" do
+      expect(Tag.lookup_by_classification_name("test_category")).not_to be_nil
+      expect(Tag.lookup_by_classification_name("test_category").name).to eq(parent_ns)
     end
 
     it "doesn't find non tag" do
-      expect(Tag.find_by_classification_name("test_entry")).to be_nil
+      expect(Tag.lookup_by_classification_name("test_entry")).to be_nil
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -459,15 +459,32 @@ describe User do
     end
   end
 
-  describe ".find_by_lower_email" do
+  describe ".lookup_by_lower_email" do
     it "uses cache" do
       u = FactoryBot.build(:user_with_email)
-      expect(User.find_by_lower_email(u.email.upcase, u)).to eq(u)
+      expect(User.lookup_by_lower_email(u.email.upcase, u)).to eq(u)
     end
 
     it "finds in the table" do
       u = FactoryBot.create(:user_with_email)
-      expect(User.find_by_lower_email(u.email.upcase)).to eq(u)
+      expect(User.lookup_by_lower_email(u.email.upcase)).to eq(u)
+    end
+  end
+
+  describe ".lookup_by_email" do
+    it "looks up user by email" do
+      u = FactoryBot.create(:user_with_email)
+
+      expect(User.lookup_by_email(u.email)).to eq(u)
+    end
+  end
+
+  describe ".lookup_by_userid" do
+    it "looks up user by email" do
+      u = FactoryBot.create(:user)
+
+      expect(User.lookup_by_userid(u.userid)).to eq(u)
+      expect(User.lookup_by_userid!(u.userid)).to eq(u)
     end
   end
 

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -82,6 +82,26 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".lookup_by_full_location" do
+    it "should lookup vm by full location" do
+      storage = Storage.new(:name => "//test/storage")
+      vm = FactoryBot.create(:vm_vmware, :name => 'vm', :vendor => 'vmware', :storage => storage, :location => 'test_location')
+
+      expect(storage.save!).to be_truthy
+      expect(VmOrTemplate.lookup_by_full_location("#{storage.name}/#{vm.location}")).to eq(vm)
+    end
+  end
+
+  describe ".lookup_by_path" do
+    it "should lookup vm by path" do
+      storage = Storage.new(:name => "//test/storage")
+      vm = FactoryBot.create(:vm_vmware, :name => 'vm', :vendor => 'vmware', :storage => storage, :location => 'test_location')
+
+      expect(storage.save!).to be_truthy
+      expect(VmOrTemplate.lookup_by_path("#{storage.name}/#{vm.location}")).to eq(vm)
+    end
+  end
+
   describe ".miq_expression_includes_any_ipaddresses_arel" do
     subject              { FactoryBot.create(:vm) }
     let(:no_hardware_vm) { FactoryBot.create(:vm) }

--- a/spec/support/automation_helper.rb
+++ b/spec/support/automation_helper.rb
@@ -76,7 +76,7 @@ module Spec
       end
 
       def add_call_method
-        aec = MiqAeClass.find_by_fqname('/ManageIQ/System/Request')
+        aec = MiqAeClass.lookup_by_fqname('/ManageIQ/System/Request')
         aei = aec.ae_instances.detect { |ins| ins.name == 'Call_Method' } if aec
         return if aei
         aef = aec.ae_fields.detect { |fld| fld.name == 'meth1' }

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -147,7 +147,7 @@ module EvmSpecHelper
   def self.yaml_import(domain, options, attrs = {})
     Tenant.seed
     MiqAeImport.new(domain, options.merge('tenant' => Tenant.root_tenant)).import
-    dom = MiqAeNamespace.find_by_fqname(domain)
+    dom = MiqAeNamespace.lookup_by_fqname(domain)
     dom&.update(attrs.reverse_merge(:enabled => true))
   end
 end

--- a/spec/support/quota_helper.rb
+++ b/spec/support/quota_helper.rb
@@ -2,7 +2,7 @@ module Spec
   module Support
     module QuotaHelper
       def create_category_and_tag(category, tag)
-        cat = Classification.find_by_name(category)
+        cat = Classification.lookup_by_name(category)
         cat = Classification.create_category!(:name         => category,
                                               :single_value => false,
                                               :description  => category) unless cat

--- a/tools/miqldap_to_sssd/configure_database.rb
+++ b/tools/miqldap_to_sssd/configure_database.rb
@@ -73,7 +73,7 @@ module MiqLdapToSssd
     end
 
     def find_user(userid)
-      user = User.find_by_userid(userid)
+      user = User.lookup_by_userid(userid)
       user || User.in_my_region.where('lower(userid) = ?', userid).order(:lastlogon).last
     end
   end

--- a/tools/reset_admin_password.rb
+++ b/tools/reset_admin_password.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require File.expand_path("../config/environment", __dir__)
 
-user = User.find_by_userid("admin")
+user = User.lookup_by_userid("admin")
 if ARGV[0].nil?
   print "Password: "
   user.password = STDIN.noecho(&:gets).chomp


### PR DESCRIPTION
These find_by_* methods have conflicts with rails dynamic
finding. This PR migrates these methods to lookup_by_*. 
Followup PR will be posted to show deprecation warning
to the callers using the old find_by_* methods.
    
find_by_id inside acts_as_ar_model.rb will be in a separate PR.

Followup PRs:

- [ ] ManageIQ/manageiq-providers-amazon#562
- [ ] ManageIQ/manageiq-api#675
- [ ] ManageIQ/manageiq-automation_engine#373
- [ ] ManageIQ/manageiq-consumption#165
- [ ] ManageIQ/manageiq-content#584
- [ ] ManageIQ/manageiq-pods#333
- [ ] ManageIQ/manageiq-providers-vmware#455
- [ ] ManageIQ/manageiq-ui-classic#6219

Checked repos that do not have callers to the defined find_by_* methods: manageiq-providers-ovirt, manageiq-providers-azure, manageiq-schema, manageiq-smartstate, manageiq-providers-scvmm, manageiq-gems-pending