### PR TITLE
Add a verify_credentials_task method

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -2,6 +2,7 @@ class ExtManagementSystem < ApplicationRecord
   include CustomActionsMixin
   include SupportsFeatureMixin
   include ExternalUrlMixin
+  include VerifyCredentialsMixin
 
   def self.with_tenant(tenant_id)
     tenant = Tenant.find(tenant_id)

--- a/app/models/mixins/authentication_mixin.rb
+++ b/app/models/mixins/authentication_mixin.rb
@@ -22,33 +22,6 @@ module AuthenticationMixin
       assocs = zone.respond_to?(assoc) ? zone.send(assoc) : []
       assocs.each { |a| a.authentication_check_types_queue(:attempt => 1) }
     end
-
-    def self.validate_credentials_task(args, user_id, zone)
-      task_opts = {
-        :action => "Validate EMS Provider Credentials",
-        :userid => user_id
-      }
-
-      queue_opts = {
-        :args        => [*args],
-        :class_name  => name,
-        :method_name => "raw_connect?",
-        :queue_name  => "generic",
-        :role        => "ems_operations",
-        :zone        => zone
-      }
-
-      task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
-      task = MiqTask.wait_for_taskid(task_id, :timeout => 30)
-
-      if task.nil?
-        error_message = "Task Error"
-      elsif MiqTask.status_error?(task.status) || MiqTask.status_timeout?(task.status)
-        error_message = task.message
-      end
-
-      [error_message.blank?, error_message]
-    end
   end
 
   def supported_auth_attributes

--- a/app/models/mixins/verify_credentials_mixin.rb
+++ b/app/models/mixins/verify_credentials_mixin.rb
@@ -1,0 +1,77 @@
+module VerifyCredentialsMixin
+  extend ActiveSupport::Concern
+
+  included do
+    class << self
+      Vmdb::Deprecation.deprecate_methods self, :validate_credentials_task => :verify_credentials_task
+    end
+  end
+
+  module ClassMethods
+    def validate_credentials_task(args, user_id, zone)
+      task_opts = {
+        :action => "Validate EMS Provider Credentials",
+        :userid => user_id
+      }
+
+      queue_opts = {
+        :args        => [*args],
+        :class_name  => name,
+        :method_name => "raw_connect?",
+        :queue_name  => "generic",
+        :role        => "ems_operations",
+        :zone        => zone
+      }
+
+      task_id = MiqTask.generic_action_with_callback(task_opts, queue_opts)
+      task = MiqTask.wait_for_taskid(task_id, :timeout => 30)
+
+      if task.nil?
+        error_message = "Task Error"
+      elsif MiqTask.status_error?(task.status) || MiqTask.status_timeout?(task.status)
+        error_message = task.message
+      end
+
+      [error_message.blank?, error_message]
+    end
+
+    def verify_credentials_task(userid, zone, options)
+      task_opts = {
+        :action => "Verify EMS Provider Credentials",
+        :userid => userid
+      }
+
+      encrypt_verify_credential_params!(options)
+
+      queue_opts = {
+        :args        => [options],
+        :class_name  => name,
+        :method_name => "verify_credentials?",
+        :queue_name  => "generic",
+        :role        => "ems_operations",
+        :zone        => zone
+      }
+
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+
+    def verify_credentials?(args)
+      # Prevent the connection details, including the password, from being leaked into the logs
+      # and MiqQueue by only returning true/false
+      !!verify_credentials(args)
+    end
+
+    private
+
+    # Ensure that any passwords are encrypted before putting them onto the queue for any
+    # DDF fields which are a password type
+    def encrypt_verify_credential_params!(options)
+      params_for_create[:fields].each do |field|
+        key_path = field[:name].split(".")
+        if options.key_path?(key_path)
+          options.store_path(key_path, MiqPassword.try_encrypt(options.fetch_path(key_path))) if field[:type] == "password"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a method that takes the options returned by
ems.params_for_create and calls a common verify_credentials API call on
the provider.

This can be called by the API/UI without needing to know anything about
the specific provider in a common way.

~~TODO need to update the task with the failure and ensure a boolean is returned so we don't leak the credentials on the queue.~~

https://github.com/ManageIQ/manageiq/issues/18818