### PR TITLE
Remove repmgr10 from the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV DATABASE_URL=postgresql://root@localhost/vmdb_production?encoding=utf8&pool=
 RUN yum -y install --setopt=tsflags=nodocs \
                    memcached               \
                    postgresql-server       \
-                   repmgr10                \
                    mod_ssl                 \
                    openssh-clients         \
                    openssh-server          \


### PR DESCRIPTION
HA is handled in the console and we don't install the console
on the container images so we don't need repmgr.