### PR TITLE
Dialog#destroy should ignore resource actions linking nonexisting entities

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -191,8 +191,12 @@ class Dialog < ApplicationRecord
   end
 
   def reject_if_has_resource_actions
-    if resource_actions.length > 0
-      connected_components = resource_actions.collect { |ra| ra.resource_type.constantize.find(ra.resource_id) }
+    connected_components = resource_actions.collect do |ra|
+      # not find - we need nil when not found
+      ra.resource_type.constantize.find_by(:id => ra.resource_id)
+    end.compact
+
+    if connected_components.length > 0
       errors.add(:base, _("Dialog cannot be deleted because it is connected to other components: %{components}") % {:components => connected_components.map { |cc| cc.class.name + ":" + cc.id.to_s + " - " + cc.try(:name) }})
       throw :abort
     end

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -120,6 +120,16 @@ describe Dialog do
       expect(err_msg).to eq("Dialog cannot be deleted because it is connected to other components: [\"Dialog:#{dialog.id} - #{dialog.name}\"]")
       expect(Dialog.count).to eq(1)
     end
+
+    it "does destroy dialog with only obsolete resource_action association" do
+      custom_button = FactoryBot.create(:custom_button, :applies_to_class => 'Vm')
+      FactoryBot.create(:resource_action, :action => nil, :dialog => dialog, :resource_type => 'CustomButton', :resource_id => custom_button.id)
+
+      custom_button.delete  # deliberately not destroy, otherwise the ResourceAction gets removed too
+
+      expect(dialog.destroy).to be_truthy
+      expect(Dialog.count).to eq(0)
+    end
   end
 
   describe "dialog structures" do


### PR DESCRIPTION
Currently, if you have a Dialog associated with a Custom Button,
and `delete` the custom button (as opposed to `destroy`; that should not happen, but apparently does),

deleting the dialog will fail, because `ra.resource_type.constantize.find(ra.resource_id)` throws an exception as the resource no longer exists. (The resource being a removed custom button.)

So, updating `reject_if_has_resource_action` to ignore resource actions pointing to nonexistent resources.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1770300
@miq-bot add_label bug, hammer/yes, ivanchuk/yes

---

I'm more convinced that this fixes the BZ, than that the problem is something we should fix.
However, for custom buttons, this is not the first time it happened (https://github.com/ManageIQ/manageiq/pull/19573 and https://github.com/ManageIQ/manageiq-schema/pull/370 being mildly related),
so IMO it makes sense to make sure we don't crash in such situations.

Cc @d-m-u, feel free to disagree ;)