### PR TITLE
[V2V][IVANCHUK] Fix create_job in JobProxyDispatcher specs

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -1,5 +1,5 @@
 class InfraConversionJob < Job
-  def self.create_job(options)
+  def self.create_job(options = {})
     super(name, options)
   end
 

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -19,7 +19,7 @@ describe JobProxyDispatcher do
   end
 
   describe '.waiting?' do
-    let(:vm_scan_job) { VmScan.create_job }
+    let(:vm_scan_job) { VmScan.create_job('VmScan') }
     let(:infra_conversion_job) { InfraConversionJob.create_job }
 
     it 'returns true if VmScan state is waiting to start and InfraConversionJob state is finished' do


### PR DESCRIPTION
This is a followup to https://github.com/ManageIQ/manageiq/pull/19277. Unfortunately, there was a core change that broke backwards compatibility.

https://github.com/ManageIQ/manageiq/commit/508683b937b4319f9d07c863b9a9a562625c01dc#diff-96955d17ecd8f0296297c7dc1392d347

So, this is an update for Ivanchuk and earlier that updates the `InfraConversionJob.create_job` method to use an empty hash as a default value, as well as explicitly specify a process name to the old core method during factory creation.