### PR TITLE
Cu capture queue 1

### DIFF
--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -125,10 +125,72 @@ describe ManageIQ::Providers::BaseManager::MetricsCapture do
   describe ".perf_capture_queue" do
     before do
       MiqRegion.seed
+      @zone = miq_server.zone
     end
 
     let(:host) { FactoryBot.create(:host_target_vmware, :ext_management_system => ems).tap { MiqQueue.delete_all } }
     let(:vm) { host.vms.first }
+
+    context "with enabled and disabled vmware targets", :with_enabled_disabled_vmware do
+      let(:expected_queue_items) do
+        {
+          %w[ManageIQ::Providers::Vmware::InfraManager::Host perf_capture_realtime]   => 3,
+          %w[ManageIQ::Providers::Vmware::InfraManager::Host perf_capture_historical] => 24,
+          %w[Storage perf_capture_hourly]                                             => 1,
+          %w[ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_realtime]     => 2,
+          %w[ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_historical]   => 16,
+          %w[MiqTask destroy_older_by_condition]                                      => 1
+        }
+      end
+
+      it "should queue up enabled targets" do
+        stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
+        Metric::Capture.perf_capture_timer(@ems_vmware.id)
+
+        expect(MiqQueue.group(:class_name, :method_name).count).to eq(expected_queue_items)
+        assert_metric_targets(Metric::Targets.capture_ems_targets(@ems_vmware.reload))
+      end
+
+      it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
+        Metric::Capture.perf_capture_timer(@ems_vmware.id)
+        messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
+        messages.each { |m| m.update_attribute(:state, "dequeue") }
+
+        Metric::Capture.perf_capture_timer(@ems_vmware.id)
+
+        messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
+        messages.each { |m| expect(m.lock_version).to eq(1) }
+      end
+    end
+
+    context "with enabled and disabled openstack targets" do
+      before do
+        @ems_openstack = FactoryBot.create(:ems_openstack, :zone => miq_server.zone)
+        @availability_zone = FactoryBot.create(:availability_zone_target)
+        @ems_openstack.availability_zones << @availability_zone
+        @vms_in_az = FactoryBot.create_list(:vm_openstack, 2, :ems_id => @ems_openstack.id)
+        @availability_zone.vms = @vms_in_az
+        @availability_zone.vms.push(FactoryBot.create(:vm_openstack, :ems_id => nil))
+        @vms_not_in_az = FactoryBot.create_list(:vm_openstack, 3, :ems_id => @ems_openstack.id)
+
+        MiqQueue.delete_all
+      end
+
+      context "executing perf_capture_timer" do
+        before do
+          stub_settings(:performance => {:history => {:initial_capture_days => 7}})
+          Metric::Capture.perf_capture_timer(@ems_openstack.id)
+        end
+
+        it "should queue up enabled targets" do
+          expected_targets = Metric::Targets.capture_ems_targets(@ems_openstack)
+          expect(MiqQueue.group(:method_name).count).to eq('perf_capture_realtime'      => expected_targets.count,
+                                                           'perf_capture_historical'    => expected_targets.count * 8,
+                                                           'destroy_older_by_condition' => 1)
+          assert_metric_targets(expected_targets)
+        end
+      end
+    end
 
     context "for queue prioritization" do
       it "should queue up realtime capture for vm" do

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -51,9 +51,7 @@ describe ManageIQ::Providers::BaseManager::MetricsCapture do
           expected_targets = Metric::Targets.capture_ems_targets(ems.reload, :exclude_storages => true)
           expected = expected_targets.flat_map { |t| [[t, "historical"]] * 2 } # Vm, Host, Host, Vm, Host
 
-          selected = queue_intervals(MiqQueue.all)
-
-          expect(selected).to match_array(expected)
+          expect(queue_intervals).to match_array(expected)
         end
       end
     end
@@ -148,7 +146,8 @@ describe ManageIQ::Providers::BaseManager::MetricsCapture do
         Metric::Capture.perf_capture_timer(@ems_vmware.id)
 
         expect(MiqQueue.group(:class_name, :method_name).count).to eq(expected_queue_items)
-        assert_metric_targets(Metric::Targets.capture_ems_targets(@ems_vmware.reload))
+        targets = Metric::Targets.capture_ems_targets(@ems_vmware.reload)
+        expect(queue_intervals).to match_array(metric_targets(targets))
       end
 
       it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
@@ -187,7 +186,7 @@ describe ManageIQ::Providers::BaseManager::MetricsCapture do
           expect(MiqQueue.group(:method_name).count).to eq('perf_capture_realtime'      => expected_targets.count,
                                                            'perf_capture_historical'    => expected_targets.count * 8,
                                                            'destroy_older_by_condition' => 1)
-          assert_metric_targets(expected_targets)
+          expect(queue_intervals).to match_array(metric_targets(expected_targets))
         end
       end
     end

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -6,11 +6,16 @@ describe ManageIQ::Providers::InfraManager::MetricsCapture do
 
   before do
     MiqRegion.seed
-    storages = FactoryBot.create_list(:storage_target_vmware, 2)
-    clusters = FactoryBot.create_list(:cluster_target, 2, :ext_management_system => ems)
+    storages = FactoryBot.create_list(:storage_vmware, 2)
+    storages.each_with_index { |st, i| st.perf_capture_enabled = i.even? }
+    clusters = FactoryBot.create_list(:ems_cluster, 2, :ext_management_system => ems)
+    clusters.each_with_index { |cl, i| cl.perf_capture_enabled = i.even? }
 
     6.times do |n|
-      host = FactoryBot.create(:host_target_vmware, :ext_management_system => ems, :ems_cluster => clusters[n / 2])
+      host = FactoryBot.create(:host_vmware, :ext_management_system => ems, :ems_cluster => clusters[n / 2], :perf_capture_enabled => n.even?)
+      2.times do |i|
+        FactoryBot.create(:vm_vmware, :ext_management_system => ems, :host => host, :raw_power_state => i.even? ? "poweredOn" : "poweredOff")
+      end
       host.storages << storages[n / 3]
     end
 

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -1,24 +1,34 @@
 describe ManageIQ::Providers::InfraManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
+  let(:miq_server) { EvmSpecHelper.local_miq_server }
+  let(:ems) { FactoryBot.create(:ems_vmware, :zone => miq_server.zone) }
+
   before do
     MiqRegion.seed
-    @zone = EvmSpecHelper.local_miq_server.zone
+    storages = FactoryBot.create_list(:storage_target_vmware, 2)
+    clusters = FactoryBot.create_list(:cluster_target, 2, :ext_management_system => ems)
+
+    6.times do |n|
+      host = FactoryBot.create(:host_target_vmware, :ext_management_system => ems, :ems_cluster => clusters[n / 2])
+      host.storages << storages[n / 3]
+    end
+
+    MiqQueue.delete_all
+    ems.reload
   end
 
   describe ".capture_ems_targets" do
-    context "with vmware", :with_enabled_disabled_vmware do
-      it "finds enabled targets" do
-        targets = described_class.new(nil, @ems_vmware).send(:capture_ems_targets)
-        assert_infra_targets_enabled targets
-        expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host Storage])
-      end
+    it "finds enabled targets" do
+      targets = described_class.new(nil, ems).send(:capture_ems_targets)
+      assert_infra_targets_enabled targets
+      expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host Storage])
+    end
 
-      it "finds enabled targets excluding storages" do
-        targets = described_class.new(nil, @ems_vmware).send(:capture_ems_targets, :exclude_storages => true)
-        assert_infra_targets_enabled targets
-        expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host])
-      end
+    it "finds enabled targets excluding storages" do
+      targets = described_class.new(nil, ems).send(:capture_ems_targets, :exclude_storages => true)
+      assert_infra_targets_enabled targets
+      expect(targets.map { |t| t.class.name }).to match_array(%w[ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Host ManageIQ::Providers::Vmware::InfraManager::Vm ManageIQ::Providers::Vmware::InfraManager::Host])
     end
   end
 

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -33,69 +33,6 @@ describe Metric::Capture do
     end
   end
 
-  describe ".perf_capture_timer" do
-    context "with enabled and disabled vmware targets", :with_enabled_disabled_vmware do
-      let(:expected_queue_items) do
-        {
-          %w[ManageIQ::Providers::Vmware::InfraManager::Host perf_capture_realtime]   => 3,
-          %w[ManageIQ::Providers::Vmware::InfraManager::Host perf_capture_historical] => 24,
-          %w[Storage perf_capture_hourly]                                             => 1,
-          %w[ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_realtime]     => 2,
-          %w[ManageIQ::Providers::Vmware::InfraManager::Vm perf_capture_historical]   => 16,
-          %w[MiqTask destroy_older_by_condition]                                      => 1
-        }
-      end
-
-      it "should queue up enabled targets" do
-        stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-        Metric::Capture.perf_capture_timer(@ems_vmware.id)
-
-        expect(MiqQueue.group(:class_name, :method_name).count).to eq(expected_queue_items)
-        assert_metric_targets(Metric::Targets.capture_ems_targets(@ems_vmware.reload))
-      end
-
-      it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
-        Metric::Capture.perf_capture_timer(@ems_vmware.id)
-        messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
-        messages.each { |m| m.update_attribute(:state, "dequeue") }
-
-        Metric::Capture.perf_capture_timer(@ems_vmware.id)
-
-        messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
-        messages.each { |m| expect(m.lock_version).to eq(1) }
-      end
-    end
-
-    context "with enabled and disabled openstack targets" do
-      before do
-        @ems_openstack = FactoryBot.create(:ems_openstack, :zone => @zone)
-        @availability_zone = FactoryBot.create(:availability_zone_target)
-        @ems_openstack.availability_zones << @availability_zone
-        @vms_in_az = FactoryBot.create_list(:vm_openstack, 2, :ems_id => @ems_openstack.id)
-        @availability_zone.vms = @vms_in_az
-        @availability_zone.vms.push(FactoryBot.create(:vm_openstack, :ems_id => nil))
-        @vms_not_in_az = FactoryBot.create_list(:vm_openstack, 3, :ems_id => @ems_openstack.id)
-
-        MiqQueue.delete_all
-      end
-
-      context "executing perf_capture_timer" do
-        before do
-          stub_settings(:performance => {:history => {:initial_capture_days => 7}})
-          Metric::Capture.perf_capture_timer(@ems_openstack.id)
-        end
-
-        it "should queue up enabled targets" do
-          expected_targets = Metric::Targets.capture_ems_targets(@ems_openstack)
-          expect(MiqQueue.group(:method_name).count).to eq('perf_capture_realtime'      => expected_targets.count,
-                                                           'perf_capture_historical'    => expected_targets.count * 8,
-                                                           'destroy_older_by_condition' => 1)
-          assert_metric_targets(expected_targets)
-        end
-      end
-    end
-  end
-
   describe ".standard_capture_threshold" do
     let(:host) { FactoryBot.build(:host_vmware) }
 

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -25,113 +25,97 @@ describe Metric::CiMixin::Rollup do
     let(:storage) { FactoryBot.create(:storage_vmware, :perf_capture_enabled => true) }
     let(:host4)   { FactoryBot.create(:host_vmware, :ext_management_system => ems, :perf_capture_enabled => true, :ems_cluster => host2.ems_cluster) }
 
-    context "with enabled and disabled targets" do
-      context "executing perf_capture_timer" do
-        before do
-          vm
-          vm2
-          host3
-          host4
-          @ems_vmware = ems
-          @vmware_clusters = [host2.ems_cluster]
-          @expected_targets = [vm, vm2, host, host2, host3, host4, storage]
+    context "executing capture_ems_targets for realtime targets with parent objects" do
+      before do
+        stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
+        vm
+        vm2
+        host3
+        host4
+      end
 
-          stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-          Metric::Capture.perf_capture_timer(@ems_vmware.id)
-        end
+      it "should create tasks and queue callbacks for perf_capture_timer" do
+        ems.perf_capture_object.perf_capture
 
-        context "executing capture_ems_targets for realtime targets with parent objects" do
-          it "should create tasks and queue callbacks for perf_capture_timer" do
-            # stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-            # Metric::Capture.perf_capture_timer(@ems_vmware.id)
-            @vmware_clusters.each do |cluster|
-              expected_hosts = cluster.hosts.select { |h| @expected_targets.include?(h) }
-              next if expected_hosts.empty?
+        cluster = host2.ems_cluster
+        expected_hosts = [host2, host4]
 
-              task = MiqTask.find_by(:name => "Performance rollup for EmsCluster:#{cluster.id}")
-              expect(task).not_to be_nil
-              expect(task.context_data[:targets]).to match_array(cluster.hosts.collect { |h| "ManageIQ::Providers::Vmware::InfraManager::Host:#{h.id}" })
+        task = MiqTask.find_by(:name => "Performance rollup for EmsCluster:#{cluster.id}")
+        expect(task).not_to be_nil
+        expect(task.context_data[:targets]).to match_array(cluster.hosts.collect { |h| "ManageIQ::Providers::Vmware::InfraManager::Host:#{h.id}" })
 
-              expected_hosts.each do |host|
-                messages = MiqQueue.where(:class_name  => 'ManageIQ::Providers::Vmware::InfraManager::Host',
-                                          :instance_id => host.id,
-                                          :method_name => "perf_capture_realtime")
-                expect(messages.size).to eq(1)
-                messages.each do |m|
-                  expect(m.miq_callback).not_to be_nil
-                  expect(m.miq_callback[:method_name]).to eq(:perf_capture_callback)
-                  expect(m.miq_callback[:args]).to eq([[task.id]])
+        expected_hosts.each do |host|
+          messages = MiqQueue.where(:class_name  => 'ManageIQ::Providers::Vmware::InfraManager::Host',
+                                    :instance_id => host.id,
+                                    :method_name => "perf_capture_realtime")
+          expect(messages.size).to eq(1)
+          messages.each do |m|
+            expect(m.miq_callback).not_to be_nil
+            expect(m.miq_callback[:method_name]).to eq(:perf_capture_callback)
+            expect(m.miq_callback[:args]).to eq([[task.id]])
 
-                  m.delivered("ok", "Message delivered successfully", nil)
-                end
-              end
-
-              task.reload
-              expect(task.state).to eq("Finished")
-
-              message = MiqQueue.find_by(:method_name => "perf_rollup_range", :class_name => "EmsCluster", :instance_id => cluster.id)
-              expect(message).not_to be_nil
-              expect(message.args).to eq([task.context_data[:start], task.context_data[:end], task.context_data[:interval], nil])
-            end
-          end
-
-          it "calling perf_capture_timer when existing capture messages are on the queue should merge messages and append new task id to cb args" do
-            # stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-            # Metric::Capture.perf_capture_timer(@ems_vmware.id)
-            Metric::Capture.perf_capture_timer(@ems_vmware.id)
-            @vmware_clusters.each do |cluster|
-              expected_hosts = cluster.hosts.select { |h| @expected_targets.include?(h) }
-              next if expected_hosts.empty?
-
-              tasks = MiqTask.where(:name => "Performance rollup for EmsCluster:#{cluster.id}").order("id DESC")
-              expect(tasks.length).to eq(2)
-              tasks.each do |task|
-                expect(task.context_data[:targets]).to match_array(cluster.hosts.collect { |h| "ManageIQ::Providers::Vmware::InfraManager::Host:#{h.id}" })
-              end
-
-              task_ids = tasks.collect(&:id)
-
-              expected_hosts.each do |host|
-                messages = MiqQueue.where(:class_name  => 'ManageIQ::Providers::Vmware::InfraManager::Host',
-                                          :instance_id => host.id,
-                                          :method_name => "perf_capture_realtime")
-                expect(messages.size).to eq(1)
-                host.update_attribute(:last_perf_capture_on, 1.minute.from_now.utc)
-                messages.each do |m|
-                  next if m.miq_callback[:args].blank?
-
-                  expect(m.miq_callback).not_to be_nil
-                  expect(m.miq_callback[:method_name]).to eq(:perf_capture_callback)
-                  expect(m.miq_callback[:args].first.sort).to eq(task_ids.sort)
-
-                  status, message, result = m.deliver
-                  m.delivered(status, message, result)
-                end
-              end
-
-              tasks.each do |task|
-                task.reload
-                expect(task.state).to eq("Finished")
-              end
-            end
-          end
-
-          it "calling perf_capture_timer a second time should create another task with the correct time window" do
-            # Metric::Capture.perf_capture_timer(@ems_vmware.id)
-            Metric::Capture.perf_capture_timer(@ems_vmware.id)
-
-            @vmware_clusters.each do |cluster|
-              expected_hosts = cluster.hosts.select { |h| @expected_targets.include?(h) }
-              next if expected_hosts.empty?
-
-              tasks = MiqTask.where(:name => "Performance rollup for EmsCluster:#{cluster.id}").order("id")
-              expect(tasks.length).to eq(2)
-
-              t1, t2 = tasks
-              expect(t2.context_data[:start]).to eq(t1.context_data[:end])
-            end
+            m.delivered("ok", "Message delivered successfully", nil)
           end
         end
+
+        task.reload
+        expect(task.state).to eq("Finished")
+
+        message = MiqQueue.find_by(:method_name => "perf_rollup_range", :class_name => "EmsCluster", :instance_id => cluster.id)
+        expect(message).not_to be_nil
+        expect(message.args).to eq([task.context_data[:start], task.context_data[:end], task.context_data[:interval], nil])
+      end
+
+      it "calling perf_capture_timer when existing capture messages are on the queue should merge messages and append new task id to cb args" do
+        ems.perf_capture_object.perf_capture
+        ems.perf_capture_object.perf_capture
+
+        cluster = host2.ems_cluster
+        expected_hosts = [host2, host4]
+
+        tasks = MiqTask.where(:name => "Performance rollup for EmsCluster:#{cluster.id}").order("id DESC")
+        expect(tasks.length).to eq(2)
+        tasks.each do |task|
+          expect(task.context_data[:targets]).to match_array(cluster.hosts.collect { |h| "ManageIQ::Providers::Vmware::InfraManager::Host:#{h.id}" })
+        end
+
+        task_ids = tasks.collect(&:id)
+
+        expected_hosts.each do |host|
+          messages = MiqQueue.where(:class_name  => 'ManageIQ::Providers::Vmware::InfraManager::Host',
+                                    :instance_id => host.id,
+                                    :method_name => "perf_capture_realtime")
+          expect(messages.size).to eq(1)
+          host.update(:last_perf_capture_on => 1.minute.from_now.utc)
+          messages.each do |m|
+            next if m.miq_callback[:args].blank?
+
+            expect(m.miq_callback).not_to be_nil
+            expect(m.miq_callback[:method_name]).to eq(:perf_capture_callback)
+            expect(m.miq_callback[:args].first.sort).to eq(task_ids.sort)
+
+            status, message, result = m.deliver
+            m.delivered(status, message, result)
+          end
+        end
+
+        tasks.each do |task|
+          task.reload
+          expect(task.state).to eq("Finished")
+        end
+      end
+
+      it "calling perf_capture_timer a second time should create another task with the correct time window" do
+        ems.perf_capture_object.perf_capture
+        ems.perf_capture_object.perf_capture
+
+        cluster = host2.ems_cluster
+
+        tasks = MiqTask.where(:name => "Performance rollup for EmsCluster:#{cluster.id}").order("id")
+        expect(tasks.length).to eq(2)
+
+        t1, t2 = tasks
+        expect(t2.context_data[:start]).to eq(t1.context_data[:end])
       end
     end
 

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -50,32 +50,6 @@ module Spec
   end
 end
 
-# These contexts expect the following setup:
-#
-# before do
-#   MiqRegion.seed
-#   @zone = EvmSpecHelper.local_miq_server.zone
-# end
-RSpec.shared_context 'with enabled/disabled vmware targets', :with_enabled_disabled_vmware do
-  before do
-    @ems_vmware = FactoryBot.create(:ems_vmware, :zone => @zone)
-    @storages = FactoryBot.create_list(:storage_target_vmware, 2)
-    @vmware_clusters = FactoryBot.create_list(:cluster_target, 2)
-    @ems_vmware.ems_clusters = @vmware_clusters
-
-    6.times do |n|
-      host = FactoryBot.create(:host_target_vmware, :ext_management_system => @ems_vmware)
-      @ems_vmware.hosts << host
-
-      @vmware_clusters[n / 2].hosts << host if n < 4
-      host.storages << @storages[n / 3]
-    end
-
-    MiqQueue.delete_all
-    @ems_vmware.reload
-  end
-end
-
 RSpec.shared_context "with a small environment and time_profile", :with_small_vmware do
   before do
     @ems_vmware = FactoryBot.create(:ems_vmware, :zone => @zone)

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -74,8 +74,6 @@ RSpec.shared_context 'with enabled/disabled vmware targets', :with_enabled_disab
     MiqQueue.delete_all
     @ems_vmware.reload
   end
-
-  let(:all_targets) { Metric::Targets.capture_ems_targets(@ems_vmware) }
 end
 
 RSpec.shared_context "with a small environment and time_profile", :with_small_vmware do

--- a/spec/support/metric_helper.rb
+++ b/spec/support/metric_helper.rb
@@ -2,21 +2,16 @@ module Spec
   module Support
     module MetricHelper
       # given (enabled) capture_targets, compare with suggested queue entries
-      def assert_metric_targets(expected_targets)
-        expected = expected_targets.flat_map do |t|
+      def metric_targets(expected_targets)
+        expected_targets.flat_map do |t|
           # Storage is hourly only
           # Non-storage historical is expecting 7 days back, plus partial day = 8
           t.kind_of?(Storage) ? [[t, "hourly"]] : [[t, "realtime"]] + [[t, "historical"]] * 8
         end
-        selected = queue_intervals(
-          MiqQueue.where(:method_name => %w[perf_capture_hourly perf_capture_realtime perf_capture_historical])
-        )
-
-        expect(selected).to match_array(expected)
       end
 
       # @return [Array<Array<Object, String>>] List of object and interval names in miq queue
-      def queue_intervals(items)
+      def queue_intervals(items = MiqQueue.where(:method_name => %w[perf_capture_hourly perf_capture_realtime perf_capture_historical]))
         items.map do |q|
           interval_name = q.method_name.sub("perf_capture_", "")
           [Object.const_get(q.class_name).find(q.instance_id), interval_name]


### PR DESCRIPTION
Further streamline Metrics Cap & U metrics tests.

### Goal

- Remove references to `Metrics::Targets.capture_ems_targets` (from specs)
- Remove use of `:{storage,vm,host}_target_vmware` (which enable/disable every other one created)
- Only test the enabled/disabled object selection in a single set of tests. All other tests are written to work with enabled tests.
- No longer test queue counts but actually what goes on the queue.

This will allow us to move some of the `Metrics::Targets` methods into the `MetricsCapture` class hierarchy.
This will also allow us more transparency when we want to change what we put on the queue.

### NOTE

Doing a diff without whitespace can help on a few of the commits.

https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/45