### PR TITLE
Remove removing_snapshots state

### DIFF
--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine finish abort_job cancel error].each do |signal|
+    %w[start wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -364,7 +364,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w[start remove_snapshots poll_remove_snapshots_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine].each do |signal|
+    %w[start wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -383,8 +383,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows cancel signal'
       it_behaves_like 'allows error signal'
 
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -406,36 +404,6 @@ RSpec.describe InfraConversionJob, :v2v do
         job.state = 'started'
       end
 
-      it_behaves_like 'allows remove_snapshots signal'
-      it_behaves_like 'allows finish signal'
-      it_behaves_like 'allows abort_job signal'
-      it_behaves_like 'allows cancel signal'
-      it_behaves_like 'allows error signal'
-
-      it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
-      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
-      it_behaves_like 'doesn\'t allow run_migration_playbook signal'
-      it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
-      it_behaves_like 'doesn\'t allow shutdown_vm signal'
-      it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
-      it_behaves_like 'doesn\'t allow transform_vm signal'
-      it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
-      it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
-      it_behaves_like 'doesn\'t allow apply_right_sizing signal'
-      it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
-      it_behaves_like 'doesn\'t allow power_on_vm signal'
-      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
-      it_behaves_like 'doesn\'t allow mark_vm_migrated signal'
-      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
-    end
-
-    context 'removing_snapshots' do
-      before do
-        job.state = 'removing_snapshots'
-      end
-
-      it_behaves_like 'allows poll_remove_snapshots_complete signal'
       it_behaves_like 'allows wait_for_ip_address signal'
       it_behaves_like 'allows finish signal'
       it_behaves_like 'allows abort_job signal'
@@ -443,7 +411,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -472,8 +439,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
@@ -502,8 +467,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
@@ -529,8 +492,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -558,8 +519,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -587,8 +546,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -615,8 +572,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -644,8 +599,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -675,8 +628,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -702,8 +653,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -731,8 +680,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -762,8 +709,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -791,8 +736,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'allows error signal'
 
       it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow remove_snapshots signal'
-      it_behaves_like 'doesn\'t allow poll_remove_snapshots_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -812,93 +755,16 @@ RSpec.describe InfraConversionJob, :v2v do
   context 'transition methods' do
     context '#start' do
       it 'to poll_automate_state_machine when preflight_check passes' do
-        expect(job).to receive(:queue_signal).with(:remove_snapshots)
+        expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
         job.signal(:start)
         expect(task.reload.state).to eq('migrate')
-      end
-    end
-
-    context '#remove_snapshots' do
-      before { job.state = 'started' }
-
-      context 'without any snapshots' do
-        it 'does not queue the task' do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-          expect(vm_vmware).not_to receive(:remove_all_snapshots)
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-          expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
-          job.signal(:remove_snapshots)
-        end
-      end
-
-      context 'with snapshots' do
-        before { FactoryBot.create(:snapshot, :vm_or_template => vm_vmware) }
-
-        it 'queues the remove_all_snapshots task' do
-          Timecop.freeze(2019, 2, 6) do
-            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-            expect(job).to receive(:queue_signal).with(:poll_remove_snapshots_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
-            job.signal(:remove_snapshots)
-            task = MiqTask.find(job.context[:async_task_id_removing_snapshots])
-            expect(task).to have_attributes(
-              :name   => "Removing all snapshots for #{vm_vmware.name}",
-              :state  => MiqTask::STATE_QUEUED,
-              :status => MiqTask::STATUS_OK,
-              :userid => user.id.to_s
-            )
-          end
-        end
-      end
-    end
-
-    context '#poll_remove_snapshots_complete' do
-      let(:async_task) { FactoryBot.create(:miq_task, :userid => user.id) }
-
-      before do
-        job.state = 'removing_snapshots'
-        job.context[:async_task_id_removing_snapshots] = async_task.id
-      end
-
-      it 'abort_conversion when remove_snapshots times out' do
-        job.context[:retries_removing_snapshots] = 960
-        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_error)
-        expect(job).to receive(:abort_conversion).with('Removing snapshots timed out', 'error')
-        job.signal(:poll_remove_snapshots_complete)
-      end
-
-      it 'retries if async task is not finished' do
-        async_task.update!(:state => MiqTask::STATE_ACTIVE)
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
-          expect(job).to receive(:queue_signal).with(:poll_remove_snapshots_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
-          job.signal(:poll_remove_snapshots_complete)
-        end
-      end
-
-      it 'exits if async task is finished and its status is Ok' do
-        async_task.update!(:state => MiqTask::STATE_FINISHED, :status => MiqTask::STATUS_OK)
-        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-        expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
-        job.signal(:poll_remove_snapshots_complete)
-      end
-
-      it 'fails if async task is finished and its status is Error' do
-        async_task.update!(:state => MiqTask::STATE_FINISHED, :status => MiqTask::STATUS_ERROR, :message => 'Fake error message')
-        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_error)
-        expect(job).to receive(:abort_conversion).with('Fake error message', 'error')
-        job.signal(:poll_remove_snapshots_complete)
       end
     end
 
     context '#wait_for_ip_address' do
       before do
         task.update_options(:migration_phase => 'pre')
-        job.state = 'waiting_for_ip_address'
+        job.state = 'started'
       end
 
       it 'abort_conversion when waiting_on_ip_address times out' do


### PR DESCRIPTION
User feedback is that snapshots should not be removed during migration to allow a complete rollback in case of failure. Previously, we considered that virt-v2v could not convert a VM with snapshots, so we forcefully removed existing snapshots. But this assumption is wrong.

This PR removes the `removing_snapshots` state and adjusts the transitions.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1759147