### PR TITLE
Add queue name to ManageIQ::Providers::CloudManager::Vm queue methods

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -199,7 +199,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   #
   def add_security_group_queue(userid, security_group)
     task_opts = {
-      :action => "associating Security Group with Instance for user #{userid}",
+      :action => "adding Security Group to Instance for user #{userid}",
       :userid => userid
     }
 
@@ -224,19 +224,26 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raise NotImplementedError, _("raw_remove_security_group must be implemented in a subclass")
   end
 
+  # Remove a security group to the VM as a queued task and return the task id.
+  # The queue name and the queue zone are derived from the EMS. The userid and
+  # security group id are mandatory.
+  #
   def remove_security_group_queue(userid, security_group)
     task_opts = {
-      :action => "associating Security Group with Instance for user #{userid}",
+      :action => "removing Security Group from Instance for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'remove_security_group',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :args        => [security_group]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -162,19 +162,26 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raise NotImplementedError, _("raw_disassociate_floating_ip must be implemented in a subclass")
   end
 
+  # Disassociate an IP address with the VM as a queued task and return the task id.
+  # The queue name and the queue zone are derived from the EMS. The userid and
+  # IP address are mandatory.
+  #
   def disassociate_floating_ip_queue(userid, ip_address)
     task_opts = {
       :action => "disassociating floating IP with Instance for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'disassociate_floating_ip',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :args        => [ip_address]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -162,7 +162,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raise NotImplementedError, _("raw_disassociate_floating_ip must be implemented in a subclass")
   end
 
-  # Disassociate an IP address with the VM as a queued task and return the task id.
+  # Disassociate an IP address from the VM as a queued task and return the task id.
   # The queue name and the queue zone are derived from the EMS. The userid and
   # IP address are mandatory.
   #
@@ -193,19 +193,26 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raise NotImplementedError, _("raw_add_security_group must be implemented in a subclass")
   end
 
+  # Add a security group to the VM as a queued task and return the task id.
+  # The queue name and the queue zone are derived from the EMS. The userid and
+  # security group id are mandatory.
+  #
   def add_security_group_queue(userid, security_group)
     task_opts = {
       :action => "associating Security Group with Instance for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'add_security_group',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :args        => [security_group]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -259,19 +259,26 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     super || orchestration_stack.try(:direct_service)
   end
 
+  # Live migrate a VM as a high priority queued task and return the task id.
+  # The queue name and the queue zone are derived from the EMS. The userid
+  # and VM are mandatory, with any options forwarded to the live_migrate method.
+  #
   def self.live_migrate_queue(userid, vm, options = {})
     task_opts = {
       :action => "migrating Instance for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => vm.class.name,
       :method_name => 'live_migrate',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
+      :queue_name  => vm.queue_name_for_ems_operations,
       :zone        => vm.my_zone,
       :args        => [vm.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -282,19 +282,26 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 
+  # Evacuate a VM as a high priority queued task and return the task id.
+  # The queue name and the queue zone are derived from the EMS. The userid
+  # and VM are mandatory, with any options forwarded to the evacuate method.
+  #
   def self.evacuate_queue(userid, vm, options = {})
     task_opts = {
       :action => "evacuating Instance for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => vm.class.name,
       :method_name => 'evacuate',
       :priority    => MiqQueue::HIGH_PRIORITY,
       :role        => 'ems_operations',
+      :queue_name  => vm.queue_name_for_ems_operations,
       :zone        => vm.my_zone,
       :args        => [vm.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -131,19 +131,26 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raise NotImplementedError, _("raw_associate_floating_ip must be implemented in a subclass")
   end
 
+  # Associate an IP address with the VM as a queued task and return the task id.
+  # The queue name and the queue zone are derived from the EMS. The userid and
+  # IP address are mandatory.
+  #
   def associate_floating_ip_queue(userid, ip_address)
     task_opts = {
       :action => "associating floating IP with Instance for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'associate_floating_ip',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => queue_name_for_ems_operations,
       :zone        => my_zone,
       :args        => [ip_address]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -224,7 +224,7 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
     raise NotImplementedError, _("raw_remove_security_group must be implemented in a subclass")
   end
 
-  # Remove a security group to the VM as a queued task and return the task id.
+  # Remove a security group from the VM as a queued task and return the task id.
   # The queue name and the queue zone are derived from the EMS. The userid and
   # security group id are mandatory.
   #

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -1,5 +1,9 @@
 describe VmCloud do
-  subject { FactoryBot.create(:vm_cloud) }
+  let(:ems) { FactoryBot.create(:ems_cloud) }
+  let(:user) { FactoryBot.create(:user, :userid => 'test') }
+  let(:queue_name) { 'vm_cloud_queue' }
+
+  subject { FactoryBot.create(:vm_cloud, :ext_management_system => ems) }
 
   context "relationships" do
     let(:resource_group) { FactoryBot.create(:resource_group) }
@@ -42,6 +46,36 @@ describe VmCloud do
         expect(subject.service).to eq(service_root)
         expect(subject.direct_service).to eq(service)
       end
+    end
+  end
+
+  context "queued methods" do
+    before do
+      allow(ems).to receive(:queue_name_for_ems_operations).and_return(queue_name)
+    end
+
+    it 'queues an associate floating IP task with associate_floating_ip_queue' do
+      ip_address = '1.2.3.4'
+      task_id = subject.associate_floating_ip_queue(user.userid, ip_address)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "associating floating IP with Instance for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'associate_floating_ip',
+        :role        => 'ems_operations',
+        :queue_name  => queue_name,
+        :zone        => ems.my_zone,
+        :args        => [ip_address]
+      )
+    end
+
+    it 'requires an ip address for the associate floating ip queue task' do
+      expect { subject.associate_floating_ip_queue }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -1,7 +1,6 @@
 describe VmCloud do
   let(:ems) { FactoryBot.create(:ems_cloud) }
   let(:user) { FactoryBot.create(:user, :userid => 'test') }
-  let(:queue_name) { 'vm_cloud_queue' }
 
   subject { FactoryBot.create(:vm_cloud, :ext_management_system => ems) }
 
@@ -50,10 +49,6 @@ describe VmCloud do
   end
 
   context "queued methods" do
-    before do
-      allow(ems).to receive(:queue_name_for_ems_operations).and_return(queue_name)
-    end
-
     it 'queues an associate floating IP task with associate_floating_ip_queue' do
       ip_address = '1.2.3.4'
       task_id = subject.associate_floating_ip_queue(user.userid, ip_address)
@@ -68,7 +63,7 @@ describe VmCloud do
         :class_name  => described_class.name,
         :method_name => 'associate_floating_ip',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => ems.queue_name_for_ems_operations,
         :zone        => ems.my_zone,
         :args        => [ip_address]
       )
@@ -93,7 +88,7 @@ describe VmCloud do
         :class_name  => described_class.name,
         :method_name => 'disassociate_floating_ip',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => ems.queue_name_for_ems_operations,
         :zone        => ems.my_zone,
         :args        => [ip_address]
       )
@@ -118,7 +113,7 @@ describe VmCloud do
         :class_name  => described_class.name,
         :method_name => 'add_security_group',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => ems.queue_name_for_ems_operations,
         :zone        => ems.my_zone,
         :args        => [security_group.id]
       )
@@ -143,7 +138,7 @@ describe VmCloud do
         :class_name  => described_class.name,
         :method_name => 'remove_security_group',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => ems.queue_name_for_ems_operations,
         :zone        => ems.my_zone,
         :args        => [security_group.id]
       )
@@ -167,7 +162,7 @@ describe VmCloud do
         :class_name  => described_class.name,
         :method_name => 'live_migrate',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => subject.queue_name_for_ems_operations,
         :zone        => subject.my_zone,
         :args        => [subject.id, {}]
       )
@@ -191,7 +186,7 @@ describe VmCloud do
         :class_name  => described_class.name,
         :method_name => 'evacuate',
         :role        => 'ems_operations',
-        :queue_name  => queue_name,
+        :queue_name  => subject.queue_name_for_ems_operations,
         :zone        => subject.my_zone,
         :args        => [subject.id, {}]
       )


### PR DESCRIPTION
This PR adds a queue_name to all of the `ManageIQ::Providers::CloudManager::Vm` queued methods.

I've also added some specs (these methods were previously uncovered) and added some comments on those methods.

Part of #19543

Cross repo tests at https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/36