### PR TITLE
Fix service template provision request spec

### DIFF
--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -113,7 +113,7 @@ describe MiqProvision do
             service_provision_request = FactoryBot.create(:service_template_provision_request, :description => request_descripton)
             @vm_prov.update(:miq_request_id => service_provision_request.id)
 
-            expect(service_provision_request).not_to receive(:update_description_from_tasks)
+            expect(service_provision_request).not_to receive(:update)
             @vm_prov.update_vm_name(@target_vm_name, :update_request => true)
 
             expect(service_provision_request.description).to eq(request_descripton)


### PR DESCRIPTION
This PR fixes an invalid partial in the `miq_provision_spec.rb` file. Specifically, a `ServiceTemplateProvisionRequest` instance is checking against `update_description_from_tasks`. However, that model does not implement that method.

The `update_description_from_tasks` method is defined in the `MiqProvisionRequest` model, which is a subclass of `MiqRequest`, but the `ServiceTemplateProvisionRequest` model inherits from `MiqRequest` directly.

Since `update_description_from_tasks` is just a wrapper around `update`, I've switched it to check against `update` instead.