### PR TITLE
Add currency model and factory

### DIFF
--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -1,0 +1,1 @@
+Currency = ChargebackRateDetailCurrency

--- a/spec/factories/currency.rb
+++ b/spec/factories/currency.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :currency do
+    code  { "EUR" }
+    name { "Euro" }
+    full_name { "Euro" }
+    symbol { "€" }
+    unicode_hex { "8364" }
+  end
+end


### PR DESCRIPTION
pulled out from https://github.com/ManageIQ/manageiq/pull/19538 

I just  need this small change in order to change it in other repos before we remove `ChargebackRateDetailCurrency`

@miq-bot assign @kbrock 
@miq-bot add_label technical debt

