### PR TITLE
metrics_capture supports ems

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -1,8 +1,9 @@
 class ManageIQ::Providers::BaseManager::MetricsCapture
   include Vmdb::Logging
 
-  attr_reader :target
-  def initialize(target)
+  attr_reader :target, :ems
+  def initialize(target, ems = nil)
     @target = target
+    @ems = ems
   end
 end


### PR DESCRIPTION
This allows metrics_capture to support multiple targets within an ems

The signature is backwards compatible

The tests in this repo run against openstack and vmware.
vmware is the only provider that overrides `initialize()`

extracted from #19492