### PR TITLE
Raise exception if nested file will never be found

### DIFF
--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -15,14 +15,6 @@ module RequireNested
       Object.require_nested name
     end
   end
-
-  def require_nested_all
-    path = File.join(caller(1, 1).first.split('.rb').first, "*.rb") # determining caller file location
-    Dir.glob(path).sort.each do |full_path|
-      name = File.basename(full_path, '.rb')
-      require_nested(name.classify.to_sym)
-    end
-  end
 end
 
 Module.include RequireNested

--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -6,6 +6,7 @@ module RequireNested
     filename = "#{self}::#{name}".underscore
     filename = name.to_s.underscore if self == Object
     if Rails.application.config.cache_classes
+      raise LoadError, "No such file to load -- #{filename}" unless ActiveSupport::Dependencies.search_for_file(filename)
       autoload name, filename
     else
       require_dependency filename

--- a/lib/extensions/require_nested.rb
+++ b/lib/extensions/require_nested.rb
@@ -11,6 +11,27 @@ module RequireNested
       require_dependency filename
     end
 
+    # If the nested constant has a top-level constant with the same name, then both
+    # must be defined at the same time, otherwise the Rails autoloader can get
+    # confused.
+    #
+    # For example, suppose we have the following
+    #
+    #     # app/models/thing_grouper.rb
+    #     class ThingGrouper < ApplicationRecord
+    #       require_nested :Thing
+    #     end
+    #
+    #     # app/models/thing_grouper/thing.rb
+    #     class ThingGrouper::Thing; end
+    #
+    #     # app/models/thing.rb
+    #     class Thing < ApplicationRecord; end
+    #
+    # When the require_nested call is made, we will define `ThingGrouper`'s nested
+    # `Thing`, but at the same time we must also define `::Thing` in order to allow
+    # the Rails autloader to work correctly.  We do this by using a special-case call
+    # to `require_nested` on `Object`, if a top-level `thing.rb` file exists.
     if ActiveSupport::Dependencies.search_for_file(name.to_s.underscore) && self != Object
       Object.require_nested name
     end


### PR DESCRIPTION
It is possible to give autoload an invalid path, and that issue will
never be found until the associated constant is vivified.  This causes
issues where people forget to remove the require_nested calls when they
remove the files.  Now, it's not possible to forget, because an
exception will be raised as soon as the parent file is loaded.

This PR is built upon some commits to clarify the code and remove dead code, which came up as part of my research on how this method works.

See also https://github.com/ManageIQ/manageiq/pull/5270 , where the commented code was added.  Basically, Rails has trouble with matching nested and top-level const names, and the code in question gets around that by loading both the nested and top-level at the same time.

@carbonin Please review.