### PR TITLE
Adding Volume Snapshot (CloudVolumeSnapshot) to RBAC

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -13,6 +13,7 @@ module Rbac
       CloudSubnet
       CloudTenant
       CloudVolume
+      CloudVolumeSnapshot
       ConfigurationProfile
       ConfigurationScriptBase
       ConfigurationScriptSource

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -364,6 +364,24 @@ describe Rbac::Filterer do
           expect(results).to match_array [owner_tenant]
         end
       end
+
+      context 'searching for instances of CloudVolumeSnapshot' do
+        let!(:csv) { FactoryBot.create_list(:cloud_volume_snapshot, 2).first }
+
+        before do
+          csv.tag_with('/managed/environment/prod', :ns => '*')
+        end
+
+        it 'lists only tagged CloudVolumeSnapshot' do
+          results = described_class.search(:class => CloudVolumeSnapshot, :user => user).first
+          expect(results).to match_array [csv]
+        end
+
+        it 'lists only all CloudVolumeSnapshot' do
+          results = described_class.search(:class => CloudVolumeSnapshot, :user => admin_user).first
+          expect(results).to match_array CloudVolumeSnapshot.all
+        end
+      end
     end
 
     context 'with virtual custom attributes' do


### PR DESCRIPTION
This enables RBAC checking on volume snapshots. Previously RBAC was not filtering on this class and users with managed filters (tags) were able to see all ever instance of a volume snapshot.

https://bugzilla.redhat.com/show_bug.cgi?id=1757994