### PR TITLE
Remove bogus stub for JobProxyDispatcherVmProxies4Job

### DIFF
--- a/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_proxies4job_spec.rb
@@ -1,4 +1,4 @@
-describe "JobProxyDispatcherVmProxies4Job" do
+RSpec.describe "JobProxyDispatcherVmProxies4Job" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do
@@ -55,7 +55,6 @@ describe "JobProxyDispatcherVmProxies4Job" do
         before do
           @job = @vm.raw_scan
           allow(@vm).to receive_messages(:storage2proxies => [])
-          allow(@vm).to receive_messages(:storage2activeproxies => [])
         end
 
         it "should call 'log_all_proxies'" do


### PR DESCRIPTION
This PR removes an invalid (and unused) stub for `:storage2activeproxies` which should be `:storage2active_proxies` (i.e. missing underscore).

However, since it is neither valid nor used, I removed it completely rather than fix it, which had no effect. The specs still pass.