### PR TITLE
Parenthesize .to change {} to prevent ambiguity

### DIFF
--- a/spec/mailers/generic_mailer_spec.rb
+++ b/spec/mailers/generic_mailer_spec.rb
@@ -41,7 +41,7 @@ describe GenericMailer do
 
     it 'does not queue any mail notifications' do
       @args[:attachment] = [{:content_type => "text/plain", :filename => "generic_mailer_test.txt", :body => "generic_notification with text/plain attachment" * 10}]
-      expect { GenericMailer.deliver_queue(:generic_notification, @args) }.not_to change { MiqQueue.count }
+      expect { GenericMailer.deliver_queue(:generic_notification, @args) }.not_to(change { MiqQueue.count })
     end
   end
 

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -54,7 +54,7 @@ describe Authenticator::Database do
       end
 
       it "updates lastlogon" do
-        expect { authenticate }.to change { alice.reload.lastlogon }
+        expect { authenticate }.to(change { alice.reload.lastlogon })
       end
     end
 
@@ -86,7 +86,7 @@ describe Authenticator::Database do
       end
 
       it "doesn't change lastlogon" do
-        expect { authenticate rescue nil }.not_to change { alice.reload.lastlogon }
+        expect { authenticate rescue nil }.not_to(change { alice.reload.lastlogon })
       end
     end
 
@@ -140,7 +140,7 @@ describe Authenticator::Database do
         authenticate
       end
       it "updates lastlogon" do
-        expect { authenticate }.to change { vincent.reload.lastlogon }
+        expect { authenticate }.to(change { vincent.reload.lastlogon })
       end
     end
   end

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -164,7 +164,7 @@ describe Authenticator::Httpd do
         end
 
         it "updates lastlogon" do
-          expect { authenticate }.to change { alice.reload.lastlogon }
+          expect { authenticate }.to(change { alice.reload.lastlogon })
         end
       end
 
@@ -192,7 +192,7 @@ describe Authenticator::Httpd do
         end
 
         it "updates lastlogon" do
-          expect { authenticate }.to change { alice.reload.lastlogon }
+          expect { authenticate }.to(change { alice.reload.lastlogon })
         end
 
         it "immediately completes the task" do
@@ -243,7 +243,7 @@ describe Authenticator::Httpd do
         authenticate rescue nil
       end
       it "doesn't change lastlogon" do
-        expect { authenticate rescue nil }.not_to change { alice.reload.lastlogon }
+        expect { authenticate rescue nil }.not_to(change { alice.reload.lastlogon })
       end
 
       context "with specific failure message" do
@@ -278,33 +278,33 @@ describe Authenticator::Httpd do
         let!(:sally_upn) { FactoryBot.create(:user, :userid => 'sAlly@example.com') }
 
         it "leaves user record with userid in username format unchanged" do
-          expect { authenticate }.to_not change { sally_username.reload.userid }
+          expect { authenticate }.to_not(change { sally_username.reload.userid })
         end
 
         it "leaves user record with userid in distinguished name format unchanged" do
-          expect { authenticate }.to_not change { sally_dn.reload.userid }
+          expect { authenticate }.to_not(change { sally_dn.reload.userid })
         end
 
         it "downcases user record with userid in upn format" do
           expect { authenticate }
-            .to change { sally_upn.reload.userid }.from("sAlly@example.com").to("sally@example.com")
+            .to(change { sally_upn.reload.userid }.from("sAlly@example.com").to("sally@example.com"))
         end
       end
 
       context "when user record with userid in upn format does not already exists" do
         it "updates userid from username format to upn format" do
           sally_username = FactoryBot.create(:user, :userid => 'sally')
-          expect { authenticate }.to change { sally_username.reload.userid }.from("sally").to("sally@example.com")
+          expect { authenticate }.to(change { sally_username.reload.userid }.from("sally").to("sally@example.com"))
         end
 
         it "updates userid from distinguished name format to upn format" do
           sally_dn = FactoryBot.create(:user, :userid => dn)
-          expect { authenticate }.to change { sally_dn.reload.userid }.from(dn).to("sally@example.com")
+          expect { authenticate }.to(change { sally_dn.reload.userid }.from(dn).to("sally@example.com"))
         end
 
         it "does not modify userid if already in upn format" do
           sally_upn = FactoryBot.create(:user, :userid => 'sally@example.com')
-          expect { authenticate }.to_not change { sally_upn.reload.userid }
+          expect { authenticate }.to_not(change { sally_upn.reload.userid })
         end
       end
 
@@ -315,17 +315,17 @@ describe Authenticator::Httpd do
 
         it "does not modify the user record when userid is in username format" do
           sally_username = FactoryBot.create(:user, :userid => 'sally', :id => other_region_id)
-          expect { authenticate }.to_not change { sally_username.reload.userid }
+          expect { authenticate }.to_not(change { sally_username.reload.userid })
         end
 
         it "does not modify the user record when userid is in distinguished name format" do
           sally_dn = FactoryBot.create(:user, :userid => dn, :id => other_region_id)
-          expect { authenticate }.to_not change { sally_dn.reload.userid }
+          expect { authenticate }.to_not(change { sally_dn.reload.userid })
         end
 
         it "does not modify the user record when userid is in already upn format" do
           sally_upn = FactoryBot.create(:user, :userid => 'sally@example.com', :id => other_region_id)
-          expect { authenticate }.to_not change { sally_upn.reload.userid }
+          expect { authenticate }.to_not(change { sally_upn.reload.userid })
         end
       end
     end
@@ -400,7 +400,7 @@ describe Authenticator::Httpd do
         end
 
         it "creates a new User" do
-          expect { authenticate }.to change { User.where(:userid => 'bob@example.com').count }.from(0).to(1)
+          expect { authenticate }.to(change { User.where(:userid => 'bob@example.com').count }.from(0).to(1))
         end
 
         context "with no matching groups" do
@@ -436,7 +436,7 @@ describe Authenticator::Httpd do
           end
 
           it "doesn't create a new User" do
-            expect { authenticate }.not_to change { User.where(:userid => 'bob').count }.from(0)
+            expect { authenticate }.not_to(change { User.where(:userid => 'bob').count }.from(0))
           end
 
           it "immediately marks the task as errored" do
@@ -457,7 +457,7 @@ describe Authenticator::Httpd do
           end
 
           it "creates a new User with name set to FirstName + LastName" do
-            expect { authenticate }.to change { User.where(:name => 'Betty Boop').count }.from(0).to(1)
+            expect { authenticate }.to(change { User.where(:name => 'Betty Boop').count }.from(0).to(1))
           end
         end
 
@@ -471,7 +471,7 @@ describe Authenticator::Httpd do
           end
 
           it "creates a new User with the userid set to the UPN" do
-            expect { authenticate }.to change { User.where(:name => 'sam@example.com').count }.from(0).to(1)
+            expect { authenticate }.to(change { User.where(:name => 'sam@example.com').count }.from(0).to(1))
           end
         end
       end

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -224,7 +224,7 @@ describe Authenticator::Ldap do
         end
 
         it "updates lastlogon" do
-          expect { authenticate }.to change { alice.reload.lastlogon }
+          expect { authenticate }.to(change { alice.reload.lastlogon })
         end
 
         context "with no corresponding LDAP user" do
@@ -269,7 +269,7 @@ describe Authenticator::Ldap do
         end
 
         it "updates lastlogon" do
-          expect { authenticate }.to change { alice.reload.lastlogon }
+          expect { authenticate }.to(change { alice.reload.lastlogon })
         end
 
         it "immediately completes the task" do
@@ -324,7 +324,7 @@ describe Authenticator::Ldap do
         authenticate rescue nil
       end
       it "doesn't change lastlogon" do
-        expect { authenticate rescue nil }.not_to change { alice.reload.lastlogon }
+        expect { authenticate rescue nil }.not_to(change { alice.reload.lastlogon })
       end
     end
 
@@ -401,7 +401,7 @@ describe Authenticator::Ldap do
           end
 
           it "creates a new User" do
-            expect { authenticate }.to change { User.where(:userid => 'bob').count }.from(0).to(1)
+            expect { authenticate }.to(change { User.where(:userid => 'bob').count }.from(0).to(1))
           end
         end
 
@@ -452,7 +452,7 @@ describe Authenticator::Ldap do
         end
 
         it "creates a new User" do
-          expect { authenticate }.to change { User.where(:userid => 'bob').count }.from(0).to(1)
+          expect { authenticate }.to(change { User.where(:userid => 'bob').count }.from(0).to(1))
         end
 
         context "with no matching groups" do
@@ -488,7 +488,7 @@ describe Authenticator::Ldap do
           end
 
           it "doesn't create a new User" do
-            expect { authenticate }.not_to change { User.where(:userid => 'bob').count }.from(0)
+            expect { authenticate }.not_to(change { User.where(:userid => 'bob').count }.from(0))
           end
 
           it "immediately marks the task as errored" do
@@ -503,7 +503,7 @@ describe Authenticator::Ldap do
           let(:username) { 'betty' }
 
           it "creates a new User with name set to givenname + sn" do
-            expect { authenticate }.to change { User.where(:name => 'Betty Builderson').count }.from(0).to(1)
+            expect { authenticate }.to(change { User.where(:name => 'Betty Builderson').count }.from(0).to(1))
           end
         end
 
@@ -511,7 +511,7 @@ describe Authenticator::Ldap do
           let(:username) { 'sam' }
 
           it "creates a new User with name set to the userid" do
-            expect { authenticate }.to change { User.where(:name => 'sam').count }.from(0).to(1)
+            expect { authenticate }.to(change { User.where(:name => 'sam').count }.from(0).to(1))
           end
         end
       end

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -310,7 +310,7 @@ describe CustomButton do
     service_template1 = FactoryBot.create(:service_template)
     service_template2 = FactoryBot.create(:service_template)
     button = FactoryBot.create(:custom_button, :applies_to => service_template1)
-    expect { button.copy(:applies_to => service_template2) }.to change { CustomButton.count }.by(1)
+    expect { button.copy(:applies_to => service_template2) }.to(change { CustomButton.count }.by(1))
   end
 
   describe "publish custom button event" do

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -39,7 +39,7 @@ describe Job do
         end
 
         it "should queue a timeout job if one not already on there" do
-          expect { @job.timeout! }.to change { MiqQueue.count }.by(1)
+          expect { @job.timeout! }.to(change { MiqQueue.count }.by(1))
         end
 
         it "should be timed out after 5 minutes" do
@@ -51,12 +51,12 @@ describe Job do
       end
 
       it "should not queue a timeout job if one is already on there" do
-        expect { @job.timeout! }.not_to change { MiqQueue.count }
+        expect { @job.timeout! }.not_to(change { MiqQueue.count })
       end
 
       it "should queue a timeout job if one is there, but it is failed" do
         MiqQueue.first.update(:state => MiqQueue::STATE_ERROR)
-        expect { @job.timeout! }.to change { MiqQueue.count }.by(1)
+        expect { @job.timeout! }.to(change { MiqQueue.count }.by(1))
       end
     end
 

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -279,7 +279,7 @@ describe MiqGroup do
 
       expect {
         MiqGroup.seed
-      }.to change { MiqGroup.count }
+      }.to(change { MiqGroup.count })
       expect(MiqGroup.last.name).to eql('EvmRole-test_role')
       expect(MiqGroup.last.sequence).to eql(1)
     end

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -12,7 +12,7 @@ describe ServiceTemplate do
       copy = nil
       expect do
         copy = template.public_send(*[:template_copy, name].compact)
-      end.to change { ServiceTemplate.count }.by(1)
+      end.to(change { ServiceTemplate.count }.by(1))
       expect(copy.persisted?).to be(true)
       expect(copy.guid).not_to eq(template.guid)
       expect(copy.display).to be(false)

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -28,7 +28,7 @@ describe Session do
     it "purges an old session" do
       FactoryBot.create(:session, :updated_at => 1.year.ago, :raw_data => {:userid => "admin"})
 
-      expect { described_class.purge(0, 1) }.to change { described_class.count }.from(1).to(0)
+      expect { described_class.purge(0, 1) }.to(change { described_class.count }.from(1).to(0))
     end
 
     it "logs out users before destroying stale sessions" do
@@ -44,7 +44,7 @@ describe Session do
     it "handles a session with bad data" do
       FactoryBot.create(:session, :updated_at => 1.year.ago, :data => "Data that can't be marshaled")
 
-      expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
+      expect { described_class.purge(0) }.to(change { described_class.count }.from(1).to(0))
     end
 
     context "given some token store data" do
@@ -53,13 +53,13 @@ describe Session do
       it "will purge an expired token" do
         FactoryBot.create(:session, :raw_data => {:expires_on => 1.second.ago})
 
-        expect { described_class.purge(0) }.to change { described_class.count }.from(1).to(0)
+        expect { described_class.purge(0) }.to(change { described_class.count }.from(1).to(0))
       end
 
       it "won't purge an unexpired token" do
         FactoryBot.create(:session, :raw_data => {:expires_on => 1.second.from_now})
 
-        expect { described_class.purge(0) }.not_to change { described_class.count }
+        expect { described_class.purge(0) }.not_to(change { described_class.count })
       end
     end
 
@@ -69,7 +69,7 @@ describe Session do
 
         expect do
           expect(described_class.purge_one_batch(0, 1)).to eq 1
-        end.to change { described_class.count }.from(2).to(1)
+        end.to(change { described_class.count }.from(2).to(1))
       end
     end
   end

--- a/spec/models/vmdb_metric_spec.rb
+++ b/spec/models/vmdb_metric_spec.rb
@@ -6,6 +6,6 @@ describe VmdbMetric do
   it "should purge" do
     expect do
       VmdbMetric.purge_daily_timer
-    end.to change { MiqQueue.count }.by(1)
+    end.to(change { MiqQueue.count }.by(1))
   end
 end


### PR DESCRIPTION
Having .to change {block} is ambiguous, add parens around (change {})