### PR TITLE
Remove invalid 'mock' partial in ManageIQ::Providers::Inventory::Persister specs

### DIFF
--- a/spec/models/manageiq/providers/inventory/persister/serializing_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/serializing_spec.rb
@@ -12,8 +12,6 @@ describe ManageIQ::Providers::Inventory::Persister do
   #
   before do
     @ems = FactoryBot.create(:ems_cloud)
-
-    allow(Settings.ems_refresh).to receive(:mock).and_return({})
   end
 
   it "tests we can serialize inventory object with nested lazy references" do


### PR DESCRIPTION
`Config::Options` - which is what `Settings.ems_refresh` returns - does not implement a `mock` method. This causes strict partial validation to fail. Removing it had no effect.