### PR TITLE
[Gem] Virtual Attributes 1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
-gem "activerecord-virtual_attributes", "~>1.4.0"
+gem "activerecord-virtual_attributes", "~>1.5.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -21,7 +21,7 @@ class SecurityGroup < ApplicationRecord
   # TODO(lsmola) we should be able to remove table security_groups_vms, if it's unused now. Can't be backported
   has_many :vms, -> { distinct }, :through => :network_ports, :source => :device, :source_type => 'VmOrTemplate'
 
-  virtual_total :total_vms, :vms, :uses => :vms
+  virtual_total :total_vms, :vms
 
   def self.non_cloud_network
     where(:cloud_network_id => nil)

--- a/spec/models/security_group_spec.rb
+++ b/spec/models/security_group_spec.rb
@@ -1,18 +1,18 @@
 describe SecurityGroup do
-  before do
-    provider = FactoryBot.create(:ems_amazon)
-    cn       = FactoryBot.create(:cloud_network)
-    @sg1     = FactoryBot.create(:security_group,
-                                  :name                  => "sq_1",
-                                  :ext_management_system => provider.network_manager,
-                                  :cloud_network         => cn)
-    @sg2     = FactoryBot.create(:security_group,
-                                  :name                  => "sq_1",
-                                  :ext_management_system => provider.network_manager)
-  end
+  describe ".non_cloud_network" do
+    let(:provider) { FactoryBot.create(:ems_amazon) }
 
-  it ".non_cloud_network" do
-    expect(SecurityGroup.non_cloud_network).to eq([@sg2])
+    before do
+      @sg1 = FactoryBot.create(:security_group,
+                               :ext_management_system => provider.network_manager,
+                               :cloud_network         => FactoryBot.create(:cloud_network))
+      @sg2 = FactoryBot.create(:security_group,
+                               :ext_management_system => provider.network_manager)
+    end
+
+    it "calculates in the database" do
+      expect(SecurityGroup.non_cloud_network).to eq([@sg2])
+    end
   end
 
   describe "#total_vms" do


### PR DESCRIPTION
followup for https://github.com/ManageIQ/activerecord-virtual_attributes/pull/52

with that PR, `SecurityGroups#total_vms` is now sql friendly so the tests need to change

(this won't be green w/o that PR merged)

- [ ] https://travis-ci.org/kbrock/manageiq-cross_repo/builds/620701353
- [x] https://github.com/ManageIQ/activerecord-virtual_attributes/pull/52 (and release a new gem)