### PR TITLE
Use ActiveSupport's parent method for the ems class

### DIFF
--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker < ::MiqE
   require_nested :Runner
 
   def self.ems_class
-    ManageIQ::Providers::StorageManager::CinderManager
+    parent
   end
 
   def self.settings_name

--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresh_worker.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker < ::MiqEm
   require_nested :Runner
 
   def self.ems_class
-    ManageIQ::Providers::StorageManager::SwiftManager
+    parent
   end
 
   def self.settings_name

--- a/spec/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker_spec.rb
@@ -1,0 +1,7 @@
+describe ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker do
+  describe ".ems_class" do
+    it "is the parent manager" do
+      expect(described_class.ems_class).to eq(ManageIQ::Providers::StorageManager::CinderManager)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/storage_manager/swift_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/storage_manager/swift_manager/refresh_worker_spec.rb
@@ -1,0 +1,7 @@
+describe ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker do
+  describe ".ems_class" do
+    it "is the parent manager" do
+      expect(described_class.ems_class).to eq(ManageIQ::Providers::StorageManager::SwiftManager)
+    end
+  end
+end


### PR DESCRIPTION
This makes the storage manager classes consistent with the rest of the ems workers.

@Fryguy found this while trying to grok the logic we need for the orchestrator.