### PR TITLE
[HAMMER] In active_record 5.0 join_keys takes a klass argument

### DIFF
--- a/tools/cleanup_duplicate_host_guest_devices.rb
+++ b/tools/cleanup_duplicate_host_guest_devices.rb
@@ -56,7 +56,7 @@ guest_devices_to_delete.each_slice(opts[:page_size]).with_index do |slice, index
 
   dependents.each do |assoc|
     delete_meth = assoc.options[:dependent]
-    foreign_key = assoc.join_keys.key
+    foreign_key = assoc.join_keys(assoc.klass).key
 
     if %i[delete destroy].include?(delete_meth)
       assoc.klass.where(foreign_key => slice).send("#{delete_meth}_all")


### PR DESCRIPTION
In active_record 5.1 join_keys takes no arguments [0] but in 5.0 it takes a required klass argument [1].

[0] https://apidock.com/rails/v5.1.7/ActiveRecord/Reflection/AbstractReflection/join_keys
[1] https://apidock.com/rails/ActiveRecord/Reflection/BelongsToReflection/join_keys

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1757026