### PR TITLE
Add an interface method for raw_connect

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -327,6 +327,12 @@ class ExtManagementSystem < ApplicationRecord
     !!raw_connect(*params)
   end
 
+  # Interface method that should be defined within the EMS of the provider.
+  #
+  def self.raw_connect(*_args)
+    raise NotImplementedError, _("must be implemented in a subclass")
+  end
+
   def self.model_name_from_emstype(emstype)
     model_from_emstype(emstype).try(:name)
   end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -719,6 +719,13 @@ describe ExtManagementSystem do
     end
   end
 
+  context "raw_connect" do
+    it 'defines a raw_connect method which raises an error' do
+      expect(described_class).to respond_to(:raw_connect)
+      expect { described_class.raw_connect }.to raise_error(NotImplementedError, _("must be implemented in a subclass"))
+    end
+  end
+
   describe ".inventory_status" do
     it "works with infra providers" do
       ems = FactoryBot.create(:ems_infra)


### PR DESCRIPTION
Internally the `ExtManagementSystem.raw_connect?` method calls `ExtManagementSystem.raw_connect`, but this method is not defined in the model. Instead, it's relying on the providers to define it.

So, this PR creates an interface method for it that simply raises a `NotImplementedError`.

Cross repo tests at: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/52