### PR TITLE
Remove waiting_for_stop_before_restart monitor status

### DIFF
--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -60,10 +60,6 @@ module MiqServer::WorkerManagement::Monitor
     result
   end
 
-  def restart_worker(w, reason = nil)
-    stop_worker(w, reason)
-  end
-
   def clean_worker_records
     processed_workers = []
     miq_workers.each do |w|
@@ -117,7 +113,7 @@ module MiqServer::WorkerManagement::Monitor
       msg = "#{w.format_full_log_msg} is being stopped because system resources exceeded threshold, it will be restarted once memory has freed up"
       _log.warn(msg)
       MiqEvent.raise_evm_event_queue_in_region(w.miq_server, "evm_server_memory_exceeded", :event_details => msg, :type => w.class.name)
-      restart_worker(w, MiqServer::MEMORY_EXCEEDED)
+      stop_worker(w, MiqServer::MEMORY_EXCEEDED)
       break
     end
   end

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -61,7 +61,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def restart_worker(w, reason = nil)
-    stop_worker(w, :waiting_for_stop_before_restart, reason)
+    stop_worker(w, :waiting_for_stop, reason)
   end
 
   def clean_worker_records
@@ -81,7 +81,7 @@ module MiqServer::WorkerManagement::Monitor
     processed_worker_ids = []
     miq_workers.each do |w|
       next unless w.is_stopped?
-      next unless [:waiting_for_stop_before_restart, :waiting_for_stop].include?(worker_get_monitor_status(w.pid))
+      next unless worker_get_monitor_status(w.pid) == :waiting_for_stop
       worker_set_monitor_status(w.pid, nil)
       processed_worker_ids << w.id
     end
@@ -94,7 +94,7 @@ module MiqServer::WorkerManagement::Monitor
     processed_workers = []
     miq_workers.each do |w|
       next unless monitor_reason_not_responding?(w)
-      next unless [:waiting_for_stop_before_restart, :waiting_for_stop].include?(worker_get_monitor_status(w.pid))
+      next unless worker_get_monitor_status(w.pid) == :waiting_for_stop
       processed_workers << w
       worker_not_responding(w)
       worker_delete(w.pid)

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -61,7 +61,7 @@ module MiqServer::WorkerManagement::Monitor
   end
 
   def restart_worker(w, reason = nil)
-    stop_worker(w, :waiting_for_stop, reason)
+    stop_worker(w, reason)
   end
 
   def clean_worker_records

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -15,7 +15,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
       msg = "#{w.format_full_log_msg} has not responded in #{Time.now.utc - w.last_heartbeat} seconds, restarting worker"
       _log.error(msg)
       MiqEvent.raise_evm_event_queue(w.miq_server, "evm_worker_not_responding", :event_details => msg, :type => w.class.name)
-      restart_worker(w, MiqServer::NOT_RESPONDING)
+      stop_worker(w, MiqServer::NOT_RESPONDING)
       return false
     end
 
@@ -35,7 +35,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
                                      :event_details => msg,
                                      :type          => w.class.name,
                                      :full_data     => full_data)
-      restart_worker(w)
+      stop_worker(w)
       return false
     end
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -54,14 +54,14 @@ describe "MiqWorker Monitor" do
         end
 
         it "will kill the worker with the highest memory" do
-          expect(@miq_server).to receive(:restart_worker).with(@worker_to_kill, :memory_exceeded)
+          expect(@miq_server).to receive(:stop_worker).with(@worker_to_kill, :memory_exceeded)
           @miq_server.do_system_limit_exceeded
         end
 
         it "will handle workers with nil memory_usage" do
           @worker_to_keep.update!(:memory_usage => nil)
 
-          expect(@miq_server).to receive(:restart_worker).with(@worker_to_kill, :memory_exceeded)
+          expect(@miq_server).to receive(:stop_worker).with(@worker_to_kill, :memory_exceeded)
           @miq_server.do_system_limit_exceeded
         end
       end

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -376,19 +376,19 @@ describe "MiqWorker Monitor" do
 
           it "should trigger memory threshold if worker is started" do
             worker.status = MiqWorker::STATUS_STARTED
-            expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop_before_restart).once
+            expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop).once
             server.validate_worker(worker)
           end
 
           it "should trigger memory threshold if worker is ready" do
             worker.status = MiqWorker::STATUS_READY
-            expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop_before_restart).once
+            expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop).once
             server.validate_worker(worker)
           end
 
           it "should trigger memory threshold if worker is working" do
             worker.status = MiqWorker::STATUS_WORKING
-            expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop_before_restart).once
+            expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop).once
             server.validate_worker(worker)
           end
 


### PR DESCRIPTION
The last difference in behavior for this status vs waiting_for_stop
was removed in 8b8ab8d64a609b21024eab679f3890cb90fb3f19 in 2010

Additionally this PR removes the `MiqServer#restart_worker` as it didn't restart the worker, it just stopped it with the special monitor status. But in reality there was nothing special about that status so it just caused confusion.

What is actually happening is a worker is stopped if it's not responding or exceeds it's memory limit. Then, later the server starts a new worker to take its place. This isn't a "restart".

cc @Fryguy @gtanzillo 