### PR TITLE
Use secret_key_base to avoid rails 5.2 deprecation

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -27,9 +27,9 @@ module MiqWebServerWorkerMixin
     end
 
     def configure_secret_token(token = MiqDatabase.first.session_secret_token)
-      return if Rails.application.config.secret_token
+      return if Rails.application.config.secret_key_base
 
-      Rails.application.config.secret_token = token
+      Rails.application.config.secret_key_base = token
 
       # To set a secret token after the Rails.application is initialized,
       # we need to reset the secrets since they are cached:

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -15,38 +15,39 @@ describe MiqWebServerWorkerMixin do
   end
 
   before do
-    @token   = Rails.application.config.secret_token
+    @token   = Rails.application.config.secret_key_base
     @secrets = Rails.application.secrets
     MiqDatabase.seed
   end
 
   after do
-    Rails.application.config.secret_token = @token
+    Rails.application.config.secret_key_base = @token
     Rails.application.secrets = @secrets
   end
 
   it ".configure_secret_token defaults to MiqDatabase session_secret_token" do
-    Rails.application.config.secret_token = nil
+    Rails.application.config.secret_key_base = nil
 
     test_class.configure_secret_token
-    expect(Rails.application.secrets[:secret_token]).to eq(MiqDatabase.first.session_secret_token)
+    expect(Rails.application.config.secret_key_base).to eq(MiqDatabase.first.session_secret_token)
   end
 
   it ".configure_secret_token accepts an input token" do
-    Rails.application.config.secret_token = nil
+    Rails.application.config.secret_key_base = nil
 
     token = SecureRandom.hex(64)
     test_class.configure_secret_token(token)
-    expect(Rails.application.secrets[:secret_token]).to eq(token)
+    expect(Rails.application.config.secret_key_base).to eq(token)
   end
 
   it ".configure_secret_token does not reset secrets when token already configured" do
-    Rails.application.config.secret_token = SecureRandom.hex(64)
+    existing_value = SecureRandom.hex(64)
+    Rails.application.config.secret_key_base = existing_value
     Rails.application.secrets = nil
     Rails.application.secrets
 
     test_class.configure_secret_token
-    expect(Rails.application.secrets[:secret_token]).to eq(Rails.application.config.secret_token)
+    expect(Rails.application.config.secret_key_base).to eq(existing_value)
   end
 
   it "#rails_server_options" do


### PR DESCRIPTION
Fixes:
DEPRECATION WARNING: `secrets.secret_token` is deprecated in favor of
`secret_key_base` and will be removed in Rails 6.0. (called from <top
(required)> at /home/travis/build/jrafanie/manageiq/config/environment.rb:5)


Cross repo tests:  https://travis-ci.org/jrafanie/manageiq-cross_repo-tests/builds/612059762

