### PR TITLE
metrics: set ems in metrics_capture object

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -1,6 +1,10 @@
 module Metric::CiMixin::Capture
   def perf_capture_object
-    self.class.parent::MetricsCapture.new(self)
+    if self.kind_of?(ExtManagementSystem)
+      self.class::MetricsCapture.new(nil, ext_management_system)
+    else
+      self.class.parent::MetricsCapture.new(self, ext_management_system)
+    end
   end
 
   delegate :perf_collect_metrics, :to => :perf_capture_object


### PR DESCRIPTION
Fixes issue with azure build failure due to metrics collection.

### Details

Each provider's metrics_collection handles the `ems` differently.

I had changed the metrics_capture to have an optional `ems` in #19511, to make sure vmware worked: https://github.com/ManageIQ/manageiq-providers-vmware/pull/475 - but this caused issues with azure. Now we're passing in `ems` (in the second branch of the `if`) so azure and all ems will be happy.

### Enhancement

The first branch of the `if` enables `Ems.perf_capture_object` - which is the main purpose of our changes to metrics_collection. This is so metrics can be collected for an ems (rather than for only targets). 