### PR TITLE
Cu schedule collector by ems

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -43,12 +43,13 @@ module Metric::Capture
                 ::Settings.performance.capture_threshold_with_alerts.default)
   end
 
-  def self.perf_capture_timer(zone = nil)
+  def self.perf_capture_timer(ems_id)
     _log.info("Queueing performance capture...")
 
-    zone ||= MiqServer.my_server.zone
+    ems = ExtManagementSystem.find(ems_id)
+    zone = ems.zone
     perf_capture_health_check(zone)
-    targets = Metric::Targets.capture_targets(zone)
+    targets = Metric::Targets.capture_ems_targets(ems)
 
     targets_by_rollup_parent = calc_targets_by_rollup_parent(targets)
     target_options = calc_target_options(zone, targets_by_rollup_parent)

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -68,13 +68,16 @@ class MiqScheduleWorker::Jobs
   end
 
   def metric_capture_perf_capture_timer
-    queue_work(
-      :class_name  => "Metric::Capture",
-      :method_name => "perf_capture_timer",
-      :role        => "ems_metrics_coordinator",
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :state       => ["ready", "dequeue"]
-    )
+    MiqServer.my_server.zone.ems_metrics_collectable.each do |ems|
+      queue_work(
+        :class_name  => "Metric::Capture",
+        :method_name => "perf_capture_timer",
+        :args        => [ems.id],
+        :role        => "ems_metrics_coordinator",
+        :priority    => MiqQueue::HIGH_PRIORITY,
+        :state       => ["ready", "dequeue"]
+      )
+    end
   end
 
   def metric_purging_purge_realtime_timer

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -68,16 +68,13 @@ class MiqScheduleWorker::Jobs
   end
 
   def metric_capture_perf_capture_timer
-    zone = MiqServer.my_server(true).zone
-    if zone.role_active?("ems_metrics_coordinator")
-      queue_work(
-        :class_name  => "Metric::Capture",
-        :method_name => "perf_capture_timer",
-        :role        => "ems_metrics_coordinator",
-        :priority    => MiqQueue::HIGH_PRIORITY,
-        :state       => ["ready", "dequeue"]
-      )
-    end
+    queue_work(
+      :class_name  => "Metric::Capture",
+      :method_name => "perf_capture_timer",
+      :role        => "ems_metrics_coordinator",
+      :priority    => MiqQueue::HIGH_PRIORITY,
+      :state       => ["ready", "dequeue"]
+    )
   end
 
   def metric_purging_purge_realtime_timer

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -526,6 +526,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
   private
 
+  # @returns Hash<class, Integer> Hash of ems_class => refresh_interval
   def schedule_settings_for_ems_refresh
     ExtManagementSystem.leaf_subclasses.each.with_object({}) do |klass, hash|
       next unless klass.ems_type

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -194,6 +194,11 @@ class Zone < ApplicationRecord
     ext_management_systems.select { |e| e.kind_of?(EmsCloud) }
   end
 
+  # @return [Array<ExtManagementSystem>] All emses that can collect Capacity and Utilization metrics
+  def ems_metrics_collectable
+    ext_management_systems.select { |e| e.kind_of?(EmsCloud) || e.kind_of?(EmsInfra) || e.kind_of?(ManageIQ::Providers::ContainerManager) }
+  end
+
   def ems_networks
     ext_management_systems.select { |e| e.kind_of?(ManageIQ::Providers::NetworkManager) }
   end


### PR DESCRIPTION
We suggest that customers should configure one ems per zone.
So running collection by zone is typically just running collection by ems.

### before

scheduler sends no parameter for collector.
collector defaults to the current zone
collector gets all vms/hosts for the zone and sends off a message to collect each.

### after

scheduler sends an ems for collector
collector gets all vms/hosts for the ems and sends off a message to collect each.

old messages for collectors still default to the current zone.

/thanks @d-m-u 