### PR TITLE
Fixed sorting in TenantQuotas report

### DIFF
--- a/app/models/tenant_quota.rb
+++ b/app/models/tenant_quota.rb
@@ -56,6 +56,7 @@ class TenantQuota < ApplicationRecord
   virtual_column :used, :type => :float
   virtual_column :allocated, :type => :float
   virtual_column :available, :type => :float
+  virtual_column :description, :type => :string
 
   alias_attribute :total, :value
 
@@ -63,8 +64,12 @@ class TenantQuota < ApplicationRecord
     self.unit = default_unit unless unit.present?
   end
 
+  def description
+    TenantQuota.tenant_quota_description(name.to_sym)
+  end
+
   def self.format_quota_value(field, field_value, tenant_quota_name)
-    if field == "tenant_quotas.name"
+    if %w[tenant_quotas.name tenant_quotas.description].include?(field)
       TenantQuota.tenant_quota_description(tenant_quota_name.to_sym)
     else
       row = QUOTA_BASE[tenant_quota_name.to_sym]

--- a/product/reports/780_Tenants - Tenant Quotas/001_Tenant Quotas.yaml
+++ b/product/reports/780_Tenants - Tenant Quotas/001_Tenant Quotas.yaml
@@ -15,20 +15,21 @@ include:
   tenant_quotas:
     columns:
     - name
+    - description
     - total
     - used
     - allocated
     - available
 cols:
 - name
-- tenant_quotas.name
+- tenant_quotas.description
 - tenant_quotas.total
 - tenant_quotas.used
 - tenant_quotas.allocated
 - tenant_quotas.available
 col_order:
 - name
-- tenant_quotas.name
+- tenant_quotas.description
 - tenant_quotas.total
 - tenant_quotas.used
 - tenant_quotas.allocated

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -244,6 +244,19 @@ describe TenantQuota do
     end
   end
 
+  describe ".format_quota_value" do
+    let(:quota_name) { "cpu_allocated" }
+    let(:quota_description) { "Allocated Virtual CPUs" }
+
+    it "returns quota description if field to format is 'tenant_quotas.name'" do
+      expect(described_class.format_quota_value("tenant_quotas.name", "something", quota_name)).to eq(quota_description)
+    end
+
+    it "returns quota description if field to format is 'tenant_quotas.description'" do
+      expect(described_class.format_quota_value("tenant_quotas.description", "something", quota_name)).to eq(quota_description)
+    end
+  end
+
   describe "#quota_hash" do
     it "has cpu_allocated attributes" do
       expect(described_class.new(:tenant => tenant, :name => "cpu_allocated", :value => 4096).tap(&:valid?).quota_hash).to eq(


### PR DESCRIPTION
**Issue:** quota names saved in Db are not descriptive and not translated. So, TenantQuota report replaces Db value with human readable and translated value.
Example: ```cpu_allocated``` will be shown as ```Allocated Virtual CPUs```.
BUT sorting by ```quota_name``` column was executed before substitution and final result looks in strange order.

**Fix:**  Introduce virtual column ```TenantQuota#description``` and use it in report instead of ```TenanatQuota#name``` so sorting will be executed on actual visible strings

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1761430

**BEFORE:**
![before](https://user-images.githubusercontent.com/6556758/67050072-ae206580-f105-11e9-9816-13df7ba0717a.png)

**AFTER:**
![after](https://user-images.githubusercontent.com/6556758/67048551-6946ff80-f102-11e9-997a-734d0ca479f0.png)

@miq-bot add-label bug, reporting, ivanchuk/yes,  changelog/no