### PR TITLE
Fix or remove invalid partials for ConversionHost specs

### DIFF
--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ConversionHost, :v2v do
 
   shared_examples_for "#check_ssh_connection" do
     it "fails when SSH send an error" do
-      allow(conversion_host).to receive(:connect).and_raise('Unexpected failure')
+      allow(conversion_host).to receive(:connect_ssh).and_raise('Unexpected failure')
       expect(conversion_host.check_ssh_connection).to eq(false)
     end
 
@@ -240,9 +240,6 @@ RSpec.describe ConversionHost, :v2v do
 
       before do
         allow(ems).to receive(:authentications).and_return(ssh_auth)
-        allow(ssh_auth).to receive(:where).with(:authype => 'ssh_keypair').and_return(ssh_auth)
-        allow(ssh_auth).to receive(:where).and_return(ssh_auth)
-        allow(ssh_auth).to receive(:not).with(:userid => nil, :auth_key => nil).and_return([ssh_auth])
       end
 
       it_behaves_like "#check_ssh_connection"


### PR DESCRIPTION
If you enable strict partial double validation you will currently see 3 errors in the conversion host specs. In one case I think we were just accidentally stubbing the wrong method name, but the other two don't appear to actually do anything meaningful since the specs still passed without them.

```
Failures:

  1) ConversionHost resource provider is rhevm host userid is set and host password is set behaves like #check_ssh_connection fails when SSH send an error
     Failure/Error: allow(conversion_host).to receive(:connect).and_raise('Unexpected failure')
       #<ConversionHost id: 81, name: "conversion_host_0000000000007", address: nil, type: nil, resource_type: "Host", resource_id: 36, version: nil, max_concurrent_tasks: nil, vddk_transport_supported: true, ssh_transport_supported: nil, created_at: "2019-11-08 14:53:36", updated_at: "2019-11-08 14:53:36", concurrent_transformation_limit: nil, cpu_limit: nil, memory_limit: nil, network_limit: nil, blockio_limit: nil> does not implement: connect
     Shared Example Group: "#check_ssh_connection" called from ./spec/models/conversion_host_spec.rb:163
     # ./spec/models/conversion_host_spec.rb:133:in `block (3 levels) in <top (required)>'

  2) ConversionHost resource provider is openstack ems authentications contains ssh_auth behaves like #check_ssh_connection fails when SSH send an error
     Failure/Error: allow(ssh_auth).to receive(:where).with(:authype => 'ssh_keypair').and_return(ssh_auth)
       #<ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair id: 31, name: nil, authtype: "ssh_keypair", userid: "testuser", password: nil, resource_id: 105, resource_type: "ExtManagementSystem", created_on: "2019-11-08 14:53:40", updated_on: "2019-11-08 14:53:40", last_valid_on: nil, last_invalid_on: nil, credentials_changed_on: nil, status: "Valid", status_details: nil, type: "ManageIQ::Providers::Openstack::InfraManager::Auth...", auth_key: "v2:{eUnU7Rp54AVtTEYeGLsgATT/fPnWeAP3tbcfYuf/Bvc=}", fingerprint: nil, service_account: nil, challenge: nil, login: nil, public_key: nil, htpassd_users: [], ldap_id: [], ldap_email: [], ldap_name: [], ldap_preferred_user_name: [], ldap_bind_dn: nil, ldap_insecure: nil, ldap_url: nil, request_header_challenge_url: nil, request_header_login_url: nil, request_header_headers: [], request_header_preferred_username_headers: [], request_header_name_headers: [], request_header_email_headers: [], open_id_sub_claim: nil, open_id_user_info: nil, open_id_authorization_endpoint: nil, open_id_token_endpoint: nil, open_id_extra_scopes: [], open_id_extra_authorize_parameters: nil, certificate_authority: nil, google_hosted_domain: nil, github_organizations: [], rhsm_sku: nil, rhsm_pool_id: nil, rhsm_server: nil, manager_ref: nil, options: nil, evm_owner_id: nil, miq_group_id: nil, tenant_id: nil, become_username: nil, become_password: nil, auth_key_password: nil> does not implement: where
     Shared Example Group: "#check_ssh_connection" called from ./spec/models/conversion_host_spec.rb:248
     # ./spec/models/conversion_host_spec.rb:243:in `block (4 levels) in <top (required)>'

  3) ConversionHost resource provider is openstack ems authentications contains ssh_auth behaves like #check_ssh_connection succeeds when SSH command succeeds
     Failure/Error: allow(ssh_auth).to receive(:where).with(:authype => 'ssh_keypair').and_return(ssh_auth)
       #<ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair id: 32, name: nil, authtype: "ssh_keypair", userid: "testuser", password: nil, resource_id: 109, resource_type: "ExtManagementSystem", created_on: "2019-11-08 14:53:40", updated_on: "2019-11-08 14:53:40", last_valid_on: nil, last_invalid_on: nil, credentials_changed_on: nil, status: "Valid", status_details: nil, type: "ManageIQ::Providers::Openstack::InfraManager::Auth...", auth_key: "v2:{eUnU7Rp54AVtTEYeGLsgATT/fPnWeAP3tbcfYuf/Bvc=}", fingerprint: nil, service_account: nil, challenge: nil, login: nil, public_key: nil, htpassd_users: [], ldap_id: [], ldap_email: [], ldap_name: [], ldap_preferred_user_name: [], ldap_bind_dn: nil, ldap_insecure: nil, ldap_url: nil, request_header_challenge_url: nil, request_header_login_url: nil, request_header_headers: [], request_header_preferred_username_headers: [], request_header_name_headers: [], request_header_email_headers: [], open_id_sub_claim: nil, open_id_user_info: nil, open_id_authorization_endpoint: nil, open_id_token_endpoint: nil, open_id_extra_scopes: [], open_id_extra_authorize_parameters: nil, certificate_authority: nil, google_hosted_domain: nil, github_organizations: [], rhsm_sku: nil, rhsm_pool_id: nil, rhsm_server: nil, manager_ref: nil, options: nil, evm_owner_id: nil, miq_group_id: nil, tenant_id: nil, become_username: nil, become_password: nil, auth_key_password: nil> does not implement: where
     Shared Example Group: "#check_ssh_connection" called from ./spec/models/conversion_host_spec.rb:248
     # ./spec/models/conversion_host_spec.rb:243:in `block (4 levels) in <top (required)>'

Finished in 6.76 seconds (files took 8.01 seconds to load)
67 examples, 3 failures
```