### PR TITLE
RBAC: Add sui_dashboard_show under sui_dashboard

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6412,6 +6412,10 @@
     :feature_type: node
     :identifier: sui_dashboard
     :children:
+    - :name: View Dashboard
+      :description: Display any dashboards
+      :feature_type: view
+      :identifier: sui_dashboard_show
     - :name: Monthly Charge view
       :description: Display monthly charges
       :feature_type: view


### PR DESCRIPTION
right now, as of https://github.com/ManageIQ/manageiq/pull/16212, the `sui_dashboard` feature has only 1 child ("monthly charge view"):

```yaml
  - :name: Dashboard
    :description: Dashboard features
    :feature_type: node
    :identifier: sui_dashboard
    :children:
    - :name: Monthly Charge view
      :description: Display monthly charges
      :feature_type: view
      :identifier: sui_dashboard_monthly_charge_view
```

Which makes it impossible to actually hide the monthy charge view without also dropping the whole dashboard.
(SUI is using the `sui_dashboard` parent to determine whether a dashboard should be visible now, but that always implies `sui_dashboard_monthly_charge_view`)

=> Introducing a separate `sui_dashboard_show` feature to become the new "show dashboard" feature (and then https://github.com/ManageIQ/manageiq-ui-service/pull/1611 to switch to it).

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1783356

(`sui_dashboard` is not anywhere in `miq_user_roles`, so, not adding this one either, the parent is `sui` used by `EvmRole-user_self_service`)