### PR TITLE
Fix typo in OperationsWorker worker_roles

### DIFF
--- a/app/models/manageiq/providers/base_manager/operations_worker/runner.rb
+++ b/app/models/manageiq/providers/base_manager/operations_worker/runner.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::BaseManager::OperationsWorker::Runner < ::MiqQueueWorkerBase::Runner
   def worker_roles
-    %w[ems_operations"]
+    %w[ems_operations]
   end
 
   attr_reader :ems


### PR DESCRIPTION
Fix a typo in the worker_roles for the operations worker

Introduced by https://github.com/ManageIQ/manageiq/pull/19476

:man_facepalming: 