### PR TITLE
Subclass Folders, Datacenters, and StorageClusters

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -19,21 +19,6 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :hosts,             :uses => :all_relationships
 
   #
-  # Provider Object methods
-  #
-  # TODO: Vmware specific - Fix when we subclass EmsFolder
-
-  def provider_object(connection)
-    # TODO once EmsFolders are subclassed this can be moved to the vmware repo
-    ems_ref_obj = VimString.new(ems_ref, ems_ref_type, :ManagedObjectReference)
-    connection.getVimFolderByMor(ems_ref_obj)
-  end
-
-  def provider_object_release(handle)
-    handle.release if handle rescue nil
-  end
-
-  #
   # Relationship methods
   #
 
@@ -122,38 +107,6 @@ class EmsFolder < ApplicationRecord
   # Indicates if the folder is able to have child VMs
   def vm_folder?
     path.any? { |folder| folder.name == "vm" && folder.hidden? }
-  end
-
-  # TODO: refactor by vendor/hypervisor (currently, this assumes VMware)
-  def register_host(host)
-    host = Host.extract_objects(host)
-    raise _("Host cannot be nil") if host.nil?
-    userid, password = host.auth_user_pwd(:default)
-    network_address  = host.address
-
-    with_provider_connection do |vim|
-      handle = provider_object(vim)
-      begin
-        _log.info("Invoking addStandaloneHost with options: address => #{network_address}, #{userid}")
-        cr_mor = handle.addStandaloneHost(network_address, userid, password)
-      rescue VimFault => verr
-        fault = verr.vimFaultInfo.fault
-        raise if     fault.nil?
-        raise unless fault.xsiType == "SSLVerifyFault"
-
-        ssl_thumbprint = fault.thumbprint
-        _log.info("Invoking addStandaloneHost with options: address => #{network_address}, userid => #{userid}, sslThumbprint => #{ssl_thumbprint}")
-        cr_mor = handle.addStandaloneHost(network_address, userid, password, :sslThumbprint => ssl_thumbprint)
-      end
-
-      host_mor                   = vim.computeResourcesByMor[cr_mor].host.first
-      host.ems_ref               = host_mor
-      host.ems_ref_type          = "HostSystem"
-      host.ext_management_system = ext_management_system
-      host.save!
-      add_host(host)
-      host.refresh_ems
-    end
   end
 
   # Folder pathing methods

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -109,6 +109,10 @@ class EmsFolder < ApplicationRecord
     path.any? { |folder| folder.name == "vm" && folder.hidden? }
   end
 
+  def register_host(_host)
+    raise NotImplementedError, _("register_host must be implemented by a subclass")
+  end
+
   # Folder pathing methods
   # TODO: Store the full path directly in the folder objects for performance reasons
 

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -1,9 +1,12 @@
 module ManageIQ::Providers
   class InfraManager < BaseManager
     require_nested :Cluster
+    require_nested :Datacenter
+    require_nested :Folder
     require_nested :ProvisionWorkflow
     require_nested :ResourcePool
     require_nested :Storage
+    require_nested :StorageCluster
     require_nested :Template
     require_nested :Vm
     require_nested :VmOrTemplate

--- a/app/models/manageiq/providers/infra_manager/datacenter.rb
+++ b/app/models/manageiq/providers/infra_manager/datacenter.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::InfraManager::Datacenter < ::Datacenter
+end

--- a/app/models/manageiq/providers/infra_manager/folder.rb
+++ b/app/models/manageiq/providers/infra_manager/folder.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::InfraManager::Folder < ::EmsFolder
+end

--- a/app/models/manageiq/providers/infra_manager/storage_cluster.rb
+++ b/app/models/manageiq/providers/infra_manager/storage_cluster.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::InfraManager::StorageCluster < ::StorageCluster
+end

--- a/spec/factories/ems_folder.rb
+++ b/spec/factories/ems_folder.rb
@@ -19,7 +19,8 @@ FactoryBot.define do
   # VMware specific folders
   #
 
-  factory :vmware_folder, :parent => :ems_folder do
+  factory :vmware_folder,
+          :parent => :ems_folder, :class => "ManageIQ::Providers::Vmware::InfraManager::Folder" do
     sequence(:ems_ref) { |n| "group-d#{n}" }
     ems_ref_type       { "Folder" }
   end
@@ -65,7 +66,8 @@ FactoryBot.define do
     hidden { true }
   end
 
-  factory :vmware_datacenter, :parent => :vmware_folder, :class => "Datacenter" do
+  factory :vmware_datacenter,
+          :parent => :datacenter, :class => "ManageIQ::Providers::Vmware::InfraManager::Datacenter" do
     sequence(:name)    { |n| "Test Datacenter #{seq_padded_for_sorting(n)}" }
     sequence(:ems_ref) { |n| "datacenter-#{n}" }
     ems_ref_type       { "Datacenter" }


### PR DESCRIPTION
Create provider subclasses of Folder, Datacenter, and StorageCluster.

The new inheritance tree looks like:
```
                                       EmsFolder
                /                          |                 \             \
         Datacenter                  StorageCluster           \             \
            /                              |                   \             \
     ::IM::Datacenter             ::IM::StorageCluster     ::IM::Folder ::AM::InventoryGroup
        /                                  |                         \
{Microsoft,Redhat,Vmware}::Datacenter Vmware::StorageCluster {Microsoft,Redhat,Vmware}::Folder

`::IM => ManageIQ::Providers::InfraManager`
`::AM => ManageIQ::Providers::AutomationManager`
```

Provider Tree views:
![Screenshot from 2019-11-26 10-21-48](https://user-images.githubusercontent.com/12851112/69647109-ebe2a900-1036-11ea-9503-33397d9e6017.png)


Provision dialog:
![Screenshot from 2019-11-26 10-22-53](https://user-images.githubusercontent.com/12851112/69647124-f0a75d00-1036-11ea-9396-693ad0dd49f6.png)

Both still work as expected.

Depends:
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/6453
- [x] https://github.com/ManageIQ/manageiq-schema/pull/436

Merge together with:
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/481
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/440
- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/151

Cross Repo Test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/14