### PR TITLE
Variable name typo in miq_schedule import

### DIFF
--- a/app/models/miq_schedule/import_export.rb
+++ b/app/models/miq_schedule/import_export.rb
@@ -61,7 +61,7 @@ module MiqSchedule::ImportExport
       miq_schedule = handle_miq_report_attributes_for_import(miq_schedule) if miq_schedule["resource_type"] == "MiqReport"
 
       unless miq_schedule['userid'] == 'admin' || miq_schedule['userid'] == 'system'
-        miq_schedule['userid'] = User.find_by(:id => report["userid"])
+        miq_schedule['userid'] = User.find_by(:id => miq_schedule['userid'])
       end
 
       new_or_existing_schedule = MiqSchedule.where(:name => miq_schedule["name"], :resource_type => miq_schedule["resource_type"]).first_or_initialize


### PR DESCRIPTION
I think this was supposed to be the ```miq_schedule```? It ~~probably~~ definitely doesn't work as is. 

@miq-bot add_reviewer @lpichler 
@miq-bot add_label bug


https://bugzilla.redhat.com/show_bug.cgi?id=1753647
