### PR TITLE
[wip] clean up and moving factory objects to their own repo

### DIFF
--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -7,13 +7,10 @@ FactoryBot.define do
 
   factory :configuration_script_payload, :class => "ConfigurationScriptPayload", :parent => :configuration_script_base
   factory :ansible_playbook,
-          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook",
+          :class  => "ManageIQ::Providers::AutomationManager::ConfigurationScriptPayload",
           :parent => :configuration_script_payload
 
   factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
-  factory :configuration_workflow,
-          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow",
-          :parent => :configuration_script
   factory :ansible_configuration_script,
           :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
           :parent => :configuration_script

--- a/spec/factories/configuration_script.rb
+++ b/spec/factories/configuration_script.rb
@@ -11,9 +11,6 @@ FactoryBot.define do
           :parent => :configuration_script_payload
 
   factory :configuration_script, :class => "ConfigurationScript", :parent => :configuration_script_base
-  factory :ansible_configuration_script,
-          :class  => "ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript",
-          :parent => :configuration_script
   factory :embedded_ansible_configuration_script,
           :class  => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript",
           :parent => :configuration_script

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -339,7 +339,15 @@ FactoryBot.define do
     end
   end
 
+  trait(:configuration_workflow) do
+    after(:create) do |x|
+      type = (x.type.split("::")[0..2] + %w(AutomationManager ConfigurationWorkflow)).join("::")
+      x.configuration_scripts << FactoryBot.create(:configuration_workflow, :type => type)
+    end
+  end
+
   # Leaf classes for automation_manager
+
   factory :embedded_automation_manager_ansible,
           :aliases => ["manageiq/providers/embedded_ansible/automation_manager"],
           :class   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -339,13 +339,6 @@ FactoryBot.define do
     end
   end
 
-  trait(:configuration_workflow) do
-    after(:create) do |x|
-      type = (x.type.split("::")[0..2] + %w(AutomationManager ConfigurationWorkflow)).join("::")
-      x.configuration_scripts << FactoryBot.create(:configuration_workflow, :type => type)
-    end
-  end
-
   # Leaf classes for automation_manager
   factory :embedded_automation_manager_ansible,
           :aliases => ["manageiq/providers/embedded_ansible/automation_manager"],

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -113,18 +113,8 @@ FactoryBot.define do
 
   factory :automation_manager,
           :aliases => ["manageiq/providers/automation_manager"],
-          :class   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
+          :class   => "ManageIQ::Providers::AutomationManager",
           :parent  => :ext_management_system
-
-  factory :external_automation_manager,
-          :aliases => ["manageiq/providers/external_automation_manager"],
-          :class   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
-          :parent  => :automation_manager
-
-  factory :embedded_automation_manager,
-          :aliases => ["manageiq/providers/embedded_automation_manager"],
-          :class   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",
-          :parent  => :automation_manager
 
   factory :provisioning_manager,
           :aliases => ["manageiq/providers/provisioning_manager"],
@@ -357,11 +347,10 @@ FactoryBot.define do
   end
 
   # Leaf classes for automation_manager
-
   factory :embedded_automation_manager_ansible,
           :aliases => ["manageiq/providers/embedded_ansible/automation_manager"],
           :class   => "ManageIQ::Providers::EmbeddedAnsible::AutomationManager",
-          :parent  => :embedded_automation_manager
+          :parent  => :automation_manager
 
   # Leaf classes for provisioning_manager
 

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
@@ -1,6 +1,6 @@
 describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
   context 'catalog types' do
-    let(:ems) { FactoryBot.create(:embedded_automation_manager) }
+    let(:ems) { FactoryBot.create(:embedded_automation_manager_ansible) }
 
     it "#supported_catalog_types" do
       expect(ems.supported_catalog_types).to eq(%w(generic_ansible_playbook))


### PR DESCRIPTION
To keep provider-implementation-specific objects in their corresponding repo. 