### PR TITLE
Enable workers as containers

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -95,6 +95,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def check_not_responding(class_name = nil)
+    return [] if MiqEnvironment::Command.is_podified?
     processed_workers = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -96,6 +96,7 @@ module MiqServer::WorkerManagement::Monitor
 
   def check_not_responding(class_name = nil)
     return [] if MiqEnvironment::Command.is_podified?
+
     processed_workers = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)

--- a/app/models/miq_server/worker_management/monitor/system_limits.rb
+++ b/app/models/miq_server/worker_management/monitor/system_limits.rb
@@ -9,11 +9,13 @@ module MiqServer::WorkerManagement::Monitor::SystemLimits
   }
 
   def kill_workers_due_to_resources_exhausted?
+    return false if MiqEnvironment::Command.is_podified?
     options = worker_monitor_settings[:kill_algorithm].merge(:type => :kill)
     invoke_algorithm(options)
   end
 
   def enough_resource_to_start_worker?(worker_class)
+    return true if MiqEnvironment::Command.is_podified?
     # HACK, sync_config is done in the server, while this method is called from miq_worker
     # This method should move to the worker and the server should pass the settings.
     sync_config if worker_monitor_settings.nil? || child_worker_settings.nil?

--- a/app/models/miq_server/worker_management/monitor/system_limits.rb
+++ b/app/models/miq_server/worker_management/monitor/system_limits.rb
@@ -10,12 +10,14 @@ module MiqServer::WorkerManagement::Monitor::SystemLimits
 
   def kill_workers_due_to_resources_exhausted?
     return false if MiqEnvironment::Command.is_podified?
+
     options = worker_monitor_settings[:kill_algorithm].merge(:type => :kill)
     invoke_algorithm(options)
   end
 
   def enough_resource_to_start_worker?(worker_class)
     return true if MiqEnvironment::Command.is_podified?
+
     # HACK, sync_config is done in the server, while this method is called from miq_worker
     # This method should move to the worker and the server should pass the settings.
     sync_config if worker_monitor_settings.nil? || child_worker_settings.nil?

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -2,6 +2,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
   extend ActiveSupport::Concern
 
   def validate_worker(w)
+    return true if MiqEnvironment::Command.is_podified?
     time_threshold   = get_time_threshold(w)
     memory_threshold = get_memory_threshold(w)
 

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -3,6 +3,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
 
   def validate_worker(w)
     return true if MiqEnvironment::Command.is_podified?
+
     time_threshold   = get_time_threshold(w)
     memory_threshold = get_memory_threshold(w)
 

--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -31,6 +31,6 @@ class MiqUiWorker < MiqWorker
   end
 
   def container_image_name
-    "manageiq/manageiq-ui-worker"
+    "manageiq-ui-worker"
   end
 end

--- a/app/models/miq_ui_worker/runner.rb
+++ b/app/models/miq_ui_worker/runner.rb
@@ -1,3 +1,8 @@
 class MiqUiWorker::Runner < MiqWorker::Runner
   include MiqWebServerRunnerMixin
+
+  def prepare
+    super
+    MiqApache::Control.start if MiqEnvironment::Command.is_podified?
+  end
 end

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -358,8 +358,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.containerized_worker?
-    # un-rearch containers until further notice
-    return false
+    MiqEnvironment::Command.is_podified? && supports_container?
   end
 
   def containerized_worker?
@@ -527,6 +526,8 @@ class MiqWorker < ApplicationRecord
   end
 
   def status_update
+    return if MiqEnvironment::Command.is_podified?
+
     begin
       pinfo = MiqProcess.processInfo(pid)
     rescue Errno::ESRCH

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -48,6 +48,7 @@ class MiqWorker < ApplicationRecord
 
   def self.workers
     return (self.has_minimal_env_option? ? 1 : 0) if MiqServer.minimal_env? && check_for_minimal_role
+    return 0 unless has_required_role?
     return @workers.call if @workers.kind_of?(Proc)
     return @workers unless @workers.nil?
     workers_configured_count
@@ -137,7 +138,7 @@ class MiqWorker < ApplicationRecord
   def self.sync_workers
     w       = include_stopping_workers_on_synchronize ? find_alive : find_current_or_starting
     current = w.length
-    desired = self.has_required_role? ? workers : 0
+    desired = workers
     result  = {:adds => [], :deletes => []}
 
     if current != desired

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -14,8 +14,8 @@ class MiqWorker
     end
 
     def scale_deployment
-      ContainerOrchestrator.new.scale(worker_deployment_name, self.class.workers_configured_count)
-      delete_container_objects if self.class.workers_configured_count.zero?
+      ContainerOrchestrator.new.scale(worker_deployment_name, self.class.workers)
+      delete_container_objects if self.class.workers.zero?
     end
 
     def container_image_namespace

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -9,7 +9,7 @@ class MiqWorker
       definition[:spec][:template][:spec][:terminationGracePeriodSeconds] = self.class.worker_settings[:stopping_timeout].seconds
 
       container = definition[:spec][:template][:spec][:containers].first
-      container[:image] = "#{container_image_name}:#{container_image_tag}"
+      container[:image] = "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
       container[:env] << {:name => "WORKER_CLASS_NAME", :value => self.class.name}
     end
 
@@ -18,8 +18,12 @@ class MiqWorker
       delete_container_objects if self.class.workers_configured_count.zero?
     end
 
+    def container_image_namespace
+      ENV["CONTAINER_IMAGE_NAMESPACE"]
+    end
+
     def container_image_name
-      "manageiq/manageiq-base-worker"
+      "manageiq-base-worker"
     end
 
     def container_image_tag

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -47,7 +47,7 @@ class MiqWorker
 
     # Can be overriden by including classes
     def container_image_name
-      "manageiq/manageiq-webserver-worker"
+      "manageiq-webserver-worker"
     end
   end
 end

--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -55,7 +55,7 @@ module MiqWebServerWorkerMixin
 
       workers = find_current_or_starting
       current = workers.length
-      desired = self.has_required_role? ? self.workers : 0
+      desired = self.workers
       result  = {:adds => [], :deletes => []}
       ports = all_ports_in_use
 

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -58,15 +58,11 @@ class ContainerOrchestrator
 
     def default_environment
       [
-        {:name => "ARTEMIS_USER",            :value => ENV["ARTEMIS_USER"]},
-        {:name => "DATABASE_SERVICE_NAME",   :value => ENV["DATABASE_SERVICE_NAME"]},
         {:name => "GUID",                    :value => MiqServer.my_guid},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
-        {:name      => "ARTEMIS_PASSWORD",
-         :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "artemis-password"}}},
         {:name      => "DATABASE_URL",
          :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "database-url"}}},
         {:name      => "V2_KEY",


### PR DESCRIPTION
This PR reverts the commit which disabled workers to be run as containers in OpenShift.

It also removes some information around artemis which is no longer planned to be used and fixes some additional bugs.

Notably it changes the `MiqWorker.workers` method to return a count of 0 when we are missing a required role for the specific worker type. Previously this method would return the configured type regardless of the roles on the server. In OpenShift, this will allow us to scale down workers