### PR TITLE
Fix MiqSchedule spec with arguments

### DIFF
--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -206,8 +206,8 @@ describe MiqSchedule do
 
   context 'with schedule infrastructure and valid run_ats' do
     before do
-      @valid_run_ats =  [{:start_time => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}},
-                         {:start_time => "2010-07-08 04:10:00 Z", :interval => {:unit => "once"}}]
+      @valid_run_ats = [{:start_time => "2010-07-08 04:10:00 Z", :interval => {:unit => "daily", :value => "1"}},
+                        {:start_time => "2010-07-08 04:10:00 Z", :interval => {:unit => "once"}}]
     end
 
     it "hourly schedule" do
@@ -512,7 +512,7 @@ describe MiqSchedule do
         before do
           @east_tz = "Eastern Time (US & Canada)"
           @ak_tz = "Alaska"
-          @utc_tz  = "UTC"
+          @utc_tz = "UTC"
           # Tue, 06 Oct 2010 01:00:00 AKDT -08:00
           @ak_time = Time.parse("Sun October 6 01:00:00 -0800 2010")
           Timecop.travel(@ak_time + 10.minutes)
@@ -977,9 +977,13 @@ describe MiqSchedule do
         end
 
         it "and responds to the method with arguments" do
-          schedule = FactoryBot.create(:miq_schedule, :resource => resource, :sched_action => {:method => "name", :args => ["abc", 123, :a => 1]})
+          schedule = FactoryBot.create(
+            :miq_schedule,
+            :resource     => resource,
+            :sched_action => {:method => "raise_cluster_event", :args => ["abc", 123]}
+          )
 
-          expect_any_instance_of(Host).to receive("name").once.with("abc", 123, :a => 1)
+          expect_any_instance_of(Host).to receive("raise_cluster_event").once.with("abc", 123)
 
           MiqSchedule.queue_scheduled_work(schedule.id, nil, "abc", nil)
         end


### PR DESCRIPTION
At the moment the test for `MiqSchedule#queue_scheduled_work` for a resource that exists is not really valid. The problem is that it tries to pass arguments to the `Host#name` method.

If you turn on strict partial validation, this will bomb with something like:

```
wrong number of arguments (given 3, expected 0)
     # ./app/models/miq_schedule.rb:91:in `queue_scheduled_work'
     # ./spec/models/miq_schedule_spec.rb:984:in `block (5 levels) in <top (required)>'
```
This is because `Host#name` doesn't actually accept arguments.

This PR updates the spec a bit, using a method that actually does take arguments. I also cleaned up a few rubocop warnings.