### PR TITLE
Base monolithic container image on pods ui worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE_REF=latest
-FROM manageiq/manageiq-pods:frontend-${IMAGE_REF}
+FROM manageiq/manageiq-ui-worker:${IMAGE_REF}
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq
 
 ## Set build ARG
@@ -18,6 +18,7 @@ RUN yum -y install --setopt=tsflags=nodocs \
     yum clean all
 
 VOLUME [ "/var/lib/pgsql/data" ]
+VOLUME [ ${APP_ROOT} ]
 
 # Initialize SSH
 RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
@@ -34,8 +35,8 @@ RUN ${APPLIANCE_ROOT}/setup && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
     echo "# This file intentionally left blank. ManageIQ maintains its own SSL configuration" > /etc/httpd/conf.d/ssl.conf
 
-## Copy appliance-initialize script and service unit file
-COPY docker-assets/appliance-initialize.sh /usr/bin
+## Overwrite entrypoint from pods repo
+COPY docker-assets/entrypoint /usr/local/bin
 
 EXPOSE 443 22
 

--- a/docker-assets/check-dependent-services.sh
+++ b/docker-assets/check-dependent-services.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/bin/true

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-# Source EVM environment 
+/usr/sbin/crond &
+
+# Check if memcached is running, if not start it
+pidof memcached
+test $? -ne 0 && /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -d
+
+# Source EVM environment
 [ -f /etc/default/evm ] &&  . /etc/default/evm
-[[ -s ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh ]] && source "${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh"
 
 function create_v2_key() {
   V2_KEY=$(ruby -ropenssl -rbase64 -e 'puts Base64.strict_encode64(Digest::SHA256.digest(OpenSSL::Random.random_bytes(32))[0, 32])')
-  write_v2_key
+  cat > /var/www/miq/vmdb/certs/v2_key << KEY
+---
+:algorithm: aes-256-cbc
+:key: ${V2_KEY}
+KEY
   unset V2_KEY
 }
 
@@ -17,7 +26,12 @@ echo "== Checking MIQ database status =="
 [[ -d /var/lib/pgsql/data/base ]]
 if [ $? -eq 0 ]; then
   echo "** DB already initialized"
-  exit 0
+  echo "** Starting postgresql"
+
+  su postgres -c "pg_ctl -D ${APPLIANCE_PG_DATA} start"
+  test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
+
+  bundle exec rake db:migrate
 else
   echo "** DB has not been initialized"
 
@@ -35,10 +49,6 @@ else
   su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
   test $? -ne 0 && echo "!! Failed to inject MIQ root Role" && exit 1
 
-  # Check if memcached is running, if not start it
-  pidof memcached
-  test $? -ne 0 && /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -d
-
   echo "** Starting DB setup"
   pushd ${APP_ROOT}
     create_v2_key
@@ -48,5 +58,8 @@ else
   echo "** MIQ database has been initialized"
 
   generate_miq_server_cert.sh
-  exit 0
 fi
+
+rm -f /var/www/miq/vmdb/tmp/pids/evm.pid
+
+exec ruby /var/www/miq/vmdb/lib/workers/bin/evm_server.rb


### PR DESCRIPTION
To do this I overwrote the entrypoint from the base image with
what is mostly the previous appliance initialize script.

The main changes I made were to add the server start at the end
and to remove the old container scripts references by pasting
the v2 key writing function into where it was previously called.

Additionally I removed starting memcached from the block that only
gets called if the database doesn't exist. We should start memcached
regardless.

This should allow the container to be started after a clean stop
Fixes #17274