### PR TITLE
[EmbeddedAnsible] Fix job_plays for API

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/job.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job < ManageIQ::P
 
   belongs_to :miq_task, :foreign_key => :ems_ref, :inverse_of => false
 
+  virtual_has_many :job_plays
+
   #
   # Allowed options are
   #   :limit      => String


### PR DESCRIPTION
The Service UI makes use of the API to fetch both `.stdout` and `.job_plays` together in a single call.  Without this definition, `.job_plays` is not recognized as a valid attribute to fetch, and the following error is returned from the API call by the ServiceUI:

```json
{
  "error": {
    "kind":"bad_request",
    "message":"Invalid attributes specified: job_plays",
    "klass":"Api::BadRequestError"
  }
}
```

This fixes that error, though a follow up is most likely going to be necessary in `manageiq-ui-service` since it seems like they are striping out the html data we are sending them, so the formatting looks like garbage...

<img width="1173" alt="Screen Shot 2019-09-20 at 2 51 17 PM" src="https://user-images.githubusercontent.com/314014/65354945-65cd6080-dbb6-11e9-975a-0775219c4b52.png">

(Note:  In the above screenshot, the "Plays" is zero, but that is because I am using an older version of the appliance where the `job_plays` attribute wasn't implemented.  That should be fixed in the latest release.)

Links
-----

* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753721