### PR TITLE
Refactor authenticator spec

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -151,7 +151,7 @@ module Authenticator
       end
     end
 
-    def find_external_identity(username, *args)
+    def find_external_identity(_username, *_args)
       raise NoMethodError, "required interface method 'find_external_identity' not defined by subclass"
     end
 

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -109,7 +109,7 @@ module Authenticator
 
       run_task(taskid, "Authorizing") do |task|
         begin
-          identity = find_external_identity(username, *args)
+          identity = find_external_identity(username, args[0], args[1])
 
           unless identity
             msg = "Authentication failed for userid #{username}, unable to find user object in #{self.class.proper_name}"
@@ -151,7 +151,7 @@ module Authenticator
       end
     end
 
-    def find_external_identity(_username, *_args)
+    def find_external_identity(_username, _user_attrs, _membership_list)
       raise NotImplementedError, _("find_external_identity must be implemented in a subclass")
     end
 

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -152,7 +152,7 @@ module Authenticator
     end
 
     def find_external_identity(_username, *_args)
-      raise NotImplementedError, "required interface method 'find_external_identity' not defined by subclass"
+      raise NotImplementedError, _("find_external_identity must be implemented in a subclass")
     end
 
     def find_or_initialize_user(identity, username)

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -152,7 +152,7 @@ module Authenticator
     end
 
     def find_external_identity(_username, *_args)
-      raise NoMethodError, "required interface method 'find_external_identity' not defined by subclass"
+      raise NotImplementedError, "required interface method 'find_external_identity' not defined by subclass"
     end
 
     def find_or_initialize_user(identity, username)

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -151,6 +151,10 @@ module Authenticator
       end
     end
 
+    def find_external_identity(username, *args)
+      raise NoMethodError, "required interface method 'find_external_identity' not defined by subclass"
+    end
+
     def find_or_initialize_user(identity, username)
       userid = userid_for(identity, username)
       user   = case_insensitive_find_by_userid(userid)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -35,7 +35,7 @@ module Authenticator
     end
 
     def find_external_identity(_username, *args)
-      args
+      args # should be [user_attributes, membership_list]
     end
 
     def groups_for(identity)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -34,8 +34,8 @@ module Authenticator
       request.headers['X-EXTERNAL-AUTH-ERROR']
     end
 
-    def find_external_identity(_username, user_attrs, membership_list)
-      [user_attrs, membership_list]
+    def find_external_identity(_username, *args)
+      args
     end
 
     def groups_for(identity)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -34,8 +34,8 @@ module Authenticator
       request.headers['X-EXTERNAL-AUTH-ERROR']
     end
 
-    def find_external_identity(_username, *args)
-      args # should be [user_attributes, membership_list]
+    def find_external_identity(_username, user_attrs, membership_list)
+      [user_attrs, membership_list]
     end
 
     def groups_for(identity)

--- a/app/models/authenticator/ldap.rb
+++ b/app/models/authenticator/ldap.rb
@@ -71,7 +71,7 @@ module Authenticator
         ldap_bind(username, password)
     end
 
-    def find_external_identity(username, *_args)
+    def find_external_identity(username, _user_attrs, _membership_list)
       # Ldap will be used for authentication and role assignment
       _log.info("Bind DN: [#{config[:bind_dn]}]")
       _log.info(" User FQDN: [#{username}]")

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -25,7 +25,7 @@ describe Authenticator do
     end
 
     it 'Updates the user groups when no matching groups' do
-      allow(authenticator).to receive(:find_external_identity).with(any_args)
+      expect(authenticator).to receive(:find_external_identity)
         .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, []])
 
       authenticator.authorize(task.id, user.userid)
@@ -33,7 +33,7 @@ describe Authenticator do
     end
 
     it 'Updates the user groups' do
-      allow(authenticator).to receive(:find_external_identity).with(any_args)
+      expect(authenticator).to receive(:find_external_identity)
         .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, groups.collect(&:name)])
 
       authenticator.authorize(task.id, user.userid)

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -25,7 +25,7 @@ describe Authenticator do
     end
 
     it 'Updates the user groups when no matching groups' do
-      expect(authenticator).to receive(:find_external_identity)
+      allow(authenticator).to receive(:find_external_identity).with(any_args)
         .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, []])
 
       authenticator.authorize(task.id, user.userid)
@@ -33,7 +33,7 @@ describe Authenticator do
     end
 
     it 'Updates the user groups' do
-      expect(authenticator).to receive(:find_external_identity)
+      allow(authenticator).to receive(:find_external_identity).with(any_args)
         .and_return([{:username => user.userid, :fullname => user.name, :domain => "example.com"}, groups.collect(&:name)])
 
       authenticator.authorize(task.id, user.userid)

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -1,4 +1,4 @@
-describe Authenticator do
+RSpec.describe Authenticator do
   describe '.for' do
     it "instantiates the matching class" do
       expect(Authenticator.for(:mode => 'database')).to be_a(Authenticator::Database)
@@ -49,31 +49,31 @@ describe Authenticator do
     end
 
     it "returns external groups matching internal ones" do
-      create_groups(%w(group1 group2 group3))
-      matched_groups = authenticator.send(:match_groups, %w(group2 group4))
-      expect(matched_groups.collect(&:description)).to match_array(%w(group2))
+      create_groups(%w[group1 group2 group3])
+      matched_groups = authenticator.send(:match_groups, %w[group2 group4])
+      expect(matched_groups.collect(&:description)).to match_array(%w[group2])
     end
 
     it "matches groups without case sensitivity" do
-      create_groups(%w(group1 group2 GROUP3 GROUP4))
-      matched_groups = authenticator.send(:match_groups, %w(Group3 Group5))
-      expect(matched_groups.collect(&:description)).to match_array(%w(GROUP3))
+      create_groups(%w[group1 group2 GROUP3 GROUP4])
+      matched_groups = authenticator.send(:match_groups, %w[Group3 Group5])
+      expect(matched_groups.collect(&:description)).to match_array(%w[GROUP3])
     end
 
     it "returns empty list when no groups match" do
-      create_groups(%w(group1 group2))
-      matched_groups = authenticator.send(:match_groups, %w(group3))
+      create_groups(%w[group1 group2])
+      matched_groups = authenticator.send(:match_groups, %w[group3])
       expect(matched_groups).to be_empty
     end
 
     it "only returns matched group for the current region" do
       FactoryBot.create(:miq_group,
-                         :description => "group2",
-                         :id          => ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1))
+                        :description => "group2",
+                        :id          => ApplicationRecord.id_in_region(1, ApplicationRecord.my_region_number + 1))
       FactoryBot.create(:miq_group, :description => "group1")
       group2 = FactoryBot.create(:miq_group, :description => "group2")
 
-      matched_groups = authenticator.send(:match_groups, %w(group2))
+      matched_groups = authenticator.send(:match_groups, %w[group2])
       expect(MiqGroup.where(:description => "group2").count).to eq(2)
       expect(matched_groups.count).to             eq(1)
       expect(matched_groups.first.id).to          eq(group2.id)


### PR DESCRIPTION
With partial double verification enabled, you will see two failures in the authenticator specs:

```
1) Authenticator#authorize Updates the user groups
     Failure/Error: identity = find_external_identity(username, *args)
     
     ArgumentError:
       Wrong number of arguments. Expected 3, got 1.
     # ./app/models/authenticator/base.rb:112:in `block in authorize'
     # ./app/models/authenticator/base.rb:274:in `run_task'
     # ./app/models/authenticator/base.rb:110:in `authorize'
     # ./spec/models/authenticator_spec.rb:39:in `block (3 levels) in <top (required)>'

  2) Authenticator#authorize Updates the user groups when no matching groups
     Failure/Error: identity = find_external_identity(username, *args)
     
     ArgumentError:
       Wrong number of arguments. Expected 3, got 1.
     # ./app/models/authenticator/base.rb:112:in `block in authorize'
     # ./app/models/authenticator/base.rb:274:in `run_task'
     # ./app/models/authenticator/base.rb:110:in `authorize'
     # ./spec/models/authenticator_spec.rb:31:in `block (3 levels) in <top (required)>'
```
The first fundamental issue is that we have a base class relying on an internal method called `find_external_identity` to be defined by subclasses. I'm guessing this was simply overlooked, so this PR adds an interface method that ensures that subclasses which use it must define it.

The second issue is that different subclasses have a different method signature for their version of `find_external_identity`. As far as I can tell there are 3 subclasses that use it: app/models/authenticator/httpd.rb (core), app/models/authenticator/ldap.rb (core) and app/models/authenticator/amazon.rb (from the Amazon provider). They are defined like so:

amazon.rb: `def find_external_identity(username, *_args)`
httpd.rb: `def find_external_identity(_username, user_attrs, membership_list)`
ldap.rb: `def find_external_identity(username, *_args)`

This is kind of odd IMO, but it's working because the base class just splats the arguments.

~~The spec itself seems peculiar, as it's using an `expect` where I'm pretty sure we just want an `allow` + `any_args`, so I've updated that.~~

Update: Just in case it is actually meant to be an expectation, I've reverted that.

However, even with these changes I'm getting the same failure. I'm not sure if FactoryBot is getting confused by the arity or what yet.

To see this in action you need to update `spec/spec_helper.rb`. Add this at line 35 (inside the config.mock_with :rspec block):

`c.verify_partial_doubles = true`

Then run `bundle exec rspec spec/models/authenticator_spec.rb`.

Originally smoked out via https://github.com/ManageIQ/manageiq/pull/18659

*UPDATE*: I've updated the PR to actually modify the httpd method to be consistent with the interface, and now the specs pass. Please let me know if that's acceptable.

I've also fixed some rubocop warnings.