### PR TITLE
Autoload Rails Models unless called from safe_load

### DIFF
--- a/config/initializers/yaml_autoloader.rb
+++ b/config/initializers/yaml_autoloader.rb
@@ -1,8 +1,12 @@
-# Autoload Rails Models
+# Autoload Rails Models unless called from safe_load
 # see https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/psych_ext.rb
 
+# Psych::ClassLoader::Restricted is the class_loader if you use safe_load and was
+# added in psych 2.0.0:
+# https://github.com/ruby/psych/commit/2c644e184192975b261a81f486a04defa3172b3f
+# Note, ruby 2.4.0 shipped with psych 2.2.2+.  This class_loader would not work with ruby 2.3 and older.
 Psych::Visitors::ToRuby.prepend Module.new {
   def resolve_class(klass_name)
-    klass_name && klass_name.safe_constantize || super
+    (class_loader.class != Psych::ClassLoader::Restricted && klass_name && klass_name.safe_constantize) || super
   end
 }

--- a/spec/initializers/yaml_autoloader_spec.rb
+++ b/spec/initializers/yaml_autoloader_spec.rb
@@ -1,17 +1,29 @@
+require 'fileutils'
+require 'pathname'
+
 describe Psych::Visitors::ToRuby do
-  let(:missing_model) { Rails.root.join("app/models/zzz_model.rb") }
+  let(:model_directory) { Pathname.new(Dir.mktmpdir("yaml_autoloader")) }
+  let(:missing_model)   { model_directory.join("zzz_model.rb") }
 
   before do
     File.write(missing_model, "class ZzzModel\nend\n")
+    ActiveSupport::Dependencies.autoload_paths << model_directory
   end
 
   after do
-    require 'fileutils'
     FileUtils.rm_f(missing_model)
+    ActiveSupport::Dependencies.autoload_paths.reject! { |p| p == model_directory }
+    Object.send(:remove_const, "ZzzModel") if Object.const_defined?("ZzzModel")
   end
 
-  it "missing constants during yaml load are autoloaded" do
+  it "YAML.load autoloads missing constants" do
     dump = "--- !ruby/object:ZzzModel {}\n"
     expect(YAML.load(dump).class.name).to eql "ZzzModel"
+  end
+
+  it "YAML.safe_load does not autoload missing constants" do
+    dump = "--- !ruby/object:ZzzModel {}\n"
+    expect(YAML.load(dump).class.name).to eql "ZzzModel"
+    expect { YAML.safe_load(dump) }.to raise_error(Psych::DisallowedClass)
   end
 end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2240,7 +2240,7 @@ describe Rbac::Filterer do
         service2.update(:service_template => nil)
 
         # exclude service2 (no service template)
-        exp = YAML.safe_load("--- !ruby/object:MiqExpression
+        exp = YAML.load("--- !ruby/object:MiqExpression
         exp:
           and:
           - IS NOT EMPTY:
@@ -2269,7 +2269,7 @@ describe Rbac::Filterer do
         FactoryBot.create_list(:service, 1, :parent => root_service) # matches ruby and sql filter, not rbac
 
         # expression with sql AND ruby
-        exp = YAML.safe_load("--- !ruby/object:MiqExpression
+        exp = YAML.load("--- !ruby/object:MiqExpression
         exp:
           and:
           - IS NOT EMPTY:


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1789153

Psych::ClassLoader::Restricted is the class_loader if you use safe_load and was
added in psych 2.0.0:
https://github.com/ruby/psych/commit/2c644e184192975b261a81f486a04defa3172b3f

Note, ruby 2.4.0 shipped with psych 2.2.2+.  This class_loader would not work with ruby 2.3 and older.

From the BZ:

Steps to Reproduce:
1. bundle exec rails c
2. YAML.load("--- !ruby/object:PidFile {}\n")
3. exit console and do step 1 again
4. YAML.safe_load("--- !ruby/object:PidFile {}\n")


Actual results:

```
$ bundle exec rails c
...
irb(main):001:0> defined?(PidFile)
=> nil
irb(main):002:0> YAML.load("--- !ruby/object:PidFile {}\n")
=> #<PidFile:0x00007fd988e9b718>
```

```
$ bundle exec rails c
...
irb(main):001:0> defined?(PidFile)
=> nil
irb(main):002:0> YAML.safe_load("--- !ruby/object:PidFile {}\n")
=> #<PidFile:0x00007f9ba73d5a28>
```

This should have failed ^^^


Expected results:

```
$ bundle exec rails c
...
irb(main):001:0> defined?(PidFile)
=> nil
irb(main):002:0> YAML.load("--- !ruby/object:PidFile {}\n")
=> #<PidFile:0x00007f9d55bdd8b0>
```
```
$ bundle exec rails c
...
irb(main):001:0> defined?(PidFile)
=> nil
irb(main):002:0> YAML.safe_load("--- !ruby/object:PidFile {}\n")
Traceback (most recent call last):
       16: from railties (5.1.7) lib/rails/commands/console/console_command.rb:17:in `start'
        ...
        1: from /Users/joerafaniello/.rubies/ruby-2.6.5/lib/ruby/2.6.0/psych/class_loader.rb:97:in `find'
Psych::DisallowedClass (Tried to load unspecified class: PidFile)
```

This is what should be happening ^^^