### PR TITLE
Remove seed on rails server start in development.

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -23,6 +23,7 @@ module MiqWebServerWorkerMixin
     end
 
     def preload_for_worker_role
+      raise "Expected database to be seeded via `rake db:seed`." unless EvmDatabase.seeded_primordially?
       configure_secret_token
     end
 

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -77,8 +77,26 @@ class EvmDatabase
     seed(OTHER_SEEDABLE_CLASSES)
   end
 
+  # Returns whether or not a primordial seed has completed.
+  def self.seeded_primordially?
+    # While not technically accurate, as someone could just insert a record
+    # directly, this is the simplest check at the moment to guess whether or not
+    # a primordial seed has completed.
+    MiqDatabase.any? && MiqRegion.in_my_region.any?
+  end
+
+  # Returns whether or not a full seed has completed.
+  def self.seeded?
+    # While not technically accurate, as someone could just insert a record
+    # directly, this is the simplest check at the moment to guess whether or not
+    # a full seed has completed.
+    #
+    # MiqAction was chosen because it cannot be added by a user directly.
+    seeded_primordially? && MiqAction.in_my_region.any?
+  end
+
   def self.skip_seeding?
-    ENV['SKIP_SEEDING'] && MiqDatabase.any?
+    ENV['SKIP_SEEDING'] && seeded_primordially?
   end
   private_class_method :skip_seeding?
 

--- a/lib/vmdb/initializer.rb
+++ b/lib/vmdb/initializer.rb
@@ -7,9 +7,6 @@ module Vmdb
       #   * command line(rails server)
       #   * debugger
       if defined?(Rails::Server)
-        # preload_for_worker_role depends on seeding, principally MiqDatabase
-        EvmDatabase.seed_primordial
-
         MiqUiWorker.preload_for_worker_role
         MiqServer.my_server.starting_server_record
         MiqServer.my_server.update(:status => "started")

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -73,6 +73,46 @@ describe EvmDatabase do
     end
   end
 
+  def simulate_primordial_seed
+    described_class.seed(["MiqDatabase", "MiqRegion"])
+  end
+
+  def simulate_full_seed
+    described_class.seed(["MiqDatabase", "MiqRegion", "MiqAction"])
+  end
+
+  describe ".seeded_primordially?" do
+    it "when not seeded" do
+      expect(EvmDatabase.seeded_primordially?).to be false
+    end
+
+    it "when seeded primordially" do
+      simulate_primordial_seed
+      expect(EvmDatabase.seeded_primordially?).to be true
+    end
+
+    it "when fully seeded" do
+      simulate_full_seed
+      expect(EvmDatabase.seeded_primordially?).to be true
+    end
+  end
+
+  describe ".seeded?" do
+    it "when not seeded" do
+      expect(EvmDatabase.seeded?).to be false
+    end
+
+    it "when seeded primordially" do
+      simulate_primordial_seed
+      expect(EvmDatabase.seeded?).to be false
+    end
+
+    it "when fully seeded" do
+      simulate_full_seed
+      expect(EvmDatabase.seeded?).to be true
+    end
+  end
+
   describe ".skip_seeding? (private)" do
     it "will not skip when SKIP_SEEDING is not set" do
       expect(ENV).to receive(:[]).with("SKIP_SEEDING").and_return(nil)
@@ -85,7 +125,7 @@ describe EvmDatabase do
     end
 
     it "will skip when SKIP_SEEDING is set and the database is seeded" do
-      MiqDatabase.seed
+      simulate_primordial_seed
       expect(ENV).to receive(:[]).with("SKIP_SEEDING").and_return("true")
       expect(described_class.send(:skip_seeding?)).to be_truthy
     end


### PR DESCRIPTION
In a production setting, evmserverd will be resposible for seeding the
database.  In a development setting, we should not be seeding when we
start the UI.  Developers should instead be encouraged to use bin/update
or call db:seed directly when changes are made.  Since most developers
need to call bin/update before starting a rails server, in order to
build the UI assets, this is part of the normal workflow.

This change should eliminate about 1 second at rails server boot in
development.

Some more:
- Seeding the database will change records in the database, and if pointing to someone else's database (say a customer database or a testing database), then we are modifying the target environment, making diagnostics harder by dirtying the source.
- Seeding the database is a blocking operation as it takes a lock on critical tables.  While in development this doesn't really matter much, it's better to remove it to avoid that.
