### PR TITLE
Remove VMwareWebService from the main Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,6 @@ end
 
 group :vmware, :manageiq_default do
   manageiq_plugin "manageiq-providers-vmware"
-  gem "vmware_web_service",             "~>0.4.0"
 end
 
 ### shared dependencies


### PR DESCRIPTION
This removes the VMwareWebService gem from the core Gemfile now that all
core references to VMwareWebService and MiqVim have been moved to the
VMware repo.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/53

Fixes https://github.com/ManageIQ/manageiq/issues/18428