### PR TITLE
Set zip validate_entry_sizes to true for rubyzip 1.3.0

### DIFF
--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -97,6 +97,9 @@ module VMDB
 
     def self.zip_logs(zip_filename, dirs, userid = "system")
       require 'zip/filesystem'
+      # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
+      # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
+      Zip.validate_entry_sizes = true
 
       zip_dir = Rails.root.join("data", "user", userid)
       FileUtils.mkdir_p(zip_dir) unless File.exist?(zip_dir)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -124,6 +124,10 @@ describe VMDB::Util do
 
   context ".add_zip_entry(private)" do
     require 'zip/filesystem'
+    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
+    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
+    Zip.validate_entry_sizes = true
+
     let(:origin_file) { Tempfile.new 'origin' }
     let(:symlink_level_1) { create_temp_symlink 'symlink_level_1', origin_file.path }
     let(:symlink_level_2) { create_temp_symlink 'symlink_level_2', symlink_level_1 }


### PR DESCRIPTION
This flag must be set in order to use the validation against zip bombs described in https://github.com/rubyzip/rubyzip/pull/403; they set it to false by default in 1.3.0 for backwards compatibility. 

See
https://github.com/rubyzip/rubyzip/pull/403#issue-317103816

@miq-bot assign @jrafanie 
There's also an automate engine PR to address this: https://github.com/ManageIQ/manageiq-automation_engine/pull/377 

@simaishi sorry for the delay