### PR TITLE
Fix invalid partials for MiqRequestWorkflow specs

### DIFF
--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -5,6 +5,14 @@ describe MiqRequestWorkflow do
   let(:ems_folder) { FactoryBot.create(:ems_folder) }
   let(:datacenter) { FactoryBot.create(:ems_folder, :type => "Datacenter") }
 
+  before("#validate") do
+    module TempModule
+      def some_validation_method; end
+      def some_required_method; end
+    end
+    workflow.extend(TempModule)
+  end
+
   context "#validate" do
     let(:dialog) { workflow.instance_variable_get(:@dialogs) }
 
@@ -17,14 +25,14 @@ describe MiqRequestWorkflow do
       it "calls the validation_method if defined" do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :validation_method, :some_validation_method)
 
-        expect(workflow).to receive(:some_validation_method).once
+        expect(workflow).to receive(:send).with(:some_validation_method, any_args).once
         expect(workflow.validate({})).to be true
       end
 
       it "returns false when validation fails" do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :validation_method, :some_validation_method)
 
-        expect(workflow).to receive(:some_validation_method).and_return("Some Error")
+        expect(workflow).to receive(:send).with(:some_validation_method, any_args).and_return("Some Error")
         expect(workflow.validate({})).to be false
       end
     end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -8,7 +8,10 @@ describe MiqRequestWorkflow do
   before("#validate") do
     module TempModule
       def some_validation_method; end
+      def other_validation_method; end
       def some_required_method; end
+      def some_required_method_1; end
+      def some_required_method_2; end
     end
     workflow.extend(TempModule)
   end
@@ -51,7 +54,7 @@ describe MiqRequestWorkflow do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :required_method, :some_required_method)
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :required, true)
 
-        expect(workflow).to receive(:some_required_method).and_return("Some Error")
+        expect(workflow).to receive(:send).with(:some_required_method, any_args).and_return("Some Error")
         expect(workflow.validate({})).to be false
       end
     end
@@ -62,8 +65,8 @@ describe MiqRequestWorkflow do
                                                                                             :some_required_method_2])
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :required, true)
 
-        expect(workflow).to receive(:some_required_method_1)
-        expect(workflow).to receive(:some_required_method_2)
+        expect(workflow).to receive(:send).with(:some_required_method_1, any_args)
+        expect(workflow).to receive(:send).with(:some_required_method_2, any_args)
         expect(workflow.validate({})).to be true
       end
     end
@@ -73,8 +76,8 @@ describe MiqRequestWorkflow do
         dialog.store_path(:dialogs, :customize, :fields, :root_password, :validation_method, :some_validation_method)
         dialog.store_path(:dialogs, :customize, :fields, :root_password_2, :validation_method, :other_validation_method)
 
-        expect(workflow).to receive(:some_validation_method).and_return("Some Error")
-        expect(workflow).to receive(:other_validation_method)
+        expect(workflow).to receive(:send).with(:some_validation_method, any_args).and_return("Some Error")
+        expect(workflow).to receive(:send).with(:other_validation_method, any_args)
         expect(workflow.validate({})).to be false
       end
     end

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -6,14 +6,11 @@ describe MiqRequestWorkflow do
   let(:datacenter) { FactoryBot.create(:ems_folder, :type => "Datacenter") }
 
   before("#validate") do
-    module TempModule
-      def some_validation_method; end
-      def other_validation_method; end
-      def some_required_method; end
-      def some_required_method_1; end
-      def some_required_method_2; end
-    end
-    workflow.extend(TempModule)
+    workflow.define_singleton_method(:some_validation_method) {}
+    workflow.define_singleton_method(:other_validation_method) {}
+    workflow.define_singleton_method(:some_required_method) {}
+    workflow.define_singleton_method(:some_required_method_1) {}
+    workflow.define_singleton_method(:some_required_method_2) {}
   end
 
   context "#validate" do

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -5,16 +5,16 @@ describe MiqRequestWorkflow do
   let(:ems_folder) { FactoryBot.create(:ems_folder) }
   let(:datacenter) { FactoryBot.create(:ems_folder, :type => "Datacenter") }
 
-  before("#validate") do
-    workflow.define_singleton_method(:some_validation_method) {}
-    workflow.define_singleton_method(:other_validation_method) {}
-    workflow.define_singleton_method(:some_required_method) {}
-    workflow.define_singleton_method(:some_required_method_1) {}
-    workflow.define_singleton_method(:some_required_method_2) {}
-  end
-
   context "#validate" do
     let(:dialog) { workflow.instance_variable_get(:@dialogs) }
+
+    before do
+      workflow.define_singleton_method(:some_validation_method) {}
+      workflow.define_singleton_method(:other_validation_method) {}
+      workflow.define_singleton_method(:some_required_method) {}
+      workflow.define_singleton_method(:some_required_method_1) {}
+      workflow.define_singleton_method(:some_required_method_2) {}
+    end
 
     context "validation_method" do
       it "skips validation if no validation_method is defined" do


### PR DESCRIPTION
With strict partial validation in place, the current `MiqRequestWorkflow` specs will generate this sort of error because the expected methods are not actually defined on the workflow object:

```
 Failure/Error: expect(workflow).to receive(:some_required_method_1)
       #<MiqProvisionWorkflow:0x000000001be2cf00 @values={:provision_dialog_name=>"miq_provision_dialogs", :miq_request_dialog_name=>"miq_provision_dialogs"}, @filters={}, @requester=#<User id: 19000000000088, name: "Test User 86", email: nil, icon: nil, created_on: "2020-01-09 15:14:17", updated_on: "2020-01-09 15:14:17", userid: "user77", settings: {}, lastlogon: nil, lastlogoff: nil, current_group_id: 19000000000441, first_name: nil, last_name: nil, password_digest: "$2a$10$FTbGT/y/PQ1HvoOoc1FcyuuTtHzfop/uG/mcEAJLYpz...">, @dialogs={:dialogs=>{:customize=>{:description=>"Customize", :fields=>{:root_password=>{:description=>"Root Password", :required=>true, :display=>:edit, :data_type=>:string, :required_method=>[:some_required_method_1, :some_required_method_2]}}}}}> does not implement: some_required_method_1
```

This PR updates the specs so that the workflow object implements those methods first, and modifies the expectation to check for `:send` + `:any_args` since internally it uses `send`, plus a series of arguments

https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_request_workflow.rb#L180