### PR TITLE
[HAMMER] dialog_spec#destroy - move dialog creation into a let

### DIFF
--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -106,13 +106,14 @@ describe Dialog do
   end
 
   context "#destroy" do
+    let(:dialog) { FactoryBot.create(:dialog) }
+
     it "destroy without resource_action association" do
-      expect(FactoryGirl.create(:dialog).destroy).to be_truthy
+      expect(dialog.destroy).to be_truthy
       expect(Dialog.count).to eq(0)
     end
 
     it "destroy with resource_action association" do
-      dialog = FactoryGirl.create(:dialog)
       FactoryGirl.create(:resource_action, :action => "Provision", :dialog => dialog, :resource_type => Dialog, :resource_id => dialog.id)
       expect { dialog.destroy }
       .to raise_error(RuntimeError, "Dialog cannot be deleted because it is connected to other components: [\"Dialog:#{dialog.id} - #{dialog.name}\"]")


### PR DESCRIPTION
fixes hammer backport of https://github.com/ManageIQ/manageiq/pull/19574
failing with `undefined local variable or method 'dialog'`
because it was missing the `let` from https://github.com/ManageIQ/manageiq/pull/18479

Cc @simaishi 
@miq-bot assign simaishi
@miq-bot add_label test