### PR TITLE
VMware storages can be in maintenance mode

### DIFF
--- a/app/models/host_storage.rb
+++ b/app/models/host_storage.rb
@@ -10,7 +10,7 @@ class HostStorage < ApplicationRecord
 
   class << self
     def writable_accessible
-      writable.accessible
+      writable.accessible.joins(:storage).merge(Storage.available)
     end
   end
 end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -27,6 +27,8 @@ class Storage < ApplicationRecord
 
   virtual_has_many  :storage_clusters
 
+  scope :available, -> { where(:maintenance => [nil, false]) }
+
   validates_presence_of     :name
   # We can't uncomment this until the SmartProxy starts sending location when registering VMs
   # validates_uniqueness_of   :location


### PR DESCRIPTION
datastore maintenance mode was added in vSphere 5.0

I think it makes sense for this to be part of writable_accessible scoping; it's gonna be shot down by Adam but I like merge and merge is cool... so here we are. 

Part of work for https://bugzilla.redhat.com/show_bug.cgi?id=1394909

There's an engine change associated with this but I wanted to get this up first.
