### PR TITLE
Bump rubyzip to 1.3.0 for CVE-2019-16892

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
-gem "rubyzip",                        "~>1.2.2",       :require => false
+gem "rubyzip",                        "~>1.3.0",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
 gem "sys-filesystem",                 "~>1.2.0"


### PR DESCRIPTION
Seen in the automate engine currently: https://hakiri.io/github/ManageIQ/manageiq-automation_engine/master/01ca1fe4d416d4f374e3bd7912af6281d7e72fd6/warnings?name=Denial+of+Service


includes https://github.com/rubyzip/rubyzip/pull/403


depends on
https://github.com/ManageIQ/manageiq-automation_engine/pull/375

<img width="678" alt="Screen Shot 2019-10-01 at 12 00 41 PM" src="https://user-images.githubusercontent.com/16326669/65979344-1e12c880-e443-11e9-8b46-618f278b34cc.png">
