### PR TITLE
Add queue_name to VmOrTemplate::Operations::Snapshot queue methods

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -142,6 +142,9 @@ module VmOrTemplate::Operations::Snapshot
     raw_remove_all_snapshots
   end
 
+  # Remove all snapshots as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS. The userid is mandatory.
+  #
   def remove_all_snapshots_queue(userid)
     task_opts = {
       :name   => "Removing all snapshots for #{name}",
@@ -154,6 +157,7 @@ module VmOrTemplate::Operations::Snapshot
       :instance_id => id,
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,
+      :queue_name  => queue_name_for_ems_operations,
       :args        => []
     }
 

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -83,7 +83,8 @@ module VmOrTemplate::Operations::Snapshot
       :instance_id => id,
       :method_name => 'remove_snapshot',
       :args        => [snapshot_id],
-      :role        => "ems_operations",
+      :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :task_id     => task_id
     )

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -157,7 +157,7 @@ module VmOrTemplate::Operations::Snapshot
       :instance_id => id,
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,
-      :queue_name  => queue_name_for_ems_operations,
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :args        => []
     }
 

--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -77,6 +77,10 @@ module VmOrTemplate::Operations::Snapshot
     raw_remove_snapshot(snapshot_id)
   end
 
+  # Remove a snapshot as a queued operation and return the queue object. The
+  # queue name and the queue zone are derived from the EMS. The snapshot id
+  # is mandatory, while a task id is optional.
+  #
   def remove_snapshot_queue(snapshot_id, task_id = nil)
     MiqQueue.put_unless_exists(
       :class_name  => self.class.name,
@@ -90,13 +94,18 @@ module VmOrTemplate::Operations::Snapshot
     )
   end
 
+  # Remove a evm snapshot as a queued operation and return the queue object. The
+  # queue name and the queue zone are derived from the EMS. The snapshot id
+  # is mandatory, while a task id is optional.
+  #
   def remove_evm_snapshot_queue(snapshot_id, task_id = nil)
     MiqQueue.put_unless_exists(
       :class_name  => self.class.name,
       :instance_id => id,
       :method_name => 'remove_evm_snapshot',
       :args        => [snapshot_id],
-      :role        => "ems_operations",
+      :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :task_id     => task_id
     )

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
   let(:snapshots) { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
 
   context "queued methods" do
-    after(:each) { MiqQueue.delete_all }
+    after(:context) { MiqQueue.delete_all }
 
     it 'queues as expected in remove_snapshot_queue' do
       queue = vm.remove_snapshot_queue(snapshots.first.id)

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -2,12 +2,17 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
   before { EvmSpecHelper.local_miq_server }
   after(:context) { MiqQueue.delete_all }
 
-  let(:user)      { FactoryBot.create(:user, :userid => 'test') }
-  let(:ems)       { FactoryBot.create(:ems_vmware) }
-  let(:vm)        { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
-  let(:snapshots) { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
+  let(:user)       { FactoryBot.create(:user, :userid => 'test') }
+  let(:ems)        { FactoryBot.create(:ems_vmware) }
+  let(:vm)         { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+  let(:snapshots)  { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
+  let(:queue_name) { 'snapshot_queue' }
 
   context "queued methods" do
+    before do
+      allow(ems).to receive(:queue_name_for_ems_operations).and_return(queue_name)
+    end
+
     it 'queues as expected in remove_snapshot_queue' do
       queue = vm.remove_snapshot_queue(snapshots.first.id)
 
@@ -15,7 +20,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :class_name  => vm.class.name,
         :method_name => 'remove_snapshot',
         :role        => 'ems_operations',
-        :queue_name  => 'generic',
+        :queue_name  => queue_name,
         :zone        => vm.my_zone,
         :args        => [snapshots.first.id],
         :task_id     => nil
@@ -29,7 +34,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :class_name  => vm.class.name,
         :method_name => 'remove_evm_snapshot',
         :role        => 'ems_operations',
-        :queue_name  => 'generic',
+        :queue_name  => queue_name,
         :zone        => vm.my_zone,
         :args        => [snapshots.first.id],
         :task_id     => nil
@@ -49,7 +54,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :class_name  => vm.class.name,
         :method_name => 'remove_all_snapshots',
         :role        => 'ems_operations',
-        :queue_name  => 'generic',
+        :queue_name  => queue_name,
         :zone        => ems.my_zone,
         :args        => []
       )

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
   let(:snapshots) { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
 
   context "queued methods" do
+    after(:each) { MiqQueue.delete_all }
+
     it 'queues as expected in remove_snapshot_queue' do
       queue = vm.remove_snapshot_queue(snapshots.first.id)
 

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe VmOrTemplate::Operations::Snapshot do
   before { EvmSpecHelper.local_miq_server }
+  after(:context) { MiqQueue.delete_all }
 
   let(:user)      { FactoryBot.create(:user, :userid => 'test') }
   let(:ems)       { FactoryBot.create(:ems_vmware) }
@@ -7,8 +8,6 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
   let(:snapshots) { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
 
   context "queued methods" do
-    after(:context) { MiqQueue.delete_all }
-
     it 'queues as expected in remove_snapshot_queue' do
       queue = vm.remove_snapshot_queue(snapshots.first.id)
 

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
   let(:ems)        { FactoryBot.create(:ems_vmware) }
   let(:vm)         { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
   let(:snapshots)  { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
-  let(:queue_name) { 'snapshot_queue' }
 
   context "queued methods" do
-    before do
-      allow(ems).to receive(:queue_name_for_ems_operations).and_return(queue_name)
-    end
-
     it 'queues as expected in remove_snapshot_queue' do
       queue = vm.remove_snapshot_queue(snapshots.first.id)
 
@@ -20,7 +15,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :class_name  => vm.class.name,
         :method_name => 'remove_snapshot',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => vm.queue_name_for_ems_operations,
         :zone        => vm.my_zone,
         :args        => [snapshots.first.id],
         :task_id     => nil
@@ -34,7 +29,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :class_name  => vm.class.name,
         :method_name => 'remove_evm_snapshot',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => vm.queue_name_for_ems_operations,
         :zone        => vm.my_zone,
         :args        => [snapshots.first.id],
         :task_id     => nil
@@ -54,7 +49,7 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :class_name  => vm.class.name,
         :method_name => 'remove_all_snapshots',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => ems.queue_name_for_ems_operations,
         :zone        => ems.my_zone,
         :args        => []
       )

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -1,13 +1,14 @@
 RSpec.describe VmOrTemplate::Operations::Snapshot do
   before { EvmSpecHelper.local_miq_server }
 
-  let(:ems)      { FactoryBot.create(:ems_vmware) }
-  let(:vm)       { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
-  let(:snapshot) { FactoryBot.create(:snapshot, :vm_or_template => vm) }
+  let(:user)      { FactoryBot.create(:user, :userid => 'test') }
+  let(:ems)       { FactoryBot.create(:ems_vmware) }
+  let(:vm)        { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+  let(:snapshots) { FactoryBot.create_list(:snapshot, 2, :vm_or_template => vm) }
 
   context "queued methods" do
-    it 'queues an update task with remove_snapshot_queue' do
-      queue = vm.remove_snapshot_queue(snapshot.id)
+    it 'queues as expected in remove_snapshot_queue' do
+      queue = vm.remove_snapshot_queue(snapshots.first.id)
 
       expect(queue).to have_attributes(
         :class_name  => vm.class.name,
@@ -15,13 +16,13 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :role        => 'ems_operations',
         :queue_name  => 'generic',
         :zone        => vm.my_zone,
-        :args        => [snapshot.id],
+        :args        => [snapshots.first.id],
         :task_id     => nil
       )
     end
 
-    it 'queues an update task with remove_evm_snapshot_queue' do
-      queue = vm.remove_evm_snapshot_queue(snapshot.id)
+    it 'queues as expected with remove_evm_snapshot_queue' do
+      queue = vm.remove_evm_snapshot_queue(snapshots.first.id)
 
       expect(queue).to have_attributes(
         :class_name  => vm.class.name,
@@ -29,8 +30,27 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :role        => 'ems_operations',
         :queue_name  => 'generic',
         :zone        => vm.my_zone,
-        :args        => [snapshot.id],
+        :args        => [snapshots.first.id],
         :task_id     => nil
+      )
+    end
+
+    it 'queues an update task with remove_all_snapshots_queue' do
+      task_id = vm.remove_all_snapshots_queue(user.userid)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "Removing all snapshots for #{vm.name}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => vm.class.name).first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => 'remove_all_snapshots',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => []
       )
     end
   end

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -19,5 +19,19 @@ RSpec.describe VmOrTemplate::Operations::Snapshot do
         :task_id     => nil
       )
     end
+
+    it 'queues an update task with remove_evm_snapshot_queue' do
+      queue = vm.remove_evm_snapshot_queue(snapshot.id)
+
+      expect(queue).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => 'remove_evm_snapshot',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => vm.my_zone,
+        :args        => [snapshot.id],
+        :task_id     => nil
+      )
+    end
   end
 end

--- a/spec/models/vm_or_template/operations/snapshot_spec.rb
+++ b/spec/models/vm_or_template/operations/snapshot_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe VmOrTemplate::Operations::Snapshot do
+  before { EvmSpecHelper.local_miq_server }
+
+  let(:ems)      { FactoryBot.create(:ems_vmware) }
+  let(:vm)       { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+  let(:snapshot) { FactoryBot.create(:snapshot, :vm_or_template => vm) }
+
+  context "queued methods" do
+    it 'queues an update task with remove_snapshot_queue' do
+      queue = vm.remove_snapshot_queue(snapshot.id)
+
+      expect(queue).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => 'remove_snapshot',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => vm.my_zone,
+        :args        => [snapshot.id],
+        :task_id     => nil
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `VmOrTemplate::Operations::Snapshot#remove_snapshot_queue`,  `VmOrTemplate::Operations::Snapshot#remove_evm_snapshot_queue` and `VmOrTemplate::Operations::Snapshot#remove_all_snapshots_queue` mixin methods.

I've also added some specs (there were previously none for this mixin) and added some comments to those methods.

Part of #19543