### PR TITLE
Rename method to avoid name conflict with AR#update.

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
@@ -17,7 +17,7 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
     my_signal(false, :deploy_orchestration_stack, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
-  def update
+  def reconfigure
     time = Time.zone.now
     update(:started_on => time)
     miq_task.update(:started_on => time)
@@ -124,7 +124,7 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
     {
       :initializing               => {'initialize'       => 'waiting_to_start'},
       :start                      => {'waiting_to_start' => 'running'},
-      :update                     => {'waiting_to_start' => 'updating'},
+      :reconfigure                => {'waiting_to_start' => 'updating'},
       :deploy_orchestration_stack => {'running'          => 'stack_job'},
       :update_orchestration_stack => {'updating'         => 'stack_job'},
       :poll_stack_status          => {'stack_job'        => 'stack_job'},

--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -57,7 +57,7 @@ class ServiceOrchestration < Service
     }
     @update_stack_job = ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner.create_job(job_options)
     update(:options => options.merge(:update_stack_job_id => @update_stack_job.id))
-    @update_stack_job.signal(:update)
+    @update_stack_job.signal(:reconfigure)
   end
 
   def orchestration_stack

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -218,7 +218,7 @@ describe ServiceOrchestration do
 
     it 'calls OrchestrationTemplateRunner' do
       job = FactoryBot.create(:job)
-      allow(job).to receive(:signal).with(:update)
+      allow(job).to receive(:signal).with(:reconfigure)
       allow(ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner).to receive(:create_job) do |options|
         expect(options[:update_options][:parameters]).to include(
           'InstanceType'   => 'cg1.4xlarge',


### PR DESCRIPTION
Follow up of https://github.com/ManageIQ/manageiq/pull/19284.

@miq-bot assign @tinaafitz 
@miq-bot add_label bug

cc @bzwei 