### PR TITLE
[IVANCHUK] Lock 'money' gem to 6.13.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "manageiq-password",              "~>0.3",         :require => false
 gem "manageiq-postgres_ha_admin",     "~>3.1",         :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
+gem "money",                          "=6.13.4",       :require => false
 gem "more_core_extensions",           "~>3.7"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.16.1",      :require => false


### PR DESCRIPTION
As per discussion with @Fryguy, locking ivanchuk to use money gem 6.13.4

Related PR for master branch: https://github.com/ManageIQ/manageiq/pull/19567