### PR TITLE
test new method not deprecated one

### DIFF
--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -266,7 +266,7 @@ describe AuthenticationMixin do
       end
     end
 
-    context ".validate_credentials_task" do
+    context ".verify_credentials_task" do
       let(:args) { %w(userid password foo) }
       let(:queue_opts) do
         {
@@ -290,7 +290,7 @@ describe AuthenticationMixin do
         allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
         allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(ok_task)
 
-        expect(ExtManagementSystem.validate_credentials_task(args, 'userid', 'zone')).to eq([true, nil])
+        expect(ExtManagementSystem.verify_credentials_task(args, 'userid', 'zone')).to eq([true, nil])
       end
 
       it "returns failure with an error message" do
@@ -299,7 +299,7 @@ describe AuthenticationMixin do
         allow(MiqTask).to receive(:generic_action_with_callback).with(task_opts, queue_opts).and_return(1)
         allow(MiqTask).to receive(:wait_for_taskid).with(1, :timeout => 30).and_return(error_task)
 
-        expect(ExtManagementSystem.validate_credentials_task(args, 'userid', 'zone')).to eq([false, message])
+        expect(ExtManagementSystem.verify_credentials_task(args, 'userid', 'zone')).to eq([false, message])
       end
     end
 


### PR DESCRIPTION
removes:

```
DEPRECATION WARNING: validate_credentials_task is deprecated and will be removed from ManageIQ K-release (use verify_credentials_task instead) (called from block (4 levels) in <top (required)> at /home/travis/build/ManageIQ/manageiq/spec/models/mixins/authentication_mixin_spec.rb:302)
```