### PR TITLE
remove rhn deprecation warnings from test suite

### DIFF
--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -91,7 +91,7 @@ describe RegistrationSystem do
     end
 
     it "should rescue NotImplementedError" do
-      allow_any_instance_of(LinuxAdmin::Rhn).to receive_messages(:registered? => true)
+      allow(LinuxAdmin::RegistrationSystem).to receive(:registration_type_uncached).and_return(LinuxAdmin::RegistrationSystem)
       expect(RegistrationSystem.verify_credentials(creds)).to be_falsey
     end
 


### PR DESCRIPTION
When running `registration_system_spec.rb` we receive deprecation warnings:

```
[DEPRECATION] 'LinuxAdmin::Rhn' is deprecated.  Please use 'LinuxAdmin::SubscriptionManager' instead.
```

This warning comes from the subscription manager detection routine even considering Rhn.

Note - https://github.com/ManageIQ/linux_admin/pull/202 is removing this class, so we want to remove the reference to `Rhn` soon anyway