### PR TITLE
Test the RefreshWorker not the EmsRefreshCoreWorker

### DIFF
--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -5,7 +5,7 @@ describe PerEmsWorkerMixin do
     @ems_queue_name = "ems_#{@ems.id}"
 
     # General stubbing for testing any worker (methods called during initialize)
-    @worker_record = FactoryBot.create(:miq_ems_refresh_core_worker, :queue_name => "ems_#{@ems.id}", :miq_server => server)
+    @worker_record = FactoryBot.create(:miq_ems_refresh_worker, :queue_name => "ems_#{@ems.id}", :miq_server => server)
     @worker_class  = @worker_record.class
   end
 


### PR DESCRIPTION
Don't use the MiqEmsRefreshCoreWorker for testing per_ems_worker mixin
since that worker will be going away (https://github.com/ManageIQ/manageiq-providers-vmware/pull/488).