### PR TITLE
Fix category/classification sporadic test failure

### DIFF
--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,6 +1,3 @@
 FactoryBot.define do
-  factory(:category) do
-    sequence(:name)        { |n| "category_#{seq_padded_for_sorting(n)}" }
-    sequence(:description) { |n| "category #{seq_padded_for_sorting(n)}" }
-  end
+  factory(:category, :parent => :classification, :class => 'Category')
 end


### PR DESCRIPTION
Categories and classifications use the same table.
The factories use different sequence numbers but the same template
for text.
This means the name or description field can be non-unique.

Which means the tests fail. Currently [manageiq-api master](https://travis-ci.org/ManageIQ/manageiq-api/builds/587297331) is red for this reason

Solution is to pointing category and classification to the same
number sequence generators, so they no longer will produce
duplicate names.

thanks @d-m-u for helping me debug this