### PR TITLE
Reload stale source_tenant after destroying self (rails 5.2)

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -159,6 +159,8 @@ module ManageIQ::Providers
 
     def destroy_mapped_tenants
       if source_tenant
+        # We just destroyed ourself, reload the source_tenant association
+        source_tenant.reload
         source_tenant.all_subtenants.destroy_all
         source_tenant.all_subprojects.destroy_all
         source_tenant.destroy

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -355,7 +355,7 @@ class Tenant < ApplicationRecord
 
   def ensure_can_be_destroyed
     errors.add(:base, _("A tenant with groups associated cannot be deleted.")) if miq_groups.non_tenant_groups.exists?
-    errors.add(:base, _("A tenant created by tenant mapping cannot be deleted.")) if source
+    errors.add(:base, _("A tenant created by tenant mapping cannot be deleted.")) if source&.persisted?
     throw :abort unless errors[:base].empty?
   end
 


### PR DESCRIPTION
In rails 5.2, this stale source_tenant has a "source" CloudManager
during this "after_destroy" callback. This causes the
source_tenant.destroy to fail, thinking the "source" CloudManager still
exists.

Fixes:
```
  5) ManageIQ::Providers::CloudManager OpenStack CloudTenant Mapping #sync_cloud_tenants_with_tenants creation of tenant tree  cleans up created tenant tree when the ems is destroyed
     Failure/Error: expect(Tenant.count).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/models/manageiq/providers/cloud_manager_spec.rb:205:in `block (5 levels) in <top (required)>'
```