### PR TITLE
Move method set_tenant_from_group to OwnershipMixin

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -36,8 +36,6 @@ class Authentication < ApplicationRecord
   before_save :set_credentials_changed_on
   after_save :after_authentication_changed
 
-  before_validation :set_tenant_from_group
-
   serialize :options
 
   include OwnershipMixin
@@ -153,10 +151,6 @@ class Authentication < ApplicationRecord
   end
 
   private
-
-  def set_tenant_from_group
-    self.tenant_id = miq_group.tenant_id if miq_group
-  end
 
   def set_credentials_changed_on
     return unless @auth_changed

--- a/app/models/mixins/ownership_mixin.rb
+++ b/app/models/mixins/ownership_mixin.rb
@@ -2,6 +2,8 @@ module OwnershipMixin
   extend ActiveSupport::Concern
 
   included do
+    before_validation :set_tenant_from_group
+
     belongs_to :evm_owner, :class_name => "User"
     belongs_to :miq_group
 
@@ -105,5 +107,9 @@ module OwnershipMixin
   def owned_by_current_ldap_group
     ldap_group = User.current_user.try(:ldap_group)
     ldap_group && owning_ldap_group && (owning_ldap_group.downcase == ldap_group.downcase)
+  end
+
+  def set_tenant_from_group
+    self.tenant_id = miq_group.tenant_id if miq_group
   end
 end

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -52,8 +52,6 @@ class OrchestrationStack < ApplicationRecord
 
   virtual_column :stdout, :type => :string
 
-  before_validation :set_tenant_from_group
-
   scope :without_type, ->(type) { where.not(:type => type) }
 
   alias_method :orchestration_stack_parameters, :parameters
@@ -97,10 +95,6 @@ class OrchestrationStack < ApplicationRecord
 
   def stdout(format = nil)
     format.nil? ? try(:raw_stdout) : try(:raw_stdout, format)
-  end
-
-  def set_tenant_from_group
-    self.tenant_id = miq_group.tenant_id if miq_group
   end
 
   private :directs_and_indirects

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -53,7 +53,6 @@ class Service < ApplicationRecord
   virtual_has_one    :reconfigure_dialog
   virtual_has_one    :user
 
-  before_validation :set_tenant_from_group
   before_create :update_attributes_from_dialog
 
   delegate :provision_dialog, :to => :miq_request, :allow_nil => true
@@ -381,10 +380,6 @@ class Service < ApplicationRecord
 
   def raise_provisioned_event
     MiqEvent.raise_evm_event(self, :service_provisioned)
-  end
-
-  def set_tenant_from_group
-    self.tenant_id = miq_group.tenant_id if miq_group
   end
 
   def tenant_identity

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -191,7 +191,6 @@ class VmOrTemplate < ApplicationRecord
   virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true, :type => :float
   delegate :connect_lans, :disconnect_lans, :to => :hardware, :allow_nil => true
 
-  before_validation :set_tenant_from_group
   after_save :save_genealogy_information
 
   scope :active,       ->       { where.not(:ems_id => nil) }
@@ -1843,10 +1842,6 @@ class VmOrTemplate < ApplicationRecord
   end
 
   private
-
-  def set_tenant_from_group
-    self.tenant_id = miq_group.tenant_id if miq_group
-  end
 
   def power_state=(new_power_state)
     super


### PR DESCRIPTION
it looks like that method `set_tenant_from_group` belongs to  `OwnershipMixin` because:

- `OwnershipMixin` defines `belongs_to: miq_group` and `miq_group` is used in this method 
-  just models with `OwnershipMixin` have defined `set_tenant_from_group`
- always when I add `OwnershipMixin`  to any model it requires also adding this method
and `before_validation :set_tenant_from_group` but you will find this later when you will notice that `the Model#tenant_id` is not set - so this change will help with this.


@miq-bot assign @kbrock 

@miq-bot add_label technical debt

