### PR TITLE
Don't return nil for delegated NetworkManager associations

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -60,7 +60,7 @@ module ManageIQ::Providers
     has_many :availability_zones, -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
 
     # Relationships delegated to parent manager
-    delegate :cloud_tenants,
+    virtual_delegate :cloud_tenants,
              :flavors,
              :cloud_resource_quotas,
              :cloud_volumes,
@@ -80,7 +80,8 @@ module ManageIQ::Providers
              :total_miq_templates,
              :hosts,
              :to        => :parent_manager,
-             :allow_nil => true
+             :allow_nil => true,
+             :default => []
 
     def self.supported_types_and_descriptions_hash
       supported_subclasses.select(&:supports_ems_network_new?).each_with_object({}) do |klass, hash|


### PR DESCRIPTION
If a NetworkManager doesn't have a parent_manager (e.g. Nuage) don't
return nil for delegated associations.

This is an issue where we are assuming that associations will at least return an empty assoc not nil e.g.: [`(hosts + ems_clusters).inject(0) { |v, obj| v + (obj.send(field) || 0) }`](https://github.com/ManageIQ/manageiq/blob/master/app/models/ext_management_system.rb#L697-L699)

Before:
```
>> ManageIQ::Providers::Nuage::NetworkManager.first.hosts
=> nil
```

After:
```
>> ManageIQ::Providers::Nuage::NetworkManager.first.hosts
=> []
```
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1767747