### PR TITLE
Don't pass a block to expect

### DIFF
--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -54,7 +54,7 @@ describe Authenticator::Database do
       end
 
       it "updates lastlogon" do
-        expect(-> { authenticate }).to change { alice.reload.lastlogon }
+        expect { authenticate }.to change { alice.reload.lastlogon }
       end
     end
 
@@ -66,7 +66,7 @@ describe Authenticator::Database do
       end
 
       it "fails" do
-        expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+        expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
       end
 
       it "records one failing audit entry" do
@@ -86,7 +86,7 @@ describe Authenticator::Database do
       end
 
       it "doesn't change lastlogon" do
-        expect(-> { authenticate rescue nil }).not_to change { alice.reload.lastlogon }
+        expect { authenticate rescue nil }.not_to change { alice.reload.lastlogon }
       end
     end
 
@@ -98,7 +98,7 @@ describe Authenticator::Database do
       end
 
       it "fails" do
-        expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError)
+        expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError)
       end
 
       it "records one failing audit entry" do
@@ -140,7 +140,7 @@ describe Authenticator::Database do
         authenticate
       end
       it "updates lastlogon" do
-        expect(-> { authenticate }).to change { vincent.reload.lastlogon }
+        expect { authenticate }.to change { vincent.reload.lastlogon }
       end
     end
   end

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -164,7 +164,7 @@ describe Authenticator::Httpd do
         end
 
         it "updates lastlogon" do
-          expect(-> { authenticate }).to change { alice.reload.lastlogon }
+          expect { authenticate }.to change { alice.reload.lastlogon }
         end
       end
 
@@ -192,7 +192,7 @@ describe Authenticator::Httpd do
         end
 
         it "updates lastlogon" do
-          expect(-> { authenticate }).to change { alice.reload.lastlogon }
+          expect { authenticate }.to change { alice.reload.lastlogon }
         end
 
         it "immediately completes the task" do
@@ -207,7 +207,7 @@ describe Authenticator::Httpd do
       let(:headers) { super().except('X-Remote-User') }
 
       it "fails" do
-        expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+        expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
       end
 
       it "puts the right name in a failing audit entry" do
@@ -225,7 +225,7 @@ describe Authenticator::Httpd do
       let(:username) { '' }
 
       it "fails" do
-        expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+        expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
       end
 
       it "records one failing audit entry" do
@@ -243,7 +243,7 @@ describe Authenticator::Httpd do
         authenticate rescue nil
       end
       it "doesn't change lastlogon" do
-        expect(-> { authenticate rescue nil }).not_to change { alice.reload.lastlogon }
+        expect { authenticate rescue nil }.not_to change { alice.reload.lastlogon }
       end
 
       context "with specific failure message" do
@@ -278,15 +278,15 @@ describe Authenticator::Httpd do
         let!(:sally_upn) { FactoryBot.create(:user, :userid => 'sAlly@example.com') }
 
         it "leaves user record with userid in username format unchanged" do
-          expect(-> { authenticate }).to_not change { sally_username.reload.userid }
+          expect { authenticate }.to_not change { sally_username.reload.userid }
         end
 
         it "leaves user record with userid in distinguished name format unchanged" do
-          expect(-> { authenticate }).to_not change { sally_dn.reload.userid }
+          expect { authenticate }.to_not change { sally_dn.reload.userid }
         end
 
         it "downcases user record with userid in upn format" do
-          expect(-> { authenticate })
+          expect { authenticate }
             .to change { sally_upn.reload.userid }.from("sAlly@example.com").to("sally@example.com")
         end
       end
@@ -294,17 +294,17 @@ describe Authenticator::Httpd do
       context "when user record with userid in upn format does not already exists" do
         it "updates userid from username format to upn format" do
           sally_username = FactoryBot.create(:user, :userid => 'sally')
-          expect(-> { authenticate }).to change { sally_username.reload.userid }.from("sally").to("sally@example.com")
+          expect { authenticate }.to change { sally_username.reload.userid }.from("sally").to("sally@example.com")
         end
 
         it "updates userid from distinguished name format to upn format" do
           sally_dn = FactoryBot.create(:user, :userid => dn)
-          expect(-> { authenticate }).to change { sally_dn.reload.userid }.from(dn).to("sally@example.com")
+          expect { authenticate }.to change { sally_dn.reload.userid }.from(dn).to("sally@example.com")
         end
 
         it "does not modify userid if already in upn format" do
           sally_upn = FactoryBot.create(:user, :userid => 'sally@example.com')
-          expect(-> { authenticate }).to_not change { sally_upn.reload.userid }
+          expect { authenticate }.to_not change { sally_upn.reload.userid }
         end
       end
 
@@ -315,17 +315,17 @@ describe Authenticator::Httpd do
 
         it "does not modify the user record when userid is in username format" do
           sally_username = FactoryBot.create(:user, :userid => 'sally', :id => other_region_id)
-          expect(-> { authenticate }).to_not change { sally_username.reload.userid }
+          expect { authenticate }.to_not change { sally_username.reload.userid }
         end
 
         it "does not modify the user record when userid is in distinguished name format" do
           sally_dn = FactoryBot.create(:user, :userid => dn, :id => other_region_id)
-          expect(-> { authenticate }).to_not change { sally_dn.reload.userid }
+          expect { authenticate }.to_not change { sally_dn.reload.userid }
         end
 
         it "does not modify the user record when userid is in already upn format" do
           sally_upn = FactoryBot.create(:user, :userid => 'sally@example.com', :id => other_region_id)
-          expect(-> { authenticate }).to_not change { sally_upn.reload.userid }
+          expect { authenticate }.to_not change { sally_upn.reload.userid }
         end
       end
     end
@@ -339,7 +339,7 @@ describe Authenticator::Httpd do
 
       context "using local authorization" do
         it "fails" do
-          expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError)
+          expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError)
         end
 
         it "records one successful and one failing audit entry" do
@@ -400,7 +400,7 @@ describe Authenticator::Httpd do
         end
 
         it "creates a new User" do
-          expect(-> { authenticate }).to change { User.where(:userid => 'bob@example.com').count }.from(0).to(1)
+          expect { authenticate }.to change { User.where(:userid => 'bob@example.com').count }.from(0).to(1)
         end
 
         context "with no matching groups" do
@@ -436,7 +436,7 @@ describe Authenticator::Httpd do
           end
 
           it "doesn't create a new User" do
-            expect(-> { authenticate }).not_to change { User.where(:userid => 'bob').count }.from(0)
+            expect { authenticate }.not_to change { User.where(:userid => 'bob').count }.from(0)
           end
 
           it "immediately marks the task as errored" do
@@ -457,7 +457,7 @@ describe Authenticator::Httpd do
           end
 
           it "creates a new User with name set to FirstName + LastName" do
-            expect(-> { authenticate }).to change { User.where(:name => 'Betty Boop').count }.from(0).to(1)
+            expect { authenticate }.to change { User.where(:name => 'Betty Boop').count }.from(0).to(1)
           end
         end
 
@@ -471,7 +471,7 @@ describe Authenticator::Httpd do
           end
 
           it "creates a new User with the userid set to the UPN" do
-            expect(-> { authenticate }).to change { User.where(:name => 'sam@example.com').count }.from(0).to(1)
+            expect { authenticate }.to change { User.where(:name => 'sam@example.com').count }.from(0).to(1)
           end
         end
       end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -224,13 +224,13 @@ describe Authenticator::Ldap do
         end
 
         it "updates lastlogon" do
-          expect(-> { authenticate }).to change { alice.reload.lastlogon }
+          expect { authenticate }.to change { alice.reload.lastlogon }
         end
 
         context "with no corresponding LDAP user" do
           let(:alice_data) { nil }
           it "fails" do
-            expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+            expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
           end
         end
       end
@@ -269,7 +269,7 @@ describe Authenticator::Ldap do
         end
 
         it "updates lastlogon" do
-          expect(-> { authenticate }).to change { alice.reload.lastlogon }
+          expect { authenticate }.to change { alice.reload.lastlogon }
         end
 
         it "immediately completes the task" do
@@ -296,7 +296,7 @@ describe Authenticator::Ldap do
         context "with no corresponding LDAP user" do
           let(:alice_data) { nil }
           it "fails" do
-            expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+            expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
           end
         end
       end
@@ -306,7 +306,7 @@ describe Authenticator::Ldap do
       let(:password) { 'incorrect' }
 
       it "fails" do
-        expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+        expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
       end
 
       it "records one failing audit entry" do
@@ -324,7 +324,7 @@ describe Authenticator::Ldap do
         authenticate rescue nil
       end
       it "doesn't change lastlogon" do
-        expect(-> { authenticate rescue nil }).not_to change { alice.reload.lastlogon }
+        expect { authenticate rescue nil }.not_to change { alice.reload.lastlogon }
       end
     end
 
@@ -335,7 +335,7 @@ describe Authenticator::Ldap do
         let(:password) { 'incorrect' }
 
         it "fails" do
-          expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+          expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
         end
 
         it "records one failing audit entry" do
@@ -356,7 +356,7 @@ describe Authenticator::Ldap do
 
       context "using local authorization" do
         it "fails" do
-          expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError)
+          expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError)
         end
 
         it "records one successful and one failing audit entry" do
@@ -401,7 +401,7 @@ describe Authenticator::Ldap do
           end
 
           it "creates a new User" do
-            expect(-> { authenticate }).to change { User.where(:userid => 'bob').count }.from(0).to(1)
+            expect { authenticate }.to change { User.where(:userid => 'bob').count }.from(0).to(1)
           end
         end
 
@@ -409,7 +409,7 @@ describe Authenticator::Ldap do
           let(:config) { super().merge(:default_group_for_users => 'bubble') }
 
           it "fails" do
-            expect(-> { authenticate }).to raise_error(MiqException::MiqEVMLoginError)
+            expect { authenticate }.to raise_error(MiqException::MiqEVMLoginError)
           end
         end
       end
@@ -452,7 +452,7 @@ describe Authenticator::Ldap do
         end
 
         it "creates a new User" do
-          expect(-> { authenticate }).to change { User.where(:userid => 'bob').count }.from(0).to(1)
+          expect { authenticate }.to change { User.where(:userid => 'bob').count }.from(0).to(1)
         end
 
         context "with no matching groups" do
@@ -488,7 +488,7 @@ describe Authenticator::Ldap do
           end
 
           it "doesn't create a new User" do
-            expect(-> { authenticate }).not_to change { User.where(:userid => 'bob').count }.from(0)
+            expect { authenticate }.not_to change { User.where(:userid => 'bob').count }.from(0)
           end
 
           it "immediately marks the task as errored" do
@@ -503,7 +503,7 @@ describe Authenticator::Ldap do
           let(:username) { 'betty' }
 
           it "creates a new User with name set to givenname + sn" do
-            expect(-> { authenticate }).to change { User.where(:name => 'Betty Builderson').count }.from(0).to(1)
+            expect { authenticate }.to change { User.where(:name => 'Betty Builderson').count }.from(0).to(1)
           end
         end
 
@@ -511,7 +511,7 @@ describe Authenticator::Ldap do
           let(:username) { 'sam' }
 
           it "creates a new User with name set to the userid" do
-            expect(-> { authenticate }).to change { User.where(:name => 'sam').count }.from(0).to(1)
+            expect { authenticate }.to change { User.where(:name => 'sam').count }.from(0).to(1)
           end
         end
       end

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -58,14 +58,14 @@ describe Authenticator::Ldap do
     it "password is blank" do
       @password = ""
       expect(AuditEvent).to receive(:failure)
-      expect(-> { subject }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+      expect { subject }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
     end
 
     it "ldap bind fails" do
       allow(@miq_ldap).to receive_messages(:bind => false)
 
       expect(AuditEvent).to receive(:failure)
-      expect(-> { subject }).to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
+      expect { subject }.to raise_error(MiqException::MiqEVMLoginError, "Authentication failed")
     end
 
     context "ldap binds" do


### PR DESCRIPTION
Rspec expect doesn't allow passing a block to expect as an argument:
```
     Failure/Error: expect(-> { authenticate }).to change { User.where(:name => 'Betty Builderson').count }.from(0).to(1)
       You must pass a block rather than an argument to `expect` to use the provided block expectation matcher (change `User.where(:name => 'Betty Builderson').count` from 0 to 1).
```