### PR TITLE
Remove unused server options parsing

### DIFF
--- a/lib/workers/bin/evm_server.rb
+++ b/lib/workers/bin/evm_server.rb
@@ -1,4 +1,4 @@
 require File.expand_path("../../../config/environment", __dir__)
 require "workers/evm_server"
 
-EvmServer.start(*ARGV)
+EvmServer.start

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -2,17 +2,11 @@ require 'miq-process'
 require 'pid_file'
 
 class EvmServer
-  OPTIONS_PARSER_SETTINGS = [
-    [:mode, 'EVM Server Mode', String],
-  ]
-
   ##
   # String used as a title for a linux process. Visible in ps, htop, ...
   SERVER_PROCESS_TITLE = 'MIQ Server'.freeze
 
-  def initialize(cfg = {})
-    @cfg = cfg
-
+  def initialize
     $log ||= Rails.logger
   end
 
@@ -35,16 +29,6 @@ class EvmServer
   end
 
   def self.start(*args)
-    # Parse the args into the global config variable
-    cfg = {}
-
-    opts = OptionParser.new
-    self::OPTIONS_PARSER_SETTINGS.each do |key, desc, type|
-      opts.on("--#{key} VAL", desc, type) { |v| cfg[key] = v }
-    end
-    opts.parse(*args)
-
-    # Start the Server object
-    new(cfg).start
+    new.start
   end
 end


### PR DESCRIPTION
Previously, we accept any CLI options passed in through ARGV, parse them, and
set them in an instance variable cfg in the EvmServer but it's never used through
the instance variable and there is no attr_reader for it.

Note, even though this CLI option parsing was for the server mode, I'm still
able to run the server in minimal mode without this code, further demonstrating
the deadness of this code.