### PR TITLE
Pass some explicit arguments to raw_connect for ExtManagementSystem specs

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -712,10 +712,8 @@ RSpec.describe ExtManagementSystem do
 
   describe ".raw_connect?" do
     it "returns true if validation was successful" do
-      connection = double
-      allow(ManageIQ::Providers::Amazon::CloudManager).to receive(:raw_connect).and_return(connection)
-
-      expect(ManageIQ::Providers::Amazon::CloudManager.raw_connect?('abc', 'xxx', 'EC2', 'eastus')).to eq(true)
+      allow(described_class).to receive(:raw_connect).and_return(double)
+      expect(described_class.raw_connect?).to eq(true)
     end
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -1,4 +1,4 @@
-describe ExtManagementSystem do
+RSpec.describe ExtManagementSystem do
   describe ".with_tenant" do
     # tenant_root
     #   \___ tenant_eye_bee_em (service_template_eye_bee_em)
@@ -715,7 +715,7 @@ describe ExtManagementSystem do
       connection = double
       allow(ManageIQ::Providers::Amazon::CloudManager).to receive(:raw_connect).and_return(connection)
 
-      expect(ManageIQ::Providers::Amazon::CloudManager.raw_connect?).to eq(true)
+      expect(ManageIQ::Providers::Amazon::CloudManager.raw_connect?('abc', 'xxx', 'EC2', 'eastus')).to eq(true)
     end
   end
 


### PR DESCRIPTION
Currently the spec for `raw_connect` will fail in ext_management_system_spec.rb with the following error if strict partials are enabled:

```
1) ExtManagementSystem.raw_connect? returns true if validation was successful
     Failure/Error: !!raw_connect(*params)

     ArgumentError:
       Wrong number of arguments. Expected 4 to 7, got 0.
     # ./app/models/ext_management_system.rb:327:in `raw_connect?'
     # ./spec/models/ext_management_system_spec.rb:718:in `block (3 levels) in <top (required)>'
```

We should pass explicit arguments, even if bogus, in order to properly match the method.

