### PR TITLE
Load graphql only in puma process bundler groups (api/ui)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -188,7 +188,9 @@ group :rest_api, :manageiq_default do
   manageiq_plugin "manageiq-api"
 end
 
-group :graphql_api, :manageiq_default do
+group :graphql_api do
+  # Note, you still need to mount the engine in the UI / rest api processes:
+  # mount ManageIQ::GraphQL::Engine, :at => '/graphql'
   manageiq_plugin "manageiq-graphql"
 end
 

--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -67,9 +67,9 @@ MIQ_WORKER_TYPES = {
   "MiqReportingWorker"                                                          => %i(manageiq_default),
   "MiqScheduleWorker"                                                           => %i(manageiq_default),
   "MiqSmartProxyWorker"                                                         => %i(manageiq_default),
-  "MiqUiWorker"                                                                 => %i(manageiq_default ui_dependencies),
+  "MiqUiWorker"                                                                 => %i(manageiq_default ui_dependencies graphql_api),
   "MiqVimBrokerWorker"                                                          => %i(manageiq_default),
-  "MiqWebServiceWorker"                                                         => %i(manageiq_default),
+  "MiqWebServiceWorker"                                                         => %i(manageiq_default graphql_api),
   "MiqRemoteConsoleWorker"                                                      => %i(manageiq_default),
 }.freeze
 


### PR DESCRIPTION
Only puma based processes could utilize graphql by mounting the engine. Removing
it from manageiq_default drops loaded features from 2696 to 2337.

Cross repo tests: https://travis-ci.org/jrafanie/manageiq-cross_repo-tests/builds/612103084
