### PR TITLE
Don't convert user-type email to upn

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -507,7 +507,7 @@ class MiqRequestWorkflow
     unless email.blank?
       l = MiqLdap.new
       if l.bind_with_default == true
-        raise _("No information returned for %{email}") % {:email => email} if (d = l.get_user_info(email)).nil?
+        raise _("No information returned for %{email}") % {:email => email} if (d = l.get_user_info(email, "mail")).nil?
         [:first_name, :last_name, :address, :city, :state, :zip, :country, :title, :company,
          :department, :office, :phone, :phone_mobile, :manager, :manager_mail, :manager_phone].each do |prop|
           @values["owner_#{prop}".to_sym] = d[prop].try(:dup)

--- a/lib/miq_ldap.rb
+++ b/lib/miq_ldap.rb
@@ -310,7 +310,7 @@ class MiqLdap
     user_type ||= @user_type.split("-").first
     if dn?(username)
       user_type = "dn"
-    elsif upn?(username)
+    elsif user_type != "mail" && upn?(username)
       user_type = "upn"
     end
 
@@ -338,7 +338,7 @@ class MiqLdap
     obj.first if obj
   end
 
-  def get_user_info(username, user_type = 'mail')
+  def get_user_info(username, user_type = nil)
     user = get_user_object(username, user_type)
     return nil if user.nil?
 

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -207,6 +207,15 @@ describe MiqLdap do
 
       ldap.get_user_object("myuserid@mycompany.com", "bad_user_type")
     end
+
+    it "filters by mail=<user> when user_type is mail" do
+      ldap = MiqLdap.new(:host => ["192.0.2.2"])
+      @opts[:attributes] = ["*", "memberof"]
+      @opts[:filter] = "(mail=myuserid@mycompany.com)"
+      expect(ldap).to receive(:search).with(@opts)
+
+      ldap.get_user_object("myuserid@mycompany.com", "mail")
+    end
   end
 
   context "#fqusername" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1769517

**Summary:**
Fix user_type==`mail` support in MiqLdap#get_user_object

**Details:** 

The user_type is not always set, requiring MiqLdap#get_user_object to attempt to determine the user_type based on the format of the user_name

The provider VM provisioning screens in the UI provide for the ability to lookup a user by email address in the Idp. The MiqLdap client was erroneously converting the user_type to `User Principle Name` **(UPN)** when the username format matched **string@string**

This PR  addresses this issue by:
1 - Explicitly specifying the user-type of mail in MiqRequestWorkflow#retrieve_ldap, which is used by the UI when doing user lookup by email.
2 - Ensuring the user_type is not set to UPN when user_type is mail.