### PR TITLE
Add queue name for cloud template ems operations

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -24,6 +24,11 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     ext_management_system.class::Template
   end
 
+  # Create a cloud image as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the provided EMS instance. The EMS
+  # instance and a userid are mandatory. Any +options+ are forwarded as
+  # arguments to the +create_image+ method.
+  #
   def self.create_image_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "Creating Cloud Template for user #{userid}",
@@ -35,8 +40,10 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
       :method_name => 'create_image',
       :role        => 'ems_operations',
       :zone        => ext_management_system.my_zone,
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :args        => [ext_management_system.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
@@ -62,6 +69,7 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
       :action => "updating Cloud Template for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'update_image',
@@ -70,6 +78,7 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
       :zone        => ext_management_system.my_zone,
       :args        => [options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -64,6 +64,9 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     klass.raw_create_image(ext_management_system, options)
   end
 
+  # Update a cloud template as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def update_image_queue(userid, options = {})
     task_opts = {
       :action => "updating Cloud Template for user #{userid}",

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -98,19 +98,25 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
     raise NotImplementedError, _("raw_update_image must be implemented in a subclass")
   end
 
+  # Delete a cloud template as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the EMS, and a userid is mandatory.
+  #
   def delete_image_queue(userid)
     task_opts = {
       :action => "Deleting Cloud Template for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'delete_image',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => []
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/template.rb
+++ b/app/models/manageiq/providers/cloud_manager/template.rb
@@ -78,6 +78,7 @@ class ManageIQ::Providers::CloudManager::Template < ::MiqTemplate
       :method_name => 'update_image',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [options]
     }

--- a/spec/models/manageiq/providers/cloud_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/template_spec.rb
@@ -1,11 +1,35 @@
-describe TemplateCloud do
-  describe "actions" do
+RSpec.describe TemplateCloud do
+  let(:ems) { FactoryBot.create(:ems_cloud) }
+  let(:user) { FactoryBot.create(:user, :userid => 'test') }
+
+  context "actions" do
     it "#post_create_actions" do
       expect(subject).to receive(:reconnect_events)
       expect(subject).to receive(:classify_with_parent_folder_path)
       expect(MiqEvent).to receive(:raise_evm_event).with(subject, "vm_template", :vm => subject)
 
       subject.post_create_actions
+    end
+  end
+
+  context "queued methods" do
+    it 'queues a create task with create_image_queue' do
+      task_id = described_class.create_image_queue(user.userid, ems)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "Creating Cloud Template for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'create_image',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => [ems.id, {}]
+      )
     end
   end
 end


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the ems operations within the `ManageIQ::Providers::CloudManager::Template` model.

I've also added some specs (these methods were previously uncovered), and added some comments on those methods.

On a side note, I changed the described class to `ManageIQ::Providers::CloudManager::Template` instead of using `TemplateCloud`, which I guess is some kind of alias (?).

Part of #19543