### PR TITLE
Add external_distributed_virtual_switch

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -10,7 +10,9 @@ module ManageIQ::Providers
     include AvailabilityMixin
 
     has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
+    has_many :external_distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
     has_many :distributed_virtual_lans, -> { distinct }, :through => :distributed_virtual_switches, :source => :lans
+    has_many :external_distributed_virtual_lans, -> { distinct }, :through => :external_distributed_virtual_switches, :source => :lans
     has_many :host_virtual_switches, -> { distinct }, :through => :hosts
 
     has_many :host_hardwares,             :through => :hosts, :source => :hardware

--- a/app/models/manageiq/providers/infra_manager/external_distributed_virtual_switch.rb
+++ b/app/models/manageiq/providers/infra_manager/external_distributed_virtual_switch.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::InfraManager::ExternalDistributedVirtualSwitch < ::Switch
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :external_distributed_virtual_switches, :class_name => "ManageIQ::Providers::InfraManager"
+end

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -195,6 +195,15 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def external_distributed_virtual_switches
+          add_properties(
+            :manager_ref          => %i[uid_ems],
+            :attributes_blacklist => %i[parent],
+            :secondary_refs       => {:by_switch_uuid => %i[switch_uuid]}
+          )
+          add_common_default_values
+        end
+
         def lans
           add_properties(
             :manager_ref                  => %i(switch uid_ems),
@@ -206,6 +215,13 @@ module ManageIQ::Providers
           add_properties(
             :manager_ref                  => %i(switch uid_ems),
             :parent_inventory_collections => %i(distributed_virtual_switches),
+          )
+        end
+
+        def external_distributed_virtual_lans
+          add_properties(
+            :manager_ref                  => %i(switch uid_ems),
+            :parent_inventory_collections => %i(external_distributed_virtual_switches),
           )
         end
 


### PR DESCRIPTION
This is required for rhv provider to support the networks managed by
external providers.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1767787
Required for: ManageIQ/manageiq-providers-ovirt#444