### PR TITLE
Use automate timeout for service.execute when execution_ttl is not set for a service

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook.rb
@@ -1,8 +1,6 @@
 class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
 
-  DEFAULT_EXECUTION_TTL = 100.minutes # automate state machine aborts after 100 retries at a minute interval
-
   def self.display_name(number = 1)
     n_('Playbook (Embedded Ansible)', 'Playbooks (Embedded Ansible)', number)
   end
@@ -20,7 +18,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook < Manage
     credentials = collect_credentials(vars)
 
     kwargs = {:become_enabled => vars[:become_enabled]}
-    kwargs[:timeout]   = vars[:execution_ttl].present? ? vars[:execution_ttl].to_i.minutes : DEFAULT_EXECUTION_TTL
+    kwargs[:timeout]   = vars[:execution_ttl].to_i.minutes
     kwargs[:verbosity] = vars[:verbosity].to_i if vars[:verbosity].present?
 
     workflow.create_job({}, extra_vars, playbook_vars, vars[:hosts], credentials, kwargs).tap do |job|

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -489,7 +489,18 @@ class Service < ApplicationRecord
   def configuration_script
   end
 
-  private def update_attributes_from_dialog
+  def set_automate_timeout(timeout, action = nil)
+    options[automate_timeout_key(action)] = timeout
+    save!
+  end
+
+  private
+
+  def update_attributes_from_dialog
     Service::DialogProperties.parse(options[:dialog], evm_owner).each { |key, value| self[key] = value }
+  end
+
+  def automate_timeout_key(action)
+    action.nil? ? :automate_timeout : "#{action.downcase}_automate_timeout".to_sym
   end
 end

--- a/app/models/service_ansible_playbook.rb
+++ b/app/models/service_ansible_playbook.rb
@@ -47,6 +47,11 @@ class ServiceAnsiblePlaybook < ServiceGeneric
     )
     opts[:hosts] = hosts_array(opts.delete(:hosts))
 
+    if opts[:execution_ttl].blank?
+      opts[:execution_ttl] = options[automate_timeout_key(action)]
+      _log.info("execution_ttl is set to automate timeout [#{opts[:execution_ttl]}] minutes")
+    end
+
     _log.info("Launching Ansible job with options:")
     $log.log_hashes(opts, :filter => ["api_token", "token"])
     new_job = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job.create_job(my_playbook, decrypt_options(opts))

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
 
   context "#run" do
     it "launches the referenced ansible playbook" do
-      job = playbook.run
+      job = playbook.run(:execution_ttl => 100)
 
       expect(job).to be_a ManageIQ::Providers::AnsiblePlaybookWorkflow
       expect(job.options[:env_vars]).to eq({})

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -225,6 +225,27 @@ describe(ServiceAnsiblePlaybook) do
       }
       expect(loaded_service.job(action)).to have_attributes(expected_job_attributes)
     end
+
+    it 'uses automate timeout if no execution_ttl' do
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job) do |_jobtemp, opts|
+        expect(opts[:execution_ttl]).to eq(77)
+        runner_job
+      end
+      expect(loaded_service.options[:provision_job_options][:execution_ttl]).to be nil
+      loaded_service.options[:provision_automate_timeout] = 77
+      loaded_service.launch_ansible_job(action)
+    end
+
+    it 'uses specified execution_ttl' do
+      timeout = config_info_options.dig(:config_info, :provision, :execution_ttl)
+      expect(ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job).to receive(:create_job) do |_jobtemp, opts|
+        expect(opts[:execution_ttl]).to eq(timeout)
+        runner_job
+      end
+      loaded_service.options[:provision_job_options][:execution_ttl] = timeout
+      loaded_service.options[:provision_automate_timeout] = 77
+      loaded_service.launch_ansible_job(action)
+    end
   end
 
   describe '#check_completed' do


### PR DESCRIPTION
Use the timeout value of automate field for service execute step when a playbook service doesn't have a user specified execution_ttl.

Include https://github.com/ManageIQ/manageiq-automation_engine/pull/393.
include https://github.com/ManageIQ/manageiq-content/pull/611.

@miq_bot assign @tinaafitz
@miq_bot add_label enhancement, changelog/yes, services, embedded ansible