### PR TITLE
Use a relation for groups when testing current region specs

### DIFF
--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -184,7 +184,7 @@ describe MiqWidget do
         end
 
         it 'only returns groups in the current region' do
-          groups = [@group1, @group2]
+          groups = MiqGroup.where(id: [@group1, @group2].map(&:id))
           expect(MiqGroup).to receive(:in_my_region).and_return(groups)
           allow(groups).to receive(:where).and_return(groups)
           @widget_report_vendor_and_guest_os.grouped_subscribers

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -184,7 +184,7 @@ describe MiqWidget do
         end
 
         it 'only returns groups in the current region' do
-          groups = MiqGroup.where(:id => [@group1, @group2].map(&:id))
+          groups = MiqGroup.where(:id => [@group1, @group2])
           expect(MiqGroup).to receive(:in_my_region).and_return(groups)
           allow(groups).to receive(:where).and_return(groups)
           @widget_report_vendor_and_guest_os.grouped_subscribers

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -184,7 +184,7 @@ describe MiqWidget do
         end
 
         it 'only returns groups in the current region' do
-          groups = MiqGroup.where(id: [@group1, @group2].map(&:id))
+          groups = MiqGroup.where(:id => [@group1, @group2].map(&:id))
           expect(MiqGroup).to receive(:in_my_region).and_return(groups)
           allow(groups).to receive(:where).and_return(groups)
           @widget_report_vendor_and_guest_os.grouped_subscribers


### PR DESCRIPTION
With strict partial validation enabled, this spec currently fails because an array doesn't implement a `where` method. In RSpec 4 this will be enabled by default, so I'd like to clean it up.

This PR simply changes the array to an actual relation.