### PR TITLE
Add interface method for OrchestrationTemplate.eligible_manager_types

### DIFF
--- a/app/models/orchestration_template.rb
+++ b/app/models/orchestration_template.rb
@@ -123,6 +123,13 @@ class OrchestrationTemplate < ApplicationRecord
     [stack_name_opt]
   end
 
+  # Typically the provider's cloud or infra manager class name. Providers that need
+  # something more advanced should define this within their respective subclass.
+  #
+  def self.eligible_manager_types
+    raise NotImplementedError, _("eligible_manager_types must be implemented in subclass")
+  end
+
   # List managers that may be able to deploy this template
   def self.eligible_managers
     Rbac::Filterer.filtered(ExtManagementSystem, :named_scope => [[:with_eligible_manager_types, eligible_manager_types]])


### PR DESCRIPTION
The `eligible_manager_types` method is apparently expected by subclasses, but is never actually defined in the parent class. The result is that attempting to call `OrchestrationTemplate.eligible_managers` will bomb. It will also cause the current specs to fail with strict partial validation.

On a side note, there is some question about what the purpose of `eligible_managers` is in general since it would seem that it's always going to be the provider's cloud manager, at least based on all the examples I saw (vmware, azure, amazon, openstack). The only oddity was the Amazon provider, which instead "registered" itself upon being loaded, but the end result is the same.

But, for now, this is what I went with until further notice.