### PR TITLE
CloudNetwork, NetworkPort and SecurityGroup belong to a ResourceGroup

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -9,6 +9,7 @@ class CloudNetwork < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_tenant
   belongs_to :orchestration_stack
+  belongs_to :resource_group
 
   has_many :cloud_subnets, :dependent => :destroy
   has_many :network_routers, -> { distinct }, :through => :cloud_subnets

--- a/app/models/network_port.rb
+++ b/app/models/network_port.rb
@@ -6,6 +6,7 @@ class NetworkPort < ApplicationRecord
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::NetworkManager"
   belongs_to :cloud_tenant
   belongs_to :device, :polymorphic => true
+  belongs_to :resource_group
 
   has_many :network_port_security_groups, :dependent => :destroy
   has_many :security_groups, :through => :network_port_security_groups

--- a/app/models/resource_group.rb
+++ b/app/models/resource_group.rb
@@ -5,6 +5,10 @@ class ResourceGroup < ApplicationRecord
   has_many :vm_or_templates
 
   # Rely on default scopes to get expected information
-  has_many :vms, :class_name => 'Vm'
+  has_many :vms, :class_name => 'Vm', :dependent => :nullify
   has_many :templates, :class_name => 'MiqTemplate'
+
+  has_many :cloud_networks, :dependent => :nullify
+  has_many :network_ports, :dependent => :nullify
+  has_many :security_groups, :dependent => :nullify
 end

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -13,6 +13,7 @@ class SecurityGroup < ApplicationRecord
   belongs_to :network_group
   belongs_to :cloud_subnet
   belongs_to :network_router
+  belongs_to :resource_group
   has_many   :firewall_rules, :as => :resource, :dependent => :destroy
 
   has_many :network_port_security_groups, :dependent => :destroy

--- a/spec/models/resource_group_spec.rb
+++ b/spec/models/resource_group_spec.rb
@@ -26,6 +26,9 @@ describe ResourceGroup do
     before do
       @vm       = FactoryBot.create(:vm_google, :template => false, :resource_group => resource_group)
       @template = FactoryBot.create(:template_google, :template => true, :resource_group => resource_group)
+      @cloud_network = FactoryBot.create(:cloud_network, :resource_group => resource_group)
+      @network_port = FactoryBot.create(:network_port, :resource_group => resource_group)
+      @security_group = FactoryBot.create(:security_group, :resource_group => resource_group)
     end
 
     it "returns the expected results for vms" do
@@ -41,6 +44,18 @@ describe ResourceGroup do
     it "returns the expected results for vm_or_templates" do
       expect(resource_group.vm_or_templates).to include(@template)
       expect(resource_group.vm_or_templates).to include(@vm)
+    end
+
+    it "returns the expected results for cloud_networks" do
+      expect(resource_group.cloud_networks).to include(@cloud_network)
+    end
+
+    it "returns the expected results for network_ports" do
+      expect(resource_group.network_ports).to include(@network_port)
+    end
+
+    it "returns the expected results for security_groups" do
+      expect(resource_group.security_groups).to include(@security_group)
     end
   end
 end


### PR DESCRIPTION
In this commit we model a `belongs_to` relationship to a `ResourceGroup` for `CloudNetwork`, `NetworkPort` and `SecurityGroup`. A `ResourceGroup` now has a `has_many` relationship to these network entities. This mirrors the existing relationship between the `ResourceGroup`
and `Vm`s. 

### Rationale
This change is relevant in the context of Azure and AzureStack providers. 

It will allow us to intuitively infer related DB targets in the scope of targeted refresh for resource groups (an ongoing effort). Currently we can only do `resource_group.vms`, but to retrieve networks, network ports and security groups witin a specific resource group, we would have to use `.where(ems_ref LIKE <resource_group.name>)`, since resource group name is a part of every AzureStack resource's `ems_ref`.

### WIP
- [x] Requires related PR in manageiq-schema [ManageIQ/manageiq-schema#420](https://github.com/ManageIQ/manageiq-schema/pull/420) to be merged

### Links
* Azure Resource Manager - [Resource Group overview](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups)

@miq-bot add_label enhancement
@miq-bot assign @agrare