### PR TITLE
Don't require VMwareWebService/MiqVimVm in Snapshot

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -616,19 +616,13 @@ class MiqAction < ApplicationRecord
     age_threshold = (Time.now.utc - action.options[:age])
     has_ch = false
     snaps_to_delete = rec.snapshots.each_with_object([]) do |s, arr|
-      has_ch = true if s.is_a_type?(:consolidate_helper)
-      next if s.is_a_type?(:evm_snapshot) || s.is_a_type?(:vcb_snapshot)
+      next if s.is_a_type?(:evm_snapshot)
 
       arr << s if s.create_time < age_threshold
     end
 
     if snaps_to_delete.empty?
       MiqPolicy.logger.info("#{log_prefix} has no snapshots older than [#{age_threshold}]")
-      return
-    end
-
-    if has_ch
-      MiqPolicy.logger.warn("#{log_prefix} has a Consolidate Helper snapshot, no shanpshots will be deleted")
       return
     end
 
@@ -650,22 +644,13 @@ class MiqAction < ApplicationRecord
     has_ch = false
     snap   = nil
     rec.snapshots.order("create_time DESC").each do |s|
-      if s.is_a_type?(:consolidate_helper)
-        has_ch = true
-        next
-      end
-      next if s.is_a_type?(:evm_snapshot) || s.is_a_type?(:vcb_snapshot)
+      next if s.is_a_type?(:evm_snapshot)
 
       snap ||= s # Take the first eligable snapshot
     end
 
     if snap.nil?
       MiqPolicy.logger.info("#{log_prefix} has no snapshots available to delete")
-      return
-    end
-
-    if has_ch
-      MiqPolicy.logger.warn("#{log_prefix} has a Consolidate Helper snapshot, no shanpshot will be deleted")
       return
     end
 


### PR DESCRIPTION
Snapshot was requiring some constants from VMwareWebService/MiqVimVm and
MiqAction was checking for some VMware specifics (Consolidate Helper/VCB).

Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/485
Cross Repo Tests of UI/API: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/22

https://github.com/ManageIQ/manageiq/issues/18428
https://github.com/ManageIQ/manageiq/issues/19440