### PR TITLE
Enumerable#reverse_each is faster than Enumerable#reverse.each

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -633,7 +633,7 @@ class MiqAction < ApplicationRecord
     end
 
     task_id = "action_#{action.id}_vm_#{rec.id}"
-    snaps_to_delete.sort_by(&:create_time).reverse.each do |s| # Delete newest to oldest
+    snaps_to_delete.sort_by(&:create_time).reverse_each do |s| # Delete newest to oldest
       MiqPolicy.logger.info("#{log_prefix} Deleting Snapshot: Name: [#{s.name}] Id: [#{s.id}] Create Time: [#{s.create_time}]")
       rec.remove_snapshot_queue(s.id, task_id)
     end

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -297,7 +297,7 @@ describe Metric::CiMixin::Capture do
         if queue_items.any? && realtime_start_time
           interval_start_time = vm.last_perf_capture_on
           interval_end_time   = interval_start_time + 1.day
-          queue_items.reverse.each do |q_item|
+          queue_items.reverse_each do |q_item|
             verify_historical_queue_item(q_item, interval_start_time, interval_end_time)
 
             interval_start_time = interval_end_time


### PR DESCRIPTION
Performance-wise, prefer Enumerable#reverse_each and Array#reverse_each to Enumerable#reverse.each and Array#reverse.each, respectively.