### PR TITLE
Add queue_name to ems operations within CloudVolume::Operations mixin

### DIFF
--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -5,7 +5,6 @@ module CloudVolume::Operations
   end
 
   module InstanceMethods
-
     # Attach a cloud volume as a queued task and return the task id. The queue
     # name and the queue zone are derived from the server EMS, and both a userid
     # and server EMS ref are mandatory. The device is optional.
@@ -84,15 +83,19 @@ module CloudVolume::Operations
 
     def validate_volume_available
       msg = validate_volume
+
       return {:available => msg[:available], :message => msg[:message]} unless msg.nil?
       return {:available => true, :message => nil} if status == "available"
+
       {:available => false, :message => _("The volume can't be attached, status has to be 'available'")}
     end
 
     def validate_volume_in_use
       msg = validate_volume
+
       return {:available => msg[:available], :message => msg[:message]} unless msg[:available]
       return {:available => true, :message => nil} if status == "in-use"
+
       {:available => false, :message => _("The volume can't be detached, status has to be 'in-use'")}
     end
   end

--- a/app/models/cloud_volume/operations.rb
+++ b/app/models/cloud_volume/operations.rb
@@ -5,19 +5,27 @@ module CloudVolume::Operations
   end
 
   module InstanceMethods
+
+    # Attach a cloud volume as a queued task and return the task id. The queue
+    # name and the queue zone are derived from the server EMS, and both a userid
+    # and server EMS ref are mandatory. The device is optional.
+    #
     def attach_volume_queue(userid, server_ems_ref, device = nil)
       task_opts = {
         :action => "attaching Cloud Volume for user #{userid}",
         :userid => userid
       }
+
       queue_opts = {
         :class_name  => self.class.name,
         :method_name => 'attach_volume',
         :instance_id => id,
         :role        => 'ems_operations',
+        :queue_name  => ext_management_system.queue_name_for_ems_operations,
         :zone        => ext_management_system.my_zone,
         :args        => [server_ems_ref, device]
       }
+
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
 
@@ -29,19 +37,26 @@ module CloudVolume::Operations
       validate_unsupported(_("Attach Volume Operation"))
     end
 
+    # Detach a cloud volume as a queued task and return the task id. The queue
+    # name and the queue zone are derived from the server EMS, and both a userid
+    # and server EMS ref are mandatory.
+    #
     def detach_volume_queue(userid, server_ems_ref)
       task_opts = {
         :action => "detaching Cloud Volume for user #{userid}",
         :userid => userid
       }
+
       queue_opts = {
         :class_name  => self.class.name,
         :method_name => 'detach_volume',
         :instance_id => id,
         :role        => 'ems_operations',
+        :queue_name  => ext_management_system.queue_name_for_ems_operations,
         :zone        => ext_management_system.my_zone,
         :args        => [server_ems_ref]
       }
+
       MiqTask.generic_action_with_callback(task_opts, queue_opts)
     end
 

--- a/spec/models/cloud_volume/cloud_volume_operations_spec.rb
+++ b/spec/models/cloud_volume/cloud_volume_operations_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'CloudVolume::Operations' do
-  let(:ems)          { FactoryBot.create(:ems_vmware) }
-  let(:vm)           { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+  let(:ems)          { FactoryBot.create(:ems_cloud) }
+  let(:vm)           { FactoryBot.create(:vm_cloud, :ext_management_system => ems) }
   let(:cloud_volume) { FactoryBot.create(:cloud_volume, :ext_management_system => ems) }
   let(:user)         { FactoryBot.create(:user, :userid => 'test') }
 

--- a/spec/models/cloud_volume/cloud_volume_operations_spec.rb
+++ b/spec/models/cloud_volume/cloud_volume_operations_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe 'CloudVolume::Operations' do
+  let(:disk)         { FactoryBot.create(:disk) }
+  let(:ems)          { FactoryBot.create(:ems_vmware) }
+  let(:cloud_volume) { FactoryBot.create(:cloud_volume, :ext_management_system => ems) }
+  let(:user)         { FactoryBot.create(:user, :userid => 'test') }
+
+  context "queued methods" do
+    it "queues an attach task with attach_volume_queue" do
+      task_id = cloud_volume.attach_volume_queue(user.userid, ems.id, disk.id)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "attaching Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => cloud_volume.class.name).first).to have_attributes(
+        :class_name  => cloud_volume.class.name,
+        :method_name => 'attach_volume',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [ems.id, disk.id]
+      )
+    end
+
+    it "queues a detach task with detach_volume_queue" do
+      task_id = cloud_volume.detach_volume_queue(user.userid, ems.id)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "detaching Cloud Volume for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => cloud_volume.class.name).first).to have_attributes(
+        :class_name  => cloud_volume.class.name,
+        :method_name => 'detach_volume',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [ems.id]
+      )
+    end
+  end
+end

--- a/spec/models/cloud_volume/cloud_volume_operations_spec.rb
+++ b/spec/models/cloud_volume/cloud_volume_operations_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe 'CloudVolume::Operations' do
-  let(:disk)         { FactoryBot.create(:disk) }
   let(:ems)          { FactoryBot.create(:ems_vmware) }
+  let(:vm)           { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
   let(:cloud_volume) { FactoryBot.create(:cloud_volume, :ext_management_system => ems) }
   let(:user)         { FactoryBot.create(:user, :userid => 'test') }
 
   context "queued methods" do
     it "queues an attach task with attach_volume_queue" do
-      task_id = cloud_volume.attach_volume_queue(user.userid, ems.id, disk.id)
+      task_id = cloud_volume.attach_volume_queue(user.userid, vm.ext_management_system.id, vm.id)
 
       expect(MiqTask.find(task_id)).to have_attributes(
         :name   => "attaching Cloud Volume for user #{user.userid}",
@@ -20,12 +20,12 @@ RSpec.describe 'CloudVolume::Operations' do
         :role        => 'ems_operations',
         :queue_name  => 'generic',
         :zone        => ems.my_zone,
-        :args        => [ems.id, disk.id]
+        :args        => [ems.id, vm.id]
       )
     end
 
     it "queues a detach task with detach_volume_queue" do
-      task_id = cloud_volume.detach_volume_queue(user.userid, ems.id)
+      task_id = cloud_volume.detach_volume_queue(user.userid, vm.ext_management_system.id)
 
       expect(MiqTask.find(task_id)).to have_attributes(
         :name   => "detaching Cloud Volume for user #{user.userid}",


### PR DESCRIPTION
This PR adds a `queue_name` to the queue options for the `CloudVolume::Operations#attach_volume_queue` method. I've also added some specs (this mixin doesn't appear to have had existing test coverage), and added some comments on those methods.

Part of #19543