### PR TITLE
Cap&U Extract logic to determine queue items

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -204,13 +204,8 @@ module Metric::Capture
 
     targets.each do |target|
       interval_name = perf_target_to_interval_name(target)
-
       options = target_options[target]
-
       target.perf_capture_queue(interval_name, options)
-      if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
-        target.perf_capture_queue('historical')
-      end
     rescue => err
       _log.warn("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
     end

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -207,14 +207,12 @@ module Metric::Capture
 
       options = target_options[target]
 
-      begin
-        target.perf_capture_queue(interval_name, options)
-        if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
-          target.perf_capture_queue('historical')
-        end
-      rescue => err
-        _log.warn("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
+      target.perf_capture_queue(interval_name, options)
+      if !target.kind_of?(Storage) && use_historical && target.last_perf_capture_on.nil?
+        target.perf_capture_queue('historical')
       end
+    rescue => err
+      _log.warn("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")
     end
   end
   private_class_method :queue_captures

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -20,11 +20,6 @@ module Metric::Capture
     historical_days.days.ago.utc.beginning_of_day
   end
 
-  def self.targets_archived_from
-    archived_for_setting = Settings.performance.targets.archived_for
-    archived_for_setting.to_i_with_method.seconds.ago.utc
-  end
-
   def self.concurrent_requests(interval_name)
     requests = ::Settings.performance.concurrent_requests[interval_name]
     requests = 20 if requests < 20 && interval_name == 'realtime'

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -57,7 +57,13 @@ module Metric::CiMixin::Capture
       realtime_cut_off = 4.hours.ago.utc.beginning_of_day
       items =
         if last_perf_capture_on.nil?
-          [[interval_name, realtime_cut_off]]
+          # for initial refresh of non-Storage objects, also go back historically
+          if !kind_of?(Storage) && Metric::Capture.historical_days != 0
+            [[interval_name, realtime_cut_off]] +
+              split_capture_intervals("historical", Metric::Capture.historical_start_time, 1.day.from_now.utc.beginning_of_day)
+          else
+            [[interval_name, realtime_cut_off]]
+          end
         elsif last_perf_capture_on < realtime_cut_off
           [[interval_name, realtime_cut_off]] +
             split_capture_intervals("historical", last_perf_capture_on, realtime_cut_off)

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -45,7 +45,7 @@ module Metric::CiMixin::Capture
 
     # Determine the items to queue up
     # cb is the task used to group cluster realtime metrics
-    cb = nil
+    cb = {:class_name => self.class.name, :instance_id => id, :method_name => :perf_capture_callback, :args => [[task_id]]} if task_id && interval_name == 'realtime'
     if interval_name == 'historical'
       start_time = Metric::Capture.historical_start_time if start_time.nil?
       end_time ||= 1.day.from_now.utc.beginning_of_day # Ensure no more than one historical collection is queue up in the same day
@@ -70,8 +70,6 @@ module Metric::CiMixin::Capture
         else
           [interval_name]
         end
-
-      cb = {:class_name => self.class.name, :instance_id => id, :method_name => :perf_capture_callback, :args => [[task_id]]} if task_id
     end
 
     # Queue up the actual items

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -28,8 +28,8 @@ module Metric::CiMixin::Capture
   private :split_capture_intervals
 
   def perf_capture_queue(interval_name, options = {})
-    start_time = options[:start_time]
-    end_time   = options[:end_time]
+    start_time = options[:start_time]&.utc
+    end_time   = options[:end_time]&.utc
     priority   = options[:priority] || Metric::Capture.const_get("#{interval_name.upcase}_PRIORITY")
     task_id    = options[:task_id]
     zone       = options[:zone] || my_zone
@@ -39,9 +39,6 @@ module Metric::CiMixin::Capture
     raise ArgumentError, "invalid interval_name '#{interval_name}'" unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
     raise ArgumentError, "end_time cannot be specified if start_time is nil" if start_time.nil? && !end_time.nil?
     raise ArgumentError, "target does not have an ExtManagementSystem" if ems.nil?
-
-    start_time = start_time.utc unless start_time.nil?
-    end_time = end_time.utc unless end_time.nil?
 
     # Determine the items to queue up
     # cb is the task used to group cluster realtime metrics

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -8,6 +8,11 @@ module Metric::Targets
     MiqRegion.my_region.perf_capture_always = options
   end
 
+  def self.targets_archived_from
+    archived_for_setting = Settings.performance.targets.archived_for
+    archived_for_setting.to_i_with_method.seconds.ago.utc
+  end
+
   def self.capture_ems_targets(ems, options = {})
     case ems
     when EmsCloud                                then capture_cloud_targets([ems], options)
@@ -49,7 +54,7 @@ module Metric::Targets
 
   def self.with_archived(scope)
     # We will look also for freshly archived entities, if the entity was short-lived or even sub-hour
-    archived_from = Metric::Capture.targets_archived_from
+    archived_from = targets_archived_from
     scope.where(:deleted_on => nil).or(scope.where(:deleted_on => (archived_from..Time.now.utc)))
   end
 


### PR DESCRIPTION
Now, only call `perf_capture_queue` a single time:

- following the flow is easier
- tests are easier to write since they don't deal with the external edge case.
- can move `perf_capture_queue` from `ci_mixin/capture.rb` to `metrics/capture.rb`:
  - reduced the number of methods in `VMs` and others.
  - centralizes collection logic in a single set of objects
  - allows us to make ems optimizations since we can reduce the number of lookups
  - allows us to make ems specific changes