### PR TITLE
Add MiqServer#server_role_names=

### DIFF
--- a/app/models/miq_server/role_management.rb
+++ b/app/models/miq_server/role_management.rb
@@ -134,19 +134,12 @@ module MiqServer::RoleManagement
   alias_method :my_roles,            :server_role_names
   alias_method :assigned_role_names, :server_role_names
 
-  def role
-    server_role_names.join(',')
-  end
-  alias_method :my_role,       :role
-  alias_method :assigned_role, :role
-
-  def role=(val)
+  def server_role_names=(roles)
     zone.lock do
-      val = val.to_s.strip.downcase
-      if val.blank?
+      if roles.blank?
         server_roles.delete_all
       else
-        desired = (val == "*" ? ServerRole.all_names : val.split(",").collect { |v| v.strip.downcase }.sort)
+        desired = (roles == "*" ? ServerRole.all_names : roles.map { |role| role.strip.downcase }.sort)
         current = server_role_names
 
         # MiqServer#server_role_names may include database scoped roles, which are managed elsewhere,
@@ -165,6 +158,17 @@ module MiqServer::RoleManagement
       end
     end
 
+    roles
+  end
+
+  def role
+    server_role_names.join(',')
+  end
+  alias_method :my_role,       :role
+  alias_method :assigned_role, :role
+
+  def role=(val)
+    self.server_role_names = val == "*" ? val : val.split(",")
     role
   end
 

--- a/spec/models/miq_server/role_management_spec.rb
+++ b/spec/models/miq_server/role_management_spec.rb
@@ -63,6 +63,33 @@ RSpec.describe "Server Role Management" do
       end
     end
 
+    context "server_role_names=" do
+      it "normal case" do
+        @miq_server.assign_role('ems_operations', 1)
+        expect(@miq_server.server_role_names).to eq(['ems_operations'])
+
+        desired = %w[event scheduler user_interface]
+        @miq_server.server_role_names = desired
+        expect(@miq_server.server_role_names).to eq(desired)
+      end
+
+      it "with a duplicate existing role" do
+        @miq_server.assign_role('ems_operations', 1)
+
+        desired = %w[ems_operations ems_operations scheduler]
+        @miq_server.server_role_names = desired
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
+      end
+
+      it "with duplicate new roles" do
+        @miq_server.assign_role('event', 1)
+
+        desired = %w[ems_operations scheduler scheduler]
+        @miq_server.server_role_names = desired
+        expect(@miq_server.server_role_names).to eq(%w[ems_operations scheduler])
+      end
+    end
+
     it "should assign role properly when requested" do
       @roles = [['ems_operations', 1], ['event', 2], ['ems_metrics_coordinator', 1], ['scheduler', 1], ['reporting', 1]]
       @roles.each do |role, priority|


### PR DESCRIPTION
There is a `#role` and a `#role=` method that takes a comma separated
list, then a `#server_role_names` which takes an array but no
`#server_roles_names=`.