### PR TITLE
[IVANCHUK] Update manageiq-postgres_ha_admin to 3.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "manageiq-api-client",            "~>0.3.3",       :require => false
 gem "manageiq-loggers",               "~>0.3.0",       :require => false
 gem "manageiq-messaging",             "~>0.1.4",       :require => false
 gem "manageiq-password",              "~>0.3",         :require => false
-gem "manageiq-postgres_ha_admin",     "~>3.1",         :require => false
+gem "manageiq-postgres_ha_admin",     "~>3.1", ">=3.1.1", :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)
 gem "money",                          "=6.13.4",       :require => false


### PR DESCRIPTION
For downstream build with existing Gemfile.lock, bundle currently fails with:

```
Bundler could not find compatible versions for gem "linux_admin":
  In Gemfile:
    manageiq-gems-pending was resolved to 0.1.0, which depends on
      linux_admin (~> 2.0)

    manageiq-postgres_ha_admin (~> 3.1) was resolved to 3.1.0, which depends on
      linux_admin (~> 1.0)
```
manageiq-postgres_ha_admin 3.1.1 removes [linux_admin dependency](https://github.com/ManageIQ/manageiq-postgres_ha_admin/pull/19). Needed as a part of linux_admin 2.0 update for https://bugzilla.redhat.com/show_bug.cgi?id=1784556