### PR TITLE
Pin sprockets to ~>3.0 to fix missing manifest.js errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>1.3.0",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
+gem "sprockets",                      "~>3.0",         :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
 gem "sys-filesystem",                 "~>1.2.0"
 gem "terminal",                                        :require => false


### PR DESCRIPTION
With sprockets 4.0 we get the following error building the UI assets:
```
rails aborted!
Sprockets::Railtie::ManifestNeededError: Expected to find a manifest file in `app/assets/config/manifest.js`
But did not, please create this file and use it to link any assets that need
to be rendered by your app:
```

Pinning to ~>3.0 fixes this issue.

Example travis failure: https://travis-ci.org/ManageIQ/manageiq-providers-ovirt/jobs/595259206#L1813