### PR TITLE
Rename max_concurrent_tasks_per_host setting

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -115,7 +115,7 @@ class ConversionHost < ApplicationRecord
   # want that value cached.
   #
   def check_concurrent_tasks
-    max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
+    max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_conversion_host
     active_tasks.count < max_tasks
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1093,7 +1093,7 @@
     :retry_interval: 15 # in seconds
   :limits:
     :max_concurrent_tasks_per_ems: 10
-    :max_concurrent_tasks_per_host: 10
+    :max_concurrent_tasks_per_conversion_host: 10
     :cpu_limit_per_host: unlimited
     :network_limit_per_host: unlimited
 :ui:

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -37,7 +37,7 @@ class InfraConversionThrottler
 
         _log.debug("-- Eligible conversion hosts:")
         eligible_hosts.each do |eh|
-          max_tasks = eh.max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
+          max_tasks = eh.max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_conversion_host
           _log.debug("--- #{eh.name} [#{eh.active_tasks.count}/#{max_tasks}]")
         end
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe ConversionHost, :v2v do
 
     context "#check_concurrent_tasks" do
       context "default max concurrent tasks is equal to current active tasks" do
-        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 1}}) }
+        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_conversion_host => 1}}) }
         it { expect(conversion_host_1.check_concurrent_tasks).to eq(false) }
       end
 
       context "default max concurrent tasks is greater than current active tasks" do
-        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 10}}) }
+        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_conversion_host => 10}}) }
         it { expect(conversion_host_1.check_concurrent_tasks).to eq(true) }
       end
 


### PR DESCRIPTION
To implement https://github.com/ManageIQ/manageiq/issues/19562, we will want to have a new setting to configure the maximum number of concurrent conversions per VMware host, with a default to 20. Looking at the existing settings, it appears that renaming `max_concurrent_tasks_per_host` into `max_concurrent_tasks_per_conversion_host` would make sense to reduce confusion.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1777274
Depends on: https://github.com/ManageIQ/manageiq-v2v/pull/1073