### PR TITLE
Add queue_name to ems operations for ManageIQ::Providers::CloudManager::AuthKeyPair

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -10,18 +10,26 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::Authentication
     ext_management_system.class::AuthKeyPair
   end
 
+  # Create an auth key pair as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the provided EMS instance. The EMS
+  # instance and a userid are mandatory. Any +options+ are forwarded as
+  # arguments to the +create_key_pair+ method.
+  #
   def self.create_key_pair_queue(userid, ext_management_system, options = {})
     task_opts = {
       :action => "creating Auth Key Pair for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
-      :class_name  => "ManageIQ::Providers::CloudManager::AuthKeyPair",
+      :class_name  => 'ManageIQ::Providers::CloudManager::AuthKeyPair',
       :method_name => 'create_key_pair',
       :role        => 'ems_operations',
+      :queue_name  => ext_management_system.queue_name_for_ems_operations,
       :zone        => ext_management_system.my_zone,
       :args        => [ext_management_system.id, options]
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
+++ b/app/models/manageiq/providers/cloud_manager/auth_key_pair.rb
@@ -49,19 +49,25 @@ class ManageIQ::Providers::CloudManager::AuthKeyPair < ::Authentication
     )
   end
 
+  # Delete an auth key pair as a queued task and return the task id. The queue
+  # name and the queue zone are derived from the resource, and a userid is mandatory.
+  #
   def delete_key_pair_queue(userid)
     task_opts = {
       :action => "deleting Auth Key Pair for user #{userid}",
       :userid => userid
     }
+
     queue_opts = {
       :class_name  => self.class.name,
       :method_name => 'delete_key_pair',
       :instance_id => id,
       :role        => 'ems_operations',
+      :queue_name  => resource.queue_name_for_ems_operations,
       :zone        => resource.my_zone,
       :args        => []
     }
+
     MiqTask.generic_action_with_callback(task_opts, queue_opts)
   end
 

--- a/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
@@ -1,6 +1,7 @@
 describe ManageIQ::Providers::CloudManager::AuthKeyPair do
-  let(:ems)  { FactoryBot.create(:ems_cloud) }
+  let(:ems) { FactoryBot.create(:ems_cloud) }
   let(:user) { FactoryBot.create(:user, :userid => 'test') }
+  let(:auth_key_pair) { FactoryBot.create(:auth_key_pair_cloud, :resource => ems) }
 
   context 'create and delete actions' do
     it "has methods" do
@@ -30,6 +31,34 @@ describe ManageIQ::Providers::CloudManager::AuthKeyPair do
         :zone        => ems.my_zone,
         :args        => [ems.id, {}]
       )
+    end
+
+    it 'requires a userid and ems for a queued create task' do
+      expect { described_class.create_key_pair_queue }.to raise_error(ArgumentError)
+      expect { described_class.create_key_pair_queue(user.userid) }.to raise_error(ArgumentError)
+    end
+
+    it 'queues a delete task with delete_key_pair_queue' do
+      task_id = auth_key_pair.delete_key_pair_queue(user.userid)
+
+      expect(MiqTask.find(task_id)).to have_attributes(
+        :name   => "deleting Auth Key Pair for user #{user.userid}",
+        :state  => "Queued",
+        :status => "Ok"
+      )
+
+      expect(MiqQueue.where(:class_name => described_class.name).first).to have_attributes(
+        :class_name  => described_class.name,
+        :method_name => 'delete_key_pair',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => ems.my_zone,
+        :args        => []
+      )
+    end
+
+    it 'requires a userid for a queued delete task' do
+      expect { auth_key_pair.delete_key_pair_queue }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
This PR adds a queue_name to the queue options for the `ManageIQ::Providers::CloudManager::AuthKeyPair` queued methods that are ems operations.

I've also added some specs since these methods were previously uncovered, as well as some comments.

Part of #19543

Cross-repo tests at https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/40