### PR TITLE
V2v distribute conversions among vmware hosts

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -115,7 +115,7 @@ class ConversionHost < ApplicationRecord
   # want that value cached.
   #
   def check_concurrent_tasks
-    max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
+    max_tasks = max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_conversion_host
     active_tasks.count < max_tasks
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1093,7 +1093,7 @@
     :retry_interval: 15 # in seconds
   :limits:
     :max_concurrent_tasks_per_ems: 10
-    :max_concurrent_tasks_per_host: 10
+    :max_concurrent_tasks_per_conversion_host: 10
     :cpu_limit_per_host: unlimited
     :network_limit_per_host: unlimited
 :ui:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1094,8 +1094,10 @@
   :limits:
     :max_concurrent_tasks_per_ems: 10
     :max_concurrent_tasks_per_conversion_host: 10
+    :max_concurrent_tasks_per_vmware_host: 20
     :cpu_limit_per_host: unlimited
     :network_limit_per_host: unlimited
+    :optimize_vmware_vm_placement: false
 :ui:
   :mark_translated_strings: false
   :display_ops_database: false

--- a/db/fixtures/classifications.yml
+++ b/db/fixtures/classifications.yml
@@ -1059,6 +1059,29 @@
   :example_text: VM has been migrated.
   :default: true
   :single_value: "1"
+- :description: Host eligible for disk transfer during VM transformation
+  :entries:
+  - :description: True
+    :read_only: "0"
+    :syntax: string
+    :name: "true"
+    :example_text:
+    :default: true
+    single_value: "1"
+  - :description: False
+    :read_only: "0"
+    :syntax: string
+    :name: "false"
+    :example_text:
+    :default: true
+    single_value: "1"
+  :readonly: "0"
+  :syntax: string
+  :show: true
+  :name: transformation_eligible_for_disk_transfer
+  :example_text: Whether a host is eligible for disk transfer during transformation (default: True)
+  :default: true
+  :single_value: "1"
 - :description: Quota - Max VMs
   :entries:
   - :description: "1"

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -37,7 +37,7 @@ class InfraConversionThrottler
 
         _log.debug("-- Eligible conversion hosts:")
         eligible_hosts.each do |eh|
-          max_tasks = eh.max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_host
+          max_tasks = eh.max_concurrent_tasks || Settings.transformation.limits.max_concurrent_tasks_per_conversion_host
           _log.debug("--- #{eh.name} [#{eh.active_tasks.count}/#{max_tasks}]")
         end
 

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -62,7 +62,7 @@ class InfraConversionThrottler
 
   # @return [Hash] the list of jobs in state 'running', grouped by conversion host
   def self.running_conversion_jobs
-    running = InfraConversionJob.where(:state => 'running')
+    running = InfraConversionJob.where.not(:state => ["finished", "waiting_to_start"])
     _log.info("Running InfraConversionJob: #{running.count}")
     running.group_by { |job| job.migration_task.conversion_host }
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe ConversionHost, :v2v do
 
     context "#check_concurrent_tasks" do
       context "default max concurrent tasks is equal to current active tasks" do
-        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 1}}) }
+        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_conversion_host => 1}}) }
         it { expect(conversion_host_1.check_concurrent_tasks).to eq(false) }
       end
 
       context "default max concurrent tasks is greater than current active tasks" do
-        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_host => 10}}) }
+        before { stub_settings_merge(:transformation => {:limits => {:max_concurrent_tasks_per_conversion_host => 10}}) }
         it { expect(conversion_host_1.check_concurrent_tasks).to eq(true) }
       end
 


### PR DESCRIPTION
This PR aims at overcoming the current limitation of 20 concurrent migrations when using VDDK. This limitation is in fact per VMware host, but we currently don't know what VMware host will be used for the disk transfer, so we recommend limiting to 20 concurrent migrations overall.

In the implementation, we want to migrate (Vm.migrate) the virtual machine to another eligible VMware host, so that all hosts share the load. The mechanism is to look for the least utilized VMware host that can access the VM disks. We introduce a new Settings entry `transformation / max_concurrent_tasks_per_vmware_host` that defaults to 20.

Also, to not change the current behavior of the state machine, we add another Settings entry`transformation / optimize_vmware_vm_placement` that defaults to `false`. This means that the user has to consciously enable this feature.

The migration would only be done for cold migration and would happen once the VM is powered off. The reason is that a migration is almost instantaneous when the VM is off, so we can afford this extra step. Doing it on a powered on VM could have an impact on the VM performance, and even on the cluster stability. That's why we add this state in InfraConversionJob after the `shutdown_vm` states.

We also want to add a tag to the hosts that shouldn't be used for disk transfer, so that the user can create a safe area for intensive virtual machines. The classification definition is part of the PR.

The eligibility would then be criteria:

- Host is not tagged as not eligible
- Host has access to virtual machine disks (datastores)
- Host has less running disk transfers than the limit (default: 20)

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1777274
Depends on: https://github.com/ManageIQ/manageiq/pull/19563