### PR TITLE
[HAMMER] Lock money gem to 6.13.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "manageiq-messaging",                              :require => false, :git =
 gem "manageiq-postgres_ha_admin",     "~>3.0",         :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
+gem "money",                          "=6.13.1",       :require => false
 gem "more_core_extensions",           "~>3.5"
 gem "nakayoshi_fork",                 "~>0.0.3"  # provides a more CoW friendly fork (GC a few times before fork)
 gem "net-ldap",                       "~>0.16.1",      :require => false


### PR DESCRIPTION
Hammer branch version of https://github.com/ManageIQ/manageiq/pull/19577, but use `6.13.1` which is what downstream build is currently using for this branch.