### PR TITLE
Remove require_nested ConfigurationScript

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager.rb
@@ -12,7 +12,6 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager < ManageIQ::Provid
   require_nested :VaultCredential
   require_nested :VmwareCredential
 
-  require_nested :ConfigurationScript
   require_nested :ConfigurationScriptSource
   require_nested :ConfigurationWorkflow
   require_nested :ConfiguredSystem


### PR DESCRIPTION
`ConfigurationScript` has been removed in https://github.com/ManageIQ/manageiq/pull/19383 but for some reason it's still being required from `AutomationManager`. This PR removes that requirement, otherwise the application fails with:

```
[----] W, [2019-10-25T09:38:23.133766 #18000:2abbf0119168]  WARN -- : DEPRECATION WARNING: You didn't set `secret_key_base`. Read the upgrade documentation to learn more about this new config option. (called from env_config at /home/milan/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/railties-5.1.7/lib/rails/application.rb:247)
[----] I, [2019-10-25T09:38:23.134668 #18000:2abbf0119168]  INFO -- : Started GET "/" for ::1 at 2019-10-25 09:38:23 +0200
[----] F, [2019-10-25T09:38:24.497252 #18000:2abbf0119168] FATAL -- :   
[----] F, [2019-10-25T09:38:24.497378 #18000:2abbf0119168] FATAL -- : LoadError (No such file to load -- manageiq/providers/embedded_ansible/automation_manager/configuration_script.rb):
[----] F, [2019-10-25T09:38:24.497454 #18000:2abbf0119168] FATAL -- :   
[----] F, [2019-10-25T09:38:24.497539 #18000:2abbf0119168] FATAL -- : activesupport (5.1.7) lib/active_support/dependencies.rb:477:in `load'
activesupport (5.1.7) lib/active_support/dependencies.rb:477:in `block in load_file'
activesupport (5.1.7) lib/active_support/dependencies.rb:662:in `new_constants_in'
activesupport (5.1.7) lib/active_support/dependencies.rb:476:in `load_file'
activesupport (5.1.7) lib/active_support/dependencies.rb:374:in `block in require_or_load'
activesupport (5.1.7) lib/active_support/dependencies.rb:36:in `block in load_interlock'
activesupport (5.1.7) lib/active_support/dependencies/interlock.rb:12:in `block in loading'
activesupport (5.1.7) lib/active_support/concurrency/share_lock.rb:149:in `exclusive'
activesupport (5.1.7) lib/active_support/dependencies/interlock.rb:11:in `loading'
activesupport (5.1.7) lib/active_support/dependencies.rb:36:in `load_interlock'
activesupport (5.1.7) lib/active_support/dependencies.rb:357:in `require_or_load'
activesupport (5.1.7) lib/active_support/dependencies.rb:335:in `depend_on'
activesupport (5.1.7) lib/active_support/dependencies.rb:251:in `require_dependency'
lib/extensions/require_nested.rb:11:in `require_nested'
app/models/manageiq/providers/embedded_ansible/automation_manager.rb:15:in `<class:AutomationManager>'
app/models/manageiq/providers/embedded_ansible/automation_manager.rb:1:in `<top (required)>'

```

@miq-bot add_label bug