### PR TITLE
Add back missing requires for rubyzip

### DIFF
--- a/lib/vmdb/util.rb
+++ b/lib/vmdb/util.rb
@@ -96,6 +96,7 @@ module VMDB
     end
 
     def self.zip_logs(zip_filename, dirs, userid = "system")
+      require 'zip/filesystem'
       zip_dir = Rails.root.join("data", "user", userid)
       FileUtils.mkdir_p(zip_dir) unless File.exist?(zip_dir)
 

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -123,6 +123,8 @@ describe VMDB::Util do
   end
 
   context ".add_zip_entry(private)" do
+    require 'zip/filesystem'
+
     let(:origin_file) { Tempfile.new 'origin' }
     let(:symlink_level_1) { create_temp_symlink 'symlink_level_1', origin_file.path }
     let(:symlink_level_2) { create_temp_symlink 'symlink_level_2', symlink_level_1 }


### PR DESCRIPTION
Yes okay I broke it in https://github.com/ManageIQ/manageiq/pull/19629, we needed to keep the requires. 

@miq-bot assign @jrafanie 

~~the related pr is https://github.com/ManageIQ/manageiq-automation_engine/pull/400~~ 

😭 the cross repo tests didn't ...

