### PR TITLE
[V2V] Extend InfraConversionJob timeout

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -1,4 +1,8 @@
 class InfraConversionJob < Job
+
+  # Override default timeout to allow large disks VM migration
+  DEFAULT_TIMEOUT = 36.hours
+
   #
   # State-transition diagram:
   #                              :poll_conversion                         :poll_post_stage

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -1,7 +1,4 @@
 class InfraConversionJob < Job
-  # Override default timeout to allow large disks VM migration
-  DEFAULT_TIMEOUT = 36.hours
-
   #
   # State-transition diagram:
   #                              :poll_conversion                         :poll_post_stage
@@ -138,6 +135,10 @@ class InfraConversionJob < Job
   end
 
   # --- Override Job methods to handle cancelation properly  --- #
+
+  def self.current_job_timeout(_timeout_adjustment = 1)
+    36.hours
+  end
 
   def process_abort(*args)
     message, status = args

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -1,5 +1,4 @@
 class InfraConversionJob < Job
-
   # Override default timeout to allow large disks VM migration
   DEFAULT_TIMEOUT = 36.hours
 


### PR DESCRIPTION
InfraConversionJob class inherits from Job class. And Job class implements a timeout mechanism with a default timeout of 5 minutes. A VM migration is likely to take more than 5 minutes, so this PR sets the ~~`DEFAULT_TIMEOUT` constant~~ `self.current_job_timeout` method to 36 hours to allow large VM to migrate.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1759062