### PR TITLE
[WIP] Create a generic ems operations mixin

### DIFF
--- a/app/models/mixins/ems_operations_task_mixin.rb
+++ b/app/models/mixins/ems_operations_task_mixin.rb
@@ -1,0 +1,61 @@
+module EmsOperationsTaskMixin
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def create_generic_task_queue(klass, userid, ext_management_system, method_name, options = {})
+      task_opts = {
+        :action => "Creating #{klass.name} for user #{userid}",
+        :userid => userid
+      }
+
+      queue_opts = {
+        :class_name  => klass.name,
+        :method_name => method_name,
+        :role        => 'ems_operations',
+        :queue_name  => ext_management_system.queue_name_for_ems_operations,
+        :zone        => ext_management_system.my_zone,
+        :args        => [ext_management_system.id, options]
+      }
+
+      MiqTask.generic_action_with_callback(task_opts, queue_opts)
+    end
+  end
+
+  def delete_generic_task_queue(klass, userid, method_name)
+    task_opts = {
+      :action => "Deleting #{klass.name} for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => klass.name,
+      :method_name => method_name,
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => ext_management_system.my_zone,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+
+  def update_generic_task_queue(klass, method_name, options = {})
+    task_opts = {
+      :action => "updating #{klass.name} for user #{userid}",
+      :userid => userid
+    }
+
+    queue_opts = {
+      :class_name  => klass.name,
+      :method_name => method_name,
+      :instance_id => id,
+      :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => ext_management_system.my_zone,
+      :args        => [options]
+    }
+
+    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  end
+end

--- a/app/models/mixins/ems_operations_task_mixin.rb
+++ b/app/models/mixins/ems_operations_task_mixin.rb
@@ -4,13 +4,13 @@ module EmsOperationsTaskMixin
   module ClassMethods
     def create_generic_task_queue(userid, ext_management_system, options = {})
       task_opts = {
-        :action => "Creating #{table.name} for user #{userid}",
+        :action => "Creating #{class_name.downcase} for user #{userid}",
         :userid => userid
       }
 
       queue_opts = {
-        :class_name  => table.name,
-        :method_name => "create_#{table.name.to_s.downcase}",
+        :class_name  => class_name,
+        :method_name => "create_#{class_name.to_s.downcase}",
         :role        => 'ems_operations',
         :queue_name  => ext_management_system.queue_name_for_ems_operations,
         :zone        => ext_management_system.my_zone,
@@ -23,13 +23,13 @@ module EmsOperationsTaskMixin
 
   def delete_generic_task_queue(userid)
     task_opts = {
-      :action => "Deleting #{table.name} for user #{userid}",
+      :action => "Deleting #{class.to_s.downcase} for user #{userid}",
       :userid => userid
     }
 
     queue_opts = {
       :class_name  => table.name,
-      :method_name => "delete_#{table.name.to_s.downcase}",
+      :method_name => "delete_#{class.to_s.downcase}",
       :instance_id => id,
       :role        => 'ems_operations',
       :queue_name  => ext_management_system.queue_name_for_ems_operations,
@@ -42,7 +42,7 @@ module EmsOperationsTaskMixin
 
   def update_generic_task_queue(options = {})
     task_opts = {
-      :action => "updating #{table.name} for user #{userid}",
+      :action => "updating #{class.to_s.downcase} for user #{userid}",
       :userid => userid
     }
 

--- a/app/models/mixins/ems_operations_task_mixin.rb
+++ b/app/models/mixins/ems_operations_task_mixin.rb
@@ -2,15 +2,15 @@ module EmsOperationsTaskMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def create_generic_task_queue(klass, userid, ext_management_system, method_name, options = {})
+    def create_generic_task_queue(userid, ext_management_system, options = {})
       task_opts = {
-        :action => "Creating #{klass.name} for user #{userid}",
+        :action => "Creating #{table.name} for user #{userid}",
         :userid => userid
       }
 
       queue_opts = {
-        :class_name  => klass.name,
-        :method_name => method_name,
+        :class_name  => table.name,
+        :method_name => "create_#{table.name.to_s.downcase}",
         :role        => 'ems_operations',
         :queue_name  => ext_management_system.queue_name_for_ems_operations,
         :zone        => ext_management_system.my_zone,
@@ -21,15 +21,15 @@ module EmsOperationsTaskMixin
     end
   end
 
-  def delete_generic_task_queue(klass, userid, method_name)
+  def delete_generic_task_queue(userid)
     task_opts = {
-      :action => "Deleting #{klass.name} for user #{userid}",
+      :action => "Deleting #{table.name} for user #{userid}",
       :userid => userid
     }
 
     queue_opts = {
-      :class_name  => klass.name,
-      :method_name => method_name,
+      :class_name  => table.name,
+      :method_name => "delete_#{table.name.to_s.downcase}",
       :instance_id => id,
       :role        => 'ems_operations',
       :queue_name  => ext_management_system.queue_name_for_ems_operations,
@@ -40,15 +40,15 @@ module EmsOperationsTaskMixin
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
-  def update_generic_task_queue(klass, method_name, options = {})
+  def update_generic_task_queue(options = {})
     task_opts = {
-      :action => "updating #{klass.name} for user #{userid}",
+      :action => "updating #{table.name} for user #{userid}",
       :userid => userid
     }
 
     queue_opts = {
-      :class_name  => klass.name,
-      :method_name => method_name,
+      :class_name  => table.name,
+      :method_name => "update_#{table.name.to_s.downcase}",
       :instance_id => id,
       :role        => 'ems_operations',
       :queue_name  => ext_management_system.queue_name_for_ems_operations,


### PR DESCRIPTION
There appears to be similar code between queued ems operations that could be refactored into a mixin. For now I've called it `EmsOperationsTaskMixin` and it implements 3 methods:

* create_generic_task_queue (singleton)
* delete_generic_task_queue
* update_generic_task_queue

Under the hood these all ultimately call `MiqTask.generic_action_with_callback(task_opts, queue_opts)`, hence the "generic" in the method names, with slight differences in the action name and args. We can quibble about the module name, method names, etc, but hopefully you get the picture.

