### PR TITLE
Set my_queue_name for MiqProvisionRequests

### DIFF
--- a/app/models/miq_provision_request.rb
+++ b/app/models/miq_provision_request.rb
@@ -73,6 +73,10 @@ class MiqProvisionRequest < MiqRequest
     'ems_operations'
   end
 
+  def my_queue_name
+    source.ext_management_system&.queue_name_for_ems_operations
+  end
+
   def requested_task_idx
     (1..get_option(:number_of_vms).to_i).to_a
   end

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -80,6 +80,7 @@ module MiqRequestTask::StateMachine
       :deliver_on     => 10.seconds.from_now.utc,
       :zone           => my_zone,
       :role           => my_role,
+      :queue_name     => my_queue_name,
       :tracking_label => tracking_label_id,
       :miq_callback => {:class_name => self.class.name, :instance_id => id, :method_name => :execute_callback}
     )

--- a/spec/models/miq_provision_request_spec.rb
+++ b/spec/models/miq_provision_request_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe MiqProvisionRequest do
         expect(@pr.miq_request.first_approval).to eq(MiqApproval.first)
       end
 
+      it "should return the correct queue_name" do
+        expect(@pr.my_queue_name).to eq(vm_template.ext_management_system.queue_name_for_ems_operations)
+      end
+
       it "should return a workflow class" do
         expect(@pr.workflow_class).to eq(ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow)
       end


### PR DESCRIPTION
We need to set the queue_name for any ems_operations queue items, this
includes the first one and any requeue_phase calls.

https://github.com/ManageIQ/manageiq/issues/19543