### PR TITLE
[WIP] Add service template name uniqueness validation

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -47,7 +47,7 @@ class ServiceTemplate < ApplicationRecord
   include_concern 'Filter'
   include_concern 'Copy'
 
-  validates :name, :presence => true
+  validates :name, :presence => true, :unique_within_region => true
   belongs_to :tenant
 
   has_many   :service_templates, :through => :service_resources, :source => :resource, :source_type => 'ServiceTemplate'

--- a/spec/models/service_template_transformation_plan_spec.rb
+++ b/spec/models/service_template_transformation_plan_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe ServiceTemplateTransformationPlan, :v2v do
     it 'validates unique name' do
       described_class.create_catalog_item(catalog_item_options)
       expect { described_class.create_catalog_item(catalog_item_options) }.to raise_error(
-        ActiveRecord::RecordInvalid, 'Validation failed: ServiceTemplateTransformationPlan: Name has already been taken'
+        ActiveRecord::RecordInvalid, /Validation failed: ServiceTemplateTransformationPlan: Name is not unique within region \d{2}, ServiceTemplateTransformationPlan: Name has already been taken/
       )
     end
 


### PR DESCRIPTION
The issue of us lacking service template name uniqueness came up recently and I thought I'd make a quick fix for it if anyone's interested...

The original issue: 
https://github.com/ManageIQ/manageiq/pull/19142 

There's a related schema PR: https://github.com/ManageIQ/manageiq-schema/pull/431

I know this will break tests, and I'm not sure what the answer to Brandon's question about ```These are replicated, so do they need to be unique across all regions or unique within a region?``` is.

EDIT:
Fine, okay. So this is a bad idea for multiple reasons: 1) rbac -- unless the user in question is a super-admin they may not be able to see all service templates anyway so we have the unfortunate problem where they might hit a validation telling them that there is a dup without them actually being able to see it, and 2) the replication means that we can't ensure that different regions do not have dups. 