### PR TITLE
Output constant must match the constantized class name

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -50,6 +50,8 @@ module MiqServer::WorkerManagement::Monitor
     self.class.monitor_class_names.each do |class_name|
       begin
         c = class_name.constantize
+        raise NameError, "Constant problem: expected: #{class_name}, constantized: #{c.name}" unless c.name == class_name
+
         c.ensure_systemd_files if c.systemd_worker?
         result[c.name] = c.sync_workers
         result[c.name][:adds].each { |pid| worker_add(pid) unless pid.nil? }


### PR DESCRIPTION
Constantize can demodulize to an incorrect class, so we should skip any class
names that don't constantize to the expected class.

In this example, if you do the following in rails console, you'll get the
following:

Autoload the base manager eventcatcher:

ManageIQ::Providers::BaseManager::EventCatcher

Try to constantize a non existing event catcher in a valid provider namespace:
"ManageIQ::Providers::Foreman::ProvisioningManager::EventCatcher".constantize
   =>  ManageIQ::Providers::BaseManager::EventCatcher

Seen in the logs for https://bugzilla.redhat.com/show_bug.cgi?id=1759711