### PR TITLE
Return MiqTask id from MiqWidget.queue_generate_content

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -206,13 +206,14 @@ class MiqWidget < ApplicationRecord
       unless MiqTask.exists?(:name   => "Generate Widget: '#{title}'",
                              :userid => User.current_userid || 'system',
                              :state  => %w(Queued Active))
-        create_task(group_hash.length)
+        task = create_task(group_hash.length)
 
         _log.info("#{log_prefix} Queueing Content Generation")
         group_hash.each do |g, u|
           options = generate_content_options(g, u)
           queue_generate_content_for_users_or_group(*options)
         end
+        task.id
       end
     end
   end

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -318,6 +318,12 @@ describe MiqWidget do
       }
     end
 
+    it "returns MiqTask id if successful" do
+      return_value = @widget.queue_generate_content
+      expect(return_value).to equal(MiqTask.where(:name => "Generate Widget: '#{@widget.title}'",
+                                                  :id   => @widget.reload.miq_task_id).first.id)
+    end
+
     it "for groups without visibility" do
       expect(@widget).to receive(:queue_generate_content_for_users_or_group).once
       @widget.queue_generate_content


### PR DESCRIPTION
Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/6334

BZ https://bugzilla.redhat.com/show_bug.cgi?id=1703068

I need `MiqWidget.queue_generate_content` to return id of created `MiqTask` so I can wait for it to be done before refreshing the UI part.

@miq-bot add_label ivanchuk/no, enhancement

@lpichler This is really quick fix that works for me. Any input? Thanks :)