### PR TITLE
Allow provider subclasses of Storage

### DIFF
--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -3,6 +3,7 @@ module ManageIQ::Providers
     require_nested :Cluster
     require_nested :ProvisionWorkflow
     require_nested :ResourcePool
+    require_nested :Storage
     require_nested :Template
     require_nested :Vm
     require_nested :VmOrTemplate

--- a/app/models/manageiq/providers/infra_manager/storage.rb
+++ b/app/models/manageiq/providers/infra_manager/storage.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::InfraManager::Storage < ::Storage
+end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -1,4 +1,6 @@
 class Storage < ApplicationRecord
+  include NewWithTypeStiMixin
+
   belongs_to :ext_management_system, :foreign_key => :ems_id, :inverse_of => :storages
 
   has_many :vms_and_templates, :foreign_key => :storage_id, :dependent => :nullify, :class_name => "VmOrTemplate"


### PR DESCRIPTION
Allow providers to subclass the Storage model.

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-schema/pull/443

Dependent:
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/494
- [ ] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/154
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/448

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/35

https://github.com/ManageIQ/manageiq/issues/19440