### PR TITLE
Store currency info to report result for chargeback report results

### DIFF
--- a/app/models/chargeback.rb
+++ b/app/models/chargeback.rb
@@ -45,34 +45,31 @@ class Chargeback < ActsAsArModel
   end
 
   def self.report_settings
-    @@report_settings_cash ||= begin
-      rate_settings = []
-      @@report_settings ||= {}
-      @@report_settings[:rates] ||= []
+    return {} unless @rates
 
-      @@report_settings[:rates].each do |rate|
-        rate_hash = rate.attributes
-        rate_hash['chargeback_rate_details'] = []
-        rate_hash['currency_symbol'] = rate.currency_symbol
+    rate_settings = []
 
-        rate.chargeback_rate_details.each do |detail|
-          detail_hash = {}
-          detail_hash['chargeback_tiers'] = []
+    @rates.each do |rate|
+      rate_hash = rate.attributes
+      rate_hash['chargeback_rate_details'] = []
+      rate_hash['currency'] = rate.currency&.attributes
 
-          detail.chargeback_tiers.each do |tier|
-            detail_hash['chargeback_tiers'].push(tier.attributes)
-          end
+      rate.chargeback_rate_details.each do |detail|
+        detail_hash = {}
+        detail_hash['chargeback_tiers'] = []
 
-          detail_hash['detail'] = detail.attributes
-          rate_hash['chargeback_rate_details'].push(detail_hash)
+        detail.chargeback_tiers.each do |tier|
+          detail_hash['chargeback_tiers'].push(tier.attributes)
         end
 
-        rate_settings.push(rate_hash)
+        detail_hash['detail'] = detail.attributes
+        rate_hash['chargeback_rate_details'].push(detail_hash)
       end
 
-      default_currency_symbol = rate_settings&.first&.dig('currency_symbol') || RatesCache.new.currency_for_report
-      {:rates => rate_settings, :default_currency_symbol => default_currency_symbol }
+      rate_settings.push(rate_hash)
     end
+
+    {:rates => rate_settings, :currency => rate_settings.first&.dig('currency')}
   end
 
   def self.build_results_for_report_chargeback(options)
@@ -83,16 +80,14 @@ class Chargeback < ActsAsArModel
     rates = RatesCache.new(options)
     _log.debug("With report options: #{options.inspect}")
 
-    @@report_settings = {}
-    @@report_settings[:rates] = []
-    @@report_settings_cash = nil
+    @rates = []
 
     MiqRegion.all.each do |region|
       _log.debug("For region #{region.region}")
 
       ConsumptionHistory.for_report(self, options, region.region) do |consumption|
         rates_to_apply = rates.get(consumption)
-        @@report_settings[:rates] |= rates_to_apply
+        @rates |= rates_to_apply
 
         key = report_row_key(consumption)
         _log.debug("Report row key #{key}")

--- a/app/models/chargeback/rates_cache.rb
+++ b/app/models/chargeback/rates_cache.rb
@@ -21,6 +21,11 @@ class Chargeback
         end
     end
 
+    def current_rate_assigment
+      rate = ChargebackRate.get_assignments(:compute)[0] || ChargebackRate.get_assignments(:storage)[0]
+      rate&.fetch_path(:cb_rate)
+    end
+
     private
 
     def rates(consumption)

--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -172,15 +172,16 @@ class ChargebackRate < ApplicationRecord
 
     result
   end
-  ###########################################################
-
-  private
 
   def currency
     # Note that the currency should be relation to ChargebackRate, not ChargebackRateDetail. We cannot work
     # with various currencies within single ChargebackRate. This is to be fixed later in series of db migrations.
     chargeback_rate_details.first.try(:detail_currency)
   end
+
+  ###########################################################
+
+  private
 
   def ensure_unassigned
     if assigned?

--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -400,6 +400,11 @@ module MiqReport::Generator
 
     report = dup
     report.table = nil
+
+    if db_klass.try(:report_settings).present?
+      report.rpt_options[:report_settings] = db_klass.report_settings
+    end
+
     res.report = report
     res.save
     _log.info("Finished creating report result with id [#{res.id}] for report id: [#{id}], name: [#{name}]")

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -401,9 +401,12 @@ class Service < ApplicationRecord
   def chargeback_report
     report_result = MiqReportResult.find_by(:name => chargeback_report_name)
     if report_result.nil?
-      {:results => []}
+      {:results => [], :currency => nil}
     else
-      {:results => report_result.result_set}
+      results = {:results => report_result.result_set}
+      rate_currency = report_result&.report&.rpt_options&.fetch_path(:report_settings, :currency)
+      results[:currency] = rate_currency || Chargeback::RatesCache.new.current_rate_assigment&.currency&.attributes
+      results
     end
   end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -716,6 +716,17 @@ RSpec.describe ChargebackVm do
           expect(subject.cpu_used_metric).to be_within(0.01).of(used_metric)
           expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
           expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
+
+          expect(ChargebackVm.report_settings[:default_currency_symbol]).to eq(chargeback_rate.currency_symbol)
+
+          expected_chargeback_rate = ChargebackVm.report_settings[:rates].first
+          expect(expected_chargeback_rate.except('chargeback_rate_details', 'currency_symbol')).to eq(chargeback_rate.attributes)
+
+          expected_chargeback_rate_detail = expected_chargeback_rate['chargeback_rate_details'].first['detail']
+          expect(expected_chargeback_rate_detail).to eq(ChargebackRateDetail.find(expected_chargeback_rate_detail['id']).attributes)
+
+          expected_chargeback_rate_tier = expected_chargeback_rate['chargeback_rate_details'].first['chargeback_tiers'].first
+          expect(expected_chargeback_rate_tier).to eq(ChargebackTier.find(expected_chargeback_rate_tier['id']).attributes)
         end
       end
 

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -717,10 +717,10 @@ RSpec.describe ChargebackVm do
           expect(subject.cpu_used_cost).to be_within(0.01).of(used_metric * hourly_rate * hours_in_month)
           expect(subject.cpu_allocated_cost).to be_within(0.01).of(cpu_count * count_hourly_rate * hours_in_month)
 
-          expect(ChargebackVm.report_settings[:default_currency_symbol]).to eq(chargeback_rate.currency_symbol)
+          expect(ChargebackVm.report_settings[:currency]).to eq(chargeback_rate.currency.attributes)
 
           expected_chargeback_rate = ChargebackVm.report_settings[:rates].first
-          expect(expected_chargeback_rate.except('chargeback_rate_details', 'currency_symbol')).to eq(chargeback_rate.attributes)
+          expect(expected_chargeback_rate.except('chargeback_rate_details', 'currency')).to eq(chargeback_rate.attributes)
 
           expected_chargeback_rate_detail = expected_chargeback_rate['chargeback_rate_details'].first['detail']
           expect(expected_chargeback_rate_detail).to eq(ChargebackRateDetail.find(expected_chargeback_rate_detail['id']).attributes)


### PR DESCRIPTION
- adds new mechanism how to store additional info to report  result at report generation time
- it stores whole chargeback rates info and currency for chargeback reports 
- currency is exposed in API  (this was needed for the BZ)


NOTE: it uses currency from first rate when we have selected more rates


Links
-----
https://bugzilla.redhat.com/show_bug.cgi?id=1767386


@miq-bot assign @gtanzillo 
@miq-bot add_label chargeback, enhancement


cc @himdel 


API:
`/api/services/8?expand=resources&attributes=chargeback_report`
```
{
    "href": "http://localhost:3090/api/services/8",
    "price": null,
    "chargeback_report": {
        "results": [
            {
               ....
       "currency": {
            "id": "1",
            "code": "USD",
            "name": "United States Dollar",
            "full_name": "United States Dollar",
            "symbol": "$",
            "unicode_hex": "36",
            "created_at": "2019-01-10T15:06:14Z",
            "updated_at": "2019-04-10T20:03:54Z"
        }
...
```
