### PR TITLE
Removing groups changes users current group

### DIFF
--- a/app/models/miq_group.rb
+++ b/app/models/miq_group.rb
@@ -304,7 +304,8 @@ class MiqGroup < ApplicationRecord
     throw :abort unless errors[:base].empty?
   end
 
+  # tell users that this group is goinga away - and the users should fix their current group
   def reset_current_group_for_users
-    User.where(:id => user_ids, :current_group_id => id).each(&:change_current_group)
+    User.where(:current_group_id => id).each(&:change_current_group)
   end
 end

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -534,9 +534,15 @@ describe MiqGroup do
       testgroup3 = FactoryBot.create(:miq_group)
       user1 = FactoryBot.create(:user, :miq_groups => [testgroup1, testgroup2], :current_group => testgroup2)
       user2 = FactoryBot.create(:user, :miq_groups => [testgroup1, testgroup3], :current_group => testgroup3)
-      expect { testgroup2.destroy }.not_to raise_error
-      expect(User.find_by(:id => user1.id).current_group.id).to eq(testgroup1.id)
-      expect(User.find_by(:id => user2.id).current_group.id).to eq(testgroup3.id)
+      user3 = FactoryBot.create(:user, :miq_groups => [testgroup1, testgroup2], :current_group => testgroup1)
+
+      testgroup2.destroy
+      expect(user1.reload.current_group.id).to eq(testgroup1.id)
+      expect(user1.miq_group_ids).to eq([testgroup1.id])
+      expect(user2.reload.current_group.id).to eq(testgroup3.id)
+      expect(user2.miq_group_ids).to match_array([testgroup1.id, testgroup3.id])
+      expect(user3.reload.current_group.id).to eq(testgroup1.id)
+      expect(user3.miq_group_ids).to eq([testgroup1.id])
     end
 
     it "should not be called if the user does not have the deleted group as the current_group" do

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -14,7 +14,7 @@ describe MiqWidgetSet do
   context "with a group" do
     it "being deleted" do
       expect(MiqWidgetSet.count).to eq(1)
-      user.miq_groups = []
+      user.destroy
       group.destroy
       expect(MiqWidgetSet.count).to eq(0)
     end


### PR DESCRIPTION
When removing a group that is a user's `current_group_id`, change it.

The `{before,after}_destroy` hooks work differently in rails 5.2

The user-group association is now removed before the cleanup.
So using this association to lookup users will always look at no users, since those records are deleted.

Removing this dependency then just focuses on users who have a stale current_group.
Which is the basic premise of this task

so now, user's `default_group` are properly updated.

Added the third test case around groups to be super sure this is working