### PR TITLE
Remove server capabilities serialized column

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -223,6 +223,8 @@ class MiqServer < ApplicationRecord
       ].each { |k| server_hash[k] = nil }
     end
 
+    server_hash[:has_vix_disk_lib] = server.is_vix_disk_supported?
+
     server.update(server_hash)
 
     _log.info("Server IP Address: #{server.ipaddress}")    unless server.ipaddress.blank?

--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -46,7 +46,6 @@ module MiqServer::ConfigurationManagement
       zone = Zone.in_my_region.find_by(:name => data.zone)
       update(:zone => zone) if zone
     end
-    update_capabilities
 
     save
   end

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -166,13 +166,9 @@ module MiqServer::ServerSmartProxy
   end
 
   def concurrent_job_max
-    update_capabilities
-    capabilities[:concurrent_miqproxies].to_i
-  end
-
-  def max_concurrent_miqproxies
     return 0 unless self.is_a_proxy?
-    MiqSmartProxyWorker.worker_settings[:count]
+
+    MiqSmartProxyWorker.fetch_worker_settings_from_server(self)[:count].to_i
   end
 
   def update_capabilities
@@ -181,7 +177,6 @@ module MiqServer::ServerSmartProxy
     # since they are determined by local resources.
     if MiqServer.my_server == self
       capabilities[:vixDisk] = self.is_vix_disk_supported?
-      capabilities[:concurrent_miqproxies] = max_concurrent_miqproxies
     end
   end
 end

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -5,10 +5,6 @@ module MiqServer::ServerSmartProxy
 
   SMART_ROLES = %w(smartproxy smartstate).freeze
 
-  included do
-    serialize :capabilities
-  end
-
   module ClassMethods
     # Called from VM scan job as well as scan_sync_vm
 
@@ -32,7 +28,7 @@ module MiqServer::ServerSmartProxy
   end
 
   def is_vix_disk?
-    self.has_active_role?(:SmartProxy) && capabilities && capabilities[:vixDisk]
+    has_vix_disk_lib? && self.has_active_role?(:SmartProxy)
   end
 
   def vm_scan_host_affinity?
@@ -107,7 +103,7 @@ module MiqServer::ServerSmartProxy
       ost.config = OpenStruct.new(
         :vmdb               => true,
         :forceFleeceDefault => true,
-        :capabilities       => capabilities
+        :capabilities       => {:vixDisk => has_vix_disk_lib?}
       )
 
       target.perform_metadata_scan(ost)
@@ -151,32 +147,22 @@ module MiqServer::ServerSmartProxy
 
   # TODO: This should be moved - where?
   def is_vix_disk_supported?
-    caps = {:vixDisk => false}
+    # This is only available on Linux
+    return false unless Sys::Platform::IMPL == :linux
+
     begin
-      # This is only available on Linux
-      if Sys::Platform::IMPL == :linux
-        require 'VMwareWebService/VixDiskLib/VixDiskLib'
-        caps[:vixDisk] = true
-      end
+      require 'VMwareWebService/VixDiskLib/VixDiskLib'
+      return true
     rescue Exception
       # It is ok if we hit an error, it just means the library is not available to load.
     end
 
-    caps[:vixDisk]
+    false
   end
 
   def concurrent_job_max
     return 0 unless self.is_a_proxy?
 
     MiqSmartProxyWorker.fetch_worker_settings_from_server(self)[:count].to_i
-  end
-
-  def update_capabilities
-    self.capabilities = {} if capabilities.nil?
-    # We can only update these values if we are working on the local server
-    # since they are determined by local resources.
-    if MiqServer.my_server == self
-      capabilities[:vixDisk] = self.is_vix_disk_supported?
-    end
   end
 end

--- a/spec/models/miq_server/server_smart_proxy_spec.rb
+++ b/spec/models/miq_server/server_smart_proxy_spec.rb
@@ -1,0 +1,33 @@
+describe "MiqServer::ServerSmartProxy" do
+  let(:server) { EvmSpecHelper.local_miq_server }
+  before { ServerRole.seed }
+
+  describe "#is_vix_disk?" do
+    it "is false without the smartproxy role" do
+      server.update(:has_vix_disk_lib => true)
+      expect(server.is_vix_disk?).to be_falsey
+    end
+
+    it "is true with smartproxy and vix disk lib" do
+      server.update(:has_vix_disk_lib => true)
+      server.role = "smartproxy"
+      server.assigned_server_roles.update(:active => true)
+
+      expect(server.is_vix_disk?).to be_truthy
+    end
+  end
+
+  describe "#concurrent_job_max" do
+    it "is 0 without the smartproxy role" do
+      expect(server.concurrent_job_max).to eq(0)
+    end
+
+    it "is the number of smart proxy workers when the role is active" do
+      server.role = "smartproxy"
+      server.assigned_server_roles.update(:active => true)
+      stub_settings(:workers => {:worker_base => {:queue_worker_base => {:smart_proxy_worker => {:count => 5}}}})
+
+      expect(server.concurrent_job_max).to eq(5)
+    end
+  end
+end

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -3,7 +3,7 @@ describe VmScan do
   context "A VM Scan job in multiple zones" do
     before do
       # local zone
-      @server1 = EvmSpecHelper.local_miq_server(:capabilities => {:vixDisk => true})
+      @server1 = EvmSpecHelper.local_miq_server(:has_vix_disk_lib => true)
       @user      = FactoryBot.create(:user_with_group, :userid => "tester")
       @ems       = FactoryBot.create(:ems_vmware_with_authentication, :name   => "Test EMS", :zone => @server1.zone,
                                       :tenant                                  => FactoryBot.create(:tenant))
@@ -19,7 +19,7 @@ describe VmScan do
                                       :storage               => @storage)
 
       # remote zone
-      @server2 = EvmSpecHelper.remote_miq_server(:capabilities => {:vixDisk => true})
+      @server2 = EvmSpecHelper.remote_miq_server(:has_vix_disk_lib => true)
       @user2     = FactoryBot.create(:user_with_group, :userid => "tester2")
       @storage2  = FactoryBot.create(:storage, :name => "test_storage2", :store_type => "VMFS")
       @host2     = FactoryBot.create(:host, :name => "test_host2", :hostname => "test_host2",


### PR DESCRIPTION
The column only contained two keys (`:concurrent_miqproxies` and `:vixDisk`).

The concurrent miq proxies value was a copy of the count of smart proxy workers which was updated every time the config changed; we should just query the settings directly. My guess is that, previously we could not query settings for other servers, which meant that anything a different server needed had to be stored somewhere else in the database.

The vix disk value is still needed, but is not tied to settings so there was no reason to update it every time the settings were activated. We can also now remove the serialized column and give vix disk its own flag in the servers table. The second commit does this as well as moves the check for vix disk support to server start.

The format of the old capabilities hash is preserved in the scanning openstruct to avoid changing the [vmware provider gem](https://github.com/ManageIQ/manageiq-providers-vmware/blob/3922ffa1e0ed80c30000643007473136474a470a/app/models/manageiq/providers/vmware/infra_manager/vm_or_template_shared/scanning.rb#L47-L48), but if we think that's worth changing here as well we can go that route.

requires https://github.com/ManageIQ/manageiq-schema/pull/439