### PR TITLE
DialogField: Don't use gettext in model constants

### DIFF
--- a/app/models/dialog_field.rb
+++ b/app/models/dialog_field.rb
@@ -62,16 +62,16 @@ class DialogField < ApplicationRecord
   ]
 
   DIALOG_FIELD_TYPES = {
-    "DialogFieldTextBox"         => _("Text Box"),
-    "DialogFieldTextAreaBox"     => _("Text Area Box"),
-    "DialogFieldCheckBox"        => _("Check Box"),
-    "DialogFieldDropDownList"    => _("Drop Down List"),
+    "DialogFieldTextBox"         => N_("Text Box"),
+    "DialogFieldTextAreaBox"     => N_("Text Area Box"),
+    "DialogFieldCheckBox"        => N_("Check Box"),
+    "DialogFieldDropDownList"    => N_("Drop Down List"),
     # Commented out next to field types until they can be implemented
     #    "DialogFieldButton" => "Button",
-    "DialogFieldTagControl"      => _("Tag Control"),
-    "DialogFieldDateControl"     => _("Date Control"),
-    "DialogFieldDateTimeControl" => _("Date/Time Control"),
-    "DialogFieldRadioButton"     => _("Radio Button")
+    "DialogFieldTagControl"      => N_("Tag Control"),
+    "DialogFieldDateControl"     => N_("Date Control"),
+    "DialogFieldDateTimeControl" => N_("Date/Time Control"),
+    "DialogFieldRadioButton"     => N_("Radio Button")
   }
 
   DIALOG_FIELD_DYNAMIC_CLASSES = %w(


### PR DESCRIPTION
Using `_()` in a model constant means that the thing will be evaluated just once (at appliance start) and any subsequent use of the constant won't reflect the change of the locale. We need to use `N_()` instead.

@miq-bot add_label bug, ivanchuk/yes, internationalization