### PR TITLE
Differentiate deployment names by server

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -31,11 +31,15 @@ class MiqWorker
       "latest"
     end
 
+    def deployment_prefix
+      "#{MiqServer.my_server.compressed_id}-"
+    end
+
     def worker_deployment_name
       @worker_deployment_name ||= begin
         deployment_name = abbreviated_class_name.dup.chomp("Worker").sub("Manager", "").sub(/^Miq/, "")
         deployment_name << "-#{Array(ems_id).map { |id| ApplicationRecord.split_id(id).last }.join("-")}" if respond_to?(:ems_id)
-        deployment_name.underscore.dasherize.tr("/", "-")
+        "#{deployment_prefix}#{deployment_name.underscore.dasherize.tr("/", "-")}"
       end
     end
   end

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -7,11 +7,13 @@ class MiqWorker
     def create_container_objects
       orchestrator = ContainerOrchestrator.new
 
-      orchestrator.create_service(worker_deployment_name, SERVICE_PORT)
+      orchestrator.create_service(service_name, service_label, SERVICE_PORT)
       orchestrator.create_deployment(worker_deployment_name) do |definition|
         configure_worker_deployment(definition)
 
-        definition[:spec][:serviceName] = worker_deployment_name
+        definition[:spec][:serviceName] = service_name
+        definition[:spec][:template][:metadata][:labels].merge!(service_label)
+
         container = definition[:spec][:template][:spec][:containers].first
         container[:ports] = [{:containerPort => SERVICE_PORT}]
         container[:env] << {:name => "PORT", :value => container_port.to_s}
@@ -25,7 +27,7 @@ class MiqWorker
     def delete_container_objects
       orch = ContainerOrchestrator.new
       orch.delete_deployment(worker_deployment_name)
-      orch.delete_service(worker_deployment_name)
+      orch.delete_service(service_name)
     end
 
     def stop_container
@@ -38,6 +40,14 @@ class MiqWorker
         :initialDelaySeconds => 60,
         :timeoutSeconds      => 3
       }
+    end
+
+    def service_label
+      {:service => service_name}
+    end
+
+    def service_name
+      worker_deployment_name.delete_prefix(deployment_prefix)
     end
 
     # Can be overriden by including classes

--- a/lib/container_orchestrator.rb
+++ b/lib/container_orchestrator.rb
@@ -22,8 +22,8 @@ class ContainerOrchestrator
     raise unless e.message =~ /already exists/
   end
 
-  def create_service(name, port)
-    definition = service_definition(name, port)
+  def create_service(name, selector, port)
+    definition = service_definition(name, selector, port)
     yield(definition) if block_given?
     kube_connection.create_service(definition)
   rescue KubeException => e

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -26,7 +26,7 @@ class ContainerOrchestrator
       }
     end
 
-    def service_definition(name, port)
+    def service_definition(name, selector, port)
       {
         :metadata => {
           :name      => name,
@@ -34,7 +34,7 @@ class ContainerOrchestrator
           :namespace => my_namespace
         },
         :spec     => {
-          :selector => {:name => name},
+          :selector => selector,
           :ports    => [{
             :name       => "#{name}-#{port}",
             :port       => port,

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -106,9 +106,11 @@ describe ContainerOrchestrator do
           ports = definition[:spec][:ports]
           expect(ports.first).to eq(:name => "http-80", :port => 80, :targetPort => 80)
           expect(ports.last).to eq(:name => "https", :port => 443, :targetPort => 5000)
+
+          expect(definition[:spec][:selector][:service]).to eq("http")
         end
 
-        subject.create_service("http", 80) do |spec|
+        subject.create_service("http", {:service => "http"}, 80) do |spec|
           spec[:spec][:ports] << {:name => "https", :port => 443, :targetPort => 5000}
         end
       end
@@ -117,7 +119,7 @@ describe ContainerOrchestrator do
         error = KubeException.new(500, "service already exists", "")
         expect(kube_connection_stub).to receive(:create_service).and_raise(error)
 
-        expect { subject.create_service("http", 80) }.not_to raise_error
+        expect { subject.create_service("http", {:service => "http"}, 80) }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
This is required for when we have workers belonging to different
"servers" running in the same namespace.

This commit also attempts to deal with the possibility of multiple
service based worker deployments. We need the service name to remain
static so that we can configure the httpd pod correctly. To achieve
this we strip the server identifier off the front of the worker
deployment name for service workers to get the service name.

This commit deals with multiple service worker deployments by
changing the label selector on the service from the deployment
name to a more generic label for the service name which all
deployments for that service will have.

This allows the single service to front all of the separate service
deployments.

In practice, I would expect a single "server" to run the UI role
so the service to deployment would still be 1-to-1

https://github.com/ManageIQ/manageiq-pods/issues/353