### PR TITLE
Fix run_command_via_queue without arguments

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -339,7 +339,7 @@ class VmOrTemplate < ApplicationRecord
     MiqTask.generic_action_with_callback(task_options, command_queue_options(queue_options))
   end
 
-  def run_command_via_queue(method_name, queue_options)
+  def run_command_via_queue(method_name, queue_options = {})
     queue_options[:method_name] = method_name
     MiqQueue.put(command_queue_options(queue_options))
   end

--- a/spec/models/vm_or_template/operations/power_spec.rb
+++ b/spec/models/vm_or_template/operations/power_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe VmOrTemplate::Operations::Power do
+  let(:ems) { FactoryBot.create(:ems_infra) }
+  let(:vm)  { FactoryBot.create(:vm_infra, :ext_management_system => ems) }
+
+  context "#start_queue" do
+    it "queues a raw_start method" do
+      vm.start_queue
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => "raw_start"
+      )
+    end
+  end
+
+  context "stop_queue" do
+    it "queues a raw_stop method" do
+      vm.stop_queue
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => "raw_stop"
+      )
+    end
+  end
+
+  context "suspend_queue" do
+    it "queues a raw_stop method" do
+      vm.suspend_queue
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => "raw_suspend"
+      )
+    end
+  end
+
+  context "shelve_offload_queue" do
+    it "queues a raw_stop method" do
+      vm.shelve_offload_queue
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => "raw_shelve_offload"
+      )
+    end
+  end
+
+  context "pause_queue" do
+    it "queues a raw_stop method" do
+      vm.pause_queue
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => "raw_pause"
+      )
+    end
+  end
+end


### PR DESCRIPTION
The run_command_via_queue optional queue_options argument accidentally
did not have a default value causing these operations to fail.