### PR TITLE
Arel-ize vm#num_cpus

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -32,6 +32,8 @@ class Hardware < ApplicationRecord
 
   virtual_aggregate :used_disk_storage,      :disks, :sum, :used_disk_storage
   virtual_aggregate :allocated_disk_storage, :disks, :sum, :size
+  virtual_total     :num_disks,              :disks
+  virtual_total     :num_hard_disks,         :hard_disks
 
   def ipaddresses
     @ipaddresses ||= if networks.loaded?

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -154,7 +154,6 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :hostnames,                            :type => :string_set, :uses => {:hardware => :hostnames}
   virtual_column :mac_addresses,                        :type => :string_set, :uses => {:hardware => :mac_addresses}
   virtual_column :memory_exceeds_current_host_headroom, :type => :string,     :uses => [:mem_cpu, {:host => [:hardware, :ext_management_system]}]
-  virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
 
@@ -174,6 +173,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_delegate :name, :to => :ems_cluster, :prefix => true, :allow_nil => true, :type => :string
   virtual_delegate :vmm_product, :to => :host, :prefix => :v_host, :allow_nil => true, :type => :string
   virtual_delegate :v_pct_free_disk_space, :v_pct_used_disk_space, :to => :hardware, :allow_nil => true, :type => :float
+  virtual_delegate :num_cpu, :to => "hardware.cpu_sockets", :allow_nil => true, :default => 0, :type => :integer
   virtual_delegate :cpu_total_cores, :cpu_cores_per_socket, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
   virtual_delegate :annotation, :to => :hardware, :prefix => "v", :allow_nil => true, :type => :string
   virtual_delegate :ram_size_in_bytes,                  :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
@@ -1567,10 +1567,6 @@ class VmOrTemplate < ApplicationRecord
 
   def ram_size_in_bytes_by_state
     ram_size_by_state * 1.megabyte
-  end
-
-  def num_cpu
-    hardware.try(:cpu_sockets) || 0
   end
 
   def has_rdm_disk

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -154,8 +154,6 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :hostnames,                            :type => :string_set, :uses => {:hardware => :hostnames}
   virtual_column :mac_addresses,                        :type => :string_set, :uses => {:hardware => :mac_addresses}
   virtual_column :memory_exceeds_current_host_headroom, :type => :string,     :uses => [:mem_cpu, {:host => [:hardware, :ext_management_system]}]
-  virtual_column :num_hard_disks,                       :type => :integer,    :uses => {:hardware => :hard_disks}
-  virtual_column :num_disks,                            :type => :integer,    :uses => {:hardware => :disks}
   virtual_column :num_cpu,                              :type => :integer,    :uses => :hardware
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
@@ -1544,6 +1542,8 @@ class VmOrTemplate < ApplicationRecord
                    :to => :hardware, :allow_nil => true, :uses => {:hardware => :disks}, :type => :integer
 
   virtual_delegate :provisioned_storage, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer
+  virtual_delegate :num_disks, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer, :uses => {:hardware => :disks}
+  virtual_delegate :num_hard_disks, :to => :hardware, :allow_nil => true, :default => 0, :type => :integer, :uses => {:hardware => :hard_disks}
 
   def used_storage
     used_disk_storage.to_i + ram_size_in_bytes
@@ -1571,14 +1571,6 @@ class VmOrTemplate < ApplicationRecord
 
   def num_cpu
     hardware.try(:cpu_sockets) || 0
-  end
-
-  def num_disks
-    hardware.nil? ? 0 : hardware.disks.size
-  end
-
-  def num_hard_disks
-    hardware.nil? ? 0 : hardware.hard_disks.size
   end
 
   def has_rdm_disk

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -55,6 +55,22 @@ describe Hardware do
     end
   end
 
+  describe ".num_disks", ".num_hard_disks" do
+    let(:hardware) { FactoryBot.create(:hardware) }
+
+    before { FactoryBot.create_list(:disk, 3, :hardware => hardware, :device_type => 'disk') }
+
+    it "calculates in ruby" do
+      expect(hardware.num_disks).to eq(3)
+      expect(hardware.num_hard_disks).to eq(3)
+    end
+
+    it "calculates in the database" do
+      expect(virtual_column_sql_value(Hardware, "num_disks")).to eq(3)
+      expect(virtual_column_sql_value(Hardware, "num_hard_disks")).to eq(3)
+    end
+  end
+
   describe ".v_pct_free_disk_space" do
     context "with empty hardware" do
       let(:hardware) { FactoryBot.build(:hardware) }

--- a/spec/models/miq_report/generator_spec.rb
+++ b/spec/models/miq_report/generator_spec.rb
@@ -195,18 +195,18 @@ describe MiqReport::Generator do
       # it also allows cols to override col_order for requesting extra columns
       rpt = MiqReport.new(:db               => "VmOrTemplate",
                           :include          => {},
-                          :cols             => %w(name num_cpu),
+                          :cols             => %w[name v_datastore_path],
                           :col_order        => %w(name host.name storage.name),
                           :include_for_find => {:snapshots => {}})
-      expect(rpt.get_include_for_find).to eq(:num_cpu => {}, :host => {}, :storage => {}, :snapshots => {})
+      expect(rpt.get_include_for_find).to eq(:v_datastore_path => {}, :host => {}, :storage => {}, :snapshots => {})
     end
 
     it "uses col_order and virtual attributes" do
       rpt = MiqReport.new(:db               => "VmOrTemplate",
                           :include          => {},
-                          :col_order        => %w(name num_cpu host.name storage.name),
+                          :col_order        => %w[name v_datastore_path host.name storage.name],
                           :include_for_find => {:snapshots => {}})
-      expect(rpt.get_include_for_find).to eq(:num_cpu => {}, :host => {}, :storage => {}, :snapshots => {})
+      expect(rpt.get_include_for_find).to eq(:v_datastore_path => {}, :host => {}, :storage => {}, :snapshots => {})
     end
   end
 end

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -798,6 +798,38 @@ describe VmOrTemplate do
     end
   end
 
+  describe ".num_disks", ".num_hard_disks" do
+    let(:vm) { FactoryBot.create(:vm_vmware, :hardware => hardware) }
+    let(:hardware) { FactoryBot.create(:hardware, :memory_mb => 10) }
+    let(:disk) { FactoryBot.create(:disk, :device_type => 'disk', :hardware => hardware) }
+
+    it "calculates in ruby with null hardware" do
+      vm = FactoryBot.create(:vm_vmware)
+      expect(vm.num_disks).to eq(0)
+    end
+
+    it "uses calculated (inline) attribute with null hardware" do
+      vm = FactoryBot.create(:vm_vmware)
+      vm2 = VmOrTemplate.select(:id, :num_disks, :num_hard_disks).find_by(:id => vm.id)
+      expect { expect(vm2.num_disks).to eq(0) }.to match_query_limit_of(0)
+      expect { expect(vm2.num_hard_disks).to eq(0) }.to match_query_limit_of(0)
+    end
+
+    it "calculates in ruby" do
+      vm
+      disk # make sure the record is created
+      expect(vm.num_disks).to eq(1)
+      expect(vm.num_hard_disks).to eq(1)
+    end
+
+    it "uses calculated (inline) attribute" do
+      vm
+      disk # make sure the record is created
+      expect(virtual_column_sql_value(VmOrTemplate, "num_disks")).to eq(1)
+      expect(virtual_column_sql_value(VmOrTemplate, "num_hard_disks")).to eq(1)
+    end
+  end
+
   describe ".ram_size", ".mem_cpu" do
     let(:vm) { FactoryBot.create(:vm_vmware, :hardware => hardware) }
     let(:hardware) { FactoryBot.create(:hardware, :memory_mb => 10) }


### PR DESCRIPTION
Converting a few parameters to arel / sql friendly versions.

Currently, these parameters need to be declared as `references().includes()` or `includes()`. Making this change allows them to be brought back with `select()` parameters. This is much more efficient:

```ruby
# 3 examples:
records = VmOrTemplate.includes(:num_cpu).references(:num_cpu).select(:id, :name)
records = VmOrTemplate.includes(:num_cpu).select(:id, :name)
records = VmOrTemplate.select(:id, :name, :num_cpu)

# and then it is used:
records.to_a.each { |r| puts "#{r.i}, #{r.name}, #{r.num_cpu}" }
```

numbers
---

`num_cpu`

|     ms | bytes | objects |query | qry ms |     rows |`num_cpu`
|    ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|    348.6 | 31,342,518* | 150,087 |    1 |   286.8 |    1,906 |`before-ri`
|  160.6 | 9,198,161* | 86,413 |    2 |  76.3 |    2,760 |`before-i`
|   78.2 | 3,837,563* | 55,684 |    1 |  42.4 |    1,906 |`after-s`
| **51%** | **58%** | **36%** | **50%** | **44.4%** | **31%** | `i` to `s` difference

\* Memory usage does not reflect 219 freed objects. 
\* Memory usage does not reflect 43 freed objects. 
\* Memory usage does not reflect 14 freed objects. 

---

`num_disks`

|        ms |    bytes |  objects |query |   qry ms |     rows |`num_disks`
|       ---:|      ---:|      ---:|  ---:|      ---:|      ---:| ---
|     552.3 | 41,139,673* | 267,393 |    1 |   450.3 |    2,270 |`before-r-i`
|     253.2 | 16,018,558* |  148,641 |    3 |    107.5 |    3,884 |`before-i`
|     90.7 | 3,844,300* |  55,827 |    1 |    42.5 |    1,906 |`after-s`
| **64%**| **76%** | **62%**| **67%** | **61%** | **51%** | `i` to `s` difference

\* Memory usage does not reflect 310 freed objects. 
\* Memory usage does not reflect 76 freed objects. 
\* Memory usage does not reflect 14 freed objects. 

---

`num_hard_disks`

For kicks, I also ran `num_hard_disks` with no `references()` or `includes()` - so see how far we've come.

|     ms | bytes | objects |query | qry ms |     rows |`num_hard_disks`
|    ---:|   ---:|   ---:|  ---:|   ---:|      ---:| ---
|  4,729.6 | 28,332,892* | 2,792,992 |2,761 | 1,894.8 |    2,760 |`before-x`
|    663.9 | 44,943,311* | 391,575 |    1 |   505.4 |    2,033 |`before-r-i`
|  291.1 | 21,118,126* | 228,945 |    3 |  99.5 |    3,647 |`before-i`
|   75.6 | 3,850,005* | 55,922 |    1 |  42.2 |    1,906 |`after-s`
| **74%** | **82%** | **76%** | **67%** | **58%** | **48%** | `i` to `s` difference

\* Memory usage does not reflect 821,005 freed objects. 
\* Memory usage does not reflect 272 freed objects. 
\* Memory usage does not reflect 71 freed objects. 
\* Memory usage does not reflect 14 freed objects. 


notes
---

```ruby
bookend("before-ri", gc: true) {
  VmOrTemplate.includes(:num_cpu).references(:num_cpu).select(:id, :name).to_a.map(&:num_cpu)
}
bookend("before-i", gc: true)  {
  VmOrTemplate.includes(:num_cpu).select(:id, :name).to_a.map(&:num_cpu)
}
bookend("after-s", gc: true)     {
  VmOrTemplate.select(:id, :name, :num_cpu)         .to_a.map(&:num_cpu)
}
```