### PR TITLE
replicate_server_settings is parsing serverid incorrect

### DIFF
--- a/tools/replicate_server_settings.rb
+++ b/tools/replicate_server_settings.rb
@@ -9,12 +9,11 @@ opts = Optimist.options(ARGV) do
          "Example: #{__FILE__} -d -s 1 -p ems/ems_amazon/additional_instance_types"
 
   opt :dry_run,  "Dry Run",                                                :short => "d"
-  opt :serverid, "Replicating source server Id (default: current server)", :short => "s"
+  opt :serverid, "Replicating source server Id (default: current server)", :short => "s", :type => :integer
   opt :path,     "Replicating source path within advanced settings hash",  :short => "p", :default => ""
 end
 
-puts opts.inspect
 Optimist.die :path, "is required" unless opts[:path_given]
 
-server = opts[:serverid] ? MiqServer.find(opts[:serverid]) : MiqServer.my_server
+server = opts[:serverid_given] ? MiqServer.find(opts[:serverid]) : MiqServer.my_server
 ServerSettingsReplicator.replicate(server, opts[:path], opts[:dry_run])


### PR DESCRIPTION
When providing a server id to replicate_server_settings.rb it is always parsed as 'true' and not as the supplied value.



Steps for Testing/QA [Optional]
-------------------------------

```
./replicate_server_settings.rb -d -s 7 -p company
```
Results in:
```
{:dry_run=>true, :serverid=>true, :path=>"company", :help=>false, :dry_run_given=>true, :serverid_given=>true, :path_given=>true}
Traceback (most recent call last):
        1: from ./replicate_server_settings.rb:19:in `<main>'
/usr/local/lib/ruby/gems/2.5.0/gems/activerecord-5.1.7/lib/active_record/core.rb:189:in `find': Couldn't find MiqServer with 'id'=true (ActiveRecord::RecordNotFound)
```