### PR TITLE
Make GuestDevice taggable

### DIFF
--- a/app/models/guest_device.rb
+++ b/app/models/guest_device.rb
@@ -21,6 +21,8 @@ class GuestDevice < ApplicationRecord
 
   alias_attribute :name, :device_name
 
+  acts_as_miq_taggable
+
   def self.with_ethernet_type
     where(:device_type => "ethernet")
   end


### PR DESCRIPTION
This PR adds the ability to tag a GuestDevice. The primary goal is to set a purpose for the network interfaces, in order to use the correct IP address to connect to the managed object. As described in https://github.com/ManageIQ/manageiq/issues/19548, it will be used for Ansible inventory and connection to ESXi hosts in the context of Migration.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1749313