### PR TITLE
[WIP] Replace ActsAsArModel with QueryRelation in PglogicalSubscription

### DIFF
--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -45,7 +45,7 @@ class PglogicalSubscription
     when :last
       collection.last
     else
-      collection.select{ |e| e[:id] == mode }
+      collection.select{ |e| e.id == mode }
     end
   end
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -34,8 +34,8 @@ class PglogicalSubscription
     self.class.connection
   end
 
-  # Interface method required by QueryRelation. If +mode+ is not a hash option,
-  # it assumes the argument is an id.
+  # Interface method required by QueryRelation. If +mode+ is not a symbol
+  # then it assumes the argument is an id.
   #
   def self.search(mode, options = {})
     collection = subscriptions.collect { |s| new(subscription_to_columns(s)) }

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -132,13 +132,14 @@ class PglogicalSubscription
   end
 
   def validate(new_connection_params = {})
-    find_password if new_connection_params['password'].blank?
+    new_connection_params.symbolize_keys!
+    find_password if new_connection_params[:password].blank?
     connection_hash = attributes.merge(new_connection_params.delete_blanks)
-    MiqRegionRemote.validate_connection_settings(connection_hash['host'],
-                                                 connection_hash['port'],
-                                                 connection_hash['user'],
-                                                 connection_hash['password'],
-                                                 connection_hash['dbname'])
+    MiqRegionRemote.validate_connection_settings(connection_hash[:host],
+                                                 connection_hash[:port],
+                                                 connection_hash[:user],
+                                                 connection_hash[:password],
+                                                 connection_hash[:dbname])
   end
 
   def backlog

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -3,6 +3,7 @@ require 'pg/logical_replication'
 require 'query_relation'
 
 class PglogicalSubscription
+  include Vmdb::Logging
   include ActiveModel::Model
   extend QueryRelation::Queryable
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -23,6 +23,7 @@ class PglogicalSubscription
   #
   def initialize(**kwargs)
     kwargs.each do |key, value|
+      raise ArgumentError, "invalid key '#{key}'" unless attributes.include?(key)
       self.send("#{key}=",value)
     end
   end

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -29,8 +29,8 @@ class PglogicalSubscription
     end
   end
 
-  # A list of attributes typically used on inspection, and necessary
-  # for ActiveModel::AttributeMethods, if used.
+  # A list of attributes typically used on inspection, and used for validation
+  # within the constructor.
   #
   def attributes
     {

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -4,10 +4,28 @@ require 'query_relation'
 
 class PglogicalSubscription
   include Vmdb::Logging
-  include ActiveModel::Model
   extend QueryRelation::Queryable
 
   attr_accessor :id, :status, :dbname, :host, :user, :password, :port, :provider_region, :provider_region_name
+
+  # Create and return a new PglogicalSubscription instance. The possible
+  # options that can be passed to the constructor are:
+  #
+  # * id
+  # * status
+  # * dbname
+  # * host
+  # * user
+  # * password
+  # * port
+  # * provider_region
+  # * provider_region_name
+  #
+  def initialize(**kwargs)
+    kwargs.each do |key, value|
+      self.send("#{key}=",value)
+    end
+  end
 
   # A list of attributes typically used on inspection, and necessary
   # for ActiveModel::AttributeMethods, if used.

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -45,7 +45,7 @@ class PglogicalSubscription
     when :last
       collection.last
     else
-      collection.select{ |e| e.id == mode }
+      collection.find{ |e| e.id == mode } or raise ActiveRecord::RecordNotFound
     end
   end
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -9,6 +9,9 @@ class PglogicalSubscription
 
   attr_accessor :id, :status, :dbname, :host, :user, :password, :port, :provider_region, :provider_region_name
 
+  # A list of attributes typically used on inspection, and necessary
+  # for ActiveModel::AttributeMethods, if used.
+  #
   def attributes
     {
       :id                   => @id,
@@ -50,6 +53,8 @@ class PglogicalSubscription
     end
   end
 
+  # Filter a +collection+ based on various +options+ that are used by QueryRelation.
+  #
   def self.filter_collection(collection, options)
     collection = collection.drop(options[:offset]) if options[:offset]
     collection = collection.take(options[:limit]) if options[:limit]
@@ -57,14 +62,13 @@ class PglogicalSubscription
     collection
   end
 
+  # Find a record by id, but return nil instead of raising an error if it's not found.
+  #
   def self.lookup_by_id(to_find)
     search(to_find)
   rescue ActiveRecord::RecordNotFound
     nil
   end
-
-  singleton_class.send(:alias_method, :find_by_id, :lookup_by_id)
-  Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_id => :lookup_by_id)
 
   def save!(reload_failover_monitor = true)
     assert_different_region!

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -53,6 +53,10 @@ class PglogicalSubscription
     end
   end
 
+  class << self
+    alias find search
+  end
+
   # Filter a +collection+ based on various +options+ that are used by QueryRelation.
   #
   def self.filter_collection(collection, options)

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -24,6 +24,7 @@ class PglogicalSubscription
   def initialize(**kwargs)
     kwargs.each do |key, value|
       raise ArgumentError, "invalid key '#{key}'" unless attributes.include?(key)
+
       send("#{key}=", value)
     end
   end

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -49,7 +49,7 @@ class PglogicalSubscription
     when :last
       collection.last
     else
-      collection.find { |e| e.id == mode } or raise ActiveRecord::RecordNotFound
+      collection.find { |e| e.id == mode } || raise(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -49,7 +49,7 @@ class PglogicalSubscription
     when :last
       collection.last
     else
-      collection.find{ |e| e.id == mode } or raise ActiveRecord::RecordNotFound
+      collection.find { |e| e.id == mode } or raise ActiveRecord::RecordNotFound
     end
   end
 
@@ -58,7 +58,7 @@ class PglogicalSubscription
   def self.filter_collection(collection, options)
     collection = collection.drop(options[:offset]) if options[:offset]
     collection = collection.take(options[:limit]) if options[:limit]
-    collection = collection.select{ |hash| hash.slice(*options[:where].keys) == options[:where] } if options[:where]
+    collection = collection.select { |hash| hash.slice(*options[:where].keys) == options[:where] } if options[:where]
     collection
   end
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -24,7 +24,7 @@ class PglogicalSubscription
   def initialize(**kwargs)
     kwargs.each do |key, value|
       raise ArgumentError, "invalid key '#{key}'" unless attributes.include?(key)
-      self.send("#{key}=",value)
+      send("#{key}=", value)
     end
   end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -65,6 +65,7 @@ describe PglogicalSubscription do
         :host                 => "example.com",
         :user                 => "root",
         :password             => nil,
+        :port                 => nil,
         :provider_region      => remote_region1,
         :provider_region_name => "The region"
       },
@@ -134,7 +135,7 @@ describe PglogicalSubscription do
     it "retrieves no records with no records" do
       with_no_records
       expect(described_class.all).to be_empty
-      expect(described_class.search(:all).to be_empty
+      expect(described_class.search(:all)).to be_empty
     end
   end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -127,7 +127,7 @@ describe PglogicalSubscription do
 
     it "supports find(:all) with records" do
       with_records
-      actual_attrs = described_class.all.map(&:attributes)
+      actual_attrs = described_class.search(:all).map(&:attributes)
       expect(actual_attrs).to match_array(expected_attrs)
     end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -134,7 +134,7 @@ describe PglogicalSubscription do
     it "retrieves no records with no records" do
       with_no_records
       expect(described_class.all).to be_empty
-      expect(described_class.all).to be_empty
+      expect(described_class.search(:all).to be_empty
     end
   end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -169,7 +169,7 @@ describe PglogicalSubscription do
     it "retrieves the specified record with records" do
       with_records
       expected = expected_attrs.first
-      rec = described_class.search(expected["id"])
+      rec = described_class.search(expected[:id])
       expect(rec.attributes).to eq(expected)
     end
 
@@ -183,7 +183,7 @@ describe PglogicalSubscription do
     it "returns the specified record with records" do
       with_records
       expected = expected_attrs.first
-      rec = described_class.lookup_by_id(expected["id"])
+      rec = described_class.lookup_by_id(expected[:id])
       expect(rec.attributes).to eq(expected)
     end
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -59,40 +59,47 @@ describe PglogicalSubscription do
   let(:expected_attrs) do
     [
       {
-        "id"                   => "region_#{remote_region1}_subscription",
-        "status"               => "replicating",
-        "dbname"               => "vmdb's_test",
-        "host"                 => "example.com",
-        "user"                 => "root",
-        "provider_region"      => remote_region1,
-        "provider_region_name" => "The region"
+        :id                   => "region_#{remote_region1}_subscription",
+        :status               => "replicating",
+        :dbname               => "vmdb's_test",
+        :host                 => "example.com",
+        :user                 => "root",
+        :password             => nil,
+        :provider_region      => remote_region1,
+        :provider_region_name => "The region"
       },
       {
-        "id"              => "region_#{remote_region3}_subscription",
-        "status"          => "down",
-        "dbname"          => "vmdb_development",
-        "host"            => "example.com",
-        "user"            => "root",
-        "port"            => 5432,
-        "provider_region" => remote_region3
+        :id                   => "region_#{remote_region3}_subscription",
+        :status               => "down",
+        :dbname               => "vmdb_development",
+        :host                 => "example.com",
+        :user                 => "root",
+        :password             => nil,
+        :port                 => 5432,
+        :provider_region      => remote_region3,
+        :provider_region_name => nil
       },
       {
-        "id"              => "region_#{remote_region4}_subscription",
-        "status"          => "initializing",
-        "dbname"          => "vmdb_production",
-        "host"            => "example.com",
-        "user"            => "root",
-        "port"            => 5432,
-        "provider_region" => remote_region4
+        :id                   => "region_#{remote_region4}_subscription",
+        :status               => "initializing",
+        :dbname               => "vmdb_production",
+        :host                 => "example.com",
+        :user                 => "root",
+        :password             => nil,
+        :port                 => 5432,
+        :provider_region      => remote_region4,
+        :provider_region_name => nil
       },
       {
-        "id"              => "region_#{remote_region2}_subscription",
-        "status"          => "disabled",
-        "dbname"          => "vmdb_test2",
-        "host"            => "test.example.com",
-        "user"            => "postgres",
-        "port"            => 5432,
-        "provider_region" => remote_region2
+        :id                   => "region_#{remote_region2}_subscription",
+        :status               => "disabled",
+        :dbname               => "vmdb_test2",
+        :host                 => "test.example.com",
+        :user                 => "postgres",
+        :password             => nil,
+        :port                 => 5432,
+        :provider_region      => remote_region2,
+        :provider_region_name => nil
       }
     ]
   end
@@ -120,54 +127,54 @@ describe PglogicalSubscription do
 
     it "supports find(:all) with records" do
       with_records
-      actual_attrs = described_class.find(:all).map(&:attributes)
+      actual_attrs = described_class.all.map(&:attributes)
       expect(actual_attrs).to match_array(expected_attrs)
     end
 
     it "retrieves no records with no records" do
       with_no_records
       expect(described_class.all).to be_empty
-      expect(described_class.find(:all)).to be_empty
+      expect(described_class.all).to be_empty
     end
   end
 
   describe ".first" do
     it "retrieves the first record with records" do
       with_records
-      rec = described_class.find(:first)
+      rec = described_class.first
       expect(rec.attributes).to eq(expected_attrs.first)
     end
 
     it "returns nil with no records" do
       with_no_records
-      expect(described_class.find(:first)).to be_nil
+      expect(described_class.first).to be_nil
     end
   end
 
   describe ".last" do
     it "retrieves the last record with :last" do
       with_records
-      rec = described_class.find(:last)
+      rec = described_class.last
       expect(rec.attributes).to eq(expected_attrs.last)
     end
 
     it "returns nil with :last" do
       with_no_records
-      expect(described_class.find(:last)).to be_nil
+      expect(described_class.last).to be_nil
     end
   end
 
-  describe ".find" do
+  describe ".search" do
     it "retrieves the specified record with records" do
       with_records
       expected = expected_attrs.first
-      rec = described_class.find(expected["id"])
+      rec = described_class.search(expected["id"])
       expect(rec.attributes).to eq(expected)
     end
 
     it "raises when no record is found" do
       with_no_records
-      expect { described_class.find("doesnt_exist") }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.search("doesnt_exist") }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -248,7 +255,7 @@ describe PglogicalSubscription do
       with_records
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
 
-      sub = described_class.find(:first)
+      sub = described_class.first
       sub.host = "other-host.example.com"
       allow(sub).to receive(:assert_different_region!)
 
@@ -344,7 +351,7 @@ describe PglogicalSubscription do
   end
 
   describe "#delete" do
-    let(:sub) { described_class.find(:first) }
+    let(:sub) { described_class.first }
 
     it "drops the subscription" do
       allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first], [])
@@ -418,7 +425,7 @@ describe PglogicalSubscription do
     it "validates existing subscriptions with new parameters" do
       allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first])
 
-      sub = described_class.find(:first)
+      sub = described_class.first
       expect(sub.host).to eq "example.com"
       expect(sub.port).to be_blank
       expect(sub.user).to eq "root"

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -179,6 +179,12 @@ describe PglogicalSubscription do
     end
   end
 
+  describe ".find" do
+    it "is an alias for search" do
+      expect(described_class.method(:find)).to eql(described_class.method(:search))
+    end
+  end
+
   describe ".lookup_by_id" do
     it "returns the specified record with records" do
       with_records


### PR DESCRIPTION
Back in https://github.com/ManageIQ/manageiq/pull/11120, the `ActsAsArModel `stuff was split out into its own gem. Well, the querying/finding part of it anyway.

This is an attempt to actually use it within the current models that are still using `ActsAsArModel`. As far as I can tell, it affects these five files in core:

* app/models/chargeback.rb
* app/models/pglogical_subscription.rb
* app/models/vim_performance_trend.rb
* app/models/live_metric.rb
* lib/acts_as_ar_scope.rb

For now, this focuses on just `PglogicalSubscription`. I'm not sure if vim_performance_trend.rb will be relevant with the pending removal of the vim broker, nor do I remember if live_metric is relevant with the removal of kubernetes.

Cross repo tests at: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/51