### PR TITLE
Allow dashboards for different groups to have the same name

### DIFF
--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -2,6 +2,7 @@ class MiqWidgetSet < ApplicationRecord
   acts_as_miq_set
 
   before_destroy :destroy_user_versions
+  before_save    :keep_group_when_saving
 
   WIDGET_DIR =  File.expand_path(File.join(Rails.root, "product/dashboard/dashboards"))
 
@@ -15,7 +16,7 @@ class MiqWidgetSet < ApplicationRecord
 
   def destroy_user_versions
     # userid, group_id and name are set for user version
-    # owner_type and owner_id are set for group version
+    # group_id, owner_type and owner_id are set for group version
     return if userid
 
     # When we destroy a WidgetSet for a group, we also want to destroy all user-modified versions
@@ -97,5 +98,11 @@ class MiqWidgetSet < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Dashboard', 'Dashboards', number)
+  end
+
+  private
+
+  def keep_group_when_saving
+    self.group_id = owner_id if owner_type == "MiqGroup" && owner_id.present?
   end
 end

--- a/app/models/miq_widget_set.rb
+++ b/app/models/miq_widget_set.rb
@@ -28,10 +28,14 @@ class MiqWidgetSet < ApplicationRecord
   end
 
   def self.where_unique_on(name, user = nil)
+    # user is nil for dashboards set for group
     userid = user.try(:userid)
-    group_id = user.try(:current_group_id)
     # a unique record is defined by name, group_id and userid
-    where(:name => name, :group_id => group_id, :userid => userid)
+    if userid.present?
+      where(:name => name, :group_id => user.current_group_id, :userid => userid)
+    else
+      where(:name => name, :userid => nil)
+    end
   end
 
   def self.subscribed_for_user(user)

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -133,8 +133,8 @@ describe MiqWidgetSet do
     let(:name) { "New Dashboard Name" }
     let(:tab) { "Dashboard Tab" }
 
-    it "raises error if passed name already taken" do
-      expect { MiqWidgetSet.copy_dashboard(@ws_group, @ws_group.name, tab) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: MiqWidgetSet: Name has already been taken")
+    it "does not raises error if the same dashboard name used for different groups" do
+      expect { MiqWidgetSet.copy_dashboard(@ws_group, @ws_group.name, tab) }.not_to raise_error
     end
 
     it "raises error if passed tab name is empty" do


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/18924

This PR should go together with Data Migration PR https://github.com/ManageIQ/manageiq-schema/pull/432, which will copy ```owner_id``` to ```group_id```
