### PR TITLE
Move the important parts of monitoring workers into #monitor_workers

### DIFF
--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -46,22 +46,6 @@ module MiqServer::WorkerManagement::Heartbeat
     worker_set_message(w, message, *args) unless w.nil?
   end
 
-  def request_workers_to_sync_config(resync_needed = false)
-    processed_worker_ids = []
-    miq_workers.each do |w|
-      # Note, STATUSES_CURRENT_OR_STARTING doesn't include 'stopping'.
-      # We already restarted 'stopping' workers, so we bail out early here.
-      # 'stopping' workers continue to run and heartbeat through drb, which
-      # updates the in memory @workers.  The last heartbeat in the workers row is
-      # NOT updated because we no longer call validate_heartbeat when we skip validate_worker below.
-      next unless MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
-      processed_worker_ids << w.id
-      next unless validate_worker(w)
-      worker_set_message(w, "sync_config") if resync_needed
-    end
-    processed_worker_ids
-  end
-
   # Get the latest heartbeat between the SQL and memory (updated via DRb)
   def validate_heartbeat(w)
     last_heartbeat = workers_last_heartbeat(w)

--- a/app/models/miq_server/worker_management/heartbeat.rb
+++ b/app/models/miq_server/worker_management/heartbeat.rb
@@ -47,7 +47,7 @@ module MiqServer::WorkerManagement::Heartbeat
   end
 
   # Get the latest heartbeat between the SQL and memory (updated via DRb)
-  def validate_heartbeat(w)
+  def persist_last_heartbeat(w)
     last_heartbeat = workers_last_heartbeat(w)
 
     if w.last_heartbeat.nil?

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -106,7 +106,7 @@ module MiqServer::WorkerManagement::Monitor
       # We already restarted 'stopping' workers, so we bail out early here.
       # 'stopping' workers continue to run and heartbeat through drb, which
       # updates the in memory @workers.  The last heartbeat in the workers row is
-      # NOT updated because we no longer call validate_heartbeat when we skip validate_worker below.
+      # NOT updated because we no longer call persist_last_heartbeat when we skip validate_worker below.
       next unless MiqWorker::STATUSES_CURRENT_OR_STARTING.include?(w.status)
       processed_worker_ids << w.id
       next unless validate_worker(w)

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -4,10 +4,6 @@ module MiqServer::WorkerManagement::Monitor::Validation
   def validate_worker(w)
     return true if MiqEnvironment::Command.is_podified?
 
-    w.validate_active_messages
-
-    persist_last_heartbeat(w)
-
     if !worker_heartbeat_valid?(w)
       stop_worker(w, MiqServer::NOT_RESPONDING)
       return false

--- a/app/models/miq_server/worker_management/monitor/validation.rb
+++ b/app/models/miq_server/worker_management/monitor/validation.rb
@@ -9,7 +9,7 @@ module MiqServer::WorkerManagement::Monitor::Validation
 
     w.validate_active_messages
 
-    validate_heartbeat(w)
+    persist_last_heartbeat(w)
 
     if time_threshold.seconds.ago.utc > w.last_heartbeat
       msg = "#{w.format_full_log_msg} has not responded in #{Time.now.utc - w.last_heartbeat} seconds, restarting worker"

--- a/spec/models/miq_server/worker_management/heartbeat_spec.rb
+++ b/spec/models/miq_server/worker_management/heartbeat_spec.rb
@@ -1,5 +1,5 @@
 describe MiqServer::WorkerManagement::Heartbeat do
-  context "#validate_heartbeat" do
+  context "#persist_last_heartbeat" do
     let(:miq_server) { EvmSpecHelper.local_miq_server.tap(&:setup_drb_variables) }
     let(:pid)        { 1234 }
     let(:worker)     { FactoryBot.create(:miq_worker, :miq_server_id => miq_server.id, :pid => pid) }
@@ -9,7 +9,7 @@ describe MiqServer::WorkerManagement::Heartbeat do
         t = Time.now.utc
         Timecop.freeze(t) do
           miq_server.worker_heartbeat(pid)
-          miq_server.validate_heartbeat(worker)
+          miq_server.persist_last_heartbeat(worker)
         end
 
         expect(worker.reload.last_heartbeat).to be_within(1.second).of(t)
@@ -38,7 +38,7 @@ describe MiqServer::WorkerManagement::Heartbeat do
           [0, 5].each do |i|
             Timecop.freeze(first_heartbeat) do
               miq_server.worker_heartbeat(pid)
-              miq_server.validate_heartbeat(worker)
+              miq_server.persist_last_heartbeat(worker)
             end
 
             expect(worker.reload.last_heartbeat).to be_within(1.second).of(first_heartbeat + i)
@@ -61,7 +61,7 @@ describe MiqServer::WorkerManagement::Heartbeat do
           [0, 5, 10, 15].each do |i|
             Timecop.freeze(first_heartbeat + i) do
               miq_server.worker_heartbeat(pid)
-              miq_server.validate_heartbeat(worker)
+              miq_server.persist_last_heartbeat(worker)
             end
 
             expect(worker.reload.last_heartbeat).to be_within(1.second).of(first_heartbeat)
@@ -77,7 +77,7 @@ describe MiqServer::WorkerManagement::Heartbeat do
           [0, 5].each do |i|
             Timecop.freeze(first_heartbeat) do
               miq_server.worker_heartbeat(pid)
-              miq_server.validate_heartbeat(worker)
+              miq_server.persist_last_heartbeat(worker)
             end
 
             expect(worker.reload.last_heartbeat).to be_within(1.second).of(first_heartbeat + i)

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -337,28 +337,6 @@ describe "MiqWorker Monitor" do
             expect(server.validate_worker(worker)).to be_falsey
             expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPING)
           end
-
-          context "to a file" do
-            before do
-              ENV["WORKER_HEARTBEAT_METHOD"] = "file"
-            end
-
-            after do
-              ENV["WORKER_HEARTBEAT_METHOD"] = nil
-            end
-
-            it "should mark not responding if not recently heartbeated via file" do
-              allow(server).to receive(:workers_last_heartbeat_to_file).and_return(20.minutes.ago)
-
-              expect(server.validate_worker(worker)).to be_falsey
-              expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPING)
-            end
-
-            it "should detect responding if recently heartbeated via file" do
-              expect(server.validate_worker(worker)).to be_truthy
-              expect(worker.reload.status).to eq(MiqWorker::STATUS_READY)
-            end
-          end
         end
 
         context "for excessive memory" do

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -362,7 +362,10 @@ describe "MiqWorker Monitor" do
         end
 
         context "for excessive memory" do
-          before { worker.memory_usage = 2.gigabytes }
+          before do
+            worker.memory_usage = 2.gigabytes
+            worker.update(:last_heartbeat => Time.now.utc)
+          end
 
           it "should not trigger memory threshold if worker is creating" do
             worker.status = MiqWorker::STATUS_CREATING


### PR DESCRIPTION
Builds on https://github.com/ManageIQ/manageiq/pull/19605

Highly recommended to review this one commit-by-commit.

Each commit in this PR tries to make it more clear that the side-effects built into methods like `request_workers_to_sync_config`,  `validate_worker`, and `validate_heartbeat` are actually the most important parts of `MiqServer#monitor_workers` with the end goal of getting the meat of those methods callable from `#monitor_workers` directly as well as giving them better names.

Additionally this PR resolves the issue described [here](https://github.com/ManageIQ/manageiq/pull/19585#issuecomment-562331193) which was that the seemingly reasonable change of calling `request_workers_to_sync_config` only when we needed to sync config would actually cause massive amounts of worker timeouts or un-monitored workers.