### PR TITLE
Display is deprecated, use visible

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -88,15 +88,15 @@ class Service < ApplicationRecord
 
   validates :name, :presence => true
 
-  default_value_for :display, false
+  default_value_for :visible, false
   default_value_for :initiator, 'user'
   default_value_for :lifecycle_state, 'unprovisioned'
   default_value_for :retired, false
 
-  validates :display, :inclusion => { :in => [true, false] }
+  validates :visible, :inclusion => { :in => [true, false] }
   validates :retired, :inclusion => { :in => [true, false] }
 
-  scope :displayed, ->              { where(:display => true) }
+  scope :displayed, ->              { where(:visible => true) }
   scope :retired,   ->(bool = true) { where(:retired => bool) }
 
   supports :reconfigure do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -676,14 +676,14 @@ describe Service do
     end
   end
 
-  describe "#display" do
+  describe "#visible" do
     it "defaults to false" do
       service = described_class.new
-      expect(service.display).to be(false)
+      expect(service.visible).to be(false)
     end
 
     it "cannot be nil" do
-      service = FactoryBot.build(:service, :display => nil)
+      service = FactoryBot.build(:service, :visible => nil)
       expect(service).not_to be_valid
     end
   end

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -395,17 +395,17 @@ describe ServiceTemplate do
 
     it "should pass display attribute to created top level service" do
       @svc_a.display = true
-      expect(@svc_a.create_service(double(:options => {:dialog => {}}, :get_user => service_user)).display).to eq(true)
+      expect(@svc_a.create_service(double(:options => {:dialog => {}}, :get_user => service_user)).visible).to eq(true)
     end
 
     it "should set created child service's display to false" do
       @svc_a.display = true
       allow(@svc_b).to receive(:add_resource!)
-      expect(@svc_a.create_service(double(:options => {:dialog => {}}, :get_user => service_user), @svc_b).display).to eq(false)
+      expect(@svc_a.create_service(double(:options => {:dialog => {}}, :get_user => service_user), @svc_b).visible).to eq(false)
     end
 
     it "should set created service's display to false by default" do
-      expect(@svc_a.create_service(double(:options => {:dialog => {}}, :get_user => service_user)).display).to eq(false)
+      expect(@svc_a.create_service(double(:options => {:dialog => {}}, :get_user => service_user)).visible).to eq(false)
     end
 
     it "should return all parent services for a service" do


### PR DESCRIPTION
As of 9c72451aa29, display still works but is a deprecated attribute.

Hopefully this fixes many of the deprecations in travis:

```
DEPRECATION WARNING: display is deprecated and will be removed from ManageIQ K-release (visible) (called from block in add_resource! at /home/travis/build/ManageIQ/manageiq/app/models/mixins/service_mixin.rb:31)
.DEPRECATION WARNING: display is deprecated and will be removed from ManageIQ K-release (visible) (called from new at /home/travis/build/ManageIQ/manageiq/app/models/mixins/new_with_type_sti_mixin.rb:16)
DEPRECATION WARNING: display is deprecated and will be removed from ManageIQ K-release (visible) (called from create_service at /home/travis/build/ManageIQ/manageiq/app/models/service_template.rb:226)
```