### PR TITLE
Add a queue_name to the IsoDatastore#synchronize_advertised_images_queue method

### DIFF
--- a/app/models/iso_datastore.rb
+++ b/app/models/iso_datastore.rb
@@ -8,11 +8,15 @@ class IsoDatastore < ApplicationRecord
     ext_management_system.try(:name)
   end
 
+  # Synchronize advertised images as a queued task. The
+  # queue name and the queue zone are derived from the EMS.
+  #
   def synchronize_advertised_images_queue
     MiqQueue.put_unless_exists(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => "synchronize_advertised_images",
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.try(:my_zone),
       :role        => "ems_operations"
     )
@@ -25,10 +29,11 @@ class IsoDatastore < ApplicationRecord
   end
 
   def synchronize_advertised_images
-    log_for    = "ISO Datastore on Management System <#{name}>"
+    log_for = "ISO Datastore on Management System <#{name}>"
 
     _log.info("Synchronizing images on #{log_for}...")
     db_image_hash = iso_images.index_by(&:name)
+
     advertised_images.each do |image_name|
       if db_image_hash.include?(image_name)
         db_image_hash.delete(image_name)
@@ -41,6 +46,7 @@ class IsoDatastore < ApplicationRecord
 
     clear_association_cache
     update_attribute(:last_refresh_on, Time.now.utc)
+
     _log.info("Synchronizing images on #{log_for}...Complete")
   rescue ManageIQ::Providers::Redhat::InfraManager::OvirtServices::Error
   end

--- a/spec/models/iso_datastore_spec.rb
+++ b/spec/models/iso_datastore_spec.rb
@@ -1,6 +1,21 @@
-describe IsoDatastore do
+RSpec.describe IsoDatastore do
   let(:ems) { FactoryBot.create(:ems_redhat) }
   let(:iso_datastore) { FactoryBot.create(:iso_datastore, :ext_management_system => ems) }
+
+  context "queued methods" do
+    it 'queues a sync task with synchronize_advertised_images_queue' do
+      queue = iso_datastore.synchronize_advertised_images_queue
+
+      expect(queue).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'synchronize_advertised_images',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => []
+      )
+    end
+  end
 
   describe "#advertised_images" do
     subject(:advertised_images) { iso_datastore.advertised_images }


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `IsoDatastore#synchronize_advertised_images_queue` method.

I've also added some specs, as this methods was previously uncovered.

Part of #19543