### PR TITLE
Fix an exception calling compliance_purge_timer

### DIFF
--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -219,7 +219,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
     every = worker_settings[:compliance_purge_interval]
     scheduler.schedule_every(every, :first_in => every) do
-      enqueue(:compliance_purge_interval)
+      enqueue(:compliance_purge_timer)
     end
 
     every = worker_settings[:vim_performance_states_purge_interval]


### PR DESCRIPTION
The schedule runner was calling schedule_worker_jobs.compliance_purge_interval instead of compliance_purge_timer leading to a No Method Found exception.

Related: https://github.com/ManageIQ/manageiq/pull/19264