### PR TITLE
Adding ability to update additional authentication settings

### DIFF
--- a/lib/tasks/evm_settings.rake
+++ b/lib/tasks/evm_settings.rake
@@ -1,5 +1,7 @@
 module EvmSettings
   ALLOWED_KEYS ||= [
+    "/authentication/mode",
+    "/authentication/httpd_role",
     "/authentication/sso_enabled",
     "/authentication/saml_enabled",
     "/authentication/oidc_enabled",

--- a/spec/lib/tasks/evm_settings_spec.rb
+++ b/spec/lib/tasks/evm_settings_spec.rb
@@ -2,13 +2,15 @@ require "rake"
 
 describe "EvmSettings", :type => :rake_task do
   let(:task_path) { "lib/tasks/evm_settings" }
-  let(:keys) { ["/authentication/sso_enabled", "/authentication/saml_enabled", "/authentication/oidc_enabled", "/authentication/local_login_disabled"] }
+  let(:keys) { ["/authentication/mode", "/authentication/httpd_role", "/authentication/sso_enabled", "/authentication/saml_enabled", "/authentication/oidc_enabled", "/authentication/local_login_disabled"] }
 
   describe ".get_keys" do
     context "gets the current keys" do
       it "when provider_type is none" do
         @settings_hash =
-          {:authentication => {:user_type            => "userprincipalname",
+          {:authentication => {:mode                 => "database",
+                               :httpd_role           => false,
+                               :user_type            => "userprincipalname",
                                :amazon_key           => nil,
                                :oidc_enabled         => false,
                                :saml_enabled         => false,
@@ -18,6 +20,8 @@ describe "EvmSettings", :type => :rake_task do
            :binary_blob    => {:purge_window_size    => 100}}
 
         allow(Settings).to receive(:to_hash).and_return(@settings_hash)
+        expect(STDOUT).to receive(:puts).with("/authentication/mode=database")
+        expect(STDOUT).to receive(:puts).with("/authentication/httpd_role=false")
         expect(STDOUT).to receive(:puts).with("/authentication/sso_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/saml_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")
@@ -28,7 +32,9 @@ describe "EvmSettings", :type => :rake_task do
 
       it "when provider_type is oidc" do
         @settings_hash =
-          {:authentication => {:user_type            => "userprincipalname",
+          {:authentication => {:mode                 => "httpd",
+                               :httpd_role           => true,
+                               :user_type            => "userprincipalname",
                                :amazon_key           => nil,
                                :oidc_enabled         => true,
                                :saml_enabled         => false,
@@ -38,6 +44,8 @@ describe "EvmSettings", :type => :rake_task do
            :binary_blob    => {:purge_window_size    => 100}}
 
         allow(Settings).to receive(:to_hash).and_return(@settings_hash)
+        expect(STDOUT).to receive(:puts).with("/authentication/mode=httpd")
+        expect(STDOUT).to receive(:puts).with("/authentication/httpd_role=true")
         expect(STDOUT).to receive(:puts).with("/authentication/sso_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/saml_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=true")
@@ -48,7 +56,9 @@ describe "EvmSettings", :type => :rake_task do
 
       it "when provider_type is saml" do
         @settings_hash =
-          {:authentication => {:user_type            => "userprincipalname",
+          {:authentication => {:mode                 => "httpd",
+                               :httpd_role           => true,
+                               :user_type            => "userprincipalname",
                                :amazon_key           => nil,
                                :oidc_enabled         => false,
                                :saml_enabled         => true,
@@ -58,6 +68,8 @@ describe "EvmSettings", :type => :rake_task do
            :binary_blob    => {:purge_window_size    => 100}}
 
         allow(Settings).to receive(:to_hash).and_return(@settings_hash)
+        expect(STDOUT).to receive(:puts).with("/authentication/mode=httpd")
+        expect(STDOUT).to receive(:puts).with("/authentication/httpd_role=true")
         expect(STDOUT).to receive(:puts).with("/authentication/sso_enabled=false")
         expect(STDOUT).to receive(:puts).with("/authentication/saml_enabled=true")
         expect(STDOUT).to receive(:puts).with("/authentication/oidc_enabled=false")


### PR DESCRIPTION
Adding ability to update the /authentication/mode  well as the /authentication/httpd_role via bundle exec rake evm:settings:set

This is needed to allow the Authentication to be configured from the appliance console CLI to SAML/OIDC and Back.
