### PR TITLE
[V2V] Add VM validation for warm migration eligibility and updated specs to …

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,6 @@
+c
+vm.snapshots.first.name
+vm.snapshots.count
+vm.v_total_snapshots
+vm.v_total_snapshots.count
+n

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,6 +1,0 @@
-c
-vm.snapshots.first.name
-vm.snapshots.count
-vm.v_total_snapshots
-vm.v_total_snapshots.count
-n

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -96,6 +96,7 @@ module SupportsFeatureMixin
     :launch_vmrc_console                 => 'Launch VMRC Console',
     :admin_ui                            => 'Open Admin UI for a Provider',
     :live_migrate                        => 'Live Migration',
+    :warm_migrate                        => 'Warm Migration',
     :migrate                             => 'Migration',
     :capture                             => 'Capture of Capacity & Utilization Metrics',
     :openscap_scan                       => 'OpenSCAP security scan',

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -63,7 +63,7 @@ module ServiceTemplateTransformationPlan::ValidateConfigInfo
           raise _("Invalid VM found #{vm_obj.name}") if vm_obj.invalid?
 
           vm_options = {}
-          vm_options[:warm_migration_compatible] = !vm_obj.snapshots.present?
+          vm_options[:warm_migration_compatible] = vm_obj.snapshots.blank?
           vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
           vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
           vm_options[:cpu_right_sizing_mode] = vm_hash[:cpu_right_sizing_mode] if vm_hash[:cpu_right_sizing_mode].present?

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -63,6 +63,7 @@ module ServiceTemplateTransformationPlan::ValidateConfigInfo
           raise _("Invalid VM found #{vm_obj.name}") if vm_obj.invalid?
 
           vm_options = {}
+          vm_options[:warm_migration_incompatible] = vm_obj.snapshots.present?
           vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
           vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
           vm_options[:cpu_right_sizing_mode] = vm_hash[:cpu_right_sizing_mode] if vm_hash[:cpu_right_sizing_mode].present?

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -63,7 +63,7 @@ module ServiceTemplateTransformationPlan::ValidateConfigInfo
           raise _("Invalid VM found #{vm_obj.name}") if vm_obj.invalid?
 
           vm_options = {}
-          vm_options[:warm_migration_incompatible] = vm_obj.snapshots.present?
+          vm_options[:warm_migration_compatible] = !vm_obj.snapshots.present?
           vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
           vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
           vm_options[:cpu_right_sizing_mode] = vm_hash[:cpu_right_sizing_mode] if vm_hash[:cpu_right_sizing_mode].present?

--- a/app/models/service_template_transformation_plan/validate_config_info.rb
+++ b/app/models/service_template_transformation_plan/validate_config_info.rb
@@ -63,7 +63,7 @@ module ServiceTemplateTransformationPlan::ValidateConfigInfo
           raise _("Invalid VM found #{vm_obj.name}") if vm_obj.invalid?
 
           vm_options = {}
-          vm_options[:warm_migration_compatible] = vm_obj.snapshots.blank?
+          vm_options[:warm_migration_compatible] = vm_obj.supports_warm_migrate?
           vm_options[:pre_ansible_playbook_service_template_id] = pre_service_id if vm_hash[:pre_service]
           vm_options[:post_ansible_playbook_service_template_id] = post_service_id if vm_hash[:post_service]
           vm_options[:cpu_right_sizing_mode] = vm_hash[:cpu_right_sizing_mode] if vm_hash[:cpu_right_sizing_mode].present?

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
   before do
     stub_const("ManageIQ::Providers::InfraManager::WarmMigrationVm", Class.new(ManageIQ::Providers::InfraManager::Vm) do
       supports :warm_migrate do
-        unsupported_reason_add(:warm_migrate, _('Warm migratiobn can not migrate a VM with snapshots')) if snapshots.present?
+        unsupported_reason_add(:warm_migrate, _('Warm migration can not migrate a VM with snapshots')) if snapshots.present?
       end
     end)
   end

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -277,9 +277,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -355,11 +355,11 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2, vm3])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group2.id, "osp_flavor_id" => flavor2.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group2.id, "osp_flavor_id" => flavor2.id, "warm_migration_compatible" => true)
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -377,7 +377,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_compatible" => true)
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_removed[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -395,9 +395,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm3])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_compatible" => true)
       expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "warm_migration_compatible" => true)
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added_and_removed[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -416,9 +416,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -436,9 +436,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_compatible" => true)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
   end
 
   let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }
-  let(:vm1) { FactoryBot.create(:vm_or_template) }
-  let(:vm2) { FactoryBot.create(:vm_or_template) }
-  let(:vm3) { FactoryBot.create(:vm_or_template) }
+  let(:vm1) { FactoryBot.create(:vm_vmware) }
+  let(:vm2) { FactoryBot.create(:vm_vmware) }
+  let(:vm3) { FactoryBot.create(:vm_vmware) }
   let(:security_group1) { FactoryBot.create(:security_group, :name => "default") }
   let(:flavor1) { FactoryBot.create(:flavor, :name => "large") }
   let(:security_group2) { FactoryBot.create(:security_group, :name => "default") }

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -277,9 +277,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -355,11 +355,11 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2, vm3])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group2.id, "osp_flavor_id" => flavor2.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group2.id, "osp_flavor_id" => flavor2.id, "warm_migration_incompatible" => false)
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -377,7 +377,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_incompatible" => false)
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_removed[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -395,9 +395,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm3])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "warm_migration_incompatible" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm3.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "warm_migration_incompatible" => false)
       expect(service_template.config_info).to eq(updated_catalog_item_options_with_vms_added_and_removed[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -416,9 +416,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.collect(&:status)).to eq([ServiceResource::STATUS_QUEUED, ServiceResource::STATUS_QUEUED])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',
@@ -436,9 +436,9 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
       expect(service_template.transformation_mapping).to eq(transformation_mapping)
       expect(service_template.vm_resources.collect(&:resource)).to match_array([vm1, vm2])
       expect(service_template.vm_resources.find_by(:resource_id => vm1.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.vm_resources.find_by(:resource_id => vm2.id).options)
-        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id)
+        .to eq("pre_ansible_playbook_service_template_id" => apst.id, "post_ansible_playbook_service_template_id" => apst.id, "osp_security_group_id" => security_group1.id, "osp_flavor_id" => flavor1.id, "warm_migration_incompatible" => false)
       expect(service_template.config_info).to eq(catalog_item_options[:config_info])
       expect(service_template.resource_actions.first).to have_attributes(
         :action => 'Provision',


### PR DESCRIPTION
For warm migration, we need to limit the list of selectable VMs in the migration plan wizard. This is done by adding `warm_migration_incompatible` property to VMs in   `app/models/service_template_transformation_plan/validate_config_info.rb `. The criteria is that the VM must not have snapshots.

https://bugzilla.redhat.com/show_bug.cgi?id=1760040