### PR TITLE
Condense attribute updates in miq_widget generate content methods

### DIFF
--- a/app/models/miq_widget.rb
+++ b/app/models/miq_widget.rb
@@ -151,8 +151,7 @@ class MiqWidget < ApplicationRecord
   end
 
   def generate_content_complete!
-    self.last_generated_content_on = Time.now.utc
-    self.save!
+    self.update!(:last_generated_content_on => Time.now.utc)
   end
 
   def generate_content_complete_message
@@ -241,10 +240,7 @@ class MiqWidget < ApplicationRecord
 
       data = content_type_klass.new(:report => report, :resource => resource, :timezone => timezone, :widget_options => options).generate(group)
       content = find_or_build_contents_for_user(group, nil, timezone)
-      content.miq_report_result = miq_report_result
-      content.contents = data
-      content.miq_group_id = group.id
-      content.save!
+      content.update!(:miq_report_result => miq_report_result, :contents => data, :miq_group_id => group.id)
     rescue => error
       _log.error("#{log_prefix} Failed for [#{group.class}] [#{group.name}] with error: [#{error.class.name}] [#{error}]")
       _log.log_backtrace(error)
@@ -286,11 +282,7 @@ class MiqWidget < ApplicationRecord
 
       data = content_type_klass.new(:report => report, :resource => resource, :timezone => timezone, :widget_options => options).generate(user)
       content = find_or_build_contents_for_user(group, user, timezone)
-      content.miq_report_result = miq_report_result
-      content.contents = data
-      content.user_id      = user.id
-      content.miq_group_id = group.id
-      content.save!
+      content.update!(:miq_report_result => miq_report_result, :contents => data, :miq_group_id => group.id, :user_id => user.id)
     rescue => error
       _log.error("#{log_prefix} Failed for [#{user.class}] [#{user.name}] with error: [#{error.class.name}] [#{error}]")
       _log.log_backtrace(error)


### PR DESCRIPTION
I don't know why not just do the attribute updates here in a single call? 


@miq-bot add label cleanup