### PR TITLE
[V2V] Add warm migration support

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -98,6 +98,16 @@ class ConversionHost < ApplicationRecord
     source_transport_method.present? && authentication_check('v2v').first && check_concurrent_tasks
   end
 
+  # Returns a boolean indication whether or not the conversion host is eligible
+  # for warm migration. To be eligible, a conversion host must have the following
+  # properties:
+  #
+  #  - The conversion is generally eligible, i.e. eligible? returns true
+  #  - The VDDK transport method is supported
+  def warm_migration_eligible?
+    eligible? && source_transport_method == 'vddk'
+  end
+
   # Returns a boolean indicating whether or not the current number of active tasks
   # exceeds the maximum number of allowable concurrent tasks specified in settings.
   #

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -180,7 +180,7 @@ class ConversionHost < ApplicationRecord
   def create_cutover_file(path)
     connect_ssh { |ssu| ssu.shell_exec("touch #{path}") }
     true
-  rescue
+  rescue StandardError
     false
   end
 

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -177,6 +177,13 @@ class ConversionHost < ApplicationRecord
     raise "Starting conversion failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
+  def create_cutover_file(path)
+    connect_ssh { |ssu| ssu.shell_exec("touch #{path}") }
+    true
+  rescue
+    false
+  end
+
   # Kill a specific remote process over ssh, sending the specified +signal+, or 'TERM'
   # if no signal is specified.
   #

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -270,9 +270,7 @@ class InfraConversionJob < Job
   def start
     migration_task.update!(:state => 'migrate')
     migration_task.update_options(:migration_phase => 'pre')
-    return queue_signal(:start_precopying_disks) if migration_task.warm_migration?
-
-    queue_signal(:wait_for_ip_address)
+    migration_task.warm_migration? ? queue_signal(:start_precopying_disks) : queue_signal(:wait_for_ip_address)
   end
 
   def start_precopying_disks

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -28,8 +28,11 @@ class InfraConversionJob < Job
     {
       :initializing                         => {'initialize'         => 'waiting_to_start'},
       :start                                => {'waiting_to_start'   => 'started'},
+      :start_precopying_disks               => {'started'            => 'precopying_disks'},
+      :poll_precopying_disks                => {'precopying_disks'   => 'precopying_disks'},
       :wait_for_ip_address                  => {
         'started'                => 'waiting_for_ip_address',
+        'precopying_disks'       => 'waiting_for_ip_address',
         'powering_on_vm'         => 'waiting_for_ip_address',
         'waiting_for_ip_address' => 'waiting_for_ip_address'
       },
@@ -75,6 +78,10 @@ class InfraConversionJob < Job
   #   }
   def state_settings
     @state_settings ||= {
+      :precopying_disks              => {
+        :description => 'Precopying disks',
+        :max_retries => 36.hours / state_retry_interval
+      },
       :waiting_for_ip_address        => {
         :description => 'Waiting for VM IP address',
         :weight      => 2,
@@ -263,7 +270,35 @@ class InfraConversionJob < Job
   def start
     migration_task.update!(:state => 'migrate')
     migration_task.update_options(:migration_phase => 'pre')
+    return queue_signal(:start_precopying_disks) if migration_task.warm_migration?
     queue_signal(:wait_for_ip_address)
+  end
+
+  def start_precopying_disks
+    update_migration_task_progress(:on_entry)
+    migration_task.run_conversion
+    queue_signal(:poll_precopying_disks, :deliver_on => Time.now.utc + state_retry_interval)
+  rescue StandardError => error
+    update_migration_task_progress(:on_error)
+    abort_conversion(error.message, 'error')
+  end
+
+  def poll_precopying_disks
+    update_migration_task_progress(:on_entry)
+    return abort_conversion('Precopying disks timed out', 'error') if polling_timeout
+
+    migration_task.get_conversion_state
+
+    unless migration_task.miq_request.options[:cutover_datetime].present? && migration_task.miq_request.options[:cutover_datetime] < Time.now.utc
+      update_migration_task_progress(:on_retry)
+      return queue_signal(:poll_precopying_disks, :deliver_on => Time.now.utc + state_retry_interval)
+    end
+
+    update_migration_task_progress(:on_exit)
+    queue_signal(:wait_for_ip_address)
+  rescue StandardError => error
+    update_migration_task_progress(:on_error)
+    abort_conversion(error.message, 'error')
   end
 
   def wait_for_ip_address
@@ -376,7 +411,8 @@ class InfraConversionJob < Job
 
   def transform_vm
     update_migration_task_progress(:on_entry)
-    migration_task.run_conversion
+    migration_task.run_conversion unless migration_task.warm_migration?
+    migration_task.cutover
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
   rescue StandardError => error

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -271,6 +271,7 @@ class InfraConversionJob < Job
     migration_task.update!(:state => 'migrate')
     migration_task.update_options(:migration_phase => 'pre')
     return queue_signal(:start_precopying_disks) if migration_task.warm_migration?
+
     queue_signal(:wait_for_ip_address)
   end
 

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -53,6 +53,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   #     :transformation_mapping_id
   #     :pre_service_id
   #     :post_service_id
+  #     :warm_migration => true|false
   #     :actions => [
   #        {:vm_id => "1", :pre_service => true, :post_service => false},
   #        {:vm_id => "2", :pre_service => true, :post_service => true},

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -70,6 +70,7 @@ module ServiceTemplateTransformationPlan::ValidateConfigInfo
           vm_options[:memory_right_sizing_mode] = vm_hash[:memory_right_sizing_mode] if vm_hash[:memory_right_sizing_mode].present?
           vm_options[:osp_flavor_id] = vm_hash[:osp_flavor_id] if vm_hash[:osp_flavor_id].present?
           vm_options[:osp_security_group_id] = vm_hash[:osp_security_group_id] if vm_hash[:osp_security_group_id].present?
+          vm_options[:warm_migration] = config_info[:warm_migration] || false
 
           # verify the vm flavor belongs to the openstack tenant/project. added as a part of validating migration plan
           if osp_flavors.present? && vm_options[:osp_flavor_id].present?

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -251,7 +251,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def cutover
     unless conversion_host.create_cutover_file(options[:virtv2v_wrapper]['cutover_file'])
-      raise "Couldn't create cutover file for #{source.name} on #{conversion_host.name}"
+      raise _("Couldn't create cutover file for #{source.name} on #{conversion_host.name}")
     end
   end
 

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -39,6 +39,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     vm_resource.options["memory_right_sizing_mode"]
   end
 
+  def warm_migration?
+    vm_resource.options["warm_migration"]
+  end
+
   def update_transformation_progress(progress)
     update_options(:progress => (options[:progress] || {}).merge(progress))
   end
@@ -243,6 +247,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   ensure
     _log.info("InfraConversionJob get_conversion_state to update_options: #{updates}")
     update_options(updates)
+  end
+
+  def cutover
+    unless conversion_host.create_cutover_file(options[:virtv2v_wrapper]['cutover_file'])
+      raise "Couldn't create cutover file for #{source.name} on #{conversion_host.name}"
+    end
   end
 
   def kill_virtv2v(signal = 'TERM')

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -332,7 +332,9 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :path     => '/',
         :query    => { :no_verify => 1 }.to_query
       ).to_s,
-      :vmware_password    => source.host.authentication_password
+      :vmware_password    => source.host.authentication_password,
+      :two_phase          => true,
+      :warm               => warm_migration?
     }
   end
 

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -27,10 +27,8 @@ class InfraConversionThrottler
         _log.debug("-- Available slots in EMS: #{slots}")
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
-        eligible_hosts = ems.conversion_hosts.select do |ch|
-          ch.eligible? && (!job.migration_task.warm_migration? || (job.migration_task.warm_migration? && ch.vddk_transport_supported))
-        end
-        eligible_hosts = eligible_hosts.sort_by { |ch| ch.active_tasks.count }
+        eligibility = job.migration_task.warm_migration? ? :warm_migration_eligible? : :eligible?
+        eligible_hosts = ems.conversion_hosts.select(&eligibility).sort_by { |ch| ch.active_tasks.count }
 
         if eligible_hosts.empty?
           _log.debug("-- No eligible conversion host for task for '#{vm_name}'")

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -28,8 +28,9 @@ class InfraConversionThrottler
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
         eligible_hosts = ems.conversion_hosts.select do |ch|
-          ch.eligible? && ( !job.migration_task.warm_migration? || (job.migration_task.warm_migration? && ch.vddk_transport_supported))
-        end.sort_by { |ch| ch.active_tasks.count }
+          ch.eligible? && (!job.migration_task.warm_migration? || (job.migration_task.warm_migration? && ch.vddk_transport_supported))
+        end
+        eligible_hosts = eligible_hosts.sort_by { |ch| ch.active_tasks.count }
 
         if eligible_hosts.empty?
           _log.debug("-- No eligible conversion host for task for '#{vm_name}'")

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -28,11 +28,13 @@ class InfraConversionThrottler
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
         eligible_hosts = ems.conversion_hosts.select do |ch|
-	  ch.eligible? && (
-	    !job.migration_task.warm_migration? ||
+          ch.eligible? &&
+          (
+            !job.migration_task.warm_migration? ||
             (job.migration_task.warm_migration? && ch.vddk_transport_supported)
-	  )
-	end.sort_by { |ch| ch.active_tasks.count }
+          )
+        end.sort_by { |ch| ch.active_tasks.count }
+
         if eligible_hosts.empty?
           _log.debug("-- No eligible conversion host for task for '#{vm_name}'")
           break

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -28,11 +28,7 @@ class InfraConversionThrottler
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
         eligible_hosts = ems.conversion_hosts.select do |ch|
-          ch.eligible? &&
-          (
-            !job.migration_task.warm_migration? ||
-            (job.migration_task.warm_migration? && ch.vddk_transport_supported)
-          )
+          ch.eligible? && ( !job.migration_task.warm_migration? || (job.migration_task.warm_migration? && ch.vddk_transport_supported))
         end.sort_by { |ch| ch.active_tasks.count }
 
         if eligible_hosts.empty?

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -27,7 +27,12 @@ class InfraConversionThrottler
         _log.debug("-- Available slots in EMS: #{slots}")
         _log.debug("- Looking for a conversion host for task for #{vm_name}")
 
-        eligible_hosts = ems.conversion_hosts.select(&:eligible?).sort_by { |ch| ch.active_tasks.count }
+        eligible_hosts = ems.conversion_hosts.select do |ch|
+	  ch.eligible? && (
+	    !job.migration_task.warm_migration? ||
+            (job.migration_task.warm_migration? && ch.vddk_transport_supported)
+	  )
+	end.sort_by { |ch| ch.active_tasks.count }
         if eligible_hosts.empty?
           _log.debug("-- No eligible conversion host for task for '#{vm_name}'")
           break

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
       :config_info => {
         :transformation_mapping_id => mapping.id,
         :actions                   => [
-          {:vm_id => vm.id.to_s, :warm_migration => true,}
+          {:vm_id => vm.id.to_s, :warm_migration => true}
         ],
       }
     }

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -1,10 +1,39 @@
 RSpec.describe InfraConversionThrottler, :v2v do
-  let(:ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
-  let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
-  let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
-  let(:task_waiting) { FactoryBot.create(:service_template_transformation_plan_task, :source => vm) }
-  let(:task_running_1) { FactoryBot.create(:service_template_transformation_plan_task, :source => vm) }
-  let(:task_running_2) { FactoryBot.create(:service_template_transformation_plan_task, :source => vm) }
+  let(:src_ems) { FactoryBot.create(:ems_vmware) }
+  let(:src_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => src_ems) }
+  let(:dst_ems) { FactoryBot.create(:ems_openstack, :zone => FactoryBot.create(:zone)) }
+  let(:dst_cluster) { FactoryBot.create(:ems_cluster_openstack, :ext_management_system => dst_ems) }
+  let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => dst_ems) }
+  let(:vm) { FactoryBot.create(:vm_openstack, :ext_management_system => dst_ems) }
+
+  let(:mapping) do
+    FactoryBot.create(:transformation_mapping).tap do |tm|
+      FactoryBot.create(:transformation_mapping_item,
+                        :source                 => src_cluster,
+                        :destination            => dst_cluster,
+                        :transformation_mapping => tm)
+    end
+  end
+
+  let(:catalog_item_options) do
+    {
+      :name        => 'Transformation Plan',
+      :description => 'a description',
+      :config_info => {
+        :transformation_mapping_id => mapping.id,
+        :actions                   => [
+          {:vm_id => vm.id.to_s, :warm_migration => true,}
+        ],
+      }
+    }
+  end
+
+  let(:plan) { ServiceTemplateTransformationPlan.create_catalog_item(catalog_item_options) }
+  let(:request) { FactoryBot.create(:service_template_transformation_plan_request, :source => plan) }
+
+  let(:task_waiting) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
+  let(:task_running_1) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
+  let(:task_running_2) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
   let(:job_waiting) { FactoryBot.create(:infra_conversion_job, :state => 'waiting_to_start') }
   let(:job_running_1) { FactoryBot.create(:infra_conversion_job, :state => 'running') }
   let(:job_running_2) { FactoryBot.create(:infra_conversion_job, :state => 'running') }
@@ -19,11 +48,10 @@ RSpec.describe InfraConversionThrottler, :v2v do
     let(:conversion_host2) { FactoryBot.create(:conversion_host, :max_concurrent_tasks => 2, :vddk_transport_supported => true, :resource => vm) }
 
     before do
-      allow(task_waiting).to receive(:destination_ems).and_return(ems)
       allow(task_waiting).to receive(:preflight_check).and_return(:status => 'Ok', :message => 'Preflight check is successful')
       allow(job_waiting).to receive(:migration_task).and_return(task_waiting)
-      allow(described_class).to receive(:pending_conversion_jobs).and_return(ems => [job_waiting])
-      allow(ems).to receive(:conversion_hosts).and_return([conversion_host1, conversion_host2])
+      allow(described_class).to receive(:pending_conversion_jobs).and_return(dst_ems => [job_waiting])
+      allow(dst_ems).to receive(:conversion_hosts).and_return([conversion_host1, conversion_host2])
       allow(conversion_host1).to receive(:check_ssh_connection).and_return(true)
       allow(conversion_host2).to receive(:check_ssh_connection).and_return(true)
       allow(conversion_host1).to receive(:authentication_check).and_return([true, 'passed'])
@@ -37,7 +65,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
     end
 
     it 'will not start a job when ems limit hit' do
-      ems.miq_custom_set('MaxTransformationRunners', 2)
+      dst_ems.miq_custom_set('MaxTransformationRunners', 2)
       allow(conversion_host1).to receive(:active_tasks).and_return([1])
       allow(conversion_host2).to receive(:active_tasks).and_return([1])
       expect(job_waiting).not_to receive(:queue_signal)
@@ -45,9 +73,17 @@ RSpec.describe InfraConversionThrottler, :v2v do
     end
 
     it 'will not start a job when conversion_host limit hit' do
-      ems.miq_custom_set('MaxTransformationRunners', 100)
+      dst_ems.miq_custom_set('MaxTransformationRunners', 100)
       allow(conversion_host1).to receive(:active_tasks).and_return([1, 2])
       allow(conversion_host2).to receive(:active_tasks).and_return([1, 2])
+      expect(job_waiting).not_to receive(:queue_signal)
+      described_class.start_conversions
+    end
+
+    it 'will not start a job if warm migration criteria are not met' do
+      allow(conversion_host1).to receive(:active_tasks).and_return([1, 2])
+      allow(conversion_host2).to receive(:active_tasks).and_return([1])
+      conversion_host2.vddk_transport_supported = false
       expect(job_waiting).not_to receive(:queue_signal)
       described_class.start_conversions
     end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ConversionHost, :v2v do
       end
     end
 
-     context "#warm_migration_eligible?" do
+    context "#warm_migration_eligible?" do
       it "fails when source transport method is ssh" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('ssh')
         allow(conversion_host_1).to receive(:authentication_check).and_return([true, 'worked'])

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -30,18 +30,34 @@ RSpec.describe ConversionHost, :v2v do
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
-      it "fails when no source transport method is enabled" do
+      it "fails when authentication check fails" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
         allow(conversion_host_1).to receive(:authentication_check).and_return([false, 'failed'])
         allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
         expect(conversion_host_1.eligible?).to eq(false)
       end
 
-      it "fails when no source transport method is enabled" do
+      it "fails when concurrent tasks check fails" do
         allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
         allow(conversion_host_1).to receive(:authentication_check).and_return([true, 'worked'])
         allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(false)
         expect(conversion_host_1.eligible?).to eq(false)
+      end
+
+      it "succeeds when all criteria are met" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('vddk')
+        allow(conversion_host_1).to receive(:authentication_check).and_return([true, 'worked'])
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.eligible?).to eq(true)
+      end
+    end
+
+     context "#warm_migration_eligible?" do
+      it "fails when source transport method is ssh" do
+        allow(conversion_host_1).to receive(:source_transport_method).and_return('ssh')
+        allow(conversion_host_1).to receive(:authentication_check).and_return([true, 'worked'])
+        allow(conversion_host_1).to receive(:check_concurrent_tasks).and_return(true)
+        expect(conversion_host_1.warm_migration_eligible?).to eq(false)
       end
 
       it "succeeds when all criteria are met" do

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -323,7 +323,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       service_template = described_class.create_catalog_item(catalog_item_options)
 
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => false, "warm_migration" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
         .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => false)
     end
@@ -392,6 +392,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       service_template.update_catalog_item(updated_catalog_item_options_with_warm_migration)
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
         "pre_ansible_playbook_service_template_id" => apst.id,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => true
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "pre_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                    => security_group1.id,
         "osp_flavor_id"                            => flavor1.id,
-	"warm_migration_compatible"                => true,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => false
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
@@ -306,7 +306,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "post_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                     => security_group1.id,
         "osp_flavor_id"                             => flavor1.id,
-	"warm_migration_compatible"                 => true,
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => false
       )
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
@@ -404,7 +404,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         :action => 'Provision',
         :fqname => described_class.default_provisioning_entry_point(nil)
       )
-     end
+    end
 
     it 'updates by adding new VMs to existing VMs and returns a transformation plan' do
       service_template = described_class.create_catalog_item(catalog_item_options)
@@ -419,7 +419,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "pre_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                    => security_group1.id,
         "osp_flavor_id"                            => flavor1.id,
-	"warm_migration_compatible"                => true,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => false
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
@@ -456,7 +456,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
         "pre_ansible_playbook_service_template_id" => apst.id,
-	"warm_migration_compatible"                => true,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => false
       )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_removed[:config_info])
@@ -477,13 +477,13 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
         "pre_ansible_playbook_service_template_id" => apst.id,
-	"warm_migration_compatible"                => true,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => false
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options).to eq(
         "pre_ansible_playbook_service_template_id"  => apst.id,
         "post_ansible_playbook_service_template_id" => apst.id,
-	"warm_migration_compatible"                 => true,
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => false
       )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added_and_removed[:config_info])
@@ -507,7 +507,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "pre_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                    => security_group1.id,
         "osp_flavor_id"                            => flavor1.id,
-	"warm_migration_compatible"                => true,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => false
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
@@ -515,7 +515,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "post_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                     => security_group1.id,
         "osp_flavor_id"                             => flavor1.id,
-	"warm_migration_compatible"                 => true,
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => false
       )
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
@@ -538,7 +538,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "pre_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                    => security_group1.id,
         "osp_flavor_id"                            => flavor1.id,
-	"warm_migration_compatible"                => true,
+        "warm_migration_compatible"                => true,
         "warm_migration"                           => false
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
@@ -546,7 +546,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "post_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                     => security_group1.id,
         "osp_flavor_id"                             => flavor1.id,
-	"warm_migration_compatible"                 => true,
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => false
       )
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "post_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                     => security_group1.id,
         "osp_flavor_id"                             => flavor1.id,
-	"warm_migration_compatible"                 => true,
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => false
       )
       expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options).to eq(
@@ -435,7 +435,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         "post_ansible_playbook_service_template_id" => apst.id,
         "osp_security_group_id"                     => security_group2.id,
         "osp_flavor_id"                             => flavor2.id,
-	"warm_migration_compatible"                 => true
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => false
       )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added[:config_info])

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -322,10 +322,21 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
 
       service_template = described_class.create_catalog_item(catalog_item_options)
 
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => false, "warm_migration" => false)
-      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => false)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                    => security_group1.id,
+        "osp_flavor_id"                            => flavor1.id,
+        "warm_migration_compatible"                => false,
+        "warm_migration"                           => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                     => security_group1.id,
+        "osp_flavor_id"                             => flavor1.id,
+        "warm_migration_compatible"                 => false,
+        "warm_migration"                            => false
+      )
     end
 
     it 'requires a transformation mapping' do
@@ -398,6 +409,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
         "pre_ansible_playbook_service_template_id"  => apst.id,
         "post_ansible_playbook_service_template_id" => apst.id,
+        "warm_migration_compatible"                 => true,
         "warm_migration"                            => true
       )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_warm_migration[:config_info])

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     }
   end
 
-  let(:updated_options_with_updated_transformation_mapping) do
+  let(:updated_catalog_item_options_with_updated_transformation_mapping) do
     {
       :name        => 'Transformation Plan Updated',
       :description => 'an updated description',
@@ -230,6 +230,23 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
         :transformation_mapping_id => transformation_mapping2.id,
         :pre_service_id            => apst.id,
         :post_service_id           => apst.id,
+        :actions                   => [
+          {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
+          {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true}
+        ],
+      }
+    }
+  end
+
+  let(:updated_catalog_item_options_with_warm_migration) do
+    {
+      :name        => 'Transformation Plan Updated',
+      :description => 'an updated description',
+      :config_info => {
+        :transformation_mapping_id => transformation_mapping2.id,
+        :pre_service_id            => apst.id,
+        :post_service_id           => apst.id,
+        :warm_migration            => true,
         :actions                   => [
           {:vm_id => vm1.id.to_s, :pre_service => true, :post_service => false},
           {:vm_id => vm2.id.to_s, :pre_service => true, :post_service => true}
@@ -277,10 +294,21 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
-      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                    => security_group1.id,
+        "osp_flavor_id"                            => flavor1.id,
+	"warm_migration_compatible"                => true,
+        "warm_migration"                           => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                     => security_group1.id,
+        "osp_flavor_id"                             => flavor1.id,
+	"warm_migration_compatible"                 => true,
+        "warm_migration"                            => false
+      )
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -353,10 +381,30 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     it 'updates the associated transformation mapping' do
       service_template = described_class.create_catalog_item(catalog_item_options)
       service_template.miq_requests = []
-      service_template.update_catalog_item(updated_options_with_updated_transformation_mapping)
+      service_template.update_catalog_item(updated_catalog_item_options_with_updated_transformation_mapping)
       expect(service_template.name).to eq('Transformation Plan Updated')
       expect(service_template.transformation_mapping).to eq(transformation_mapping2)
     end
+
+    it 'updates the warm migration option for all vms' do
+      service_template = described_class.create_catalog_item(catalog_item_options)
+      service_template.miq_requests = []
+      service_template.update_catalog_item(updated_catalog_item_options_with_warm_migration)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+        "warm_migration"                           => true
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "warm_migration"                            => true
+      )
+      expect(service_template.config_info).to eq(updated_catalog_item_options_with_warm_migration[:config_info])
+      expect(service_template.resource_actions.first).to have_attributes(
+        :action => 'Provision',
+        :fqname => described_class.default_provisioning_entry_point(nil)
+      )
+     end
 
     it 'updates by adding new VMs to existing VMs and returns a transformation plan' do
       service_template = described_class.create_catalog_item(catalog_item_options)
@@ -367,12 +415,29 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2, vm3])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
-      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
-      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group2.id, "osp_flavor_id" => flavor2.id, "warm_migration_compatible" => true)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                    => security_group1.id,
+        "osp_flavor_id"                            => flavor1.id,
+	"warm_migration_compatible"                => true,
+        "warm_migration"                           => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                     => security_group1.id,
+        "osp_flavor_id"                             => flavor1.id,
+	"warm_migration_compatible"                 => true,
+        "warm_migration"                            => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                     => security_group2.id,
+        "osp_flavor_id"                             => flavor2.id,
+	"warm_migration_compatible"                 => true
+        "warm_migration"                            => false
+      )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -389,8 +454,11 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED])
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_compatible" => true)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+	"warm_migration_compatible"                => true,
+        "warm_migration"                           => false
+      )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_removed[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -407,10 +475,17 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm3])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_compatible" => true)
-      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "warm_migration_compatible" => true)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+	"warm_migration_compatible"                => true,
+        "warm_migration"                           => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+	"warm_migration_compatible"                 => true,
+        "warm_migration"                            => false
+      )
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added_and_removed[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -428,10 +503,21 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
-      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                    => security_group1.id,
+        "osp_flavor_id"                            => flavor1.id,
+	"warm_migration_compatible"                => true,
+        "warm_migration"                           => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                     => security_group1.id,
+        "osp_flavor_id"                             => flavor1.id,
+	"warm_migration_compatible"                 => true,
+        "warm_migration"                            => false
+      )
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -448,10 +534,21 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.description).to eq('an updated description')
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
-      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
-      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
+      expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options).to eq(
+        "pre_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                    => security_group1.id,
+        "osp_flavor_id"                            => flavor1.id,
+	"warm_migration_compatible"                => true,
+        "warm_migration"                           => false
+      )
+      expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options).to eq(
+        "pre_ansible_playbook_service_template_id"  => apst.id,
+        "post_ansible_playbook_service_template_id" => apst.id,
+        "osp_security_group_id"                     => security_group1.id,
+        "osp_flavor_id"                             => flavor1.id,
+	"warm_migration_compatible"                 => true,
+        "warm_migration"                            => false
+      )
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           :transformation_mapping_id => mapping.id,
           :pre_service_id            => apst.id,
           :post_service_id           => apst.id,
+	  :warm_migration            => true,
           :actions                   => [
             {:vm_id => src_vm_1.id.to_s, :pre_service => true, :post_service => true, :osp_flavor_id => dst_flavor.id, :osp_security_group_id => dst_security_group.id},
             {:vm_id => src_vm_2.id.to_s, :pre_service => false, :post_service => false},
@@ -544,7 +545,9 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :source_disks        => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings    => task_1.network_mappings,
               :install_drivers     => true,
-              :insecure_connection => true
+              :insecure_connection => true,
+	      :two_phase           => true,
+	      :warm                => true
             )
           end
 
@@ -660,7 +663,9 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :osp_flavor_id              => openstack_flavor.ems_ref,
               :osp_security_groups_ids    => [openstack_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings           => task_1.network_mappings
+              :network_mappings           => task_1.network_mappings,
+	      :two_phase                  => true,
+	      :warm                       => true
             )
           end
         end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           :transformation_mapping_id => mapping.id,
           :pre_service_id            => apst.id,
           :post_service_id           => apst.id,
-	  :warm_migration            => true,
+          :warm_migration            => true,
           :actions                   => [
             {:vm_id => src_vm_1.id.to_s, :pre_service => true, :post_service => true, :osp_flavor_id => dst_flavor.id, :osp_security_group_id => dst_security_group.id},
             {:vm_id => src_vm_2.id.to_s, :pre_service => false, :post_service => false},
@@ -546,8 +546,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :network_mappings    => task_1.network_mappings,
               :install_drivers     => true,
               :insecure_connection => true,
-	      :two_phase           => true,
-	      :warm                => true
+              :two_phase           => true,
+              :warm                => true
             )
           end
 
@@ -664,8 +664,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :osp_security_groups_ids    => [openstack_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings           => task_1.network_mappings,
-	      :two_phase                  => true,
-	      :warm                       => true
+              :two_phase                  => true,
+              :warm                       => true
             )
           end
         end


### PR DESCRIPTION
Now that the migration workflow has been ported to `InfraConversionJob`, we need to add the warm migration states to `InfraConversionJob`. This PR implements warm migration by:

- Extending conversion host eligibility for warm migration in `InfraConversionThrottler`
- Adding the states for warm migration to `InfraConversionJob`
- Document and pass the warm migration options in `ServiceTemplateTransformationPlan`
- Add warm migration check and cutover to `ServiceTemplateTransformationPlanTask`
- Adding the creation of the cutover file to `ConversionHost`

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1761375