### PR TITLE
Use user from command's argument for schedule import 

### DIFF
--- a/app/models/miq_schedule/import_export.rb
+++ b/app/models/miq_schedule/import_export.rb
@@ -57,11 +57,13 @@ module MiqSchedule::ImportExport
       miq_schedule
     end
 
-    def import_from_hash(miq_schedule, _options = nil)
+    def import_from_hash(miq_schedule, options = nil)
       miq_schedule = handle_miq_report_attributes_for_import(miq_schedule) if miq_schedule["resource_type"] == "MiqReport"
 
-      unless miq_schedule['userid'] == 'admin' || miq_schedule['userid'] == 'system'
-        miq_schedule['userid'] = User.find_by(:id => miq_schedule['userid'])
+      input_userid = options&.dig(:userid) || miq_schedule&.dig('userid')
+      if input_userid && input_userid != 'system'
+        miq_schedule['userid'] = User.find_by(:userid => input_userid)&.userid
+        raise _("User #{input_userid} not found") unless miq_schedule['userid']
       end
 
       new_or_existing_schedule = MiqSchedule.where(:name => miq_schedule["name"], :resource_type => miq_schedule["resource_type"]).first_or_initialize

--- a/tools/import_export_schedules.rb
+++ b/tools/import_export_schedules.rb
@@ -3,7 +3,7 @@ require File.expand_path('../config/environment', __dir__)
 require 'optimist'
 
 options = Optimist.options do
-  opt :user, "userid", :short => "u", :default => "admin"
+  opt :userid, "userid for imported schedule(this option overwrites schedule's userid)", :short => "u", :type => :string
   opt :output_dir, "Output directory", :short => "d", :default => "./"
   opt :schedule, "Schedule name or id", :short => "s", :type => :string
   opt :operation, "export or import", :short => "o", :default => "export"
@@ -31,6 +31,6 @@ when 'export'
   puts "Schedule #{schedule.name} exported to #{output_path}"
   File.write(output_path, exported_yaml)
 when 'import'
-  result = MiqSchedule.import(options[:import_yaml])
+  result = MiqSchedule.import(options[:import_yaml], options)
   puts result.second[0][:message]
 end


### PR DESCRIPTION
based on this discussion https://github.com/ManageIQ/manageiq/pull/19315#pullrequestreview-290598920

it looks that this condition is useless, so let use it for situation when userid is passed as argument from command line:


```
./tools/import_export_schedules.rb -o import -y ./MiqReport_1569240610.yaml -u child_user
```


Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1753647
https://github.com/ManageIQ/manageiq/pull/19008


cc @yrudman @d-m-u 

@miq-bot assign @gtanzillo 

@miq-bot add_label bug

specs: https://github.com/ManageIQ/manageiq/pull/19257
