### PR TITLE
Allow MiqRequests to set a queue_name

### DIFF
--- a/app/models/miq_request.rb
+++ b/app/models/miq_request.rb
@@ -410,6 +410,10 @@ class MiqRequest < ApplicationRecord
     nil
   end
 
+  def my_queue_name
+    nil
+  end
+
   def task_check_on_execute
     if self.class::ACTIVE_STATES.include?(request_state)
       raise _("%{task} request is already being processed") % {:task => self.class::TASK_DESCRIPTION}

--- a/app/models/miq_request_task.rb
+++ b/app/models/miq_request_task.rb
@@ -183,6 +183,7 @@ class MiqRequestTask < ApplicationRecord
       :method_name    => "execute",
       :zone           => options.fetch(:miq_zone, zone),
       :role           => miq_request.my_role,
+      :queue_name     => miq_request.my_queue_name,
       :tracking_label => tracking_label_id,
       :deliver_on     => deliver_on,
       :miq_callback   => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -1,6 +1,7 @@
 module MiqRequestTask::StateMachine
   delegate :my_role, :to => :miq_request
   delegate :my_zone, :to => :source,      :allow_nil => true
+  delegate :my_queue_name, :to => :miq_request
 
   def tracking_label_id
     "r#{miq_request_id}_#{self.class.base_model.name.underscore}_#{id}"
@@ -56,6 +57,7 @@ module MiqRequestTask::StateMachine
       :args           => args,
       :zone           => my_zone,
       :role           => my_role,
+      :queue_name     => my_queue_name,
       :tracking_label => tracking_label_id,
     )
   end

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -154,6 +154,7 @@ describe ServiceTemplateProvisionTask do
           :instance_id    => @task_0.id,
           :method_name    => 'execute',
           :role           => 'ems_operations',
+          :queue_name     => nil,
           :zone           => 'a_zone',
           :tracking_label => tracking_label,
           :deliver_on     => nil,


### PR DESCRIPTION
Enable certain MiqRequestTasks to be processed by workers other than
Generic/Priority workers.

Part of: https://github.com/ManageIQ/manageiq/issues/19543
Parent issue: https://github.com/ManageIQ/manageiq-providers-vmware/issues/484