### PR TITLE
Split the responsibilities of #worker_heartbeat into separate methods

### DIFF
--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -340,8 +340,12 @@ class MiqWorker::Runner
     # without the oversight of MiqServer::WorkerManagement
     return if skip_heartbeat?
 
-    messages = worker_monitor_drb.worker_heartbeat(@worker.pid, @worker.class.name, @worker.queue_name)
-    messages.each { |msg, *args| process_message(msg, *args) }
+    worker_monitor_drb.register_worker(@worker.pid, @worker.class.name, @worker.queue_name)
+    worker_monitor_drb.update_worker_last_heartbeat(@worker.pid)
+
+    worker_monitor_drb.worker_get_messages(@worker.pid).each do |msg, *args|
+      process_message(msg, *args)
+    end
   rescue DRb::DRbError => err
     do_exit("Error heartbeating to MiqServer because #{err.class.name}: #{err.message}", 1)
   end

--- a/spec/models/miq_server/worker_management/heartbeat_spec.rb
+++ b/spec/models/miq_server/worker_management/heartbeat_spec.rb
@@ -8,7 +8,7 @@ describe MiqServer::WorkerManagement::Heartbeat do
       2.times do
         t = Time.now.utc
         Timecop.freeze(t) do
-          miq_server.worker_heartbeat(pid)
+          miq_server.update_worker_last_heartbeat(pid)
           miq_server.persist_last_heartbeat(worker)
         end
 
@@ -37,7 +37,6 @@ describe MiqServer::WorkerManagement::Heartbeat do
 
           [0, 5].each do |i|
             Timecop.freeze(first_heartbeat) do
-              miq_server.worker_heartbeat(pid)
               miq_server.persist_last_heartbeat(worker)
             end
 
@@ -60,7 +59,6 @@ describe MiqServer::WorkerManagement::Heartbeat do
           # iteration of the loop
           [0, 5, 10, 15].each do |i|
             Timecop.freeze(first_heartbeat + i) do
-              miq_server.worker_heartbeat(pid)
               miq_server.persist_last_heartbeat(worker)
             end
 
@@ -76,7 +74,6 @@ describe MiqServer::WorkerManagement::Heartbeat do
 
           [0, 5].each do |i|
             Timecop.freeze(first_heartbeat) do
-              miq_server.worker_heartbeat(pid)
               miq_server.persist_last_heartbeat(worker)
             end
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -215,8 +215,8 @@ describe "MiqWorker Monitor" do
             @miq_server.message_for_worker(@worker1.id, "foo")
           end
 
-          it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['foo']])
+          it "#worker_get_messages should return proper message via drb" do
+            expect(@miq_server.worker_get_messages(@worker1.pid)).to eq([['foo']])
           end
         end
 
@@ -225,8 +225,8 @@ describe "MiqWorker Monitor" do
             @miq_server.message_for_worker(@worker1.id, "sync_config")
           end
 
-          it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['sync_config']])
+          it "#worker_get_messages should return proper message via drb" do
+            expect(@miq_server.worker_get_messages(@worker1.pid)).to eq([['sync_config']])
           end
         end
 
@@ -236,8 +236,8 @@ describe "MiqWorker Monitor" do
             @miq_server.message_for_worker(@worker1.id, 'reconnect_ems', @ems_id.to_s)
           end
 
-          it "should return proper message on heartbeat via drb" do
-            expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['reconnect_ems', @ems_id.to_s]])
+          it "#worker_get_messages should return proper message via drb" do
+            expect(@miq_server.worker_get_messages(@worker1.pid)).to eq([['reconnect_ems', @ems_id.to_s]])
           end
 
           context "and an exit message" do
@@ -245,8 +245,8 @@ describe "MiqWorker Monitor" do
               @miq_server.message_for_worker(@worker1.id, 'exit')
             end
 
-            it "should return proper message on heartbeat via drb" do
-              expect(@miq_server.worker_heartbeat(@worker1.pid)).to eq([['reconnect_ems', @ems_id.to_s], ['exit']])
+            it "#worker_get_messages should return proper message via drb" do
+              expect(@miq_server.worker_get_messages(@worker1.pid)).to eq([['reconnect_ems', @ems_id.to_s], ['exit']])
             end
           end
         end


### PR DESCRIPTION
Previously #worker_heartbeat was responsible for:
- Ensuring a worker (and its metadata) was present in the server's workers hash
- Recording the heartbeat time in drb
- Fetching messages from the server

We want to refactor/remove some of these pieces and having them sitting
on top of each other makes that difficult

Part of https://github.com/ManageIQ/manageiq-pods/issues/353