### PR TITLE
Use RSpec.describe in outer block for all specs

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,4 +1,4 @@
-describe Account do
+RSpec.describe Account do
   let(:user_account1) { FactoryBot.create(:account_user) }
   let(:group_account1) { FactoryBot.create(:account_group) }
 

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -1,4 +1,4 @@
-describe ApplicationRecord do
+RSpec.describe ApplicationRecord do
   context ".human_attribute_name includes the class name in the validation error for easier troubleshooting" do
     it "single level" do
       Zone.create!(:name => "example", :description => "example")

--- a/spec/models/assigned_server_role_spec.rb
+++ b/spec/models/assigned_server_role_spec.rb
@@ -1,4 +1,4 @@
-describe AssignedServerRole do
+RSpec.describe AssignedServerRole do
   context "and Server Role seeded for 1 Region/Zone" do
     before do
       @miq_server = EvmSpecHelper.local_miq_server

--- a/spec/models/async_delete_mixin_spec.rb
+++ b/spec/models/async_delete_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe AsyncDeleteMixin do
+RSpec.describe AsyncDeleteMixin do
   def common_setup(klass)
     objects = []
     3.times do |i|

--- a/spec/models/audit_event_spec.rb
+++ b/spec/models/audit_event_spec.rb
@@ -1,4 +1,4 @@
-describe AuditEvent do
+RSpec.describe AuditEvent do
   it "should be invalid with empty attributes" do
     event = AuditEvent.new
     expect(event).not_to be_valid

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,4 +1,4 @@
-describe Authentication do
+RSpec.describe Authentication do
   describe ".set_ownership" do
     let!(:authentication) { FactoryBot.create(:authentication) }
     let(:tenant) { FactoryBot.create(:tenant) }

--- a/spec/models/authenticator/database_spec.rb
+++ b/spec/models/authenticator/database_spec.rb
@@ -1,4 +1,4 @@
-describe Authenticator::Database do
+RSpec.describe Authenticator::Database do
   subject { Authenticator::Database.new({}) }
   let!(:alice) { FactoryBot.create(:user, :userid => 'alice', :password => 'secret') }
   let!(:vincent) { FactoryBot.create(:user, :userid => 'Vincent', :password => 'secret') }

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -1,4 +1,4 @@
-describe Authenticator::Httpd do
+RSpec.describe Authenticator::Httpd do
   subject { Authenticator::Httpd.new(config) }
   let!(:alice) { FactoryBot.create(:user, :userid => 'alice') }
   let!(:cheshire) { FactoryBot.create(:user, :userid => 'cheshire@example.com') }

--- a/spec/models/authenticator/ldap_spec.rb
+++ b/spec/models/authenticator/ldap_spec.rb
@@ -1,4 +1,4 @@
-describe Authenticator::Ldap do
+RSpec.describe Authenticator::Ldap do
   subject { Authenticator::Ldap.new(config) }
   let!(:alice) { FactoryBot.create(:user, :userid => 'alice') }
   let(:config) do

--- a/spec/models/authenticator_spec.rb
+++ b/spec/models/authenticator_spec.rb
@@ -1,4 +1,4 @@
-describe Authenticator do
+RSpec.describe Authenticator do
   describe '.for' do
     it "instantiates the matching class" do
       expect(Authenticator.for(:mode => 'database')).to be_a(Authenticator::Database)

--- a/spec/models/automate_workspace_spec.rb
+++ b/spec/models/automate_workspace_spec.rb
@@ -1,4 +1,4 @@
-describe AutomateWorkspace do
+RSpec.describe AutomateWorkspace do
   describe "#merge_output!" do
     let(:aw) { FactoryBot.create(:automate_workspace, :input => input) }
     let(:password) { "ca$hc0w" }

--- a/spec/models/automation_request_spec.rb
+++ b/spec/models/automation_request_spec.rb
@@ -1,4 +1,4 @@
-describe AutomationRequest do
+RSpec.describe AutomationRequest do
   let(:admin) { FactoryBot.create(:user, :role => "admin") }
   before do
     MiqRegion.seed

--- a/spec/models/automation_task_spec.rb
+++ b/spec/models/automation_task_spec.rb
@@ -1,4 +1,4 @@
-describe AutomationTask do
+RSpec.describe AutomationTask do
   before do
     allow(MiqServer).to receive(:my_zone).and_return("default")
     @admin       = FactoryBot.create(:user_admin)

--- a/spec/models/availability_zone_spec.rb
+++ b/spec/models/availability_zone_spec.rb
@@ -1,4 +1,4 @@
-describe AvailabilityZone do
+RSpec.describe AvailabilityZone do
   it ".available" do
     FactoryBot.create(:availability_zone_amazon)
     FactoryBot.create(:availability_zone_openstack)

--- a/spec/models/binary_blob_part_spec.rb
+++ b/spec/models/binary_blob_part_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-describe BinaryBlobPart do
+RSpec.describe BinaryBlobPart do
   context "#data= and #data" do
     let(:part) { FactoryBot.build(:binary_blob_part) }
 

--- a/spec/models/binary_blob_spec.rb
+++ b/spec/models/binary_blob_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-describe BinaryBlob do
+RSpec.describe BinaryBlob do
   context "#binary= and #binary" do
     before { @blob = FactoryBot.build(:binary_blob, :name => "test") }
 

--- a/spec/models/blacklisted_event_spec.rb
+++ b/spec/models/blacklisted_event_spec.rb
@@ -1,6 +1,6 @@
 require 'workers/event_catcher'
 
-describe BlacklistedEvent do
+RSpec.describe BlacklistedEvent do
   let(:total_blacklist_entry_count) { ExtManagementSystem.descendants.collect(&:default_blacklisted_event_names).flatten.count }
   before do
     MiqRegion.seed

--- a/spec/models/bottleneck_event_spec.rb
+++ b/spec/models/bottleneck_event_spec.rb
@@ -1,4 +1,4 @@
-describe BottleneckEvent do
+RSpec.describe BottleneckEvent do
   describe ".future_event_definitions_for_obj" do
     it "contains things" do
       MiqEventDefinition.seed_default_definitions(MiqEventDefinition.all.group_by(&:name))

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,4 +1,4 @@
-describe Category do
+RSpec.describe Category do
   describe "#tags" do
     it "works" do
       clergy        = FactoryBot.create(:classification,     :name => "clergy", :single_value => 1)

--- a/spec/models/chargeback/consumption_with_rollups_spec.rb
+++ b/spec/models/chargeback/consumption_with_rollups_spec.rb
@@ -1,4 +1,4 @@
-describe Chargeback::ConsumptionWithRollups do
+RSpec.describe Chargeback::ConsumptionWithRollups do
   let(:vm)          { FactoryBot.create(:vm_microsoft) }
   let(:consumption) { described_class.new(pluck_rollup([metric_rollup]), starting_date, starting_date + 1.day) }
 

--- a/spec/models/chargeback/consumption_without_rollups_spec.rb
+++ b/spec/models/chargeback/consumption_without_rollups_spec.rb
@@ -1,4 +1,4 @@
-describe Chargeback::ConsumptionWithoutRollups do
+RSpec.describe Chargeback::ConsumptionWithoutRollups do
   let(:cores) { 7 }
   let(:mem_mb) { 1777 }
   let(:disk_size) { 12_345 }

--- a/spec/models/chargeback_container_image_spec.rb
+++ b/spec/models/chargeback_container_image_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackContainerImage do
+RSpec.describe ChargebackContainerImage do
   include Spec::Support::ChargebackHelper
 
   let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }

--- a/spec/models/chargeback_container_project_spec.rb
+++ b/spec/models/chargeback_container_project_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackContainerProject do
+RSpec.describe ChargebackContainerProject do
   include Spec::Support::ChargebackHelper
 
   let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }

--- a/spec/models/chargeback_rate_detail_measure_spec.rb
+++ b/spec/models/chargeback_rate_detail_measure_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackRateDetailMeasure do
+RSpec.describe ChargebackRateDetailMeasure do
   it "has a valid factory" do
     expect(FactoryBot.create(:chargeback_rate_detail_measure)).to be_valid
   end

--- a/spec/models/chargeback_rate_detail_spec.rb
+++ b/spec/models/chargeback_rate_detail_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackRateDetail do
+RSpec.describe ChargebackRateDetail do
   let(:field) { FactoryBot.build(:chargeable_field) }
   describe "#chargeback_rate" do
     it "is invalid without a valid chargeback_rate" do

--- a/spec/models/chargeback_rate_spec.rb
+++ b/spec/models/chargeback_rate_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackRate do
+RSpec.describe ChargebackRate do
   describe "#rate_details_relevant_to" do
     let(:count_hourly_variable_tier_rate) { {:variable_rate => '10'} }
 

--- a/spec/models/chargeback_vm/ongoing_time_period_spec.rb
+++ b/spec/models/chargeback_vm/ongoing_time_period_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackVm do
+RSpec.describe ChargebackVm do
   let(:admin) { FactoryBot.create(:user_admin) }
   let(:start_of_all_intervals) { Time.parse('2007-01-01 00:00:00Z').utc } # 0hours, Monday, 1st of month
   let(:consumed_hours) { 17 }

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -1,4 +1,4 @@
-describe ChargebackVm do
+RSpec.describe ChargebackVm do
   include Spec::Support::ChargebackHelper
 
   let(:admin) { FactoryBot.create(:user_admin) }

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -1,4 +1,4 @@
-describe Classification do
+RSpec.describe Classification do
   context ".hash_all_by_type_and_name" do
     it "with entries duped across categories should return both entries" do
       clergy        = FactoryBot.create(:classification,     :name => "clergy", :single_value => 1)

--- a/spec/models/compliance/purging_spec.rb
+++ b/spec/models/compliance/purging_spec.rb
@@ -1,4 +1,4 @@
-describe Compliance do
+RSpec.describe Compliance do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/compliance_spec.rb
+++ b/spec/models/compliance_spec.rb
@@ -1,4 +1,4 @@
-describe Compliance do
+RSpec.describe Compliance do
   context "A small virtual infrastructure" do
     let(:ems_vmware) { FactoryBot.create(:ems_vmware, :zone => zone) }
     let(:host1)      { FactoryBot.create(:host, :ext_management_system => ems_vmware) }

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,4 +1,4 @@
-describe Condition do
+RSpec.describe Condition do
   describe ".subst" do
     context "evaluation of virtual custom attributes from left and right side" do
       let(:custom_attribute_1)         { FactoryBot.create(:custom_attribute, :name => "attr_1", :value => 20) }

--- a/spec/models/configuration_location_spec.rb
+++ b/spec/models/configuration_location_spec.rb
@@ -1,3 +1,3 @@
-describe ConfigurationLocation do
+RSpec.describe ConfigurationLocation do
   it { expect(described_class.new(:title => "x").display_name).to eq("x") }
 end

--- a/spec/models/configuration_organization_spec.rb
+++ b/spec/models/configuration_organization_spec.rb
@@ -1,3 +1,3 @@
-describe ConfigurationOrganization do
+RSpec.describe ConfigurationOrganization do
   it { expect(described_class.new(:title => "x").display_name).to eq("x") }
 end

--- a/spec/models/configured_system_spec.rb
+++ b/spec/models/configured_system_spec.rb
@@ -1,4 +1,4 @@
-describe ConfiguredSystem do
+RSpec.describe ConfiguredSystem do
   it "#counterparts" do
     vm  = FactoryBot.create(:vm)
     cs1 = FactoryBot.create(:configured_system, :counterpart => vm)

--- a/spec/models/container/purging_spec.rb
+++ b/spec/models/container/purging_spec.rb
@@ -1,4 +1,4 @@
-describe Container do
+RSpec.describe Container do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_group/purging_spec.rb
+++ b/spec/models/container_group/purging_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerGroup do
+RSpec.describe ContainerGroup do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_group_spec.rb
+++ b/spec/models/container_group_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerGroup do
+RSpec.describe ContainerGroup do
   it "has container volumes and pods" do
     pvc = FactoryBot.create(
       :persistent_volume_claim,

--- a/spec/models/container_image/container_image_spec.rb
+++ b/spec/models/container_image/container_image_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerImage do
+RSpec.describe ContainerImage do
   it "counts containers" do
     group = FactoryBot.create(
       :container_group,

--- a/spec/models/container_image/purging_spec.rb
+++ b/spec/models/container_image/purging_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerImage do
+RSpec.describe ContainerImage do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_image_registry_spec.rb
+++ b/spec/models/container_image_registry_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerImageRegistry do
+RSpec.describe ContainerImageRegistry do
   it "#full_name" do
     reg = ContainerImageRegistry.new(:name => "docker.io", :host => "docker.io")
     expect(reg.full_name).to eq("docker.io")

--- a/spec/models/container_image_spec.rb
+++ b/spec/models/container_image_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerImage do
+RSpec.describe ContainerImage do
   it "#full_name" do
     image = ContainerImage.new(:name => "fedora")
     expect(image.full_name).to eq("fedora")

--- a/spec/models/container_label_tag_mapping_spec.rb
+++ b/spec/models/container_label_tag_mapping_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerLabelTagMapping do
+RSpec.describe ContainerLabelTagMapping do
   let(:cat_classification) { FactoryBot.create(:classification, :read_only => true, :name => 'kubernetes:1') }
   let(:cat_tag) { cat_classification.tag }
   let(:tag1) { cat_classification.add_entry(:name => 'value_1', :description => 'value-1').tag }

--- a/spec/models/container_node/purging_spec.rb
+++ b/spec/models/container_node/purging_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerNode do
+RSpec.describe ContainerNode do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_project/purging_spec.rb
+++ b/spec/models/container_project/purging_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerProject do
+RSpec.describe ContainerProject do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_quota/purging_spec.rb
+++ b/spec/models/container_quota/purging_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerQuota do
+RSpec.describe ContainerQuota do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_quota_item/purging_spec.rb
+++ b/spec/models/container_quota_item/purging_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerQuotaItem do
+RSpec.describe ContainerQuotaItem do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/container_quota_item_spec.rb
+++ b/spec/models/container_quota_item_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerQuotaItem do
+RSpec.describe ContainerQuotaItem do
   it "converts float to string" do
     quota_item = ContainerQuotaItem.new(:resource       => 'cpu',
                                         :quota_desired  => 4.2,

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -1,4 +1,4 @@
-describe Currency do
+RSpec.describe Currency do
   describe '.seed' do
     it "returns supported currencies" do
       Currency.seed

--- a/spec/models/custom_attribute_spec.rb
+++ b/spec/models/custom_attribute_spec.rb
@@ -1,4 +1,4 @@
-describe CustomAttribute do
+RSpec.describe CustomAttribute do
   let(:string_custom_attribute) { FactoryBot.build(:custom_attribute, :name => "foo", :value => "string", :resource_type => 'ExtManagementSystem') }
   let(:time_custom_attribute) { FactoryBot.build(:custom_attribute, :name => "bar", :value => DateTime.current, :resource_type => 'ExtManagementSystem') }
   let(:int_custom_attribute) { FactoryBot.build(:custom_attribute, :name => "foobar", :value => 5, :resource_type => 'ExtManagementSystem') }

--- a/spec/models/custom_button_event_spec.rb
+++ b/spec/models/custom_button_event_spec.rb
@@ -1,4 +1,4 @@
-describe CustomButtonEvent do
+RSpec.describe CustomButtonEvent do
   let(:custom_button) { FactoryBot.create(:custom_button, :applies_to_class => "Vm", :name => "Test Button") }
   let(:ae_entry_point) { "/SYSTEM/PROCESS/Request" }
   let(:cb_event) do

--- a/spec/models/custom_button_set_spec.rb
+++ b/spec/models/custom_button_set_spec.rb
@@ -1,4 +1,4 @@
-describe CustomButtonSet do
+RSpec.describe CustomButtonSet do
   context "find_all_by_class_name" do
     it "should return all Service and ServiceTemplate buttons only, when ServiceTemplate class is passed in" do
       set_data = {:applies_to_class => "Service", :group_index => 2}

--- a/spec/models/custom_button_spec.rb
+++ b/spec/models/custom_button_spec.rb
@@ -1,4 +1,4 @@
-describe CustomButton do
+RSpec.describe CustomButton do
   describe '.with_array_order' do
     context 'order by array' do
       let!(:custom_button_1) { FactoryBot.create(:custom_button, :name => 'AAA', :applies_to_id => 100, :applies_to_class => Vm) }

--- a/spec/models/customization_template_cloud_init_spec.rb
+++ b/spec/models/customization_template_cloud_init_spec.rb
@@ -1,4 +1,4 @@
-describe CustomizationTemplateCloudInit do
+RSpec.describe CustomizationTemplateCloudInit do
   context "#default_filename" do
     it "should be user-data.txt" do
       expect(described_class.new.default_filename).to eq('user-data.txt')

--- a/spec/models/customization_template_spec.rb
+++ b/spec/models/customization_template_spec.rb
@@ -1,4 +1,4 @@
-describe CustomizationTemplate do
+RSpec.describe CustomizationTemplate do
   context "unique name validation" do
     it "doesn't allow same name, same pxe_image_type in same region" do
       pit = FactoryBot.create(:pxe_image_type)

--- a/spec/models/customization_template_sysprep_spec.rb
+++ b/spec/models/customization_template_sysprep_spec.rb
@@ -1,4 +1,4 @@
-describe CustomizationTemplateSysprep do
+RSpec.describe CustomizationTemplateSysprep do
   context "#default_filename" do
     it "should be unattend.xml" do
       expect(described_class.new.default_filename).to eq('unattend.xml')

--- a/spec/models/database_backup_spec.rb
+++ b/spec/models/database_backup_spec.rb
@@ -1,4 +1,4 @@
-describe DatabaseBackup do
+RSpec.describe DatabaseBackup do
   context "region" do
     let!(:region) { FactoryBot.create(:miq_region, :region => 3) }
 

--- a/spec/models/dialog/ansible_playbook_service_dialog_spec.rb
+++ b/spec/models/dialog/ansible_playbook_service_dialog_spec.rb
@@ -1,4 +1,4 @@
-describe Dialog::AnsiblePlaybookServiceDialog do
+RSpec.describe Dialog::AnsiblePlaybookServiceDialog do
   describe "#create_dialog" do
     it "creates a dialog for a playbook with variables" do
       extra_vars = {

--- a/spec/models/dialog/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/models/dialog/ansible_tower_job_template_dialog_service_spec.rb
@@ -1,4 +1,4 @@
-describe Dialog::AnsibleTowerJobTemplateDialogService do
+RSpec.describe Dialog::AnsibleTowerJobTemplateDialogService do
   let(:template) { FactoryBot.create(:ansible_configuration_script) }
   let(:survey) do
     "{\"spec\":[{\"index\": 0, \"question_name\": \"Param1\", \"min\": 10, \

--- a/spec/models/dialog/container_template_service_dialog_spec.rb
+++ b/spec/models/dialog/container_template_service_dialog_spec.rb
@@ -1,4 +1,4 @@
-describe Dialog::ContainerTemplateServiceDialog do
+RSpec.describe Dialog::ContainerTemplateServiceDialog do
   describe "#create_dialog" do
     let(:container_template) { FactoryBot.create(:container_template) }
     let(:params) { [] }

--- a/spec/models/dialog/orchestration_template_service_dialog_spec.rb
+++ b/spec/models/dialog/orchestration_template_service_dialog_spec.rb
@@ -1,4 +1,4 @@
-describe Dialog::OrchestrationTemplateServiceDialog do
+RSpec.describe Dialog::OrchestrationTemplateServiceDialog do
   let(:orchestration_template) do
     FactoryBot.create(:orchestration_template).tap do |template|
       allow(template).to receive(:parameter_groups).and_return(param_groups)

--- a/spec/models/dialog_field_association_validator_spec.rb
+++ b/spec/models/dialog_field_association_validator_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldAssociationValidator do
+RSpec.describe DialogFieldAssociationValidator do
   let(:dialog_field_association_validator) { described_class.new }
 
   describe "circular_references" do

--- a/spec/models/dialog_field_check_box_spec.rb
+++ b/spec/models/dialog_field_check_box_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldCheckBox do
+RSpec.describe DialogFieldCheckBox do
   describe "#checked?" do
     let(:dialog_field) { described_class.new(:value => value) }
 

--- a/spec/models/dialog_field_date_control_spec.rb
+++ b/spec/models/dialog_field_date_control_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldDateControl do
+RSpec.describe DialogFieldDateControl do
   describe "#value" do
     let(:dialog_field) { described_class.new(:dynamic => dynamic, :value => value) }
 

--- a/spec/models/dialog_field_date_time_control_spec.rb
+++ b/spec/models/dialog_field_date_time_control_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldDateTimeControl do
+RSpec.describe DialogFieldDateTimeControl do
   context "legacy tests" do
     let!(:user) do
       User.current_user = FactoryBot.create(:user)

--- a/spec/models/dialog_field_drop_down_list_spec.rb
+++ b/spec/models/dialog_field_drop_down_list_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldDropDownList do
+RSpec.describe DialogFieldDropDownList do
   context "dialog_field_drop_down_list" do
     let(:data_type) { "string" }
     let(:sort_by) { :description }

--- a/spec/models/dialog_field_importer_spec.rb
+++ b/spec/models/dialog_field_importer_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldImporter do
+RSpec.describe DialogFieldImporter do
   let(:dialog_field_importer) { described_class.new }
 
   describe "#import_field" do

--- a/spec/models/dialog_field_radio_button_spec.rb
+++ b/spec/models/dialog_field_radio_button_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldRadioButton do
+RSpec.describe DialogFieldRadioButton do
   let(:dialog_field_radio_button) do
     DialogFieldRadioButton.new(
       :dialog          => dialog,

--- a/spec/models/dialog_field_serializer_spec.rb
+++ b/spec/models/dialog_field_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldSerializer do
+RSpec.describe DialogFieldSerializer do
   let(:resource_action_serializer) { double("ResourceActionSerializer") }
   let(:dialog_field_serializer) { described_class.new(resource_action_serializer) }
 

--- a/spec/models/dialog_field_sorted_item_spec.rb
+++ b/spec/models/dialog_field_sorted_item_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldSortedItem do
+RSpec.describe DialogFieldSortedItem do
   describe "#initialize_value_context" do
     let(:dialog_field) do
       described_class.new(

--- a/spec/models/dialog_field_spec.rb
+++ b/spec/models/dialog_field_spec.rb
@@ -1,4 +1,4 @@
-describe DialogField do
+RSpec.describe DialogField do
   context "legacy tests" do
 
     let(:df) { FactoryBot.create(:dialog_field) }

--- a/spec/models/dialog_field_tag_control_spec.rb
+++ b/spec/models/dialog_field_tag_control_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldTagControl do
+RSpec.describe DialogFieldTagControl do
   def add_entry(cat, options)
     raise "entries can only be added to classifications" unless cat.category?
     # Inherit from parent classification

--- a/spec/models/dialog_field_text_area_box_spec.rb
+++ b/spec/models/dialog_field_text_area_box_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldTextAreaBox do
+RSpec.describe DialogFieldTextAreaBox do
   let(:dialog_field) { described_class.new }
 
   describe "#normalize_automate_values" do

--- a/spec/models/dialog_field_text_box_spec.rb
+++ b/spec/models/dialog_field_text_box_spec.rb
@@ -1,4 +1,4 @@
-describe DialogFieldTextBox do
+RSpec.describe DialogFieldTextBox do
   describe "#initialize_value_context" do
     let(:field) do
       described_class.new(

--- a/spec/models/dialog_group_serializer_spec.rb
+++ b/spec/models/dialog_group_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe DialogGroupSerializer do
+RSpec.describe DialogGroupSerializer do
   let(:dialog_field_serializer) { double("DialogFieldSerializer") }
   let(:dialog_group_serializer) { described_class.new(dialog_field_serializer) }
 

--- a/spec/models/dialog_group_spec.rb
+++ b/spec/models/dialog_group_spec.rb
@@ -1,4 +1,4 @@
-describe DialogGroup do
+RSpec.describe DialogGroup do
   let(:dialog_group) { FactoryBot.build(:dialog_group, :label => 'group') }
   context "#validate_children" do
     it "fails without element" do

--- a/spec/models/dialog_import_validator_spec.rb
+++ b/spec/models/dialog_import_validator_spec.rb
@@ -1,4 +1,4 @@
-describe DialogImportValidator do
+RSpec.describe DialogImportValidator do
   let(:dialog_field_association_validator) { instance_double("DialogFieldAssociationValidator") }
   let(:dialog_import_validator) { described_class.new(dialog_field_association_validator) }
 

--- a/spec/models/dialog_serializer_spec.rb
+++ b/spec/models/dialog_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe DialogSerializer do
+RSpec.describe DialogSerializer do
   let(:dialog_tab_serializer) { double("DialogTabSerializer") }
   let(:dialog_serializer) { described_class.new(dialog_tab_serializer) }
 

--- a/spec/models/dialog_spec.rb
+++ b/spec/models/dialog_spec.rb
@@ -1,4 +1,4 @@
-describe Dialog do
+RSpec.describe Dialog do
   describe ".seed" do
     let(:dialog_import_service) { double("DialogImportService") }
     let(:test_file_path) { "spec/fixtures/files/dialogs" }

--- a/spec/models/dialog_tab_serializer_spec.rb
+++ b/spec/models/dialog_tab_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe DialogTabSerializer do
+RSpec.describe DialogTabSerializer do
   let(:dialog_group_serializer) { double("DialogGroupSerializer") }
   let(:dialog_tab_serializer) { described_class.new(dialog_group_serializer) }
 

--- a/spec/models/dialog_tab_spec.rb
+++ b/spec/models/dialog_tab_spec.rb
@@ -1,4 +1,4 @@
-describe DialogTab do
+RSpec.describe DialogTab do
   let(:dialog_tab) { FactoryBot.build(:dialog_tab, :label => 'tab') }
   context "#validate_children" do
     it "fails without box" do

--- a/spec/models/dialog_yaml_serializer_spec.rb
+++ b/spec/models/dialog_yaml_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe DialogYamlSerializer do
+RSpec.describe DialogYamlSerializer do
   let(:dialog_tab_serializer) { double("DialogTabSerializer") }
   let(:dialog_yaml_serializer) { described_class.new(dialog_tab_serializer) }
 

--- a/spec/models/dictionary_spec.rb
+++ b/spec/models/dictionary_spec.rb
@@ -1,4 +1,4 @@
-describe Dictionary do
+RSpec.describe Dictionary do
   context ".gettext" do
     context "with empty text" do
       it("returns an empty string") { expect(described_class.gettext("")).to eq("") }

--- a/spec/models/disk_spec.rb
+++ b/spec/models/disk_spec.rb
@@ -1,4 +1,4 @@
-describe Disk do
+RSpec.describe Disk do
   include Spec::Support::ArelHelper
 
   describe ".used_disk_storage" do

--- a/spec/models/drift_state/purging_spec.rb
+++ b/spec/models/drift_state/purging_spec.rb
@@ -1,5 +1,5 @@
 # this is basically copied from miq_report_result/purging.rb
-describe DriftState do
+RSpec.describe DriftState do
   context "::Purging" do
     before do
       @vmdb_config = {

--- a/spec/models/dynamic_dialog_field_value_processor_spec.rb
+++ b/spec/models/dynamic_dialog_field_value_processor_spec.rb
@@ -1,4 +1,4 @@
-describe DynamicDialogFieldValueProcessor do
+RSpec.describe DynamicDialogFieldValueProcessor do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:dynamic_dialog_field_value_processor) { described_class.new }
 

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -1,4 +1,4 @@
-describe EmsCluster do
+RSpec.describe EmsCluster do
   context("VMware") do
     before do
       @cluster = FactoryBot.create(:ems_cluster)

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -1,4 +1,4 @@
-describe EmsEvent do
+RSpec.describe EmsEvent do
   context "model" do
     let(:ems1) { FactoryBot.create(:ems_kubernetes) }
     let(:ems2) { FactoryBot.create(:ems_kubernetes) }

--- a/spec/models/ems_folder_spec.rb
+++ b/spec/models/ems_folder_spec.rb
@@ -1,4 +1,4 @@
-describe EmsFolder do
+RSpec.describe EmsFolder do
   context "with folder tree" do
     before do
       @root = FactoryBot.create(:ems_folder, :name => "root")

--- a/spec/models/ems_refresh/link_inventory_spec.rb
+++ b/spec/models/ems_refresh/link_inventory_spec.rb
@@ -1,4 +1,4 @@
-describe EmsRefresh::LinkInventory do
+RSpec.describe EmsRefresh::LinkInventory do
   context ".link_ems_inventory" do
     let!(:ems) do
       _, _, zone = EvmSpecHelper.local_guid_miq_server_zone

--- a/spec/models/ems_refresh/metadata_relats_spec.rb
+++ b/spec/models/ems_refresh/metadata_relats_spec.rb
@@ -1,4 +1,4 @@
-describe EmsRefresh::MetadataRelats do
+RSpec.describe EmsRefresh::MetadataRelats do
   context ".vmdb_relats" do
     before do
       @zone        = FactoryBot.create(:zone)

--- a/spec/models/ems_refresh/save_inventory_infra_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_infra_spec.rb
@@ -1,4 +1,4 @@
-describe EmsRefresh::SaveInventoryInfra do
+RSpec.describe EmsRefresh::SaveInventoryInfra do
   let(:refresher) do
     Class.new do
       include EmsRefresh::SaveInventoryInfra

--- a/spec/models/ems_refresh/save_inventory_spec.rb
+++ b/spec/models/ems_refresh/save_inventory_spec.rb
@@ -1,4 +1,4 @@
-describe EmsRefresh::SaveInventory do
+RSpec.describe EmsRefresh::SaveInventory do
   context ".save_vms_inventory" do
     before do
       @zone = FactoryBot.create(:zone)

--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -1,6 +1,6 @@
 require "inventory_refresh"
 
-describe EmsRefresh do
+RSpec.describe EmsRefresh do
   context ".queue_refresh" do
     before do
       _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -1,4 +1,4 @@
-describe Endpoint do
+RSpec.describe Endpoint do
   let(:endpoint) { FactoryBot.build(:endpoint) }
 
   describe "#verify_ssl" do

--- a/spec/models/entitlement_spec.rb
+++ b/spec/models/entitlement_spec.rb
@@ -1,4 +1,4 @@
-describe Entitlement do
+RSpec.describe Entitlement do
   describe "validation" do
     it "can have a managed filter if it doesn't have a filter expression" do
       entitlement = FactoryBot.build(:entitlement)

--- a/spec/models/event_stream/purging_spec.rb
+++ b/spec/models/event_stream/purging_spec.rb
@@ -1,4 +1,4 @@
-describe EventStream do
+RSpec.describe EventStream do
   context "::Purging" do
     context ".purge_queue" do
       before do

--- a/spec/models/event_stream_spec.rb
+++ b/spec/models/event_stream_spec.rb
@@ -1,4 +1,4 @@
-describe EventStream do
+RSpec.describe EventStream do
   describe ".event_groups" do
     EventStream.event_groups.each do |group_name, group_data|
       EventStream::GROUP_LEVELS.each do |level|

--- a/spec/models/file_depot_ftp_anonymous_spec.rb
+++ b/spec/models/file_depot_ftp_anonymous_spec.rb
@@ -1,4 +1,4 @@
-describe FileDepotFtpAnonymous do
+RSpec.describe FileDepotFtpAnonymous do
   it "should require credentials for anonymous" do
     expect(FileDepotFtpAnonymous.requires_credentials?).to eq true
     expect(FileDepotFtpAnonymous.new.login_credentials[0]).to eq "anonymous"

--- a/spec/models/file_depot_ftp_spec.rb
+++ b/spec/models/file_depot_ftp_spec.rb
@@ -1,4 +1,4 @@
-describe FileDepotFtp do
+RSpec.describe FileDepotFtp do
   before do
     _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
   end

--- a/spec/models/file_depot_nfs_spec.rb
+++ b/spec/models/file_depot_nfs_spec.rb
@@ -1,4 +1,4 @@
-describe FileDepotNfs do
+RSpec.describe FileDepotNfs do
   let(:uri)            { "nfs://ignore.com/directory" }
   let(:actual_uri)     { "nfs://actual_bucket/doo_directory" }
   let(:file_depot_nfs) { FileDepotNfs.new(:uri => uri) }

--- a/spec/models/file_depot_spec.rb
+++ b/spec/models/file_depot_spec.rb
@@ -1,4 +1,4 @@
-describe FileDepot do
+RSpec.describe FileDepot do
   it ".depot_description_to_class" do
     expect(described_class.depot_description_to_class("FTP")).to eq(FileDepotFtp)
     expect(described_class.depot_description_to_class("NFS")).to eq(FileDepotNfs)

--- a/spec/models/file_depot_swift_spec.rb
+++ b/spec/models/file_depot_swift_spec.rb
@@ -1,4 +1,4 @@
-describe FileDepotSwift do
+RSpec.describe FileDepotSwift do
   let(:uri) { "swift://server.example.com/bucket" }
   let(:merged_uri) { "swift://server.example.com:5678/bucket?region=test_openstack_region&api_version=v3&domain_id=default" }
   let(:merged_default_uri) { "swift://server.example.com:5000/bucket?region=test_openstack_region&api_version=v3&domain_id=default" }

--- a/spec/models/filesystem_spec.rb
+++ b/spec/models/filesystem_spec.rb
@@ -1,4 +1,4 @@
-describe Filesystem do
+RSpec.describe Filesystem do
   let(:filesystem_conf_file_ascii) do
     <<-EOT
 ## NB: Unpolished config file

--- a/spec/models/firewall_rule_spec.rb
+++ b/spec/models/firewall_rule_spec.rb
@@ -1,4 +1,4 @@
-describe FirewallRule do
+RSpec.describe FirewallRule do
   let(:firewall_rule) { FactoryBot.create(:firewall_rule) }
 
   context "#operating_system" do

--- a/spec/models/firmware_binary_spec.rb
+++ b/spec/models/firmware_binary_spec.rb
@@ -1,4 +1,4 @@
-describe FirmwareBinary do
+RSpec.describe FirmwareBinary do
   subject { FactoryBot.create(:firmware_binary) }
 
   describe '#allow_duplicate_endpoint_url?' do

--- a/spec/models/firmware_registry/rest_api_depot_spec.rb
+++ b/spec/models/firmware_registry/rest_api_depot_spec.rb
@@ -1,4 +1,4 @@
-describe FirmwareRegistry::RestApiDepot do
+RSpec.describe FirmwareRegistry::RestApiDepot do
   before do
     VCR.configure do |config|
       config.filter_sensitive_data('AUTHORIZATION') { Base64.encode64("#{user}:#{pass}").chomp }

--- a/spec/models/firmware_registry_spec.rb
+++ b/spec/models/firmware_registry_spec.rb
@@ -1,4 +1,4 @@
-describe FirmwareRegistry do
+RSpec.describe FirmwareRegistry do
   before  { EvmSpecHelper.create_guid_miq_server_zone }
   subject { FactoryBot.create(:firmware_registry) }
 

--- a/spec/models/firmware_target_spec.rb
+++ b/spec/models/firmware_target_spec.rb
@@ -1,4 +1,4 @@
-describe FirmwareTarget do
+RSpec.describe FirmwareTarget do
   let(:attrs)       { { :manufacturer => 'manu', :model => 'model' } }
   let(:other_attrs) { { :manufacturer => 'other-manu', :model => 'other-model' } }
 

--- a/spec/models/generic_object_definition_spec.rb
+++ b/spec/models/generic_object_definition_spec.rb
@@ -1,4 +1,4 @@
-describe GenericObjectDefinition do
+RSpec.describe GenericObjectDefinition do
   let(:definition) do
     FactoryBot.create(
       :generic_object_definition,

--- a/spec/models/generic_object_spec.rb
+++ b/spec/models/generic_object_spec.rb
@@ -1,4 +1,4 @@
-describe GenericObject do
+RSpec.describe GenericObject do
   let(:go_object_name) { "load_balancer_1" }
   let(:max_number)     { 100 }
   let(:server_name)    { "test_server" }

--- a/spec/models/git_repository_spec.rb
+++ b/spec/models/git_repository_spec.rb
@@ -1,4 +1,4 @@
-describe GitRepository do
+RSpec.describe GitRepository do
   describe "#url" do
     it "missing" do
       expect(FactoryBot.build(:git_repository, :url => nil)).to_not be_valid

--- a/spec/models/guest_device_spec.rb
+++ b/spec/models/guest_device_spec.rb
@@ -1,4 +1,4 @@
-describe GuestDevice do
+RSpec.describe GuestDevice do
   let!(:vm_gd) { FactoryBot.create(:guest_device_nic) }
   let!(:vm) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :guest_devices => [vm_gd])) }
 

--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -1,4 +1,4 @@
-describe Hardware do
+RSpec.describe Hardware do
   include Spec::Support::ArelHelper
   let(:vm) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware)) }
   let(:template) { FactoryBot.create(:template_vmware, :hardware => FactoryBot.create(:hardware)) }

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -1,4 +1,4 @@
-describe Host do
+RSpec.describe Host do
   it "groups and users joins" do
     user1  = FactoryBot.create(:account_user)
     user2  = FactoryBot.create(:account_user)

--- a/spec/models/import_file_upload_spec.rb
+++ b/spec/models/import_file_upload_spec.rb
@@ -1,4 +1,4 @@
-describe ImportFileUpload do
+RSpec.describe ImportFileUpload do
   let(:import_file_upload) { described_class.create }
 
   describe "#policy_import_data" do

--- a/spec/models/job/state_machine_spec.rb
+++ b/spec/models/job/state_machine_spec.rb
@@ -1,4 +1,4 @@
-describe Job, "::StateMachine" do
+RSpec.describe Job, "::StateMachine" do
   subject(:job) do
     # Job is expected to be subclassed by something
     # that implements load_transitions

--- a/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
+++ b/spec/models/job_proxy_dispatcher_embedded_scan_spec.rb
@@ -1,4 +1,4 @@
-describe "JobProxyDispatcherEmbeddedScanSpec" do
+RSpec.describe "JobProxyDispatcherEmbeddedScanSpec" do
   describe "dispatch embedded" do
     include Spec::Support::JobProxyDispatcherHelper
 

--- a/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
+++ b/spec/models/job_proxy_dispatcher_get_eligible_proxies_for_job_spec.rb
@@ -1,4 +1,4 @@
-describe "JobProxyDispatcherGetEligibleProxiesForJob" do
+RSpec.describe "JobProxyDispatcherGetEligibleProxiesForJob" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do

--- a/spec/models/job_proxy_dispatcher_spec.rb
+++ b/spec/models/job_proxy_dispatcher_spec.rb
@@ -1,4 +1,4 @@
-describe JobProxyDispatcher do
+RSpec.describe JobProxyDispatcher do
   include Spec::Support::JobProxyDispatcherHelper
 
   NUM_VMS = 3

--- a/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_miq_server_proxies_spec.rb
@@ -1,4 +1,4 @@
-describe "JobProxyDispatcherVmMiqServerProxies" do
+RSpec.describe "JobProxyDispatcherVmMiqServerProxies" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "with two servers on same zone, vix disk enabled for all, " do

--- a/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
+++ b/spec/models/job_proxy_dispatcher_vm_storage2proxies_spec.rb
@@ -1,4 +1,4 @@
-describe "JobProxyDispatcherVmStorage2Proxies" do
+RSpec.describe "JobProxyDispatcherVmStorage2Proxies" do
   include Spec::Support::JobProxyDispatcherHelper
 
   context "two vix disk enabled servers," do

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -1,4 +1,4 @@
-describe Job do
+RSpec.describe Job do
   context "With a single scan job," do
     before do
       @server1 = EvmSpecHelper.local_miq_server(:is_master => true)

--- a/spec/models/lan_spec.rb
+++ b/spec/models/lan_spec.rb
@@ -1,4 +1,4 @@
-describe Lan do
+RSpec.describe Lan do
   let(:lan) { FactoryBot.create(:lan) }
   let!(:vm) { FactoryBot.create(:vm_vmware, :hardware => FactoryBot.create(:hardware, :guest_devices => [FactoryBot.create(:guest_device_nic, :lan => lan)])) }
   let!(:template) { FactoryBot.create(:template_vmware, :hardware => FactoryBot.create(:hardware, :guest_devices => [FactoryBot.create(:guest_device_nic, :lan => lan)])) }

--- a/spec/models/live_metric_spec.rb
+++ b/spec/models/live_metric_spec.rb
@@ -1,4 +1,4 @@
-describe LiveMetric do
+RSpec.describe LiveMetric do
   let(:raw_conditions) do
     "resource_type = 'VmOrTemplate' and resource_id = 6 " \
     "and timestamp >= '2016-04-03 00:00:00' and timestamp <= '2016-04-05 23:00:00' " \

--- a/spec/models/log_collection_spec.rb
+++ b/spec/models/log_collection_spec.rb
@@ -1,4 +1,4 @@
-describe "LogCollection" do
+RSpec.describe "LogCollection" do
   before do
     _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
   end

--- a/spec/models/manageiq/providers/ansible_playbook_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ansible_playbook_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::AnsiblePlaybookWorkflow do
+RSpec.describe ManageIQ::Providers::AnsiblePlaybookWorkflow do
   let(:job)     { described_class.create_job(*options).tap { |job| job.state = state } }
   let(:options) { [{"ENV" => "VAR"}, {"arg1" => "val1"}, {:playbook_path => "/path/to/playbook"}, %w[192.0.2.0 192.0.2.1], {:verbosity => 3}] }
   let(:state)   { "waiting_to_start" }

--- a/spec/models/manageiq/providers/ansible_role_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ansible_role_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::AnsibleRoleWorkflow do
+RSpec.describe ManageIQ::Providers::AnsibleRoleWorkflow do
   let(:job)          { described_class.create_job(*options).tap { |job| job.state = state } }
   let(:role_options) { {:role_name => 'role_name', :roles_path => '/path/to/role', :role_skip_facts => true } }
   let(:options)      { [{"ENV" => "VAR"}, {"arg1" => "val1"}, role_options, {:verbosity => 4}] }

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::BaseManager::MetricsCapture do
+RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
   subject { described_class.new(nil, ems) }

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::BaseManager::Refresher do
+RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
   context "#initialize" do
     let(:ems1) { FactoryBot.create(:ext_management_system) }
     let(:ems2) { FactoryBot.create(:ext_management_system) }

--- a/spec/models/manageiq/providers/base_manager_spec.rb
+++ b/spec/models/manageiq/providers/base_manager_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::BaseManager do
+RSpec.describe ManageIQ::Providers::BaseManager do
   context ".default_blacklisted_event_names" do
     it 'returns an empty array for the base class' do
       expect(described_class.default_blacklisted_event_names).to eq([])

--- a/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/auth_key_pair_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::AuthKeyPair do
+RSpec.describe ManageIQ::Providers::CloudManager::AuthKeyPair do
   let(:ems) { FactoryBot.create(:ems_cloud) }
   let(:user) { FactoryBot.create(:user, :userid => 'test') }
   let(:auth_key_pair) { FactoryBot.create(:auth_key_pair_cloud, :resource => ems) }

--- a/spec/models/manageiq/providers/cloud_manager/configuration_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/configuration_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::Provision::Configuration do
+RSpec.describe ManageIQ::Providers::CloudManager::Provision::Configuration do
   it "#userdata_payload is clear text" do
     template  = FactoryBot.build(:customization_template, :script => "#cloud-init")
     provision = ManageIQ::Providers::CloudManager::Provision.new

--- a/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/metrics_capture_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::MetricsCapture do
+RSpec.describe ManageIQ::Providers::CloudManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
   before do

--- a/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/orchestration_stack_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::OrchestrationStack do
+RSpec.describe ManageIQ::Providers::CloudManager::OrchestrationStack do
   let!(:root_stack) do
     FactoryBot.create(:orchestration_stack_cloud).tap do |stack|
       FactoryBot.create(:vm_cloud, :orchestration_stack => stack)

--- a/spec/models/manageiq/providers/cloud_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/provision_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::Provision do
+RSpec.describe ManageIQ::Providers::CloudManager::Provision do
   context "Cloning" do
     let(:provider) { FactoryBot.create(:ems_cloud) }
     let(:template) { FactoryBot.create(:template_cloud, :ext_management_system => provider) }

--- a/spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_or_template_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::CloudManager::VmOrTemplate do
+RSpec.describe ManageIQ::Providers::CloudManager::VmOrTemplate do
   describe "#all" do
     it "scopes" do
       vm = FactoryBot.create(:vm_openstack)

--- a/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager/vm_spec.rb
@@ -1,4 +1,4 @@
-describe VmCloud do
+RSpec.describe VmCloud do
   let(:ems) { FactoryBot.create(:ems_cloud) }
   let(:user) { FactoryBot.create(:user, :userid => 'test') }
 

--- a/spec/models/manageiq/providers/cloud_manager_spec.rb
+++ b/spec/models/manageiq/providers/cloud_manager_spec.rb
@@ -1,4 +1,4 @@
-describe EmsCloud do
+RSpec.describe EmsCloud do
   it ".types" do
     expected_types = [ManageIQ::Providers::Amazon::CloudManager,
                       ManageIQ::Providers::Azure::CloudManager,

--- a/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/container_manager/metrics_capture_spec.rb
@@ -1,3 +1,3 @@
-describe ManageIQ::Providers::ContainerManager::MetricsCapture do
+RSpec.describe ManageIQ::Providers::ContainerManager::MetricsCapture do
   include Spec::Support::MetricHelper
 end

--- a/spec/models/manageiq/providers/container_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/container_manager/orchestration_stack_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::ContainerManager::OrchestrationStack do
+RSpec.describe ManageIQ::Providers::ContainerManager::OrchestrationStack do
   let(:stack) { FactoryBot.create(:orchestration_stack_container) }
 
   describe '#retire_now' do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/configuration_script_source_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScriptSource do
   context "with a local repo" do
     let(:manager) do
       FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/credential_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential do
   let(:embedded_ansible) { ManageIQ::Providers::EmbeddedAnsible::AutomationManager }
   let(:manager) do
     FactoryBot.create(:provider_embedded_ansible, :default_organization => 1).managers.first

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job/status_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job/status_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job::Status do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job::Status do
   # The following specs are copied from the 'ansible job status' spec helper
   # from the AnsibleTower Provider repo, but have been modified to make sense
   # for the case of AnsibleRunner implementation.  Previously was:

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/job_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job do
   let(:job) { FactoryBot.create(:embedded_ansible_job) }
 
   before do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager/playbook_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Playbook do
   let(:manager)               { FactoryBot.create(:embedded_automation_manager_ansible, :provider) }
   let(:ansible_script_source) { FactoryBot.create(:embedded_ansible_configuration_script_source, :manager_id => manager.id) }
   let(:playbook)              { FactoryBot.create(:embedded_playbook, :configuration_script_source => ansible_script_source) }

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
   context 'catalog types' do
     let(:ems) { FactoryBot.create(:embedded_automation_manager_ansible) }
 

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible::Provider do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible::Provider do
   subject { FactoryBot.create(:provider_embedded_ansible) }
 
   let(:miq_server) { FactoryBot.create(:miq_server) }

--- a/spec/models/manageiq/providers/embedded_ansible_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmbeddedAnsible do
+RSpec.describe ManageIQ::Providers::EmbeddedAnsible do
   describe ".seed" do
     let(:provider) { ManageIQ::Providers::EmbeddedAnsible::Provider.first }
     let(:manager)  { provider.automation_manager }

--- a/spec/models/manageiq/providers/ems_infra_spec.rb
+++ b/spec/models/manageiq/providers/ems_infra_spec.rb
@@ -1,4 +1,4 @@
-describe EmsInfra do
+RSpec.describe EmsInfra do
   it ".types" do
     expected_types = [ManageIQ::Providers::Vmware::InfraManager,
                       ManageIQ::Providers::Redhat::InfraManager,

--- a/spec/models/manageiq/providers/ems_refresh_workflow_spec.rb
+++ b/spec/models/manageiq/providers/ems_refresh_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::EmsRefreshWorkflow do
+RSpec.describe ManageIQ::Providers::EmsRefreshWorkflow do
   context '.create_job' do
     it 'leaves job waiting to start' do
       options = {}

--- a/spec/models/manageiq/providers/inflector/methods_spec.rb
+++ b/spec/models/manageiq/providers/inflector/methods_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::Inflector::Methods do
+RSpec.describe ManageIQ::Providers::Inflector::Methods do
   context "#provider_name" do
     it "returns name for an instance" do
       manager = ManageIQ::Providers::Amazon::CloudManager.new

--- a/spec/models/manageiq/providers/inflector_spec.rb
+++ b/spec/models/manageiq/providers/inflector_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::Inflector do
+RSpec.describe ManageIQ::Providers::Inflector do
   context "#provider_name" do
     it "returns the name for an instance of a manager" do
       manager = ManageIQ::Providers::Amazon::CloudManager.new

--- a/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/metrics_capture_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::InfraManager::MetricsCapture do
+RSpec.describe ManageIQ::Providers::InfraManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
   let(:miq_server) { EvmSpecHelper.local_miq_server }

--- a/spec/models/manageiq/providers/infra_manager/template_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/template_spec.rb
@@ -1,4 +1,4 @@
-describe TemplateInfra do
+RSpec.describe TemplateInfra do
   context "#post_create_actions" do
     it "without a host relationship" do
       expect(subject).to receive(:reconnect_events)

--- a/spec/models/manageiq/providers/infra_manager/vm_or_template_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/vm_or_template_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::InfraManager::VmOrTemplate do
+RSpec.describe ManageIQ::Providers::InfraManager::VmOrTemplate do
   describe "#all" do
     it "scopes" do
       vm = FactoryBot.create(:vm_vmware)

--- a/spec/models/manageiq/providers/infra_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager/vm_spec.rb
@@ -1,4 +1,4 @@
-describe VmInfra do
+RSpec.describe VmInfra do
   context "#post_create_actions" do
     it "without a host relationship" do
       expect(subject).to receive(:reconnect_events)

--- a/spec/models/manageiq/providers/infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/infra_manager_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::InfraManager do
+RSpec.describe ManageIQ::Providers::InfraManager do
   describe ".ems_timeouts" do
     before do
       stub_settings(:ems => {:ems_amazon => {},

--- a/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
@@ -1,7 +1,7 @@
 require "inventory_refresh"
 require_relative 'test_persister'
 
-describe ManageIQ::Providers::Inventory::Persister::Builder do
+RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   before :each do
     @ems = FactoryBot.create(:ems_cloud)
     @persister = create_persister

--- a/spec/models/manageiq/providers/inventory/persister/serializing_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/serializing_spec.rb
@@ -2,7 +2,7 @@ require_relative 'helpers/spec_parsed_data'
 require_relative 'test_persister'
 require_relative 'targeted_refresh_spec_helper'
 
-describe ManageIQ::Providers::Inventory::Persister do
+RSpec.describe ManageIQ::Providers::Inventory::Persister do
   include SpecParsedData
   include TargetedRefreshSpecHelper
 

--- a/spec/models/manageiq/providers/native_operation_workflow_spec.rb
+++ b/spec/models/manageiq/providers/native_operation_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::NativeOperationWorkflow do
+RSpec.describe ManageIQ::Providers::NativeOperationWorkflow do
   context "post_refresh" do
     before do
       vm = FactoryBot.create(:vm)

--- a/spec/models/manageiq/providers/network_manager_spec.rb
+++ b/spec/models/manageiq/providers/network_manager_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::NetworkManager do
+RSpec.describe ManageIQ::Providers::NetworkManager do
   let(:vms) { FactoryBot.create(:vm) }
   let(:template) { FactoryBot.create(:miq_template) }
 

--- a/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/physical_infra_manager/physical_infra_manager_spec.rb
@@ -1,4 +1,4 @@
-describe ManageIQ::Providers::PhysicalInfraManager do
+RSpec.describe ManageIQ::Providers::PhysicalInfraManager do
   before :all do
     @auth = { :user => 'admin', :pass => 'smartvm', :host => 'localhost', :port => '3000' }
   end

--- a/spec/models/message_timeout_handling_spec.rb
+++ b/spec/models/message_timeout_handling_spec.rb
@@ -1,4 +1,4 @@
-describe "Message Timeout Handling" do
+RSpec.describe "Message Timeout Handling" do
   before do
     @guid = SecureRandom.uuid
     allow(MiqServer).to receive(:my_guid).and_return(@guid)

--- a/spec/models/metering_container_image_spec.rb
+++ b/spec/models/metering_container_image_spec.rb
@@ -1,4 +1,4 @@
-describe MeteringContainerImage do
+RSpec.describe MeteringContainerImage do
   include Spec::Support::ChargebackHelper
   let(:base_options) { {:interval_size => 2, :end_interval_offset => 0, :ext_options => {:tz => 'UTC'} } }
   let(:hourly_rate)       { 0.01 }

--- a/spec/models/metering_container_project_spec.rb
+++ b/spec/models/metering_container_project_spec.rb
@@ -1,4 +1,4 @@
-describe MeteringContainerProject do
+RSpec.describe MeteringContainerProject do
   include Spec::Support::ChargebackHelper
 
   let(:admin) { FactoryBot.create(:user_admin) }

--- a/spec/models/metering_vm_spec.rb
+++ b/spec/models/metering_vm_spec.rb
@@ -1,4 +1,4 @@
-describe MeteringVm do
+RSpec.describe MeteringVm do
   include Spec::Support::ChargebackHelper
 
   let(:admin) { FactoryBot.create(:user_admin) }

--- a/spec/models/metric/capture_spec.rb
+++ b/spec/models/metric/capture_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Capture do
+RSpec.describe Metric::Capture do
   include Spec::Support::MetricHelper
 
   before do

--- a/spec/models/metric/ci_mixin/capture_spec.rb
+++ b/spec/models/metric/ci_mixin/capture_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::CiMixin::Capture do
+RSpec.describe Metric::CiMixin::Capture do
   require ManageIQ::Providers::Openstack::Engine.root.join("spec/tools/openstack_data/openstack_data_test_helper")
   let(:zone) { EvmSpecHelper.create_guid_miq_server_zone[2] }
   let(:mock_meter_list) { OpenstackMeterListData.new }

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::CiMixin::Rollup do
+RSpec.describe Metric::CiMixin::Rollup do
   before do
     MiqRegion.seed
 

--- a/spec/models/metric/ci_mixin_spec.rb
+++ b/spec/models/metric/ci_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::CiMixin do
+RSpec.describe Metric::CiMixin do
   context "with a Vm" do
     let(:vm) { FactoryBot.create(:vm_vmware) }
 

--- a/spec/models/metric/common_spec.rb
+++ b/spec/models/metric/common_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Common do
+RSpec.describe Metric::Common do
   let(:host) { FactoryBot.create(:host) }
   let(:metric) do
     FactoryBot.create(:metric_rollup_host_hr,

--- a/spec/models/metric/config_settings_spec.rb
+++ b/spec/models/metric/config_settings_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::ConfigSettings do
+RSpec.describe Metric::ConfigSettings do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
   end

--- a/spec/models/metric/finders_spec.rb
+++ b/spec/models/metric/finders_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Finders do
+RSpec.describe Metric::Finders do
   before do
     MiqRegion.seed
 

--- a/spec/models/metric/helper_spec.rb
+++ b/spec/models/metric/helper_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Helper do
+RSpec.describe Metric::Helper do
   before do
     EvmSpecHelper.local_miq_server
   end

--- a/spec/models/metric/processing_spec.rb
+++ b/spec/models/metric/processing_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Processing do
+RSpec.describe Metric::Processing do
   context "#add_missing_intervals" do
     let(:time_now) { Time.current }
     let(:last_perf) { FactoryBot.create(:metric_rollup_vm_hr, :timestamp => time_now) }

--- a/spec/models/metric/purging_spec.rb
+++ b/spec/models/metric/purging_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Purging do
+RSpec.describe Metric::Purging do
   let(:settings) do
     {
       :performance => {

--- a/spec/models/metric/statistic_spec.rb
+++ b/spec/models/metric/statistic_spec.rb
@@ -1,4 +1,4 @@
-describe Metric::Statistic do
+RSpec.describe Metric::Statistic do
   context ".calculate_stat_columns" do
     let(:ems_openshift) do
       FactoryBot.create(:ems_openshift, :hostname => 't', :port => 8443, :name => 't')

--- a/spec/models/metric_rollup/chargeback_helper_spec.rb
+++ b/spec/models/metric_rollup/chargeback_helper_spec.rb
@@ -1,4 +1,4 @@
-describe MetricRollup do
+RSpec.describe MetricRollup do
   describe '#parents_determining_rate' do
     let(:ems) { FactoryBot.build(:ems_vmware) }
 

--- a/spec/models/metric_rollup_spec.rb
+++ b/spec/models/metric_rollup_spec.rb
@@ -1,4 +1,4 @@
-describe MetricRollup do
+RSpec.describe MetricRollup do
   describe "metric_rollups view" do
     it "creates an object with an id" do
       metric = described_class.create!(:timestamp => Time.now.utc)

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -1,4 +1,4 @@
-describe Metric do
+RSpec.describe Metric do
   include Spec::Support::MetricHelper
 
   before do

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAeClass do
+RSpec.describe MiqAeClass do
   include Spec::Support::AutomationHelper
 
   describe "name attribute validation" do

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAeField do
+RSpec.describe MiqAeField do
   describe "#to_export_xml" do
     let(:default_value) { nil }
     let(:miq_ae_field) do

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAeInstance do
+RSpec.describe MiqAeInstance do
   context "legacy tests" do
     before do
       @user = FactoryBot.create(:user_with_group)

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAeMethod do
+RSpec.describe MiqAeMethod do
   let(:user) { FactoryBot.create(:user_with_group) }
   it "should return editable as false if the parent namespace/class is not editable" do
     n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)

--- a/spec/models/miq_ae_namespace_spec.rb
+++ b/spec/models/miq_ae_namespace_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAeNamespace do
+RSpec.describe MiqAeNamespace do
   describe "name attribute validation" do
     subject { described_class.new }
 

--- a/spec/models/miq_ae_value_spec.rb
+++ b/spec/models/miq_ae_value_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAeValue do
+RSpec.describe MiqAeValue do
   describe "#to_export_xml" do
     let(:miq_ae_value) do
       described_class.new(

--- a/spec/models/miq_alert_eval_internal_spec.rb
+++ b/spec/models/miq_alert_eval_internal_spec.rb
@@ -1,4 +1,4 @@
-describe "MiqAlert Evaluation Internal" do
+RSpec.describe "MiqAlert Evaluation Internal" do
   context "With VM as a target," do
     before do
       @vm = FactoryBot.create(:vm_vmware)

--- a/spec/models/miq_alert_set_spec.rb
+++ b/spec/models/miq_alert_set_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAlertSet do
+RSpec.describe MiqAlertSet do
   context ".seed" do
     it "should create the prometheus profiles" do
       expect(MiqAlertSet.count).to eq(0)

--- a/spec/models/miq_alert_spec.rb
+++ b/spec/models/miq_alert_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAlert do
+RSpec.describe MiqAlert do
   context "With single server with a single generic worker with the notifier role," do
     before do
       @miq_server = EvmSpecHelper.local_miq_server(:role => 'notifier')

--- a/spec/models/miq_alert_status_action_spec.rb
+++ b/spec/models/miq_alert_status_action_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAlertStatusAction do
+RSpec.describe MiqAlertStatusAction do
   let(:alert) { FactoryBot.create(:miq_alert_status) }
   let(:user) { FactoryBot.create(:user) }
   let(:user2) { FactoryBot.create(:user, :name => 'user2') }

--- a/spec/models/miq_alert_status_spec.rb
+++ b/spec/models/miq_alert_status_spec.rb
@@ -1,4 +1,4 @@
-describe MiqAlertStatus do
+RSpec.describe MiqAlertStatus do
   let(:ems)                    { FactoryBot.create(:ems_vmware, :name => 'ems') }
   let(:alert)                  { FactoryBot.create(:miq_alert_status) }
   let(:user1)                  { FactoryBot.create(:user, :name => 'user1') }

--- a/spec/models/miq_approval_spec.rb
+++ b/spec/models/miq_approval_spec.rb
@@ -1,4 +1,4 @@
-describe MiqApproval do
+RSpec.describe MiqApproval do
   it "#approver= also sets approver_name" do
     approval = FactoryBot.build(:miq_approval)
     user     = FactoryBot.create(:user)

--- a/spec/models/miq_bulk_import_spec.rb
+++ b/spec/models/miq_bulk_import_spec.rb
@@ -1,4 +1,4 @@
-describe MiqBulkImport do
+RSpec.describe MiqBulkImport do
   context AssetTagImport do
     before do
       @file = StringIO.new("name,owner\nJD-C-T4.0.1.44,Joe")

--- a/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
+++ b/spec/models/miq_cockpit_ws_worker/authenticator_spec.rb
@@ -1,4 +1,4 @@
-describe MiqCockpitWsWorker::Authenticator do
+RSpec.describe MiqCockpitWsWorker::Authenticator do
   describe '#authenticate_for_host' do
     before do
       @auth = MiqCockpitWsWorker::Authenticator

--- a/spec/models/miq_compare_spec.rb
+++ b/spec/models/miq_compare_spec.rb
@@ -1,4 +1,4 @@
-describe MiqCompare do
+RSpec.describe MiqCompare do
   context "Marshal.dump and Marshal.load" do
     it "with Vms" do
       vm1 = FactoryBot.create(:vm_vmware)

--- a/spec/models/miq_database_spec.rb
+++ b/spec/models/miq_database_spec.rb
@@ -1,4 +1,4 @@
-describe MiqDatabase do
+RSpec.describe MiqDatabase do
   describe ".encrypted_columns" do
     it "returns the encrypted columns" do
       expected = %w(csrf_secret_token csrf_secret_token_encrypted session_secret_token session_secret_token_encrypted)

--- a/spec/models/miq_dialog/seeding_spec.rb
+++ b/spec/models/miq_dialog/seeding_spec.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-describe MiqDialog do
+RSpec.describe MiqDialog do
   describe "::Seeding" do
     include_examples(".seed called multiple times", 20)
 

--- a/spec/models/miq_enterprise_spec.rb
+++ b/spec/models/miq_enterprise_spec.rb
@@ -1,4 +1,4 @@
-describe MiqEnterprise do
+RSpec.describe MiqEnterprise do
   include_examples ".seed called multiple times"
 
   let(:enterprise) { FactoryBot.create(:miq_enterprise) }

--- a/spec/models/miq_event_definition_set_spec.rb
+++ b/spec/models/miq_event_definition_set_spec.rb
@@ -1,4 +1,4 @@
-describe MiqEventDefinitionSet do
+RSpec.describe MiqEventDefinitionSet do
   describe ".seed" do
     context 'seeding from a csv file' do
       before { MiqEventDefinitionSet.seed }

--- a/spec/models/miq_event_definition_spec.rb
+++ b/spec/models/miq_event_definition_spec.rb
@@ -1,4 +1,4 @@
-describe MiqEventDefinition do
+RSpec.describe MiqEventDefinition do
   let(:event_defs) { MiqEventDefinition.all.group_by(&:name) }
   describe '.seed_default_events' do
     context 'there are 2 event definition sets' do

--- a/spec/models/miq_event_spec.rb
+++ b/spec/models/miq_event_spec.rb
@@ -1,4 +1,4 @@
-describe MiqEvent do
+RSpec.describe MiqEvent do
   context "seeded" do
     context ".raise_evm_job_event" do
       it "vm" do

--- a/spec/models/miq_filter_spec.rb
+++ b/spec/models/miq_filter_spec.rb
@@ -1,4 +1,4 @@
-describe MiqFilter do
+RSpec.describe MiqFilter do
   let(:ems)             { FactoryBot.create(:ems_vmware, :name => 'ems') }
   let(:datacenter)      { FactoryBot.create(:ems_folder, :name => "Datacenters").tap { |dc| dc.parent = ems } }
   let(:mtc)             { FactoryBot.create(:datacenter, :name => "MTC").tap { |mtc| mtc.parent = datacenter } }

--- a/spec/models/miq_group_spec.rb
+++ b/spec/models/miq_group_spec.rb
@@ -1,4 +1,4 @@
-describe MiqGroup do
+RSpec.describe MiqGroup do
   include Spec::Support::ArelHelper
 
   describe "#settings" do

--- a/spec/models/miq_policy/import_export_spec.rb
+++ b/spec/models/miq_policy/import_export_spec.rb
@@ -1,4 +1,4 @@
-describe MiqPolicy::ImportExport do
+RSpec.describe MiqPolicy::ImportExport do
   context '.import_from_hash' do
     it "loads attributes" do
       p_hash = {

--- a/spec/models/miq_policy_content_spec.rb
+++ b/spec/models/miq_policy_content_spec.rb
@@ -1,4 +1,4 @@
-describe MiqPolicyContent do
+RSpec.describe MiqPolicyContent do
   context 'Empty content' do
     describe '#export_to_array' do
       subject { FactoryBot.create(:miq_policy_content).export_to_array }

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -1,4 +1,4 @@
-describe MiqPolicy do
+RSpec.describe MiqPolicy do
   context "Testing edge cases on conditions" do
     # The conditions reflection on MiqPolicy is affected when called through a
     # belongs_to or has_one, which is used under the covers in MiqSet.  This

--- a/spec/models/miq_product_feature_spec.rb
+++ b/spec/models/miq_product_feature_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProductFeature do
+RSpec.describe MiqProductFeature do
   let(:miq_product_feature_class) do
     Class.new(described_class) do
       def self.with_parent_tenant_nodes

--- a/spec/models/miq_provision/post_install_callback_spec.rb
+++ b/spec/models/miq_provision/post_install_callback_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvision::PostInstallCallback do
+RSpec.describe MiqProvision::PostInstallCallback do
   let(:included_class) do
     Class.new do
       include MiqProvision::PostInstallCallback

--- a/spec/models/miq_provision/state_machine_spec.rb
+++ b/spec/models/miq_provision/state_machine_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvision do
+RSpec.describe MiqProvision do
   context "::StateMachine" do
     let(:req_user) { FactoryBot.create(:user_with_group) }
     let(:ems)      { FactoryBot.create(:ems_openstack_with_authentication) }

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvisionRequestTemplate do
+RSpec.describe MiqProvisionRequestTemplate do
   let(:user)             { FactoryBot.create(:user) }
   let(:template)         do
     FactoryBot.create(:template_vmware,

--- a/spec/models/miq_provision_spec.rb
+++ b/spec/models/miq_provision_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvision do
+RSpec.describe MiqProvision do
   context "A new provision request," do
     before do
       @os = OperatingSystem.new(:product_name => 'Microsoft Windows')

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvisionVirtWorkflow do
+RSpec.describe MiqProvisionVirtWorkflow do
   let(:workflow) { FactoryBot.create(:miq_provision_virt_workflow) }
 
   context "#new" do

--- a/spec/models/miq_provision_workflow_spec.rb
+++ b/spec/models/miq_provision_workflow_spec.rb
@@ -1,6 +1,6 @@
 silence_warnings { MiqProvisionWorkflow.const_set("DIALOGS_VIA_AUTOMATE", false) }
 
-describe MiqProvisionWorkflow do
+RSpec.describe MiqProvisionWorkflow do
   let(:admin) { FactoryBot.create(:user_admin) }
   let(:server) { EvmSpecHelper.local_miq_server }
   let(:dialog) { FactoryBot.create(:miq_dialog_provision) }

--- a/spec/models/miq_queue_worker_base/runner_spec.rb
+++ b/spec/models/miq_queue_worker_base/runner_spec.rb
@@ -1,4 +1,4 @@
-describe MiqQueueWorkerBase::Runner do
+RSpec.describe MiqQueueWorkerBase::Runner do
   context "#get_message_via_drb" do
     let(:server) { EvmSpecHelper.local_miq_server }
     let(:worker) { FactoryBot.create(:miq_generic_worker, :miq_server => server, :pid => 123) }

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRegion do
+RSpec.describe MiqRegion do
   let(:region) { FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number) }
   # the first id from a region other than ours
   let(:external_region_id) do

--- a/spec/models/miq_remote_console_worker/runner_spec.rb
+++ b/spec/models/miq_remote_console_worker/runner_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRemoteConsoleWorker::Runner do
+RSpec.describe MiqRemoteConsoleWorker::Runner do
   describe '#check_internal_thread' do
     subject do
       w = described_class.allocate

--- a/spec/models/miq_report/async_spec.rb
+++ b/spec/models/miq_report/async_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport do
+RSpec.describe MiqReport do
   context "Generator::Async" do
     context ".async_generate_tables" do
       let(:report) do

--- a/spec/models/miq_report/charting_spec.rb
+++ b/spec/models/miq_report/charting_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport do
+RSpec.describe MiqReport do
   before do
     EvmSpecHelper.local_miq_server
 

--- a/spec/models/miq_report/formats_spec.rb
+++ b/spec/models/miq_report/formats_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport::Formats do
+RSpec.describe MiqReport::Formats do
   describe '.default_format_details_for' do
     let(:human_mb_details) do
       { :description => 'Suffixed Megabytes (MB, GB)',

--- a/spec/models/miq_report/formatters/csv_spec.rb
+++ b/spec/models/miq_report/formatters/csv_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport::Formatters::Csv do
+RSpec.describe MiqReport::Formatters::Csv do
   describe "#to_csv" do
     let(:col_options) { nil }
     let(:table_data) do

--- a/spec/models/miq_report/formatting_spec.rb
+++ b/spec/models/miq_report/formatting_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport, "::Formatting" do
+RSpec.describe MiqReport, "::Formatting" do
   subject { described_class.new(:db => "Vm") }
 
   describe "#format_currency_with_delimiter" do

--- a/spec/models/miq_report/generator/html_spec.rb
+++ b/spec/models/miq_report/generator/html_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport do
+RSpec.describe MiqReport do
   let(:miq_report) { FactoryBot.create(:miq_report) }
 
   before do

--- a/spec/models/miq_report/generator_spec.rb
+++ b/spec/models/miq_report/generator_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport::Generator do
+RSpec.describe MiqReport::Generator do
   include Spec::Support::ChargebackHelper
 
   before do

--- a/spec/models/miq_report/import_export_spec.rb
+++ b/spec/models/miq_report/import_export_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport::ImportExport do
+RSpec.describe MiqReport::ImportExport do
   before do
     @some_user = FactoryGirl.create(:user)
     @some_group = FactoryGirl.create(:miq_group)

--- a/spec/models/miq_report/search_spec.rb
+++ b/spec/models/miq_report/search_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReport do
+RSpec.describe MiqReport do
   include Spec::Support::ArelHelper
 
   context "::Search" do

--- a/spec/models/miq_report/seeding_spec.rb
+++ b/spec/models/miq_report/seeding_spec.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-describe MiqReport do
+RSpec.describe MiqReport do
   describe "::Seeding" do
     include_examples(".seed called multiple times", begin
       (Dir.glob(MiqReport::REPORT_DIR.join("**/*.yaml")) + Dir.glob(MiqReport::COMPARE_DIR.join("**/*.yaml"))).count

--- a/spec/models/miq_report_result/purging_spec.rb
+++ b/spec/models/miq_report_result/purging_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReportResult do
+RSpec.describe MiqReportResult do
   context "::Purging" do
     let(:settings) do
       {

--- a/spec/models/miq_report_result/result_set_operations_spec.rb
+++ b/spec/models/miq_report_result/result_set_operations_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReportResult::ResultSetOperations do
+RSpec.describe MiqReportResult::ResultSetOperations do
   describe ".result_set_for_reporting" do
     let(:result_set_options_base) { {'limit' => '1000'} }
 

--- a/spec/models/miq_report_result_spec.rb
+++ b/spec/models/miq_report_result_spec.rb
@@ -1,4 +1,4 @@
-describe MiqReportResult do
+RSpec.describe MiqReportResult do
   before do
     EvmSpecHelper.local_miq_server
 

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -38,7 +38,7 @@ shared_examples "custom_report_with_custom_attributes" do |base_report, custom_a
   end
 end
 
-describe MiqReport do
+RSpec.describe MiqReport do
   include Spec::Support::ChargebackHelper
 
   context ".for_user" do

--- a/spec/models/miq_request_spec.rb
+++ b/spec/models/miq_request_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRequest do
+RSpec.describe MiqRequest do
   let(:fred)   { FactoryBot.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred',   :email => "fred@example.com") }
   let(:barney) { FactoryBot.create(:user_with_group, :name => 'Barney Rubble',   :userid => 'barney', :email => "barney@example.com") }
 

--- a/spec/models/miq_request_task/dumping_spec.rb
+++ b/spec/models/miq_request_task/dumping_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRequestTask do
+RSpec.describe MiqRequestTask do
   context "::Dumping" do
     let(:task) { FactoryBot.create(:miq_request_task) }
 

--- a/spec/models/miq_request_task/post_install_callback_spec.rb
+++ b/spec/models/miq_request_task/post_install_callback_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRequestTask::PostInstallCallback do
+RSpec.describe MiqRequestTask::PostInstallCallback do
   let(:miq_request) { FactoryBot.build(:miq_provision_request, :requester => user) }
   let(:task)        { FactoryBot.create(:miq_request_task, :miq_request => miq_request) }
   let(:user)        { FactoryBot.build(:user) }

--- a/spec/models/miq_request_task/state_machine_spec.rb
+++ b/spec/models/miq_request_task/state_machine_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRequestTask do
+RSpec.describe MiqRequestTask do
   context "::StateMachine" do
     context "#signal" do
       it "will deal with exceptions" do

--- a/spec/models/miq_request_workflow_spec.rb
+++ b/spec/models/miq_request_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe MiqRequestWorkflow do
+RSpec.describe MiqRequestWorkflow do
   let(:workflow) { FactoryBot.build(:miq_provision_workflow) }
   let(:ems) { FactoryBot.create(:ext_management_system) }
   let(:resource_pool) { FactoryBot.create(:resource_pool) }

--- a/spec/models/miq_schedule_filter_spec.rb
+++ b/spec/models/miq_schedule_filter_spec.rb
@@ -1,4 +1,4 @@
-describe "MiqSchedule Filter" do
+RSpec.describe "MiqSchedule Filter" do
   context "Getting schedule targets" do
     before do
       @server1 = EvmSpecHelper.local_miq_server

--- a/spec/models/miq_schedule_spec.rb
+++ b/spec/models/miq_schedule_spec.rb
@@ -1,4 +1,4 @@
-describe MiqSchedule do
+RSpec.describe MiqSchedule do
   before { EvmSpecHelper.create_guid_miq_server_zone }
 
   context "import/export" do

--- a/spec/models/miq_schedule_worker/jobs_spec.rb
+++ b/spec/models/miq_schedule_worker/jobs_spec.rb
@@ -1,4 +1,4 @@
-describe MiqScheduleWorker::Jobs do
+RSpec.describe MiqScheduleWorker::Jobs do
   context "#ems_refresh_timer" do
     it "with no EMSes" do
       described_class.new.ems_refresh_timer(ManageIQ::Providers::Vmware::InfraManager)

--- a/spec/models/miq_schedule_worker/runner_spec.rb
+++ b/spec/models/miq_schedule_worker/runner_spec.rb
@@ -1,4 +1,4 @@
-describe MiqScheduleWorker::Runner do
+RSpec.describe MiqScheduleWorker::Runner do
   context ".new" do
     before do
       @miq_server = EvmSpecHelper.local_miq_server(:is_master => true)

--- a/spec/models/miq_schedule_worker/scheduler_spec.rb
+++ b/spec/models/miq_schedule_worker/scheduler_spec.rb
@@ -1,6 +1,6 @@
 require 'rufus/scheduler'
 
-describe MiqScheduleWorker::Scheduler do
+RSpec.describe MiqScheduleWorker::Scheduler do
   let(:logger) { double("Logger") }
   let(:schedules) { [] }
   let(:rufus_scheduler) { Rufus::Scheduler.new }

--- a/spec/models/miq_search_spec.rb
+++ b/spec/models/miq_search_spec.rb
@@ -1,4 +1,4 @@
-describe MiqSearch do
+RSpec.describe MiqSearch do
   describe '#descriptions' do
     it "hashes" do
       srchs = [

--- a/spec/models/miq_server/at_startup_spec.rb
+++ b/spec/models/miq_server/at_startup_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer, "::AtStartup" do
+RSpec.describe MiqServer, "::AtStartup" do
   describe ".clean_dequeued_messages" do
     before do
       _guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer, "::ConfigurationManagement" do
+RSpec.describe MiqServer, "::ConfigurationManagement" do
   describe "#settings" do
     shared_examples_for "#settings" do
       it "with no changes in the database" do

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -1,4 +1,4 @@
-describe "Server Environment Management" do
+RSpec.describe "Server Environment Management" do
   context ".spartan_mode" do
     before { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
     after { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }

--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -76,7 +76,7 @@ shared_examples "post_logs_fails" do |is_zone_depot, is_server_depot, context|
   end
 end
 
-describe MiqServer do
+RSpec.describe MiqServer do
   context "LogManagement" do
     let(:server_depot) { FactoryBot.create(:file_depot) }
     let(:zone_depot) { FactoryBot.create(:file_depot) }

--- a/spec/models/miq_server/queue_management_spec.rb
+++ b/spec/models/miq_server/queue_management_spec.rb
@@ -1,4 +1,4 @@
-describe "Queue Management" do
+RSpec.describe "Queue Management" do
   let(:server) { EvmSpecHelper.local_miq_server }
 
   describe "#ntp_reload_queue" do

--- a/spec/models/miq_server/server_smart_proxy_spec.rb
+++ b/spec/models/miq_server/server_smart_proxy_spec.rb
@@ -1,4 +1,4 @@
-describe "MiqServer::ServerSmartProxy" do
+RSpec.describe "MiqServer::ServerSmartProxy" do
   let(:server) { EvmSpecHelper.local_miq_server }
   before { ServerRole.seed }
 

--- a/spec/models/miq_server/status_management_spec.rb
+++ b/spec/models/miq_server/status_management_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer do
+RSpec.describe MiqServer do
   context "StatusManagement" do
     before do
       @guid, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/miq_server/update_management_spec.rb
+++ b/spec/models/miq_server/update_management_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer do
+RSpec.describe MiqServer do
   before do
     MiqRegion.seed
     @server = EvmSpecHelper.local_miq_server(:zone => Zone.seed)

--- a/spec/models/miq_server/worker_management/heartbeat_spec.rb
+++ b/spec/models/miq_server/worker_management/heartbeat_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer::WorkerManagement::Heartbeat do
+RSpec.describe MiqServer::WorkerManagement::Heartbeat do
   context "#persist_last_heartbeat" do
     let(:miq_server) { EvmSpecHelper.local_miq_server }
     let(:worker)     { FactoryBot.create(:miq_worker, :miq_server_id => miq_server.id) }

--- a/spec/models/miq_server/worker_management/monitor/kill_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/kill_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer::WorkerManagement::Monitor::Kill do
+RSpec.describe MiqServer::WorkerManagement::Monitor::Kill do
   context "#kill_all_workers" do
     let(:server)   { EvmSpecHelper.create_guid_miq_server_zone.second }
     let(:is_local) { true }

--- a/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor/system_limits_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer do
+RSpec.describe MiqServer do
   context "WorkerManagement::Monitor::SystemLimits" do
     before do
       _, @server, = EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/miq_server/worker_management/monitor_spec.rb
+++ b/spec/models/miq_server/worker_management/monitor_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer::WorkerManagement::Monitor do
+RSpec.describe MiqServer::WorkerManagement::Monitor do
   context "#check_not_responding" do
     let(:server) { EvmSpecHelper.local_miq_server }
     let(:worker) do

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -1,4 +1,4 @@
-describe "MiqWorker Monitor" do
+RSpec.describe "MiqWorker Monitor" do
   context "After Setup," do
     before do
       allow(MiqWorker).to receive(:nice_increment).and_return("+10")

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -1,4 +1,4 @@
-describe MiqServer do
+RSpec.describe MiqServer do
   context ".seed" do
     before do
       MiqRegion.seed

--- a/spec/models/miq_snmp_spec.rb
+++ b/spec/models/miq_snmp_spec.rb
@@ -1,4 +1,4 @@
-describe MiqSnmp do
+RSpec.describe MiqSnmp do
   describe '.trap_v2' do
     it 'calls subst_oid' do
       expect(MiqSnmp).to receive(:subst_oid).at_least(1).and_return("1.2.3")

--- a/spec/models/miq_task/purging_spec.rb
+++ b/spec/models/miq_task/purging_spec.rb
@@ -1,4 +1,4 @@
-describe MiqTask do
+RSpec.describe MiqTask do
   context "::Purging" do
     describe ".purge_by_date" do
       before do

--- a/spec/models/miq_task_spec.rb
+++ b/spec/models/miq_task_spec.rb
@@ -1,4 +1,4 @@
-describe MiqTask do
+RSpec.describe MiqTask do
   context "when I add an MiqTask" do
     let(:miq_task) { FactoryBot.create(:miq_task_plain) }
 

--- a/spec/models/miq_template_spec.rb
+++ b/spec/models/miq_template_spec.rb
@@ -1,4 +1,4 @@
-describe MiqTemplate do
+RSpec.describe MiqTemplate do
   it ".corresponding_model" do
     expect(described_class.corresponding_model).to eq(Vm)
     expect(ManageIQ::Providers::Vmware::InfraManager::Template.corresponding_model).to eq(ManageIQ::Providers::Vmware::InfraManager::Vm)

--- a/spec/models/miq_ui_worker_spec.rb
+++ b/spec/models/miq_ui_worker_spec.rb
@@ -1,4 +1,4 @@
-describe MiqUiWorker do
+RSpec.describe MiqUiWorker do
   context ".all_ports_in_use" do
     before do
       require 'util/miq-process'

--- a/spec/models/miq_user_role_spec.rb
+++ b/spec/models/miq_user_role_spec.rb
@@ -1,4 +1,4 @@
-describe MiqUserRole do
+RSpec.describe MiqUserRole do
   before do
     @expected_user_role_count = 20
   end

--- a/spec/models/miq_user_scope_spec.rb
+++ b/spec/models/miq_user_scope_spec.rb
@@ -1,4 +1,4 @@
-describe MiqUserScope do
+RSpec.describe MiqUserScope do
   context "testing hash_to_scope method" do
     before do
     end

--- a/spec/models/miq_widget/chart_content_spec.rb
+++ b/spec/models/miq_widget/chart_content_spec.rb
@@ -1,4 +1,4 @@
-describe "Widget Chart Content" do
+RSpec.describe "Widget Chart Content" do
   let(:widget) { MiqWidget.find_by(:description => "chart_vendor_and_guest_os") }
   before do
     _guid, _server, _zone = EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/miq_widget/content_option_generator_spec.rb
+++ b/spec/models/miq_widget/content_option_generator_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWidget::ContentOptionGenerator do
+RSpec.describe MiqWidget::ContentOptionGenerator do
   let(:content_option_generator) { described_class.new }
 
   describe "#generate" do

--- a/spec/models/miq_widget/import_export_spec.rb
+++ b/spec/models/miq_widget/import_export_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWidget::ImportExport do
+RSpec.describe MiqWidget::ImportExport do
   context "legacy tests" do
     before do
       MiqReport.seed_report("Vendor and Guest OS")

--- a/spec/models/miq_widget/import_from_hash_spec.rb
+++ b/spec/models/miq_widget/import_from_hash_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWidget do
+RSpec.describe MiqWidget do
   context ".import_from_hash" do
     before do
       @user       = FactoryBot.create(:user_admin)

--- a/spec/models/miq_widget/report_content_spec.rb
+++ b/spec/models/miq_widget/report_content_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWidget, "::ReportContent" do
+RSpec.describe MiqWidget, "::ReportContent" do
   let(:vm_count) { 2 }
   let(:widget) do
     MiqWidget.sync_from_hash(YAML.load("

--- a/spec/models/miq_widget_set_spec.rb
+++ b/spec/models/miq_widget_set_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWidgetSet do
+RSpec.describe MiqWidgetSet do
   let(:group) { user.current_group }
   let(:user)  { FactoryBot.create(:user_with_group) }
   before do

--- a/spec/models/miq_widget_spec.rb
+++ b/spec/models/miq_widget_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWidget do
+RSpec.describe MiqWidget do
   describe '.seed' do
     before { [MiqReport].each(&:seed) }
     include_examples(".seed called multiple times", begin

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWorker::ContainerCommon do
+RSpec.describe MiqWorker::ContainerCommon do
   before { EvmSpecHelper.local_miq_server }
   let(:compressed_server_id) { MiqServer.my_server.compressed_id }
 

--- a/spec/models/miq_worker/runner_spec.rb
+++ b/spec/models/miq_worker/runner_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWorker::Runner do
+RSpec.describe MiqWorker::Runner do
   context "#start" do
     before do
       allow_any_instance_of(MiqWorker::Runner).to receive(:worker_initialization)

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWorker do
+RSpec.describe MiqWorker do
   context "::Runner" do
     def all_workers
       MiqWorker.descendants.select { |c| c.subclasses.empty? }

--- a/spec/models/miq_worker_type_spec.rb
+++ b/spec/models/miq_worker_type_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWorkerType do
+RSpec.describe MiqWorkerType do
   describe ".seed" do
     before { described_class.seed }
 

--- a/spec/models/mixins/aggregation_mixin_spec.rb
+++ b/spec/models/mixins/aggregation_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe AggregationMixin do
+RSpec.describe AggregationMixin do
   let(:cpu_speed) { 2_999 * 8 }
   let(:memory)    { 2_048 }
   let(:hardware_args) do

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe AssignmentMixin do
+RSpec.describe AssignmentMixin do
   # too ingrained in AR - has many, acts_as_miq_taggable, ...
   let(:test_class) { MiqAlertSet }
 

--- a/spec/models/mixins/authentication_mixin_spec.rb
+++ b/spec/models/mixins/authentication_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe AuthenticationMixin do
+RSpec.describe AuthenticationMixin do
   include Spec::Support::ArelHelper
 
   let(:host)            { FactoryBot.create(:host) }

--- a/spec/models/mixins/availability_mixin_spec.rb
+++ b/spec/models/mixins/availability_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe AvailabilityMixin do
+RSpec.describe AvailabilityMixin do
   let(:test_class) do
     Class.new do
       include AvailabilityMixin

--- a/spec/models/mixins/ci_feature_mixin_spec.rb
+++ b/spec/models/mixins/ci_feature_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe CiFeatureMixin do
+RSpec.describe CiFeatureMixin do
   let(:service) { FactoryBot.create(:service) }
   describe "#retireable?" do
     it "vm is retireable" do

--- a/spec/models/mixins/cloud_tenancy_mixin_spec.rb
+++ b/spec/models/mixins/cloud_tenancy_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe CloudTenancyMixin do
+RSpec.describe CloudTenancyMixin do
   let(:root_tenant) do
     Tenant.seed
   end

--- a/spec/models/mixins/cockpit_support_mixin_spec.rb
+++ b/spec/models/mixins/cockpit_support_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe CockpitSupportMixin do
+RSpec.describe CockpitSupportMixin do
   context '#supports_launch_cockpit?' do
     context 'Container Groups' do
       before do

--- a/spec/models/mixins/compliance_mixin_spec.rb
+++ b/spec/models/mixins/compliance_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe ComplianceMixin do
+RSpec.describe ComplianceMixin do
   include Spec::Support::ArelHelper
 
   let(:host)           { FactoryBot.create(:host) }

--- a/spec/models/mixins/configuration_management_mixin_spec.rb
+++ b/spec/models/mixins/configuration_management_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe ConfigurationManagementMixin do
+RSpec.describe ConfigurationManagementMixin do
   let(:miq_server) { FactoryBot.create(:miq_server, :zone => zone, :status => "started") }
   let(:region)     { FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number) }
   let(:settings)   { {:some_test_setting => {:setting => {:deeper => 1}, :other => 2}} }

--- a/spec/models/mixins/custom_actions_mixin_spec.rb
+++ b/spec/models/mixins/custom_actions_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe CustomActionsMixin do
+RSpec.describe CustomActionsMixin do
   let(:test_class) do
     Class.new(ActiveRecord::Base) do
       def self.name; "TestClass"; end

--- a/spec/models/mixins/custom_attribute_mixin_spec.rb
+++ b/spec/models/mixins/custom_attribute_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe CustomAttributeMixin do
+RSpec.describe CustomAttributeMixin do
   let(:supported_factories) { [:vm_redhat, :host] }
   let(:test_class) do
     Class.new(ActiveRecord::Base) do

--- a/spec/models/mixins/deprecation_mixin_spec.rb
+++ b/spec/models/mixins/deprecation_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe DeprecationMixin do
+RSpec.describe DeprecationMixin do
   # Host.deprecate_attribute :address, :hostname
   context ".arel_attribute" do
     it "works for deprecate_attribute columns" do

--- a/spec/models/mixins/drift_state_mixin_spec.rb
+++ b/spec/models/mixins/drift_state_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe DriftStateMixin do
+RSpec.describe DriftStateMixin do
   include Spec::Support::ArelHelper
 
   let(:host) { FactoryBot.create(:host) }

--- a/spec/models/mixins/event_mixin_spec.rb
+++ b/spec/models/mixins/event_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe EventMixin do
+RSpec.describe EventMixin do
   context "Included in a test class with events" do
     let(:test_class) do
       Class.new do

--- a/spec/models/mixins/external_url_spec.rb
+++ b/spec/models/mixins/external_url_spec.rb
@@ -1,4 +1,4 @@
-describe ExternalUrlMixin do
+RSpec.describe ExternalUrlMixin do
   let(:test_class) do
     Class.new(ActiveRecord::Base) do
       def self.name; 'TestClass'; end

--- a/spec/models/mixins/live_metrics_mixin_spec.rb
+++ b/spec/models/mixins/live_metrics_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe LiveMetricsMixin do
+RSpec.describe LiveMetricsMixin do
   subject do
     Class.new do
       include LiveMetricsMixin

--- a/spec/models/mixins/miq_provision_mixin_spec.rb
+++ b/spec/models/mixins/miq_provision_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe MiqProvisionMixin do
+RSpec.describe MiqProvisionMixin do
   describe "#get_owner" do
     let(:owner) { FactoryBot.create(:user_with_email) }
     let(:options) { {:owner_email => owner.email} }

--- a/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
+++ b/spec/models/mixins/miq_web_server_worker_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe MiqWebServerWorkerMixin do
+RSpec.describe MiqWebServerWorkerMixin do
   it "build_uri (ipv6)" do
     test_class = Class.new do
       include MiqWebServerWorkerMixin

--- a/spec/models/mixins/new_with_type_sti_mixin_spec.rb
+++ b/spec/models/mixins/new_with_type_sti_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe NewWithTypeStiMixin do
+RSpec.describe NewWithTypeStiMixin do
   context ".new" do
     it "without type" do
       expect(Host.new.class).to eq(Host)

--- a/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_type_worker_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe PerEmsTypeWorkerMixin do
+RSpec.describe PerEmsTypeWorkerMixin do
   let(:worker)       { FactoryBot.create(:miq_ems_metrics_collector_worker) }
   let(:worker_class) { worker.class }
 

--- a/spec/models/mixins/per_ems_worker_mixin_spec.rb
+++ b/spec/models/mixins/per_ems_worker_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe PerEmsWorkerMixin do
+RSpec.describe PerEmsWorkerMixin do
   before do
     _guid, server, zone = EvmSpecHelper.create_guid_miq_server_zone
     @ems = FactoryBot.create(:ems_vmware, :with_unvalidated_authentication, :zone => zone)

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe ProcessTasksMixin do
+RSpec.describe ProcessTasksMixin do
   let(:test_class) do
     Class.new(ApplicationRecord) do
       include ProcessTasksMixin

--- a/spec/models/mixins/purging_mixin_spec.rb
+++ b/spec/models/mixins/purging_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe PurgingMixin do
+RSpec.describe PurgingMixin do
   let(:example_class) { PolicyEvent }
   let(:purge_date) { 2.weeks.ago }
 

--- a/spec/models/mixins/relationship_mixin_spec.rb
+++ b/spec/models/mixins/relationship_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe RelationshipMixin do
+RSpec.describe RelationshipMixin do
   let(:test_rel_type) { "testing" }
   #      0
   #  1        2

--- a/spec/models/mixins/scanning_mixin_spec.rb
+++ b/spec/models/mixins/scanning_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe ScanningMixin do
+RSpec.describe ScanningMixin do
   let(:test_instance) do
     Class.new do
       include ScanningMixin

--- a/spec/models/mixins/supports_feature_mixin_spec.rb
+++ b/spec/models/mixins/supports_feature_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe SupportsFeatureMixin do
+RSpec.describe SupportsFeatureMixin do
   before do
     stub_const('SupportsFeatureMixin::QUERYABLE_FEATURES',
                SupportsFeatureMixin::QUERYABLE_FEATURES.merge(

--- a/spec/models/mixins/tenancy_mixin_spec.rb
+++ b/spec/models/mixins/tenancy_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe TenancyMixin do
+RSpec.describe TenancyMixin do
   let(:root_tenant) do
     Tenant.seed
   end

--- a/spec/models/mixins/tenant_identity_mixin_spec.rb
+++ b/spec/models/mixins/tenant_identity_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe TenantIdentityMixin do
+RSpec.describe TenantIdentityMixin do
   describe '#tenant_identity' do
     let(:admin)      { FactoryBot.create(:user_with_group, :userid => "admin") }
     let(:tenant)     { FactoryBot.create(:tenant) }

--- a/spec/models/mixins/tenant_quotas_mixin_spec.rb
+++ b/spec/models/mixins/tenant_quotas_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe TenantQuotasMixin do
+RSpec.describe TenantQuotasMixin do
   before do
     Tenant.seed
   end

--- a/spec/models/mixins/timezone_mixin_spec.rb
+++ b/spec/models/mixins/timezone_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe TimezoneMixin do
+RSpec.describe TimezoneMixin do
   let(:test_class) do
     Class.new do
       include TimezoneMixin

--- a/spec/models/mixins/yaml_import_export_mixin_spec.rb
+++ b/spec/models/mixins/yaml_import_export_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe YAMLImportExportMixin do
+RSpec.describe YAMLImportExportMixin do
   let(:test_class) { Class.new { include YAMLImportExportMixin } }
 
   before do

--- a/spec/models/notification/purging_spec.rb
+++ b/spec/models/notification/purging_spec.rb
@@ -1,4 +1,4 @@
-describe Notification do
+RSpec.describe Notification do
   context "::Purging" do
     describe ".purge_by_date" do
       it "purges old notifications" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,4 +1,4 @@
-describe Notification, :type => :model do
+RSpec.describe Notification, :type => :model do
   before { allow(User).to receive_messages(:server_timezone => 'UTC') }
   before { NotificationType.seed }
   let(:tenant) { FactoryBot.create(:tenant) }

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -1,4 +1,4 @@
-describe NotificationType, :type => :model do
+RSpec.describe NotificationType, :type => :model do
   describe '.seed' do
     it 'has not seeded records before seed is run' do
       expect(described_class.count).to be_zero

--- a/spec/models/openscap_result_spec.rb
+++ b/spec/models/openscap_result_spec.rb
@@ -1,4 +1,4 @@
-describe OpenscapResult do
+RSpec.describe OpenscapResult do
   let(:openscap_result) { described_class.new(:id => 17) }
   context "#html" do
     it "raises exception if there is no blob" do

--- a/spec/models/operating_system_spec.rb
+++ b/spec/models/operating_system_spec.rb
@@ -1,4 +1,4 @@
-describe OperatingSystem do
+RSpec.describe OperatingSystem do
   context "#normalize_os_name" do
     {
       "an_amazing_undiscovered_os" => "unknown",

--- a/spec/models/orchestration_stack/retirement_management_spec.rb
+++ b/spec/models/orchestration_stack/retirement_management_spec.rb
@@ -1,4 +1,4 @@
-describe "Service Retirement Management" do
+RSpec.describe "Service Retirement Management" do
   let(:user) { FactoryBot.create(:user_miq_request_approver) }
   let(:orchestration_stack) { FactoryBot.create(:orchestration_stack) }
   let(:stack_with_owner) { FactoryBot.create(:orchestration_stack, :evm_owner => user) }

--- a/spec/models/orchestration_stack_retire_task_spec.rb
+++ b/spec/models/orchestration_stack_retire_task_spec.rb
@@ -1,4 +1,4 @@
-describe OrchestrationStackRetireTask do
+RSpec.describe OrchestrationStackRetireTask do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:orchestration_stack) { FactoryBot.create(:orchestration_stack) }
   let(:miq_request) { FactoryBot.create(:orchestration_stack_retire_request, :requester => user, :source => orchestration_stack) }

--- a/spec/models/orchestration_template_spec.rb
+++ b/spec/models/orchestration_template_spec.rb
@@ -1,4 +1,4 @@
-describe OrchestrationTemplate do
+RSpec.describe OrchestrationTemplate do
   describe ".find_or_create_by_contents" do
     context "when the template does not exist" do
       let(:query_hash) { FactoryBot.build(:orchestration_template).as_json.symbolize_keys }

--- a/spec/models/partition_alignment_spec.rb
+++ b/spec/models/partition_alignment_spec.rb
@@ -1,4 +1,4 @@
-describe "PartitionAlignment" do
+RSpec.describe "PartitionAlignment" do
   context "Running test" do
     before do
       aligned = 64.kilobytes

--- a/spec/models/partition_spec.rb
+++ b/spec/models/partition_spec.rb
@@ -1,4 +1,4 @@
-describe Partition do
+RSpec.describe Partition do
   it "#partition_type_name" do
     partition = FactoryBot.create(:partition)
 

--- a/spec/models/persistent_volume_claim_spec.rb
+++ b/spec/models/persistent_volume_claim_spec.rb
@@ -1,4 +1,4 @@
-describe PersistentVolumeClaim do
+RSpec.describe PersistentVolumeClaim do
   describe "#storage_capacity" do
     let(:storage_size) { 123_456_789 }
 

--- a/spec/models/persistent_volume_spec.rb
+++ b/spec/models/persistent_volume_spec.rb
@@ -1,4 +1,4 @@
-describe PersistentVolume do
+RSpec.describe PersistentVolume do
   it "has container volumes and pods" do
     pvc = FactoryBot.create(
       :persistent_volume_claim,

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -1,4 +1,4 @@
-describe PglogicalSubscription do
+RSpec.describe PglogicalSubscription do
   let(:remote_region1) { ApplicationRecord.my_region_number + 1 }
   let(:remote_region2) { ApplicationRecord.my_region_number + 2 }
   let(:remote_region3) { ApplicationRecord.my_region_number + 3 }

--- a/spec/models/physical_server_firmware_update_request_spec.rb
+++ b/spec/models/physical_server_firmware_update_request_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServerFirmwareUpdateRequest do
+RSpec.describe PhysicalServerFirmwareUpdateRequest do
   it '.TASK_DESCRIPTION' do
     expect(described_class::TASK_DESCRIPTION).to eq('Physical Server Firmware Update')
   end

--- a/spec/models/physical_server_firmware_update_task/state_machine_spec.rb
+++ b/spec/models/physical_server_firmware_update_task/state_machine_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServerFirmwareUpdateTask do
+RSpec.describe PhysicalServerFirmwareUpdateTask do
   let(:server)  { FactoryBot.create(:physical_server) }
   let(:src_ids) { [server.id] }
 

--- a/spec/models/physical_server_firmware_update_task_spec.rb
+++ b/spec/models/physical_server_firmware_update_task_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServerFirmwareUpdateTask do
+RSpec.describe PhysicalServerFirmwareUpdateTask do
   it '#description' do
     expect(subject.description).to eq('Physical Server Firmware Update')
   end

--- a/spec/models/physical_server_provision_request_spec.rb
+++ b/spec/models/physical_server_provision_request_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServerProvisionRequest do
+RSpec.describe PhysicalServerProvisionRequest do
   it '.TASK_DESCRIPTION' do
     expect(described_class::TASK_DESCRIPTION).to eq('Physical Server Provisioning')
   end

--- a/spec/models/physical_server_provision_task/state_machine_spec.rb
+++ b/spec/models/physical_server_provision_task/state_machine_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServerProvisionTask do
+RSpec.describe PhysicalServerProvisionTask do
   let(:server) { FactoryBot.create(:physical_server) }
 
   subject { described_class.new(:source => server) }

--- a/spec/models/physical_server_provision_task_spec.rb
+++ b/spec/models/physical_server_provision_task_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServerProvisionTask do
+RSpec.describe PhysicalServerProvisionTask do
   it '#description' do
     expect(subject.description).to eq('Provision Physical Server')
   end

--- a/spec/models/physical_server_spec.rb
+++ b/spec/models/physical_server_spec.rb
@@ -1,4 +1,4 @@
-describe PhysicalServer do
+RSpec.describe PhysicalServer do
   let(:attrs)    { { :manufacturer => 'manu', :model => 'model' } }
   let!(:binary1) { FactoryBot.create(:firmware_binary) }
   let!(:binary2) { FactoryBot.create(:firmware_binary) }

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -1,4 +1,4 @@
-describe Picture do
+RSpec.describe Picture do
   subject { FactoryBot.build(:picture) }
 
   it "auto-creates needed directory" do

--- a/spec/models/policy_event/purging_spec.rb
+++ b/spec/models/policy_event/purging_spec.rb
@@ -1,4 +1,4 @@
-describe PolicyEvent do
+RSpec.describe PolicyEvent do
   context "::Purging" do
     context ".purge_timer" do
       before do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,4 +1,4 @@
-describe Provider do
+RSpec.describe Provider do
   let(:provider) { described_class.new }
 
   describe "#verify_ssl" do

--- a/spec/models/pxe_image_ipxe_spec.rb
+++ b/spec/models/pxe_image_ipxe_spec.rb
@@ -1,4 +1,4 @@
-describe PxeImageIpxe do
+RSpec.describe PxeImageIpxe do
   let(:image) { FactoryBot.create(:pxe_image_ipxe) }
 
   context "#build_pxe_contents" do

--- a/spec/models/pxe_image_pxelinux_spec.rb
+++ b/spec/models/pxe_image_pxelinux_spec.rb
@@ -1,4 +1,4 @@
-describe PxeImagePxelinux do
+RSpec.describe PxeImagePxelinux do
   let(:image) { FactoryBot.create(:pxe_image_pxelinux) }
 
   context "#build_pxe_contents" do

--- a/spec/models/pxe_image_spec.rb
+++ b/spec/models/pxe_image_spec.rb
@@ -1,4 +1,4 @@
-describe PxeImage do
+RSpec.describe PxeImage do
   let(:image) { FactoryBot.create(:pxe_image) }
 
   context "#build_pxe_contents" do

--- a/spec/models/pxe_image_type_spec.rb
+++ b/spec/models/pxe_image_type_spec.rb
@@ -1,4 +1,4 @@
-describe PxeImageType do
+RSpec.describe PxeImageType do
   context "#esx?" do
     it "with a nil name" do
       expect(subject).not_to be_esx

--- a/spec/models/pxe_menu_ipxe_spec.rb
+++ b/spec/models/pxe_menu_ipxe_spec.rb
@@ -1,4 +1,4 @@
-describe PxeMenuIpxe do
+RSpec.describe PxeMenuIpxe do
   before do
     @contents = <<-PXEMENU
 #!ipxe

--- a/spec/models/pxe_menu_pxelinux_spec.rb
+++ b/spec/models/pxe_menu_pxelinux_spec.rb
@@ -1,4 +1,4 @@
-describe PxeMenuPxelinux do
+RSpec.describe PxeMenuPxelinux do
   before do
     @contents = <<-PXEMENU
 default vesamenu.c32

--- a/spec/models/pxe_menu_spec.rb
+++ b/spec/models/pxe_menu_spec.rb
@@ -1,4 +1,4 @@
-describe PxeMenu do
+RSpec.describe PxeMenu do
   before do
     @contents_pxelinux = <<-PXEMENU
 default vesamenu.c32

--- a/spec/models/pxe_server_spec.rb
+++ b/spec/models/pxe_server_spec.rb
@@ -1,4 +1,4 @@
-describe PxeServer do
+RSpec.describe PxeServer do
   before do
     EvmSpecHelper.local_miq_server
     @pxe_server = FactoryBot.create(:pxe_server)

--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -1,6 +1,6 @@
 require "tempfile"
 
-describe RegistrationSystem do
+RSpec.describe RegistrationSystem do
   let(:creds) { {:userid => "SomeUser", :password => "SomePass"} }
   let(:proxy_creds) { {:userid => "bob", :password => "pass"} }
   before do

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,4 +1,4 @@
-describe Relationship do
+RSpec.describe Relationship do
   describe "#filtered?" do
     before do
       @rel = FactoryBot.build(:relationship_vm_vmware)

--- a/spec/models/resource_action_serializer_spec.rb
+++ b/spec/models/resource_action_serializer_spec.rb
@@ -1,4 +1,4 @@
-describe ResourceActionSerializer do
+RSpec.describe ResourceActionSerializer do
   let(:resource_action_serializer) { described_class.new }
 
   describe "#serialize" do

--- a/spec/models/resource_action_spec.rb
+++ b/spec/models/resource_action_spec.rb
@@ -1,4 +1,4 @@
-describe ResourceAction do
+RSpec.describe ResourceAction do
   context "#deliver_to_automate_from_dialog" do
     let(:user) { FactoryBot.create(:user_with_group) }
     let(:zone_name) { "default" }

--- a/spec/models/resource_action_workflow_spec.rb
+++ b/spec/models/resource_action_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe ResourceActionWorkflow do
+RSpec.describe ResourceActionWorkflow do
   let(:admin) { FactoryBot.create(:user_with_group) }
 
   context "#create" do

--- a/spec/models/resource_group_spec.rb
+++ b/spec/models/resource_group_spec.rb
@@ -1,4 +1,4 @@
-describe ResourceGroup do
+RSpec.describe ResourceGroup do
   let(:resource_group) do
     FactoryBot.create(
       :resource_group,

--- a/spec/models/resource_pool_spec.rb
+++ b/spec/models/resource_pool_spec.rb
@@ -1,4 +1,4 @@
-describe ResourcePool do
+RSpec.describe ResourcePool do
   context "Testing VM count virtual columns" do
     before do
       @rp1 = FactoryBot.create(:resource_pool, :name => "RP 1")

--- a/spec/models/retirement_manager_spec.rb
+++ b/spec/models/retirement_manager_spec.rb
@@ -1,4 +1,4 @@
-describe RetirementManager do
+RSpec.describe RetirementManager do
   describe "#check" do
     it "with retirement date, runs retirement checks" do
       _, _, zone = EvmSpecHelper.local_guid_miq_server_zone

--- a/spec/models/scan_item/seeding_spec.rb
+++ b/spec/models/scan_item/seeding_spec.rb
@@ -1,6 +1,6 @@
 require 'fileutils'
 
-describe ScanItem do
+RSpec.describe ScanItem do
   describe "::Seeding" do
     include_examples(".seed called multiple times", 6)
 

--- a/spec/models/security_group_spec.rb
+++ b/spec/models/security_group_spec.rb
@@ -1,4 +1,4 @@
-describe SecurityGroup do
+RSpec.describe SecurityGroup do
   include Spec::Support::ArelHelper
 
   describe ".non_cloud_network" do

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -1,4 +1,4 @@
-describe ServerRole do
+RSpec.describe ServerRole do
   context "Without Seeding" do
     before do
       @server_roles = []

--- a/spec/models/service/aggregation_spec.rb
+++ b/spec/models/service/aggregation_spec.rb
@@ -1,4 +1,4 @@
-describe Service do
+RSpec.describe Service do
   it "#aggregate_all_vm_memory_on_disk will not raise when the attribute is nil" do
     service = FactoryBot.create(:service)
     expect(service).to receive(:has_attribute?).with("aggregate_all_vm_memory_on_disk").and_return(true)

--- a/spec/models/service/dialog_properties/retirement_spec.rb
+++ b/spec/models/service/dialog_properties/retirement_spec.rb
@@ -1,4 +1,4 @@
-describe Service::DialogProperties::Retirement do
+RSpec.describe Service::DialogProperties::Retirement do
   let(:time) { Time.new(2018, 7, 21, 12, 20, 0, 0) }
 
   it 'with a nil parameter' do

--- a/spec/models/service/dialog_properties_spec.rb
+++ b/spec/models/service/dialog_properties_spec.rb
@@ -1,4 +1,4 @@
-describe Service::DialogProperties do
+RSpec.describe Service::DialogProperties do
   it 'with a nil parameter and nil user' do
     options = nil
     expect(described_class.parse(options, nil)).to eq({})

--- a/spec/models/service/linking_workflow_spec.rb
+++ b/spec/models/service/linking_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe Service::LinkingWorkflow do
+RSpec.describe Service::LinkingWorkflow do
   let(:service)  { FactoryBot.create(:service) }
   let(:provider) { FactoryBot.create(:ems_vmware) }
   let(:uid_ems_array) { ["423c9963-378c-813f-1dbd-630e464d59d4", "423cf3e2-e319-3953-993f-fd8513db951d"] }

--- a/spec/models/service/resource_linking_spec.rb
+++ b/spec/models/service/resource_linking_spec.rb
@@ -1,4 +1,4 @@
-describe Service do
+RSpec.describe Service do
   describe '#add_provider_vms' do
     let(:service)  { FactoryBot.create(:service, :evm_owner => FactoryBot.create(:user)) }
     let(:provider) { FactoryBot.create(:ems_vmware) }

--- a/spec/models/service/retirement_management_spec.rb
+++ b/spec/models/service/retirement_management_spec.rb
@@ -1,4 +1,4 @@
-describe "Service Retirement Management" do
+RSpec.describe "Service Retirement Management" do
   let(:user) { FactoryBot.create(:user_miq_request_approver) }
   let(:service_with_owner) { FactoryBot.create(:service, :evm_owner => user) }
   let(:service_ansible_playbook) { FactoryBot.create(:service_ansible_playbook) }

--- a/spec/models/service_ansible_playbook_spec.rb
+++ b/spec/models/service_ansible_playbook_spec.rb
@@ -1,4 +1,4 @@
-describe(ServiceAnsiblePlaybook) do
+RSpec.describe(ServiceAnsiblePlaybook) do
   let(:runner_job)      { FactoryBot.create(:embedded_ansible_job) }
   let(:playbook)        { FactoryBot.create(:embedded_playbook) }
   let(:basic_service)   { FactoryBot.create(:service_ansible_playbook, :options => config_info_options) }

--- a/spec/models/service_ansible_tower_spec.rb
+++ b/spec/models/service_ansible_tower_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceAnsibleTower do
+RSpec.describe ServiceAnsibleTower do
   let(:tower) { FactoryBot.create(:automation_manager_ansible_tower) }
   let(:template_by_dialog) { FactoryBot.create(:ansible_configuration_script, :manager => tower) }
   let(:template_by_setter) { FactoryBot.create(:ansible_configuration_script, :manager => tower) }

--- a/spec/models/service_container_template_spec.rb
+++ b/spec/models/service_container_template_spec.rb
@@ -1,4 +1,4 @@
-describe(ServiceContainerTemplate) do
+RSpec.describe(ServiceContainerTemplate) do
   let(:action) { ResourceAction::PROVISION }
   let(:stack_status) { double("ManageIQ::Providers::Openshift::ContainerManager::OrchestrationStack::Status") }
   let(:stack) do

--- a/spec/models/service_orchestration/provision_tagging_spec.rb
+++ b/spec/models/service_orchestration/provision_tagging_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceOrchestration::ProvisionTagging do
+RSpec.describe ServiceOrchestration::ProvisionTagging do
   shared_examples_for 'service_orchestration VM tagging' do
     it 'assign tags' do
       expect(miq_request_task).to receive(:provision_priority).and_return(provision_priority)

--- a/spec/models/service_orchestration_spec.rb
+++ b/spec/models/service_orchestration_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceOrchestration do
+RSpec.describe ServiceOrchestration do
   let(:manager_by_setter)  { FactoryBot.create(:ems_amazon) }
   let(:template_by_setter) { FactoryBot.create(:orchestration_template) }
   let(:manager_by_dialog)  { FactoryBot.create(:ems_amazon) }

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceOrder do
+RSpec.describe ServiceOrder do
   def create_request
     FactoryBot.create(:service_template_provision_request,
                        :process   => false,

--- a/spec/models/service_reconfigure_request_spec.rb
+++ b/spec/models/service_reconfigure_request_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceReconfigureRequest do
+RSpec.describe ServiceReconfigureRequest do
   let(:request) do
     described_class.new(:options => {:src_id => 123})
   end

--- a/spec/models/service_reconfigure_task_spec.rb
+++ b/spec/models/service_reconfigure_task_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceReconfigureTask do
+RSpec.describe ServiceReconfigureTask do
   let(:user)     { FactoryBot.create(:user_with_group) }
   let(:template) { FactoryBot.create(:service_template, :name => 'Test Template') }
   let(:service)  { FactoryBot.create(:service, :name => 'Test Service', :service_template => template) }

--- a/spec/models/service_record_spec.rb
+++ b/spec/models/service_record_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceResource do
+RSpec.describe ServiceResource do
   context "default values" do
     before do
       @resource = ServiceResource.new

--- a/spec/models/service_resource_spec.rb
+++ b/spec/models/service_resource_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceResource do
+RSpec.describe ServiceResource do
   it "default values" do
     expect(subject.group_idx).to eq(0)
     expect(subject.scaling_min).to eq(1)

--- a/spec/models/service_retire_task_spec.rb
+++ b/spec/models/service_retire_task_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceRetireTask do
+RSpec.describe ServiceRetireTask do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:vm) { FactoryBot.create(:vm) }
   let(:service) { FactoryBot.create(:service, :lifecycle_state => 'provisioned') }

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,4 +1,4 @@
-describe Service do
+RSpec.describe Service do
   include_examples "OwnershipMixin"
 
   context "service events" do

--- a/spec/models/service_template/copy_spec.rb
+++ b/spec/models/service_template/copy_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplate do
+RSpec.describe ServiceTemplate do
   describe "#template_copy" do
     let(:custom_button)                  { FactoryBot.create(:custom_button, :applies_to => service_template) }
     let(:custom_button_for_service)      { FactoryBot.create(:custom_button, :applies_to_class => "Service") }

--- a/spec/models/service_template_ansible_playbook_spec.rb
+++ b/spec/models/service_template_ansible_playbook_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateAnsiblePlaybook do
+RSpec.describe ServiceTemplateAnsiblePlaybook do
   let(:user)     { FactoryBot.create(:user_with_group) }
   let(:auth_one) { FactoryBot.create(:embedded_ansible_credential) }
   let(:auth_two) { FactoryBot.create(:embedded_ansible_credential) }

--- a/spec/models/service_template_ansible_tower_spec.rb
+++ b/spec/models/service_template_ansible_tower_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateAnsibleTower do
+RSpec.describe ServiceTemplateAnsibleTower do
   let(:ra1) { FactoryBot.create(:resource_action, :action => 'Provision') }
   let(:ra2) { FactoryBot.create(:resource_action, :action => 'Retirement') }
   let(:service_dialog) { FactoryBot.create(:dialog) }

--- a/spec/models/service_template_catalog_spec.rb
+++ b/spec/models/service_template_catalog_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateCatalog do
+RSpec.describe ServiceTemplateCatalog do
   let(:root_tenant) do
     Tenant.seed
   end

--- a/spec/models/service_template_container_template_spec.rb
+++ b/spec/models/service_template_container_template_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateContainerTemplate do
+RSpec.describe ServiceTemplateContainerTemplate do
   let(:service_template_catalog) { FactoryBot.create(:service_template_catalog) }
   let(:container_template) { FactoryBot.create(:container_template, :ems_id => ems.id) }
   let(:ems) { FactoryBot.create(:ems_openshift) }

--- a/spec/models/service_template_filter_spec.rb
+++ b/spec/models/service_template_filter_spec.rb
@@ -1,4 +1,4 @@
-describe "Service Filter" do
+RSpec.describe "Service Filter" do
   include Spec::Support::ServiceTemplateHelper
 
   before do

--- a/spec/models/service_template_orchestration_spec.rb
+++ b/spec/models/service_template_orchestration_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateOrchestration do
+RSpec.describe ServiceTemplateOrchestration do
   subject { FactoryBot.create(:service_template_orchestration) }
 
   describe '#create_subtasks' do

--- a/spec/models/service_template_provision_request_quota_spec.rb
+++ b/spec/models/service_template_provision_request_quota_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateProvisionRequest do
+RSpec.describe ServiceTemplateProvisionRequest do
   include Spec::Support::QuotaHelper
   include Spec::Support::ServiceTemplateHelper
 

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateProvisionRequest do
+RSpec.describe ServiceTemplateProvisionRequest do
   let(:admin) { FactoryBot.create(:user_admin) }
   context "with multiple tasks" do
     before do

--- a/spec/models/service_template_provision_task_spec.rb
+++ b/spec/models/service_template_provision_task_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplateProvisionTask do
+RSpec.describe ServiceTemplateProvisionTask do
   context "with multiple tasks" do
     before do
       @admin = FactoryBot.create(:user_with_group)

--- a/spec/models/service_template_spec.rb
+++ b/spec/models/service_template_spec.rb
@@ -1,4 +1,4 @@
-describe ServiceTemplate do
+RSpec.describe ServiceTemplate do
   include_examples "OwnershipMixin"
 
   describe ".with_tenant" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,4 +1,4 @@
-describe Session do
+RSpec.describe Session do
   describe "#raw_data" do
     it "returns the unmarshaled data" do
       session = FactoryBot.build(:session, :data => "BAh7BjoLdXNlcmlkSSIKYWRtaW4GOgZFVA==\n")

--- a/spec/models/settings_change_spec.rb
+++ b/spec/models/settings_change_spec.rb
@@ -1,4 +1,4 @@
-describe SettingsChange do
+RSpec.describe SettingsChange do
   describe "#key_path" do
     it "with multiple parts in the key" do
       change = described_class.new(:key => "/api/token_ttl")

--- a/spec/models/storage_file_spec.rb
+++ b/spec/models/storage_file_spec.rb
@@ -1,4 +1,4 @@
-describe StorageFile do
+RSpec.describe StorageFile do
   context "#is_snapshot_disk_file" do
     it "false if NOT .vmdk extension" do
       stub_file = double(:ext_name => 'txt')

--- a/spec/models/storage_spec.rb
+++ b/spec/models/storage_spec.rb
@@ -1,4 +1,4 @@
-describe Storage do
+RSpec.describe Storage do
   describe "#total_unregistered_vms" do
     let(:ext_management_system)  { FactoryBot.create(:ext_management_system) }
     let(:host)                   { FactoryBot.create(:host) }

--- a/spec/models/sysprep_file_spec.rb
+++ b/spec/models/sysprep_file_spec.rb
@@ -1,6 +1,6 @@
 require "stringio"
 
-describe SysprepFile do
+RSpec.describe SysprepFile do
   let(:good_ini) { "[section1]\n; some comment on section1\nvar1 = foo\nvar2 = bar" }
   let(:bad_ini)  { "; some comment on section1\nvar1_foo\nINI_DATA" }
   let(:good_xml) { "<?xml version=\"1.0\"?><unattend/>" }

--- a/spec/models/system_service_spec.rb
+++ b/spec/models/system_service_spec.rb
@@ -1,4 +1,4 @@
-describe SystemService do
+RSpec.describe SystemService do
   describe ".svc_type" do
     it "has nice names" do
       ss = FactoryBot.build(:system_service, :svc_type => "4")

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,4 +1,4 @@
-describe Tag do
+RSpec.describe Tag do
   describe ".list" do
     it "returns an empty string for something that is untaggable" do
       account = FactoryBot.create(:account)

--- a/spec/models/tenant_quota_spec.rb
+++ b/spec/models/tenant_quota_spec.rb
@@ -1,4 +1,4 @@
-describe TenantQuota do
+RSpec.describe TenantQuota do
   let(:tenant) { FactoryBot.create(:tenant) }
 
   describe "#valid?" do

--- a/spec/models/tenant_spec.rb
+++ b/spec/models/tenant_spec.rb
@@ -1,4 +1,4 @@
-describe Tenant do
+RSpec.describe Tenant do
   include_examples ".seed called multiple times"
 
   let(:tenant) { described_class.new(:domain => 'x.com', :parent => default_tenant) }

--- a/spec/models/time_profile_spec.rb
+++ b/spec/models/time_profile_spec.rb
@@ -1,4 +1,4 @@
-describe TimeProfile do
+RSpec.describe TimeProfile do
   before do
     @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryBot.create(:ems_vmware, :zone => @server.zone)

--- a/spec/models/transformation_mapping/cloud_best_fit_spec.rb
+++ b/spec/models/transformation_mapping/cloud_best_fit_spec.rb
@@ -1,4 +1,4 @@
-describe TransformationMapping::CloudBestFit do
+RSpec.describe TransformationMapping::CloudBestFit do
   let(:ems)         { FactoryBot.create(:ems_openstack) }
   let(:vm)          { FactoryBot.create(:vm_vmware, :hardware => vm_hardware) }
   let(:vm_hardware) { FactoryBot.create(:hardware, :cpu1x2, :ram1GB) }

--- a/spec/models/user/user_ldap_methods_spec.rb
+++ b/spec/models/user/user_ldap_methods_spec.rb
@@ -1,4 +1,4 @@
-describe Authenticator::Ldap do
+RSpec.describe Authenticator::Ldap do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
     @auth_config = {

--- a/spec/models/user_password_spec.rb
+++ b/spec/models/user_password_spec.rb
@@ -1,6 +1,6 @@
 require 'bcrypt'
 
-describe "User Password" do
+RSpec.describe "User Password" do
   context "With admin user" do
     before do
       EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-describe User do
+RSpec.describe User do
   context "validations" do
     it "should ensure presence of name" do
       expect(FactoryBot.build(:user, :name => nil)).not_to be_valid

--- a/spec/models/vim_performance_state/purging_spec.rb
+++ b/spec/models/vim_performance_state/purging_spec.rb
@@ -1,4 +1,4 @@
-describe VimPerformanceState do
+RSpec.describe VimPerformanceState do
   context "::Purging" do
     describe ".purge_by_orphaned" do
       it "purges all the orphaned rows for all referenced classes" do

--- a/spec/models/vim_performance_tag_spec.rb
+++ b/spec/models/vim_performance_tag_spec.rb
@@ -1,4 +1,4 @@
-describe VimPerformanceTag do
+RSpec.describe VimPerformanceTag do
   before do
     @server = EvmSpecHelper.local_miq_server
     @ems    = FactoryBot.create(:ems_vmware, :zone => @server.zone)

--- a/spec/models/vim_performance_tag_value_spec.rb
+++ b/spec/models/vim_performance_tag_value_spec.rb
@@ -1,4 +1,4 @@
-describe VimPerformanceTagValue do
+RSpec.describe VimPerformanceTagValue do
   context "#get_metrics" do
     let(:ts) { Time.zone.now }
     let(:category) { [] }

--- a/spec/models/vm/operations_spec.rb
+++ b/spec/models/vm/operations_spec.rb
@@ -1,4 +1,4 @@
-describe 'VM::Operations' do
+RSpec.describe 'VM::Operations' do
   before do
     @miq_server = EvmSpecHelper.local_miq_server
     @ems        = FactoryBot.create(:ems_vmware, :zone => @miq_server.zone)

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -1,4 +1,4 @@
-describe "VM Retirement Management" do
+RSpec.describe "VM Retirement Management" do
   let(:user) { FactoryBot.create(:user_miq_request_approver) }
   let(:vm_with_owner) { FactoryBot.create(:vm, :evm_owner => user, :host => FactoryBot.create(:host)) }
   let(:region) { FactoryBot.create(:miq_region, :region => ApplicationRecord.my_region_number) }

--- a/spec/models/vm/snapshotting_spec.rb
+++ b/spec/models/vm/snapshotting_spec.rb
@@ -1,4 +1,4 @@
-describe "VM Snapshotting" do
+RSpec.describe "VM Snapshotting" do
   before { EvmSpecHelper.local_miq_server }
   let(:vm) { FactoryBot.create(:vm) }
 

--- a/spec/models/vm_migrate_task_spec.rb
+++ b/spec/models/vm_migrate_task_spec.rb
@@ -1,4 +1,4 @@
-describe VmMigrateTask do
+RSpec.describe VmMigrateTask do
   describe '.do_request' do
     let(:vm) { Vm.new }
     let(:folder) { FactoryBot.create(:ems_folder) }

--- a/spec/models/vm_migrate_workflow_spec.rb
+++ b/spec/models/vm_migrate_workflow_spec.rb
@@ -1,4 +1,4 @@
-describe VmMigrateWorkflow do
+RSpec.describe VmMigrateWorkflow do
   include Spec::Support::WorkflowHelper
   let(:admin) { FactoryBot.create(:user_with_group) }
   let(:ems) { FactoryBot.create(:ems_vmware) }

--- a/spec/models/vm_or_template/operations/configuration_spec.rb
+++ b/spec/models/vm_or_template/operations/configuration_spec.rb
@@ -1,4 +1,4 @@
-describe VmOrTemplate::Operations::Configuration do
+RSpec.describe VmOrTemplate::Operations::Configuration do
   context "#raw_add_disk" do
     let(:disk_name) { "abc" }
     let(:disk_size) { "123" }

--- a/spec/models/vm_or_template/scanning_spec.rb
+++ b/spec/models/vm_or_template/scanning_spec.rb
@@ -1,4 +1,4 @@
-describe VmOrTemplate::Scanning do
+RSpec.describe VmOrTemplate::Scanning do
   describe ".scan_timeout_adjustment_multiplier" do
     it "when called for Template class, returns numeric value" do
       expect(MiqTemplate.scan_timeout_adjustment_multiplier).to be_kind_of(Numeric)

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -1,4 +1,4 @@
-describe VmOrTemplate do
+RSpec.describe VmOrTemplate do
   include Spec::Support::ArelHelper
 
   let(:vm)      { FactoryBot.create(:vm_or_template) }

--- a/spec/models/vm_reconfigure_request_spec.rb
+++ b/spec/models/vm_reconfigure_request_spec.rb
@@ -1,4 +1,4 @@
-describe VmReconfigureRequest do
+RSpec.describe VmReconfigureRequest do
   let(:admin)         { FactoryBot.create(:user, :userid => "tester") }
   let(:ems_vmware)    { FactoryBot.create(:ems_vmware, :zone => zone2) }
   let(:host_hardware) { FactoryBot.build(:hardware, :cpu_total_cores => 40, :cpu_sockets => 10, :cpu_cores_per_socket => 4) }

--- a/spec/models/vm_reconfigure_task_spec.rb
+++ b/spec/models/vm_reconfigure_task_spec.rb
@@ -1,4 +1,4 @@
-describe VmReconfigureTask do
+RSpec.describe VmReconfigureTask do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:ems_vmware)    { FactoryBot.create(:ems_vmware, :zone => zone2) }
   let(:host_hardware) { FactoryBot.build(:hardware, :cpu_total_cores => 40, :cpu_sockets => 10, :cpu_cores_per_socket => 4) }

--- a/spec/models/vm_retire_task_spec.rb
+++ b/spec/models/vm_retire_task_spec.rb
@@ -1,4 +1,4 @@
-describe VmRetireTask do
+RSpec.describe VmRetireTask do
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:vm) { FactoryBot.create(:vm) }
   let(:miq_request) { FactoryBot.create(:vm_retire_request, :requester => user) }

--- a/spec/models/vm_scan_spec.rb
+++ b/spec/models/vm_scan_spec.rb
@@ -1,4 +1,4 @@
-describe VmScan do
+RSpec.describe VmScan do
   # test cases for BZ #1454936
   context "A VM Scan job in multiple zones" do
     before do

--- a/spec/models/vm_spec.rb
+++ b/spec/models/vm_spec.rb
@@ -1,4 +1,4 @@
-describe Vm do
+RSpec.describe Vm do
   include_examples "OwnershipMixin"
 
   it "#corresponding_model" do

--- a/spec/models/vmdb_database/metric_capture_spec.rb
+++ b/spec/models/vmdb_database/metric_capture_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbDatabase do
+RSpec.describe VmdbDatabase do
   context "::MetricCapture" do
     context "#capture_database_metrics" do
       let(:db) { FactoryBot.create(:vmdb_database) }

--- a/spec/models/vmdb_database/seeding_spec.rb
+++ b/spec/models/vmdb_database/seeding_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbDatabase do
+RSpec.describe VmdbDatabase do
   describe "::Seeding" do
     let(:connection) { ApplicationRecord.connection }
 

--- a/spec/models/vmdb_database_connection_spec.rb
+++ b/spec/models/vmdb_database_connection_spec.rb
@@ -1,6 +1,6 @@
 require "concurrent/atomic/event"
 
-describe VmdbDatabaseConnection do
+RSpec.describe VmdbDatabaseConnection do
   self.use_transactional_tests = false
   after :all do
     # HACK: Some other tests (around Automate) rely on the fact there's

--- a/spec/models/vmdb_database_setting_spec.rb
+++ b/spec/models/vmdb_database_setting_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbDatabaseSetting do
+RSpec.describe VmdbDatabaseSetting do
   before do
     @db = FactoryBot.create(:vmdb_database)
   end

--- a/spec/models/vmdb_database_spec.rb
+++ b/spec/models/vmdb_database_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbDatabase do
+RSpec.describe VmdbDatabase do
   let(:db) { FactoryBot.create(:vmdb_database, :name => ActiveRecord::Base.connection.current_database) }
 
   let(:table) { FactoryBot.create(:vmdb_table_evm,  :vmdb_database => db) }

--- a/spec/models/vmdb_index_spec.rb
+++ b/spec/models/vmdb_index_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbIndex do
+RSpec.describe VmdbIndex do
   context "#capture_metrics" do
     let(:index) { FactoryBot.create(:vmdb_index, :name => "accounts_pkey") }
 

--- a/spec/models/vmdb_metric_spec.rb
+++ b/spec/models/vmdb_metric_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbMetric do
+RSpec.describe VmdbMetric do
   before do
     EvmSpecHelper.create_guid_miq_server_zone
   end

--- a/spec/models/vmdb_table_evm_spec.rb
+++ b/spec/models/vmdb_table_evm_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbTableEvm do
+RSpec.describe VmdbTableEvm do
   let(:db)    { FactoryBot.create(:vmdb_database) }
   let(:table) { FactoryBot.create(:vmdb_table_evm, :vmdb_database => db, :name => "accounts") }
 

--- a/spec/models/vmdb_table_spec.rb
+++ b/spec/models/vmdb_table_spec.rb
@@ -1,4 +1,4 @@
-describe VmdbTable do
+RSpec.describe VmdbTable do
   context "#latest_hourly_metric" do
     let(:db)    { FactoryBot.create(:vmdb_database) }
     let(:table) { FactoryBot.create(:vmdb_table, :vmdb_database => db, :name => 'foo') }

--- a/spec/models/volume_spec.rb
+++ b/spec/models/volume_spec.rb
@@ -1,4 +1,4 @@
-describe Volume do
+RSpec.describe Volume do
   context "#volume_group" do
     it "nil when starts with '***physical_'," do
       expect(Volume.new(:volume_group => '***physical_scsi0:0:1').volume_group).to be_falsey

--- a/spec/models/widget_import_validator_spec.rb
+++ b/spec/models/widget_import_validator_spec.rb
@@ -1,4 +1,4 @@
-describe WidgetImportValidator do
+RSpec.describe WidgetImportValidator do
   let(:widget_import_validator) { described_class.new }
 
   describe "#determine_validity" do


### PR DESCRIPTION
To be consistent across specs let's change the outer `describe` block to `RSpec.describe`. This seems to be the preferred style (based on the relishapp.com examples, as well as the pragprog book) and I think it's going to be mandatory for the outer block in rspec 4.