### PR TITLE
Passes result_format when automate workspace is not expected

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -94,7 +94,7 @@ class CustomButton < ApplicationRecord
   end
 
   def invoke(target, source = nil)
-    args = resource_action.automate_queue_hash(target, {}, User.current_user)
+    args = resource_action.automate_queue_hash(target, {"result_format" => 'ignore'}, User.current_user)
 
     publish_event(source, target, args)
     MiqQueue.put(queue_opts(target, args))
@@ -142,7 +142,7 @@ class CustomButton < ApplicationRecord
       :userid => User.current_user
     }
 
-    args = resource_action.automate_queue_hash(target, {}, User.current_user)
+    args = resource_action.automate_queue_hash(target, {"result_format" => 'ignore'}, User.current_user)
 
     publish_event(source, target, args)
     MiqTask.generic_action_with_callback(task_opts, queue_opts(target, args))

--- a/app/models/resource_action.rb
+++ b/app/models/resource_action.rb
@@ -30,7 +30,6 @@ class ResourceAction < ApplicationRecord
     end
 
     attrs = (ae_attributes || {}).merge(override_attrs || {})
-    attrs["result_format"] = 'ignore'
 
     {
       :namespace        => ae_namespace,

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -4,7 +4,7 @@ describe ResourceAction do
     let(:zone_name) { "default" }
     let(:ra) { FactoryBot.create(:resource_action) }
     let(:miq_server) { FactoryBot.create(:miq_server) }
-    let(:ae_attributes) { { "result_format" => "ignore"} }
+    let(:ae_attributes) { {} }
     let(:q_args) do
       {
         :namespace        => nil,
@@ -114,8 +114,12 @@ describe ResourceAction do
     let(:user)   { FactoryBot.create(:user_with_group) }
     let(:target) { FactoryBot.create(:vm_vmware) }
 
-    it "adds result_format" do
-      expect(ra.automate_queue_hash(target, {}, user)).to include(:attrs => {"result_format"=>"ignore"})
+    it "passes result_format" do
+      expect(ra.automate_queue_hash(target, {"result_format"=>"ignore"}, user)).to include(:attrs => {"result_format"=>"ignore"})
+    end
+
+    it "does not pass result_format by default" do
+      expect(ra.automate_queue_hash(target, {}, user)).not_to include(:attrs => {"result_format"=>"ignore"})
     end
   end
 end


### PR DESCRIPTION
Dynamic dialog expects a workspace object from [`deliver_to_automate_from_dialog_field`](https://github.com/ManageIQ/manageiq/blob/b7c9523e41be7406c2bde8554424d5caf0017ca7/app/models/dynamic_dialog_field_value_processor.rb#L8).

Undo https://github.com/ManageIQ/manageiq/pull/19270.

@miq-bot assign @tinaafitz
@miq-bot add_label bug, Ivanchuk/yes, changelog/yes
cc @martinpovolny