### PR TITLE
DialogFieldTagControl - don't add <None> for multiselects

### DIFF
--- a/app/models/dialog_field_tag_control.rb
+++ b/app/models/dialog_field_tag_control.rb
@@ -37,6 +37,10 @@ class DialogFieldTagControl < DialogFieldSortedItem
     !single_value?
   end
 
+  def multiselect?
+    force_multi_value
+  end
+
   def self.allowed_tag_categories
     tag_cats = Classification.is_category.where(:show => true, :read_only => false).includes(:tag).to_a
 
@@ -64,7 +68,7 @@ class DialogFieldTagControl < DialogFieldSortedItem
     end
 
     empty = required? ? "<Choose>" : "<None>"
-    blank_value = [{:id => nil, :name => empty, :description => empty}]
+    blank_value = multiselect? ? [] : [{:id => nil, :name => empty, :description => empty}]
 
     return blank_value + available_tags if sort_field == :none
 

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -151,12 +151,13 @@ describe DialogFieldTagControl do
 
   describe "#values" do
     let(:dialog_field) { described_class.new(:options => options, :data_type => data_type, :required => required) }
-    let(:options) { {:category_id => category_id, :sort_by => sort_by, :sort_order => sort_order} }
+    let(:options) { {:category_id => category_id, :sort_by => sort_by, :sort_order => sort_order, :force_single_value => single?} }
     let(:category_id) { 123 }
     let(:required) { false }
     let(:sort_by) { :none }
     let(:sort_order) { :ascending }
     let(:data_type) { "string" }
+    let(:single?) { true }
 
     before do
       allow(Classification).to receive(:find_by).with(:id => category_id).and_return(classification)
@@ -165,8 +166,20 @@ describe DialogFieldTagControl do
     shared_examples_for "DialogFieldTagControl#values when required is true" do
       let(:required) { true }
 
-      it "the blank value uses 'Choose' for its name and description" do
-        expect(dialog_field.values[0]).to eq(:id => nil, :name => "<Choose>", :description => "<Choose>")
+      context "singlevalue" do
+        let(:single?) { true }
+
+        it "the blank value uses 'Choose' for its name and description" do
+          expect(dialog_field.values[0]).to eq(:id => nil, :name => "<Choose>", :description => "<Choose>")
+        end
+      end
+
+      context "multi value" do
+        let(:single?) { false }
+
+        it "has no blank value" do
+          expect(%w[<Choose> <None>]).to_not include(dialog_field.values[0][:name])
+        end
       end
     end
 


### PR DESCRIPTION
when selecting one option from a list, having `<None>` (or `<Choose>`) in the list makes sense
when selecting 0 or more options from a multiselect, neither `<None>` or `<Choose>` can be in the actual list of options.

This matches what https://github.com/ManageIQ/manageiq/pull/19148 did for `DialogTagDropDownList`,
(including introducing the `multiselect?` method).

(Previously, the options were added to tags in https://github.com/ManageIQ/manageiq/pull/14348)

Cc @eclarizio - can you review please?
Cc @skateman,
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6393
and partly addresses the issue in https://github.com/ManageIQ/manageiq-ui-classic/issues/6392

@miq-bot add_label bug, automate