### PR TITLE
Added missing product feature - "Rename VM"

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -5471,6 +5471,10 @@
         :description: Edit a VM
         :feature_type: admin
         :identifier: vm_edit
+      - :name: Rename VM
+        :description: Rename VM
+        :feature_type: admin
+        :identifier: vm_rename
       - :name: Transform
         :description: Transform VM
         :feature_type: admin


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1768003

Rename VM feature in UI was added in https://github.com/ManageIQ/manageiq-ui-classic/pull/4351/

before
![before](https://user-images.githubusercontent.com/3450808/68149258-902b7100-ff0b-11e9-8a65-002d112348d8.png)

after
![after](https://user-images.githubusercontent.com/3450808/68149263-93bef800-ff0b-11e9-9949-a073d8075df0.png)
