### PR TITLE
Schedule the check for timed out queue messages once for the region

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -545,6 +545,10 @@ class MiqQueue < ApplicationRecord
     end
   end
 
+  def self.check_for_timeout
+    where(:state => STATE_DEQUEUE).find_each(&:check_for_timeout)
+  end
+
   def finished?
     FINISHED_STATES.include?(state)
   end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -545,8 +545,12 @@ class MiqQueue < ApplicationRecord
     end
   end
 
+  def self.candidates_for_timeout
+    where(:state => STATE_DEQUEUE).where("(select date_part('epoch', updated_on) + msg_timeout) < ?", Time.now.to_i)
+  end
+
   def self.check_for_timeout
-    where(:state => STATE_DEQUEUE).where("(select date_part('epoch', updated_on) + msg_timeout) < ?", Time.now.to_i).each(&:check_for_timeout)
+    candidates_for_timeout.each(&:check_for_timeout)
   end
 
   def finished?

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -546,7 +546,7 @@ class MiqQueue < ApplicationRecord
   end
 
   def self.check_for_timeout
-    where(:state => STATE_DEQUEUE).find_each(&:check_for_timeout)
+    where(:state => STATE_DEQUEUE).where("(select date_part('epoch', updated_on) + msg_timeout) < ?", Time.now.to_i).each(&:check_for_timeout)
   end
 
   def finished?

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -166,6 +166,10 @@ class MiqScheduleWorker::Jobs
     end
   end
 
+  def queue_miq_queue_check_for_timeout
+    queue_work(:class_name => "MiqQueue", :method_name => "check_for_timeout", :zone => nil)
+  end
+
   def check_for_stuck_dispatch(threshold_seconds)
     class_n = "JobProxyDispatcher"
     method_n = "dispatch"

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -114,7 +114,7 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
   end
 
   def schedules_for_scheduler_role
-    # These schedules need to run only once in a zone per interval, so let the single scheduler role handle them
+    # These schedules need to run only once in a region per interval, so let the single scheduler role handle them
     return unless schedule_enabled?(:scheduler)
     scheduler = scheduler_for(:scheduler)
     # Schedule - Check for timed out jobs
@@ -199,6 +199,10 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
     scheduler.schedule_every(worker_settings[:vim_performance_states_purge_interval]) do
       enqueue(:vim_performance_states_purge_timer)
+    end
+
+    scheduler.schedule_every(worker_settings[:queue_timeout_interval]) do
+      enqueue(:queue_miq_queue_check_for_timeout)
     end
 
     # Schedule every 24 hours

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -52,22 +52,6 @@ module MiqServer::WorkerManagement::Monitor::Validation
     false
   end
 
-  def validate_active_messages(processed_worker_ids = [])
-    actives = MiqQueue.where(:state => 'dequeue').includes(:handler)
-    actives.each do |msg|
-      next if processed_worker_ids.include?(msg.handler_id)
-
-      # Exclude messages on starting/started servers
-      handler = msg.handler
-      handler_server = handler.respond_to?(:miq_server) ? handler.miq_server : handler
-      if handler_server.kind_of?(MiqServer) && handler_server != self
-        next if [MiqServer::STATUS_STARTED, MiqServer::STATUS_STARTING].include?(handler_server.status)
-      end
-
-      msg.check_for_timeout(_log.prefix)
-    end
-  end
-
   private
 
   def usage_exceeds_threshold?(usage, threshold)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1238,6 +1238,7 @@
       :performance_rollup_purging_start_delay: 5.minutes
       :policy_events_purge_interval: 1.day
       :poll: 15.seconds
+      :queue_timeout_interval: 15.seconds
       :report_result_purge_interval: 1.week
       :server_log_stats_interval: 5.minutes
       :server_stats_interval: 60.seconds

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -318,58 +318,6 @@ describe MiqServer do
         expect(@miq_server.quiesce_workers_loop_timeout?).not_to be_truthy
       end
 
-      context "with an active messsage and a second server" do
-        before do
-          @msg = FactoryBot.create(:miq_queue, :state => 'dequeue')
-          @miq_server2 = FactoryBot.create(:miq_server, :is_master => true, :zone => @zone)
-        end
-
-        it "will validate the 'started' first server's active message when called on it" do
-          @msg.handler = @miq_server.reload
-          @msg.save
-          expect_any_instance_of(MiqQueue).to receive(:check_for_timeout)
-          @miq_server.validate_active_messages
-        end
-
-        it "will validate the 'not responding' first server's active message when called on it" do
-          @miq_server.update_attribute(:status, 'not responding')
-          @msg.handler = @miq_server.reload
-          @msg.save
-          expect_any_instance_of(MiqQueue).to receive(:check_for_timeout)
-          @miq_server.validate_active_messages
-        end
-
-        it "will validate the 'not resonding' second server's active message when called on first server" do
-          @miq_server2.update_attribute(:status, 'not responding')
-          @msg.handler = @miq_server2
-          @msg.save
-          expect_any_instance_of(MiqQueue).to receive(:check_for_timeout)
-          @miq_server.validate_active_messages
-        end
-
-        it "will NOT validate the 'started' second server's active message when called on first server" do
-          @miq_server2.update_attribute(:status, 'started')
-          @msg.handler = @miq_server2
-          @msg.save
-          expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).never
-          @miq_server.validate_active_messages
-        end
-
-        it "will validate a worker's active message when called on the worker's server" do
-          @msg.handler = @worker
-          @msg.save
-          expect_any_instance_of(MiqQueue).to receive(:check_for_timeout)
-          @miq_server.validate_active_messages
-        end
-
-        it "will not validate a worker's active message when called on the worker's server if already processed" do
-          @msg.handler = @worker
-          @msg.save
-          expect_any_instance_of(MiqQueue).to receive(:check_for_timeout).never
-          @miq_server.validate_active_messages([@worker.id])
-        end
-      end
-
       context "#server_timezone" do
         it "utc with no system default" do
           stub_settings(:server => {:timezone => nil})


### PR DESCRIPTION
Previously, for some reason, we were checking the queue for timed out messages every time we called `MiqServer#monitor_workers` (by default every 15 seconds). The logic to determine which workers needed their messages checked for timeout was also a bit too complex.

This PR moves the check for timed out queue messages to a schedule which is run once every 10 minutes for the entire region. Ten minutes was chosen as the default because that is also the default queue message timeout.