### PR TITLE
metrics capture gap by ems

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -75,7 +75,8 @@ module Metric::Capture
             end
     emses.each do |ems|
       targets = Metric::Targets.capture_ems_targets(ems, :exclude_storages => true)
-      targets.each { |target| target.perf_capture_queue('historical', :start_time => start_time, :end_time => end_time, :zone => zone) }
+      target_options = Hash.new { |_n, _v| {:start_time => start_time, :end_time => end_time, :zone => ems.zone, :interval => 'historical'} }
+      queue_captures(targets, target_options)
     end
 
     _log.info("Queueing performance capture for range: [#{start_time} - #{end_time}]...Complete")
@@ -216,8 +217,8 @@ module Metric::Capture
     use_historical = historical_days != 0
 
     targets.each do |target|
-      interval_name = perf_target_to_interval_name(target)
-      options = target_options[target]
+      options = target_options[target] || {}
+      interval_name = options[:interval] || perf_target_to_interval_name(target)
       target.perf_capture_queue(interval_name, options)
     rescue => err
       _log.warn("Failed to queue perf_capture for target [#{target.class.name}], [#{target.id}], [#{target.name}]: #{err}")

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -64,6 +64,9 @@ module Metric::Capture
   end
 
   def self.perf_capture_gap(start_time, end_time, zone_id = nil, ems_id = nil)
+    raise ArgumentError, "end_time and start_time must be specified" if start_time.nil? || end_time.nil?
+    raise _("Start time must be earlier than End time") if start_time > end_time
+
     _log.info("Queueing performance capture for range: [#{start_time} - #{end_time}]...")
 
     emses = if ems_id
@@ -75,7 +78,7 @@ module Metric::Capture
             end
     emses.each do |ems|
       targets = Metric::Targets.capture_ems_targets(ems, :exclude_storages => true)
-      target_options = Hash.new { |_n, _v| {:start_time => start_time, :end_time => end_time, :zone => ems.zone, :interval => 'historical'} }
+      target_options = Hash.new { |_n, _v| {:start_time => start_time.utc, :end_time => end_time.utc, :zone => ems.zone, :interval => 'historical'} }
       queue_captures(targets, target_options)
     end
 

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -18,7 +18,6 @@ module Metric::CiMixin::Capture
   end
 
   def split_capture_intervals(interval_name, start_time, end_time, threshold = 1.day)
-    raise _("Start time must be earlier than End time") if start_time > end_time
     # Create an array of ordered pairs from start_time and end_time so that each ordered pair is contained
     # within the threshold.  Then, reverse it so the newest ordered pair is first:
     # start_time = 2017/01/01 12:00:00, end_time = 2017/01/04 12:00:00
@@ -32,8 +31,8 @@ module Metric::CiMixin::Capture
   private :split_capture_intervals
 
   def perf_capture_queue(interval_name, options = {})
-    start_time = options[:start_time]&.utc
-    end_time   = options[:end_time]&.utc
+    start_time = options[:start_time]
+    end_time   = options[:end_time]
     priority   = options[:priority] || Metric::Capture.interval_priority(interval_name)
     task_id    = options[:task_id]
     zone       = options[:zone] || my_zone
@@ -41,7 +40,6 @@ module Metric::CiMixin::Capture
     ems        = ems_for_capture_target
 
     raise ArgumentError, "invalid interval_name '#{interval_name}'" unless Metric::Capture::VALID_CAPTURE_INTERVALS.include?(interval_name)
-    raise ArgumentError, "end_time cannot be specified if start_time is nil" if start_time.nil? && !end_time.nil?
     raise ArgumentError, "target does not have an ExtManagementSystem" if ems.nil?
 
     # cb is the task used to group cluster realtime metrics

--- a/app/models/metric/targets.rb
+++ b/app/models/metric/targets.rb
@@ -21,6 +21,9 @@ module Metric::Targets
     end
   end
 
+  # If a Cluster, standalone Host, or Storage is not enabled, skip it.
+  # If a Cluster is enabled, capture all of its Hosts.
+  # If a Host is enabled, capture all of its Vms.
   def self.capture_infra_targets(emses, options)
     load_infra_targets_data(emses, options)
     all_hosts = capture_host_targets(emses)
@@ -146,16 +149,5 @@ module Metric::Targets
   def self.capture_vm_targets(emses, hosts)
     enabled_host_ids = hosts.select(&:perf_capture_enabled?).index_by(&:id)
     emses.flat_map { |e| e.vms.select { |v| enabled_host_ids.key?(v.host_id) && v.state == 'on' && v.supports_capture? } }
-  end
-
-  # If a Cluster, standalone Host, or Storage is not enabled, skip it.
-  # If a Cluster is enabled, capture all of its Hosts.
-  # If a Host is enabled, capture all of its Vms.
-  def self.capture_targets(zone = nil, options = {})
-    zone = MiqServer.my_server.zone if zone.nil?
-    zone = Zone.find(zone) if zone.kind_of?(Integer)
-    zone.ems_metrics_collectable.flat_map do |ems|
-      capture_ems_targets(ems, options) || []
-    end
   end
 end

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -161,7 +161,7 @@ describe Metric::Capture do
       context "executing perf_capture_gap" do
         before do
           t = Time.now.utc
-          Metric::Capture.perf_capture_gap(t - 7.days, t - 5.days)
+          Metric::Capture.perf_capture_gap(t - 7.days, t - 5.days, nil, @ems_vmware.id)
         end
 
         it "should queue up enabled targets for historical" do

--- a/tools/metrics_capture_gap.rb
+++ b/tools/metrics_capture_gap.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 require File.expand_path('../config/environment', __dir__)
 
-if ARGV.length != 2
-  puts "Usage: rails runner #{$0} start_date end_date"
+if ARGV.length < 2 || ARGV.length > 3
+  puts "Usage: rails runner #{$PROGRAM_NAME} start_date end_date [ems_id]"
   puts
   puts "  start_date and end_date must be in iso8601 format (e.g. 2010-02-15T00:00:00Z)."
   exit 1
 end
-start_date, end_date = *ARGV
+start_date, end_date, ems_id = *ARGV
 
 def log(msg)
   $log.info("MIQ(#{__FILE__}) #{msg}")
@@ -15,5 +15,5 @@ def log(msg)
 end
 
 log("Queueing metrics capture for [#{start_date}..#{end_date}]...")
-Metric::Capture.perf_capture_gap(Time.parse(start_date), Time.parse(end_date))
+Metric::Capture.perf_capture_gap(Time.parse(start_date).utc, Time.parse(end_date).utc, nil, ems_id&.to_i)
 log("Queueing metrics capture for [#{start_date}..#{end_date}]...Complete")


### PR DESCRIPTION
Extracted from #19492. This is part of the initiative towards ems centric collection (vs zone). 

### before

- UI requests collecting gap metrics for a zone.

### after

- UI can request collecting gap metrics for a zone or an ems.
- Moved the date logic to the 1 place dates are passed in. It is now run 1 time.
- Consolidated queue captures to `queue_captures`, the same method that regular metrics is done.

note: Since there is typically 1 ems per zone, this change is pretty much a tomato/potatoe kind of thing.  (But being ems centric buys us things down the line)