### PR TITLE
Add CloudObject* to RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -8,6 +8,8 @@ module Rbac
       Authentication
       AvailabilityZone
       CloudNetwork
+      CloudObjectStoreContainer
+      CloudObjectStoreObject
       CloudSubnet
       CloudTenant
       CloudVolume


### PR DESCRIPTION
CloudObjectStoreContainer and CloudObjectStoreObject are missing from RBAC. 


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1411702

@miq-bot assign @lpichler 