### PR TITLE
[WIP] List tags classification only when they tags

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -270,7 +270,9 @@ class Classification < ApplicationRecord
   end
 
   def entries
-    children
+    tag_ids = children.map(&:tag_id)
+    existing_tags = Tag.where(:id => tag_ids).ids
+    children.select { |x| existing_tags.include?(x.tag_id) }
   end
 
   def lookup_by_entry(type)


### PR DESCRIPTION
when classification don't have a tag it causes issues in tag management in UI.

cc @jrafanie @gtanzillo @yrudman 

it hides some problems with relations between tag and classification - so I am presenting it in case we will consider that it is good to have this restriction.  

