### PR TITLE
Allow for setting warm migration cutover datetime

### DIFF
--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -76,7 +76,7 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   end
 
   def update_catalog_item(options, _auth_user = nil)
-    if options[:config_info].present? && options[:config_info][:warm_migration_cutover_datetime].present?
+    if options.dig(:config_info, :warm_migration_cutover_datetime)
       return update_cutover_datetime(options[:config_info][:warm_migration_cutover_datetime])
     end
 

--- a/app/models/service_template_transformation_plan.rb
+++ b/app/models/service_template_transformation_plan.rb
@@ -76,6 +76,10 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   end
 
   def update_catalog_item(options, _auth_user = nil)
+    if options[:config_info].present? && options[:config_info][:warm_migration_cutover_datetime].present?
+      return update_cutover_datetime(options[:config_info][:warm_migration_cutover_datetime])
+    end
+
     raise _("Editing a plan in progress is prohibited") if %w(active pending).include?(miq_requests.sort_by(&:created_on).last.try(:request_state))
 
     if miq_requests.any? || options[:config_info].nil?
@@ -97,6 +101,22 @@ class ServiceTemplateTransformationPlan < ServiceTemplate
   end
 
   private
+
+  def update_cutover_datetime(datetime)
+    raise _('Cannot update cutover date for non-warm migration') unless config_info[:warm_migration]
+
+    begin
+      dt = Time.iso8601(datetime)
+    rescue ArgumentError => err
+      raise _('Error parsing datetime: %{error}') % {:error => err}
+    else
+      raise _('Cannot set cutover date in the past') if Time.current > dt
+
+      config_info[:warm_migration_cutover_datetime] = datetime
+      save
+      reload
+    end
+  end
 
   def enforce_single_service_parent(_resource)
   end


### PR DESCRIPTION
This PR allows for setting cutover date & time for a wam migration `ServiceTemplate`. This information will be a iso-formated datetime string and will land in `config_info[:warm_migration_cutover_datetime]`

Ordinarilly, we would not need to create anything special here, since we already have a way (in backend & API) to update an existing service template: `update_catalog_item()` routine.

Though the routine normally will not allow to update a ServiceTemplate which is "in progress" (i.e. tasks for it are already running).

The usual workflow for a warm migration plan is:
1. the template for warm migration is created and immediately ordered
2. as soon as the template is ordered, the pre-copying phase of the migration starts (i.e. the plan is already in progress)
3. at some point the user decides to add a cutover date

The change that I'm proposing here allows to add the cutover datetime to a warm migration template which is already in progress and would allow to expose this funcionality via API as:

```
# cat post.json
{
  "action" : "edit",
  "resource" : {
    "config_info": {
        "warm_migration_cutover_datetime": "2020-05-01T01:01:01"
    }
  }
}
# curl -s -d@post.json http://admin:smartvm@localhost:3000/api/service_templates/75|json_reformat|grep warm_migration_cutover
            "warm_migration_cutover_datetime": "2020-05-01T01:01:01"
```

@fdupont-redhat 