### PR TITLE
Add and subclass scan_timeout_adjustment_multiplier method

### DIFF
--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -37,6 +37,25 @@ module VmOrTemplate::Scanning
   end
 
   #
+  # Default Adjustment Multiplier is 1 (i.e. no change to timeout)
+  #   since this is a multiplier, timeout * 1 = timeout
+  #
+  # Subclasses MAY choose to override this
+  #
+  module ClassMethods
+    def scan_timeout_adjustment_multiplier
+      1
+    end
+  end
+
+  #
+  # Instance method delegates to class method for convenience
+  #
+  def scan_timeout_adjustment_multiplier
+    self.class.scan_timeout_adjustment_multiplier
+  end
+
+  #
   # Subclasses need to override this method if a storage association
   # is not required for SSA.
   #


### PR DESCRIPTION
Dependent PRs

- [x] [Azure](https://github.com/ManageIQ/manageiq-providers-azure/pull/364)
- [x] [OpenStack](https://github.com/ManageIQ/manageiq-providers-openstack/pull/530)
- [x] [SCVMM](https://github.com/ManageIQ/manageiq-providers-scvmm/pull/143)
