### PR TITLE
Add queue_name to queued method options for Flavor model

### DIFF
--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -58,9 +58,11 @@ class Flavor < ApplicationRecord
       :class_name  => 'Flavor',
       :method_name => 'create_flavor',
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [ext_management_system.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
@@ -86,14 +88,17 @@ class Flavor < ApplicationRecord
       :action => "Deleting flavor for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => "Flavor",
       :method_name => 'delete_flavor',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => []
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -48,6 +48,10 @@ class Flavor < ApplicationRecord
          .references(:cloud_tenants, :tenants, :ext_management_system)
   end
 
+  # Create a flavor as a queued task and return the task id. The queue name and
+  # the queue zone are derived from the provided EMS instance. The EMS instance
+  # and a userid are mandatory.
+  #
   def self.create_flavor_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "Creating flavor for user #{userid}",
@@ -83,6 +87,9 @@ class Flavor < ApplicationRecord
     klass.raw_create_flavor(ext_management_system, options)
   end
 
+  # Delete a flavor as a queued task and return the task id. The queue name and
+  # the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def delete_flavor_queue(userid)
     task_opts = {
       :action => "Deleting flavor for user #{userid}",
@@ -90,7 +97,7 @@ class Flavor < ApplicationRecord
     }
 
     queue_opts = {
-      :class_name  => "Flavor",
+      :class_name  => 'Flavor',
       :method_name => 'delete_flavor',
       :instance_id => id,
       :role        => 'ems_operations',

--- a/spec/models/flavor_spec.rb
+++ b/spec/models/flavor_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Flavor do
     end
 
     it 'requires a userid and ems for a queued create task' do
-      expect{ described_class.create_flavor_queue }.to raise_error(ArgumentError)
-      expect{ described_class.create_flavor_queue(user.userid) }.to raise_error(ArgumentError)
+      expect { described_class.create_flavor_queue }.to raise_error(ArgumentError)
+      expect { described_class.create_flavor_queue(user.userid) }.to raise_error(ArgumentError)
     end
 
     it 'queues a delete task with delete_flavor_queue' do
@@ -78,7 +78,7 @@ RSpec.describe Flavor do
     end
 
     it 'requires a userid for a queued delete task' do
-      expect{ flavor.delete_flavor_queue }.to raise_error(ArgumentError)
+      expect { flavor.delete_flavor_queue }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/models/flavor_spec.rb
+++ b/spec/models/flavor_spec.rb
@@ -1,5 +1,7 @@
-describe Flavor do
+RSpec.describe Flavor do
   let(:ems) { FactoryBot.create(:ems_openstack) }
+  let(:flavor) { FactoryBot.create(:flavor, :name => 'large', :ext_management_system => ems) }
+  let(:user) { FactoryBot.create(:user, :userid => 'test') }
 
   context 'when calling raw_create_flavor methods' do
     it 'raises NotImplementedError' do
@@ -30,6 +32,30 @@ describe Flavor do
     it 'should call raw_delete_flavor' do
       expect(subject).to receive(:raw_delete_flavor)
       subject.delete_flavor
+    end
+  end
+
+  context 'queued methods', :queue do
+    it 'queues a delete task' do
+      task_id = flavor.delete_flavor_queue(user.userid)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "Deleting flavor for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'delete_flavor',
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      )
+    end
+
+    it 'requires a userid for a queued delete task' do
+      expect{ flavor.delete_flavor_queue }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/models/flavor_spec.rb
+++ b/spec/models/flavor_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Flavor do
     end
   end
 
-  context 'queued methods', :queue do
+  context 'queued methods' do
     it 'queues a create task with create_flavor_queue' do
       task_id = described_class.create_flavor_queue(user.userid, ems)
 


### PR DESCRIPTION
This PR adds a `queue_name` to the queue options for the `Flavor.create_flavor_queue` and `Flavor#delete_flavor_queue` methods. I've also added some specs (these methods were previously uncovered), and some comments on those methods.

Part of https://github.com/ManageIQ/manageiq/issues/19543