### PR TITLE
Remove worker classes only the kill_order list

### DIFF
--- a/lib/workers/miq_worker_types.rb
+++ b/lib/workers/miq_worker_types.rb
@@ -91,12 +91,9 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   MiqGenericWorker
   MiqEventHandler
   ManageIQ::Providers::Azure::CloudManager::RefreshWorker
-  ManageIQ::Providers::Azure::NetworkManager::RefreshWorker
   ManageIQ::Providers::AzureStack::CloudManager::RefreshWorker
   ManageIQ::Providers::AzureStack::NetworkManager::RefreshWorker
   ManageIQ::Providers::Amazon::CloudManager::RefreshWorker
-  ManageIQ::Providers::Amazon::NetworkManager::RefreshWorker
-  ManageIQ::Providers::Amazon::StorageManager::Ebs::RefreshWorker
   ManageIQ::Providers::Amazon::StorageManager::S3::RefreshWorker
   ManageIQ::Providers::Amazon::AgentCoordinatorWorker
   ManageIQ::Providers::Google::CloudManager::RefreshWorker
@@ -111,7 +108,6 @@ MIQ_WORKER_TYPES_IN_KILL_ORDER = %w(
   ManageIQ::Providers::Redfish::PhysicalInfraManager::RefreshWorker
   ManageIQ::Providers::Redhat::InfraManager::RefreshWorker
   ManageIQ::Providers::Openstack::CloudManager::RefreshWorker
-  ManageIQ::Providers::Openstack::NetworkManager::RefreshWorker
   ManageIQ::Providers::Redhat::NetworkManager::RefreshWorker
   ManageIQ::Providers::Openstack::InfraManager::RefreshWorker
   ManageIQ::Providers::StorageManager::CinderManager::RefreshWorker


### PR DESCRIPTION
Some worker classes were in the `MIQ_WORKER_TYPES_IN_KILL_ORDER` list
but not in the `MIQ_WORKER_TYPES` list and have since had their classes
removed.

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/436