### PR TITLE
Don't start every MetricsCollectorWorker

### DIFF
--- a/app/models/mixins/per_ems_type_worker_mixin.rb
+++ b/app/models/mixins/per_ems_type_worker_mixin.rb
@@ -3,13 +3,15 @@ module PerEmsTypeWorkerMixin
 
   included do
     self.check_for_minimal_role = false
-    @workers = lambda do
-      return 0 unless self.any_valid_ems_in_zone?
-      workers_configured_count
-    end
   end
 
   module ClassMethods
+    def workers
+      return 0 unless any_valid_ems_in_zone?
+
+      super
+    end
+
     def ems_class
       parent
     end


### PR DESCRIPTION
Fix the `#workers` method for any worker that includes the PerEmsTypeWorkerMixin (aka just the MetricsCollectorWorkers).

This was setting an instance variable `@workers` but this wasn't actually being called so the ivar was never set up.  This led to every metrics collector worker for every EMS type to be started if the role was enabled.

https://github.com/ManageIQ/manageiq/pull/19494