### PR TITLE
Cap&U subclass MetricsCapture

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -18,7 +18,7 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
   # Capture all metrics for an ems
   def perf_capture
     perf_capture_health_check
-    targets = Metric::Targets.capture_ems_targets(ems)
+    targets = capture_ems_targets
 
     targets_by_rollup_parent = calc_targets_by_rollup_parent(targets)
     target_options = calc_target_options(targets_by_rollup_parent)
@@ -28,7 +28,7 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
 
   # target is an ExtManagementSystem
   def perf_capture_gap(start_time, end_time)
-    targets = Metric::Targets.capture_ems_targets(ems, :exclude_storages => true)
+    targets = capture_ems_targets(:exclude_storages => true)
     target_options = Hash.new { |_n, _v| {:start_time => start_time.utc, :end_time => end_time.utc, :interval => 'historical'} }
     queue_captures(targets, target_options)
   end
@@ -77,6 +77,10 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
         false
       end
     end
+  end
+
+  def capture_ems_targets(options = {})
+    Metric::Targets.capture_ems_targets(ems, options)
   end
 
   # if it has not been run, or it was a very long time ago, just run it

--- a/app/models/manageiq/providers/cloud_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/cloud_manager/metrics_capture.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::CloudManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  def capture_ems_targets(options = {})
+    Metric::Targets.capture_cloud_targets([ems], options)
+  end
+end

--- a/app/models/manageiq/providers/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/container_manager/metrics_capture.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::ContainerManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  def capture_ems_targets(options = {})
+    Metric::Targets.capture_container_targets([ems], options)
+  end
+end

--- a/app/models/manageiq/providers/infra_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/infra_manager/metrics_capture.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::InfraManager::MetricsCapture < ManageIQ::Providers::BaseManager::MetricsCapture
+  def capture_ems_targets(options = {})
+    Metric::Targets.capture_infra_targets([ems], options)
+  end
+end

--- a/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
@@ -10,18 +10,16 @@ describe ManageIQ::Providers::CloudManager::MetricsCapture do
     context "with openstack", :with_openstack_and_availability_zones do
       it "finds enabled targets" do
         targets = described_class.new(nil, @ems_openstack).send(:capture_ems_targets)
-        assert_cloud_targets_enabled targets, %w[ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm]
+        assert_cloud_targets_enabled targets
+        expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm])
       end
     end
   end
 
   private
 
-  def assert_cloud_targets_enabled(targets, expected_types)
-    selected_types = []
+  def assert_cloud_targets_enabled(targets)
     targets.each do |t|
-      selected_types << t.class.name
-
       expected_enabled = case t
                          # Vm's perf_capture_enabled? is its availability_zone's perf_capture setting,
                          #   or true if it has no availability_zone
@@ -31,7 +29,5 @@ describe ManageIQ::Providers::CloudManager::MetricsCapture do
                          end
       expect(expected_enabled).to be_truthy
     end
-
-    expect(selected_types).to match_array(expected_types)
   end
 end

--- a/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
@@ -1,0 +1,37 @@
+describe ManageIQ::Providers::CloudManager::MetricsCapture do
+  include Spec::Support::MetricHelper
+
+  before do
+    MiqRegion.seed
+    @zone = EvmSpecHelper.local_miq_server.zone
+  end
+
+  describe ".capture_ems_targets" do
+    context "with openstack", :with_openstack_and_availability_zones do
+      it "finds enabled targets" do
+        targets = described_class.new(nil, @ems_openstack).send(:capture_ems_targets)
+        assert_cloud_targets_enabled targets, %w[ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm]
+      end
+    end
+  end
+
+  private
+
+  def assert_cloud_targets_enabled(targets, expected_types)
+    selected_types = []
+    targets.each do |t|
+      selected_types << t.class.name
+
+      expected_enabled = case t
+                         # Vm's perf_capture_enabled? is its availability_zone's perf_capture setting,
+                         #   or true if it has no availability_zone
+                         when Vm then                t.availability_zone ? t.availability_zone.perf_capture_enabled? : true
+                         when AvailabilityZone then  t.perf_capture_enabled?
+                         when Storage then           t.perf_capture_enabled?
+                         end
+      expect(expected_enabled).to be_truthy
+    end
+
+    expect(selected_types).to match_array(expected_types)
+  end
+end

--- a/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
@@ -1,0 +1,3 @@
+describe ManageIQ::Providers::ContainerManager::MetricsCapture do
+  include Spec::Support::MetricHelper
+end

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -1,4 +1,6 @@
-describe Metric::Targets do
+describe ManageIQ::Providers::InfraManager::MetricsCapture do
+  include Spec::Support::MetricHelper
+
   before do
     MiqRegion.seed
     @zone = EvmSpecHelper.local_miq_server.zone
@@ -7,20 +9,13 @@ describe Metric::Targets do
   describe ".capture_ems_targets" do
     context "with vmware", :with_enabled_disabled_vmware do
       it "finds enabled targets" do
-        targets = Metric::Targets.capture_ems_targets(@ems_vmware)
+        targets = described_class.new(nil, @ems_vmware).send(:capture_ems_targets)
         assert_infra_targets_enabled targets, %w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host Storage]
       end
 
       it "finds enabled targets excluding storages" do
-        targets = Metric::Targets.capture_ems_targets(@ems_vmware, :exclude_storages => true)
+        targets = described_class.new(nil, @ems_vmware).send(:capture_ems_targets, :exclude_storages => true)
         assert_infra_targets_enabled targets, %w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host]
-      end
-    end
-
-    context "with openstack", :with_openstack_and_availability_zones do
-      it "finds enabled targets" do
-        targets = Metric::Targets.capture_ems_targets(@ems_openstack)
-        assert_cloud_targets_enabled targets, %w[ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm ManageIQ::Providers::Openstack::CloudManager::Vm]
       end
     end
   end
@@ -37,24 +32,6 @@ describe Metric::Targets do
                          when Vm then      t.host.perf_capture_enabled?
                          when Host then    t.perf_capture_enabled? || t.ems_cluster.perf_capture_enabled?
                          when Storage then t.perf_capture_enabled?
-                         end
-      expect(expected_enabled).to be_truthy
-    end
-
-    expect(selected_types).to match_array(expected_types)
-  end
-
-  def assert_cloud_targets_enabled(targets, expected_types)
-    selected_types = []
-    targets.each do |t|
-      selected_types << t.class.name
-
-      expected_enabled = case t
-                         # Vm's perf_capture_enabled? is its availability_zone's perf_capture setting,
-                         #   or true if it has no availability_zone
-                         when Vm then                t.availability_zone ? t.availability_zone.perf_capture_enabled? : true
-                         when AvailabilityZone then  t.perf_capture_enabled?
-                         when Storage then           t.perf_capture_enabled?
                          end
       expect(expected_enabled).to be_truthy
     end

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -1,10 +1,4 @@
 describe Metric::CiMixin::Capture do
-  before do
-    MiqRegion.seed
-
-    @zone = EvmSpecHelper.local_miq_server.zone
-  end
-
   require ManageIQ::Providers::Openstack::Engine.root.join("spec/tools/openstack_data/openstack_data_test_helper")
   let(:zone) { EvmSpecHelper.create_guid_miq_server_zone[2] }
   let(:mock_meter_list) { OpenstackMeterListData.new }
@@ -409,58 +403,6 @@ describe Metric::CiMixin::Capture do
           verify_perf_capture_queue_historical(last_capture_on, 8)
           Timecop.travel(current_time + 20.minutes)
           verify_perf_capture_queue_historical(last_capture_on, 8)
-        end
-      end
-    end
-  end
-
-  describe ".perf_capture_realtime_now" do
-    context "with enabled and disabled targets", :with_enabled_disabled_vmware do
-      context "executing perf_capture_realtime_now" do
-        before do
-          @vm = Vm.first
-          @vm.perf_capture_realtime_now
-        end
-
-        it "should queue up realtime capture for vm" do
-          expect(MiqQueue.count).to eq(1)
-
-          msg = MiqQueue.first
-          expect(msg.priority).to eq(MiqQueue::HIGH_PRIORITY)
-          expect(msg.instance_id).to eq(@vm.id)
-          expect(msg.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
-        end
-
-        context "with an existing queue item at a lower priority" do
-          before do
-            MiqQueue.first.update_attribute(:priority, MiqQueue::NORMAL_PRIORITY)
-            @vm.perf_capture_realtime_now
-          end
-
-          it "should raise the priority of the existing queue item" do
-            expect(MiqQueue.count).to eq(1)
-
-            msg = MiqQueue.first
-            expect(msg.priority).to eq(MiqQueue::HIGH_PRIORITY)
-            expect(msg.instance_id).to eq(@vm.id)
-            expect(msg.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
-          end
-        end
-
-        context "with an existing queue item at a higher priority" do
-          before do
-            MiqQueue.first.update_attribute(:priority, MiqQueue::MAX_PRIORITY)
-            @vm.perf_capture_realtime_now
-          end
-
-          it "should not lower the priority of the existing queue item" do
-            expect(MiqQueue.count).to eq(1)
-
-            msg = MiqQueue.first
-            expect(msg.priority).to eq(MiqQueue::MAX_PRIORITY)
-            expect(msg.instance_id).to eq(@vm.id)
-            expect(msg.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
-          end
         end
       end
     end

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -75,17 +75,3 @@ RSpec.shared_context "with a small environment and time_profile", :with_small_vm
     MiqQueue.delete_all
   end
 end
-
-RSpec.shared_context "with openstack", :with_openstack_and_availability_zones do
-  before do
-    @ems_openstack = FactoryBot.create(:ems_openstack, :zone => @zone)
-    @availability_zone = FactoryBot.create(:availability_zone_target)
-    @ems_openstack.availability_zones << @availability_zone
-    @vms_in_az = FactoryBot.create_list(:vm_openstack, 2, :ems_id => @ems_openstack.id)
-    @availability_zone.vms = @vms_in_az
-    @availability_zone.vms.push(FactoryBot.create(:vm_openstack, :ems_id => nil))
-    @vms_not_in_az = FactoryBot.create_list(:vm_openstack, 3, :ems_id => @ems_openstack.id)
-
-    MiqQueue.delete_all
-  end
-end


### PR DESCRIPTION
This got bigger than I thought it would.

creates subclasses for MetricsCapture (currently around `capture_ems_targets`)
put those tests in appropriate place
