### PR TITLE
VmOrTemplate::Operations#rename_queue - use run_command_via_task, not run_command_via_queue

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -83,7 +83,7 @@ module VmOrTemplate::Operations
       :userid => userid
     }
 
-    run_command_via_queue(task_opts, :method_name => "rename", :args => [new_name])
+    run_command_via_task(task_opts, :method_name => "rename", :args => [new_name])
   end
 
   def raw_set_custom_field(_attribute, _value)


### PR DESCRIPTION
Before https://github.com/ManageIQ/manageiq/pull/19544/commits/019591673788aae54fb5459137d0e5bfbbf90f23,
the function returned the result of `MiqTask.generic_action_with_callback`.

Now, it uses `run_command_via_queue`, leading to [red ui travis](https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/615790473#L2060)

    1) Mixins::Actions::VmActions::Rename#rename_save getting proper task_id initiates wait for task
      Failure/Error: expect(controller).to receive(:initiate_wait_for_task).with(:task_id => kind_of(Integer), :action => 'rename_finished')
      ...@flash_array=[{:message=>{:text=>"VM rename: Task start failed",...


I think that's a typo:

`run_command_via_queue(method_name, queue_options)` does not match the signature and calls `MiqQueue.put`,
while `run_command_via_task(task_options, queue_options)` does match, and calls `MiqTask.generic_action_with_callback`.

Also, that change fixes the UI specs.

Cc @kbrock , @agrare 