### PR TITLE
Initial set of codeowners for providers code

### DIFF
--- a/.github/CODEOOWNERS
+++ b/.github/CODEOOWNERS
@@ -2,4 +2,6 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @fryguy
+*                                            @fryguy
+/app/models/manageiq/providers/              @agrare @fryguy
+/app/models/manageiq/providers/inventory/    @agrare @fryguy @slemrmartin


### PR DESCRIPTION
Add codeowners for all of the providers code, we can get more granular
with e.g. EmbeddedAutomationManager/EmbeddedAnsible