### PR TITLE
Update sys-filesystem gem to 1.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem "rubyzip",                        "~>1.3.0",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sprockets",                      "~>3.0",         :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
-gem "sys-filesystem",                 "~>1.2.0"
+gem "sys-filesystem",                 "~>1.3.1"
 gem "terminal",                                        :require => false
 
 # Modified gems (forked on Github)


### PR DESCRIPTION
This PR updates the sys-filesystem gem to version 1.3.1. This version includes fixes for Linux (and BSD), and all adds `mount` and `umount` singleton methods that we could potentially use in the future instead of shelling out.