### PR TITLE
Check for namespaced Datacenter classes

### DIFF
--- a/app/models/miq_request_workflow.rb
+++ b/app/models/miq_request_workflow.rb
@@ -877,7 +877,7 @@ class MiqRequestWorkflow
         else
           path << " / ".freeze << folder.name
         end
-        dh[folder.id] = path unless folder.type == "Datacenter".freeze
+        dh[folder.id] = path unless folder.datacenter?
       end
     end
 
@@ -929,7 +929,7 @@ class MiqRequestWorkflow
     # Walk the xml document parents to find the requested class
     while node.kind_of?(XmlHash::Element)
       ci = node.attributes[:object]
-      if node.name == klass_name && (datacenter == false || datacenter == true && ci.type == "Datacenter")
+      if node.name == klass_name && (datacenter == false || datacenter == true && ci.datacenter?)
         result = ci
         break
       end
@@ -1009,7 +1009,9 @@ class MiqRequestWorkflow
   end
 
   def ems_folder_to_hash_struct(ci)
-    build_ci_hash_struct(ci, [:name, :type, :hidden])
+    build_ci_hash_struct(ci, [:name, :type, :hidden]).tap do |nh|
+      nh.send("datacenter?=", ci.kind_of?(Datacenter))
+    end
   end
 
   def storage_to_hash_struct(ci)

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe MiqRequestWorkflow do
   let(:ems) { FactoryBot.create(:ext_management_system) }
   let(:resource_pool) { FactoryBot.create(:resource_pool) }
   let(:ems_folder) { FactoryBot.create(:ems_folder) }
-  let(:datacenter) { FactoryBot.create(:ems_folder, :type => "Datacenter") }
+  let(:datacenter) { FactoryBot.create(:vmware_datacenter) }
 
   context "#validate" do
     let(:dialog) { workflow.instance_variable_get(:@dialogs) }
@@ -471,7 +471,7 @@ RSpec.describe MiqRequestWorkflow do
     before do
       resource_pool.ext_management_system = ems
       ems_folder.ext_management_system = ems
-      attrs = ems_folder.attributes.merge(:object => ems_folder)
+      attrs = ems_folder.attributes.merge(:object => workflow.ems_folder_to_hash_struct(ems_folder))
       xml_hash = XmlHash::Element.new('EmsFolder', attrs)
       hash = { ResourcePool => { resource_pool.id => xml_hash } }
       workflow.instance_variable_set("@ems_xml_nodes", hash)
@@ -512,7 +512,7 @@ RSpec.describe MiqRequestWorkflow do
   context "#folder_to_datacenter" do
     before do
       datacenter.ext_management_system = ems
-      attrs = datacenter.attributes.merge(:object => datacenter, :ems => ems)
+      attrs = datacenter.attributes.merge(:object => workflow.ems_folder_to_hash_struct(datacenter), :ems => ems)
       xml_hash = XmlHash::Element.new('EmsFolder', attrs)
       hash = { EmsFolder => { datacenter.id => xml_hash } }
       workflow.instance_variable_set("@ems_xml_nodes", hash)


### PR DESCRIPTION
The provision workflow allowed_datacenters wasn't checking for namespaced Datacenter classes like `ManageIQ::Providers::Vmware::InfraManager::Datacenter`, only `"Datacenter"` exactly.

This was causing no datacenters or folders to show up in the provision dialogs.