### PR TITLE
Add an interface for get_source_and_targets

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -770,6 +770,12 @@ class MiqRequestWorkflow
   def update_field_visibility
   end
 
+  # Subclasses should define this as appropriate.
+  #
+  def get_source_and_targets(_refresh = false)
+    raise NoMethodError, "subclass failed to define a 'get_source_and_targets' method"
+  end
+
   def refresh_field_values(values)
     st = Time.now
 


### PR DESCRIPTION
It looks like `MiqRequestWorkflow` is missing a default `get_source_and_targets` implementation. This method is called internally, but is not currently defined, apparently relying on subclasses to define it.

Given that there are already several other empty method declarations within the `MiqRequestWorkflow` model, I suspect this one simply got missed. For my first pass I've decided to add a bit of strictness to it so that it will raise a more informative error. This is a very basic way to implement interface enforcement in Ruby, though there are other ways if the reviewers of this PR prefer.

Originally smoked out when I turned on strict partial double validation.