### PR TITLE
Remove zanata-related stuff from manageiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Open Source Helpers](https://www.codetriage.com/manageiq/manageiq/badges/users.svg)](https://www.codetriage.com/manageiq/manageiq)
 
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/manageiq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/manageiq)
+[![Translate](https://img.shields.io/badge/translate-transifex-blue.svg)](https://www.transifex.com/manageiq/manageiq/dashboard/)
 [![License](http://img.shields.io/badge/license-APACHE2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
 

--- a/lib/generators/manageiq/plugin/plugin_generator.rb
+++ b/lib/generators/manageiq/plugin/plugin_generator.rb
@@ -36,7 +36,6 @@ module ManageIQ
       template "LICENSE.txt"
       template "Rakefile"
       template "README.md"
-      template "zanata.xml"
       template "bin/rails"
       template "bin/setup"
       template "bin/update"

--- a/lib/generators/manageiq/plugin/templates/README.md
+++ b/lib/generators/manageiq/plugin/templates/README.md
@@ -7,7 +7,6 @@
 [![Security](https://hakiri.io/github/ManageIQ/<%= plugin_name %>/master.svg)](https://hakiri.io/github/ManageIQ/<%= plugin_name %>/master)
 
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ManageIQ/<%= plugin_name %>?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Translate](https://img.shields.io/badge/translate-zanata-blue.svg)](https://translate.zanata.org/zanata/project/view/<%= plugin_name %>)
 
 <%= plugin_description %>
 

--- a/lib/generators/manageiq/plugin/templates/zanata.xml
+++ b/lib/generators/manageiq/plugin/templates/zanata.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<config xmlns="http://zanata.org/namespace/config/">
-  <url>https://translate.zanata.org/</url>
-  <project><%= plugin_name %></project>
-  <project-version>master</project-version>
-  <project-type>gettext</project-type>
-</config>


### PR DESCRIPTION
* We use Transifex for translation now (README change)
* There's no need to generate Zanata (or even Transifex) related things in new plugin

Fixes https://github.com/ManageIQ/manageiq/issues/19390

@miq-bot add_label internationalization, technical debt