### PR TITLE
Remove `aws-sdk-ec2` dependency from core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem "activerecord-virtual_attributes", "~>1.4.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false
-gem "aws-sdk-ec2",                    "~>1.0",         :require => false # For FileDepotS3
 gem "aws-sdk-s3",                     "~>1.0",         :require => false # For FileDepotS3
 gem "bcrypt",                         "~> 3.1.10",     :require => false
 gem "bundler",                        ">=1.15",        :require => false

--- a/app/models/file_depot_s3.rb
+++ b/app/models/file_depot_s3.rb
@@ -36,9 +36,9 @@ class FileDepotS3 < FileDepot
   def verify_credentials(auth_type = nil, options = {})
 
     connection_rescue_block do
-      # EC2 does Lazy Connections, so call a cheap function
-      with_depot_connection(options.merge(:auth_type => auth_type)) do |ec2|
-        validate_connection(ec2)
+      # aws-sdk does Lazy Connections, so call a cheap function
+      with_depot_connection(options.merge(:auth_type => auth_type)) do |s3|
+        validate_connection(s3)
       end
     end
 
@@ -63,12 +63,12 @@ class FileDepotS3 < FileDepot
   end
 
   def translate_exception(err)
-    require 'aws-sdk-ec2'
+    require 'aws-sdk-s3'
 
     case err
-    when Aws::EC2::Errors::SignatureDoesNotMatch
+    when Aws::S3::Errors::SignatureDoesNotMatch
       MiqException::MiqHostError.new("SignatureMismatch - check your AWS Secret Access Key and signing method")
-    when Aws::EC2::Errors::AuthFailure
+    when Aws::S3::Errors::AuthFailure
       MiqException::MiqHostError.new("Login failed due to a bad username or password.")
     when Aws::Errors::MissingCredentialsError
       MiqException::MiqHostError.new("Missing credentials")


### PR DESCRIPTION
In short, a lot of the rational for this can be found in the first commit message.

But effectively, if we are always using the `Aws::S3` module code, the code for [`Aws::Errors::DynamicErrors`][1] should be what we are getting for as the errors for invalid S3 credentials and whatnot.

I might do some more `git-spelunking` to determine where these errors might have come from prior to the use of `DynamicErrors`.


Links
-----

* Related PR:  https://github.com/ManageIQ/manageiq/pull/19436


[1]: https://github.com/aws/aws-sdk-ruby/blob/354d36792e47f2e81b4889f322928e848e062818/gems/aws-sdk-core/lib/aws-sdk-core/errors.rb#L237-L249