### PR TITLE
Add AuthenticationMixin to Vm

### DIFF
--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -6,6 +6,7 @@ class Vm < VmOrTemplate
   include CustomActionsMixin
   include CiFeatureMixin
   include ExternalUrlMixin
+  include AuthenticationMixin
 
   include_concern 'Operations'
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -416,7 +416,7 @@ RSpec.describe ConversionHost, :v2v do
     end
 
     it "finds the credentials associated with the resource if credentials cannot be found for the conversion host" do
-      vm.ext_management_system.authentications << auth_default
+      vm.authentications << auth_default
       host.authentications << auth_default
       expect(conversion_host_vm.send(:find_credentials)).to eq(auth_default)
       expect(conversion_host_host.send(:find_credentials)).to eq(auth_default)


### PR DESCRIPTION
Today, the `ConversionHost` includes the `AuthenticationMixin` mixin to perform authentication check. The `ConversionHost` is associated to a resource: a `Host` or a `Vm`. The `Host` class also includes the `AuthenticationMixin` mixin. It seems logical that the `Vm` could also have authentications and that `ConversionHost` delegates authentication related code to its resource.

This would also allow other use cases for VM authentication, such as Ansible playbooks. If the VM class includes the `AuthenticationMixin` mixin, it allows us to define many purposes authentication. One of them would be `transformation` (or `v2v`) for VMs acting as conversion hosts. Another one could be `ansible` to store the machine credentials along with the managed object.