### PR TITLE
[V2V] Fix migration workflow

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -307,9 +307,13 @@ class InfraConversionJob < Job
     # If the target VM is powered off, we won't get an IP address, so no need to wait.
     # We don't block powered off VMs, because the playbook could still be relevant.
     if target_vm.power_state == 'on'
-      if target_vm.ipaddresses.empty?
-        update_migration_task_progress(:on_retry)
-        return queue_signal(:wait_for_ip_address)
+      # If the source VM didn't report IP addresses during pre-flight check, there's no need to wait.
+      # We don't block VMsi with no IP address, because the playbook could still be relevant.
+      unless migration_task.options[:source_vm_ipaddresses].empty?
+        if target_vm.ipaddresses.empty?
+          update_migration_task_progress(:on_retry)
+          return queue_signal(:wait_for_ip_address)
+        end
       end
     end
 

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -121,7 +121,7 @@ class InfraConversionJob < Job
         :max_retries => 15.minutes / state_retry_interval
       },
       :marking_vm_migrated           => {
-        :description => "Mark source as migrated",
+        :description => "Virtual machine successfully migrated",
         :weight      => 1
       },
       :aborting_virtv2v              => {
@@ -542,13 +542,11 @@ class InfraConversionJob < Job
     return queue_signal(:wait_for_ip_address) if target_vm.power_state == 'on' && !migration_task.canceling?
 
     migration_task.canceled if migration_task.canceling?
-    handover_to_automate
-    queue_signal(:poll_automate_state_machine)
+    queue_signal(:mark_vm_migrated)
   rescue StandardError
     update_migration_task_progress(:on_error)
     migration_task.canceled if migration_task.canceling?
-    handover_to_automate
-    queue_signal(:poll_automate_state_machine)
+    queue_signal(:mark_vm_migrated)
   end
 
   def poll_power_on_vm_complete

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -64,7 +64,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   #  virtv2v_disks and network_mappings in task options
   def preflight_check
     raise 'OSP destination and source power_state is off' if destination_ems.emstype == 'openstack' && source.power_state == 'off'
-    update_options(:source_vm_power_state => source.power_state) # This will determine power_state of destination_vm
+    update_options(
+      :source_vm_power_state => source.power_state, # This will determine power_state of destination_vm
+      :source_vm_ipaddresses => source.ipaddresses  # This will determine if we need to wait for ip addresses to appear
+    )
     destination_cluster
     virtv2v_disks
     network_mappings
@@ -174,7 +177,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def cancel
     update!(:cancelation_status => MiqRequestTask::CANCEL_STATUS_REQUESTED)
-    infra_conversion_job.cancel
   end
 
   def canceling

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -252,8 +252,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def cutover
-    unless conversion_host.create_cutover_file(options[:virtv2v_wrapper]['cutover_file'])
-      raise _("Couldn't create cutover file for #{source.name} on #{conversion_host.name}")
+    if options[:virtv2v_wrapper]['cutover_file'].present?
+      unless conversion_host.create_cutover_file(options[:virtv2v_wrapper]['cutover_file'])
+        raise _("Couldn't create cutover file for #{source.name} on #{conversion_host.name}")
+      end
     end
   end
 

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -783,6 +783,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
       it_behaves_like 'allows poll_power_on_vm_complete signal'
       it_behaves_like 'allows wait_for_ip_address signal'
+      it_behaves_like 'allows mark_vm_migrated signal'
       it_behaves_like 'allows poll_automate_state_machine signal'
       it_behaves_like 'allows finish signal'
       it_behaves_like 'allows abort_job signal'
@@ -801,7 +802,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
       it_behaves_like 'doesn\'t allow apply_right_sizing signal'
       it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
-      it_behaves_like 'doesn\'t allow mark_vm_migrated signal'
       it_behaves_like 'doesn\'t allow power_on_vm signal'
     end
 

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -991,7 +991,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
     context '#wait_for_ip_address' do
       before do
-        task.update_options(:migration_phase => 'pre')
+        task.update_options(:migration_phase => 'pre', :source_vm_ipaddresses => ['10.0.0.1'])
         job.state = 'started'
       end
 
@@ -1515,9 +1515,8 @@ RSpec.describe InfraConversionJob, :v2v do
       task.update_options(:source_vm_power_state => 'off')
       expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
       expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-      expect(job).to receive(:queue_signal).with(:poll_automate_state_machine)
+      expect(job).to receive(:queue_signal).with(:mark_vm_migrated)
       job.signal(:power_on_vm)
-      expect(task.reload.options[:workflow_runner]).to eq('automate')
     end
 
     it 'sends start request to VM if VM is off' do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -196,9 +196,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
     describe '#cancel' do
       it 'catches cancel state' do
-        task.options[:infra_conversion_job_id] = infra_conversion_job.id
-        expect(task).to receive(:infra_conversion_job).and_return(infra_conversion_job)
-        expect(infra_conversion_job).to receive(:cancel)
         task.cancel
         expect(task.cancelation_status).to eq(MiqRequestTask::CANCEL_STATUS_REQUESTED)
         expect(task.cancel_requested?).to be_truthy


### PR DESCRIPTION
When testing the changes done to the migration workflow, we identified a few issues that are fixed by this pull request.

1. If the virtual machine is powered on  and doesn't have an IP address, it will stay in the `waiting_for_ip_address` state until timeout. And the timeout will fail the migration. We register the IP addresses of the VM in `preflight_check` method and check the list is not empty.

2. When an error occurs, the infra_conversion_job cancel the migration_task, that in turn cancels the job. It leads to a duplicate cancellation.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789433