### PR TITLE
Update MiqQueue so that partials are valid

### DIFF
--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe MiqQueue do
+describe MiqQueue do
   specify { expect(FactoryBot.build(:miq_queue)).to be_valid }
 
   context "#deliver" do
@@ -53,7 +53,7 @@ RSpec.describe MiqQueue do
       expect(result).to be_nil
     end
 
-    it "passes args" do
+    it "passes multiple args" do
       expect(Storage).to receive(:scan_queue).with("1", "2").and_return("WHATEVER")
       msg = MiqQueue.new(:class_name => "Storage", :method_name => "scan_queue", :args => %w[1 2])
 

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -111,8 +111,8 @@ describe MiqQueue do
 
     it "works with MiqQueueRetryLater(deliver_on)" do
       deliver_on = Time.now.utc + 1.minute
-      allow(Storage).to receive(:foobar).and_raise(MiqException::MiqQueueRetryLater.new(:deliver_on => deliver_on))
-      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'Storage', :method_name => 'foobar')
+      allow(Storage).to receive(:ext_management_system).and_raise(MiqException::MiqQueueRetryLater.new(:deliver_on => deliver_on))
+      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'Storage', :method_name => 'ext_management_system')
       status, message, result = msg.deliver
 
       expect(status).to eq(MiqQueue::STATUS_RETRY)
@@ -123,7 +123,7 @@ describe MiqQueue do
       expect(msg.handler).to    be_nil
       expect(msg.deliver_on).to eq(deliver_on)
 
-      allow(Storage).to receive(:foobar).and_raise(MiqException::MiqQueueRetryLater.new)
+      allow(Storage).to receive(:ext_management_system).and_raise(MiqException::MiqQueueRetryLater.new)
       msg.state   = MiqQueue::STATE_DEQUEUE
       msg.handler = @miq_server
       status, _message, _result = msg.deliver
@@ -135,8 +135,8 @@ describe MiqQueue do
 
     it "sets last_exception on raised Exception" do
       ex = StandardError.new("something blewup")
-      allow(MiqServer).to receive(:foobar).and_raise(ex)
-      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'foobar')
+      allow(MiqServer).to receive(:hostname).and_raise(ex)
+      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'hostname')
       expect(msg._log).to receive(:error).with(/Error:/)
       expect(msg._log).to receive(:log_backtrace)
       status, message, _result = msg.deliver
@@ -152,12 +152,12 @@ describe MiqQueue do
       msg = FactoryBot.create(:miq_queue, :state       => MiqQueue::STATE_DEQUEUE,
                                            :handler     => @miq_server,
                                            :class_name  => 'Storage',
-                                           :method_name => 'foobar',
+                                           :method_name => 'ext_management_system',
                                            :user_id     => user.id,
                                            :args        => [1, 2, 3],
                                            :group_id    => user.current_group.id,
                                            :tenant_id   => user.current_tenant.id)
-      expect(Storage).to receive(:foobar) do
+      expect(Storage).to receive(:ext_management_system) do
         expect(User.current_user.name).to eq(user.name)
         expect(User.current_user.current_group.id).to eq(user.current_user.current_group.id)
         expect(User.current_user.current_tenant.id).to eq(user.current_user.current_tenant.id)

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -151,7 +151,7 @@ describe MiqQueue do
                                           :class_name  => 'Storage',
                                           :method_name => 'create_scan_task',
                                           :user_id     => user.id,
-                                          :args        => [1,2,3],
+                                          :args        => [1, 2, 3],
                                           :group_id    => user.current_group.id,
                                           :tenant_id   => user.current_tenant.id)
       expect(Storage).to receive(:create_scan_task) do
@@ -180,23 +180,22 @@ describe MiqQueue do
 
   it "should validate formatting of message for logging" do
     # Add various key/value combos as needs arise...
-    message_parms = [
-      {:target_id    => nil,
-       :priority     => 20,
-       :method_name  => 'perf_rollup_gap',
-       :state        => 'ready',
-       :task_id      => nil,
-       :queue_name   => 'ems_metrics_processor',
-       :class_name   => 'Metric::Rollup',
-       :instance_id  => nil,
-       :args         => [],
-       :zone         => 'default',
-       :role         => 'ems_metrics_processor',
-       :server_guid  => nil,
-       :msg_timeout  => 600,
-       :handler_type => nil
-      }
-    ]
+    message_parms = [{
+      :target_id    => nil,
+      :priority     => 20,
+      :method_name  => 'perf_rollup_gap',
+      :state        => 'ready',
+      :task_id      => nil,
+      :queue_name   => 'ems_metrics_processor',
+      :class_name   => 'Metric::Rollup',
+      :instance_id  => nil,
+      :args         => [],
+      :zone         => 'default',
+      :role         => 'ems_metrics_processor',
+      :server_guid  => nil,
+      :msg_timeout  => 600,
+      :handler_type => nil
+    }]
 
     message_parms.each do |mparms|
       msg = FactoryBot.create(:miq_queue)
@@ -218,23 +217,22 @@ describe MiqQueue do
       "---ems: ems: :address: 16.16.52.50 :hostname: 16.16.52.50 :ipaddress: 16.16.52.50 :username: administrator :password: ******** :class_name: ManageIQ::Providers::Vmware::InfraManager host: :address: 16.16.52.50 :hostname: myhost.redhat.com :ipaddress: 16.16.52.50 :username: root :password: ******** :class_name: ManageIQ::Providers::Vmware::InfraManager::HostEsx connect_to: host snapshot: use_existing: false"
     ]
 
-    message_parms = [
-      {:target_id    => nil,
-       :priority     => 20,
-       :method_name  => 'perf_rollup_gap',
-       :state        => 'ready',
-       :task_id      => nil,
-       :queue_name   => 'ems_metrics_processor',
-       :class_name   => 'Metric::Rollup',
-       :instance_id  => nil,
-       :args         => args_test,
-       :zone         => 'default',
-       :role         => 'ems_metrics_processor',
-       :server_guid  => nil,
-       :msg_timeout  => 600,
-       :handler_type => nil
-      }
-    ]
+    message_parms = [{
+      :target_id    => nil,
+      :priority     => 20,
+      :method_name  => 'perf_rollup_gap',
+      :state        => 'ready',
+      :task_id      => nil,
+      :queue_name   => 'ems_metrics_processor',
+      :class_name   => 'Metric::Rollup',
+      :instance_id  => nil,
+      :args         => args_test,
+      :zone         => 'default',
+      :role         => 'ems_metrics_processor',
+      :server_guid  => nil,
+      :msg_timeout  => 600,
+      :handler_type => nil
+    }]
 
     message_parms.each do |mparms|
       msg = FactoryBot.build(:miq_queue, mparms)
@@ -388,7 +386,7 @@ describe MiqQueue do
         msg = MiqQueue.put(
           :class_name  => "MiqQueueSpecNonArrayArgs",
           :method_name => "some_method",
-          :args        => "not_an_array",
+          :args        => "not_an_array"
         )
 
         msg_from_db = MiqQueue.find(msg.id)
@@ -404,7 +402,7 @@ describe MiqQueue do
     it "defaults :args" do
       msg = MiqQueue.put(
         :class_name  => "Class1",
-        :method_name => "Method1",
+        :method_name => "Method1"
       )
 
       msg_from_db = MiqQueue.find(msg.id)
@@ -414,7 +412,7 @@ describe MiqQueue do
     it "defaults :miq_callback" do
       msg = MiqQueue.put(
         :class_name  => "Class1",
-        :method_name => "Method1",
+        :method_name => "Method1"
       )
 
       msg_from_db = MiqQueue.find(msg.id)
@@ -440,12 +438,12 @@ describe MiqQueue do
     it "creates with :miq_callback via create_with" do
       miq_callback = {
         :class_name  => "Class1",
-        :method_name => "callback_method",
+        :method_name => "callback_method"
       }
 
       msg = MiqQueue.create_with(:miq_callback => miq_callback).put(
         :class_name  => "Class1",
-        :method_name => "Method1",
+        :method_name => "Method1"
       )
 
       msg_from_db = MiqQueue.find(msg.id)
@@ -462,7 +460,7 @@ describe MiqQueue do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
-        :args        => [1, 2],
+        :args        => [1, 2]
       )
       expect(msg.queue_name).to eq("generic")
     end
@@ -481,7 +479,7 @@ describe MiqQueue do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
-        :args        => [1, 2],
+        :args        => [1, 2]
       )
       expect(msg.priority).to eq(MiqQueue::NORMAL_PRIORITY)
     end
@@ -499,7 +497,7 @@ describe MiqQueue do
     it "creates with :prority via create_with" do
       msg = MiqQueue.create_with(:priority => MiqQueue::LOW_PRIORITY).put(
         :class_name  => "Class1",
-        :method_name => "Method1",
+        :method_name => "Method1"
       )
 
       expect(msg.priority).to eq(MiqQueue::LOW_PRIORITY)
@@ -509,7 +507,7 @@ describe MiqQueue do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
-        :args        => [1, 2],
+        :args        => [1, 2]
       )
       expect(msg.role).to eq(nil)
     end
@@ -518,7 +516,7 @@ describe MiqQueue do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
-        :args        => [1, 2],
+        :args        => [1, 2]
       )
       expect(msg.server_guid).to eq(nil)
     end
@@ -527,7 +525,7 @@ describe MiqQueue do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
-        :args        => [1, 2],
+        :args        => [1, 2]
       )
       expect(msg.msg_timeout).to eq(MiqQueue::TIMEOUT)
     end
@@ -545,7 +543,7 @@ describe MiqQueue do
     it "sets :msg_timeout via create_with" do
       msg = MiqQueue.create_with(:msg_timeout => 3.minutes).put(
         :class_name  => "Class1",
-        :method_name => "Method1",
+        :method_name => "Method1"
       )
 
       expect(msg.msg_timeout).to eq(3.minutes)
@@ -555,7 +553,7 @@ describe MiqQueue do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
         :method_name => 'method1',
-        :args        => [1, 2],
+        :args        => [1, 2]
       )
       expect(msg.deliver_on).to eq(nil)
     end
@@ -578,7 +576,7 @@ describe MiqQueue do
 
       msg = MiqQueue.create_with(:deliver_on => deliver_on).put(
         :class_name  => "Class1",
-        :method_name => "Method1",
+        :method_name => "Method1"
       )
 
       msg_from_db = MiqQueue.find(msg.id)
@@ -657,7 +655,7 @@ describe MiqQueue do
     it "should add create_with options" do
       MiqQueue.create_with(:args => [3, 3]).put_unless_exists(
         :class_name  => 'MyClass',
-        :method_name => 'method1',
+        :method_name => 'method1'
       )
 
       expect(MiqQueue.first.args).to eq([3, 3])
@@ -666,12 +664,12 @@ describe MiqQueue do
     it "should not update create_with options" do
       MiqQueue.create_with(:args => [3, 3]).put_unless_exists(
         :class_name  => 'MyClass',
-        :method_name => 'method1',
+        :method_name => 'method1'
       )
 
       MiqQueue.create_with(:args => [1, 2]).put_unless_exists(
         :class_name  => 'MyClass',
-        :method_name => 'method1',
+        :method_name => 'method1'
       )
 
       expect(MiqQueue.first.args).to eq([3, 3])
@@ -841,12 +839,12 @@ describe MiqQueue do
     it "should unqueue a message" do
       msg = MiqQueue.put(
         :class_name  => 'MyClass',
-        :method_name => 'method1',
+        :method_name => 'method1'
       # NOTE: default queue_name, state, zone
       )
       expect(MiqQueue.unqueue(
                :class_name  => 'MyClass',
-               :method_name => 'method1',
+               :method_name => 'method1'
       # NOTE: default queue_name, state, zone
       )).to eq(msg)
     end
@@ -856,7 +854,7 @@ describe MiqQueue do
         :class_name  => 'MyClass',
         :method_name => 'method1',
         :queue_name  => 'other_queue',
-        :zone        => nil,
+        :zone        => nil
       )
       msg.update(:state => MiqQueue::STATE_DEQUEUE)
 
@@ -865,7 +863,7 @@ describe MiqQueue do
                :method_name => 'method1',
                :queue_name  => 'other_queue',
                :zone        => 'myzone', # NOTE: not nil
-               :state       => [MiqQueue::STATE_DEQUEUE, MiqQueue::STATE_READY],
+               :state       => [MiqQueue::STATE_DEQUEUE, MiqQueue::STATE_READY]
       )).to eq(msg)
     end
 
@@ -879,7 +877,7 @@ describe MiqQueue do
 
       expect(MiqQueue.unqueue(
                :class_name  => 'MyClass',
-               :method_name => 'method1',
+               :method_name => 'method1'
       )).to be_nil
     end
   end

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1,4 +1,4 @@
-describe MiqQueue do
+RSpec.describe MiqQueue do
   specify { expect(FactoryBot.build(:miq_queue)).to be_valid }
 
   context "#deliver" do

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -836,17 +836,11 @@ describe MiqQueue do
       EvmSpecHelper.create_guid_miq_server_zone
     end
 
+    # NOTE: default queue_name, state, zone
     it "should unqueue a message" do
-      msg = MiqQueue.put(
-        :class_name  => 'MyClass',
-        :method_name => 'method1'
-      # NOTE: default queue_name, state, zone
-      )
-      expect(MiqQueue.unqueue(
-               :class_name  => 'MyClass',
-               :method_name => 'method1'
-      # NOTE: default queue_name, state, zone
-      )).to eq(msg)
+      msg = MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1')
+
+      expect(MiqQueue.unqueue(:class_name => 'MyClass', :method_name => 'method1')).to eq(msg)
     end
 
     it "should unqueue a message to 'any' zone, other state (when included in a list), and other queue" do
@@ -858,27 +852,23 @@ describe MiqQueue do
       )
       msg.update(:state => MiqQueue::STATE_DEQUEUE)
 
-      expect(MiqQueue.unqueue(
-               :class_name  => 'MyClass',
-               :method_name => 'method1',
-               :queue_name  => 'other_queue',
-               :zone        => 'myzone', # NOTE: not nil
-               :state       => [MiqQueue::STATE_DEQUEUE, MiqQueue::STATE_READY]
-      )).to eq(msg)
+      expect(
+        MiqQueue.unqueue(
+          :class_name  => 'MyClass',
+          :method_name => 'method1',
+          :queue_name  => 'other_queue',
+          :zone        => 'myzone', # NOTE: not nil
+          :state       => [MiqQueue::STATE_DEQUEUE, MiqQueue::STATE_READY]
+        )
+      ).to eq(msg)
     end
 
     it "should not unqueue a message from a different zone" do
       zone = FactoryBot.create(:zone)
-      MiqQueue.put(
-        :class_name  => 'MyClass',
-        :method_name => 'method1',
-        :zone        => zone.name
-      )
 
-      expect(MiqQueue.unqueue(
-               :class_name  => 'MyClass',
-               :method_name => 'method1'
-      )).to be_nil
+      MiqQueue.put(:class_name => 'MyClass', :method_name => 'method1', :zone => zone.name)
+
+      expect(MiqQueue.unqueue(:class_name => 'MyClass', :method_name => 'method1')).to be_nil
     end
   end
 
@@ -889,17 +879,13 @@ describe MiqQueue do
     end
 
     it "should default the queue name" do
-      expect(described_class.send(:default_get_options, {}
-                                 )).to include(
-                                   :queue_name => MiqQueue::DEFAULT_QUEUE
-                                 )
+      expect(described_class.send(:default_get_options, {})).to include(:queue_name => MiqQueue::DEFAULT_QUEUE)
     end
 
     it "should default the queue name and others" do
-      expect(described_class.send(
-               :default_get_options,
-               :other_key => "x"
-      )).to include(
+      expect(
+        described_class.send(:default_get_options, :other_key => "x")
+      ).to include(
         :queue_name => MiqQueue::DEFAULT_QUEUE,
         :other_key  => "x",
         :state      => MiqQueue::STATE_READY,
@@ -908,12 +894,9 @@ describe MiqQueue do
     end
 
     it "should override the queue name" do
-      expect(described_class.send(
-               :default_get_options,
-               :queue_name => "non_generic"
-      )).to include(
-        :queue_name => "non_generic"
-      )
+      expect(
+        described_class.send(:default_get_options, :queue_name => "non_generic")
+      ).to include(:queue_name => "non_generic")
     end
   end
 

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -147,13 +147,13 @@ describe MiqQueue do
     it "sets the User.current_user" do
       user = FactoryBot.create(:user_with_group, :name => 'Freddy Kreuger')
       msg = FactoryBot.create(:miq_queue, :state       => MiqQueue::STATE_DEQUEUE,
-                                           :handler     => @miq_server,
-                                           :class_name  => 'Storage',
-                                           :method_name => 'create_scan_task',
-                                           :user_id     => user.id,
-                                           :args        => [1,2,3],
-                                           :group_id    => user.current_group.id,
-                                           :tenant_id   => user.current_tenant.id)
+                                          :handler     => @miq_server,
+                                          :class_name  => 'Storage',
+                                          :method_name => 'create_scan_task',
+                                          :user_id     => user.id,
+                                          :args        => [1,2,3],
+                                          :group_id    => user.current_group.id,
+                                          :tenant_id   => user.current_tenant.id)
       expect(Storage).to receive(:create_scan_task) do
         expect(User.current_user.name).to eq(user.name)
         expect(User.current_user.current_group.id).to eq(user.current_user.current_group.id)


### PR DESCRIPTION
The MiqQueue specs currently are using `:foobar` for some partials in cases, or invalid arguments in others. The problem is that this breaks  strict partial validation. Since the actual method is mostly irrelevant we can safely use a real method instead of a made up one. It's probably more of a valid test anyway.

In a couple places I switched `MiqServer` with `Storage` in order to get access to singleton methods that would help preserve the original spirit of the tests.

I also fixed up most of the rubocop warnings while I was here, mostly trailing commas and parens alignment.