### PR TITLE
Add trait in_other_region to TimeProfile factory

### DIFF
--- a/spec/factories/time_profile.rb
+++ b/spec/factories/time_profile.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :time_profile do
     sequence(:description) { |n| "Time Profile #{seq_padded_for_sorting(n)}" }
+
+    trait :in_other_region do
+      other_region
+    end
   end
 
   factory :time_profile_with_rollup, :parent => :time_profile do


### PR DESCRIPTION
it is needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/6544.

@miq-bot add_label test
