### PR TITLE
Add default queue_name for ems_operations in MiqQueue#submit_job

### DIFF
--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -213,6 +213,7 @@ class MiqQueue < ApplicationRecord
       # options[:queue_name] = "generic"
       options[:role] = service
       options[:zone] = resource.try(:my_zone) || MiqServer.my_zone
+      options[:queue_name] = resource.try(:queue_name_for_ems_operations) || "generic"
     when "event"
       options[:queue_name] = "ems"
       options[:role] = service

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -176,9 +176,9 @@ class MiqQueue < ApplicationRecord
   #
   # target_worker:
   #
-  # @options options [String] :class
-  # @options options [String] :instance
-  # @options options [String] :method
+  # @options options [String] :class_name
+  # @options options [String] :instance_id
+  # @options options [String] :method_name
   # @options options [String] :args
   # @options options [String] :target_id (deprecated)
   # @options options [String] :data (deprecated)

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -207,10 +207,7 @@ class MiqQueue < ApplicationRecord
       options[:queue_name] = MiqEmsRefreshWorker.queue_name_for_ems(resource)
       options[:role]       = service
       options[:zone]       = resource.my_zone
-    when "ems_operations", "smartstate"
-      # ems_operations, refresh is class method
-      # some smartstate just want MiqServer.my_zone and pass in no resource
-      # options[:queue_name] = "generic"
+    when "ems_operations"
       options[:role] = service
       options[:zone] = resource.try(:my_zone) || MiqServer.my_zone
       options[:queue_name] = resource.try(:queue_name_for_ems_operations) || "generic"
@@ -228,6 +225,9 @@ class MiqQueue < ApplicationRecord
     when "smartproxy"
       options[:queue_name] = "smartproxy"
       options[:role] = "smartproxy"
+    when "smartstate"
+      options[:role] = service
+      options[:zone] = resource.try(:my_zone) || MiqServer.my_zone
     end
 
     # Note, options[:zone] is set in 'put' via 'determine_queue_zone' and handles setting

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -1,4 +1,4 @@
-describe MiqQueue do
+RSpec.describe MiqQueue do
   specify { expect(FactoryBot.build(:miq_queue)).to be_valid }
 
   context "#deliver" do
@@ -934,6 +934,25 @@ describe MiqQueue do
 
     it "without a zone" do
       expect(MiqQueue.create!(:state => "ready")).to be_kind_of(MiqQueue)
+    end
+  end
+
+  context ".submit_job", :submit_job do
+    let(:ems) { FactoryBot.create(:ems_vmware) }
+    let(:vm) { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+    let(:options) { {:method_name => 'enable', :class_name => vm.class.name, :instance_id => vm.id, :affinity => ems} }
+
+    it "sets options to expected values for an ems_operations service" do
+      queue = MiqQueue.submit_job(options.merge(:service => 'ems_operations'))
+
+      expect(queue).to have_attributes(
+        :class_name  => vm.class.name,
+        :method_name => options[:method_name],
+        :role        => 'ems_operations',
+        :queue_name  => ems.queue_name_for_ems_operations,
+        :zone        => ems.my_zone,
+        :args        => []
+      )
     end
   end
 end


### PR DESCRIPTION
Set a default queue_name within the MiqQueue#submit_job method. It will first attempt to use the `queue_name_for_ems_operations` method on the resource, otherwise it will default to 'generic'.