### PR TITLE
Unify VM Operations queue handling and set queue_name

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -43,20 +43,28 @@ module VmOrTemplate::Operations
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def unregister_queue
+    run_command_via_queue("raw_unregister")
+  end
+
   def unregister
     raise _("VM has no Provider, unable to unregister VM") unless ext_management_system
 
-    check_policy_prevent(:request_vm_unregister, :raw_unregister)
+    check_policy_prevent(:request_vm_unregister, :unregister_queue)
   end
 
   def raw_destroy
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def destroy_queue
+    run_command_via_queue("raw_destroy")
+  end
+
   def vm_destroy
     raise _("VM has no Provider, unable to destroy VM") unless ext_management_system
 
-    check_policy_prevent(:request_vm_destroy, :raw_destroy)
+    check_policy_prevent(:request_vm_destroy, :destroy_queue)
   end
 
   def raw_rename(new_name)
@@ -75,16 +83,7 @@ module VmOrTemplate::Operations
       :userid => userid
     }
 
-    queue_opts = {
-      :class_name  => self.class.name,
-      :method_name => 'rename',
-      :instance_id => id,
-      :role        => 'ems_operations',
-      :zone        => my_zone,
-      :args        => [new_name]
-    }
-
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    run_command_via_queue(task_opts, :method_name => "rename", :args => [new_name])
   end
 
   def raw_set_custom_field(_attribute, _value)

--- a/app/models/vm_or_template/operations/power.rb
+++ b/app/models/vm_or_template/operations/power.rb
@@ -3,16 +3,24 @@ module VmOrTemplate::Operations::Power
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def start_queue
+    run_command_via_queue("raw_start")
+  end
+
   def start
-    check_policy_prevent(:request_vm_start, :raw_start)
+    check_policy_prevent(:request_vm_start, :start_queue)
   end
 
   def raw_stop
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def stop_queue
+    run_command_via_queue("raw_stop")
+  end
+
   def stop
-    check_policy_prevent(:request_vm_poweroff, :raw_stop)
+    check_policy_prevent(:request_vm_poweroff, :stop_queue)
   end
 
   # Suspend saves the state of the VM to disk and shuts it down
@@ -20,8 +28,12 @@ module VmOrTemplate::Operations::Power
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def suspend_queue
+    run_command_via_queue("raw_suspend")
+  end
+
   def suspend
-    check_policy_prevent(:request_vm_suspend, :raw_suspend)
+    check_policy_prevent(:request_vm_suspend, :suspend_queue)
   end
 
   # All associated data and resources are kept but anything still in memory is not retained.
@@ -29,8 +41,12 @@ module VmOrTemplate::Operations::Power
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def shelve_queue
+    run_command_via_queue("raw_shelve")
+  end
+
   def shelve
-    check_policy_prevent(:request_vm_shelve, :raw_shelve)
+    check_policy_prevent(:request_vm_shelve, :shelve_queue)
   end
 
   # Has to be in shelved state first. Data and resource associations are deleted.
@@ -38,8 +54,12 @@ module VmOrTemplate::Operations::Power
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def shelve_offload_queue
+    run_command_via_queue("raw_shelve_offload")
+  end
+
   def shelve_offload
-    check_policy_prevent(:request_vm_shelve_offload, :raw_shelve_offload)
+    check_policy_prevent(:request_vm_shelve_offload, :shelve_offload_queue)
   end
 
   # Pause keeps the VM in memory but does not give it CPU cycles.
@@ -48,7 +68,11 @@ module VmOrTemplate::Operations::Power
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def pause_queue
+    run_command_via_queue("raw_pause")
+  end
+
   def pause
-    check_policy_prevent(:request_vm_pause, :raw_pause)
+    check_policy_prevent(:request_vm_pause, :pause_queue)
   end
 end

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -48,8 +48,12 @@ module VmOrTemplate::Operations::Snapshot
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
+  def create_snapshot_queue(name, desc = nil, memory)
+    run_command_via_queue("raw_create_snapshot", :args => [name, desc, memory])
+  end
+
   def create_snapshot(name, desc = nil, memory = false)
-    check_policy_prevent(:request_vm_create_snapshot, :raw_create_snapshot, name, desc, memory)
+    check_policy_prevent(:request_vm_create_snapshot, :create_snapshot_queue, name, desc, memory)
   end
 
   def raw_remove_snapshot(snapshot_id)

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -173,7 +173,7 @@ describe Vm do
     end
 
     it "policy passes" do
-      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:raw_start)
+      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to receive(:start_queue)
 
       allow(MiqAeEngine).to receive_messages(:deliver => ['ok', 'sucess', MiqAeEngine::MiqAeWorkspaceRuntime.new])
       @vm.start
@@ -182,7 +182,7 @@ describe Vm do
     end
 
     it "policy prevented" do
-      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to_not receive(:raw_start)
+      expect_any_instance_of(ManageIQ::Providers::Vmware::InfraManager::Vm).to_not receive(:start_queue)
 
       event = {:attributes => {"full_data" => {:policy => {:prevented => true}}}}
       allow_any_instance_of(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:get_obj_from_path).with("/").and_return(:event_stream => event)


### PR DESCRIPTION
Move the queue handling for VM operations into common methods, set the
queue_name, and queue operations after check_policy_prevent.

Any operations run from a check_policy_prevent_callback were being run in the context of the automate role which was preventing these ems_operations from being run on an operations worker.

Issue: https://github.com/ManageIQ/manageiq/issues/19543