### PR TITLE
Add queue_name to relocation_queue method

### DIFF
--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -11,19 +11,26 @@ module VmOrTemplate::Operations::Relocation
     raise NotImplementedError, _("raw_evacuate must be implemented in a subclass")
   end
 
+  # Evacuate a VM (i.e. move to another host) as a queued task and return the
+  # task id. The queue name and the queue zone are derived from the EMS, and a
+  # userid is mandatory.
+  #
   def evacuate_queue(userid, options)
     task_opts = {
       :action => "evacuating VM for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'evacuate',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :args        => [options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/vm_or_template/operations/relocation.rb
+++ b/app/models/vm_or_template/operations/relocation.rb
@@ -12,8 +12,8 @@ module VmOrTemplate::Operations::Relocation
   end
 
   # Evacuate a VM (i.e. move to another host) as a queued task and return the
-  # task id. The queue name and the queue zone are derived from the EMS, and a
-  # userid is mandatory.
+  # task id. The queue name and the queue zone are derived from the EMS, and
+  # both the userid and options are mandatory.
   #
   def evacuate_queue(userid, options)
     task_opts = {

--- a/spec/models/vm_or_template/operations/relocation_spec.rb
+++ b/spec/models/vm_or_template/operations/relocation_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe VmOrTemplate::Operations::Relocation do
+  let(:ems)  { FactoryBot.create(:ems_openstack) }
+  let(:vm)   { FactoryBot.create(:vm_openstack, :ext_management_system => ems) }
+  let(:user) { FactoryBot.create(:user, :userid => 'test') }
+
+  context "queued methods" do
+    it 'queues an update task with update_volume_queue' do
+      options = {:name => 'updated_vm_name'}
+      task_id = vm.evacuate_queue(user.userid, options)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "evacuating VM for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => vm.class.name).first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => 'evacuate',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [options]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `VmOrTemplate::Operations::Relocation#evacuate_queue` mixin method.

I've also added some specs (there were previously none for this mixin) and added some comments to that method.

Part of #19543