### PR TITLE
Don't use raw SQL conditions for WHERE in Hardware model (and fix bugs)

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -11,21 +11,20 @@ class Hardware < ApplicationRecord
 
   has_many    :disks, -> { order(:location) }, :dependent => :destroy
   has_many    :hard_disks, -> { where.not(:device_type => 'floppy').where.not(Disk.arel_table[:device_type].lower.matches('%cdrom%')).order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
-
-  has_many    :floppies, -> { where("device_type = 'floppy'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
-  has_many    :cdroms, -> { where("device_type LIKE '%cdrom%'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
+  has_many    :floppies, -> { where(:device_type => 'floppy').order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
+  has_many    :cdroms, -> { where(Disk.arel_table[:device_type].lower.matches('%cdrom%')).order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
 
   has_many    :partitions, :dependent => :destroy
   has_many    :volumes, :dependent => :destroy
 
   has_many    :guest_devices, :dependent => :destroy
-  has_many    :storage_adapters, -> { where("device_type = 'storage'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
-  has_many    :nics, -> { where("device_type = 'ethernet'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
-  has_many    :ports, -> { where("device_type != 'storage'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
-  has_many    :physical_ports, -> { where("device_type = 'physical_port'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+  has_many    :storage_adapters, -> { where(:device_type => 'storage') }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+  has_many    :nics, -> { where(:device_type => 'ethernet') }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+  has_many    :ports, -> { where.not(:device_type => 'storage') }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+  has_many    :physical_ports, -> { where(:device_type => 'physical_port') }, :class_name => "GuestDevice", :foreign_key => :hardware_id
   has_many    :connected_physical_switches, :through => :guest_devices
 
-  has_many    :management_devices, -> { where("device_type = 'management'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
+  has_many    :management_devices, -> { where(:device_type => 'management') }, :class_name => "GuestDevice", :foreign_key => :hardware_id
 
   virtual_column :ipaddresses,   :type => :string_set, :uses => :networks
   virtual_column :hostnames,     :type => :string_set, :uses => :networks

--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -10,7 +10,8 @@ class Hardware < ApplicationRecord
   has_many    :firmwares, :as => :resource, :dependent => :destroy
 
   has_many    :disks, -> { order(:location) }, :dependent => :destroy
-  has_many    :hard_disks, -> { where("device_type != 'floppy' AND device_type NOT LIKE '%cdrom%'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
+  has_many    :hard_disks, -> { where.not(:device_type => 'floppy').where.not(Disk.arel_table[:device_type].lower.matches('%cdrom%')).order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
+
   has_many    :floppies, -> { where("device_type = 'floppy'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
   has_many    :cdroms, -> { where("device_type LIKE '%cdrom%'").order(:location) }, :class_name => "Disk", :foreign_key => :hardware_id
 


### PR DESCRIPTION
first commit fixes error in report(defined in spec) generation:

```
/connection_adapters/postgresql_adapter.rb:624:in `async_exec_params': PG::AmbiguousColumn: ERROR:  column reference "device_type" is ambiguous (ActiveRecord::StatementInvalid)
LINE 1: ...dwares"."hardware_id" = "hardwares_vms"."id" AND (device_typ...
                                                             ^
: SELECT "vms"."id" AS t0_r0, ....

AS t5_r21, "hard_disks_hardwares"."ems_ref" AS t5_r22 FROM "vms" LEFT OUTER JOIN "hardwares" ON "hardwares"."vm_or_template_id" = "vms"."id" LEFT OUTER JOIN "disks" ON "disks"."hardware_id" = "hardwares"."id" LEFT OUTER JOIN "miq_request_tasks" ON "miq_request_tasks"."destination_id" = "vms"."id" AND "miq_request_tasks"."type" IN ('MiqProvision', 'ManageIQ::Providers::Kubevirt::InfraManager::Provision', 'ManageIQ::Providers::Redhat::InfraManager::Provision', 'ManageIQ::Providers::Microsoft::InfraManager::Provision', 'ManageIQ::Providers::Vmware::InfraManager::Provision', 'ManageIQ::Providers::CloudManager::Provision', 'ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso', 'ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe', 'ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe', 'ManageIQ::Providers::Amazon::CloudManager::Provision', 'ManageIQ::Providers::Azure::CloudManager::Provision', 'ManageIQ::Providers::Google::CloudManager::Provision', 'ManageIQ::Providers::Openstack::CloudManager::Provision') AND "miq_request_tasks"."type" IN ('MiqProvision', 'ManageIQ::Providers::Kubevirt::InfraManager::Provision', 'ManageIQ::Providers::Redhat::InfraManager::Provision', 'ManageIQ::Providers::Microsoft::InfraManager::Provision', 'ManageIQ::Providers::Vmware::InfraManager::Provision', 'ManageIQ::Providers::CloudManager::Provision', 'ManageIQ::Providers::Redhat::InfraManager::ProvisionViaIso', 'ManageIQ::Providers::Redhat::InfraManager::ProvisionViaPxe', 'ManageIQ::Providers::Vmware::InfraManager::ProvisionViaPxe', 'ManageIQ::Providers::Amazon::CloudManager::Provision', 'ManageIQ::Providers::Azure::CloudManager::Provision', 'ManageIQ::Providers::Google::CloudManager::Provision', 'ManageIQ::Providers::Openstack::CloudManager::Provision') AND "miq_request_tasks"."source_type" = $1 AND "miq_request_tasks"."destination_type" = $2 LEFT OUTER JOIN "vms" "miq_provision_templates_vms" ON "miq_provision_templates_vms"."id" = "miq_request_tasks"."source_id" LEFT OUTER JOIN "hardwares" "hardwares_vms" ON "hardwares_vms"."vm_or_template_id" = "miq_provision_templates_vms"."id" 


LEFT OUTER JOIN "disks" "hard_disks_hardwares" ON 
"hard_disks_hardwares"."hardware_id" = "hardwares_vms"."id" 
AND (device_type != 'floppy' AND device_type NOT LIKE '%cdrom%')  <--- BAD LINE


WHERE "vms"."type" IN ('ManageIQ::Providers::InfraManager::Vm', ...) AND "vms"."template" = $3
```

second is about the some thing but for other scopes.

@miq-bot add_label bug, refactoring
@miq-bot assign @kbrock 