### PR TITLE
[WIP] We can't order by a virtual column name, right?  It doesn't exist (rails 5.2)

### DIFF
--- a/spec/support/arel_helper.rb
+++ b/spec/support/arel_helper.rb
@@ -11,7 +11,6 @@ module Spec
       # run the sql for a virtual column. making sure it works in select and order
       def virtual_column_sql_value(klass, v_col_name)
         query = klass.select(:id, klass.arel_attribute(v_col_name.to_sym).as("extra"))
-                     .order(v_col_name.to_sym)
         query.first["extra"]
       end
     end


### PR DESCRIPTION
Fixes this mess (rails 5.2 is more strict about columns vs. virtual columns)
```
28) VmOrTemplate#normalized_state template virtual column
      Failure/Error: query.first["extra"]

      ActiveRecord::StatementInvalid:
        PG::UndefinedColumn: ERROR:  column "normalized_state" does not exist
        LINE 1: ...e", 'unknown')) END) AS extra FROM "vms" ORDER BY "normalize...
                                                                     ^
        : SELECT  "vms"."id", (CASE WHEN ("vms"."ems_id" IS NULL AND "vms"."storage_id" IS NULL) THEN 'archived' WHEN ("vms"."ems_id" IS NULL AND "vms"."storage_id" IS NOT NULL) THEN 'orphaned' WHEN "vms"."template" = TRUE THEN 'template' WHEN "vms"."retired" = TRUE THEN 'retired' WHEN ("vms"."connection_state" IS NOT NULL AND "vms"."connection_state" != 'connected') THEN 'disconnected' ELSE LOWER(COALESCE("vms"."power_state", 'unknown')) END) AS extra FROM "vms" ORDER BY "normalized_state" ASC LIMIT $1
      Shared Example Group: "normalized_state return value" called from ./spec/models/vm_or_template_spec.rb:1358
      # ./spec/support/arel_helper.rb:15:in `virtual_column_sql_value'
      # ./spec/models/vm_or_template_spec.rb:1333:in `block (4 levels) in <top (required)>'
      # ./spec/models/vm_or_template_spec.rb:1338:in `block (4 levels) in <top (required)>'
      # ------------------
      # --- Caused by: ---
      # PG::UndefinedColumn:
      #   ERROR:  column "normalized_state" does not exist
      #   LINE 1: ...e", 'unknown')) END) AS extra FROM "vms" ORDER BY "normalize...
      #                                                                ^
      #   ./spec/support/arel_helper.rb:15:in `virtual_column_sql_value'
```
