### PR TITLE
Display available disk in utilization

### DIFF
--- a/product/charts/miq_reports/vim_perf_util_4_ts.yaml
+++ b/product/charts/miq_reports/vim_perf_util_4_ts.yaml
@@ -78,7 +78,9 @@ generate_rows:
   - :function: percent_of_col
     :col_name: derived_storage_total
     :pct_col_name: derived_storage_total
-  - 0
+  - :function: percent_of_col
+    :col_name: derived_storage_free
+    :pct_col_name: derived_storage_total
   - :function: percent_of_col
     :col_name: trend_max_v_derived_storage_used
     :pct_col_name: derived_storage_total
@@ -86,7 +88,7 @@ generate_rows:
     :col_name: trend_v_derived_storage_used
     :pct_col_name: derived_storage_total
   - :col_name: derived_storage_total
-  - 0
+  - :col_name: derived_storage_free
   - :col_name: trend_max_v_derived_storage_used
   - :col_name: trend_v_derived_storage_used
 


### PR DESCRIPTION
Updating yaml (display free storage and percentage ) report which is responsible for displaying report on screenshots.


**BEFORE**
![Screenshot 2019-11-13 at 14 14 46](https://user-images.githubusercontent.com/14937244/68766900-07ee4f80-0620-11ea-9df2-ece31eb50d93.png)


**AFTER**
![Screenshot 2019-11-13 at 14 09 33](https://user-images.githubusercontent.com/14937244/68766774-cf4e7600-061f-11ea-9b4f-2861df336bb9.png)

Links
------

* https://bugzilla.redhat.com/show_bug.cgi?id=1761966


@miq-bot assign @gtanzillo 
@miq-bot add_label ivanchuk/yes 
@miq-bot add_label hammer/yes 


