### PR TITLE
DRY up get_description method in VmReconfigureTask

### DIFF
--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -9,37 +9,51 @@ class VmReconfigureTask < MiqRequestTask
     VmReconfigureTask
   end
 
-  def self.get_description(req_obj)
-    name = nil
-    if req_obj.source.nil?
-      # Single source has not been selected yet
-      if req_obj.options[:src_ids].length == 1
-        v = Vm.find_by(:id => req_obj.options[:src_ids].first)
-        name = v.nil? ? "" : v.name
-      else
-        name = "Multiple VMs"
-      end
-    else
-      name = req_obj.source.name
-    end
+  def self.get_description(req)
+    options = req.options
 
-    new_settings = []
-    if req_obj.options[:vm_memory].present?
-      new_settings << "Memory: #{req_obj.options[:vm_memory].to_i} MB"
-    end
-    new_settings << "Processor Sockets: #{req_obj.options[:number_of_sockets].to_i}" if req_obj.options[:number_of_sockets].present?
-    new_settings << "Processor Cores Per Socket: #{req_obj.options[:cores_per_socket].to_i}" if req_obj.options[:cores_per_socket].present?
-    new_settings << "Total Processors: #{req_obj.options[:number_of_cpus].to_i}" if req_obj.options[:number_of_cpus].present?
-    new_settings << "Add Disks: #{req_obj.options[:disk_add].length} : #{req_obj.options[:disk_add].collect { |d| d["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) }.join(", ")} " if req_obj.options[:disk_add].present?
-    new_settings << "Remove Disks: #{req_obj.options[:disk_remove].length}" if req_obj.options[:disk_remove].present?
-    new_settings << "Resize Disks: #{req_obj.options[:disk_resize].length}" if req_obj.options[:disk_resize].present?
-    new_settings << "Add Network Adapters: #{req_obj.options[:network_adapter_add].length}" if req_obj.options[:network_adapter_add].present?
-    new_settings << "Remove Network Adapters: #{req_obj.options[:network_adapter_remove].length}" if req_obj.options[:network_adapter_remove].present?
-    new_settings << "Edit Network Adapters: #{req_obj.options[:network_adapter_edit].length}" if req_obj.options[:network_adapter_edit].present?
-    new_settings << "Attach CD/DVDs: #{req_obj.options[:cdrom_connect].length}" if req_obj.options[:cdrom_connect].present?
-    new_settings << "Detach CD/DVDs: #{req_obj.options[:cdrom_disconnect].length}" if req_obj.options[:cdrom_disconnect].present?
-    "#{request_class::TASK_DESCRIPTION} for: #{name} - #{new_settings.join(", ")}"
+    msg = []
+    msg << build_message(options, :vm_memory, "Memory: %d MB")
+    msg << build_message(options, :number_of_sockets, "Processor Sockets: %d")
+    msg << build_message(options, :cores_per_socket, "Processor Cores Per Socket: %d")
+    msg << build_message(options, :number_of_cpus, "Total Processors: %d")
+    msg << build_disk_message(options)
+    msg << build_message(options, :disk_remove, "Remove Disks: %d", :length)
+    msg << build_message(options, :disk_resize, "Resize Disks: %d", :length)
+    msg << build_message(options, :network_adapter_add, "Add Network Adapters: %d", :length)
+    msg << build_message(options, :network_adapter_remove, "Remove Network Adapters: %d", :length)
+    msg << build_message(options, :network_adapter_edit, "Edit Network Adapters: %d", :length)
+    msg << build_message(options, :cdrom_connect, "Attach CD/DVDs: %d", :length)
+    msg << build_message(options, :cdrom_disconnect, "Detach CD/DVDs: %d", :length)
+    "#{request_class::TASK_DESCRIPTION} for: #{display_name(req)} - #{msg.compact.join(", ")}"
   end
+
+  def self.build_message(options, key, message, modifier = nil)
+    if options[key].present?
+      value = options[key]
+      value = value.send(modifier) if modifier
+      message % value
+    end
+  end
+  private_class_method :build_message
+
+  def self.build_disk_message(options)
+    if options[:disk_add].present?
+      disk_sizes = options[:disk_add].collect { |d| d["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) }
+      "Add Disks: #{options[:disk_add].length} : #{disk_sizes.join(", ")} "
+    end
+  end
+  private_class_method :build_disk_message
+
+  def self.display_name(req)
+    return req.source.name if req.source
+    return "Multiple VMs"  if req.options[:src_ids].length > 1
+
+    # Single source has not been selected yet
+    vm = Vm.find_by(:id => req.options[:src_ids])
+    vm.nil? ? "" : vm.name
+  end
+  private_class_method :display_name
 
   def after_request_task_create
     update_attribute(:description, get_description)

--- a/spec/models/vm_reconfigure_task_spec.rb
+++ b/spec/models/vm_reconfigure_task_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe VmReconfigureTask do
   end
 
   context "Single Disk add " do
-    let(:request_options) { {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}]} }
+    let(:request_options) { {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}.with_indifferent_access]} }
     let(:description_partial) { "Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} " }
 
     it_behaves_like ".get_description"
@@ -48,8 +48,8 @@ RSpec.describe VmReconfigureTask do
 
   context "Multiple Disk add " do
     let(:request_options) do
-      {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"},
-                     {"disk_size_in_mb" => "44", "persistent" => "true"}]}
+      {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}.with_indifferent_access,
+                     {"disk_size_in_mb" => "44", "persistent" => "true"}.with_indifferent_access]}
     end
     let(:description_partial) do
       "Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
@@ -73,31 +73,38 @@ RSpec.describe VmReconfigureTask do
 
   context "Disk remove/resize" do
     let(:request_options) do
-      {:disk_remove => [1],
-       :disk_resize => [1, 2]}
+      {:disk_remove => [{:disk_name => "e88da36f", :delete_backing => false}.with_indifferent_access],
+       :disk_resize => [{:disk_name => "e88da36f", :disk_size_in_mb => 153_600}.with_indifferent_access]}
     end
-    let(:description_partial) { "Remove Disks: 1, Resize Disks: 2" }
+    let(:description_partial) { "Remove Disks: 1, Resize Disks: 1" }
 
     it_behaves_like ".get_description"
   end
 
   context "Network" do
     let(:request_options) do
-      {:network_adapter_add    => [1],
-       :network_adapter_remove => [1, 2],
-       :network_adapter_edit   => [1, 2, 3]}
+      {:network_adapter_add    => [
+        {:cloud_network => 'vApp Network Name', :name => 'VM Name#NIC#2'}.with_indifferent_access,
+        {:cloud_network => nil, :name => 'VM Name#NIC#3'}.with_indifferent_access
+      ],
+       :network_adapter_remove => [{:network => {:name => 'VM Name#NIC#0'}.with_indifferent_access}],
+       :network_adapter_edit   => [{:network => "NFS Network", :name => "Network adapter 1"}.with_indifferent_access]}
     end
-    let(:description_partial) { "Add Network Adapters: 1, Remove Network Adapters: 2, Edit Network Adapters: 3" }
+    let(:description_partial) { "Add Network Adapters: 2, Remove Network Adapters: 1, Edit Network Adapters: 1" }
 
     it_behaves_like ".get_description"
   end
 
   context "CDROM" do
     let(:request_options) do
-      {:cdrom_connect    => [1],
-       :cdrom_disconnect => [1, 2]}
+      {:cdrom_connect    => [
+        {:device_name => "CD/DVD drive 1",
+         :filename    => "[NFS Share] ISO/centos.iso",
+         :storage_id  => 1234}.with_indifferent_access
+      ],
+       :cdrom_disconnect => [{:device_name => "CD/DVD drive 2"}.with_indifferent_access]}
     end
-    let(:description_partial) { "Attach CD/DVDs: 1, Detach CD/DVDs: 2" }
+    let(:description_partial) { "Attach CD/DVDs: 1, Detach CD/DVDs: 1" }
 
     it_behaves_like ".get_description"
   end

--- a/spec/models/vm_reconfigure_task_spec.rb
+++ b/spec/models/vm_reconfigure_task_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe VmReconfigureTask do
                              :request_type => 'vm_reconfigure')
   end
 
+  shared_examples_for ".get_description" do
+    it "should get the task description" do
+      expect(VmReconfigureTask.get_description(request)).to include(description_partial)
+    end
+  end
+
   describe ".base_model" do
     it "should return VmReconfigureTask" do
       expect(VmReconfigureTask.base_model).to eq(VmReconfigureTask)
@@ -35,12 +41,9 @@ RSpec.describe VmReconfigureTask do
 
   context "Single Disk add " do
     let(:request_options) { {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}]} }
+    let(:description_partial) { "Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} " }
 
-    describe ".get_description" do
-      it "should get the task description" do
-        expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} ")
-      end
-    end
+    it_behaves_like ".get_description"
   end
 
   context "Multiple Disk add " do
@@ -48,12 +51,54 @@ RSpec.describe VmReconfigureTask do
       {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"},
                      {"disk_size_in_mb" => "44", "persistent" => "true"}]}
     end
-
-    describe ".get_description" do
-      it "should get the task description" do
-        expect(VmReconfigureTask.get_description(request)).to eq("VM Reconfigure for: #{vm} - Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
-          "#{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} ")
-      end
+    let(:description_partial) do
+      "Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
+      "#{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} "
     end
+
+    it_behaves_like ".get_description"
+  end
+
+  context "Hardware Properties" do
+    let(:request_options) do
+      {:vm_memory         => 512,
+       :number_of_sockets => 2,
+       :cores_per_socket  => 4,
+       :number_of_cpus    => 1}
+    end
+    let(:description_partial) { "Memory: 512 MB, Processor Sockets: 2, Processor Cores Per Socket: 4, Total Processors: 1" }
+
+    it_behaves_like ".get_description"
+  end
+
+  context "Disk remove/resize" do
+    let(:request_options) do
+      {:disk_remove => [1],
+       :disk_resize => [1, 2]}
+    end
+    let(:description_partial) { "Remove Disks: 1, Resize Disks: 2" }
+
+    it_behaves_like ".get_description"
+  end
+
+  context "Network" do
+    let(:request_options) do
+      {:network_adapter_add    => [1],
+       :network_adapter_remove => [1, 2],
+       :network_adapter_edit   => [1, 2, 3]}
+    end
+    let(:description_partial) { "Add Network Adapters: 1, Remove Network Adapters: 2, Edit Network Adapters: 3" }
+
+    it_behaves_like ".get_description"
+  end
+
+  context "CDROM" do
+    let(:request_options) do
+      {:cdrom_connect    => [1],
+       :cdrom_disconnect => [1, 2]}
+    end
+    let(:description_partial) { "Attach CD/DVDs: 1, Detach CD/DVDs: 2" }
+
+    it_behaves_like ".get_description"
   end
 end


### PR DESCRIPTION
While reviewing the changes in https://github.com/ManageIQ/manageiq/pull/19681 it felt like this method could use a little refactoring to DRY up the logic around building the request description.

Most of the logic moved into the `build_message` method with the more complex disk logic getting a separate `build_disk_message` method.  Finally I moved the name logic into it's own method to make things a little easier to read.

This is just a refactoring with test coverage in the existing spec: https://github.com/ManageIQ/manageiq/blob/master/spec/models/vm_reconfigure_task_spec.rb

Need to add a little more spec coverage.