### PR TITLE
Address workers not present in worker list

### DIFF
--- a/app/models/manageiq/providers/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager.rb
@@ -3,7 +3,6 @@
 
 class ManageIQ::Providers::StorageManager::CinderManager < ManageIQ::Providers::StorageManager
   require_nested :RefreshParser
-  require_nested :RefreshWorker
   require_nested :Refresher
 
   include ManageIQ::Providers::StorageManager::BlockMixin

--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker.rb
@@ -1,7 +1,0 @@
-class ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_cinder
-  end
-end

--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker/runner.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker::Runner <
-  ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end

--- a/app/models/manageiq/providers/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager.rb
@@ -1,6 +1,5 @@
 class ManageIQ::Providers::StorageManager::SwiftManager < ManageIQ::Providers::StorageManager
   require_nested :RefreshParser
-  require_nested :RefreshWorker
   require_nested :Refresher
 
   include ManageIQ::Providers::StorageManager::ObjectMixin

--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresh_worker.rb
@@ -1,7 +1,0 @@
-class ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
-  def self.settings_name
-    :ems_refresh_worker_swift
-  end
-end

--- a/app/models/manageiq/providers/storage_manager/swift_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/storage_manager/swift_manager/refresh_worker/runner.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker::Runner <
-  ManageIQ::Providers::BaseManager::RefreshWorker::Runner
-end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1190,8 +1190,6 @@
         :ems_refresh_worker_google_network: {}
         :ems_refresh_worker_microsoft: {}
         :ems_refresh_worker_nuage_network: {}
-        :ems_refresh_worker_cinder: {}
-        :ems_refresh_worker_swift: {}
       :event_handler:
         :cpu_usage_threshold: 0.percent
         :nice_delta: 7

--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -110,8 +110,6 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Openstack::CloudManager::RefreshWorker
   ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker
   ManageIQ::Providers::Openstack::InfraManager::RefreshWorker
-  ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker
-  ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker
   ManageIQ::Providers::Vmware::CloudManager::RefreshWorker
   ManageIQ::Providers::Vmware::NetworkManager::RefreshWorker
   ManageIQ::Providers::Vmware::InfraManager::RefreshWorker

--- a/spec/lib/workers/miq_worker_types_spec.rb
+++ b/spec/lib/workers/miq_worker_types_spec.rb
@@ -1,0 +1,14 @@
+describe "worker types lists" do
+  let(:all_defined_workers) do
+    exceptions = %w[ManageIQ::Providers::BaseManager::OperationsWorker]
+    MiqWorker.descendants.select { |w| w.subclasses.empty? }.map(&:name) - exceptions
+  end
+
+  it "should include all the worker types" do
+    expect(MIQ_WORKER_TYPES.keys).to match_array(all_defined_workers)
+  end
+
+  it "kill list should match type list" do
+    expect(MIQ_WORKER_TYPES_IN_KILL_ORDER).to match_array(all_defined_workers)
+  end
+end

--- a/spec/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/storage_manager/cinder_manager/refresh_worker_spec.rb
@@ -1,7 +1,0 @@
-describe ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker do
-  describe ".ems_class" do
-    it "is the parent manager" do
-      expect(described_class.ems_class).to eq(ManageIQ::Providers::StorageManager::CinderManager)
-    end
-  end
-end

--- a/spec/models/manageiq/providers/storage_manager/swift_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/storage_manager/swift_manager/refresh_worker_spec.rb
@@ -1,7 +1,0 @@
-describe ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker do
-  describe ".ems_class" do
-    it "is the parent manager" do
-      expect(described_class.ems_class).to eq(ManageIQ::Providers::StorageManager::SwiftManager)
-    end
-  end
-end


### PR DESCRIPTION
These lists should really contain all the defined workers.

Right now the workers missing from `MIQ_WORKER_TYPES` are:

```
ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
ManageIQ::Providers::Azure::NetworkManager::EventCatcher
ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
ManageIQ::Providers::AzureStack::CloudManager::MetricsCollectorWorker
ManageIQ::Providers::BaseManager::OperationsWorker
ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker
ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker
ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker
```

The workers missing from `MIQ_WORKER_TYPES_IN_KILL_ORDER` are:

```
ManageIQ::Providers::Azure::NetworkManager::EventCatcher
ManageIQ::Providers::AzureStack::CloudManager::MetricsCollectorWorker
ManageIQ::Providers::BaseManager::OperationsWorker
```

@agrare I added the operations worker to an exceptions list in this spec because I'm pretty sure it's something you're actively working on.

As for the others ... all the actual worker classes are at least a year old and in some cases as many as 3 years old. I'm wondering if there's a reason these workers are in this limbo state where they have existed in the source for quite a while, but seemingly have never been run. I'm cc'ing the authors of these workers to start a discussion. In my mind (especially for the older ones) it feels like we should make a decision and either remove the worker from the provider plugin or add it to the list and make it work.

Also, the fact that the workers missing from the kill types list is a subset of the other is strange .. not sure what's going on there.

cc:

@gberginc `ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker`

@Ladas `ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker`, `ManageIQ::Providers::Azure::NetworkManager::RefreshWorker`, `ManageIQ::Providers::Azure::NetworkManager::EventCatcher`, `ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker`

@miha-plesko `ManageIQ::Providers::AzureStack::CloudManager::RefreshWorker`

@jerryk55 `ManageIQ::Providers::StorageManager::SwiftManager::RefreshWorker`

@hsong-rh `ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker`

Also cc @jrafanie and @NickLaMuro I think you guys were in here refactoring things so just keeping you in the loop.
