### PR TITLE
[GAPRINDASHVILI] Lock amazon_ssa_support to gaprindashvili branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem "american_date"
 ### providers
 group :amazon, :manageiq_default do
   manageiq_plugin "manageiq-providers-amazon"
-  gem "amazon_ssa_support",                          :require => false, :git => "https://github.com/ManageIQ/amazon_ssa_support.git", :branch => "master" # Temporary dependency to be moved to manageiq-providers-amazon when officially release
+  gem "amazon_ssa_support",                          :require => false, :git => "https://github.com/ManageIQ/amazon_ssa_support.git", :branch => "gaprindashvili" # Temporary dependency to be moved to manageiq-providers-amazon when officially release
 end
 
 group :ansible, :manageiq_default do


### PR DESCRIPTION
The amazon_ssa_support gem shouldn't use the master branch as breaking
changes can be introduced.