### PR TITLE
Move has_vix_disk_lib into vmware plugin as a seed

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -223,8 +223,6 @@ class MiqServer < ApplicationRecord
       ].each { |k| server_hash[k] = nil }
     end
 
-    server_hash[:has_vix_disk_lib] = server.is_vix_disk_supported?
-
     server.update(server_hash)
 
     _log.info("Server IP Address: #{server.ipaddress}")    unless server.ipaddress.blank?

--- a/app/models/miq_server/server_smart_proxy.rb
+++ b/app/models/miq_server/server_smart_proxy.rb
@@ -145,21 +145,6 @@ module MiqServer::ServerSmartProxy
     true
   end
 
-  # TODO: This should be moved - where?
-  def is_vix_disk_supported?
-    # This is only available on Linux
-    return false unless Sys::Platform::IMPL == :linux
-
-    begin
-      require 'VMwareWebService/VixDiskLib/VixDiskLib'
-      return true
-    rescue Exception
-      # It is ok if we hit an error, it just means the library is not available to load.
-    end
-
-    false
-  end
-
   def concurrent_job_max
     return 0 unless self.is_a_proxy?
 

--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -51,10 +51,16 @@ class EvmDatabase
     MiqAeDatastore
   ].freeze
 
-  SEEDABLE_CLASSES = PRIMORDIAL_SEEDABLE_CLASSES + OTHER_SEEDABLE_CLASSES
+  def self.seedable_classes
+    PRIMORDIAL_SEEDABLE_CLASSES + OTHER_SEEDABLE_CLASSES + seedable_plugin_classes
+  end
+
+  def self.seedable_plugin_classes
+    Vmdb::Plugins.flat_map { |p| p.try(:seedable_classes) }.compact
+  end
 
   def self.seed(classes = nil, exclude_list = [])
-    classes ||= SEEDABLE_CLASSES
+    classes ||= seedable_classes
     classes  -= exclude_list
     classes   = classes.collect(&:constantize)
 
@@ -75,7 +81,7 @@ class EvmDatabase
 
   def self.seed_rest
     return if skip_seeding?
-    seed(OTHER_SEEDABLE_CLASSES)
+    seed(OTHER_SEEDABLE_CLASSES + seedable_plugin_classes)
   end
 
   # Returns whether or not a primordial seed has completed.

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -17,8 +17,8 @@ describe EvmDatabase do
   end
 
   describe ".seed" do
-    it "seeds primordial and non-primordial classes by default" do
-      (described_class::PRIMORDIAL_SEEDABLE_CLASSES + described_class::OTHER_SEEDABLE_CLASSES).each do |klass|
+    it "seeds primordial, non-primordial, and plugin classes by default" do
+      described_class.seedable_classes.each do |klass|
         expect(klass.constantize).to receive(:seed)
       end
 
@@ -64,7 +64,7 @@ describe EvmDatabase do
 
   describe ".seed_rest" do
     it "only seeds non-primordial classes" do
-      described_class::OTHER_SEEDABLE_CLASSES.each do |klass|
+      (described_class::OTHER_SEEDABLE_CLASSES + described_class.seedable_plugin_classes).each do |klass|
         expect(klass.constantize).to receive(:seed)
       end
       expect(described_class::PRIMORDIAL_SEEDABLE_CLASSES.first.constantize).to_not receive(:seed)


### PR DESCRIPTION
This PR also adds the ability for plugins to provide a seed method for their Engine.  By extending the existing seed mechanism to plugins, we can move the has_vix_disk_lib call to the vmware plugin.

@agrare Please review.  Thoughts on this approach?
cc @carbonin 

Merge with https://github.com/ManageIQ/manageiq-providers-vmware/pull/501

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/42