### PR TITLE
Improve class_for_platform regex in MiqProvisionWorkflow

### DIFF
--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -6,7 +6,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
   def self.class_for_platform(platform)
     classy = platform.classify
 
-    if classy =~ /(.*)Infra/
+    if /Infra/.match?(classy)
       find_matching_constant("MiqProvision#{classy}Workflow") ||
         find_matching_constant("ManageIQ::Providers::#{$1}::InfraManager::ProvisionWorkflow")
     else

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -6,7 +6,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
   def self.class_for_platform(platform)
     classy = platform.classify
 
-    if /Infra/.match?(classy)
+    if classy.include?('Infra')
       find_matching_constant("MiqProvision#{classy}Workflow") ||
         find_matching_constant("ManageIQ::Providers::#{$1}::InfraManager::ProvisionWorkflow")
     else


### PR DESCRIPTION
I saw this while refactoring specs, and thought I would come back to it. Currently it's using this regex within the `class_for_platform` singleton method:

`if classy =~ /(.*)Infra/`

However, without anchoring, I cannot see a practical difference over just:

`if classy =~ /Infra/`, which is really just `classy.include?("Infra")`

The downside of the first one, though, is that it's going to add some backtracking that is inefficient. Using `String#include?` is faster.

```
require 'benchmark'

Benchmark.bm(20) do |x|
  MAX = 1000000
  classy = "ManageIQ::Providers::Infra::SomethingManager"

  x.report("classy =~ /(.*)Infra/") do
    MAX.times{ classy =~ /(.*)Infra/ }
  end

  x.report("classy =~ /Infra/") do
    MAX.times{ classy =~ /Infra/ }
  end

  x.report("/(.*)Infra/.match?(classy)") do
    MAX.times{ /(.*)Infra/.match?(classy) }
  end

  x.report("/Infra/.match?(classy)") do
    MAX.times{ /Infra/.match?(classy) }
  end

  x.report("classy[/Infra/]") do
    MAX.times{ classy[/Infra/] }
  end

  x.report("classy.include?(Infra)") do
    MAX.times{ classy.include?('Infra') }
  end
end
```

```
                            user       system     total        real
classy =~ /(.*)Infra/       0.294410   0.000326   0.294736 (  0.295334)
classy =~ /Infra/           0.127747   0.000174   0.127921 (  0.128227)
/(.*)Infra/.match?(classy)  0.259759   0.000408   0.260167 (  0.260929)
/Infra/.match?(classy)      0.100372   0.000213   0.100585 (  0.100987)
classy[/Infra/]             0.199501   0.000369   0.199870 (  0.200308)
classy.include?(Infra)      0.098464   0.000180   0.098644 (  0.098852)
```
Note that `Regexp#match?` (which was optimized in 2.4 - https://bugs.ruby-lang.org/issues/8110) and `String#include?` were very close and in multiple runs there was no clear winner.