### PR TITLE
Simplify MiqServer#monitor_workers

### DIFF
--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -46,7 +46,7 @@ module MiqServer::WorkerManagement::Heartbeat
     worker_set_message(w, message, *args) unless w.nil?
   end
 
-  def post_message_for_workers(class_name = nil, resync_needed = false, sync_message = nil)
+  def post_message_for_workers(class_name = nil, resync_needed = false)
     processed_worker_ids = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)
@@ -59,7 +59,7 @@ module MiqServer::WorkerManagement::Heartbeat
       next unless MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
       processed_worker_ids << w.id
       next unless validate_worker(w)
-      worker_set_message(w, sync_message) if resync_needed
+      worker_set_message(w, "sync_config") if resync_needed
     end
     processed_worker_ids
   end

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -46,7 +46,7 @@ module MiqServer::WorkerManagement::Heartbeat
     worker_set_message(w, message, *args) unless w.nil?
   end
 
-  def post_message_for_workers(class_name = nil, resync_needed = false)
+  def request_workers_to_sync_config(class_name = nil, resync_needed = false)
     processed_worker_ids = []
     miq_workers.each do |w|
       next unless class_name.nil? || (w.type == class_name)

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -46,11 +46,9 @@ module MiqServer::WorkerManagement::Heartbeat
     worker_set_message(w, message, *args) unless w.nil?
   end
 
-  def request_workers_to_sync_config(class_name = nil, resync_needed = false)
+  def request_workers_to_sync_config(resync_needed = false)
     processed_worker_ids = []
     miq_workers.each do |w|
-      next unless class_name.nil? || (w.type == class_name)
-
       # Note, STATUSES_CURRENT_OR_STARTING doesn't include 'stopping'.
       # We already restarted 'stopping' workers, so we bail out early here.
       # 'stopping' workers continue to run and heartbeat through drb, which

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -28,7 +28,7 @@ module MiqServer::WorkerManagement::Monitor
       processed_worker_ids += check_not_responding(class_name)
       processed_worker_ids += check_pending_stop(class_name)
       processed_worker_ids += clean_worker_records(class_name)
-      processed_worker_ids += post_message_for_workers(class_name, resync_needed)
+      processed_worker_ids += request_workers_to_sync_config(class_name, resync_needed)
     end
 
     validate_active_messages(processed_worker_ids)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -23,13 +23,10 @@ module MiqServer::WorkerManagement::Monitor
     MiqWorker.status_update_all
 
     processed_worker_ids = []
-
-    MiqWorkerType.worker_class_names.each do |class_name|
-      processed_worker_ids += check_not_responding(class_name)
-      processed_worker_ids += check_pending_stop(class_name)
-      processed_worker_ids += clean_worker_records(class_name)
-      processed_worker_ids += request_workers_to_sync_config(class_name, resync_needed)
-    end
+    processed_worker_ids += check_not_responding
+    processed_worker_ids += check_pending_stop
+    processed_worker_ids += clean_worker_records
+    processed_worker_ids += request_workers_to_sync_config(resync_needed)
 
     validate_active_messages(processed_worker_ids)
 
@@ -67,10 +64,9 @@ module MiqServer::WorkerManagement::Monitor
     stop_worker(w, :waiting_for_stop_before_restart, reason)
   end
 
-  def clean_worker_records(class_name = nil)
+  def clean_worker_records
     processed_workers = []
     miq_workers.each do |w|
-      next unless class_name.nil? || (w.type == class_name)
       next unless w.is_stopped?
       _log.info("SQL Record for #{w.format_full_log_msg}, Status: [#{w.status}] is being deleted")
       processed_workers << w
@@ -81,10 +77,9 @@ module MiqServer::WorkerManagement::Monitor
     processed_workers.collect(&:id)
   end
 
-  def check_pending_stop(class_name = nil)
+  def check_pending_stop
     processed_worker_ids = []
     miq_workers.each do |w|
-      next unless class_name.nil? || (w.type == class_name)
       next unless w.is_stopped?
       next unless [:waiting_for_stop_before_restart, :waiting_for_stop].include?(worker_get_monitor_status(w.pid))
       worker_set_monitor_status(w.pid, nil)
@@ -93,12 +88,11 @@ module MiqServer::WorkerManagement::Monitor
     processed_worker_ids
   end
 
-  def check_not_responding(class_name = nil)
+  def check_not_responding
     return [] if MiqEnvironment::Command.is_podified?
 
     processed_workers = []
     miq_workers.each do |w|
-      next unless class_name.nil? || (w.type == class_name)
       next unless monitor_reason_not_responding?(w)
       next unless [:waiting_for_stop_before_restart, :waiting_for_stop].include?(worker_get_monitor_status(w.pid))
       processed_workers << w

--- a/app/models/miq_server/worker_management/monitor/quiesce.rb
+++ b/app/models/miq_server/worker_management/monitor/quiesce.rb
@@ -5,11 +5,9 @@ module MiqServer::WorkerManagement::Monitor::Quiesce
     # do a subset of the monitor_workers loop to allow for graceful exit
     heartbeat
 
-    MiqWorkerType.worker_class_names.each do |class_name|
-      check_not_responding(class_name)
-      check_pending_stop(class_name)
-      clean_worker_records(class_name)
-    end
+    check_not_responding
+    check_pending_stop
+    clean_worker_records
 
     return true if miq_workers.all?(&:is_stopped?)
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -219,7 +219,7 @@ describe "MiqWorker Monitor" do
 
             it "should delete worker row after clean_worker_records" do
               expect(MiqWorker.count).to eq(1)
-              MiqWorkerType.worker_class_names.each { |c| @miq_server.clean_worker_records(c) }
+              @miq_server.clean_worker_records
               expect(MiqWorker.count).to eq(0)
             end
           end
@@ -231,7 +231,7 @@ describe "MiqWorker Monitor" do
 
             it "should delete worker row after clean_worker_records" do
               expect(MiqWorker.count).to eq(1)
-              MiqWorkerType.worker_class_names.each { |c| @miq_server.clean_worker_records(c) }
+              @miq_server.clean_worker_records
               expect(MiqWorker.count).to eq(0)
             end
           end
@@ -243,7 +243,7 @@ describe "MiqWorker Monitor" do
 
             it "should delete worker row after clean_worker_records" do
               expect(MiqWorker.count).to eq(1)
-              MiqWorkerType.worker_class_names.each { |c| @miq_server.clean_worker_records(c) }
+              @miq_server.clean_worker_records
               expect(MiqWorker.count).to eq(0)
             end
           end


### PR DESCRIPTION
1. removes the sync_message varaible and return value
    - This makes the `MiqServer#sync_needed?` look a bit less strange, at least from the caller
    - This also allows me to remove a parameter and rename `post_message_for_workers` as it really was only handling telling workers to sync config

2. Decreases the number of loops through the server's workers from 276 to 4 per call to `#monitor_workers`
    - Previously we had a loop over each worker type where we called methods which would each loop through the server's workers, skipping over workers which were not of the passed type.
    - The worker type had no bearing on the logic of the methods and they were never called with a specific type in mind (only ever from within a loop of all worker types).
    - To simplify this I removed the ability to call the methods with a particular type and allowed them to loop through the server's workers once each.

I also considered a loop outside of the methods where I would pass each worker as a parameter, but both `check_not_responding` and `clean_worker_records` have the chance to remove a record so that became more work than it was worth as we would have to ensure that we didn't pass a deleted worker record to the next method in the chain.