### PR TITLE
[HAMMER] Users without groups should use admin retirement

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -253,15 +253,18 @@ module RetirementMixin
   end
 
   def system_context_requester
-    if try(:evm_owner_id).present?
-      if User.find_by(:id => evm_owner_id).present?
-        return evm_owner
-      else
-        $log.info("#{name} has evm_owner_id present but no user with that id found so defaulting to admin.")
-        return User.super_admin
-      end
+    user = User.find_by(:id => evm_owner_id) if try(:evm_owner_id)
+    if user.present? && user.current_group.present?
+      $log.info("Setting retirement requester of #{name} to #{evm_owner_id}.")
+      return evm_owner
     end
-    $log.info("System context defaulting to admin user because owner of #{name} not set.")
+
+    msg = if user.present?
+            "#{name} has evm_owner present but user has no group so defaulting to admin."
+          else
+            "System context defaulting to admin user because owner of #{name} not set."
+          end
+    $log.info(msg)
     User.super_admin
   end
 

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -51,6 +51,25 @@ describe "VM Retirement Management" do
         expect(MiqRequest.first.userid).to eq("admin")
       end
     end
+
+    context "with user lacking group" do
+      let(:user1) { FactoryBot.create(:user) }
+      let(:vm_with_owner_no_group) { FactoryBot.create(:vm, :evm_owner => user1, :host => FactoryBot.create(:host)) }
+
+      it "uses admin as requester" do
+        vm_with_owner_no_group.update(:retires_on => 90.days.ago, :retirement_warn => 60, :retirement_last_warn => nil)
+
+        expect(vm_with_owner_no_group.retirement_last_warn).to be_nil
+        allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'success', MiqAeEngine::MiqAeWorkspaceRuntime.new])
+        vm_with_owner_no_group.retirement_check
+        status, message, result = MiqQueue.first.deliver
+        MiqQueue.first.delivered(status, message, result)
+
+        expect(vm_with_owner_no_group.retirement_last_warn).not_to be_nil
+        # the next test is only nil because we're not seeding a true super admin in these specs
+        expect(vm_with_owner_no_group.retirement_requester).to eq(nil)
+      end
+    end
   end
 
   it "#start_retirement" do


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq/pull/19309 which adds group check to system context for retirement

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1754043
@miq-bot assign @simaishi 