### PR TITLE
Add a --role argument to run_single_worker

### DIFF
--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -38,10 +38,25 @@ opt_parser = OptionParser.new do |opts|
     exit
   end
 
-  opts.on("-r=ROLE", "--roles=role1,role2", "Set a list of active roles for the worker (comma separated, no spaces)") do |val|
+  opts.on("-r=ROLE", "--roles=role1,role2",
+          "Set a list of active roles for the worker (comma separated, no spaces) or --roles=? to list all roles") do |val|
+    if val == "?"
+      puts all_role_names
+      exit
+    end
     options[:roles] = val.split(",")
   end
 end
+
+def all_role_names
+  path = File.expand_path("../../../db/fixtures/server_roles.csv", __dir__)
+  roles = File.read(path).lines.collect do |line|
+    line.split(",").first
+  end
+  roles.shift
+  roles
+end
+
 opt_parser.parse!
 worker_class = ARGV[0]
 


### PR DESCRIPTION
Allow run_single_worker to set active server roles while starting the 
worker.  This allows for queue workers to work since @active_roles is used
in `MiqQueue.get()`.

~~Depends on: https://github.com/ManageIQ/manageiq/pull/19327~~