### PR TITLE
Set default OrchestrationTemplateRunner timeout to 100 minutes.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
-  DEFAULT_EXECUTION_TTL = 10 # minutes
+  DEFAULT_EXECUTION_TTL = 100.minutes
 
   def minimize_indirect
     @minimize_indirect = true if @minimize_indirect.nil?
@@ -7,8 +7,7 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
   end
 
   def current_job_timeout(_timeout_adjustment = 1)
-    @execution_ttl ||=
-      (options[:execution_ttl].present? ? options[:execution_ttl].try(:to_i) : DEFAULT_EXECUTION_TTL) * 60
+    @execution_ttl ||= options[:execution_ttl].present? ? options[:execution_ttl].to_i.minutes : DEFAULT_EXECUTION_TTL
   end
 
   def start


### PR DESCRIPTION
To match the default automate timeout.

https://bugzilla.redhat.com/show_bug.cgi?id=1756292

@miq-bot assign @tinaafitz 
@miq-bot add_label bug, services
