### PR TITLE
Disable bundling rubies less than 2.5.3 on master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-raise "Ruby versions < 2.4.0 are unsupported!" if RUBY_VERSION < "2.4.0"
+raise "Ruby versions < 2.5.3 are unsupported!" if RUBY_VERSION < "2.5.3"
 raise "Ruby versions >= 2.7.0 are unsupported!" if RUBY_VERSION >= "2.7.0"
 
 source 'https://rubygems.org'


### PR DESCRIPTION
http://talk.manageiq.org/t/developers-install-the-latest-ruby-2-5-and-2-6-versions-for-use-on-master/4604