### PR TITLE
metrics simplify calc_targets_by_rollup

### DIFF
--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -133,13 +133,13 @@ module Metric::Capture
   # 1. Only calculate rollups for Hosts
   # 2. Some Hosts have an EmsCluster as a parent, others have none.
   # 3. Only Hosts with a parent are rolled up.
+  # 4. Only used for VMWare
   # @param [Array<Host|VmOrTemplate|Storage>] @targets The nodes to rollup
   # @returns Hash<String,Array<Host>>
   #   e.g.: {"EmsCluster:4"=>[Host:4], "EmsCluster:5"=>[Host:1, Host:2]}
   def self.calc_targets_by_rollup_parent(targets)
     realtime_targets = targets.select do |target|
       target.kind_of?(Host) &&
-        perf_target_to_interval_name(target) == "realtime" &&
         perf_capture_now?(target)
     end
     realtime_targets.each_with_object({}) do |target, h|

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -140,7 +140,8 @@ module Metric::Capture
   def self.calc_targets_by_rollup_parent(targets)
     realtime_targets = targets.select do |target|
       target.kind_of?(Host) &&
-        perf_capture_now?(target)
+        perf_capture_now?(target) &&
+        target.ems_cluster_id
     end
     realtime_targets.each_with_object({}) do |target, h|
       target.perf_rollup_parents("realtime").to_a.compact.each do |parent|

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -144,10 +144,9 @@ module Metric::Capture
         target.ems_cluster_id
     end
     realtime_targets.each_with_object({}) do |target, h|
-      target.perf_rollup_parents("realtime").to_a.compact.each do |parent|
-        pkey = "#{parent.class}:#{parent.id}"
-        (h[pkey] ||= []) << target
-      end
+      parent = target.ems_cluster
+      pkey = "#{parent.class}:#{parent.id}"
+      (h[pkey] ||= []) << target
     end
   end
 

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -134,14 +134,13 @@ module Metric::Capture
   # 2. Some Hosts have an EmsCluster as a parent, others have none.
   # 3. Only Hosts with a parent are rolled up.
   # @param [Array<Host|VmOrTemplate|Storage>] @targets The nodes to rollup
-  # @option options :force Force capture if this node is a host
   # @returns Hash<String,Array<Host>>
   #   e.g.: {"EmsCluster:4"=>[Host:4], "EmsCluster:5"=>[Host:1, Host:2]}
-  def self.calc_targets_by_rollup_parent(targets, options = {})
+  def self.calc_targets_by_rollup_parent(targets)
     realtime_targets = targets.select do |target|
       target.kind_of?(Host) &&
         perf_target_to_interval_name(target) == "realtime" &&
-        (options[:force] || perf_capture_now?(target))
+        perf_capture_now?(target)
     end
     realtime_targets.each_with_object({}) do |target, h|
       target.perf_rollup_parents("realtime").to_a.compact.each do |parent|


### PR DESCRIPTION
In the end of the day, we're just grouping hosts by `ems_cluster`, so that is what the code now reads.

I commented each commit with the reasoning, so you could probably just read the comments and not even look at the code transforms.


@agrare we could punt on this for now - and fix it while we move it over to vmware specific logic.