### PR TITLE
Generate retire requests from the base class name

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -11,7 +11,7 @@ module RetirementMixin
 
   module ClassMethods
     def make_retire_request(*src_ids, requester, initiated_by: 'user')
-      klass = (name.demodulize + "RetireRequest").constantize
+      klass = (base_class.name.demodulize + "RetireRequest").constantize
       options = {:src_ids => src_ids.presence, :__initiated_by__ => initiated_by, :__request_type__ => klass.request_types.first}
       set_retirement_requester(options[:src_ids], requester)
       klass.make_request(nil, options, requester)

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -1,6 +1,7 @@
 describe "Service Retirement Management" do
   let(:user) { FactoryBot.create(:user_miq_request_approver) }
   let(:service_with_owner) { FactoryBot.create(:service, :evm_owner => user) }
+  let(:service_ansible_playbook) { FactoryBot.create(:service_ansible_playbook) }
 
   before do
     @server = EvmSpecHelper.local_miq_server
@@ -100,6 +101,12 @@ describe "Service Retirement Management" do
     @service.retire(options)
     @service.reload
     expect(@service.retirement_warn).to eq(options[:warn])
+  end
+
+  it "with a Service Ansible Playbook" do
+    expect(ServiceRetireRequest).to receive(:make_request)
+      .with(nil, {:src_ids => [service_ansible_playbook.id], :__initiated_by__ => 'user', :__request_type__ => "service_retire"}, user)
+    service_ansible_playbook.class.make_retire_request(service_ansible_playbook.id, user)
   end
 
   it "with one src_id" do


### PR DESCRIPTION
```ServiceAnsiblePlaybook.demodulize + "RetireRequest"``` => bad cause we try and constantize that n there is no SAPRR; we should be using only the base class name for ```make_retire_request```

Also, it's passing specs and got BZ opener approval here: https://bugzilla.redhat.com/show_bug.cgi?id=1731559#c6 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1731559

@miq-bot add_label bug, hammer/yes, ivanchuk/yes
@miq-bot add_reviewer @tinaafitz 
@miq-bot add_reviewer @lfu 