### PR TITLE
Add a Providers::BaseManager::OperationsWorker

### DIFF
--- a/app/models/aliases/miq_ems_operations_worker.rb
+++ b/app/models/aliases/miq_ems_operations_worker.rb
@@ -1,0 +1,1 @@
+::MiqEmsOperationsWorker = ManageIQ::Providers::BaseManager::OperationsWorker

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -603,6 +603,12 @@ class ExtManagementSystem < ApplicationRecord
     "ems_#{id}"
   end
 
+  # Until all providers have an operations worker we can continue
+  # to use the GenericWorker to run ems_operations roles
+  def queue_name_for_ems_operations
+    nil
+  end
+
   def enforce_policy(target, event)
     inputs = {:ext_management_system => self}
     inputs[:vm]   = target if target.kind_of?(Vm)

--- a/app/models/manageiq/providers/base_manager/operations_worker.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker.rb
@@ -1,0 +1,26 @@
+class ManageIQ::Providers::BaseManager::OperationsWorker < MiqQueueWorkerBase
+  require_nested :Runner
+
+  include PerEmsWorkerMixin
+
+  self.required_roles = "ems_operations"
+
+  def friendly_name
+    @friendly_name ||= begin
+      ems = ext_management_system
+      if ems.nil?
+        queue_name.kind_of?(Array) ? queue_name.collect(&:titleize).join(", ") : queue_name.titleize
+      else
+        _("Operations Worker for Provider: %{name}") % {:name => ems.name}
+      end
+    end
+  end
+
+  def self.ems_class
+    parent
+  end
+
+  def self.normalized_type
+    @normalized_type ||= "ems_operations_worker"
+  end
+end

--- a/app/models/manageiq/providers/base_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker/runner.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::BaseManager::OperationsWorker::Runner < ::MiqQueueWorkerBase::Runner
+  OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
+    [:ems_id, 'EMS Instance ID', String],
+  ]
+
+  def worker_roles
+    %w[ems_operations"]
+  end
+
+  attr_reader :ems
+
+  def after_initialize
+    @ems = ExtManagementSystem.find(@cfg[:ems_id])
+    do_exit("Unable to find instance for EMS id [#{@cfg[:ems_id]}].", 1) if ems.nil?
+    do_exit("EMS id [#{ems.id}] failed authentication check.", 1) unless ems.authentication_check.first
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1174,6 +1174,7 @@
         :memory_threshold: 600.megabytes
         :nice_delta: 7
         :poll_method: :escalate
+      :ems_operations_worker: {}
       :ems_refresh_worker:
         :defaults:
           :memory_threshold: 2.gigabytes


### PR DESCRIPTION
Add a worker which can handle ems_operation type work if a provider
needs e.g. custom connection handling

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/19464