### PR TITLE
Remove the EmsRefresh.init_console method

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -23,11 +23,6 @@ module EmsRefresh
   # of quietly recording them as failures and continuing.
   mattr_accessor :debug_failures
 
-  # Development helper method for setting up the selector specs for VC
-  def self.init_console
-    ManageIQ::Providers::Vmware::InfraManager::Refresher.init_console
-  end
-
   cache_with_timeout(:queue_timeout) { MiqEmsRefreshWorker.worker_settings[:queue_timeout] || 60.minutes }
 
   def self.queue_refresh_task(target, id = nil)
@@ -75,8 +70,6 @@ module EmsRefresh
 
   def self.refresh(target, id = nil)
     require "inventory_refresh"
-
-    EmsRefresh.init_console if defined?(Rails::Console)
 
     # Handle targets passed as a single class/id pair, an array of class/id pairs, or an array of references
     targets = get_target_objects(target, id).uniq


### PR DESCRIPTION
Without using the VMwareWebService MiqVim style refresh we don't need to
setup the selector spec, we no longer need the init_console method.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/488