### PR TITLE
Update to config gem 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.15",        :require => false
 gem "byebug",                                          :require => false
 gem "color",                          "~>1.8"
-gem "config",                         "~>1.6.0",       :require => false
+gem "config",                         "~>2.0",         :require => false
 gem "dalli",                          "=2.7.6",        :require => false
 gem "default_value_for",              "~>3.3"
 gem "docker-api",                     "~>1.33.6",      :require => false

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -29,6 +29,7 @@ module Vmdb
 
     def self.init
       ::Config.overwrite_arrays = true
+      ::Config.merge_nil_values = false
       reset_settings_constant(for_resource(:my_server))
       on_reload
     end
@@ -182,8 +183,9 @@ module Vmdb
     # sources and doesn't allow you insert new sources into the middle of the
     # stack.
     def self.reset_settings_constant(settings)
-      Kernel.send(:remove_const, ::Config.const_name) if Kernel.const_defined?(::Config.const_name)
-      Kernel.const_set(::Config.const_name, settings)
+      name = ::Config.const_name
+      Object.send(:remove_const, name) if Object.const_defined?(name)
+      Object.const_set(name, settings)
     end
     private_class_method :reset_settings_constant
 


### PR DESCRIPTION
EDIT:

Added cross-repo tests against this branch:

- [x] https://travis-ci.org/jrafanie/manageiq-cross_repo/builds/600748920

* 1.7.0 introduced merge_nil_values, ironically by me, which we have to disable.
This is because we often have leaf configurations with nil values as examples,
which overwrite core values, leading to lots of problems.  For now we have to
disable this behavior.

  * https://github.com/railsconfig/config/pull/196/files
  * See also: https://github.com/ManageIQ/manageiq/pull/16982/files

* 2.0.0 changed the Config constant to be defined on Object, not Kernel, so we
need to update our configuration to reflect this same change:

  * https://github.com/railsconfig/config/pull/227/files

Also, config gem at 1.6.1 was loading dry-validation which was really slow.  Now
with 2.0.0, it uses dry-schema, which is slightly less slow.  It seems to save
~0.3 seconds on rails boot.

Config 1.6.1:

```
04:49:04 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  6.12s user 3.84s system 88% cpu 11.227 total
04:49:17 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  5.81s user 3.23s system 99% cpu 9.133 total
04:49:28 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  5.92s user 3.32s system 98% cpu 9.338 total
04:49:38 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  6.09s user 3.55s system 98% cpu 9.793 total
```

Config 2.0.0:

```
04:43:03 ~/Code/manageiq (master) (2.6.5) - time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  5.90s user 3.53s system 90% cpu 10.403 total
04:43:16 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  5.54s user 2.99s system 99% cpu 8.610 total
04:43:25 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  5.64s user 3.14s system 98% cpu 8.879 total
04:43:35 ~/Code/manageiq (master) (2.6.5) + time ruby -e "require './config/environment'"
ruby -e "require './config/environment'"  5.64s user 3.12s system 99% cpu 8.841 total
```