### PR TITLE
Check whether belongsto association exists before usage

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -797,7 +797,9 @@ module Rbac
     def belongsto_association_filtered?(vcmeta, klass)
       if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) }
         # Eject early if true
-        return true if associated_belongsto_models.any? { |associated| klass <= associated }
+        return true if associated_belongsto_models.any? do |associated|
+          klass <= associated && vcmeta.respond_to?(associated.base_model.to_s.tableize)
+        end
       end
 
       if vcmeta.kind_of?(ManageIQ::Providers::NetworkManager)

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -796,7 +796,9 @@ module Rbac
 
     def belongsto_association_filtered?(vcmeta, klass)
       if [ExtManagementSystem, Host].any? { |x| vcmeta.kind_of?(x) }
-        # Eject early if true
+        # Eject early if klass(requested for RBAC check) is allowed to be filtered by
+        # belongsto filtering generally and whether relation (based on the klass) exists on object
+        # from belongsto filter at all.
         return true if associated_belongsto_models.any? do |associated|
           klass <= associated && vcmeta.respond_to?(associated.base_model.to_s.tableize)
         end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -383,9 +383,10 @@ describe Rbac::Filterer do
     context "with ContainerManagers with user roles" do
       let(:owned_ems) { FactoryBot.create(:ems_openshift) }
       let(:other_ems) { FactoryBot.create(:ems_openshift) }
+      let(:ems_without_containers) { FactoryBot.create(:ext_management_system) }
 
       before do
-        filters = ["/belongsto/ExtManagementSystem|#{owned_ems.name}"]
+        filters = ["/belongsto/ExtManagementSystem|#{owned_ems.name}", "/belongsto/ExtManagementSystem|#{ems_without_containers.name}"]
 
         owner_group.entitlement = Entitlement.new
         owner_group.entitlement.set_managed_filters([])


### PR DESCRIPTION
after this [commit](https://github.com/ManageIQ/manageiq/pull/18654/commits/8fbebdbb34461914c82949b10360fc5e4c508e04) we are more benevolent what we can filter according to belongs to filters.

**for example** 
we can't filter `Containers`[Filterer#associated_belongsto_models] according to `ems` when containers are not defined on ems:
code in RBAC (which responsible for `belongs to filters`'s evaluation) rely on existence `ems.containers` relation.
 
and thanks to that we need to check if such relation exist.


## Links
https://bugzilla.redhat.com/show_bug.cgi?id=1755024

cc @NickLaMuro 

@miq-bot assign @kbrock 

@miq-bot add_label bug, rbac
