### PR TITLE
require specific aws gems

### DIFF
--- a/app/models/file_depot_s3.rb
+++ b/app/models/file_depot_s3.rb
@@ -10,7 +10,8 @@ class FileDepotS3 < FileDepot
   end
 
   def connect(options = {})
-    require 'aws-sdk'
+    require 'aws-sdk-s3'
+
     username = options[:username] || authentication_userid(options[:auth_type])
     password = options[:password] || authentication_password(options[:auth_type])
     # Note: The hard-coded aws_region will be removed after manageiq-ui-class implements region selection
@@ -62,7 +63,8 @@ class FileDepotS3 < FileDepot
   end
 
   def translate_exception(err)
-    require 'aws-sdk'
+    require 'aws-sdk-ec2'
+
     case err
     when Aws::EC2::Errors::SignatureDoesNotMatch
       MiqException::MiqHostError.new("SignatureMismatch - check your AWS Secret Access Key and signing method")


### PR DESCRIPTION
This is a part of global update `aws-sdk` gem to `v3`

Together with:
- https://github.com/ManageIQ/manageiq-providers-amazon/pull/488
- https://github.com/ManageIQ/manageiq-gems-pending/pull/449
- https://github.com/ManageIQ/amazon_ssa_support/pull/44

It should fix https://github.com/ManageIQ/manageiq-providers-amazon/issues/465