### PR TITLE
Rename chargeback_rate_detail_currencies to just currencies

### DIFF
--- a/config/replication_exclude_tables.yml
+++ b/config/replication_exclude_tables.yml
@@ -5,7 +5,7 @@
 - binary_blobs
 - binary_blob_parts
 - chargeable_fields
-- chargeback_rate_detail_currencies
+- currencies
 - chargeback_rate_detail_measures
 - chargeback_rate_details
 - chargeback_rates


### PR DESCRIPTION
blocked on:
- [ ] ManageIQ/manageiq-schema#421

Currencies are not related just to chargeback and we have renaming work in progress:
Per https://github.com/ManageIQ/manageiq-schema/pull/421 and https://github.com/ManageIQ/manageiq/pull/19350
