### PR TITLE
Add tool to visualize Jobs in graphviz dot format

### DIFF
--- a/tools/job_to_svg.rb
+++ b/tools/job_to_svg.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+if ARGV.empty?
+  puts "USAGE: #{__FILE__} job_class [outfile]"
+  exit 1
+end
+
+job_class, outfile = ARGV
+
+require File.expand_path("../config/environment", __dir__)
+
+job_class = job_class.constantize rescue NilClass
+unless job_class < Job
+  puts "ERROR: job_class is not a subclass of Job.\n\nValid job_class values are:"
+  puts Job.descendants.map(&:name).sort.join("\n").indent(2)
+  exit 1
+end
+
+outfile ||= "#{job_class.name.underscore.tr("/", "-")}.svg"
+File.write(outfile, job_class.to_svg)
+puts "\nWritten to #{outfile}"


### PR DESCRIPTION
@agrare @chessbyte Please review.

This uses the transitions hash to visualize the Job.  Here is an example using the VmScan class:

![vm_scan](https://user-images.githubusercontent.com/52120/70574068-33a61c00-1b71-11ea-9a2d-880ea5e9bd42.png)

Note that by default I don't render the "*" transitions, otherwise the graph is a total mess.  If that ever gets cleaned up, I could see changing the default.  FWIW, here's what it looks like with that enabled:

![Mozilla Firefox 2019-12-10 17-36-41](https://user-images.githubusercontent.com/52120/70575113-bc25bc00-1b73-11ea-9535-d550c67b6045.png)

There is also a tool to do this from the command line.  Hopefully this can help with things like #19607 .