### PR TITLE
Subclass ResourcePools

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers
   class InfraManager < BaseManager
     require_nested :Cluster
     require_nested :ProvisionWorkflow
+    require_nested :ResourcePool
     require_nested :Template
     require_nested :Vm
     require_nested :VmOrTemplate

--- a/app/models/manageiq/providers/infra_manager/resource_pool.rb
+++ b/app/models/manageiq/providers/infra_manager/resource_pool.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::InfraManager::ResourcePool < ::ResourcePool
+end

--- a/app/models/resource_pool.rb
+++ b/app/models/resource_pool.rb
@@ -1,4 +1,5 @@
 class ResourcePool < ApplicationRecord
+  include NewWithTypeStiMixin
   include TenantIdentityMixin
 
   acts_as_miq_taggable


### PR DESCRIPTION
Subclass ResourcePools to allow for provider specifics (e.g. provider_object/connection and ems_ref_obj mixins) to be added for VMware and not have to be in core.

Depends:
- [x] https://github.com/ManageIQ/manageiq-schema/pull/435

Dependent:
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/480
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/437
- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/149

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/13