### PR TITLE
Implicit arel delegation is deprecated, make it explicit (rails 5.2)

### DIFF
--- a/app/models/mixins/purging_mixin.rb
+++ b/app/models/mixins/purging_mixin.rb
@@ -149,7 +149,7 @@ module PurgingMixin
     # @return [ActiveRecord::Relation] Records to be deleted
     def purge_ids_for_remaining(remaining)
       # HACK: `as(table_name)` fixes a bug with `from("").pluck(:id)`
-      from(purge_ids_ranked_by_age.as(table_name)).where("rank > ?", remaining)
+      from(purge_ids_ranked_by_age.arel.as(table_name)).where("rank > ?", remaining)
     end
 
     # Private: Rank records by age for each resource

--- a/lib/extensions/ar_taggable.rb
+++ b/lib/extensions/ar_taggable.rb
@@ -53,7 +53,7 @@ module ActsAsTaggable
       taggings = Tagging.arel_table
       where(Tagging.where(taggings[:taggable_id].eq(arel_table[:id])
                                                 .and(taggings[:taggable_type].eq(base_class.name))
-                                                .and(taggings[:tag_id].in(tag_ids))).exists)
+                                                .and(taggings[:tag_id].in(tag_ids))).arel.exists)
     end
 
     def with_all_tags(tag_ids)


### PR DESCRIPTION
Implicit arel delegation is deprecated.

Fixes an annoying warning:

```
DEPRECATION WARNING: Delegating exists to arel is deprecated and will be removed in Rails 6.0. (called from with_any_tags at /Users/joerafaniello/Code/manageiq/lib/extensions/ar_taggable.rb:56)
```