### PR TITLE
[V2V] Use podman with UCI image instead of virt-v2v-wrapper directly

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -229,6 +229,7 @@ class ConversionHost < ApplicationRecord
 
     command = "sudo /usr/bin/podman run --privileged"
     command += " --name conversion-#{task_id}"
+    command += " --network host"
     command += " --volume /dev:/dev"
     command += " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"
     command += " --volume /var/tmp:/var/tmp"

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -158,14 +158,59 @@ class ConversionHost < ApplicationRecord
   # @raise [MiqException::MiqSshUtilHostKeyMismatch] if conversion host key has changed
   # @raise [JSON::GeneratorError] if limits hash can't be converted to JSON
   # @raise [StandardError] if any other problem happens
-  def apply_task_limits(path, limits = {})
-    connect_ssh { |ssu| ssu.put_file(path, limits.to_json) }
+  def apply_task_limits(task_id, limits = {})
+    connect_ssh { |ssu| ssu.put_file("/var/lib/uci/#{task_id}/limits.json", limits.to_json) }
   rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
-    raise "Failed to connect and apply limits in file '#{path}' with [#{err.class}: #{err}]"
+    raise "Failed to connect and apply limits for task '#{task_id}' with [#{err.class}: #{err}]"
   rescue JSON::GeneratorError => err
     raise "Could not generate JSON from limits '#{limits}' with [#{err.class}: #{err}]"
   rescue StandardError => err
-    raise "Could not apply the limits in '#{path}' on '#{resource.name}' with [#{err.class}: #{err}]"
+    raise "Could not apply the limits for task '#{task_id}' on '#{resource.name}' with [#{err.class}: #{err}]"
+  end
+
+  # Prepare the conversion assets for a specific task.
+  #
+  # @param [Integer] id of the task that needs the preparation
+  # @param [Hash] conversion options to write on the conversion host
+  #
+  # @return [Integer] length of data written to conversion options file
+  #
+  # @raise [MiqException::MiqInvalidCredentialsError] if conversion host credentials are invalid
+  # @raise [MiqException::MiqSshUtilHostKeyMismatch] if conversion host key has changed
+  # @raise [JSON::GeneratorError] if limits hash can't be converted to JSON
+  # @raise [StandardError] if any other problem happens
+  def prepare_conversion(task_id, conversion_options)
+    filtered_options = filter_options(conversion_options)
+
+    connect_ssh do |ssu|
+      # Prepare the conversion folders
+      ssu.shell_exec("mkdir -p /var/lib/uci/#{task_id} /var/log/uci/#{task_id}", nil, nil, nil)
+
+      # Write the conversion options file
+      ssu.put_file("/var/lib/uci/#{task_id}/input.json", conversion_options.to_json)
+    end
+  rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
+    raise "Failed to connect and prepare conversion for task '#{task_id}' with [#{err.class}: #{err}]"
+  rescue JSON::GeneratorError => err
+    raise "Could not generate JSON for task '#{task_id}' from options '#{filtered_options}' with [#{err.class}: #{err}]"
+  rescue StandardError => err
+    raise "Preparation of conversion for task '#{task_id}' failed on '#{resource.name}' with [#{err.class}: #{err}]"
+  end
+
+  # Build the podman command to execute conversion
+  #
+  # @param [Integer] id of the task that conversion applies to
+  #
+  # @return [String] podman command to be executed on conversion host
+  def build_podman_command(task_id)
+    "/usr/bin/podman run --privileged"\
+    " --name conversion-#{task_id}"\
+    " --volume /dev:/dev"\
+    " --volume /var/tmp:/var/tmp"\
+    " --volume /var/lib/uci/#{task_id}:/var/lib/uci"\
+    " --volume /var/log/uci/#{task_id}:/var/log/uci"\
+    " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
+    " registry.access.redhat.com/manageiq/kubevirt-v2v-conversion:ims"\
   end
 
   # Run the virt-v2v-wrapper script on the remote host and return a hash
@@ -174,21 +219,19 @@ class ConversionHost < ApplicationRecord
   # Certain sensitive fields are filtered in the error messages to prevent
   # that information from showing up in the UI or logs.
   #
-  def run_conversion(conversion_options)
-    ignore = %w[password fingerprint key]
-    filtered_options = conversion_options.clone.tap { |h| h.each { |k, _v| h[k] = "__FILTERED__" if ignore.any? { |i| k.to_s.end_with?(i) } } }
-    result = connect_ssh { |ssu| ssu.shell_exec('/usr/bin/virt-v2v-wrapper', nil, nil, conversion_options.to_json) }
-    JSON.parse(result)
+  # @param [Integer] id of the task that conversion applies to
+  def run_conversion(task_id, conversion_options)
+    filtered_options = filter_options(conversion_options)
+    prepare_conversion(task_id, conversion_options)
+    connect_ssh { |ssu| ssu.shell_exec(build_podman_command(task_id), nil, nil, nil) }
   rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
     raise "Failed to connect and run conversion using options #{filtered_options} with [#{err.class}: #{err}]"
-  rescue JSON::ParserError
-    raise "Could not parse result data after running virt-v2v-wrapper using options: #{filtered_options}. Result was: #{result}."
   rescue StandardError => err
-    raise "Starting conversion failed on '#{resource.name}' with [#{err.class}: #{err}]"
+    raise "Starting conversion for task '#{task_id}' failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
-  def create_cutover_file(path)
-    connect_ssh { |ssu| ssu.shell_exec("touch #{path}") }
+  def create_cutover_file(task_id)
+    connect_ssh { |ssu| ssu.shell_exec("touch /var/lib/uci/#{task_id}/cutover") }
     true
   rescue StandardError
     false
@@ -197,8 +240,8 @@ class ConversionHost < ApplicationRecord
   # Kill a specific remote process over ssh, sending the specified +signal+, or 'TERM'
   # if no signal is specified.
   #
-  def kill_process(pid, signal = 'TERM')
-    connect_ssh { |ssu| ssu.shell_exec("/bin/kill -s #{signal} #{pid}") }
+  def kill_virtv2v(task_id)
+    connect_ssh { |ssu| ssu.shell_exec("/usr/bin/podman kill conversion-#{task_id}") }
     true
   rescue
     false
@@ -207,23 +250,23 @@ class ConversionHost < ApplicationRecord
   # Retrieve the conversion state information from a remote file as a stream.
   # Then parse and return the stream data as a hash using JSON.parse.
   #
-  def get_conversion_state(path)
-    json_state = connect_ssh { |ssu| ssu.get_file(path, nil) }
+  def get_conversion_state(task_id)
+    json_state = connect_ssh { |ssu| ssu.get_file("/var/lib/uci/#{task_id}/state.json", nil) }
     JSON.parse(json_state)
   rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
-    raise "Failed to connect and retrieve conversion state data from file '#{path}' with [#{err.class}: #{err}"
+    raise "Failed to connect and retrieve conversion state data from file '/var/lib/uci/#{task_id}/state.json' with [#{err.class}: #{err}]"
   rescue JSON::ParserError
-    raise "Could not parse conversion state data from file '#{path}': #{json_state}"
+    raise "Could not parse conversion state data from file '/var/lib/uci/#{task_id}/state.json': #{json_state}"
   rescue StandardError => err
-    raise "Error retrieving and parsing conversion state file '#{path}' from '#{resource.name}' with [#{err.class}: #{err}"
+    raise "Error retrieving and parsing conversion state file '/var/lib/uci/#{task_id}/state.json' from '#{resource.name}' with [#{err.class}: #{err}"
   end
 
   # Get and return the contents of the remote conversion log at +path+.
   #
-  def get_conversion_log(path)
-    connect_ssh { |ssu| ssu.get_file(path, nil) }
-  rescue => e
-    raise "Could not get conversion log '#{path}' from '#{resource.name}' with [#{e.class}: #{e}"
+  def get_conversion_log(task_id, log_type)
+    connect_ssh { |ssu| ssu.get_file("/var/log/uci/#{task_id}/#{log_type}.log", nil) }
+  rescue StandardError => err
+    raise "Could not get #{log_type} log for task '#{task_id}' from '#{resource.name}' with [#{err.class}: #{err}"
   end
 
   def check_conversion_host_role(miq_task_id = nil)
@@ -297,6 +340,12 @@ class ConversionHost < ApplicationRecord
     end
 
     authentication
+  end
+
+  # Utility method to filter certain entries of a hash based on key name
+  def filter_options(options)
+    ignore = %w[password fingerprint key]
+    options.clone.tap { |h| h.each { |k, _v| h[k] = "__FILTERED__" if ignore.any? { |i| k.to_s.end_with?(i) } } }
   end
 
   # Connect to the conversion host using the MiqSshUtil wrapper using the authentication

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -206,6 +206,7 @@ class ConversionHost < ApplicationRecord
     "/usr/bin/podman run --privileged"\
     " --name conversion-#{task_id}"\
     " --volume /dev:/dev"\
+    " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"\
     " --volume /var/tmp:/var/tmp"\
     " --volume /var/lib/uci/#{task_id}:/var/lib/uci"\
     " --volume /var/log/uci/#{task_id}:/var/log/uci"\

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -207,7 +207,7 @@ class ConversionHost < ApplicationRecord
   # @raise [JSON::ParserError] if file cannot be parsed as JSON
   def luks_keys_vault_valid?
     luks_keys_vault_json = connect_ssh { |ssu| ssu.get_file("/root/.v2v_luks_keys_vault.json", nil) }
-    luks_keys_vault = JSON.parse(luks_keys_vault_json)
+    JSON.parse(luks_keys_vault_json)
     true
   rescue MiqException::MiqInvalidCredentialsError, MiqException::MiqSshUtilHostKeyMismatch => err
     raise "Failed to connect and retrieve LUKS keys vault from file '/root/.v2v_luks_keys_vault.json' with [#{err.class}: #{err}]"
@@ -237,7 +237,7 @@ class ConversionHost < ApplicationRecord
     command += " --volume /root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json" if luks_keys_vault_valid?
     command += " --volume /var/log/uci/#{task_id}:/var/log/uci"
     command += " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"
-    command += " #{uci_image}"
+    command + " #{uci_image}"
   end
 
   # Run the virt-v2v-wrapper script on the remote host and return a hash

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -213,6 +213,8 @@ class ConversionHost < ApplicationRecord
     " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"\
     " --volume /var/tmp:/var/tmp"\
     " --volume /var/lib/uci/#{task_id}:/var/lib/uci"\
+    " --volume /root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"\
+    " --volume /root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"\
     " --volume /var/log/uci/#{task_id}:/var/log/uci"\
     " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
     " #{uci_image}"

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -203,6 +203,10 @@ class ConversionHost < ApplicationRecord
   #
   # @return [String] podman command to be executed on conversion host
   def build_podman_command(task_id)
+    uci_settings = Settings.transformation.uci.container
+    uci_image = uci_settings.image
+    uci_image = "#{uci_settings.registry}/#{image}" if uci_settings.registry.present?
+
     "/usr/bin/podman run --privileged"\
     " --name conversion-#{task_id}"\
     " --volume /dev:/dev"\
@@ -211,7 +215,7 @@ class ConversionHost < ApplicationRecord
     " --volume /var/lib/uci/#{task_id}:/var/lib/uci"\
     " --volume /var/log/uci/#{task_id}:/var/log/uci"\
     " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
-    " registry.access.redhat.com/manageiq/kubevirt-v2v-conversion:ims"\
+    " #{uci_image}"
   end
 
   # Run the virt-v2v-wrapper script on the remote host and return a hash

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -142,7 +142,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
 
     logfile = options.fetch_path(:virtv2v_wrapper, "#{log_type}_log")
-    puts "LOGFILE: #{logfile}"
     if logfile.blank?
       msg = "The location of #{log_type} log was not set. Download of #{log_type} log aborted."
       _log.error(msg)

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -141,7 +141,15 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       raise MiqException::Error, msg
     end
 
-    conversion_host.get_conversion_log(id, log_type)
+    logfile = options.fetch_path(:virtv2v_wrapper, "#{log_type}_log")
+    puts "LOGFILE: #{logfile}"
+    if logfile.blank?
+      msg = "The location of #{log_type} log was not set. Download of #{log_type} log aborted."
+      _log.error(msg)
+      raise MiqException::Error, msg
+    end
+
+    conversion_host.get_conversion_log(logfile)
   end
 
   # Intend to be called by UI to display transformation log. The log is stored in MiqTask#task_results

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -333,7 +333,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   def conversion_options_source_provider_vmwarews_vddk(_storage)
     {
       :vm_name              => source.name,
-      :vm_uuid              => source.ems_ref,
+      :vm_uuid              => source.uid_ems,
       :conversion_host_uuid => conversion_host.resource.ems_ref,
       :transport_method     => 'vddk',
       :vmware_fingerprint   => source.host.thumbprint_sha1,
@@ -359,7 +359,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :host     => source.host.ipaddress,
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
-      :vm_uuid              => source.ems_ref,
+      :vm_uuid              => source.uid_ems,
       :conversion_host_uuid => conversion_host.resource.ems_ref,
       :transport_method     => 'ssh',
       :daemonize            => false

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -325,31 +325,37 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def conversion_options_source_provider_vmwarews_vddk(_storage)
     {
-      :vm_name            => source.name,
-      :transport_method   => 'vddk',
-      :vmware_fingerprint => source.host.thumbprint_sha1,
-      :vmware_uri         => URI::Generic.build(
+      :vm_name              => source.name,
+      :vm_uuid              => source.ems_ref,
+      :conversion_host_uuid => conversion_host.resource.ems_ref,
+      :transport_method     => 'vddk',
+      :vmware_fingerprint   => source.host.thumbprint_sha1,
+      :vmware_uri           => URI::Generic.build(
         :scheme   => 'esx',
         :userinfo => CGI.escape(source.host.authentication_userid),
         :host     => source.host.ipaddress,
         :path     => '/',
         :query    => { :no_verify => 1 }.to_query
       ).to_s,
-      :vmware_password    => source.host.authentication_password,
-      :two_phase          => true,
-      :warm               => warm_migration?
+      :vmware_password      => source.host.authentication_password,
+      :two_phase            => true,
+      :warm                 => warm_migration?,
+      :daemonize            => false
     }
   end
 
   def conversion_options_source_provider_vmwarews_ssh(storage)
     {
-      :vm_name          => URI::Generic.build(
+      :vm_name              => URI::Generic.build(
         :scheme   => 'ssh',
         :userinfo => 'root',
         :host     => source.host.ipaddress,
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
-      :transport_method => 'ssh'
+      :vm_uuid              => source.ems_ref,
+      :conversion_host_uuid => conversion_host.resource.ems_ref,
+      :transport_method     => 'ssh',
+      :daemonize            => false
     }
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1056,6 +1056,10 @@
     :max_concurrent_tasks_per_conversion_host: 10
     :cpu_limit_per_host: unlimited
     :network_limit_per_host: unlimited
+  :uci:
+    :container:
+      registry:
+      image: manageiq/v2v-conversion-host:latest
 :ui:
   :mark_translated_strings: false
   :display_ops_database: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1058,8 +1058,8 @@
     :network_limit_per_host: unlimited
   :uci:
     :container:
-      registry:
-      image: manageiq/v2v-conversion-host:latest
+      :registry:
+      :image: manageiq/v2v-conversion-host:latest
 :ui:
   :mark_translated_strings: false
   :display_ops_database: false

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -90,14 +90,14 @@ class InfraConversionThrottler
 
       jobs.each do |job|
         migration_task = job.migration_task
-        throttling_file_path = migration_task.options.fetch_path(:virtv2v_wrapper, 'throttling_file')
-        next unless throttling_file_path
+        next unless migration_task.virtv2v_running?
+
         limits = {
           :cpu     => cpu_limit,
           :network => network_limit
         }
         unless migration_task.options[:virtv2v_limits] == limits
-          ch.apply_task_limits(throttling_file_path, limits)
+          ch.apply_task_limits(migration_task.id, limits)
           migration_task.update_options(:virtv2v_limits => limits)
         end
       end

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe InfraConversionThrottler, :v2v do
         :network => 'unlimited'
       }
       task_running_1.options[:virtv2v_started_on] = Time.now.utc
-      task_running_1.options[:virtv2v_wrapper] = { 'state_file' => "/var/lib/uci/#{task_running_1.id}/state.json" }
+      task_running_1.options[:virtv2v_wrapper] = {'state_file' => "/var/lib/uci/#{task_running_1.id}/state.json"}
       task_running_2.options[:virtv2v_started_on] = Time.now.utc
-      task_running_2.options[:virtv2v_wrapper] = { 'state_file' => "/var/lib/uci/#{task_running_2.id}/state.json" }
+      task_running_2.options[:virtv2v_wrapper] = {'state_file' => "/var/lib/uci/#{task_running_2.id}/state.json"}
       expect(conversion_host).to receive(:apply_task_limits).with(task_running_1.id, limits)
       expect(conversion_host).to receive(:apply_task_limits).with(task_running_2.id, limits)
       described_class.apply_limits

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -119,9 +119,12 @@ RSpec.describe InfraConversionThrottler, :v2v do
         :cpu     => '25',
         :network => 'unlimited'
       }
-      task_running_1.options[:virtv2v_wrapper] = { 'throttling_file' => path }
-      task_running_2.options[:virtv2v_wrapper] = { 'throttling_file' => path }
-      expect(conversion_host).to receive(:apply_task_limits).twice.with(path, limits)
+      task_running_1.options[:virtv2v_started_on] = Time.now.utc
+      task_running_1.options[:virtv2v_wrapper] = { 'state_file' => "/var/lib/uci/#{task_running_1.id}/state.json" }
+      task_running_2.options[:virtv2v_started_on] = Time.now.utc
+      task_running_2.options[:virtv2v_wrapper] = { 'state_file' => "/var/lib/uci/#{task_running_2.id}/state.json" }
+      expect(conversion_host).to receive(:apply_task_limits).with(task_running_1.id, limits)
+      expect(conversion_host).to receive(:apply_task_limits).with(task_running_2.id, limits)
       described_class.apply_limits
       expect(task_running_1.reload.options[:virtv2v_limits]).to eq(limits)
       expect(task_running_2.reload.options[:virtv2v_limits]).to eq(limits)

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -542,6 +542,7 @@ RSpec.describe ConversionHost, :v2v do
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\
         " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
         " manageiq/v2v-conversion-host:latest"
+        " registry.access.redhat.com/manageiq/kubevirt-v2v-conversion:ims"
       )
     end
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe ConversionHost, :v2v do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
     let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host) }
-    let(:conversion_options) { {:foo => 1, :bar => 'hello', :password => 'xxx', :ssh_key => 'xyz' } }
+    let(:conversion_options) { {:foo => 1, :bar => 'hello', :password => 'xxx', :ssh_key => 'xyz'} }
     let(:filtered_options) { conversion_options.clone.update(:ssh_key => '__FILTERED__', :password => '__FILTERED__') }
 
     it "works as expected if the connection is successful but the JSON is invalid" do

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -536,6 +536,7 @@ RSpec.describe ConversionHost, :v2v do
         "/usr/bin/podman run --privileged"\
         " --name conversion-#{task.id}"\
         " --volume /dev:/dev"\
+        " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"\
         " --volume /var/tmp:/var/tmp"\
         " --volume /var/lib/uci/#{task.id}:/var/lib/uci"\
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -564,7 +564,6 @@ RSpec.describe ConversionHost, :v2v do
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\
         " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
         " manageiq/v2v-conversion-host:latest"
-        " registry.access.redhat.com/manageiq/kubevirt-v2v-conversion:ims"
       )
     end
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -559,10 +559,10 @@ RSpec.describe ConversionHost, :v2v do
         " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"\
         " --volume /var/tmp:/var/tmp"\
         " --volume /var/lib/uci/#{task.id}:/var/lib/uci"\
-        " --volume /root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"\
-        " --volume /root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"\
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\
         " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
+        " --volume /root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"\
+        " --volume /root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"\
         " manageiq/v2v-conversion-host:latest"
       )
     end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -134,12 +134,12 @@ RSpec.describe ConversionHost, :v2v do
     context "#kill_process" do
       it "returns false if if kill command failed" do
         allow(conversion_host_1).to receive(:connect_ssh).and_raise('Unexpected failure')
-        expect(conversion_host_1.kill_virtv2v(task_1.id)).to eq(false)
+        expect(conversion_host_1.kill_virtv2v(task_1.id, 'TERM')).to eq(false)
       end
 
       it "returns true if if kill command succeeded" do
         allow(conversion_host_1).to receive(:connect_ssh)
-        expect(conversion_host_1.kill_virtv2v(task_1.id)).to eq(true)
+        expect(conversion_host_1.kill_virtv2v(task_1.id, 'KILL')).to eq(true)
       end
     end
   end
@@ -535,7 +535,7 @@ RSpec.describe ConversionHost, :v2v do
     it "works as expected and returns the command when transport is VDDK and LUKS keys vault check fails" do
       allow(conversion_host).to receive(:connect_ssh).and_raise('Fake error')
       expect(conversion_host.build_podman_command(task.id, conversion_options)).to eq(
-        "sudo /usr/bin/podman run --privileged"\
+        "/usr/bin/podman run --detach --privileged"\
         " --name conversion-#{task.id}"\
         " --network host" \
         " --volume /dev:/dev"\
@@ -552,7 +552,7 @@ RSpec.describe ConversionHost, :v2v do
       conversion_options[:transport_method] = 'ssh'
       allow(conversion_host).to receive(:connect_ssh).and_return('{"fake": "json"}')
       expect(conversion_host.build_podman_command(task.id, conversion_options)).to eq(
-        "sudo /usr/bin/podman run --privileged"\
+        "/usr/bin/podman run --detach --privileged"\
         " --name conversion-#{task.id}"\
         " --network host"\
         " --volume /dev:/dev"\

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe ConversionHost, :v2v do
         " --volume /var/lib/uci/#{task.id}:/var/lib/uci"\
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\
         " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
-        " registry.access.redhat.com/manageiq/kubevirt-v2v-conversion:ims"
+        " manageiq/v2v-conversion-host:latest"
       )
     end
   end

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -134,12 +134,12 @@ RSpec.describe ConversionHost, :v2v do
     context "#kill_process" do
       it "returns false if if kill command failed" do
         allow(conversion_host_1).to receive(:connect_ssh).and_raise('Unexpected failure')
-        expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(false)
+        expect(conversion_host_1.kill_virtv2v(task_1.id)).to eq(false)
       end
 
       it "returns true if if kill command succeeded" do
         allow(conversion_host_1).to receive(:connect_ssh)
-        expect(conversion_host_1.kill_process('1234', 'KILL')).to eq(true)
+        expect(conversion_host_1.kill_virtv2v(task_1.id)).to eq(true)
       end
     end
   end
@@ -500,93 +500,127 @@ RSpec.describe ConversionHost, :v2v do
     end
   end
 
-  context "#run_conversion" do
+  context "#prepare_conversion" do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host) }
     let(:conversion_options) { {:foo => 1, :bar => 'hello', :password => 'xxx', :ssh_key => 'xyz' } }
     let(:filtered_options) { conversion_options.clone.update(:ssh_key => '__FILTERED__', :password => '__FILTERED__') }
 
-    it "works as expected if the connection is successful and the JSON is valid" do
-      allow(conversion_host).to receive(:connect_ssh).and_return({:alpha => {:beta => 'hello'}}.to_json)
-      expect(conversion_host.run_conversion(conversion_options)).to eql('alpha' => {'beta' => 'hello'})
-    end
-
     it "works as expected if the connection is successful but the JSON is invalid" do
-      allow(conversion_host).to receive(:connect_ssh).and_return('bogus')
-      expected_message = "Could not parse result data after running virt-v2v-wrapper using "\
-        "options: #{filtered_options}. Result was: bogus."
-      expect { conversion_host.run_conversion(conversion_options) }.to raise_error(expected_message)
+      allow(conversion_host).to receive(:connect_ssh).and_raise(JSON::GeneratorError, 'fake unparser error')
+      expected_message = "Could not generate JSON for task '#{task.id}' from options '#{filtered_options}' with [JSON::GeneratorError: fake unparser error]"
+      expect { conversion_host.prepare_conversion(task.id, conversion_options) }.to raise_error(expected_message)
     end
 
     it "works as expected if the connection is unsuccessful" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
-      expected_message = "Failed to connect and run conversion using options #{filtered_options}"
-      expect { conversion_host.run_conversion(conversion_options) }.to raise_error(/#{expected_message}/)
+      expected_message = "Failed to connect and prepare conversion for task '#{task.id}'"
+      expect { conversion_host.prepare_conversion(task.id, conversion_options) }.to raise_error(/#{expected_message}/)
     end
 
     it "works as expected if an unknown error occurs" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError)
-      expected_message = "Starting conversion failed on '#{vm.name}'"
-      expect { conversion_host.run_conversion(conversion_options) }.to raise_error(/#{expected_message}/)
+      expected_message = "Preparation of conversion for task '#{task.id}' failed on '#{vm.name}'"
+      expect { conversion_host.prepare_conversion(task.id, conversion_options) }.to raise_error(/#{expected_message}/)
+    end
+  end
+
+  context "#build_podman_command" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host) }
+
+    it "works as expected and returns the command" do
+      expect(conversion_host.build_podman_command(task.id)).to eq(
+        "/usr/bin/podman run --privileged"\
+        " --name conversion-#{task.id}"\
+        " --volume /dev:/dev"\
+        " --volume /var/tmp:/var/tmp"\
+        " --volume /var/lib/uci/#{task.id}:/var/lib/uci"\
+        " --volume /var/log/uci/#{task.id}:/var/log/uci"\
+        " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
+        " registry.access.redhat.com/manageiq/kubevirt-v2v-conversion:ims"
+      )
+    end
+  end
+
+  context "#run_conversion" do
+    let(:vm) { FactoryBot.create(:vm_openstack) }
+    let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
+    let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host) }
+    let(:conversion_options) { {:foo => 1, :bar => 'hello', :password => 'xxx', :ssh_key => 'xyz' } }
+    let(:filtered_options) { conversion_options.clone.update(:ssh_key => '__FILTERED__', :password => '__FILTERED__') }
+
+    it "works as expected if the connection is unsuccessful" do
+      allow(conversion_host).to receive(:prepare_conversion).and_raise(MiqException::MiqInvalidCredentialsError)
+      expected_message = "Failed to connect and run conversion using options #{filtered_options}"
+      expect { conversion_host.run_conversion(task.id, conversion_options) }.to raise_error(/#{expected_message}/)
+    end
+
+    it "works as expected if an unknown error occurs" do
+      allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError)
+      expected_message = "Starting conversion for task '#{task.id}' failed on '#{vm.name}'"
+      expect { conversion_host.run_conversion(task.id, conversion_options) }.to raise_error(/#{expected_message}/)
     end
   end
 
   context "#get_conversion_state" do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
-    let(:path) { 'some_path' }
+    let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host) }
 
     it "works as expected if the connection is successful and the JSON is valid" do
       allow(conversion_host).to receive(:connect_ssh).and_return({:alpha => {:beta => 'hello'}}.to_json)
-      expect(conversion_host.get_conversion_state(path)).to eql('alpha' => {'beta' => 'hello'})
+      expect(conversion_host.get_conversion_state(task.id)).to eql('alpha' => {'beta' => 'hello'})
     end
 
     it "works as expected if the connection is successful but the JSON is invalid" do
       allow(conversion_host).to receive(:connect_ssh).and_return('bogus')
-      expected_message = "Could not parse conversion state data from file '#{path}': bogus"
-      expect { conversion_host.get_conversion_state(path) }.to raise_error(expected_message)
+      expected_message = "Could not parse conversion state data from file '/var/lib/uci/#{task.id}/state.json': bogus"
+      expect { conversion_host.get_conversion_state(task.id) }.to raise_error(expected_message)
     end
 
     it "works as expected if the connection is unsuccessful" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
-      expected_message = "Failed to connect and retrieve conversion state data from file '#{path}'"
-      expect { conversion_host.get_conversion_state(path) }.to raise_error(/#{expected_message}/)
+      expected_message = "Failed to connect and retrieve conversion state data from file '\/var\/lib\/uci\/#{task.id}\/state.json'"
+      expect { conversion_host.get_conversion_state(task.id) }.to raise_error(/#{expected_message}/)
     end
 
     it "works as expected if an unknown error occurs" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError)
-      expected_message = "Error retrieving and parsing conversion state file '#{path}' from '#{vm.name}'"
-      expect { conversion_host.get_conversion_state(path) }.to raise_error(/#{expected_message}/)
+      expected_message = "Error retrieving and parsing conversion state file '\/var\/lib\/uci\/#{task.id}\/state.json' from '#{vm.name}'"
+      expect { conversion_host.get_conversion_state(task.id) }.to raise_error(/#{expected_message}/)
     end
   end
 
   context "#apply_task_limits" do
     let(:vm) { FactoryBot.create(:vm_openstack) }
     let(:conversion_host) { FactoryBot.create(:conversion_host, :resource => vm) }
-    let(:path) { 'some_path' }
+    let(:task) { FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host) }
     let(:limits) { { :cpu => '50', :network => '10' } }
 
     it "works as expected if the connection is successful and the JSON is generated" do
       allow(conversion_host).to receive(:connect_ssh).and_return(true)
-      expect(conversion_host.apply_task_limits(path, limits)).to be_truthy
+      expect(conversion_host.apply_task_limits(task.id, limits)).to be_truthy
     end
 
     it "works as expected if the connection is successful but the JSON is invalid" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(JSON::GeneratorError, 'fake unparser error')
       expected_message = "Could not generate JSON from limits '#{limits}' with [JSON::GeneratorError: fake unparser error]"
-      expect { conversion_host.apply_task_limits(path, limits) }.to raise_error(expected_message)
+      expect { conversion_host.apply_task_limits(task.id, limits) }.to raise_error(expected_message)
     end
 
     it "works as expected if the connection is unsuccessful" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(MiqException::MiqInvalidCredentialsError)
-      expected_message = "Failed to connect and apply limits in file '#{path}'"
-      expect { conversion_host.apply_task_limits(path, limits) }.to raise_error(/#{expected_message}/)
+      expected_message = "Failed to connect and apply limits for task '#{task.id}'"
+      expect { conversion_host.apply_task_limits(task.id, limits) }.to raise_error(/#{expected_message}/)
     end
 
     it "works as expected if an unknown error occurs" do
       allow(conversion_host).to receive(:connect_ssh).and_raise(StandardError, 'fake error')
-      expected_message = "Could not apply the limits in '#{path}' on '#{vm.name}' with [StandardError: fake error]"
-      expect { conversion_host.apply_task_limits(path, limits) }.to raise_error(expected_message)
+      expected_message = "Could not apply the limits for task '#{task.id}' on '#{vm.name}' with [StandardError: fake error]"
+      expect { conversion_host.apply_task_limits(task.id, limits) }.to raise_error(expected_message)
     end
   end
 

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -537,6 +537,7 @@ RSpec.describe ConversionHost, :v2v do
       expect(conversion_host.build_podman_command(task.id, conversion_options)).to eq(
         "sudo /usr/bin/podman run --privileged"\
         " --name conversion-#{task.id}"\
+        " --network host" \
         " --volume /dev:/dev"\
         " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"\
         " --volume /var/tmp:/var/tmp"\
@@ -553,6 +554,7 @@ RSpec.describe ConversionHost, :v2v do
       expect(conversion_host.build_podman_command(task.id, conversion_options)).to eq(
         "sudo /usr/bin/podman run --privileged"\
         " --name conversion-#{task.id}"\
+        " --network host"\
         " --volume /dev:/dev"\
         " --volume /etc/pki/ca-trust:/etc/pki/ca-trust"\
         " --volume /var/tmp:/var/tmp"\

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -385,20 +385,20 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "rescues when conversion_host.get_conversion_state fails less than 5 times" do
           task_1.update_options(:get_conversion_state_failures => 2)
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.options[:virtv2v_wrapper]['state_file']).and_raise("Fake error")
+          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
           task_1.get_conversion_state
           expect(task_1.options[:get_conversion_state_failures]).to eq(3)
         end
 
         it "rescues when conversion_host.get_conversion_state fails more than 5 times" do
           task_1.update_options(:get_conversion_state_failures => 5)
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.options[:virtv2v_wrapper]['state_file']).and_raise("Fake error")
+          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
           expect { task_1.get_conversion_state }.to raise_error("Failed to get conversion state 5 times in a row")
           expect(task_1.options[:get_conversion_state_failures]).to eq(6)
         end
 
         it "updates progress when conversion is failed" do
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.options[:virtv2v_wrapper]['state_file']).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
             "failed"       => true,
             "finished"     => true,
             "started"      => true,
@@ -421,7 +421,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         end
 
         it "updates disks progress" do
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.options[:virtv2v_wrapper]['state_file']).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
             "started"    => true,
             "disks"      => [
               { "path" => src_disk_1.filename, "progress" => 100.0 },
@@ -441,7 +441,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         end
 
         it "sets disks progress to 100% when conversion is finished and successful" do
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.options[:virtv2v_wrapper]['state_file']).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
             "finished"    => true,
             "started"     => true,
             "disks"       => [
@@ -467,7 +467,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "sets disks progress to 100% when conversion is finished and successful unless canceling" do
           task_1.canceling
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.options[:virtv2v_wrapper]['state_file']).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
             "finished"    => true,
             "started"     => true,
             "disks"       => [
@@ -679,7 +679,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             expect(task_1.conversion_options).to eq(
               :vm_name                    => src_vm_1.name,
               :vm_uuid                    => src_vm_1.ems_ref,
-              :conversion_host_uuid       => openstack_conversion_host_vm.ems_ref,
+              :conversion_host_uuid       => conversion_host.ems_ref,
               :transport_method           => 'vddk',
               :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri                 => "esx://esx_user@10.0.0.1/?no_verify=1",
@@ -721,7 +721,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             expect(task_1.conversion_options).to eq(
               :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vm_uuid                    => src_vm_1.ems_ref,
-              :conversion_host_uuid       => openstack_conversion_host_vm.ems_ref,
+              :conversion_host_uuid       => conversion_host.ems_ref,
               :transport_method           => 'ssh',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -563,21 +563,24 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name             => src_vm_1.name,
-              :transport_method    => 'vddk',
-              :vmware_fingerprint  => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
-              :vmware_uri          => "esx://esx_user@10.0.0.1/?no_verify=1",
-              :vmware_password     => 'esx_passwd',
-              :rhv_url             => "https://#{redhat_ems.hostname}/ovirt-engine/api",
-              :rhv_cluster         => redhat_cluster.name,
-              :rhv_storage         => redhat_storages.first.name,
-              :rhv_password        => redhat_ems.authentication_password,
-              :source_disks        => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings    => task_1.network_mappings,
-              :install_drivers     => true,
-              :insecure_connection => true,
-              :two_phase           => true,
-              :warm                => true
+              :vm_name              => src_vm_1.name,
+              :vm_uuid              => src_vm_1.ems_ref,
+              :conversion_host_uuid => conversion_host.resource.ems_ref,
+              :transport_method     => 'vddk',
+              :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri           => "esx://esx_user@10.0.0.1/?no_verify=1",
+              :vmware_password      => 'esx_passwd',
+              :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
+              :rhv_cluster          => redhat_cluster.name,
+              :rhv_storage          => redhat_storages.first.name,
+              :rhv_password         => redhat_ems.authentication_password,
+              :source_disks         => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings     => task_1.network_mappings,
+              :install_drivers      => true,
+              :insecure_connection  => true,
+              :two_phase            => true,
+              :warm                 => true,
+              :daemonize            => false
             )
           end
 
@@ -592,16 +595,19 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name             => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :transport_method    => 'ssh',
-              :rhv_url             => "https://#{redhat_ems.hostname}/ovirt-engine/api",
-              :rhv_cluster         => redhat_cluster.name,
-              :rhv_storage         => redhat_storages.first.name,
-              :rhv_password        => redhat_ems.authentication_password,
-              :source_disks        => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings    => task_1.network_mappings,
-              :install_drivers     => true,
-              :insecure_connection => true
+              :vm_name              => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vm_uuid              => src_vm_1.ems_ref,
+              :conversion_host_uuid => conversion_host.resource.ems_ref,
+              :transport_method     => 'ssh',
+              :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
+              :rhv_cluster          => redhat_cluster.name,
+              :rhv_storage          => redhat_storages.first.name,
+              :rhv_password         => redhat_ems.authentication_password,
+              :source_disks         => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings     => task_1.network_mappings,
+              :install_drivers      => true,
+              :insecure_connection  => true,
+              :daemonize            => false
             )
           end
         end
@@ -672,6 +678,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
               :vm_name                    => src_vm_1.name,
+              :vm_uuid                    => src_vm_1.ems_ref,
+              :conversion_host_uuid       => openstack_conversion_host_vm.ems_ref,
               :transport_method           => 'vddk',
               :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri                 => "esx://esx_user@10.0.0.1/?no_verify=1",
@@ -697,7 +705,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings           => task_1.network_mappings,
               :two_phase                  => true,
-              :warm                       => true
+              :warm                       => true,
+              :daemonize                  => false
             )
           end
         end
@@ -711,6 +720,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
               :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vm_uuid                    => src_vm_1.ems_ref,
+              :conversion_host_uuid       => openstack_conversion_host_vm.ems_ref,
               :transport_method           => 'ssh',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(
@@ -731,7 +742,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :osp_flavor_id              => openstack_flavor.ems_ref,
               :osp_security_groups_ids    => [openstack_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings           => task_1.network_mappings
+              :network_mappings           => task_1.network_mappings,
+              :daemonize                  => false
             )
           end
         end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -171,11 +171,16 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     describe '#transformation_log' do
       before do
         task.conversion_host = conversion_host
+        task.update_options(:virtv2v_wrapper => { "v2v_log" => "/fake/log/path" })
+        task.save
       end
 
       it 'gets the transformation log content' do
+        puts task.options
+        puts task.conversion_host.inspect
+        puts conversion_host.inspect
         msg = 'my transformation migration log'
-        allow(conversion_host).to receive(:get_conversion_log).with(task.id, 'v2v').and_return(msg)
+        allow(conversion_host).to receive(:get_conversion_log).with("/fake/log/path").and_return(msg)
         expect(task.transformation_log("v2v")).to eq(msg)
       end
     end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -571,7 +571,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
               :vm_name              => src_vm_1.name,
-              :vm_uuid              => src_vm_1.ems_ref,
+              :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'vddk',
               :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
@@ -603,7 +603,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
               :vm_name              => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :vm_uuid              => src_vm_1.ems_ref,
+              :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
@@ -685,7 +685,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
               :vm_name                    => src_vm_1.name,
-              :vm_uuid                    => src_vm_1.ems_ref,
+              :vm_uuid                    => src_vm_1.uid_ems,
               :conversion_host_uuid       => conversion_host.ems_ref,
               :transport_method           => 'vddk',
               :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
@@ -727,7 +727,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
               :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :vm_uuid                    => src_vm_1.ems_ref,
+              :vm_uuid                    => src_vm_1.uid_ems,
               :conversion_host_uuid       => conversion_host.ems_ref,
               :transport_method           => 'ssh',
               :osp_environment            => {

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -171,16 +171,18 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
     describe '#transformation_log' do
       before do
         task.conversion_host = conversion_host
-        task.update_options(:virtv2v_wrapper => { "v2v_log" => "/fake/log/path" })
-        task.save
+        task.options.store_path(:virtv2v_wrapper, "v2v_log", "/path/to/log.file")
+        task.save!
+      end
+
+      it 'requires transformation log location in options' do
+        task.options.store_path(:virtv2v_wrapper, "v2v_log", "")
+        expect { task.transformation_log("v2v") }.to raise_error(MiqException::Error)
       end
 
       it 'gets the transformation log content' do
-        puts task.options
-        puts task.conversion_host.inspect
-        puts conversion_host.inspect
         msg = 'my transformation migration log'
-        allow(conversion_host).to receive(:get_conversion_log).with("/fake/log/path").and_return(msg)
+        allow(conversion_host).to receive(:get_conversion_log).with(task.options[:virtv2v_wrapper]['v2v_log']).and_return(msg)
         expect(task.transformation_log("v2v")).to eq(msg)
       end
     end


### PR DESCRIPTION
To be able to integrate Universal Conversion Image (UCI) in the migration flow, we need to update ConversionHost class so that it uses podman with UCI container image instead of call virt-v2v-wrapper directly.

This pull request updates the `ConversionHost.run_conversion` method to:

1. Prepare the folder structure on the conversion host:
 a. Create the folders in `/var/lib/uci` and `/var/log/uci` based on task id for uniqueness
 b. Generate the input file for the container under the lib folder, as we can pass the options as stdin
2. Build the podman command in a separate method to have unit test, even though it's fairly simple
3. Call the command on the conversion host, still over SSH, to create a pod named after the task id

Most of the paths are now related to the task id and not to _random_ values returned by virt-v2v-wrapper, so it's more deterministic. It implies passing the task id to the conversion host methods and some rewrite and updates to the specs.

The `ConversionHost.kill_conversion` method has also been renamed and modified to kill the pod based on the task id.

The methods to retrieve the conversion state and logs have also been updated.

The pull request also creates a private utility method `filter_options` as filtered options are used in more that one place.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1788988