### PR TITLE
[IVANCHUK] Retain parity with the retirement mixin master specs where possible

### DIFF
--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -11,6 +11,11 @@ describe "VM Retirement Management" do
   end
 
   describe "#retirement_check" do
+    before do
+      # system_context_retirement relies on the presence of a user with this userid
+      FactoryBot.create(:user, :userid => "admin")
+    end
+
     context "with user" do
       it "uses user as requester" do
         expect(MiqEvent).to receive(:raise_evm_event)
@@ -44,8 +49,6 @@ describe "VM Retirement Management" do
 
     context "without user" do
       before do
-        # system_context_retirement relies on the presence of a user with this userid
-        FactoryBot.create(:user, :userid => 'admin', :role => 'super_administrator')
         user.destroy
         vm_with_owner.reload
       end


### PR DESCRIPTION
I broke the I vm retirement specs in https://github.com/ManageIQ/manageiq/pull/19309#issuecomment-548850549. 

This makes a couple changes to the existing specs to retain parity where possible with the setup on master. This file gives us trouble cause we don't seed in specs so while I can assume safely in dev that we will always have an admin user, the specs aren't true to that assumption. 

All this code is taken straight from master, it's just reproducing what we're doing there. 

The spec failure for this is: https://travis-ci.org/ManageIQ/manageiq/jobs/606067149

@miq-bot assign @simaishi 
