### PR TITLE
Use leaf classes for ems type validation

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -113,7 +113,7 @@ FactoryBot.define do
 
   factory :automation_manager,
           :aliases => ["manageiq/providers/automation_manager"],
-          :class   => "ManageIQ::Providers::AutomationManager",
+          :class   => "ManageIQ::Providers::AnsibleTower::AutomationManager",
           :parent  => :ext_management_system
 
   factory :provisioning_manager,


### PR DESCRIPTION
Recent changes put the automation thingy factory back to not being a leaf class and LJ wouldn't leaf me alone so.

From comment here: https://github.com/ManageIQ/manageiq/pull/19330/files#r329235409

as an aside, 19330 got merged while it was 1) failing tests and 2) still marked as WIP. Ugh. 

@miq-bot assign @jrafanie 
I think this's all, right? 