### PR TITLE
Use the workers proc rather than overriding the method

### DIFF
--- a/app/models/mixins/per_ems_type_worker_mixin.rb
+++ b/app/models/mixins/per_ems_type_worker_mixin.rb
@@ -3,15 +3,13 @@ module PerEmsTypeWorkerMixin
 
   included do
     self.check_for_minimal_role = false
+    @workers = lambda do
+      return 0 unless self.any_valid_ems_in_zone?
+      workers_configured_count
+    end
   end
 
   module ClassMethods
-    def workers
-      return 0 unless self.any_valid_ems_in_zone?
-      return (self.has_minimal_env_option? ? 1 : 0) if MiqServer.minimal_env?
-      workers_configured_count
-    end
-
     def ems_class
       ExtManagementSystem
     end

--- a/spec/factories/miq_worker.rb
+++ b/spec/factories/miq_worker.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
 
   factory :miq_ems_metrics_processor_worker, :class => "MiqEmsMetricsProcessorWorker", :parent => :miq_worker
 
+  factory :miq_ems_metrics_collector_worker,
+          :class  => "ManageIQ::Providers::BaseManager::MetricsCollectorWorker",
+          :parent => :miq_worker
+
   factory :miq_ems_refresh_worker,
           :parent => :miq_worker,
           :class  => "ManageIQ::Providers::BaseManager::RefreshWorker"

--- a/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
@@ -1,0 +1,46 @@
+describe PerEmsTypeWorkerMixin do
+  let(:worker)       { FactoryBot.create(:miq_ems_metrics_collector_worker) }
+  let(:worker_class) { worker.class }
+
+  before do
+    _guid, @server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+  end
+
+  describe ".workers" do
+    it "is 0 with no providers" do
+      expect(worker_class.workers).to eq(0)
+    end
+
+    context "with a provider" do
+      let!(:provider) { FactoryBot.create(:ems_vmware, :with_authentication, :zone => @zone) }
+
+      it "is 0 without the role active" do
+        expect(worker_class.workers).to eq(0)
+      end
+
+      context "with the role active" do
+        before do
+          ServerRole.seed
+          @server.role = "ems_metrics_collector"
+          @server.assigned_server_roles.update(:active => true)
+        end
+
+        it "is the number configured" do
+          configured = worker_class.workers_configured_count
+          expect(worker_class.workers).to eq(configured)
+
+          stub_settings(:workers => {:worker_base => {:queue_worker_base => {:ems_metrics_collector_worker => {:count => configured + 1}}}})
+          expect(worker_class.workers).to eq(configured + 1)
+        end
+
+        it "is 0 with the provider in the wrong zone" do
+          other_zone = FactoryBot.create(:zone)
+          provider.update(:zone => other_zone)
+          stub_settings(:workers => {:worker_base => {:queue_worker_base => {:ems_metrics_collector_worker => {:count => 5}}}})
+
+          expect(worker_class.workers).to eq(0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Commit fefccb69bc27b4a9f0cd3d99d1e9cf20c10316ea caused us to start metrics collector workers even if the role was not active.

This fixes that issue and adds tests to the `.workers` method for the `PerEmsTypeWorkerMixin`