### PR TITLE
Remove unused worker OPTIONS_PARSER_SETTINGS

### DIFF
--- a/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/base_manager/event_catcher/runner.rb
@@ -8,10 +8,6 @@ class ManageIQ::Providers::BaseManager::EventCatcher::Runner < ::MiqWorker::Runn
 
   include DuplicateBlocker
 
-  OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
-    [:ems_id, 'EMS Instance ID', String],
-  ]
-
   def after_initialize
     @ems = ExtManagementSystem.find(@cfg[:ems_id])
     do_exit("Unable to find instance for EMS ID [#{@cfg[:ems_id]}].", 1) if @ems.nil?

--- a/app/models/manageiq/providers/base_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker/runner.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::BaseManager::OperationsWorker::Runner < ::MiqQueueWorkerBase::Runner
-  OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
-    [:ems_id, 'EMS Instance ID', String],
-  ]
-
   def worker_roles
     %w[ems_operations"]
   end

--- a/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker/runner.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::BaseManager::RefreshWorker::Runner < ::MiqQueueWorkerBase::Runner
-  OPTIONS_PARSER_SETTINGS = ::MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
-    [:ems_id, 'EMS Instance ID', String],
-  ]
-
   self.delay_startup_for_vim_broker = true # NOTE: For ems_inventory role, TODO: only for VMware
 
   def after_initialize

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -5,10 +5,6 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
   define_callbacks(:dst_change)
   set_callback(:dst_change, :after, :load_user_schedules)
 
-  OPTIONS_PARSER_SETTINGS = MiqWorker::Runner::OPTIONS_PARSER_SETTINGS + [
-    [:emsid, 'EMS Instance ID', String],
-  ]
-
   ROLES_NEEDING_RESTART = ["scheduler", "ems_metrics_coordinator", "event"]
   SCHEDULE_MEDIUM_PRIORITY = MiqQueue.priority(:normal, :higher, 10)
   CLASS_TAG = "MiqSchedule"

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -11,11 +11,6 @@ class MiqWorker::Runner
 
   INTERRUPT_SIGNALS = ["SIGINT", "SIGTERM"]
 
-  # DELETE ME
-  OPTIONS_PARSER_SETTINGS = [
-    [:guid,       'EVM Worker GUID',       String],
-  ]
-
   SAFE_SLEEP_SECONDS = 60
 
   def self.start_worker(*args)


### PR DESCRIPTION
We last used this constant before we switched from spawn to fork in
98745799d17600ba07.

We've subsequently moved to use run_single_worker for launching workers and that handles
options parsing.

Related to #19580

- [ ] Depends on https://github.com/ManageIQ/manageiq-providers-vmware/pull/490 