### PR TITLE
Remove useless stub in the iso datastore specs

### DIFF
--- a/spec/models/iso_datastore_spec.rb
+++ b/spec/models/iso_datastore_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe IsoDatastore do
 
     context "ems is rhv" do
       context "supports api4" do
-        let(:supported_api_versions) { %w(3 4) }
         it "send the method to ovirt services v4" do
           expect_any_instance_of(ManageIQ::Providers::Redhat::InfraManager::OvirtServices::V4)
             .to receive(:advertised_images)

--- a/spec/models/iso_datastore_spec.rb
+++ b/spec/models/iso_datastore_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe IsoDatastore do
     end
 
     context "ems is rhv" do
-      before do
-        allow(ems).to receive(:supported_api_versions).and_return(supported_api_versions)
-      end
-
       context "supports api4" do
         let(:supported_api_versions) { %w(3 4) }
         it "send the method to ovirt services v4" do


### PR DESCRIPTION
With strict partial validation on, this spec currently fails because an ems does not implement a `supported_api_versions` method.

Removing this stub had no effect, the specs still passed.