### PR TITLE
Use data_source_exists? instead of table_exists? in ArPglogicalMigrationHelper

### DIFF
--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -1,6 +1,7 @@
 describe ArPglogicalMigrationHelper do
   shared_context "without the schema_migrations_ran table" do
     before do
+      allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_call_original
       allow(ActiveRecord::Base.connection).to receive(:table_exists?).with("schema_migrations_ran").and_return(false)
     end
   end


### PR DESCRIPTION
Currently the `ar_migration_spec.rb` will generate a failure (with a very large backtrace) if we enable strict partial double verification. The short version is this:

```
<Proc:0x0000000002f7add0@/home/travis/build/ManageIQ/manageiq/vendor/bundle/ruby/2.5.0/gems/activerecord-5.1.7/lib/active_record/type/type_map.rb:8>>>, @use_insert_returning=true, @schema_search_path="\"$user\", public", @case_insensitive_cache={"character varying"=>true}> received :table_exists? with unexpected arguments
         expected: ("schema_migrations_ran")
              got: ("schema_migrations")
        Please stub a default value first if message might be received with other args as well. 
```

At some point in Rails 5 they changed the semantics of `table_exists?` to *only* check for tables, whereas previously it checked tables and views. ~~To retain backwards compatibility, as well as avoid spec failure with strict partial verification, we can change `table_exists?` to `data_source_exists?`~~.

To replicate:

* Add `c.verify_partial_doubles = true` within the `config.mock` block inside `spec/spec_helper.rb`
* Run `bundle exec rspec spec/lib/extensions/ar_migration_spec.rb`
* Make changes proposed here
* Run again

Edit: Updated to include a partial for `ActiveRecord::SchemaMigration.table_name` because it has its own implementation of `table_exists?` that relies on it. This fixes the issue without changing the method.