### PR TITLE
Update manageiq-smartstate gem to 0.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -205,7 +205,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.3.1",       :require => false
+  gem "manageiq-smartstate",            "~>0.3.4",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Diagnostic code added for https://bugzilla.redhat.com/show_bug.cgi?id=1764847

smartstate gem now has v0.4.0, so we should probably bump to that in master. But updating to 0.3.4 for now, so this can be backported to ivanchuk.

cc @roliveri @aufi 