### PR TITLE
Update factory_bot and timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -250,6 +250,9 @@ unless ENV["APPLIANCE"]
     gem "capybara",         "~>2.5.0",  :require => false
     gem "coveralls",                    :require => false
     gem "factory_bot",      "~>5.1",    :require => false
+
+    # TODO: faker is used for url generation in git repository factory and the lenovo
+    # provider, via a xclarity_client dependency
     gem "faker",            "~>1.8",    :require => false
     gem "timecop",          "~>0.9",    :require => false
     gem "vcr",              "~>5.0",    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -249,9 +249,9 @@ unless ENV["APPLIANCE"]
     gem "brakeman",         "~>3.3",    :require => false
     gem "capybara",         "~>2.5.0",  :require => false
     gem "coveralls",                    :require => false
-    gem "factory_bot",      "~>4.11.1", :require => false
+    gem "factory_bot",      "~>5.1",    :require => false
     gem "faker",            "~>1.8",    :require => false
-    gem "timecop",          "~>0.7.3",  :require => false
+    gem "timecop",          "~>0.9",    :require => false
     gem "vcr",              "~>5.0",    :require => false
     gem "webmock",          "~>3.7",    :require => false
   end


### PR DESCRIPTION
Still trying to get the cross repo results green: 
~~https://travis-ci.org/jrafanie/manageiq-cross_repo/builds/590464881~~
https://travis-ci.org/jrafanie/manageiq-cross_repo/builds/592229933 (latest)

Fixes needed before merge:
- [x] https://github.com/ManageIQ/manageiq-content/pull/586
- [x] https://github.com/ManageIQ/manageiq-consumption/pull/167
- [x] https://github.com/ManageIQ/manageiq-consumption/pull/168
- [x] nuage: [LoadError:  cannot load such file -- qpid_proton](https://travis-ci.org/ManageIQ/manageiq-providers-nuage/jobs/591240565), fixed by https://github.com/Fryguy/manageiq-cross_repo/pull/25
- [x] v2v: https://travis-ci.org/jrafanie/manageiq-cross_repo/jobs/590464903, custom installation of qpid for tests, cross repo cannot test this yet.  