### PR TITLE
[V2V] Pin InfraConversionJob to first server where it runs

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -247,7 +247,8 @@ class InfraConversionJob < Job
       :zone        => zone,
       :task_id     => guid,
       :args        => args,
-      :deliver_on  => deliver_on
+      :deliver_on  => deliver_on,
+      :server_guid => MiqServer.my_server.guid
     )
   end
 

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe InfraConversionJob, :v2v do
   let(:user_admin)            { FactoryBot.create(:user_admin) }
   let(:group)                 { FactoryBot.create(:miq_group) }
   let(:zone)                  { FactoryBot.create(:zone) }
+  let(:server)                { FactoryBot.create(:miq_server) }
 
   let(:ems_vmware)            { FactoryBot.create(:ems_vmware, :zone => zone) }
   let(:ems_cluster_vmware)    { FactoryBot.create(:ems_cluster, :ext_management_system => ems_vmware) }
@@ -74,6 +75,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
   before do
     allow(MiqServer).to receive(:my_zone).and_return(zone.name)
+    allow(MiqServer).to receive(:my_server).and_return(server)
     allow(ServiceTemplateProvisionRequest).to receive(:destination)
   end
 


### PR DESCRIPTION
When running VM migration in a multi-appliances environment, the states of the InfraConversionJob can be execute on different appliances. It makes it difficult to follow the logs and troubleshoot issues. We will use this pinning to collect the log for a specific VM migration.

InfraConversionJob is mainly the workflow runner, but most of the long running operations are executed asynchronously, so we don't expect a high level of load on the appliance the runs the job.

This PR implement the same mechanism as [AnsibleRunnerWorkflow [L108]](https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/ansible_runner_workflow.rb#L108).

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1763043