### PR TITLE
Change NoMethodError to NotImplementedError in MiqRequestWorkflow

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -773,7 +773,7 @@ class MiqRequestWorkflow
   # Subclasses should define this as appropriate.
   #
   def get_source_and_targets(_refresh = false)
-    raise NoMethodError, "subclass failed to define a 'get_source_and_targets' method"
+    raise NotImplementedError, _("get_source_and_targets must be implemented in a subclass")
   end
 
   def refresh_field_values(values)


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/19487, apparently we have a standard regarding the error type and error message formatting, so updating to that.