### PR TITLE
Add queue_name to queued method options for CloudTenant model

### DIFF
--- a/app/models/cloud_tenant.rb
+++ b/app/models/cloud_tenant.rb
@@ -68,8 +68,8 @@ class CloudTenant < ApplicationRecord
       :method_name => 'create_cloud_tenant',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
-      :zone        => ext_management_system.my_zone,
       :queue_name  => ext_management_system.queue_name_for_ems_operations,
+      :zone        => ext_management_system.my_zone,
       :args        => [ext_management_system.id, options]
     }
 
@@ -84,20 +84,26 @@ class CloudTenant < ApplicationRecord
     raise NotImplementedError, _("raw_update_cloud_tenant must be implemented in a subclass")
   end
 
+  # Update a cloud tenant as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def update_cloud_tenant_queue(userid, options = {})
     task_opts = {
       :action => "updating Cloud Tenant for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'update_cloud_tenant',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
@@ -109,20 +115,26 @@ class CloudTenant < ApplicationRecord
     raise NotImplementedError, _("raw_delete_cloud_tenant must be implemented in a subclass")
   end
 
+  # Delete a cloud tenant as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def delete_cloud_tenant_queue(userid)
     task_opts = {
       :action => "deleting Cloud Tenant for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'delete_cloud_tenant',
       :instance_id => id,
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => []
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -1,4 +1,12 @@
-describe CloudTenant do
+RSpec.describe CloudTenant do
+  let(:user)         { FactoryBot.create(:user, :userid => 'testuser') }
+  let(:ems)          { FactoryBot.create(:ems_openstack) }
+  let(:vm1)          { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
+  let(:vm2)          { FactoryBot.create(:vm_openstack, :ext_management_system => nil) }
+  let(:vms)          { [vm1, vm2] }
+  let(:template)     { FactoryBot.create(:miq_template) }
+  let(:cloud_tenant) { FactoryBot.create(:cloud_tenant, :ext_management_system => ems, :vms => vms, :miq_templates => [template]) }
+
   it "#all_cloud_networks" do
     ems     = FactoryBot.create(:ems_openstack)
     tenant1 = FactoryBot.create(:cloud_tenant,  :ext_management_system => ems)
@@ -11,13 +19,6 @@ describe CloudTenant do
   end
 
   describe '#total_vms' do
-    let(:ems)          { FactoryBot.create(:ems_openstack) }
-    let(:vm1)          { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
-    let(:vm2)          { FactoryBot.create(:vm_openstack, :ext_management_system => nil) }
-    let(:vms)          { [vm1, vm2] }
-    let(:template)     { FactoryBot.create(:miq_template) }
-    let(:cloud_tenant) { FactoryBot.create(:cloud_tenant, :ext_management_system => ems, :vms => vms, :miq_templates => [template]) }
-
     it 'counts only vms' do
       cloud_tenant.reload
       expect(cloud_tenant.vms.map(&:id)).to match_array([vm1.id])
@@ -28,5 +29,81 @@ describe CloudTenant do
       expect(total_vms_from_select).to eq(cloud_tenant.total_vms)
       expect(cloud_tenant.vms_and_templates.count).to eq(3)
     end
+  end
+
+  context "queued methods", :queue do
+    it 'queues a create task with create_tenant_queue' do
+      task_id = described_class.create_cloud_tenant_queue(user.userid, ems)
+      klass = ems.class.name + '::CloudTenant'
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "creating Cloud Tenant for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => klass).first).to have_attributes(
+        :class_name  => klass,
+        :method_name => 'create_cloud_tenant',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {}]
+      )
+    end
+
+    it 'requires a userid and ems for a queued create task' do
+      expect { described_class.create_cloud_tenant_queue }.to raise_error(ArgumentError)
+      expect { described_class.create_cloud_tenant_queue(user.userid) }.to raise_error(ArgumentError)
+    end
+
+=begin
+    it 'queues an update task with update_tenant_queue' do
+      options = {:name => 'updated_tenant_name'}
+      task_id = cloud_tenant.update_volume_queue(user.userid, options)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "updating Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'update_tenant',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [options]
+      )
+    end
+
+    it 'requires a userid for a queued update task' do
+      expect { cloud_tenant.update_volume_queue }.to raise_error(ArgumentError)
+    end
+
+    it 'queues a delete task with delete_tenant_queue' do
+      task_id = cloud_tenant.delete_volume_queue(user.userid)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "deleting Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'delete_tenant',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => []
+      )
+    end
+
+    it 'requires a userid for a queued delete task' do
+      expect { cloud_tenant.delete_volume_queue }.to raise_error(ArgumentError)
+    end
+=end
   end
 end

--- a/spec/models/cloud_tenant_spec.rb
+++ b/spec/models/cloud_tenant_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CloudTenant do
     end
   end
 
-  context "queued methods", :queue do
+  context "queued methods" do
     it 'queues a create task with create_tenant_queue' do
       task_id = described_class.create_cloud_tenant_queue(user.userid, ems)
       klass = ems.class.name + '::CloudTenant'
@@ -57,20 +57,19 @@ RSpec.describe CloudTenant do
       expect { described_class.create_cloud_tenant_queue(user.userid) }.to raise_error(ArgumentError)
     end
 
-=begin
-    it 'queues an update task with update_tenant_queue' do
-      options = {:name => 'updated_tenant_name'}
-      task_id = cloud_tenant.update_volume_queue(user.userid, options)
+    it 'queues an update task with update_cloud_tenant_queue' do
+      options = {:name => 'updated_cloud_tenant_name'}
+      task_id = cloud_tenant.update_cloud_tenant_queue(user.userid, options)
 
       expect(MiqTask.find(task_id)).to have_attributes(
-        :name   => "updating Cloud Volume for user #{user.userid}",
+        :name   => "updating Cloud Tenant for user #{user.userid}",
         :state  => "Queued",
         :status => "Ok"
       )
 
       expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
         :class_name  => described_class.name,
-        :method_name => 'update_tenant',
+        :method_name => 'update_cloud_tenant',
         :role        => 'ems_operations',
         :queue_name  => 'generic',
         :zone        => ems.my_zone,
@@ -79,21 +78,21 @@ RSpec.describe CloudTenant do
     end
 
     it 'requires a userid for a queued update task' do
-      expect { cloud_tenant.update_volume_queue }.to raise_error(ArgumentError)
+      expect { cloud_tenant.update_cloud_tenant_queue }.to raise_error(ArgumentError)
     end
 
-    it 'queues a delete task with delete_tenant_queue' do
-      task_id = cloud_tenant.delete_volume_queue(user.userid)
+    it 'queues a delete task with delete_cloud_tenant_queue' do
+      task_id = cloud_tenant.delete_cloud_tenant_queue(user.userid)
 
       expect(MiqTask.find(task_id)).to have_attributes(
-        :name   => "deleting Cloud Volume for user #{user.userid}",
+        :name   => "deleting Cloud Tenant for user #{user.userid}",
         :state  => "Queued",
         :status => "Ok"
       )
 
       expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
         :class_name  => described_class.name,
-        :method_name => 'delete_tenant',
+        :method_name => 'delete_cloud_tenant',
         :role        => 'ems_operations',
         :queue_name  => 'generic',
         :zone        => ems.my_zone,
@@ -102,8 +101,7 @@ RSpec.describe CloudTenant do
     end
 
     it 'requires a userid for a queued delete task' do
-      expect { cloud_tenant.delete_volume_queue }.to raise_error(ArgumentError)
+      expect { cloud_tenant.delete_cloud_tenant_queue }.to raise_error(ArgumentError)
     end
-=end
   end
 end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `CloudTenant.create_cloud_tenant_queue`, `CloudTenant#update_cloud_tenant_queue` and `CloudTenant#delete_cloud_tenant_queue` methods.

I've also added some specs (these methods were previously uncovered), refactored the existing specs a bit (mostly so I could re-use the factories), and added some comments on those methods.

Part of #19543