### PR TITLE
Revert "Prefer block version of File.open to ensure file handle gets automatically closed"

### DIFF
--- a/lib/task_helpers/imports/reports.rb
+++ b/lib/task_helpers/imports/reports.rb
@@ -12,7 +12,8 @@ module TaskHelpers
                              :overwrite => options[:overwrite],
                              :save      => true }
 
-          File.open(filename, 'r') do |report_fd|
+          begin
+            report_fd = File.open(filename, 'r')
             MiqReport.import(report_fd, report_options)
           rescue ActiveModel::UnknownAttributeError, RuntimeError => err
             $log.error("Error importing #{filename} : #{err.message}")

--- a/lib/task_helpers/imports/widgets.rb
+++ b/lib/task_helpers/imports/widgets.rb
@@ -12,7 +12,8 @@ module TaskHelpers
                              :overwrite => options[:overwrite],
                              :save      => true }
 
-          File.open(filename, 'r') do |widget_fd|
+          begin
+            widget_fd = File.open(filename, 'r')
             MiqWidget.import(widget_fd, widget_options)
           rescue ActiveModel::UnknownAttributeError, RuntimeError => err
             $log.error("Error importing #{filename} : #{err.message}")


### PR DESCRIPTION
Reverts ManageIQ/manageiq#19412

We're giving developers 2 weeks to get off ruby 2.4 and I pulled trigger too early.