### PR TITLE
Remove unused partial in zone specs

### DIFF
--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,4 +1,4 @@
-describe Zone do
+RSpec.describe Zone do
   context ".seed" do
     before { MiqRegion.seed }
     include_examples ".seed called multiple times", 2
@@ -148,11 +148,6 @@ describe Zone do
   context "ConfigurationManagementMixin" do
     describe "#remote_cockpit_ws_miq_server" do
       before do
-        @csv = <<-CSV.gsub(/^\s+/, "")
-          name,description,max_concurrent,external_failover,role_scope
-          cockpit_ws,Cockpit,1,false,zone
-        CSV
-        allow(ServerRole).to receive(:seed_data).and_return(@csv)
         ServerRole.seed
         _, _, @zone = EvmSpecHelper.create_guid_miq_server_zone
       end


### PR DESCRIPTION
Within the zone specs, the `allow(ServerRole).to receive(:seed_data).and_return(@csv)` line breaks strict partial verification since ServerRole doesn't implement a seed_data method. So, it isn't actually doing anything, and the specs pass without it.

While I was here I also updated the outer describe block to RSpec.describe to be future compliant with rspec4.

Similar to https://github.com/ManageIQ/manageiq/pull/18730