### PR TITLE
[IVANCHUK] Query current/starting miq_workers, bypassing cache/stale objects

### DIFF
--- a/app/models/mixins/miq_web_server_worker_mixin.rb
+++ b/app/models/mixins/miq_web_server_worker_mixin.rb
@@ -137,6 +137,7 @@ module MiqWebServerWorkerMixin
   end
 
   def terminate
+    require 'miq-process'
     # HACK: Cannot call exit properly from UiWorker nor can we Process.kill('INT', ...) from inside the worker
     # Hence, this is an external mechanism for terminating this worker.
 


### PR DESCRIPTION
NOTE, this is an ivanchuk and older only fix.  Master is not affected, see below.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1781202

If the server deletes the row in the prior loops call to this method because the
worker exceeded memory, the subsequent call to post_message_for_workers could fail
with "can't modify frozen Hash" when trying to update the worker's heartbeat.

Incidentally fixed on master in commit:
https://github.com/ManageIQ/manageiq/commit/e6cbfa8b4625147741919c723eacac540f056099
