### PR TITLE
Save the updated widget timestamp

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -327,9 +327,7 @@ class MiqWidget < ApplicationRecord
     settings_for_build[:user_id]  = user.id  if user
     settings_for_build[:timezone] = timezone if timezone
     contents = miq_widget_contents.find_by(settings_for_build) || miq_widget_contents.build(settings_for_build)
-    contents.updated_at = Time.now.utc # Force updated timestamp to change when saved even if the new contents are the same
-
-    contents
+    contents.tap { |c| c.update!(:updated_at => Time.now.utc) }
   end
 
   # TODO: group/user support

--- a/spec/models/miq_widget/report_content_spec.rb
+++ b/spec/models/miq_widget/report_content_spec.rb
@@ -32,6 +32,7 @@ describe MiqWidget, "::ReportContent" do
   it "#generate_one_content_for_user" do
     content = widget.generate_one_content_for_user(@admin_group, @admin)
     expect(content).to be_kind_of MiqWidgetContent
+    expect(content.updated_at).to be_within(2.seconds).of(Time.now.utc)
     expect(content.contents.scan("</tr>").length).to eq(widget.options[:row_count] + 1)
     expect(content.contents.scan("</td>").length).to eq(widget.options[:row_count] * widget.options[:col_order].length)
     expect(content.contents.scan("</th>").length).to eq(widget.options[:col_order].length)
@@ -44,6 +45,7 @@ describe MiqWidget, "::ReportContent" do
   it "#generate_one_content_for_group" do
     content = widget.generate_one_content_for_group(@admin.current_group, @admin.get_timezone)
     expect(content).to be_kind_of MiqWidgetContent
+    expect(content.updated_at).to be_within(2.seconds).of(Time.now.utc)
     expect(content.contents.scan("</tr>").length).to eq(widget.options[:row_count] + 1)
     expect(content.contents.scan("</td>").length).to eq(widget.options[:row_count] * widget.options[:col_order].length)
     expect(content.contents.scan("</th>").length).to eq(widget.options[:col_order].length)


### PR DESCRIPTION
So the comment on widget content generation says that we're forcing the widget timestamp to change every time we run ```find_or_build_contents_for_user```. 

But we're not saving it anyway so I don't think it's updating.

```# Force updated timestamp to change when saved even if the new contents are the same```