### PR TITLE
Fix key_pair class lookup

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -49,7 +49,6 @@ module ManageIQ::Providers
     has_many :cloud_object_store_objects,    -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
     has_many :cloud_services,                -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
     has_many :cloud_databases,               -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :key_pairs,                     -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id, :class_name => "AuthKeyPair", :as => :resource
     has_many :hosts,                         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
     has_many :vms,                           -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
     has_many :miq_templates,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
@@ -64,6 +63,7 @@ module ManageIQ::Providers
                      :orchestration_stacks_resources,
                      :direct_orchestration_stacks,
                      :resource_groups,
+                     :key_pairs,
                      :to        => :parent_manager,
                      :allow_nil => true,
                      :default   => []


### PR DESCRIPTION
While we would like to avoid delegation, easier to just point to
the parent manager for auth key pairs

fixes issue with https://github.com/ManageIQ/manageiq/pull/19473
related to https://bugzilla.redhat.com/show_bug.cgi?id=1767747

```
irb(main):002:0> MiqExpression.miq_adv_search_lists('CloudNetwork', :exp_available_finds)
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 30, connections: 1, in use: 1, waiting_in_queue: 0
Traceback (most recent call last):
       12: from lib/miq_expression.rb:903:in `miq_adv_search_lists'
       11: from lib/miq_expression.rb:802:in `model_details'
       10: from lib/miq_expression.rb:891:in `get_relats'
        9: from lib/miq_expression.rb:942:in `build_relats'
        8: from lib/miq_expression.rb:942:in `each'
        7: from lib/miq_expression.rb:973:in `block in build_relats'
        6: from lib/miq_expression.rb:942:in `build_relats'
        5: from lib/miq_expression.rb:942:in `each'
        4: from lib/miq_expression.rb:952:in `block in build_relats'
NameError (uninitialized constant ManageIQ::Providers::NetworkManager::AuthKeyPair)
```