### PR TITLE
Move storages to belong_to an EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -72,7 +72,7 @@ class ExtManagementSystem < ApplicationRecord
   has_many :disks,             :through => :hardwares
   has_many :physical_servers,  :foreign_key => :ems_id, :inverse_of => :ext_management_system, :dependent => :destroy
 
-  has_many :storages,       -> { distinct },          :through => :hosts
+  has_many :storages, :foreign_key => :ems_id, :dependent => :destroy, :inverse_of => :ext_management_system
   has_many :ems_events,     -> { order("timestamp") }, :class_name => "EmsEvent",    :foreign_key => "ems_id",
                                                       :inverse_of => :ext_management_system
   has_many :generated_events, -> { order("timestamp") }, :class_name => "EmsEvent", :foreign_key => "generating_ems_id",

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -114,12 +114,8 @@ module ManageIQ::Providers
         end
 
         def storages
-          add_properties(
-            :manager_ref          => %i[location],
-            :complete             => false,
-            :arel                 => Storage,
-            :attributes_blacklist => %i[parent],
-          )
+          add_properties(:attributes_blacklist => %i[parent])
+          add_common_default_values
         end
 
         def hosts

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -1,4 +1,6 @@
 class Storage < ApplicationRecord
+  belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :storages
+
   has_many :vms_and_templates, :foreign_key => :storage_id, :dependent => :nullify, :class_name => "VmOrTemplate"
   has_many :miq_templates,     :foreign_key => :storage_id
   has_many :vms,               :foreign_key => :storage_id

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -22,6 +22,7 @@ class Zone < ApplicationRecord
   has_many :miq_templates,         :through => :ext_management_systems
   has_many :ems_clusters,          :through => :ext_management_systems
   has_many :physical_servers,      :through => :ext_management_systems
+  has_many :storages,              :through => :ext_management_systems
   has_many :container_nodes,       :through => :container_managers
   has_many :container_groups,      :through => :container_managers
   has_many :container_replicators, :through => :container_managers
@@ -210,11 +211,6 @@ class Zone < ApplicationRecord
 
   def self.vms_without_a_zone
     Vm.where(:ems_id => nil).to_a
-  end
-
-  def storages
-    MiqPreloader.preload(self, :ext_management_systems => {:hosts => :storages})
-    ext_management_systems.flat_map(&:storages).uniq
   end
 
   def self.storages_without_a_zone

--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
   factory :storage_vmware, :parent => :storage do
     store_type { "VMFS" }
+    sequence(:ems_ref) { |n| "datastore-#{n}" }
   end
 
   factory :storage_nfs, :parent => :storage do

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -147,10 +147,11 @@ describe ExtManagementSystem do
   end
 
   it "#total_storages" do
-    storage1 = FactoryBot.create(:storage)
-    storage2 = FactoryBot.create(:storage)
-
     ems = FactoryBot.create(:ems_vmware)
+
+    storage1 = FactoryBot.create(:storage, :ems_id => ems.id)
+    storage2 = FactoryBot.create(:storage, :ems_id => ems.id)
+
     FactoryBot.create(
       :host_vmware,
       :storages              => [storage1, storage2],

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -484,10 +484,10 @@ describe MiqAlert do
     end
 
     it "evaluates for storage" do
-      storage_in_zone = FactoryBot.create(:storage_vmware)
+      storage_in_zone = FactoryBot.create(:storage_vmware, :ems_id => @ems.id)
       FactoryBot.create(:host, :ext_management_system => @ems, :storages => [storage_in_zone])
 
-      storage_in_another = FactoryBot.create(:storage_vmware)
+      storage_in_another = FactoryBot.create(:storage_vmware, :ems_id => @ems_other.id)
       FactoryBot.create(:host, :ext_management_system => @ems_other, :storages => [storage_in_another])
 
       storage_in_host_no_ems = FactoryBot.create(:storage_vmware)


### PR DESCRIPTION
Make storages belong_to an EMS rather than being cross-ems and only
belonging to multiple hosts.

~~Depends: https://github.com/ManageIQ/manageiq-schema/pull/326~~
Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/33

Dependent:
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/492
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/447
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/6514