### PR TITLE
Remove OrchestrationStack#update_stack_queue

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -119,22 +119,6 @@ class OrchestrationStack < ApplicationRecord
     ext_management_system.try(:my_zone)
   end
 
-  def update_stack_queue(userid, template, options = {})
-    task_opts = {
-      :action => "updating Orchestration Stack for user #{userid}",
-      :userid => userid
-    }
-    queue_opts = {
-      :class_name  => self.class.name,
-      :method_name => 'update_stack',
-      :instance_id => id,
-      :role        => 'ems_operations',
-      :zone        => ext_management_system.my_zone,
-      :args        => [template, options]
-    }
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
-  end
-
   def update_stack(template, options = {})
     raw_update_stack(template, options)
   end


### PR DESCRIPTION
As per our gitter conversation, let's remove `OrchestrationStack#update_stack_queue` since it has no callers.

As per @himdel, the last caller was https://github.com/ManageIQ/manageiq-ui-classic/pull/1533/files#diff-acb3eba381d9b978014c502289714644L202, and it's not entirely clear that this method would have worked as intended anyway.

Originally part of https://github.com/ManageIQ/manageiq/issues/19543