### PR TITLE
Remove scope with_ems in VmOrTemplate

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -199,7 +199,6 @@ class VmOrTemplate < ApplicationRecord
   scope :archived,     ->       { where(:ems_id => nil, :storage_id => nil) }
   scope :orphaned,     ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
   scope :retired,      ->       { where(:retired => true) }
-  scope :with_ems,     ->       { where.not(:ems_id => nil) }
   scope :not_archived, ->       { where.not(:ems_id => nil).or(where.not(:storage_id => nil)) }
   scope :not_orphaned, ->       { where.not(:ems_id => nil).or(where(:storage_id => nil)) }
   scope :not_retired,  ->       { where(:retired => false).or(where(:retired => nil)) }

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1159,7 +1159,7 @@ describe VmOrTemplate do
       FactoryBot.create(:vm_or_template)
       FactoryBot.create(:vm_or_template, :storage => FactoryBot.create(:storage))
 
-      expect(VmOrTemplate.with_ems).to eq([vm])
+      expect(VmOrTemplate.active).to eq([vm])
     end
   end
 


### PR DESCRIPTION
because we have already scope `active`

is is used only in IU:

- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/6250

