### PR TITLE
Drop support for forking workers, use spawn by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem "manageiq-postgres_ha_admin",     "~>3.1",         :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
 gem "more_core_extensions",           "~>3.7"
-gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.16.1",      :require => false
 gem "net-ping",                       "~>1.7.4",       :require => false
 gem "openscap",                       "~>0.4.8",       :require => false

--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -17,7 +17,10 @@ class MiqWebServiceWorker < MiqWorker
   end
 
   def self.bundler_groups
-    %w[manageiq_default graphql_api]
+    # TODO: The api process now looks at the existing UI session as of: https://github.com/ManageIQ/manageiq-api/pull/543
+    # ui-classic should not be but is serialializing its classes into session, so we need to have access to them for deserialization
+    # sandboxes;FC:-ActiveSupport::HashWithIndifferentAccess{I"dashboard;FC;q{I"perf_options;FS:0ApplicationController::Performance::Options$typ0:daily_date0:hourly_date0: days0:
+    %w[manageiq_default ui_dependencies graphql_api]
   end
 
   def self.kill_priority

--- a/lib/extensions/ar_application_name.rb
+++ b/lib/extensions/ar_application_name.rb
@@ -4,10 +4,6 @@ module ArApplicationName
   # connections in the pool.  We do this because reconnect! on an instance of the
   # AR adapter created prior to our change to PGAPPNAME will have old connection
   # options, which will reset our application_name.
-  #
-  # Because we fork workers from the server, if we don't disconnect the pool,
-  # any call to reconnect! on a connection will cause the worker's connection
-  # to have the server's application_name.
   def self.name=(name)
     # TODO: this is postgresql specific
     ENV['PGAPPNAME'] = name

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -89,7 +89,7 @@ unless worker_class.has_required_role?
   exit 1
 end
 
-worker_class.before_fork
+worker_class.preload_for_worker_role if worker_class.respond_to?(:preload_for_worker_role)
 unless options[:dry_run]
   create_options = {:pid => Process.pid}
   runner_options = {}

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -22,13 +22,6 @@ describe MiqWorker do
     end
   end
 
-  it "renice" do
-    allow(AwesomeSpawn).to receive(:launch)
-    allow(described_class).to receive(:worker_settings).and_return(:nice_delta => 5)
-    result = described_class.renice(123)
-    expect(result.command_line).to eq "renice -n 5 -p 123"
-  end
-
   context ".has_required_role?" do
     def check_has_required_role(worker_role_names, expected_result)
       allow(described_class).to receive(:required_roles).and_return(worker_role_names)
@@ -382,12 +375,12 @@ describe MiqWorker do
 
       it "with ENV['APPLIANCE']" do
         begin
-          allow(MiqWorker).to receive(:nice_increment).and_return("+10")
+          allow(MiqWorker).to receive(:nice_increment).and_return("10")
           allow(@worker).to receive(:worker_options).and_return(:ems_id => 1234, :guid => @worker.guid)
           old_env = ENV.delete('APPLIANCE')
           ENV['APPLIANCE'] = 'true'
           cmd = @worker.command_line
-          expect(cmd).to start_with("nice +10")
+          expect(cmd).to start_with("nice -n 10")
           expect(cmd).to include("--ems-id 1234")
           expect(cmd).to include("--guid #{@worker.guid}")
           expect(cmd).to include("--heartbeat")


### PR DESCRIPTION
Make systemd optional on systemd enabled systems

Api/web service worker needs ui-classic as it can try to read an existing UI session, which
can contain serialized classes from ui-classic.

Previously, we tried removing fork here: #16130
It was reverted here: #16154

Some of the followups needed to fix the original problems including passing down
ems_id to per ems workers, resolved in:
#16199 and
#18648

At this point, things should just work.