### PR TITLE
Look up worker by guid not pid

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -19,6 +19,8 @@ class MiqWorker < ApplicationRecord
   scope :with_miq_server_id, ->(server_id) { where(:miq_server_id => server_id) }
   scope :with_status,        ->(status)    { where(:status => status) }
 
+  cattr_accessor :my_guid, :instance_accessor => false
+
   STATUS_CREATING = 'creating'.freeze
   STATUS_STARTING = 'starting'.freeze
   STATUS_STARTED  = 'started'.freeze
@@ -279,7 +281,7 @@ class MiqWorker < ApplicationRecord
     w
   end
 
-  cache_with_timeout(:my_worker) { server_scope.find_by(:pid => Process.pid) }
+  cache_with_timeout(:my_worker) { server_scope.find_by(:guid => my_guid) }
 
   def self.status_update_all
     MiqWorker.status_update

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -164,6 +164,7 @@ class MiqWorker::Runner
   def find_worker_record
     @worker = self.class.corresponding_model.find_by(:guid => @cfg[:guid])
     do_exit("Unable to find instance for worker GUID [#{@cfg[:guid]}].", 1) if @worker.nil?
+    MiqWorker.my_guid = @cfg[:guid]
   end
 
   def starting_worker_record

--- a/spec/factories/vmware_refresh_worker.rb
+++ b/spec/factories/vmware_refresh_worker.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :vmware_refresh_worker, :class => 'ManageIQ::Providers::Vmware::InfraManager::RefreshWorker' do
-    pid { Process.pid }
-  end
-end

--- a/spec/models/message_timeout_handling_spec.rb
+++ b/spec/models/message_timeout_handling_spec.rb
@@ -8,6 +8,7 @@ describe "Message Timeout Handling" do
     allow(MiqServer).to receive(:my_server).and_return(@miq_server)
 
     @worker = FactoryBot.create(:vmware_refresh_worker, :miq_server_id => @miq_server.id)
+    MiqWorker.my_guid = @worker.guid
   end
 
   context "A Worker Handling a Message with a timeout of 3600 seconds" do

--- a/spec/models/message_timeout_handling_spec.rb
+++ b/spec/models/message_timeout_handling_spec.rb
@@ -7,7 +7,7 @@ describe "Message Timeout Handling" do
     @miq_server = FactoryBot.create(:miq_server, :guid => @guid, :zone => @zone)
     allow(MiqServer).to receive(:my_server).and_return(@miq_server)
 
-    @worker = FactoryBot.create(:vmware_refresh_worker, :miq_server_id => @miq_server.id)
+    @worker = FactoryBot.create(:ems_refresh_worker_amazon, :miq_server_id => @miq_server.id)
     MiqWorker.my_guid = @worker.guid
   end
 

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -69,4 +69,22 @@ describe MiqWorker::Runner do
       @worker_base.send(:process_message, "sync_config")
     end
   end
+
+  context "#initialize" do
+    let(:worker) do
+      server_id = EvmSpecHelper.local_miq_server.id
+      FactoryBot.create(:miq_worker, :miq_server_id => server_id, :type => "MiqGenericWorker")
+    end
+
+    let!(:runner) { MiqWorker::Runner.new(:guid => worker.guid) }
+
+    it "configures the #worker attribute correctly" do
+      expect(runner.worker.id).to eq(worker.id)
+      expect(runner.worker.guid).to eq(worker.guid)
+    end
+
+    it "sets the MiqWorker.my_guid class attribute" do
+      expect(MiqWorker.my_guid).to eq(worker.guid)
+    end
+  end
 end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -42,6 +42,8 @@ module EvmSpecHelper
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
     clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
 
+    MiqWorker.my_guid = nil
+
     # Clear the thread local variable to prevent test contamination
     User.current_user = nil if defined?(User) && User.respond_to?(:current_user=)
 


### PR DESCRIPTION
When each worker is running as a container, each worker gets its
own process space meaning it's more than likely that there will
by duplicate worker pids for the same server. This would make
MiqWorker.my_worker unreliable.

This commit saves the worker guid into a class attribute on MiqWorker
so that we can access it at any time within the process.