### PR TITLE
Kubernetes-ify the container orchestrator

### DIFF
--- a/app/models/miq_worker/deployment_per_worker.rb
+++ b/app/models/miq_worker/deployment_per_worker.rb
@@ -3,14 +3,14 @@ class MiqWorker
     extend ActiveSupport::Concern
 
     def create_container_objects
-      ContainerOrchestrator.new.create_deployment_config(worker_deployment_name) do |definition|
+      ContainerOrchestrator.new.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition, 1)
         definition[:spec][:template][:spec][:containers].first[:env] << {:name => "EMS_IDS", :value => Array.wrap(self.class.ems_id_from_queue_name(queue_name)).join(",")}
       end
     end
 
     def delete_container_objects
-      ContainerOrchestrator.new.delete_deployment_config(worker_deployment_name)
+      ContainerOrchestrator.new.delete_deployment(worker_deployment_name)
     end
 
     def stop_container

--- a/app/models/miq_worker/replica_per_worker.rb
+++ b/app/models/miq_worker/replica_per_worker.rb
@@ -3,14 +3,14 @@ class MiqWorker
     extend ActiveSupport::Concern
 
     def create_container_objects
-      ContainerOrchestrator.new.create_deployment_config(worker_deployment_name) do |definition|
+      ContainerOrchestrator.new.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition)
       end
       scale_deployment
     end
 
     def delete_container_objects
-      ContainerOrchestrator.new.delete_deployment_config(worker_deployment_name)
+      ContainerOrchestrator.new.delete_deployment(worker_deployment_name)
     end
 
     def stop_container

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -8,7 +8,7 @@ class MiqWorker
       orchestrator = ContainerOrchestrator.new
 
       orchestrator.create_service(worker_deployment_name, SERVICE_PORT)
-      orchestrator.create_deployment_config(worker_deployment_name) do |definition|
+      orchestrator.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition)
 
         definition[:spec][:serviceName] = worker_deployment_name
@@ -24,7 +24,7 @@ class MiqWorker
 
     def delete_container_objects
       orch = ContainerOrchestrator.new
-      orch.delete_deployment_config(worker_deployment_name)
+      orch.delete_deployment(worker_deployment_name)
       orch.delete_service(worker_deployment_name)
     end
 

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -2,7 +2,7 @@ class ContainerOrchestrator
   module ObjectDefinition
     private
 
-    def deployment_config_definition(name)
+    def deployment_definition(name)
       {
         :metadata => {
           :name      => name,
@@ -10,11 +10,10 @@ class ContainerOrchestrator
           :namespace => my_namespace,
         },
         :spec     => {
-          :selector => {:name => name, :app => app_name},
+          :selector => {:matchLabels => {:name => name}},
           :template => {
             :metadata => {:name => name, :labels => {:name => name, :app => app_name}},
             :spec     => {
-              :serviceAccount     => "miq-anyuid",
               :serviceAccountName => "miq-anyuid",
               :containers         => [{
                 :name          => name,


### PR DESCRIPTION
This will allow the orchestrator to run on either OpenShift or Kubernetes by using only objects supported by both.

Fixes #17845 

