### PR TITLE
Allow for workers to be more specific in what they dequeue

### DIFF
--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -74,7 +74,7 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
     loop do
       msg = MiqQueue.get(
         :queue_name => @worker.queue_name,
-        :role       => @active_roles,
+        :role       => @worker.required_roles.presence,
         :priority   => @worker.class.queue_priority
       )
       return msg unless msg == :stale


### PR DESCRIPTION
Instead of all workers dequeueing all roles all the time, which essentially means that queue_name has to be 1:1 to a worker, allow for workers to be more specific in what type of work they dequeue.

Each EMS has their "queue_name" [link](https://github.com/ManageIQ/manageiq/blob/master/app/models/ext_management_system.rb#L602-L604), I believe it was intended that this ems-queue-name + the role would indicate which worker would dequeue the work.  With all workers dequeueing for all roles though, this means that the `ems.queue_name` is only valid for a single worker.

This happens to be the RefreshWorker since it is the only queue_worker that operates `PerEmsWorker`.  The other QueueWorker is the metrics collector but it is `PerEmsType` so its queue_name is e.g. "vmware".  If we add more `PerEmsWorker` workers we are going to start having a bad time.

E.g. I added a `Vmware::InfraManager::OperationsWorker` and when I queued something for `role: ems_operations, queue_name: ems.queue_name` I was surprised to find that the `Vmware::InfraManager::RefreshWorker` picked it up.

The alternative would be to actually make the queue_name 1:1 to a worker, in which case we should change `ems.queue_name` to something like `queue_name_for_refresh` and change the queue_name to `refresh_ems_#{id}`.