### PR TITLE
Remove invalid partial from InfraConversionJob specs

### DIFF
--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe InfraConversionJob, :v2v do
   before do
     allow(MiqServer).to receive(:my_zone).and_return(zone.name)
     allow(MiqServer).to receive(:my_server).and_return(server)
-    allow(ServiceTemplateProvisionRequest).to receive(:destination)
   end
 
   context '.create_job' do


### PR DESCRIPTION
The `ServiceTemplateProvisionRequest` model does not implement a `destination` singleton method. As a result, this will cause many errors if we turn on strict validation of partials.

Removing it did not cause any failures.