### PR TITLE
Add queue_name to queued method options for CloudObjectStoreContainer model

### DIFF
--- a/app/models/cloud_object_store_container.rb
+++ b/app/models/cloud_object_store_container.rb
@@ -19,18 +19,26 @@ class CloudObjectStoreContainer < ApplicationRecord
   supports_not :delete, :reason => N_("Delete operation is not supported.")
   supports_not :cloud_object_store_container_clear
 
+  # Create a cloud object store container as a queued task and return the task
+  # id. The queue name and the queue zone are derived from the provided EMS
+  # instance. The EMS instance and a userid are mandatory. Any +options+ are
+  # forwarded as arguments to the +cloud_object_store_container_create+ method.
+  #
   def self.cloud_object_store_container_create_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "creating Cloud Object Store Container for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
-      :class_name  => "CloudObjectStoreContainer",
+      :class_name  => 'CloudObjectStoreContainer',
       :method_name => 'cloud_object_store_container_create',
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [ext_management_system.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/spec/models/cloud_object_store_container_spec.rb
+++ b/spec/models/cloud_object_store_container_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe CloudObjectStoreContainer do
+  let(:ems) { FactoryBot.create(:ems_vmware) }
+  let(:user) { FactoryBot.create(:user, :userid => 'test') }
+
+  context "queued methods" do
+    it 'queues a create task with cloud_object_store_container_create_queue' do
+      task_id = described_class.cloud_object_store_container_create_queue(user.userid, ems)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "creating Cloud Object Store Container for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'cloud_object_store_container_create',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {}]
+      )
+    end
+
+    it 'requires a userid and ems for a queued create task' do
+      expect { described_class.cloud_object_store_container_create_queue }.to raise_error(ArgumentError)
+      expect { described_class.cloud_object_store_container_create_queue(user.userid) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `CloudObjectStoreContainer.cloud_object_store_container_create_queue` method.

I've also added some specs (there don't appear to have been any specs for this model previously) and added some comments on that method.

Part of #19543