### PR TITLE
ServiceOrder - add .v2v? virtual attribute

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -17,6 +17,8 @@ class ServiceOrder < ApplicationRecord
   before_create :assign_user
   after_create  :create_order_name
 
+  virtual_attribute :v2v?, :type => :boolean
+
   def self.find_for_user(requester, id)
     find_by!(:user => requester, :tenant => requester.current_tenant, :id => id)
   end
@@ -41,6 +43,11 @@ class ServiceOrder < ApplicationRecord
 
   def cart?
     state == STATE_CART
+  end
+
+  # v2v Service Orders are special because those don't come from the shopping cart and should be hidden in Service UI
+  def v2v?
+    miq_requests.any? { |request| request.kind_of?(ServiceTemplateTransformationPlanRequest) }
   end
 
   def checkout

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -17,7 +17,7 @@ class ServiceOrder < ApplicationRecord
   before_create :assign_user
   after_create  :create_order_name
 
-  virtual_attribute :v2v?, :type => :boolean
+  virtual_attribute :v2v?, :type => :boolean, :uses => :miq_requests
 
   def self.find_for_user(requester, id)
     find_by!(:user => requester, :tenant => requester.current_tenant, :id => id)


### PR DESCRIPTION
ordinarily, ServiceOrder is a set of orderable requests, bunched together in a shopping cart.
But v2v is also using ServiceOrder for In Progress migration plans.

Those ServiceOrders do not come from the shopping cart and do not contain regular provisioning requests.
They do contain requests of type ServiceTemplateTransformationPlanRequest.

We need to be able to tell these v2v service orders apart from the others,
because v2v migrations should not be displayed in the list of ordered services in SUI.

=> adding a virtual attribute so that we can use the API to filter out v2v service orders

Links:
original issue - https://github.com/ManageIQ/manageiq-ui-service/issues/1463
another attempt to fix this - https://github.com/ManageIQ/manageiq-schema/pull/328


Cc @djberg96 @tinaafitz @agrare (because you were involved with https://github.com/ManageIQ/manageiq-schema/pull/328)

This is my attempt to get this solved in *some* way, now :).