### PR TITLE
Update rubyzip to 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem "rake",                           ">=11.0",        :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
-gem "rubyzip",                        "~>1.3.0",       :require => false
+gem "rubyzip",                        "~>2.0.0",       :require => false
 gem "snmp",                           "~>1.2.0",       :require => false
 gem "sprockets",                      "~>3.0",         :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false

--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -96,11 +96,6 @@ module VMDB
     end
 
     def self.zip_logs(zip_filename, dirs, userid = "system")
-      require 'zip/filesystem'
-      # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
-      # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
-      Zip.validate_entry_sizes = true
-
       zip_dir = Rails.root.join("data", "user", userid)
       FileUtils.mkdir_p(zip_dir) unless File.exist?(zip_dir)
 

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -123,11 +123,6 @@ describe VMDB::Util do
   end
 
   context ".add_zip_entry(private)" do
-    require 'zip/filesystem'
-    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
-    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
-    Zip.validate_entry_sizes = true
-
     let(:origin_file) { Tempfile.new 'origin' }
     let(:symlink_level_1) { create_temp_symlink 'symlink_level_1', origin_file.path }
     let(:symlink_level_2) { create_temp_symlink 'symlink_level_2', symlink_level_1 }


### PR DESCRIPTION
We're currently using rubyzip 1.3.0 with "Zip.validate_entry_sizes = true" to address CVE-2019-16892 and should fix it. 

Tested the automate side.

@miq-bot assign @jrafanie 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1781195

## Depends on
https://github.com/ManageIQ/manageiq-automation_engine/pull/397 

update:
this is Jason:
https://giphy.com/gifs/reactiongifs-bTzmG7ok7Dc6A/tile
