### PR TITLE
remove factories that have conditional perf_capture_enabled

### DIFF
--- a/spec/factories/ems_cluster.rb
+++ b/spec/factories/ems_cluster.rb
@@ -3,11 +3,6 @@ FactoryBot.define do
     sequence(:name) { |n| "cluster_#{seq_padded_for_sorting(n)}" }
   end
 
-  factory :cluster_target, :parent => :ems_cluster do
-    after(:create) do |x|
-      x.perf_capture_enabled = toggle_on_name_seq(x)
-    end
-  end
   factory :ems_cluster_openstack, :class => "ManageIQ::Providers::Openstack::InfraManager::Cluster", :parent => :ems_cluster
   factory :ems_cluster_ovirt, :class => "ManageIQ::Providers::Redhat::InfraManager::Cluster", :parent => :ems_cluster
 end

--- a/spec/factories/host.rb
+++ b/spec/factories/host.rb
@@ -24,14 +24,6 @@ FactoryBot.define do
     end
   end
 
-  # Factories for perf_capture_timer and perf_capture_gap testing
-  factory :host_target_vmware, :parent => :host, :class => 'ManageIQ::Providers::Vmware::InfraManager::Host' do
-    after(:create) do |x|
-      x.perf_capture_enabled = toggle_on_name_seq(x)
-      2.times { x.vms << FactoryBot.create(:vm_target_vmware, :ext_management_system => x.ext_management_system) }
-    end
-  end
-
   factory :host_with_ipmi, :parent => :host do
     ipmi_address { "127.0.0.1" }
     mac_address  { "aa:bb:cc:dd:ee:ff" }

--- a/spec/factories/storage.rb
+++ b/spec/factories/storage.rb
@@ -24,11 +24,4 @@ FactoryBot.define do
   factory :storage_unknown, :parent => :storage do
     store_type { "UNKNOWN" }
   end
-
-  # Factories for perf_capture_timer and perf_capture_gap testing
-  factory :storage_target_vmware, :parent => :storage_vmware do
-    after(:create) do |x|
-      x.perf_capture_enabled = toggle_on_name_seq(x)
-    end
-  end
 end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -158,11 +158,6 @@ FactoryBot.define do
     ems_ref  { "vm-578855" }
   end
 
-  # Factories for perf_capture_timer and perf_capture_gap testing
-  factory :vm_target_vmware, :parent => :vm_vmware do
-    after(:create) { |x| x.raw_power_state = (toggle_on_name_seq(x) ? "poweredOn" : "poweredOff") }
-  end
-
   factory :vm_vmware_cloud, :class => "ManageIQ::Providers::Vmware::CloudManager::Vm", :parent => :vm_cloud do
     vendor { "vmware" }
   end

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -23,7 +23,7 @@ describe ChargebackVm do
                                                                      :cpu_speed => 9576), :vms => [vm])
     ems_cluster = FactoryBot.create(:ems_cluster, :ext_management_system => ems)
     ems_cluster.hosts << host
-    storage = FactoryBot.create(:storage_target_vmware)
+    storage = FactoryBot.create(:storage_vmware)
 
     Range.new(start_of_all_intervals, midle_of_the_first_day, true).step_value(1.hour).each do |time|
       vm.metric_rollups << FactoryBot.create(:metric_rollup_vm_hr,

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -86,7 +86,7 @@ describe ChargebackVm do
       @vm1.tag_with(@tag.name, :ns => '*')
 
       @host1   = FactoryBot.create(:host, :hardware => FactoryBot.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [@vm1])
-      @storage = FactoryBot.create(:storage_target_vmware)
+      @storage = FactoryBot.create(:storage_vmware)
       @host1.storages << @storage
 
       @ems_cluster = FactoryBot.create(:ems_cluster, :ext_management_system => ems)

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -23,7 +23,7 @@ describe MeteringContainerProject do
   let(:project) { FactoryBot.create(:container_project, :name => "my project", :ext_management_system => ems, :created_on => month_beginning) }
   let(:hardware) { FactoryBot.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576) }
   let(:host) { FactoryBot.create(:host, :storages => [storage], :hardware => hardware, :vms => [vm]) }
-  let(:storage) { FactoryBot.create(:storage_target_vmware) }
+  let(:storage) { FactoryBot.create(:storage_vmware) }
   let(:ems_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems, :hosts => [host]) }
 
   before do

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -29,7 +29,7 @@ describe MeteringVm do
   let(:vm) { FactoryBot.create(:vm_vmware, :name => "test_vm", :evm_owner => admin, :ems_ref => "ems_ref", :created_on => month_beginning) }
   let(:hardware) { FactoryBot.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576) }
   let(:host) { FactoryBot.create(:host, :storages => [storage], :hardware => hardware, :vms => [vm]) }
-  let(:storage) { FactoryBot.create(:storage_target_vmware) }
+  let(:storage) { FactoryBot.create(:storage_vmware) }
   let(:ems_cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => ems, :hosts => [host]) }
 
   before do

--- a/spec/models/metric_rollup/chargeback_helper_spec.rb
+++ b/spec/models/metric_rollup/chargeback_helper_spec.rb
@@ -9,7 +9,7 @@ describe MetricRollup do
 
     context 'VmOrTemplate' do
       let(:ems_cluster) { FactoryBot.build(:ems_cluster, :ext_management_system => ems) }
-      let(:storage) { FactoryBot.build(:storage_target_vmware) }
+      let(:storage) { FactoryBot.build(:storage_vmware) }
       let(:host) { FactoryBot.build(:host) }
       let(:vm) do
         FactoryBot.create(:vm_vmware, :name => 'test_vm', :ems_ref => 'ems_ref',

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -1205,7 +1205,7 @@ describe MiqReport do
         vm1.labels << label
 
         host1   = FactoryBot.create(:host, :hardware => FactoryBot.create(:hardware, :memory_mb => 8124, :cpu_total_cores => 1, :cpu_speed => 9576), :vms => [vm1])
-        storage = FactoryBot.create(:storage_target_vmware)
+        storage = FactoryBot.create(:storage_vmware)
         host1.storages << storage
 
         ems_cluster = FactoryBot.create(:ems_cluster, :ext_management_system => ems)

--- a/spec/models/vim_performance_analysis_spec.rb
+++ b/spec/models/vim_performance_analysis_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe VimPerformanceAnalysis do
     end
   end
 
-  let(:storage) { FactoryBot.create(:storage_target_vmware) }
+  let(:storage) { FactoryBot.create(:storage_vmware) }
   let(:host1) do
     FactoryBot.create(:host,
                        :hardware => FactoryBot.create(:hardware,


### PR DESCRIPTION
### TL;DR

Remove unnecessary factories.

### Overview

These factories don't allow a truly reproducible result.

Instead, using regular factories and manually setting `perf_capture_enabled` works better.



### Details

`toggle_on_name_seq` allows us to toggle whether the objects are enabled and disabled. Which is pretty slick. But from the caller's perspective, it is hard to know which is enabled and disabled. So this works great if you just want a general count, but if you want to actually test that this worked with an enabled object, it doesn't work so well.

https://github.com/ManageIQ/manageiq/pull/19679 removed the tests that really took advantage of this factory. So that is why it looks trivial to remove.

