### PR TITLE
remove pg warning from tests

### DIFF
--- a/lib/extensions/ar_adapter/ar_dba.rb
+++ b/lib/extensions/ar_adapter/ar_dba.rb
@@ -12,7 +12,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.class_eval do
   end
 
   def xlog_location
-    select_value("SELECT pg_current_wal_insert_lsn()")
+    select_value("SELECT pg_current_wal_insert_lsn()::varchar")
   end
 
   def xlog_location_diff(lsn1, lsn2)


### PR DESCRIPTION
removes the following warning which showed up on macs and travis:


```
unknown OID 3220: failed to recognize type of 'pg_current_wal_insert_lsn'.
It will be treated as String
```
