### PR TITLE
[WIP] DialogFieldSortedItem - move multiselect behaviour from DropDownList to parent class

### DIFF
--- a/app/models/dialog_field_drop_down_list.rb
+++ b/app/models/dialog_field_drop_down_list.rb
@@ -1,9 +1,4 @@
 class DialogFieldDropDownList < DialogFieldSortedItem
-  def initialize_with_given_value(given_value)
-    super
-    coerce_default_value_into_proper_format if force_multi_value
-  end
-
   def show_refresh_button?
     !!show_refresh_button
   end
@@ -67,12 +62,6 @@ class DialogFieldDropDownList < DialogFieldSortedItem
 
   private
 
-  def determine_selected_value
-    coerce_default_value_into_proper_format if dynamic? && force_multi_value
-
-    super
-  end
-
   def use_first_value_as_default
     self.default_value = if force_multi_value
                            [].to_json
@@ -91,14 +80,5 @@ class DialogFieldDropDownList < DialogFieldSortedItem
     else
       super(values_list)
     end
-  end
-
-  def coerce_default_value_into_proper_format
-    return unless default_value
-    unless JSON.parse(default_value).kind_of?(Array)
-      self.default_value = Array.wrap(default_value).to_json
-    end
-  rescue JSON::ParserError
-    self.default_value = Array.wrap(default_value).to_json
   end
 end

--- a/app/models/dialog_field_sorted_item.rb
+++ b/app/models/dialog_field_sorted_item.rb
@@ -11,7 +11,19 @@ class DialogFieldSortedItem < DialogField
 
   def initialize_with_given_value(given_value)
     raw_values
-    self.default_value = given_value
+    super
+    coerce_default_value_into_proper_format if multiselect?
+  end
+
+  # ensure JSON encoding for multiselect default_value
+  def coerce_default_value_into_proper_format
+    return unless default_value
+
+    unless JSON.parse(default_value).kind_of?(Array)
+      self.default_value = Array.wrap(default_value).to_json
+    end
+  rescue JSON::ParserError
+    self.default_value = Array.wrap(default_value).to_json
   end
 
   def sort_by


### PR DESCRIPTION
So that tagging can use the same code to make sure default_value for single-tag selects is the actual value (or "" for empty), while default_value for multi-tag selects is a JSON array of values ("[]" for empty).

Both `DialogFieldDropDownList` and `DialogFieldTagControl` inherit from `DialogFieldSortedItem` and can be either a single select or multiselect, using json for multiselects.

(A third child is `DialogFieldRadioButton` but that's hardcoded to return false for multiselects (since we can't have multiradios), so this shouldn't change anything there.)
    
Depends on https://github.com/ManageIQ/manageiq/pull/19696

---

@miq-bot add_label bug, automate, wip

WIP because it depends on the previous change, not sure if this works yet
the problem now:

```js
temp1.map((x) => ({label: x.label, values: x.values, default_value: x.default_value}))

0: {label: "Tag Control Single", values: Array(10), default_value: ""}
1: {label: "Tag Control Multi", values: Array(9), default_value: null}
2: {label: "Dropdown", values: Array(4), default_value: ""}
3: {label: "mDropdown", values: Array(3), default_value: "[]"}
4: {label: "nDropdown", values: Array(4), default_value: ""}
5: {label: "nmDropdown", values: Array(3), default_value: "[]"}
```