### PR TITLE
Fix current_authentication_settings spec for MiqLdapConfiguration

### DIFF
--- a/spec/tools/miq_config_sssd_ldap/miqldap_configuration_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/miqldap_configuration_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe MiqConfigSssdLdap::MiqLdapConfiguration do
     end
 
     it 'does not merge current authentication setting with options when doing a fresh configuration' do
-      config = described_class.new(options)
-      expect(config).to_not receive(:current_authentication_settings)
+      expect_any_instance_of(described_class).to_not receive(:current_authentication_settings)
+      described_class.new(options)
     end
   end
 

--- a/spec/tools/miq_config_sssd_ldap/miqldap_configuration_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/miqldap_configuration_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "miq_config_sssd_ldap"
 
-describe MiqConfigSssdLdap::MiqLdapConfiguration do
+RSpec.describe MiqConfigSssdLdap::MiqLdapConfiguration do
   describe '#initialize' do
     let(:settings) { {:tls_cacert => 'cert', :domain => "example.com"} }
     let(:options) do
@@ -17,8 +17,8 @@ describe MiqConfigSssdLdap::MiqLdapConfiguration do
     end
 
     it 'does not merge current authentication setting with options when doing a fresh configuration' do
-      expect(described_class).to_not receive(:current_authentication_settings)
-      described_class.new(options)
+      config = described_class.new(options)
+      expect(config).to_not receive(:current_authentication_settings)
     end
   end
 


### PR DESCRIPTION
The MiqLdapConfiguration#current_authentication_settings method is an instance method, not a singleton method, so the current partial isn't actually doing anything. This PR fixes that.