### PR TITLE
Fix VM Retirement Error Message

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -349,7 +349,7 @@ class VmOrTemplate < ApplicationRecord
     vms = where(:id => src_ids)
 
     missing_ids = src_ids - vms.pluck(:id)
-    _log.error("Retirement of [Vm] IDs: [#{missing_ids.join(', ')}] skipped - target(s) does not exist")
+    _log.error("Retirement of [Vm] IDs: [#{missing_ids.join(', ')}] skipped - target(s) does not exist") if missing_ids.present?
 
     vms.each do |target|
       target.check_policy_prevent('request_vm_retire', "retire_request_after_policy_check", requester.userid, :initiated_by => initiated_by)


### PR DESCRIPTION
Issue error log message only if there are invalid src_ids.

The following error log message is unconditional. It should only be issued when src_ids contains at least one invalid vm id. 
[----] E, [2020-01-13T12:50:10.880878 #10833:46b5e3c] ERROR -- : MIQ(Vm.make_retire_request) Retirement of [Vm] IDs: [] skipped - target(s) does not exist

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1789806

