### PR TITLE
Drop load balancer from the custom buttons tree in automate

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -41,7 +41,6 @@ class CustomButton < ApplicationRecord
     ExtManagementSystem,
     GenericObject,
     Host,
-    LoadBalancer,
     MiqGroup,
     MiqTemplate,
     NetworkRouter,


### PR DESCRIPTION

**Before:**
![Screenshot from 2019-09-25 10-00-45](https://user-images.githubusercontent.com/649130/65581511-e061fb80-df7b-11e9-9f22-616d9138d8b7.png)

**After:**
![Screenshot from 2019-09-25 09-59-22](https://user-images.githubusercontent.com/649130/65581502-db04b100-df7b-11e9-9679-4b035a33fa87.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1754823

@miq-bot add_label bug
@miq-bot assign @h-kataria 