### PR TITLE
Add queue_name to queued method options for CloudVolume model 

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -92,6 +92,7 @@ class CloudVolume < ApplicationRecord
       :method_name => 'update_volume',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [options]
     }

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -35,18 +35,26 @@ class CloudVolume < ApplicationRecord
     ext_management_system && ext_management_system.class::CloudVolume
   end
 
+  # Create a cloud volume as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the provided EMS instance. The EMS
+  # instance and a userid are mandatory. Any +options+ are forwarded as
+  # arguments to the +create_volume+ method.
+  #
   def self.create_volume_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "creating Cloud Volume for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
-      :class_name  => "CloudVolume",
+      :class_name  => 'CloudVolume',
       :method_name => 'create_volume',
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [ext_management_system.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
@@ -70,11 +78,15 @@ class CloudVolume < ApplicationRecord
     raise NotImplementedError, _("raw_create_volume must be implemented in a subclass")
   end
 
+  # Update a cloud volume as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def update_volume_queue(userid, options = {})
     task_opts = {
       :action => "updating Cloud Volume for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'update_volume',
@@ -83,6 +95,7 @@ class CloudVolume < ApplicationRecord
       :zone        => ext_management_system.my_zone,
       :args        => [options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
@@ -98,19 +111,25 @@ class CloudVolume < ApplicationRecord
     raise NotImplementedError, _("raw_update_volume must be implemented in a subclass")
   end
 
+  # Delete a cloud volume as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def delete_volume_queue(userid)
     task_opts = {
       :action => "deleting Cloud Volume for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'delete_volume',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => []
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/spec/models/cloud_volume_spec.rb
+++ b/spec/models/cloud_volume_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe CloudVolume do
         :class_name  => described_class.name,
         :method_name => 'create_volume',
         :role        => 'ems_operations',
+        :queue_name  => 'generic',
         :zone        => ems.my_zone,
         :args        => [ems.id, {}]
       )
@@ -47,6 +48,7 @@ RSpec.describe CloudVolume do
         :class_name  => described_class.name,
         :method_name => 'update_volume',
         :role        => 'ems_operations',
+        :queue_name  => 'generic',
         :zone        => ems.my_zone,
         :args        => [options]
       )
@@ -69,6 +71,7 @@ RSpec.describe CloudVolume do
         :class_name  => described_class.name,
         :method_name => 'delete_volume',
         :role        => 'ems_operations',
+        :queue_name  => 'generic',
         :zone        => ems.my_zone,
         :args        => []
       )

--- a/spec/models/cloud_volume_spec.rb
+++ b/spec/models/cloud_volume_spec.rb
@@ -1,9 +1,81 @@
-describe CloudVolume do
-  it ".available" do
-    disk = FactoryBot.create(:disk)
-    FactoryBot.create(:cloud_volume, :attachments => [disk])
-    cv2 = FactoryBot.create(:cloud_volume)
+RSpec.describe CloudVolume do
+  let(:disks) { FactoryBot.create_list(:disk, 2) }
+  let(:ems) { FactoryBot.create(:ems_vmware) }
+  let(:cloud_volume) { FactoryBot.create(:cloud_volume, :ext_management_system => ems, :attachments => disks) }
+  let(:user) { FactoryBot.create(:user, :userid => 'test') }
 
-    expect(described_class.available).to eq([cv2])
+  it ".available" do
+    cloud_volumes_no_backing_disks = FactoryBot.create_list(:cloud_volume, 2)
+    expect(described_class.available).to eq(cloud_volumes_no_backing_disks)
+  end
+
+  context 'queued methods' do
+    it 'queues a create task with create_volume_queue' do
+      task_id = described_class.create_volume_queue(user.userid, ems)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "creating Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'create_volume',
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {}]
+      )
+    end
+
+    it 'requires a userid and ems for a queued create task' do
+      expect { described_class.create_volume_queue }.to raise_error(ArgumentError)
+      expect { described_class.create_volume_queue(user.userid) }.to raise_error(ArgumentError)
+    end
+
+    it 'queues an update task with update_volume_queue' do
+      options = {:name => 'updated_volume_name'}
+      task_id = cloud_volume.update_volume_queue(user.userid, options)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "updating Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'update_volume',
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => [options]
+      )
+    end
+
+    it 'requires a userid for a queued update task' do
+      expect { cloud_volume.update_volume_queue }.to raise_error(ArgumentError)
+    end
+
+    it 'queues a delete task with delete_volume_queue' do
+      task_id = cloud_volume.delete_volume_queue(user.userid)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "deleting Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'delete_volume',
+        :role        => 'ems_operations',
+        :zone        => ems.my_zone,
+        :args        => []
+      )
+    end
+
+    it 'requires a userid for a queued delete task' do
+      expect { cloud_volume.delete_volume_queue }.to raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `CloudVolume.create_volume_queue`, `CloudVolume#update_volume_queue` and `CloudVolume#delete_volume_queue` methods.

I've also added some specs (these methods were previously uncovered), refactored the existing specs (mostly so I could re-use the factories), and added some comments on those methods.

Part of #19543