### PR TITLE
Remove the check for a "current" snapshot

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -4,9 +4,6 @@ module VmOrTemplate::Operations::Snapshot
   included do
     supports :snapshot_create do
       if supports_snapshots?
-        if !snapshots.blank? && snapshots.first.get_current_snapshot.nil?
-          unsupported_reason_add(:snapshot_create, _("At least one snapshot has to be active to create a new snapshot for this VM"))
-        end
         unless supports_control?
           unsupported_reason_add(:snapshot_create, unsupported_reason(:control))
         end


### PR DESCRIPTION
When creating a new snapshot and there is at least one snapshot already
we are checking to ensure that the first snapshot is "current".

This check isn't necessary and can prevent new snapshots from being
created through MIQ when it is entirely possible through the underlying
provider.

Fixes https://github.com/ManageIQ/manageiq/issues/19396