### PR TITLE
Use TERM signals instead of an exit message over drb to stop workers

### DIFF
--- a/app/models/miq_server/worker_management/monitor/stop.rb
+++ b/app/models/miq_server/worker_management/monitor/stop.rb
@@ -43,7 +43,11 @@ module MiqServer::WorkerManagement::Monitor::Stop
       w.stop_systemd_worker
     else
       w.update(:status => MiqWorker::STATUS_STOPPING)
-      worker_set_message(w, 'exit')
+      if w.pid
+        Process.kill("TERM", w.pid)
+      else
+        _log.error("Failed to stop worker #{w.inspect}; pid is nil")
+      end
     end
   end
 end

--- a/app/models/miq_server/worker_management/monitor/stop.rb
+++ b/app/models/miq_server/worker_management/monitor/stop.rb
@@ -41,8 +41,6 @@ module MiqServer::WorkerManagement::Monitor::Stop
       w.stop_container
     elsif w.systemd_worker?
       w.stop_systemd_worker
-    elsif w.respond_to?(:terminate)
-      w.terminate
     else
       w.update(:status => MiqWorker::STATUS_STOPPING)
       worker_set_message(w, 'exit')

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -9,7 +9,7 @@ class MiqWorker::Runner
   attr_accessor :last_hb, :worker, :worker_settings
   attr_reader   :active_roles, :server
 
-  INTERRUPT_SIGNALS = ["SIGINT", "SIGTERM"]
+  INTERRUPT_SIGNALS = %w[SIGINT SIGTERM].freeze
 
   SAFE_SLEEP_SECONDS = 60
 
@@ -30,10 +30,6 @@ class MiqWorker::Runner
 
   def self.corresponding_model
     parent
-  end
-
-  def self.interrupt_signals
-    INTERRUPT_SIGNALS
   end
 
   def initialize(cfg = {})
@@ -470,7 +466,7 @@ class MiqWorker::Runner
   # received from the container management system (aka OpenShift).  The SIGINT
   # trap is mostly a developer convenience.
   def setup_sigterm_trap
-    self.class.interrupt_signals.each do |signal|
+    INTERRUPT_SIGNALS.each do |signal|
       Kernel.trap(signal) { @worker_should_exit = true }
     end
   end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -249,14 +249,6 @@ class MiqWorker::Runner
     exit exit_code
   end
 
-  #
-  # Message handling methods
-  #
-
-  def message_exit(*_args)
-    do_exit("Exit request received.")
-  end
-
   def message_sync_config(*_args)
     _log.info("#{log_prefix} Synchronizing configuration...")
     sync_config

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -28,7 +28,8 @@ module MiqWebServerRunnerMixin
       Dir.chdir(Vmdb::Application.root)
       server.start
     end
-  rescue SignalException
+  rescue SignalException => e
+    raise unless MiqWorker::Runner::INTERRUPT_SIGNALS.include?(e.message)
   ensure
     @worker_should_exit = true
   end

--- a/app/models/mixins/miq_web_server_runner_mixin.rb
+++ b/app/models/mixins/miq_web_server_runner_mixin.rb
@@ -6,22 +6,17 @@ module MiqWebServerRunnerMixin
 
   def do_before_work_loop
     @worker.release_db_connection
-
-    # Since puma traps interrupts, log that we're going away and update our worker row
-    at_exit { do_exit("Exit request received.") }
   end
 
-  def start
-    _log.info("URI: #{worker.uri}")
-
-    # Do all the SQL worker preparation in the main thread
-    prepare
-
+  def run
     # The heartbeating will be done in a separate thread
-    Thread.new { run }
+    worker_thread = Thread.new { super }
 
     worker.class.configure_secret_token
     start_rails_server(worker.rails_server_options)
+
+    # when puma exits allow the heartbeat thread to exit cleanly using #do_exit
+    worker_thread.join
   end
 
   def start_rails_server(options)
@@ -33,6 +28,9 @@ module MiqWebServerRunnerMixin
       Dir.chdir(Vmdb::Application.root)
       server.start
     end
+  rescue SignalException
+  ensure
+    @worker_should_exit = true
   end
 
   def do_heartbeat_work

--- a/lib/workers/bin/run_single_worker.rb
+++ b/lib/workers/bin/run_single_worker.rb
@@ -109,8 +109,10 @@ unless options[:dry_run]
 
   begin
     runner_options[:guid] = worker.guid
+    $log.info("Starting #{worker.class.name} with runner options #{runner_options}")
     worker.class::Runner.new(runner_options).tap(&:setup_sigterm_trap).start
   ensure
+    $log.info("Deleting worker record for #{worker.class.name}, id #{worker.id}")
     worker.delete
   end
 end

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -15,6 +15,8 @@ describe MiqServer::WorkerManagement::Monitor do
     end
 
     it "destroys an unresponsive 'stopping' worker" do
+      expect(Process).to receive(:kill).with("TERM", worker.pid)
+      expect(Process).to receive(:kill).with(9, worker.pid)
       worker.update(:last_heartbeat => 20.minutes.ago)
       server.stop_worker(worker)
       server.check_not_responding
@@ -24,6 +26,7 @@ describe MiqServer::WorkerManagement::Monitor do
     end
 
     it "monitors recently heartbeated 'stopping' workers" do
+      expect(Process).to receive(:kill).with("TERM", worker.pid)
       worker.update(:last_heartbeat => 1.minute.ago)
       server.stop_worker(worker)
       server.check_not_responding

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -277,6 +277,7 @@ describe "MiqWorker Monitor" do
         context "for heartbeat" do
           it "should mark not responding if not recently heartbeated via Drb" do
             worker.update(:last_heartbeat => 20.minutes.ago)
+            expect(Process).to receive(:kill).with("TERM", worker.pid)
             expect(server.validate_worker(worker)).to be_falsey
             expect(worker.reload.status).to eq(MiqWorker::STATUS_STOPPING)
           end
@@ -301,26 +302,22 @@ describe "MiqWorker Monitor" do
           it "should trigger memory threshold if worker is started" do
             worker.status = MiqWorker::STATUS_STARTED
             expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop).once
+            expect(Process).to receive(:kill).with("TERM", worker.pid)
             server.validate_worker(worker)
           end
 
           it "should trigger memory threshold if worker is ready" do
             worker.status = MiqWorker::STATUS_READY
             expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop).once
+            expect(Process).to receive(:kill).with("TERM", worker.pid)
             server.validate_worker(worker)
           end
 
           it "should trigger memory threshold if worker is working" do
             worker.status = MiqWorker::STATUS_WORKING
             expect(server).to receive(:worker_set_monitor_status).with(worker.pid, :waiting_for_stop).once
+            expect(Process).to receive(:kill).with("TERM", worker.pid)
             server.validate_worker(worker)
-          end
-
-          it "should return proper message on heartbeat" do
-            worker.status = MiqWorker::STATUS_READY
-            expect(server.worker_heartbeat(worker.pid)).to eq([])
-            server.validate_worker(worker) # Validation will populate message
-            expect(server.worker_heartbeat(worker.pid)).to eq([['exit']])
           end
         end
       end

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -6,18 +6,6 @@ describe MiqWorker::Runner do
       allow(@worker_base).to receive(:prepare)
     end
 
-    it "SIGINT" do
-      allow(@worker_base).to receive(:run).and_raise(Interrupt)
-      expect(@worker_base).to receive(:do_exit)
-      @worker_base.start
-    end
-
-    it "SIGTERM" do
-      allow(@worker_base).to receive(:run).and_raise(SignalException, "SIGTERM")
-      expect(@worker_base).to receive(:do_exit)
-      @worker_base.start
-    end
-
     it "Handles exception TemporaryFailure" do
       allow(@worker_base).to receive(:heartbeat).and_raise(MiqWorker::Runner::TemporaryFailure)
       expect(@worker_base).to receive(:recover_from_temporary_failure)


### PR DESCRIPTION
All types of worker runtimes now use `run_single_worker.rb` to start workers and both systemd and containers require those workers to respond to TERM signals by exiting cleanly.

This PR makes process-based workers (spawn) respond the same way instead of getting a message from the server over drb.