### PR TITLE
Extract raw_* vm operations to providers

### DIFF
--- a/app/models/vm/operations/guest.rb
+++ b/app/models/vm/operations/guest.rb
@@ -12,46 +12,42 @@ module Vm::Operations::Guest
   end
 
   def raw_shutdown_guest
-    unless has_active_ems?
-      raise _("VM has no Provider, unable to shutdown guest OS")
-    end
-    run_command_via_parent(:vm_shutdown_guest)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def shutdown_guest
+    raise _("VM has no Provider, unable to shutdown guest OS") unless has_active_ems?
+
     check_policy_prevent(:request_vm_shutdown_guest, :raw_shutdown_guest)
   end
 
   def raw_standby_guest
-    unless has_active_ems?
-      raise _("VM has no Provider, unable to standby guest OS")
-    end
-    run_command_via_parent(:vm_standby_guest)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def standby_guest
+    raise _("VM has no Provider, unable to standby guest OS") unless has_active_ems?
+
     check_policy_prevent(:request_vm_standby_guest, :raw_standby_guest)
   end
 
   def raw_reboot_guest
-    unless has_active_ems?
-      raise _("VM has no Provider, unable to reboot guest OS")
-    end
-    run_command_via_parent(:vm_reboot_guest)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def reboot_guest
+    raise _("VM has no Provider, unable to reboot guest OS") unless has_active_ems?
+
     check_policy_prevent(:request_vm_reboot_guest, :raw_reboot_guest)
   end
 
   def raw_reset
-    unless has_active_ems?
-      raise _("VM has no Provider, unable to reset VM")
-    end
-    run_command_via_parent(:vm_reset)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def reset
+    raise _("VM has no Provider, unable to reset VM") unless has_active_ems?
+
     check_policy_prevent(:request_vm_reset, :raw_reset)
   end
 end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -317,15 +317,6 @@ class VmOrTemplate < ApplicationRecord
     current_state == 'terminated'
   end
 
-  def raw_set_custom_field(attribute, value)
-    raise _("VM has no EMS, unable to set custom attribute") unless ext_management_system
-    run_command_via_parent(:vm_set_custom_field, :attribute => attribute, :value => value)
-  end
-
-  def set_custom_field(attribute, value)
-    raw_set_custom_field(attribute, value)
-  end
-
   def makesmart(_options = {})
     self.smart = true
     save

--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -10,68 +10,62 @@ module VmOrTemplate::Operations
   alias_method :ruby_clone, :clone
 
   def raw_clone(name, folder, pool = nil, host = nil, datastore = nil, powerOn = false, template_flag = false, transform = nil, config = nil, customization = nil, disk = nil)
-    raise _("VM has no EMS, unable to clone") unless ext_management_system
-    folder_mor    = folder.ems_ref_obj    if folder.respond_to?(:ems_ref_obj)
-    pool_mor      = pool.ems_ref_obj      if pool.respond_to?(:ems_ref_obj)
-    host_mor      = host.ems_ref_obj      if host.respond_to?(:ems_ref_obj)
-    datastore_mor = datastore.ems_ref_obj if datastore.respond_to?(:ems_ref_obj)
-    run_command_via_parent(:vm_clone, :name => name, :folder => folder_mor, :pool => pool_mor, :host => host_mor, :datastore => datastore_mor, :powerOn => powerOn, :template => template_flag, :transform => transform, :config => config, :customization => customization, :disk => disk)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def clone(name, folder, pool = nil, host = nil, datastore = nil, powerOn = false, template_flag = false, transform = nil, config = nil, customization = nil, disk = nil)
+    raise _("VM has no EMS, unable to clone") unless ext_management_system
+
     raw_clone(name, folder, pool, host, datastore, powerOn, template_flag, transform, config, customization, disk)
   end
 
   def raw_mark_as_template
-    raise _("VM has no EMS, unable to mark as template") unless ext_management_system
-    run_command_via_parent(:vm_mark_as_template)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def mark_as_template
+    raise _("VM has no EMS, unable to mark as template") unless ext_management_system
+
     raw_mark_as_template
   end
 
   def raw_mark_as_vm(pool, host = nil)
-    raise _("VM has no EMS, unable to mark as vm") unless ext_management_system
-    pool_mor = pool.ems_ref_obj if pool.respond_to?(:ems_ref_obj)
-    host_mor = host.ems_ref_obj if host.respond_to?(:ems_ref_obj)
-    run_command_via_parent(:vm_mark_as_vm, :pool => pool_mor, :host => host_mor)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def mark_as_vm(pool, host = nil)
+    raise _("VM has no EMS, unable to mark as vm") unless ext_management_system
+
     raw_mark_as_vm(pool, host)
   end
 
   def raw_unregister
-    unless ext_management_system
-      raise _("VM has no Provider, unable to unregister VM")
-    end
-    run_command_via_parent(:vm_unregister)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def unregister
+    raise _("VM has no Provider, unable to unregister VM") unless ext_management_system
+
     check_policy_prevent(:request_vm_unregister, :raw_unregister)
   end
 
   def raw_destroy
-    unless ext_management_system
-      raise _("VM has no Provider, unable to destroy VM")
-    end
-    run_command_via_parent(:vm_destroy)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def vm_destroy
+    raise _("VM has no Provider, unable to destroy VM") unless ext_management_system
+
     check_policy_prevent(:request_vm_destroy, :raw_destroy)
   end
 
   def raw_rename(new_name)
-    unless ext_management_system
-      raise _("VM has no Provider, unable to rename VM")
-    end
-    run_command_via_parent(:vm_rename, :new_name => new_name)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def rename(new_name)
+    raise _("VM has no Provider, unable to rename VM") unless ext_management_system
+
     raw_rename(new_name)
   end
 
@@ -91,6 +85,16 @@ module VmOrTemplate::Operations
     }
 
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def raw_set_custom_field(_attribute, _value)
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
+  def set_custom_field(attribute, value)
+    raise _("VM has no EMS, unable to set custom attribute") unless ext_management_system
+
+    raw_set_custom_field(attribute, value)
   end
 
   private

--- a/app/models/vm_or_template/operations/configuration.rb
+++ b/app/models/vm_or_template/operations/configuration.rb
@@ -1,126 +1,132 @@
 module VmOrTemplate::Operations::Configuration
   def raw_set_memory(mb)
-    raise _("VM has no EMS, unable to reconfigure memory") unless ext_management_system
-    run_command_via_parent(:vm_set_memory, :value => mb)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def set_memory(mb)
+    raise _("VM has no EMS, unable to reconfigure memory") unless ext_management_system
+
     raw_set_memory(mb)
   end
 
   def raw_set_number_of_cpus(num)
-    raise _("VM has no EMS, unable to reconfigure CPUs") unless ext_management_system
-    run_command_via_parent(:vm_set_num_cpus, :value => num)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def set_number_of_cpus(num)
+    raise _("VM has no EMS, unable to reconfigure CPUs") unless ext_management_system
+
     raw_set_number_of_cpus(num)
   end
 
   def raw_connect_all_devices
-    raise _("VM has no EMS, unable to connect all devices") unless ext_management_system
-    run_command_via_parent(:vm_connect_all)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def connect_all_devices
+    raise _("VM has no EMS, unable to connect all devices") unless ext_management_system
+
     raw_connect_all_devices
   end
 
   def raw_disconnect_all_devices
-    raise _("VM has no EMS, unable to disconnect all devices") unless ext_management_system
-    run_command_via_parent(:vm_disconnect_all)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def disconnect_all_devices
+    raise _("VM has no EMS, unable to disconnect all devices") unless ext_management_system
+
     raw_disconnect_all_devices
   end
 
   def raw_connect_cdroms
-    raise _("VM has no EMS, unable to connect CD-ROM devices") unless ext_management_system
-    run_command_via_parent(:vm_connect_cdrom)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def connect_cdroms
+    raise _("VM has no EMS, unable to connect CD-ROM devices") unless ext_management_system
+
     raw_connect_cdroms
   end
 
   def raw_disconnect_cdroms
-    raise _("VM has no EMS, unable to disconnect CD-ROM devices") unless ext_management_system
-    run_command_via_parent(:vm_disconnect_cdrom)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def disconnect_cdroms
+    raise _("VM has no EMS, unable to disconnect CD-ROM devices") unless ext_management_system
+
     raw_disconnect_cdroms
   end
 
   def raw_connect_floppies
-    raise _("VM has no EMS, unable to connect Floppy devices") unless ext_management_system
-    run_command_via_parent(:vm_connect_floppy)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def connect_floppies
+    raise _("VM has no EMS, unable to connect Floppy devices") unless ext_management_system
+
     raw_connect_floppies
   end
 
   def raw_disconnect_floppies
-    raise _("VM has no EMS, unable to disconnect Floppy devices") unless ext_management_system
-    run_command_via_parent(:vm_disconnect_floppy)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def disconnect_floppies
+    raise _("VM has no EMS, unable to disconnect Floppy devices") unless ext_management_system
+
     raw_disconnect_floppies
   end
 
   def raw_add_disk(disk_name, disk_size_mb, options = {})
-    raise _("VM has no EMS, unable to add disk") unless ext_management_system
-    if options[:datastore]
-      datastore = ext_management_system.hosts.collect do |h|
-        h.writable_accessible_storages.find_by(:name => options[:datastore])
-      end.uniq.compact.first
-      raise _("Datastore does not exist or cannot be accessed, unable to add disk") unless datastore
-    end
-
-    run_command_via_parent(:vm_add_disk, :diskName => disk_name, :diskSize => disk_size_mb,
-        :thinProvisioned => options[:thin_provisioned], :dependent => options[:dependent],
-        :persistent => options[:persistent], :bootable => options[:bootable], :datastore => datastore,
-        :interface => options[:interface])
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def add_disk(disk_name, disk_size_mb, options = {})
+    raise _("VM has no EMS, unable to add disk") unless ext_management_system
+
     raw_add_disk(disk_name, disk_size_mb, options)
   end
 
   def raw_remove_disk(disk_name, options = {})
-    raise _("VM has no EMS, unable to remove disk") unless ext_management_system
-
-    options[:delete_backing] = true if options[:delete_backing].nil?
-    run_command_via_parent(:vm_remove_disk, :diskName => disk_name, :delete_backing => options[:delete_backing])
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def remove_disk(disk_name, options = {})
+    raise _("VM has no EMS, unable to remove disk") unless ext_management_system
+
     raw_remove_disk(disk_name, options)
   end
 
   def raw_attach_volume(volume_id, device = nil)
-    raise _("VM has no EMS, unable to attach volume") unless ext_management_system
-    run_command_via_parent(:vm_attach_volume, :volume_id => volume_id, :device => device)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def attach_volume(volume_id, device = nil)
+    raise _("VM has no EMS, unable to attach volume") unless ext_management_system
+
     raw_attach_volume(volume_id, device)
   end
 
   def raw_detach_volume(volume_id)
-    raise _("VM has no EMS, unable to detach volume") unless ext_management_system
-    run_command_via_parent(:vm_detach_volume, :volume_id => volume_id)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def detach_volume(volume_id, device = nil)
+    raise _("VM has no EMS, unable to detach volume") unless ext_management_system
+
     raw_detach_volume(volume_id)
   end
 
-  def spec_reconfigure(spec)
-    raise _("VM has no EMS, unable to apply reconfigure spec") unless ext_management_system
-    run_command_via_parent(:vm_reconfigure, :spec => spec)
+  def raw_reconfigure
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
+
+  def reconfigure(spec)
+    raise _("VM has no EMS, unable to apply reconfigure spec") unless ext_management_system
+
+    raw_reconfigure(spec)
+  end
+  alias spec_reconfigure reconfigure
 end

--- a/app/models/vm_or_template/operations/power.rb
+++ b/app/models/vm_or_template/operations/power.rb
@@ -1,6 +1,6 @@
 module VmOrTemplate::Operations::Power
   def raw_start
-    run_command_via_parent(:vm_start)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def start
@@ -8,7 +8,7 @@ module VmOrTemplate::Operations::Power
   end
 
   def raw_stop
-    run_command_via_parent(:vm_stop)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def stop
@@ -17,7 +17,7 @@ module VmOrTemplate::Operations::Power
 
   # Suspend saves the state of the VM to disk and shuts it down
   def raw_suspend
-    run_command_via_parent(:vm_suspend)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def suspend
@@ -26,7 +26,7 @@ module VmOrTemplate::Operations::Power
 
   # All associated data and resources are kept but anything still in memory is not retained.
   def raw_shelve
-    run_command_via_parent(:vm_shelve)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def shelve
@@ -35,7 +35,7 @@ module VmOrTemplate::Operations::Power
 
   # Has to be in shelved state first. Data and resource associations are deleted.
   def raw_shelve_offload
-    run_command_via_parent(:vm_shelve_offload)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def shelve_offload
@@ -45,7 +45,7 @@ module VmOrTemplate::Operations::Power
   # Pause keeps the VM in memory but does not give it CPU cycles.
   # Not supported in VMware, so it is the same as suspend
   def raw_pause
-    run_command_via_parent(:vm_pause)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def pause

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -32,82 +32,37 @@ module VmOrTemplate::Operations::Relocation
   end
 
   def raw_migrate(host, pool = nil, priority = "defaultPriority", state = nil)
-    raise _("VM has no EMS, unable to migrate VM") unless ext_management_system
-    raise _("Host not specified, unable to migrate VM") unless host.kind_of?(Host)
-
-    if pool.nil?
-      pool = host.default_resource_pool || (host.ems_cluster && host.ems_cluster.default_resource_pool)
-      unless pool.kind_of?(ResourcePool)
-        raise _("Default Resource Pool for Host <%{name}> not found, unable to migrate VM") % {:name => host.name}
-      end
-    else
-      unless pool.kind_of?(ResourcePool)
-        raise _("Specified Resource Pool <%{pool_name}> for Host <%{name}> is invalid, unable to migrate VM") %
-                {:pool_name => pool.inspect, :name => host.name}
-      end
-    end
-
-    if host_id == host.id
-      raise _("The VM '%{name}' can not be migrated to the same host it is already running on.") % {:name => name}
-    end
-
-    host_mor = host.ems_ref_obj
-    pool_mor = pool.ems_ref_obj
-    run_command_via_parent(:vm_migrate, :host => host_mor, :pool => pool_mor, :priority => priority, :state => state)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def migrate(host, pool = nil, priority = "defaultPriority", state = nil)
+    raise _("VM has no EMS, unable to migrate VM") unless ext_management_system
+
     raw_migrate(host, pool, priority, state)
   end
 
   def raw_relocate(host, pool = nil, datastore = nil, disk_move_type = nil, transform = nil, priority = "defaultPriority", disk = nil)
-    raise _("VM has no EMS, unable to relocate VM") unless ext_management_system
-    raise _("Unable to relocate VM: Specified Host is not a valid object") if host && !host.kind_of?(Host)
-    if pool && !pool.kind_of?(ResourcePool)
-      raise _("Unable to relocate VM: Specified Resource Pool is not a valid object")
-    end
-    if datastore && !datastore.kind_of?(Storage)
-      raise _("Unable to relocate VM: Specified Datastore is not a valid object")
-    end
-
-    if pool.nil?
-      if host
-        pool = host.default_resource_pool || (host.ems_cluster && host.ems_cluster.default_resource_pool)
-        unless pool.kind_of?(ResourcePool)
-          raise _("Default Resource Pool for Host <%{name}> not found, unable to migrate VM") % {:name => host.name}
-        end
-      end
-    else
-      unless pool.kind_of?(ResourcePool)
-        raise _("Specified Resource Pool <%{pool_name}> for Host <%{name}> is invalid, unable to migrate VM") %
-                {:pool_name => pool.inspect, :name => host.name}
-      end
-    end
-
-    host_mor      = host.ems_ref_obj if host
-    pool_mor      = pool.ems_ref_obj if pool
-    datastore_mor = datastore.ems_ref_obj if datastore
-
-    run_command_via_parent(:vm_relocate, :host => host_mor, :pool => pool_mor, :datastore => datastore_mor, :disk_move_type => disk_move_type, :transform => transform, :priority => priority, :disk => disk)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def relocate(host, pool = nil, datastore = nil, disk_move_type = nil, transform = nil, priority = "defaultPriority", disk = nil)
+    raise _("VM has no EMS, unable to relocate VM") unless ext_management_system
+
     raw_relocate(host, pool, datastore, disk_move_type, transform, priority, disk)
   end
 
   def raw_move_into_folder(folder)
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
+  def move_into_folder(folder_or_id)
     raise _("VM has no EMS, unable to move VM into a new folder") unless ext_management_system
-    raise _("Folder not specified, unable to move VM into a new folder") unless folder.kind_of?(EmsFolder)
+    folder = folder_or_id.kind_of?(Integer) ? EmsFolder.find(folder_or_id) : folder_or_id
 
     if parent_blue_folder == folder
       raise _("The VM '%{name}' is already running on the same folder as the destination.") % {:name => name}
     end
 
-    run_command_via_parent(:vm_move_into_folder, :folder => folder)
-  end
-
-  def move_into_folder(folder_or_id)
-    folder = folder_or_id.kind_of?(Integer) ? EmsFolder.find(folder_or_id) : folder_or_id
     raw_move_into_folder(folder)
   end
 

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -45,10 +45,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_create_snapshot(name, desc = nil, memory)
-    run_command_via_parent(:vm_create_snapshot, :name => name, :desc => desc, :memory => memory)
-  rescue => err
-    create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "create")
-    raise MiqException::MiqVmSnapshotError, err.to_s
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def create_snapshot(name, desc = nil, memory = false)
@@ -56,21 +53,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_snapshot(snapshot_id)
-    raise MiqException::MiqVmError, unsupported_reason(:remove_snapshot) unless supports_remove_snapshot?
-    snapshot = snapshots.find_by(:id => snapshot_id)
-    raise _("Requested VM snapshot not found, unable to remove snapshot") unless snapshot
-    begin
-      _log.info("removing snapshot ID: [#{snapshot.id}] uid_ems: [#{snapshot.uid_ems}] ems_ref: [#{snapshot.ems_ref}] name: [#{snapshot.name}] description [#{snapshot.description}]")
-
-      run_command_via_parent(:vm_remove_snapshot, :snMor => snapshot.uid_ems)
-    rescue => err
-      create_notification(:vm_snapshot_failure, :error => err.to_s, :snapshot_op => "remove")
-      if err.to_s.include?('not found')
-        raise MiqException::MiqVmSnapshotError, err.to_s
-      else
-        raise
-      end
-    end
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   #
@@ -115,8 +98,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_snapshot_by_description(description, refresh = false)
-    raise MiqException::MiqVmError, unsupported_reason(:remove_snapshot_by_description) unless supports_remove_snapshot_by_description?
-    run_command_via_parent(:vm_remove_snapshot_by_description, :description => description, :refresh => refresh)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def remove_snapshot_by_description(description, refresh = false, retry_time = nil)
@@ -139,8 +121,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_remove_all_snapshots
-    raise MiqException::MiqVmError, unsupported_reason(:remove_all_snapshots) unless supports_remove_all_snapshots?
-    run_command_via_parent(:vm_remove_all_snapshots)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def remove_all_snapshots
@@ -166,10 +147,7 @@ module VmOrTemplate::Operations::Snapshot
   end
 
   def raw_revert_to_snapshot(snapshot_id)
-    raise MiqException::MiqVmError, unsupported_reason(:revert_to_snapshot) unless supports_revert_to_snapshot?
-    snapshot = snapshots.find_by(:id => snapshot_id)
-    raise _("Requested VM snapshot not found, unable to RevertTo snapshot") unless snapshot
-    run_command_via_parent(:vm_revert_to_snapshot, :snMor => snapshot.uid_ems)
+    raise NotImplementedError, _("must be implemented in a subclass")
   end
 
   def revert_to_snapshot(snapshot_id)

--- a/spec/models/vm_migrate_task_spec.rb
+++ b/spec/models/vm_migrate_task_spec.rb
@@ -33,7 +33,7 @@ describe VmMigrateTask do
       vm.update(:name => 'aaa', :vendor => 'vmware', :location => 'somewhere')
       vm.ext_management_system = FactoryBot.create(:ext_management_system, :with_authentication)
       subject.update(:options => {:placement_folder_name => folder.id})
-      expect(vm).to receive(:run_command_via_parent).with(:vm_move_into_folder, :folder => folder)
+      expect(vm).to receive(:raw_move_into_folder).with(folder)
       expect(subject).to receive(:update_and_notify_parent).with(hash_including(:state => "migrated", :status => "Ok", :message => "Finished VM Migrate"))
       subject.do_request
     end

--- a/spec/models/vm_or_template/operations/configuration_spec.rb
+++ b/spec/models/vm_or_template/operations/configuration_spec.rb
@@ -8,7 +8,7 @@ describe VmOrTemplate::Operations::Configuration do
 
       it "raises an exception when does not find ext_management_system" do
         message = "VM has no EMS, unable to add disk"
-        expect { vm.raw_add_disk(disk_name, disk_size, {}) }.to raise_error(message)
+        expect { vm.add_disk(disk_name, disk_size, {}) }.to raise_error(message)
       end
     end
 
@@ -21,27 +21,8 @@ describe VmOrTemplate::Operations::Configuration do
 
       context "when storage exists" do
         it "adds a disk on the storage" do
-          allow(ems).to receive(:vm_add_disk)
-
-          expected_options = {
-            :diskName        => disk_name,
-            :diskSize        => disk_size,
-            :thinProvisioned => nil,
-            :dependent       => nil,
-            :persistent      => nil,
-            :bootable        => nil,
-            :datastore       => storage,
-            :interface       => nil
-          }
-          expect(vm).to receive(:run_command_via_parent).with(:vm_add_disk, expected_options).once
-          vm.raw_add_disk(disk_name, disk_size, :datastore => storage_name)
-        end
-      end
-
-      context "when storage does not exist" do
-        it "raises an exception when doesn't find storage by its name" do
-          message = "Datastore does not exist or cannot be accessed, unable to add disk"
-          expect { vm.raw_add_disk(disk_name, disk_size, :datastore => "wrong_storage_name") }.to raise_error(message)
+          expect(vm).to receive(:raw_add_disk).with(disk_name, disk_size, :datastore => storage_name).once
+          vm.add_disk(disk_name, disk_size, :datastore => storage_name)
         end
       end
     end
@@ -54,7 +35,7 @@ describe VmOrTemplate::Operations::Configuration do
       let(:vm) { FactoryBot.create(:vm_or_template) }
 
       it "raises an exception" do
-        expect { vm.raw_remove_disk(disk_name) }.to raise_error("VM has no EMS, unable to remove disk")
+        expect { vm.remove_disk(disk_name) }.to raise_error("VM has no EMS, unable to remove disk")
       end
     end
 
@@ -63,23 +44,16 @@ describe VmOrTemplate::Operations::Configuration do
       let(:vm)  { FactoryBot.create(:vm_or_template, :ext_management_system => ems) }
 
       it "defaults to delete the backing file" do
-        expected_options = {
-          :diskName       => disk_name,
-          :delete_backing => true,
-        }
-
-        expect(vm).to receive(:run_command_via_parent).with(:vm_remove_disk, expected_options)
-        vm.raw_remove_disk(disk_name)
+        expected_options = {}
+        expect(vm).to receive(:raw_remove_disk).with(disk_name, expected_options)
+        vm.remove_disk(disk_name)
       end
 
       it "can override the delete backing file option" do
-        expected_options = {
-          :diskName       => disk_name,
-          :delete_backing => false,
-        }
+        expected_options = {:delete_backing => false}
 
-        expect(vm).to receive(:run_command_via_parent).with(:vm_remove_disk, expected_options)
-        vm.raw_remove_disk(disk_name, :delete_backing => false)
+        expect(vm).to receive(:raw_remove_disk).with(disk_name, expected_options)
+        vm.remove_disk(disk_name, :delete_backing => false)
       end
     end
   end


### PR DESCRIPTION
Instead of having all of the raw_* operations defined in core calling
run_command_via_parent, leave the raw_ operations undefined and allow
them to be implemented in the different providers.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/6
Pluggability Issue: https://github.com/ManageIQ/manageiq/issues/19440

Independent: (can be merged before or after this)
- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/571

- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/361

- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/113

Depends: (these should be merged before this PR)
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/422

- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/139

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/470