### PR TITLE
Add specs to scan_timeout_adjustment_multiplier class and instance method for VmOrTemplate

### DIFF
--- a/spec/models/vm_or_template/scanning_spec.rb
+++ b/spec/models/vm_or_template/scanning_spec.rb
@@ -1,0 +1,23 @@
+describe VmOrTemplate::Scanning do
+  describe ".scan_timeout_adjustment_multiplier" do
+    it "when called for Template class, returns numeric value" do
+      expect(MiqTemplate.scan_timeout_adjustment_multiplier).to be_kind_of(Numeric)
+    end
+
+    it "when called for Vm class, returns numeric value" do
+      expect(Vm.scan_timeout_adjustment_multiplier).to be_kind_of(Numeric)
+    end
+  end
+
+  describe "#scan_timeout_adjustment_multiplier" do
+    it "when called for Vm instance, returns numeric value" do
+      vm = Vm.new
+      expect(vm.scan_timeout_adjustment_multiplier).to be_kind_of(Numeric)
+    end
+
+    it "when called for Template instance, returns numeric value" do
+      template = MiqTemplate.new
+      expect(template.scan_timeout_adjustment_multiplier).to be_kind_of(Numeric)
+    end
+  end
+end


### PR DESCRIPTION
Related PRs

- [x] [Azure](https://github.com/ManageIQ/manageiq-providers-azure/pull/365)
- [x] [OpenStack](https://github.com/ManageIQ/manageiq-providers-openstack/pull/531)
- [x] [SCVMM](https://github.com/ManageIQ/manageiq-providers-scvmm/pull/144)