### PR TITLE
[IVANCHUK] Update ruby to 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: ruby
 rvm:
-- 2.5.3
+- 2.5.5
 sudo: false
 cache:
   bundler: true


### PR DESCRIPTION
RHEL 8.1 is released and ruby is now updated to 2.5.5. The 5.11 build is now using 2.5.5, so we need to update .travis.yml for the I branch, aye aye. 