### PR TITLE
Don't use _() in model constants

### DIFF
--- a/app/models/miq_dialog.rb
+++ b/app/models/miq_dialog.rb
@@ -7,10 +7,10 @@ class MiqDialog < ApplicationRecord
   scope :with_dialog_type, ->(dialog_type) { where(:dialog_type => dialog_type) }
 
   DIALOG_TYPES = [
-    [_("VM Provision"),                "MiqProvisionWorkflow"],
-    [_("Configured System Provision"), "MiqProvisionConfiguredSystemWorkflow"],
-    [_("VM Migrate"),                  "VmMigrateWorkflow"],
-    [_("Physical Server Provision"),   "PhysicalServerProvisionWorkflow"]
+    [N_("VM Provision"),                "MiqProvisionWorkflow"],
+    [N_("Configured System Provision"), "MiqProvisionConfiguredSystemWorkflow"],
+    [N_("VM Migrate"),                  "VmMigrateWorkflow"],
+    [N_("Physical Server Provision"),   "PhysicalServerProvisionWorkflow"]
   ].freeze
 
   serialize :content


### PR DESCRIPTION
Using `_()` in a model constant means that the thing will be evaluated just once (at appliance start) and any subsequent use of the constant won't reflect the change of the locale. We need to use `N_()` instead.

This needs to be merged with https://github.com/ManageIQ/manageiq-ui-classic/pull/6254

@miq-bot add_label internationalization, bug, ivanchuk/yes