### PR TITLE
Modify MiqAction so that queue_name is set for ems operations

### DIFF
--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1022,8 +1022,8 @@ class MiqAction < ApplicationRecord
         :zone        => zone
       }
 
-      if role == 'ems_operations' && target.respond_to?(:queue_name_for_ems_operations)
-        options[:queue_name] = target.queue_name_for_ems_operations
+      if role == 'ems_operations'
+        options[:queue_name] = target.try(:queue_name_for_ems_operations) || 'generic'
       end
 
       MiqQueue.put(options)

--- a/app/models/miq_action.rb
+++ b/app/models/miq_action.rb
@@ -1011,7 +1011,8 @@ class MiqAction < ApplicationRecord
       target.send(target_method, *target_args)
     else
       MiqPolicy.logger.info("#{log_prefix} Queueing #{log_suffix}")
-      MiqQueue.put(
+
+      options = {
         :class_name  => static ? target.name : target.class.name,
         :method_name => target_method,
         :instance_id => static ? nil : target.id,
@@ -1019,7 +1020,13 @@ class MiqAction < ApplicationRecord
         :role        => role,
         :priority    => MiqQueue::HIGH_PRIORITY,
         :zone        => zone
-      )
+      }
+
+      if role == 'ems_operations' && target.respond_to?(:queue_name_for_ems_operations)
+        options[:queue_name] = target.queue_name_for_ems_operations
+      end
+
+      MiqQueue.put(options)
     end
   end
 

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -162,6 +162,12 @@ RSpec.describe MiqAction do
       @action = FactoryBot.create(:miq_action, :name => "vm_stop")
     end
 
+    it "synchronous" do
+      input = {:synchronous => true}
+      expect(MiqQueue).not_to receive(:put)
+      @action.action_vm_stop(@action, @vm, input)
+    end
+
     it "asynchronous" do
       input = {:synchronous => false}
       @action.action_vm_stop(@action, @vm, input)

--- a/spec/models/miq_action_spec.rb
+++ b/spec/models/miq_action_spec.rb
@@ -153,6 +153,31 @@ RSpec.describe MiqAction do
     end
   end
 
+  context "#action_vm_stop" do
+    before do
+      @zone   = FactoryBot.create(:zone)
+      @ems    = FactoryBot.create(:ems_vmware, :zone => @zone)
+      @host   = FactoryBot.create(:host_vmware)
+      @vm     = FactoryBot.create(:vm_vmware, :host => @host, :ext_management_system => @ems)
+      @action = FactoryBot.create(:miq_action, :name => "vm_stop")
+    end
+
+    it "asynchronous" do
+      input = {:synchronous => false}
+      @action.action_vm_stop(@action, @vm, input)
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.where(:class_name => @vm.class.name).first).to have_attributes(
+        :class_name  => @vm.class.name,
+        :method_name => 'stop',
+        :role        => 'ems_operations',
+        :queue_name  => 'generic',
+        :zone        => @ems.my_zone,
+        :args        => []
+      )
+    end
+  end
+
   context "#action_vm_retire" do
     before do
       @vm     = FactoryBot.create(:vm_vmware)


### PR DESCRIPTION
This PR modifies the private method `invoke_or_queue` so that it will set the queue_name whenever the role is an ems operation.

The name is set using the target's queue name for ems operations, or "generic" if that's not possible. In most cases the target and the rec are the same for ems operations. Only `action_vm_retire` actually has a different target and would have to default as far as I could tell.

I updated the specs a bit to include one of the other operations besides `action_vm_retire` as well.

Part of #19543

Cross-repo tests at https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/41