### PR TITLE
Remove the Runner#message_restarted method

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -261,10 +261,6 @@ class MiqWorker::Runner
     do_exit("Exit request received.")
   end
 
-  def message_restarted(*_args)
-    # just consume the restarted message
-  end
-
   def message_sync_config(*_args)
     _log.info("#{log_prefix} Synchronizing configuration...")
     sync_config


### PR DESCRIPTION
This method is only defined in the base runner class, does nothing
and is never called.

:cherries: :scissors: :fire: 