### PR TITLE
Change default queue name for ems operations to generic.

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -604,9 +604,10 @@ class ExtManagementSystem < ApplicationRecord
   end
 
   # Until all providers have an operations worker we can continue
-  # to use the GenericWorker to run ems_operations roles
+  # to use the GenericWorker to run ems_operations roles.
+  #
   def queue_name_for_ems_operations
-    nil
+    'generic'
   end
 
   def enforce_policy(target, event)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -742,4 +742,14 @@ describe ExtManagementSystem do
       expect(result[1][4..-1]).to eq([2])
     end
   end
+
+  context "#queue_name_for_ems_operations" do
+    it "defaults to 'generic' as the queue name for ems operations" do
+      ems_cloud = FactoryBot.create(:ems_cloud)
+      ems_container = FactoryBot.create(:ems_container)
+
+      expect(ems_cloud.queue_name_for_ems_operations).to eql('generic')
+      expect(ems_container.queue_name_for_ems_operations).to eql('generic')
+    end
+  end
 end


### PR DESCRIPTION
As per https://github.com/ManageIQ/manageiq/pull/19616#issuecomment-564169104, let's change the default queue name for ems operations to "generic".

Fixes https://github.com/ManageIQ/manageiq/pull/19616

Ultimately part of Part of #19543