### PR TITLE
Use table currencies if exists in ChargebackRateDetailCurrency

### DIFF
--- a/app/models/chargeback_rate_detail_currency.rb
+++ b/app/models/chargeback_rate_detail_currency.rb
@@ -8,6 +8,8 @@ class ChargebackRateDetailCurrency < ApplicationRecord
 
   has_many :chargeback_rate_detail, :foreign_key => "chargeback_rate_detail_currency_id"
 
+  self.table_name = 'currencies'
+
   CURRENCY_FILE = "/currency_iso.json".freeze
   FIXTURE_DIR = Money::Currency::Loader::DATA_PATH.freeze
 

--- a/config/replication_exclude_tables.yml
+++ b/config/replication_exclude_tables.yml
@@ -5,7 +5,7 @@
 - binary_blobs
 - binary_blob_parts
 - chargeable_fields
-- chargeback_rate_detail_currencies
+- currencies
 - chargeback_rate_detail_measures
 - chargeback_rate_details
 - chargeback_rates


### PR DESCRIPTION
Currencies are not related just to chargeback.

this is temporary check to be able slightly rename table across repos and don't break anything.

then we can rename schema https://github.com/ManageIQ/manageiq-schema/pull/421


Links
-----
https://github.com/ManageIQ/manageiq-schema/pull/421


@miq-bot assign @kbrock 

@miq-bot add_label technical debt
