### PR TITLE
[Ansible::Runner] Add extra ptyhon3 path to PYTHONPATH

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -365,6 +365,7 @@ module Ansible
       end
 
       PYTHON3_MODULE_PATHS = %w[
+        /usr/lib64/python3.6/site-packages
         /var/lib/awx/venv/ansible/lib/python3.6/site-packages
       ].freeze
       def python3_modules_path

--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -301,12 +301,9 @@ module Ansible
       end
 
       def python_env
-        python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/"
-        python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages/"
-
-        if File.exist?(python3_modules_path)
+        if python3_modules_path.present?
           { "PYTHONPATH" => python3_modules_path }
-        elsif File.exist?(python2_modules_path)
+        elsif python2_modules_path.present?
           { "PYTHONPATH" => python2_modules_path }
         else
           {}
@@ -356,6 +353,28 @@ module Ansible
 
       def env_dir(base_dir)
         FileUtils.mkdir_p(File.join(base_dir, "env")).first
+      end
+
+      PYTHON2_MODULE_PATHS = %w[
+        /var/lib/manageiq/venv/lib/python2.7/site-packages
+      ].freeze
+      def python2_modules_path
+        @python2_modules_path ||= begin
+          determine_existing_python_paths_for(*PYTHON2_MODULE_PATHS).join(File::PATH_SEPARATOR)
+        end
+      end
+
+      PYTHON3_MODULE_PATHS = %w[
+        /var/lib/awx/venv/ansible/lib/python3.6/site-packages
+      ].freeze
+      def python3_modules_path
+        @python3_modules_path ||= begin
+          determine_existing_python_paths_for(*PYTHON3_MODULE_PATHS).join(File::PATH_SEPARATOR)
+        end
+      end
+
+      def determine_existing_python_paths_for(*paths)
+        paths.select { |path| File.exist?(path) }
       end
     end
   end

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -5,6 +5,11 @@ describe Ansible::Runner do
   let(:tags)       { "tag" }
   let(:result)     { AwesomeSpawn::CommandResult.new("ansible-runner", "output", "", "0") }
 
+  after do
+    Ansible::Runner.instance_variable_set(:@python2_modules_path, nil)
+    Ansible::Runner.instance_variable_set(:@python3_modules_path, nil)
+  end
+
   describe ".run" do
     let(:playbook) { "/path/to/my/playbook" }
     before do
@@ -88,8 +93,8 @@ describe Ansible::Runner do
     end
 
     it "sets PYTHONPATH correctly with python3 modules installed " do
-      python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages/"
-      python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/"
+      python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages"
+      python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages"
 
       allow(File).to receive(:exist?).with(python2_modules_path).and_return(false)
       allow(File).to receive(:exist?).with(python3_modules_path).and_return(true)
@@ -104,8 +109,8 @@ describe Ansible::Runner do
     end
 
     it "sets PYTHONPATH correctly with python2 modules installed " do
-      python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages/"
-      python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/"
+      python2_modules_path = "/var/lib/manageiq/venv/lib/python2.7/site-packages"
+      python3_modules_path = "/var/lib/awx/venv/ansible/lib/python3.6/site-packages"
 
       allow(File).to receive(:exist?).with(python2_modules_path).and_return(true)
       allow(File).to receive(:exist?).with(python3_modules_path).and_return(false)


### PR DESCRIPTION
Adds an additional path to look in when using python3 on an appliance.

Also does a bit of refactoring to support this better in the furture and avoid path checking with each invocation of `Ansible::Runner`.  The memoization as part of the refactoring isn't really required if reviewers find it problimatic, though I don't see this changing while an appliance would still be running and loaded.  However, if we think that could potentially be an issue, then that can be removed with little performance impact as a result.


Links
-----

* Bandage fix for https://bugzilla.redhat.com/show_bug.cgi?id=1752620