### PR TITLE
Add filtering according to more fields for report result's result set

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -295,10 +295,14 @@ class MiqReport < ApplicationRecord
     result_set.map { |row| format_row(row, skip_columns, hash_value_format) }
   end
 
-  def filter_result_set(result_set, options)
-    filter_columns = validate_columns(options[:filter_column])
-    formatted_result_set = format_result_set(result_set, filter_columns)
-    result_set_filtered = formatted_result_set.select { |x| x[options[:filter_column]].include?(options[:filter_string]) }
+  def filter_result_set_record(record, filter_options)
+    filter_options.all? { |column, search_string| record[column].include?(search_string) }
+  end
+
+  def filter_result_set(result_set, filter_options)
+    validated_filter_columns = validate_columns(filter_options.keys)
+    formatted_result_set = format_result_set(result_set, validated_filter_columns)
+    result_set_filtered = formatted_result_set.select { |record| filter_result_set_record(record, filter_options) }
 
     [result_set_filtered, result_set_filtered.count]
   end

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -6,6 +6,32 @@ module MiqReportResult::ResultSetOperations
       results.slice(options['offset'].to_i, options['limit'].to_i) || []
     end
 
+    FILTER_PARAMS_MAX_COUNT = 20
+
+    def filter_field(parameter, param_number)
+      filter_param_suffix = param_number.zero? ? '' : "_#{param_number}"
+      "#{parameter}#{filter_param_suffix}"
+    end
+
+    def filtering_enabled?(options)
+      options.key?(:filter_column) || options.key?(:filter_column_1)
+    end
+
+    def filter_options(options)
+      (0...FILTER_PARAMS_MAX_COUNT).each_with_object({}) do |param_number, filter_params|
+        param_key = filter_field("filter_column", param_number)
+        param_value = options[param_key.to_sym]
+        next if param_number.zero? && param_value.nil?
+
+        break(filter_params) unless param_value
+
+        filter_string_column = filter_field("filter_string", param_number).to_sym
+        raise ArgumentError, "Value for column #{param_value} (#{param_key} parameter) is missing, please specify #{filter_string_column} parameter" unless options[filter_string_column]
+
+        filter_params[param_value] = options[filter_string_column]
+      end
+    end
+
     def result_set_for_reporting(report_result, options)
       report = report_result.report_or_miq_report
       sorting_columns = report.validate_sorting_columns(options[:sort_by])
@@ -13,9 +39,9 @@ module MiqReportResult::ResultSetOperations
 
       count_of_full_result_set = result_set.count
       if result_set.present? && report
-        if options.key?(:filter_column) && options.key?(:filter_string)
-          result_set, count_of_full_result_set = report.filter_result_set(result_set, options)
-          allowed_columns_to_format = report.col_order - [options[:filter_column]]
+        if filtering_enabled?(options)
+          result_set, count_of_full_result_set = report.filter_result_set(result_set, filter_options(options))
+          allowed_columns_to_format = report.col_order - filter_options(options).keys
         end
 
         result_set.map! { |x| x.slice(*report.col_order) }

--- a/spec/models/miq_report_result/result_set_operations_spec.rb
+++ b/spec/models/miq_report_result/result_set_operations_spec.rb
@@ -1,0 +1,75 @@
+describe MiqReportResult::ResultSetOperations do
+  describe ".result_set_for_reporting" do
+    let(:result_set_options_base) { {'limit' => '1000'} }
+
+    let(:user) { FactoryBot.create(:user_with_group) }
+
+    let(:result_set) do
+      [{"name" => "TEST_VM2", "size" => 115_533, "type" => 'small'},
+       {"name" => "TEST_VM1", "size" => 332_233, "type" => 'large'},
+       {"name" => "PROD_VM1", "size" => 112_233, "type" => 'large'}]
+    end
+
+    let(:report_result) { FactoryBot.create(:miq_report_result, :miq_group => user.current_group) }
+    let(:columns) { %w[name size type] }
+
+    let(:col_formats) { Array.new(columns.count) }
+
+    let!(:report) do
+      FactoryBot.create(:miq_report, :miq_group => user.current_group, :miq_report_results => [report_result],
+                        :col_order => columns, :col_formats => col_formats)
+    end
+
+    before do
+      allow(report_result).to receive(:result_set).and_return(result_set)
+      User.current_user = user
+    end
+
+    subject { report_result.result_set_for_reporting(result_set_options) }
+
+    let(:expected_result_set) do
+      [{"name" => "TEST_VM2", "size" => "112.8 KB", "type" => 'small'},
+       {"name" => "TEST_VM1", "size" => "324.4 KB", "type" => 'large'}]
+    end
+
+    let(:result_set_options) { result_set_options_base.merge(:filter_column => 'name', :filter_string => 'TEST') }
+
+    it "filters with one column" do
+      expect(subject[:result_set]).to match_array(expected_result_set)
+    end
+
+    context "with more columns" do
+      let(:expected_result_set) do
+        [{"name" => "TEST_VM2", "size" => "112.8 KB", "type" => 'small'}]
+      end
+
+      let(:result_set_options) do
+        result_set_options_base.merge(:filter_column => 'name', :filter_string => 'TEST', :filter_column_1 => 'type', :filter_string_1 => 'small')
+      end
+
+      it "filters" do
+        expect(subject[:result_set]).to match_array(expected_result_set)
+      end
+
+      context "with various order of parameters" do
+        let(:result_set_options) do
+          result_set_options_base.merge(:filter_column_2 => 'type', :filter_string_1 => 'TEST', :filter_column_1 => 'name', :filter_string_2 => 'small')
+        end
+
+        it "filters" do
+          expect(subject[:result_set]).to match_array(expected_result_set)
+        end
+      end
+    end
+
+    context "parameter filter_stringXX is missing and filter_columnXX is specified" do
+      let(:result_set_options) do
+        result_set_options_base.merge(:filter_column_2 => 'type', :filter_string_1 => 'TEST', :filter_column_1 => 'name')
+      end
+
+      it "raises error when " do
+        expect { subject }.to raise_error(ArgumentError, "Value for column type (filter_column_2 parameter) is missing, please specify filter_string_2 parameter")
+      end
+    end
+  end
+end


### PR DESCRIPTION
this PR extends previous work: **[API for pagination, sorting and fitltering  report results](https://github.com/ManageIQ/manageiq-api/pull/547)** 

and adds possibility to filter report results according to more fields 

this is used in API and this API is used in UI for filtering report results.

