### PR TITLE
[WIP] OrchestrationTemplateRunner#queue_signal queue name

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
@@ -96,8 +96,8 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
     end
   end
 
-  def queue_signal
-    super(role: 'ems_operations')
+  def queue_signal(*args, deliver_on: nil, priority: MiqQueue::NORMAL_PRIORITY)
+    super(*args, role: 'ems_operations', deliver_on: deliver_on, priority: priority)
   end
 
   def orchestration_stack

--- a/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
@@ -96,6 +96,10 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
     end
   end
 
+  def queue_signal
+    super(role: 'ems_operations')
+  end
+
   def orchestration_stack
     OrchestrationStack.find_by(:id => options[:orchestration_stack_id])
   end
@@ -134,20 +138,6 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
       :cancel                     => {'*'                => 'canceling'},
       :error                      => {'*'                => '*'}
     }
-  end
-
-  def queue_signal(*args, deliver_on: nil, priority: MiqQueue::NORMAL_PRIORITY)
-    MiqQueue.put(
-      :class_name  => self.class.name,
-      :method_name => 'signal',
-      :instance_id => id,
-      :priority    => priority,
-      :role        => 'ems_operations',
-      :queue_name  => options[:queue_name],
-      :zone        => options[:zone],
-      :args        => args,
-      :deliver_on  => deliver_on
-    )
   end
 
   def orchestration_manager

--- a/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
@@ -139,10 +139,11 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
   def queue_signal(*args, deliver_on: nil, priority: MiqQueue::NORMAL_PRIORITY)
     MiqQueue.put(
       :class_name  => self.class.name,
-      :method_name => "signal",
+      :method_name => 'signal',
       :instance_id => id,
       :priority    => priority,
       :role        => 'ems_operations',
+      :queue_name  => options[:queue_name],
       :zone        => options[:zone],
       :args        => args,
       :deliver_on  => deliver_on

--- a/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
+++ b/app/models/manageiq/providers/cloud_manager/orchestration_template_runner.rb
@@ -97,7 +97,7 @@ class ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner < ::Job
   end
 
   def queue_signal(*args, deliver_on: nil, priority: MiqQueue::NORMAL_PRIORITY)
-    super(*args, role: 'ems_operations', deliver_on: deliver_on, priority: priority)
+    super(*args, :role => 'ems_operations', :deliver_on => deliver_on, :priority => priority)
   end
 
   def orchestration_stack

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner do
 
   context "#queue_signal" do
     it "queues a signal with the queue_signal method" do
-      runner = described_class.create_job(:options => {:orchestration_template_id => template.id, :zone => zone})
+      runner = described_class.create_job(:options => {:orchestration_template_id => template.id}, :zone => zone.name)
       queue = runner.queue_signal
 
       expect(queue).to have_attributes(
         :class_name  => described_class.name,
         :method_name => 'signal',
-        :instance_id => template.id,
+        :instance_id => runner.id,
         :role        => 'ems_operations',
         :queue_name  => 'generic',
-        :zone        => zone.id,
+        :zone        => zone.name,
         :priority    => MiqQueue::NORMAL_PRIORITY,
         :args        => []
       )

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
@@ -1,17 +1,19 @@
 RSpec.describe ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner do
+  let(:zone) { FactoryBot.create(:zone) }
   let(:template) { FactoryBot.create(:orchestration_template) }
-  let(:runner) { described_class.new }
 
   context "#queue_signal" do
     it "queues a signal with the queue_signal method" do
+      runner = described_class.new(:options => {:orchestration_template_id => template.id, :zone => zone.id})
       queue = runner.queue_signal
 
       expect(queue).to have_attributes(
         :class_name  => described_class.name,
         :method_name => 'signal',
+        :instance_id => template.id,
         :role        => 'ems_operations',
         :queue_name  => 'generic',
-        :zone        => runner.my_zone,
+        :zone        => zone.id,
         :priority    => MiqQueue::NORMAL_PRIORITY,
         :args        => []
       )

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner do
+  let(:template) { FactoryBot.create(:orchestration_template) }
+  let(:runner) { described_class.new }
+
+  context "#queue_signal" do
+    it "queues a signal with the queue_signal method" do
+      queue = runner.queue_signal
+
+      expect(queue).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'signal',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => runner.my_zone,
+        :priority    => MiqQueue::NORMAL_PRIORITY,
+        :args        => []
+      )
+    end
+  end
+end

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_template_runner_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner do
 
   context "#queue_signal" do
     it "queues a signal with the queue_signal method" do
-      runner = described_class.new(:options => {:orchestration_template_id => template.id, :zone => zone.id})
+      runner = described_class.create_job(:options => {:orchestration_template_id => template.id, :zone => zone})
       queue = runner.queue_signal
 
       expect(queue).to have_attributes(


### PR DESCRIPTION
Updates for the `ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner#queue_signal` method.

This removes the explicit `MiqQueue.put` and just uses `super` plus a role since it ultimately already inherits that method from the `StateMachine` mixin. I also moved it back to being a public method.

WIP status for now because I'm not sure if the `queue_name` should be set here, and if so, what it should be set to. Also, I'm currently not getting the expected zone or instance id.

Originally part of #19543