### PR TITLE
Add an ext_management_system accessor to the anonymous class in the ProviderObjectMixin spec

### DIFF
--- a/spec/models/mixins/provider_object_mixin_spec.rb
+++ b/spec/models/mixins/provider_object_mixin_spec.rb
@@ -1,5 +1,10 @@
-describe ProviderObjectMixin do
-  let(:test_class) { Class.new { include ProviderObjectMixin } }
+RSpec.describe ProviderObjectMixin do
+  let(:test_class) do
+    Class.new do
+      include ProviderObjectMixin
+      attr_accessor :ext_management_system
+    end
+  end
 
   def mock_ems_with_connection
     @ems        = double("ems")


### PR DESCRIPTION
With strict partial doubles enabled, the current specs will fails with `Class does not implement #ext_management_system` for the `ProviderObjectMixin` specs.

This PR just adds an accessor to it so that we're not stubbing a method that doesn't exist.