### PR TITLE
Add a queue_name to the CloudVolumeSnapshot#delete_snapshot_queue method

### DIFF
--- a/app/models/cloud_volume_snapshot.rb
+++ b/app/models/cloud_volume_snapshot.rb
@@ -26,9 +26,15 @@ class CloudVolumeSnapshot < ApplicationRecord
     self.class.my_zone(ext_management_system)
   end
 
+  # Delete a cloud volume snapshot as a queued task and return the task id. The
+  # queue name and the queue zone are derived from the EMS. The userid is
+  # optional and defaults to 'system'.
+  #
+  # The _options argument is unused, and is strictly for interface compliance.
+  #
   def delete_snapshot_queue(userid = "system", _options = {})
     task_opts = {
-      :action => "deleting volume snapshot #{inspect} in #{ext_management_system.inspect}",
+      :action => "deleting volume snapshot for #{userid} in #{ext_management_system.name}",
       :userid => userid
     }
 
@@ -38,6 +44,7 @@ class CloudVolumeSnapshot < ApplicationRecord
       :method_name => 'delete_snapshot',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => my_zone,
       :args        => []
     }

--- a/spec/models/cloud_volume_snapshot_spec.rb
+++ b/spec/models/cloud_volume_snapshot_spec.rb
@@ -1,2 +1,25 @@
-describe CloudVolumeSnapshot do
+RSpec.describe CloudVolumeSnapshot do
+  let(:ems) { FactoryBot.create(:ems_openstack) }
+  let(:snapshot) { FactoryBot.create(:cloud_volume_snapshot, :ext_management_system => ems) }
+
+  context "queued methods" do
+    it 'queues a delete task with delete_snapshot_queue' do
+      task_id = snapshot.delete_snapshot_queue
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "deleting volume snapshot for system in #{ems.name}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'delete_snapshot',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => []
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `CloudVolumeSnapshot.delete_snapshot_queue` method.

I've also added some specs. This method was previously uncovered. It actually looks like most of the core method specs were originally put into the openstack cloud manager spec, which was later separated.

I also decided to update the action text, which for some reason had raw inspect text in it. None of the other related methods I've seen so far do this, and it's pretty fugly. So, I simplified it.

Part of #19543