### PR TITLE
Use automate timeout for orchestration service.

### DIFF
--- a/app/models/service_orchestration.rb
+++ b/app/models/service_orchestration.rb
@@ -27,14 +27,14 @@ class ServiceOrchestration < Service
   end
 
   def deploy_orchestration_stack
-    deploy_stack_options = stack_options
     job_options = {
-      :create_options            => deploy_stack_options,
+      :create_options            => stack_options,
       :orchestration_manager_id  => orchestration_manager.id,
       :orchestration_template_id => orchestration_template.id,
       :stack_name                => stack_name,
       :zone                      => my_zone
     }
+    job_options[:execution_ttl] = service_timeout(stack_options, 'provision')
 
     @deploy_stack_job = ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner.create_job(job_options)
     update(:options => options.merge(:deploy_stack_job_id => @deploy_stack_job.id))
@@ -55,6 +55,8 @@ class ServiceOrchestration < Service
       :update_options            => update_options,
       :zone                      => my_zone
     }
+    job_options[:execution_ttl] = service_timeout(update_options, 'reconfigure')
+
     @update_stack_job = ManageIQ::Providers::CloudManager::OrchestrationTemplateRunner.create_job(job_options)
     update(:options => options.merge(:update_stack_job_id => @update_stack_job.id))
     @update_stack_job.signal(:reconfigure)
@@ -202,5 +204,9 @@ class ServiceOrchestration < Service
       deploy_stack_job.class.uncached { deploy_stack_job.reload }
     end
     @orchestration_stack = deploy_stack_job.orchestration_stack
+  end
+
+  def service_timeout(hash, action)
+    hash[:execution_ttl] || options[:execution_ttl] || options[automate_timeout_key(action)]
   end
 end

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -187,6 +187,7 @@ describe ServiceOrchestration do
           :orchestration_manager_id  => manager_by_dialog.id,
           :stack_name                => service_with_dialog_options.stack_name,
           :orchestration_template_id => template_by_dialog.id,
+          :execution_ttl             => 10,
           :zone                      => service_with_dialog_options.my_zone
         )
         expect(options[:create_options]).to include(
@@ -199,6 +200,8 @@ describe ServiceOrchestration do
           :timeout_in_minutes => 30
         )
       end.and_return(job)
+
+      service_with_dialog_options.options[:execution_ttl] = 10
       service_with_dialog_options.deploy_orchestration_stack
     end
 
@@ -235,9 +238,11 @@ describe ServiceOrchestration do
         expect(options).to include(
           :orchestration_stack_id    => @stack.id,
           :orchestration_template_id => template_by_setter.id,
+          :execution_ttl             => 10,
           :zone                      => reconfigurable_service.my_zone
         )
       end.and_return(job)
+      reconfigurable_service.options[:reconfigure_automate_timeout] = 10
       reconfigurable_service.update_orchestration_stack
     end
   end


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-content/pull/618.
Related to ManageIQ/manageiq#19558

https://bugzilla.redhat.com/show_bug.cgi?id=1781353

@miq_bot assign @tinaafitz
@miq_bot add_label enhancement, changelog/yes, orchestration
