### PR TITLE
CustomButtonSet - handle deleted custom buttons still in button_order

### DIFF
--- a/spec/lib/task_helpers/exports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/exports/custom_buttons_spec.rb
@@ -12,7 +12,7 @@ describe TaskHelpers::Exports::CustomButtons do
         "set_type"    => "CustomButtonSet",
         "guid"        => custom_button_set.guid,
         "read_only"   => nil,
-        "set_data"    => nil,
+        "set_data"    => {:button_order => []},
         "mode"        => nil,
         "owner_type"  => nil,
         "owner_id"    => nil,
@@ -67,14 +67,14 @@ describe TaskHelpers::Exports::CustomButtons do
   it 'exports custom buttons to a given directory' do
     TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir)
     file_contents = File.read("#{export_dir}/CustomButtons.yaml")
-    expect(YAML.safe_load(file_contents)).to contain_exactly(*custom_button_export_test)
+    expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_export_test)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
   end
 
   it 'exports all custom buttons to a given directory' do
     TaskHelpers::Exports::CustomButtons.new.export(:directory => export_dir, :all => true)
     file_contents = File.read("#{export_dir}/CustomButtons.yaml")
-    expect(YAML.safe_load(file_contents)).to contain_exactly(*custom_button_export_test)
+    expect(YAML.safe_load(file_contents, [Symbol])).to contain_exactly(*custom_button_export_test)
     expect(Dir[File.join(export_dir, '**', '*')].count { |file| File.file?(file) }).to eq(1)
   end
 end

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -103,5 +103,19 @@ describe CustomButtonSet do
       expect(custom_button_set.children).to include(custom_button_2)
       expect(custom_button_set.children).to include(custom_button_3)
     end
+
+    it "skips nonexistent buttons, cleaning button_order" do
+      expect(custom_button_set.children.count).to eq(2)
+      expect(custom_button_set.set_data[:button_order]).to eq([custom_button_1.id, custom_button_2.id])
+
+      custom_button_2.destroy!
+      custom_button_set.save!
+
+      expect(custom_button_set.children.count).to eq(1)
+      expect(custom_button_set.children).to include(custom_button_1)
+      expect(custom_button_set.children).not_to include(custom_button_2)
+      expect(custom_button_set.children).not_to include(custom_button_3)
+      expect(custom_button_set.set_data[:button_order]).to eq([custom_button_1.id])
+    end
   end
 end


### PR DESCRIPTION
before, we would abort when attempting to edit a custom button group when all the buttons are not visible

However, removing buttons does not update all the groups button_order,
and the change to use `button_order` to set `children` (https://github.com/ManageIQ/manageiq/pull/18368) came precisely because those two aren't always consistent.

So attempting to custom_button_set.save! after a button was removed would fail,
because the id is still in button_order yet the button does not exist.

Thus, dropping validate_children in favor of update_button_order, that removes obsolete entries from button_order before saving the record.
(And no longer aborts.)

(found during investigating https://bugzilla.redhat.com/show_bug.cgi?id=1770300, no BZ yet)

For hammer, this should be backported with https://github.com/ManageIQ/manageiq-ui-classic/pull/5187.

@miq-bot add_label bug, hammer/yes, ivanchuk/yes