### PR TITLE
Removes strategies and V3 api calls

### DIFF
--- a/spec/models/iso_datastore_spec.rb
+++ b/spec/models/iso_datastore_spec.rb
@@ -1,5 +1,4 @@
 describe IsoDatastore do
-  let(:ems) { FactoryBot.create(:ems_redhat) }
   let(:iso_datastore) { FactoryBot.create(:iso_datastore, :ext_management_system => ems) }
 
   describe "#advertised_images" do
@@ -13,23 +12,11 @@ describe IsoDatastore do
     end
 
     context "ems is rhv" do
-      before do
-        allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
-      end
+      let(:ems) { FactoryBot.create(:ems_redhat, :api_version => '4.3.6') }
 
       context "supports api4" do
-        let(:supported_api_versions) { %w(3 4) }
         it "send the method to ovirt services v4" do
-          expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V4)
-            .to receive(:advertised_images)
-          advertised_images
-        end
-      end
-
-      context "does not support api4" do
-        let(:supported_api_versions) { ["3"] }
-        it "send the method to ovirt services v4" do
-          expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Strategies::V3)
+          expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4)
             .to receive(:advertised_images)
           advertised_images
         end


### PR DESCRIPTION
In the manageiq-providers-ovirt plugin we removed the V3 RHV api calls
and the strategy pattern.

Depends on:

https://github.com/ManageIQ/manageiq-providers-ovirt/pull/423