### PR TITLE
Remove unused highline gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem "fast_gettext",                   "~>2.0.1"
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.8.5"
-gem "highline",                       "~>1.6.21",      :require => false
 gem "inifile",                        "~>3.0",         :require => false
 gem "inventory_refresh",              "~>0.2.0",       :require => false
 gem "kubeclient",                     "~>4.0",         :require => false # For scaling pods at runtime

--- a/tools/pg_inspector/util.rb
+++ b/tools/pg_inspector/util.rb
@@ -1,5 +1,4 @@
 require 'yaml'
-require 'highline'
 
 module PgInspector
   class Util


### PR DESCRIPTION
This doesn't appear to be used anymore.  Last caller was removed in 5961bd9c0dabfbbdd663c5371d2a9548deae9b08