### PR TITLE
Remove OwnershipMixin from ServiceMixin

### DIFF
--- a/app/models/mixins/service_mixin.rb
+++ b/app/models/mixins/service_mixin.rb
@@ -9,7 +9,6 @@ module ServiceMixin
     serialize  :options, Hash
 
     include UuidMixin
-    include OwnershipMixin
     acts_as_miq_taggable
   end
 


### PR DESCRIPTION
`ServiceMixin` is included only in   `Service` and `ServiceTemplate` models
```
➜  manageiq git:(remove_ownership_mixin_from_ServiceMixin) ✗ ag 'include ServiceMixin'
app/models/service_template.rb
41:  include ServiceMixin

app/models/service.rb
74:  include ServiceMixin
```

and there is `OwnershipMixin` already included in those models.

and I think it is more clear that when OwnershipMixin is included in models than hidden in somewhere in other mixin to I am removing it from `ServiceMixin`


@miq-bot add_label technical debt
