### PR TITLE
Rename: ChargebackRateDetailCurrency -> Currency

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -84,7 +84,7 @@ class ChargebackRate < ApplicationRecord
         rates = cbr.delete(:rates)
 
         rates.each do |rate_detail|
-          currency = ChargebackRateDetailCurrency.find_by(:code => rate_detail.delete(:type_currency))
+          currency = Currency.find_by(:code => rate_detail.delete(:type_currency))
           field = ChargeableField.find_by(:metric => rate_detail.delete(:metric))
           rate_detail[:chargeable_field_id] = field.id
           if currency

--- a/app/models/chargeback_rate_detail.rb
+++ b/app/models/chargeback_rate_detail.rb
@@ -2,7 +2,7 @@ class ChargebackRateDetail < ApplicationRecord
   belongs_to :chargeback_rate
   belongs_to :chargeable_field
   belongs_to :detail_measure, :class_name => "ChargebackRateDetailMeasure", :foreign_key => :chargeback_rate_detail_measure_id
-  belongs_to :detail_currency, :class_name => "ChargebackRateDetailCurrency", :foreign_key => :chargeback_rate_detail_currency_id
+  belongs_to :detail_currency, :class_name => "Currency", :foreign_key => :chargeback_rate_detail_currency_id, :inverse_of => :chargeback_rate_detail
   has_many :chargeback_tiers, :dependent => :destroy, :autosave => true
 
   default_scope { joins(:chargeable_field).merge(ChargeableField.order(:group => :asc, :description => :asc)) }
@@ -278,7 +278,7 @@ class ChargebackRateDetail < ApplicationRecord
 
       chargeback_rate[:rates].each do |detail|
         detail_new = ChargebackRateDetail.new(detail.slice(*ChargebackRateDetail::FORM_ATTRIBUTES))
-        detail_new.detail_currency = ChargebackRateDetailCurrency.find_by(:code => detail[:type_currency])
+        detail_new.detail_currency = Currency.find_by(:code => detail[:type_currency])
         detail_new.metric = detail[:metric]
         detail_new.chargeable_field = ChargeableField.find_by(:metric => detail.delete(:metric))
 

--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -1,1 +1,57 @@
-Currency = ChargebackRateDetailCurrency
+class Currency < ApplicationRecord
+  belongs_to :chargeback_rate_detail
+
+  validates :code,        :presence => true, :length => {:maximum => 100}
+  validates :name,        :presence => true, :length => {:maximum => 100}
+  validates :full_name,   :presence => true, :length => {:maximum => 100}
+  validates :symbol,      :presence => true, :length => {:maximum => 100}
+
+  has_many :chargeback_rate_detail, :foreign_key => "chargeback_rate_detail_currency_id", :inverse_of => :detail_currency, :dependent => :nullify
+
+  CURRENCY_FILE = "/currency_iso.json".freeze
+  FIXTURE_DIR = Money::Currency::Loader::DATA_PATH.freeze
+
+  def self.currencies_for_select
+    # Return a hash where the keys are the possible currencies and the values are their ids
+    Currency.all.each_with_object({}) do |currency, hsh|
+      currency_code = "#{currency.symbol} [#{currency.full_name}]"
+      hsh[currency_code] = currency.id
+    end
+  end
+
+  def self.currency_file_source
+    File.join(FIXTURE_DIR, CURRENCY_FILE)
+  end
+
+  def self.currencies
+    parse_currency_file.transform_values.map do |x|
+      {:code => x[:iso_code], :name => x[:name], :full_name => x[:name], :symbol => x[:symbol]}
+    end
+  end
+
+  def self.parse_currency_file
+    json = File.read(currency_file_source)
+    json.force_encoding(::Encoding::UTF_8) if defined?(::Encoding)
+    JSON.parse(json, :symbolize_names => true)
+  end
+
+  def self.seed
+    db_currencies = Currency.all.index_by(&:code)
+    if File.exist?(currency_file_source)
+      fixture_mtime_currency = File.mtime(currency_file_source).utc
+      currencies.each do |currency|
+        rec = db_currencies[currency[:code]]
+        if rec.nil?
+          _log.info("Creating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
+          Currency.create(currency)
+        elsif fixture_mtime_currency > rec.created_at
+          rec.attributes = currency
+          if rec.changed?
+            _log.info("Updating [#{currency[:code]}] with symbols=[#{currency[:symbol]}]")
+            rec.update(:created_at => fixture_mtime_currency)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -60,7 +60,7 @@ class ServiceTemplate < ApplicationRecord
 
   belongs_to :service_template_catalog
   belongs_to :zone
-  belongs_to :currency, :class_name => "ChargebackRateDetailCurrency", :inverse_of => false
+  belongs_to :currency, :inverse_of => false
 
   has_many   :dialogs, -> { distinct }, :through => :resource_actions
   has_many   :miq_schedules, :as => :resource, :dependent => :destroy

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -29,8 +29,8 @@ class EvmDatabase
     MiqPolicySet
     ChargebackRateDetailMeasure
     ChargeableField
-    ChargebackRateDetailCurrency
     ChargebackRate
+    Currency
 
     BlacklistedEvent
     Classification

--- a/spec/factories/chargeback_rate_detail.rb
+++ b/spec/factories/chargeback_rate_detail.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :chargeback_rate_detail do
     chargeback_rate
-    detail_currency { FactoryBot.create(:chargeback_rate_detail_currency) }
+    detail_currency { FactoryBot.create(:currency) }
 
     transient do
       tiers_params { nil }

--- a/spec/factories/chargeback_rate_detail_currency.rb
+++ b/spec/factories/chargeback_rate_detail_currency.rb
@@ -1,9 +1,0 @@
-FactoryBot.define do
-  factory :chargeback_rate_detail_currency do
-    code  { "EUR" }
-    name { "Euro" }
-    full_name { "Euro" }
-    symbol { "€" }
-    unicode_hex { "8364" }
-  end
-end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -272,7 +272,7 @@ Monthly @ 5.0 + 2.5 per Megabytes from 5.0 to Infinity")
   end
 
   it "#show_rates" do
-    cbc = FactoryBot.create(:chargeback_rate_detail_currency, :code => "EUR")
+    cbc = FactoryBot.create(:currency, :code => "EUR")
 
     cbd = FactoryBot.build(:chargeback_rate_detail_fixed_compute_cost, :detail_currency => cbc)
     expect(cbd.show_rates).to eq("€ [Euro] / Day")

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -95,7 +95,7 @@ describe ChargebackRate do
 
     context 'when there are valid rate details' do
       let(:symbol) { '฿' }
-      let(:currency) { FactoryBot.create(:chargeback_rate_detail_currency, :symbol => symbol) }
+      let(:currency) { FactoryBot.create(:currency, :symbol => symbol) }
       let(:field) { FactoryBot.create(:chargeable_field) }
       let(:details) { [FactoryBot.create(:chargeback_rate_detail, :detail_currency => currency, :chargeable_field => field)] }
       it { is_expected.to eq(symbol) }

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -1,31 +1,30 @@
-describe ChargebackRateDetailCurrency do
+describe Currency do
   describe '.seed' do
     it "returns supported currencies" do
-      ChargebackRateDetailCurrency.seed
+      Currency.seed
 
       expected_currencies = %w[AED AFN ALL AMD ANG AOA ARS AUD AWG AZN BAM BBD BDT BGN BHD BIF BMD BND BOB BRL BSD BTN BWP BYN BYR BZD CAD CDF CHF CLF CLP CNY COP CRC CUC CUP CVE CZK DJF DKK DOP DZD EGP ERN ETB EUR FJD FKP GBP GEL GHS GIP GMD GNF GTQ GYD HKD HNL HRK HTG HUF IDR ILS INR IQD IRR ISK JMD JOD JPY KES KGS KHR KMF KPW KRW KWD KYD KZT LAK LBP LKR LRD LSL LYD MAD MDL MGA MKD MMK MNT MOP MRU MUR MVR MWK MXN MYR MZN NAD NGN NIO NOK NPR NZD OMR PAB PEN PGK PHP PKR PLN PYG QAR RON RSD RUB RWF SAR SBD SCR SDG SEK SGD SHP SKK SLL SOS SRD SSP STD SVC SYP SZL THB TJS TMT TND TOP TRY TTD TWD TZS UAH UGX USD UYU UZS VES VND VUV WST XAF XAG XAU XCD XDR XOF XPD XPF XPT YER ZAR ZMK ZMW]
-
-      expect(ChargebackRateDetailCurrency.all.map(&:code)).to match_array(expected_currencies)
+      expect(Currency.all.map(&:code)).to match_array(expected_currencies)
     end
   end
 
   it "has a valid factory" do
-    expect(FactoryBot.create(:chargeback_rate_detail_currency)).to be_valid
+    expect(FactoryBot.create(:currency)).to be_valid
   end
 
   it "is invalid without a code" do
-    expect(FactoryBot.build(:chargeback_rate_detail_currency, :code => nil)).not_to be_valid
+    expect(FactoryBot.build(:currency, :code => nil)).not_to be_valid
   end
 
   it "is invalid without a name" do
-    expect(FactoryBot.build(:chargeback_rate_detail_currency, :name => nil)).not_to be_valid
+    expect(FactoryBot.build(:currency, :name => nil)).not_to be_valid
   end
 
   it "is invalid without a full_name" do
-    expect(FactoryBot.build(:chargeback_rate_detail_currency, :full_name => nil)).not_to be_valid
+    expect(FactoryBot.build(:currency, :full_name => nil)).not_to be_valid
   end
 
   it "is invalid without a symbol" do
-    expect(FactoryBot.build(:chargeback_rate_detail_currency, :symbol => nil)).not_to be_valid
+    expect(FactoryBot.build(:currency, :symbol => nil)).not_to be_valid
   end
 end


### PR DESCRIPTION
- renaming model and its usages (In specs)
- TODO: rename column: 
`ChargebackRateDetail#chargeback_rate_detail_currency_id` -> `ChargebackRateDetail#currency_id`

Links
-----
related (merged) PRs:

* https://github.com/ManageIQ/manageiq/pull/19350
* https://github.com/ManageIQ/manageiq-schema/pull/421


@miq-bot assign @kbrock 

@miq-bot add_label technical debt
