### PR TITLE
[V2V] Remove handover from shutdown_vm transition

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -396,7 +396,6 @@ class InfraConversionJob < Job
     end
 
     update_migration_task_progress(:on_exit)
-    handover_to_automate
     queue_signal(:transform_vm)
   rescue StandardError => error
     update_migration_task_progress(:on_error)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1074,7 +1074,6 @@ RSpec.describe InfraConversionJob, :v2v do
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
         expect(job).to receive(:queue_signal).with(:transform_vm)
         job.signal(:shutdown_vm)
-        expect(task.reload.options[:workflow_runner]).to eq('automate')
       end
 
       it 'sends shutdown request to VM if VM supports shutdown_guest' do


### PR DESCRIPTION
When implementing the InfraConversionJob state machine, we forgot to remove the `handover_to_automate` call in `shutdown_vm` transition method. This PR removes it.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1759062