### PR TITLE
Updated vm_reconfigure_task in app/models to add disk size information.

### DIFF
--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -30,7 +30,7 @@ class VmReconfigureTask < MiqRequestTask
     new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" if req_obj.options[:number_of_sockets].present?
     new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" if req_obj.options[:cores_per_socket].present?
     new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" if req_obj.options[:number_of_cpus].present?
-    new_settings << "Add Disks: #{req_obj.options[:disk_add].length}" if req_obj.options[:disk_add].present?
+    new_settings << "Add Disks: #{req_obj.options[:disk_add].length} : #{req_obj.options[:disk_add].collect { |d| d["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) }.join(", ")} " if req_obj.options[:disk_add].present?
     new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" if req_obj.options[:disk_remove].present?
     new_settings << "Resize Disks: #{req_obj.options[:disk_resize].length}" if req_obj.options[:disk_resize].present?
     new_settings << "Add Network Adapters: #{req_obj.options[:network_adapter_add].length}" if req_obj.options[:network_adapter_add].present?

--- a/spec/models/vm_reconfigure_task_spec.rb
+++ b/spec/models/vm_reconfigure_task_spec.rb
@@ -1,0 +1,66 @@
+describe VmReconfigureTask do
+  let(:user) { FactoryBot.create(:user_with_group) }
+  let(:ems_vmware)    { FactoryBot.create(:ems_vmware, :zone => zone2) }
+  let(:host_hardware) { FactoryBot.build(:hardware, :cpu_total_cores => 40, :cpu_sockets => 10, :cpu_cores_per_socket => 4) }
+  let(:host)          { FactoryBot.build(:host, :hardware => host_hardware) }
+  let(:vm_hardware)   { FactoryBot.build(:hardware, :virtual_hw_version => "07") }
+  let(:vm) { FactoryBot.create(:vm_vmware, :hardware => vm_hardware, :host => host) }
+
+  let(:request) do
+    VmReconfigureRequest.create(:requester    => user,
+                                :options      => {:src_ids  => [vm.id],
+                                                  :disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}]},
+                                :request_type => 'vm_reconfigure')
+  end
+
+  let(:task) do
+    VmReconfigureTask.create(:userid       => user.userid,
+                             :miq_request  => request,
+                             :source       => vm,
+                             :request_type => 'vm_reconfigure')
+  end
+  context "Single Disk add " do
+    describe "#self.base_model" do
+      it "should return VmReconfigureTask" do
+        expect(VmReconfigureTask.base_model).to eq(VmReconfigureTask)
+      end
+    end
+
+    describe "#self.get_description" do
+      it "should get the task description" do
+        expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} ")
+      end
+    end
+
+    describe "#after_request_task_create" do
+      it "should set the task description" do
+        task.after_request_task_create
+        expect(task.description).to include("VM Reconfigure for: #{vm} - ")
+      end
+    end
+  end
+
+  context "Multiple Disk add " do
+    let(:request) do
+      VmReconfigureRequest.create(:requester    => user,
+                                  :options      => {:src_ids  => [vm.id],
+                                                    :disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"},
+                                                                  {"disk_size_in_mb" => "44", "persistent" => "true"}]},
+                                  :request_type => 'vm_reconfigure')
+    end
+
+    describe "#self.get_description" do
+      it "should get the task description" do
+        expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
+          "#{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} ")
+      end
+    end
+
+    describe "#after_request_task_create" do
+      it "should set the task description" do
+        task.after_request_task_create
+        expect(task.description).to include("VM Reconfigure for: #{vm} - ")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously we were just showing number of disks added, now we will display disk size(s) in the description.

Fixes:https://bugzilla.redhat.com/show_bug.cgi?id=1772762

Request before change:


<img width="137" alt="Screen Shot 2020-01-03 at 10 45 41 AM" src="https://user-images.githubusercontent.com/11841651/71732862-43361f00-2e16-11ea-8fc4-5d39f36eae36.png">

Request after change:

<img width="132" alt="Screen Shot 2020-01-03 at 10 46 02 AM" src="https://user-images.githubusercontent.com/11841651/71732881-4cbf8700-2e16-11ea-8120-9b2b3d76ddb0.png">

@miq-bot add_label bug
@miq-bot assign @tinaafitz