### PR TITLE
fix sporadic test with state_machine_spec

### DIFF
--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -116,8 +116,8 @@ describe MiqProvision do
 
           task.signal(:post_create_destination)
 
-          expect(task.destination.retires_on).to be_between(retires_on - 1.second, retires_on + 1.second)
-          expect(vm.reload.retires_on).to        be_between(retires_on - 1.second, retires_on + 1.second)
+          expect(task.destination.retires_on).to be_between(retires_on - 2.seconds, retires_on + 2.seconds)
+          expect(vm.reload.retires_on).to        be_between(retires_on - 2.seconds, retires_on + 2.seconds)
           expect(vm.retirement_warn).to          eq(0)
           expect(vm.retired).to                  be_falsey
         end
@@ -135,7 +135,7 @@ describe MiqProvision do
           task.signal(:post_create_destination)
 
           expect(task.destination.retires_on).to eq(retires_on)
-          expect(vm.reload.retires_on).to        be_between(retires_on - 1.second, retires_on + 1.second)
+          expect(vm.reload.retires_on).to        be_between(retires_on - 2.seconds, retires_on + 2.seconds)
           expect(vm.retirement_warn).to          eq(retirement_warn_days)
           expect(vm.retired).to                  be_falsey
         end


### PR DESCRIPTION
it sometimes takes more than 1 second to run
`Task#post_create_destination`

https://travis-ci.org/ManageIQ/manageiq/jobs/613616923#L727