### PR TITLE
Use RSpec.describe in outer block for all specs

### DIFF
--- a/spec/lib/active_record_query_parts_spec.rb
+++ b/spec/lib/active_record_query_parts_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveRecordQueryParts do
+RSpec.describe ActiveRecordQueryParts do
   context "glob to sql" do
     it "replaces '*'" do
       expect(described_class.glob_to_sql_like("a*b*c")).to eq("a%b%c")

--- a/spec/lib/acts_as_ar_model_spec.rb
+++ b/spec/lib/acts_as_ar_model_spec.rb
@@ -1,4 +1,4 @@
-describe ActsAsArModel do
+RSpec.describe ActsAsArModel do
   # id is a default column included regardless if it's in the set_columns_hash
   let(:col_names_strs) { %w(str id int flt dt) }
 

--- a/spec/lib/acts_as_ar_scope_spec.rb
+++ b/spec/lib/acts_as_ar_scope_spec.rb
@@ -1,4 +1,4 @@
-describe ActsAsArScope do
+RSpec.describe ActsAsArScope do
   context "AR backed model" do
     # model contains ids of important vms - acts like ar model
     let(:important_vm_model) do

--- a/spec/lib/ansible/runner/response_spec.rb
+++ b/spec/lib/ansible/runner/response_spec.rb
@@ -1,4 +1,4 @@
-describe Ansible::Runner::Response do
+RSpec.describe Ansible::Runner::Response do
   subject { described_class.new(:base_dir => base_dir, :ident => ident) }
 
   let(:ident)        { described_class.new(:base_dir => '').ident }

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -1,4 +1,4 @@
-describe Ansible::Runner do
+RSpec.describe Ansible::Runner do
   let(:uuid)       { "201ac780-7bf4-0136-3b9e-54e1ad8b3cf4" }
   let(:env_vars)   { {"ENV1" => "VAL1", "ENV2" => "VAL2"} }
   let(:extra_vars) { {"id" => uuid} }

--- a/spec/lib/container_orchestrator_spec.rb
+++ b/spec/lib/container_orchestrator_spec.rb
@@ -1,4 +1,4 @@
-describe ContainerOrchestrator do
+RSpec.describe ContainerOrchestrator do
   let(:kube_apps_connection) { subject.send(:kube_apps_connection) }
   let(:kube_connection)      { subject.send(:kube_connection) }
   let(:cert)                 { Tempfile.new("cert") }

--- a/spec/lib/ems_event_helper_spec.rb
+++ b/spec/lib/ems_event_helper_spec.rb
@@ -1,4 +1,4 @@
-describe EmsEventHelper do
+RSpec.describe EmsEventHelper do
   context "fb12322 - MiqAeEvent.build_evm_event blows up expecting inputs[:policy] to be an instance of MiqPolicy, but it is a hash of { :vmdb_class => 'MiqPolicy', :vmdb_id => 42}" do
     before do
       [Zone, ExtManagementSystem, Host, Vm, Storage, EmsEvent, MiqEventDefinition, MiqPolicy, MiqAction, MiqPolicyContent, MiqPolicySet].each(&:delete_all)

--- a/spec/lib/evm_database_ops_spec.rb
+++ b/spec/lib/evm_database_ops_spec.rb
@@ -1,5 +1,5 @@
 require 'util/runcmd'
-describe EvmDatabaseOps do
+RSpec.describe EvmDatabaseOps do
   let(:file_storage) { double("MiqSmbSession", :disconnect => nil) }
   let(:local_backup) { "/tmp/backup_1" }
   let(:input_path)   { "foo/bar/mkfifo" }

--- a/spec/lib/evm_database_spec.rb
+++ b/spec/lib/evm_database_spec.rb
@@ -1,6 +1,6 @@
 require 'manageiq-postgres_ha_admin'
 
-describe EvmDatabase do
+RSpec.describe EvmDatabase do
   subject { described_class }
   context "#local?" do
     ["localhost", "127.0.0.1", "", nil].each do |host|

--- a/spec/lib/extensions/ar_base_model_spec.rb
+++ b/spec/lib/extensions/ar_base_model_spec.rb
@@ -1,4 +1,4 @@
-describe "ar_base_model extension" do
+RSpec.describe "ar_base_model extension" do
   context "with a test class" do
     let(:test_class) do
       Class.new(ActiveRecord::Base) do

--- a/spec/lib/extensions/ar_base_spec.rb
+++ b/spec/lib/extensions/ar_base_spec.rb
@@ -1,4 +1,4 @@
-describe "ar_base extension" do
+RSpec.describe "ar_base extension" do
   context "with a test class" do
     let(:test_class) do
       Class.new(ActiveRecord::Base) do

--- a/spec/lib/extensions/ar_column_names_spec.rb
+++ b/spec/lib/extensions/ar_column_names_spec.rb
@@ -1,4 +1,4 @@
-describe "ar_column_names extension" do
+RSpec.describe "ar_column_names extension" do
   context "With an empty test class" do
     it "should have the correct column names symbols" do
       expect(SchemaMigration.column_names_symbols).to eq([:version])

--- a/spec/lib/extensions/ar_dba_spec.rb
+++ b/spec/lib/extensions/ar_dba_spec.rb
@@ -1,4 +1,4 @@
-describe "ar_dba extension" do
+RSpec.describe "ar_dba extension" do
   let(:connection) { ApplicationRecord.connection }
 
   describe "#xlog_location" do

--- a/spec/lib/extensions/ar_extract_objects_spec.rb
+++ b/spec/lib/extensions/ar_extract_objects_spec.rb
@@ -1,4 +1,4 @@
-describe "ArExtractObjects" do
+RSpec.describe "ArExtractObjects" do
   context "ArExtractObjectsTest" do
     before do
       vms = (0...2).collect { FactoryBot.create(:vm_vmware) }

--- a/spec/lib/extensions/ar_migration_spec.rb
+++ b/spec/lib/extensions/ar_migration_spec.rb
@@ -1,4 +1,4 @@
-describe ArPglogicalMigrationHelper do
+RSpec.describe ArPglogicalMigrationHelper do
   shared_context "without the schema_migrations_ran table" do
     before do
       allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_call_original

--- a/spec/lib/extensions/ar_nested_count_by_spec.rb
+++ b/spec/lib/extensions/ar_nested_count_by_spec.rb
@@ -1,4 +1,4 @@
-describe "AR Nested Count By extension" do
+RSpec.describe "AR Nested Count By extension" do
   context "miq_queue with messages" do
     let(:zone1) { EvmSpecHelper.local_miq_server.zone }
     let(:zone2) { FactoryBot.create(:zone) }

--- a/spec/lib/extensions/ar_number_of_spec.rb
+++ b/spec/lib/extensions/ar_number_of_spec.rb
@@ -1,4 +1,4 @@
-describe "#number_of" do
+RSpec.describe "#number_of" do
   it "caches the results" do
     h = FactoryBot.create(:host)
     FactoryBot.create_list(:vm, 2, :host => h)

--- a/spec/lib/extensions/ar_order_spec.rb
+++ b/spec/lib/extensions/ar_order_spec.rb
@@ -1,4 +1,4 @@
-describe "ar_order extension" do
+RSpec.describe "ar_order extension" do
   # includes a has_many AND references the has many
   # this introduces a DISTINCT to the query.
   # rails uses limited_ids_for (which calls columns_for_distinct) to run a quick query

--- a/spec/lib/extensions/ar_references_spec.rb
+++ b/spec/lib/extensions/ar_references_spec.rb
@@ -1,4 +1,4 @@
-describe "ar_references" do
+RSpec.describe "ar_references" do
   describe ".includes_to_references" do
     it "supports none" do
       expect(Vm.includes_to_references(nil)).to eq([])

--- a/spec/lib/extensions/ar_region_spec.rb
+++ b/spec/lib/extensions/ar_region_spec.rb
@@ -1,4 +1,4 @@
-describe ArRegion do
+RSpec.describe ArRegion do
   it "exposes #region_number as a virtual column" do
     expect(Vm).to have_virtual_column(:region_number)
   end

--- a/spec/lib/extensions/ar_taggable_spec.rb
+++ b/spec/lib/extensions/ar_taggable_spec.rb
@@ -1,4 +1,4 @@
-describe ActsAsTaggable do
+RSpec.describe ActsAsTaggable do
   before do
     @host1 = FactoryBot.create(:host, :name => "HOST1")
     @host1.tag_with("red blue yellow", :ns => "/test", :cat => "tags")

--- a/spec/lib/extensions/ar_yaml_spec.rb
+++ b/spec/lib/extensions/ar_yaml_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveRecord::AttributeAccessorThatYamls do
+RSpec.describe ActiveRecord::AttributeAccessorThatYamls do
   Vm.class_eval do
     include ActiveRecord::AttributeAccessorThatYamls
     attr_accessor_that_yamls :access1, :access2

--- a/spec/lib/extensions/database_configuration_spec.rb
+++ b/spec/lib/extensions/database_configuration_spec.rb
@@ -1,4 +1,4 @@
-describe "DatabaseConfiguration patch" do
+RSpec.describe "DatabaseConfiguration patch" do
   let(:db_config_path) { File.expand_path "../../../config/database.yml", __dir__ }
   let(:fake_db_config) { Pathname.new("does/not/exist") }
 

--- a/spec/lib/git_worktree_spec.rb
+++ b/spec/lib/git_worktree_spec.rb
@@ -1,4 +1,4 @@
-describe GitWorktree do
+RSpec.describe GitWorktree do
   context "repository" do
     before do
       @git_db = "TestGit.git"

--- a/spec/lib/manageiq_spec.rb
+++ b/spec/lib/manageiq_spec.rb
@@ -8,7 +8,7 @@
 
 require 'manageiq'
 
-describe ManageIQ do
+RSpec.describe ManageIQ do
   def without_rails(rb_cmd)
     miq_lib_file = Rails.root.join("lib", "manageiq.rb")
     `#{Gem.ruby} -e 'require "#{miq_lib_file}"; print #{rb_cmd}'`

--- a/spec/lib/miq_apache/control_spec.rb
+++ b/spec/lib/miq_apache/control_spec.rb
@@ -1,4 +1,4 @@
-describe MiqApache::Control do
+RSpec.describe MiqApache::Control do
   it "should run_apache_cmd with start when calling start" do
     expect(MiqApache::Control).to receive(:run_apache_cmd).with('start')
     MiqApache::Control.start

--- a/spec/lib/miq_cockpit_spec.rb
+++ b/spec/lib/miq_cockpit_spec.rb
@@ -1,4 +1,4 @@
-describe MiqCockpit::WS do
+RSpec.describe MiqCockpit::WS do
   before do
     @server = FactoryBot.create(:miq_server, :hostname => "hostname")
     @miq_server = EvmSpecHelper.local_miq_server

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -1,4 +1,4 @@
-describe MiqExpression do
+RSpec.describe MiqExpression do
   describe '#reporting_available_fields' do
     let(:vm) { FactoryBot.create(:vm) }
     let!(:custom_attribute) { FactoryBot.create(:custom_attribute, :name => 'my_attribute_1', :resource => vm) }

--- a/spec/lib/miq_ldap_spec.rb
+++ b/spec/lib/miq_ldap_spec.rb
@@ -1,6 +1,6 @@
 # encoding: US-ASCII
 
-describe MiqLdap do
+RSpec.describe MiqLdap do
   before do
     @host     = 'mycompany.com'
 

--- a/spec/lib/miq_pglogical_spec.rb
+++ b/spec/lib/miq_pglogical_spec.rb
@@ -1,4 +1,4 @@
-describe MiqPglogical do
+RSpec.describe MiqPglogical do
   let(:ar_connection) { ApplicationRecord.connection }
   let(:pglogical)     { PG::LogicalReplication::Client.new(ar_connection.raw_connection) }
 

--- a/spec/lib/miq_preloader_spec.rb
+++ b/spec/lib/miq_preloader_spec.rb
@@ -1,4 +1,4 @@
-describe MiqPreloader do
+RSpec.describe MiqPreloader do
   describe ".preload" do
     it "preloads once from an object" do
       ems = FactoryBot.create(:ems_infra)

--- a/spec/lib/pdf_generator_spec.rb
+++ b/spec/lib/pdf_generator_spec.rb
@@ -1,4 +1,4 @@
-describe PdfGenerator do
+RSpec.describe PdfGenerator do
   let(:generator) do
     double("PdfGenerator subclass", :available? => true, :pdf_from_string => "pdf-data")
   end

--- a/spec/lib/pid_file_spec.rb
+++ b/spec/lib/pid_file_spec.rb
@@ -1,4 +1,4 @@
-describe PidFile do
+RSpec.describe PidFile do
   before do
     @fname = 'foo.bar'
     @pid_file = PidFile.new(@fname)

--- a/spec/lib/postponed_translation_spec.rb
+++ b/spec/lib/postponed_translation_spec.rb
@@ -1,4 +1,4 @@
-describe PostponedTranslation do
+RSpec.describe PostponedTranslation do
   context "translate" do
     it "calls Kernel#format" do
       pt = PostponedTranslation.new("Test %s") { "foo" }

--- a/spec/lib/query_counter_spec.rb
+++ b/spec/lib/query_counter_spec.rb
@@ -1,4 +1,4 @@
-describe Spec::Support::QueryCounter do
+RSpec.describe Spec::Support::QueryCounter do
   it "counts named queries" do
     expect(Spec::Support::QueryCounter.count { Host.first }).to eq(1)
   end

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -1,4 +1,4 @@
-describe Rbac::Filterer do
+RSpec.describe Rbac::Filterer do
   describe "using expressions as managed filters" do
     it "supports OR conditions across categories" do
       filter = MiqExpression.new(

--- a/spec/lib/rbac_spec.rb
+++ b/spec/lib/rbac_spec.rb
@@ -1,4 +1,4 @@
-describe Rbac do
+RSpec.describe Rbac do
   before { allow(User).to receive_messages(:server_timezone => "UTC") }
 
   describe ".resources_shared_with" do

--- a/spec/lib/remote_console/client_adapter/web_mks_legacy_spec.rb
+++ b/spec/lib/remote_console/client_adapter/web_mks_legacy_spec.rb
@@ -1,4 +1,4 @@
-describe RemoteConsole::ClientAdapter::WebMKSLegacy do
+RSpec.describe RemoteConsole::ClientAdapter::WebMKSLegacy do
   let(:record) { FactoryBot.create(:system_console, :url => '/12345') }
   subject { described_class.new(record, nil) }
 

--- a/spec/lib/remote_console/client_adapter/web_mks_spec.rb
+++ b/spec/lib/remote_console/client_adapter/web_mks_spec.rb
@@ -1,4 +1,4 @@
-describe RemoteConsole::ClientAdapter::WebMKS do
+RSpec.describe RemoteConsole::ClientAdapter::WebMKS do
   let(:record) { FactoryBot.create(:system_console, :secret => '12345') }
   subject { described_class.new(record, nil) }
 

--- a/spec/lib/remote_console/client_adapter_spec.rb
+++ b/spec/lib/remote_console/client_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe RemoteConsole::ClientAdapter do
+RSpec.describe RemoteConsole::ClientAdapter do
   describe '.new' do
     let(:record) { FactoryBot.create(:system_console, :protocol => protocol, :ssl => ssl) }
     let(:ssl) { false }

--- a/spec/lib/remote_console/rack_server_spec.rb
+++ b/spec/lib/remote_console/rack_server_spec.rb
@@ -1,4 +1,4 @@
-describe RemoteConsole::RackServer do
+RSpec.describe RemoteConsole::RackServer do
   before do
     allow(logger).to receive(:info)
     @server = described_class.new(:logger => logger)

--- a/spec/lib/remote_console/server_adapter_spec.rb
+++ b/spec/lib/remote_console/server_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe RemoteConsole::ServerAdapter do
+RSpec.describe RemoteConsole::ServerAdapter do
   describe '.new' do
     let(:record) { FactoryBot.create(:system_console, :protocol => protocol) }
 

--- a/spec/lib/services/dialog_import_service_spec.rb
+++ b/spec/lib/services/dialog_import_service_spec.rb
@@ -1,7 +1,7 @@
 require "dialog_field_importer"
 require "dialog_import_validator"
 
-describe DialogImportService do
+RSpec.describe DialogImportService do
   let(:dialog_import_service) { described_class.new(dialog_field_importer, dialog_import_validator) }
   let(:dialog_field_importer) { double("DialogFieldImporter") }
   let(:dialog_import_validator) { double("DialogImportValidator") }

--- a/spec/lib/services/resource_sharer_spec.rb
+++ b/spec/lib/services/resource_sharer_spec.rb
@@ -1,4 +1,4 @@
-describe ResourceSharer do
+RSpec.describe ResourceSharer do
   before { allow(User).to receive_messages(:server_timezone => "UTC") }
 
   describe "#share" do

--- a/spec/lib/task_helpers/exports/alert_sets_spec.rb
+++ b/spec/lib/task_helpers/exports/alert_sets_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::AlertSets do
+RSpec.describe TaskHelpers::Exports::AlertSets do
   let(:guid) { "eca41687-5ca9-40f2-93f7-3fe1ef08e16e" }
 
   let(:alert_set_export_attrs) do

--- a/spec/lib/task_helpers/exports/alerts_spec.rb
+++ b/spec/lib/task_helpers/exports/alerts_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::Alerts do
+RSpec.describe TaskHelpers::Exports::Alerts do
   let(:guid) { "8f0d49a0-22b0-0135-5de8-54ee7549b627" }
 
   let(:alert_export_attrs) do

--- a/spec/lib/task_helpers/exports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/exports/custom_buttons_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::CustomButtons do
+RSpec.describe TaskHelpers::Exports::CustomButtons do
   let!(:custom_button)     { FactoryBot.create(:custom_button, :name => "export_test_button", :description => "Export Test", :applies_to_class => "Vm") }
   let!(:custom_button2)    { FactoryBot.create(:custom_button, :name => "export_test_button2", :description => "Export Test", :applies_to_class => "Service") }
   let!(:custom_button_set) { FactoryBot.create(:custom_button_set, :name => "custom_button_set", :description => "Default Export Test") }

--- a/spec/lib/task_helpers/exports/customization_templates_spec.rb
+++ b/spec/lib/task_helpers/exports/customization_templates_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::CustomizationTemplates do
+RSpec.describe TaskHelpers::Exports::CustomizationTemplates do
   let(:template_name) { "Basic root pass template" }
   let(:template_type) { "CustomizationTemplateCloudInit" }
   let(:template_desc) { "This template takes use of rootpassword defined in the UI" }

--- a/spec/lib/task_helpers/exports/generic_object_definitions_spec.rb
+++ b/spec/lib/task_helpers/exports/generic_object_definitions_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::GenericObjectDefinitions do
+RSpec.describe TaskHelpers::Exports::GenericObjectDefinitions do
   let(:export_dir) do
     Dir.mktmpdir('miq_exp_dir')
   end

--- a/spec/lib/task_helpers/exports/policies_spec.rb
+++ b/spec/lib/task_helpers/exports/policies_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::Policies do
+RSpec.describe TaskHelpers::Exports::Policies do
   let(:guid) { "a61314d5-67bd-435f-9c82-b82226e0a7fe" }
   let(:guid2) { "ac7e2972-f2b2-4ebe-b29d-97eefaac7615" }
 

--- a/spec/lib/task_helpers/exports/policy_sets_spec.rb
+++ b/spec/lib/task_helpers/exports/policy_sets_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::PolicySets do
+RSpec.describe TaskHelpers::Exports::PolicySets do
   let(:guid) { "a3734dcc-e25d-4164-ba95-1114568d491a" }
   let(:guid2) { "328593c3-a0a2-4a31-8d58-1a3eeef0ce95" }
 

--- a/spec/lib/task_helpers/exports/provision_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/provision_dialogs_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::ProvisionDialogs do
+RSpec.describe TaskHelpers::Exports::ProvisionDialogs do
   let(:dialog_name1) { "default_dialog" }
   let(:dialog_name2) { "custom_dialog" }
   let(:dialog_desc1) { "Default Provisioning Dialog" }

--- a/spec/lib/task_helpers/exports/reports_spec.rb
+++ b/spec/lib/task_helpers/exports/reports_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::Reports do
+RSpec.describe TaskHelpers::Exports::Reports do
   let(:export_dir) do
     Dir.mktmpdir('miq_exp_dir')
   end

--- a/spec/lib/task_helpers/exports/roles_spec.rb
+++ b/spec/lib/task_helpers/exports/roles_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::Roles do
+RSpec.describe TaskHelpers::Exports::Roles do
   let(:role_test_export) do
     [{"name"                => "Test Role",
       "read_only"           => false,

--- a/spec/lib/task_helpers/exports/service_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/service_dialogs_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::ServiceDialogs do
+RSpec.describe TaskHelpers::Exports::ServiceDialogs do
   let(:buttons) { "the buttons" }
   let(:description1) { "the first description" }
   let(:description2) { "the second description" }

--- a/spec/lib/task_helpers/exports/tags_spec.rb
+++ b/spec/lib/task_helpers/exports/tags_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::Tags do
+RSpec.describe TaskHelpers::Exports::Tags do
   let(:parent)      { FactoryBot.create(:classification, :name => "export_test_category",   :description => "Export Test") }
   let(:def_parent)  { FactoryBot.create(:classification, :name => "default_test_category",  :description => "Default Export Test",   :default => true) }
   let(:def_parent2) { FactoryBot.create(:classification, :name => "default_test2_category", :description => "Default Export Test 2", :default => true) }

--- a/spec/lib/task_helpers/exports/widgets_spec.rb
+++ b/spec/lib/task_helpers/exports/widgets_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports::Widgets do
+RSpec.describe TaskHelpers::Exports::Widgets do
   let(:export_dir) do
     Dir.mktmpdir('miq_exp_dir')
   end

--- a/spec/lib/task_helpers/exports_spec.rb
+++ b/spec/lib/task_helpers/exports_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Exports do
+RSpec.describe TaskHelpers::Exports do
   describe '.safe_filename' do
     it 'should return a filename without spaces' do
       filename = TaskHelpers::Exports.safe_filename('filename without spaces')

--- a/spec/lib/task_helpers/imports/alert_sets_spec.rb
+++ b/spec/lib/task_helpers/imports/alert_sets_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::AlertSets do
+RSpec.describe TaskHelpers::Imports::AlertSets do
   let(:data_dir)           { File.join(File.expand_path(__dir__), 'data', 'alert_sets') }
   let(:alert_set_file)     { 'Alert_Profile_VM_Import_Test.yaml' }
   let(:bad_alert_set_file) { 'Bad_Alert_Profile_Host_Import_Test.yml' }

--- a/spec/lib/task_helpers/imports/alerts_spec.rb
+++ b/spec/lib/task_helpers/imports/alerts_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::Alerts do
+RSpec.describe TaskHelpers::Imports::Alerts do
   let(:data_dir)       { File.join(File.expand_path(__dir__), 'data', 'alerts') }
   let(:alert_file)     { 'Alert_Import_Test.yaml' }
   let(:bad_alert_file) { 'Bad_Alert_Import_Test.yml' }

--- a/spec/lib/task_helpers/imports/custom_buttons_spec.rb
+++ b/spec/lib/task_helpers/imports/custom_buttons_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::CustomButtons do
+RSpec.describe TaskHelpers::Imports::CustomButtons do
   let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'custom_buttons') }
   let(:custom_button_file)            { 'CustomButtons.yaml' }
   let(:bad_custom_button_file)        { 'CustomButtonsBad.yaml' }

--- a/spec/lib/task_helpers/imports/customization_templates_spec.rb
+++ b/spec/lib/task_helpers/imports/customization_templates_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::CustomizationTemplates do
+RSpec.describe TaskHelpers::Imports::CustomizationTemplates do
   describe "#import" do
     let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'customization_templates') }
     let(:ct_file) { "existing_ct_and_pit.yaml" }

--- a/spec/lib/task_helpers/imports/generic_object_definitions_spec.rb
+++ b/spec/lib/task_helpers/imports/generic_object_definitions_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::GenericObjectDefinitions do
+RSpec.describe TaskHelpers::Imports::GenericObjectDefinitions do
   describe "#import" do
     let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'generic_object_definitions') }
     let(:options) { { :source => source, :overwrite => overwrite } }

--- a/spec/lib/task_helpers/imports/policies_spec.rb
+++ b/spec/lib/task_helpers/imports/policies_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::Policies do
+RSpec.describe TaskHelpers::Imports::Policies do
   let(:data_dir)        { File.join(File.expand_path(__dir__), 'data', 'policies') }
   let(:policy_file)     { 'Policy_Import_Test.yaml' }
   let(:bad_policy_file) { 'Bad_Policy_Import_Test.yml' }

--- a/spec/lib/task_helpers/imports/policy_sets_spec.rb
+++ b/spec/lib/task_helpers/imports/policy_sets_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::PolicySets do
+RSpec.describe TaskHelpers::Imports::PolicySets do
   let(:data_dir)            { File.join(File.expand_path(__dir__), 'data', 'policy_sets') }
   let(:policy_set_file)     { 'Policy_Profile_Import_Test.yaml' }
   let(:bad_policy_set_file) { 'Bad_Policy_Profile_Import_Test.yml' }

--- a/spec/lib/task_helpers/imports/provision_dialogs_spec.rb
+++ b/spec/lib/task_helpers/imports/provision_dialogs_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::ProvisionDialogs do
+RSpec.describe TaskHelpers::Imports::ProvisionDialogs do
   let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'provision_dialogs') }
   let(:dialog_file) { 'MiqProvisionWorkflow-test_miq_provision_dialogs_template.yaml' }
   let(:mod_dialog_file) { 'MiqProvisionWorkflow-test_miq_provision_dialogs_template_modified.yml' }

--- a/spec/lib/task_helpers/imports/reports_spec.rb
+++ b/spec/lib/task_helpers/imports/reports_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::Reports do
+RSpec.describe TaskHelpers::Imports::Reports do
   describe "#import" do
     let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'reports') }
     let(:rpt_file1) { "Test_Report.yaml" }

--- a/spec/lib/task_helpers/imports/roles_spec.rb
+++ b/spec/lib/task_helpers/imports/roles_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::Roles do
+RSpec.describe TaskHelpers::Imports::Roles do
   let(:data_dir)        { File.join(File.expand_path(__dir__), 'data', 'roles') }
   let(:role_file)       { 'Role_Import_Test.yaml' }
   let(:bad_role_file)   { 'Bad_Role_Import_Test.yml' }

--- a/spec/lib/task_helpers/imports/service_dialogs_spec.rb
+++ b/spec/lib/task_helpers/imports/service_dialogs_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::ServiceDialogs do
+RSpec.describe TaskHelpers::Imports::ServiceDialogs do
   let(:data_dir)         { File.join(File.expand_path(__dir__), 'data', 'service_dialogs') }
   let(:dialog_file)      { 'Simple_Dialog.yaml' }
   let(:mod_dialog_file)  { 'Simple_Dialog_modified.yml' }

--- a/spec/lib/task_helpers/imports/tags_spec.rb
+++ b/spec/lib/task_helpers/imports/tags_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::Tags do
+RSpec.describe TaskHelpers::Imports::Tags do
   let(:data_dir)        { File.join(File.expand_path(__dir__), 'data', 'tags') }
   let(:tag_file1)       { 'Import_Test.yaml' }
   let(:tag_file2)       { 'Location.yaml' }

--- a/spec/lib/task_helpers/imports/widgets_spec.rb
+++ b/spec/lib/task_helpers/imports/widgets_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports::Widgets do
+RSpec.describe TaskHelpers::Imports::Widgets do
   describe "#import" do
     let(:data_dir) { File.join(File.expand_path(__dir__), 'data', 'widgets') }
     let(:widget_file1) { "Test_Widget.yaml" }

--- a/spec/lib/task_helpers/imports_spec.rb
+++ b/spec/lib/task_helpers/imports_spec.rb
@@ -1,4 +1,4 @@
-describe TaskHelpers::Imports do
+RSpec.describe TaskHelpers::Imports do
   describe '.validate_source' do
     before do
       @import_dir = Dir.mktmpdir('miq_imp_dir')

--- a/spec/lib/tasks/dialogs_spec.rb
+++ b/spec/lib/tasks/dialogs_spec.rb
@@ -1,6 +1,6 @@
 require "rake"
 
-describe "dialogs" do
+RSpec.describe "dialogs" do
   let(:task_path) { "lib/tasks/dialogs" }
 
   describe "import", :type => :rake_task do

--- a/spec/lib/tasks/evm_application_spec.rb
+++ b/spec/lib/tasks/evm_application_spec.rb
@@ -2,7 +2,7 @@ require "tempfile"
 require "fileutils"
 require Rails.root.join("lib", "tasks", "evm_application")
 
-describe EvmApplication do
+RSpec.describe EvmApplication do
   context ".server_state" do
     it "with a valid status" do
       EvmSpecHelper.create_guid_miq_server_zone

--- a/spec/lib/tasks/evm_settings_spec.rb
+++ b/spec/lib/tasks/evm_settings_spec.rb
@@ -1,6 +1,6 @@
 require "rake"
 
-describe "EvmSettings", :type => :rake_task do
+RSpec.describe "EvmSettings", :type => :rake_task do
   let(:task_path) { "lib/tasks/evm_settings" }
   let(:keys) { ["/authentication/mode", "/authentication/httpd_role", "/authentication/sso_enabled", "/authentication/saml_enabled", "/authentication/oidc_enabled", "/authentication/local_login_disabled"] }
 

--- a/spec/lib/unique_within_region_validator_spec.rb
+++ b/spec/lib/unique_within_region_validator_spec.rb
@@ -1,4 +1,4 @@
-describe UniqueWithinRegionValidator do
+RSpec.describe UniqueWithinRegionValidator do
   describe "#unique_within_region" do
     context "class without STI" do
       let(:case_sensitive_class) do

--- a/spec/lib/uuid_mixin_spec.rb
+++ b/spec/lib/uuid_mixin_spec.rb
@@ -1,4 +1,4 @@
-describe UuidMixin do
+RSpec.describe UuidMixin do
   let(:test_class) do
     Class.new(ActiveRecord::Base) do
       def self.name; "TestClass"; end

--- a/spec/lib/vmdb/appliance_spec.rb
+++ b/spec/lib/vmdb/appliance_spec.rb
@@ -1,6 +1,6 @@
 require 'stringio'
 
-describe Vmdb::Appliance do
+RSpec.describe Vmdb::Appliance do
   describe ".installed_rpms (private)" do
     it "writes the correct string" do
       file = StringIO.new

--- a/spec/lib/vmdb/fast_gettext_helper_spec.rb
+++ b/spec/lib/vmdb/fast_gettext_helper_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::FastGettextHelper do
+RSpec.describe Vmdb::FastGettextHelper do
   describe ".register_locales" do
     it "registers locales across all threads" do
       Thread.new do

--- a/spec/lib/vmdb/gettext/debug_spec.rb
+++ b/spec/lib/vmdb/gettext/debug_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Gettext::Debug do
+RSpec.describe Vmdb::Gettext::Debug do
   before { Vmdb::FastGettextHelper.register_locales }
 
   let(:instance) do

--- a/spec/lib/vmdb/loggers/azure_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/azure_logger_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Loggers::AzureLogger do
+RSpec.describe Vmdb::Loggers::AzureLogger do
   before do
     @log_stream = StringIO.new
     @log = described_class.new(@log_stream)

--- a/spec/lib/vmdb/loggers/container_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/container_logger_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Loggers::ContainerLogger::Formatter do
+RSpec.describe Vmdb::Loggers::ContainerLogger::Formatter do
   it "stuff" do
     time = Time.now
     result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")

--- a/spec/lib/vmdb/loggers/fog_logger_spec.rb
+++ b/spec/lib/vmdb/loggers/fog_logger_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Loggers::FogLogger do
+RSpec.describe Vmdb::Loggers::FogLogger do
   before do
     @log_stream = StringIO.new
     @log = described_class.new(@log_stream)

--- a/spec/lib/vmdb/loggers_spec.rb
+++ b/spec/lib/vmdb/loggers_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Loggers do
+RSpec.describe Vmdb::Loggers do
   let(:log_file) { Rails.root.join("log", "foo.log").to_s }
 
   def in_container_env(example)

--- a/spec/lib/vmdb/permission_stores_spec.rb
+++ b/spec/lib/vmdb/permission_stores_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::PermissionStores do
+RSpec.describe Vmdb::PermissionStores do
   it 'should be configurable' do
     stub_vmdb_permission_store do
       Vmdb::PermissionStores.configure do |config|

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Plugins do
+RSpec.describe Vmdb::Plugins do
   it ".all" do
     all = described_class.all
 

--- a/spec/lib/vmdb/settings/hash_differ_spec.rb
+++ b/spec/lib/vmdb/settings/hash_differ_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Settings::HashDiffer do
+RSpec.describe Vmdb::Settings::HashDiffer do
   let(:before_hash) do
     {
       :values => {

--- a/spec/lib/vmdb/settings/validator_spec.rb
+++ b/spec/lib/vmdb/settings/validator_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Settings::Validator do
+RSpec.describe Vmdb::Settings::Validator do
   describe ".new" do
     it "with a Hash" do
       validator = described_class.new(:session => {:timeout => 123})

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,4 +1,4 @@
-describe Vmdb::Settings do
+RSpec.describe Vmdb::Settings do
   describe ".on_reload" do
     it "is called on top-level ::Settings.reload!" do
       expect(described_class).to receive(:on_reload)

--- a/spec/lib/vmdb/util_spec.rb
+++ b/spec/lib/vmdb/util_spec.rb
@@ -1,4 +1,4 @@
-describe VMDB::Util do
+RSpec.describe VMDB::Util do
   context ".http_proxy_uri" do
     it "without config settings" do
       stub_settings(:http_proxy => { :default => {} })

--- a/spec/lib/workers/heartbeat_spec.rb
+++ b/spec/lib/workers/heartbeat_spec.rb
@@ -42,7 +42,7 @@ shared_examples_for "heartbeat file checker" do |heartbeat_file = nil|
   end
 end
 
-describe Workers::Heartbeat do
+RSpec.describe Workers::Heartbeat do
   describe ".file_check" do
     context "using the default heartbeat_file" do
       let(:test_heartbeat_file) { ManageIQ.root.join("tmp", "spec", "test.hb") }

--- a/spec/tools/copy_reports_structure_spec.rb
+++ b/spec/tools/copy_reports_structure_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require 'copy_reports_structure/report_structure'
 
-describe ReportStructure do
+RSpec.describe ReportStructure do
   let(:group_name) { "SourceGroup" }
   let(:settings) { {"reports_menus" => [["Configuration Management", ["Virtual Machines", ["Vendor and Type"]]]]} }
   let(:role)  { FactoryBot.create(:miq_user_role) }

--- a/spec/tools/environment_builders/openstack/tests/interaction_methods_spec.rb
+++ b/spec/tools/environment_builders/openstack/tests/interaction_methods_spec.rb
@@ -2,7 +2,7 @@ require_relative '../interaction_methods'
 
 $LOAD_PATH << Rails.root.join("tools").to_s
 
-describe Openstack::InteractionMethods do
+RSpec.describe Openstack::InteractionMethods do
   let(:host1_data) { {:name => "name1", :connection_state => 'connection_state1', :settings => {}} }
   let(:host2_data) { {:name => "name2", :connection_state => 'connection_state2', :settings => {}} }
   let(:host3_data) { {:name => "name3", :connection_state => 'connection_state', :settings => {}} }

--- a/spec/tools/fix_auth/auth_config_model_spec.rb
+++ b/spec/tools/fix_auth/auth_config_model_spec.rb
@@ -4,7 +4,7 @@ require "fix_auth/auth_model"
 require "fix_auth/auth_config_model"
 require "fix_auth/models"
 
-describe FixAuth::AuthConfigModel do
+RSpec.describe FixAuth::AuthConfigModel do
   let(:v1_key)  { ManageIQ::Password.generate_symmetric }
   let(:pass)    { "password" }
   let(:enc_v1)  { ManageIQ::Password.new.encrypt(pass, "v1", v1_key) }

--- a/spec/tools/fix_auth/auth_model_spec.rb
+++ b/spec/tools/fix_auth/auth_model_spec.rb
@@ -4,7 +4,7 @@ require "fix_auth/auth_model"
 require "fix_auth/auth_config_model"
 require "fix_auth/models"
 
-describe FixAuth::AuthModel do
+RSpec.describe FixAuth::AuthModel do
   let(:v0_key)  { ManageIQ::Password::Key.new("AES-128-CBC", Base64.encode64("9999999999999999"), Base64.encode64("5555555555555555")) }
   let(:v1_key)  { ManageIQ::Password.generate_symmetric }
   let(:pass)    { "password" }

--- a/spec/tools/fix_auth/cli_spec.rb
+++ b/spec/tools/fix_auth/cli_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth/cli"
 
-describe FixAuth::Cli do
+RSpec.describe FixAuth::Cli do
   describe "#parse" do
     it "should assign defaults" do
       opts = described_class.new.parse([], {})

--- a/spec/tools/fix_auth/fix_auth_spec.rb
+++ b/spec/tools/fix_auth/fix_auth_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "fix_auth"
 
-describe FixAuth::FixAuth do
+RSpec.describe FixAuth::FixAuth do
   describe "#fix_database_yml" do
     it "supports --hardcode" do
       subject = described_class.new(:password => 'newpass', :root => '/', :databaseyml => true)

--- a/spec/tools/fix_auth/models_spec.rb
+++ b/spec/tools/fix_auth/models_spec.rb
@@ -4,7 +4,7 @@ require "fix_auth"
 require "tempfile"
 require "yaml"
 
-describe FixAuth::FixDatabaseYml do
+RSpec.describe FixAuth::FixDatabaseYml do
   # TODO: add legacy password tests
 
   it "updates password" do

--- a/spec/tools/miq_config_sssd_ldap/auth_establish_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/auth_establish_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "miq_config_sssd_ldap"
 
-describe MiqConfigSssdLdap::AuthEstablish do
+RSpec.describe MiqConfigSssdLdap::AuthEstablish do
   describe '#run_auth_establish' do
     before do
       @initial_settings = {:mode => "bob", :ldaphost => ["hostname"], :ldapport => 22}

--- a/spec/tools/miq_config_sssd_ldap/cli_config_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/cli_config_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "miq_config_sssd_ldap/cli_config"
 
-describe MiqConfigSssdLdap::CliConfig do
+RSpec.describe MiqConfigSssdLdap::CliConfig do
   before do
     @all_opts = :tls_cacert, :tls_cacertdir, :domain, :ldaphost, :ldapport, :user_type, :user_suffix, :mode,
                 :bind_dn, :bind_pwd, :only_change_userids, :skip_post_conversion_userid_change

--- a/spec/tools/miq_config_sssd_ldap/cli_convert_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/cli_convert_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "miq_config_sssd_ldap/cli_convert"
 
-describe MiqConfigSssdLdap::CliConvert do
+RSpec.describe MiqConfigSssdLdap::CliConvert do
   before do
     @all_opts = :tls_cacert, :tls_cacertdir, :domain, :only_change_userids, :skip_post_conversion_userid_change
     stub_const("LOGGER", double)

--- a/spec/tools/miq_config_sssd_ldap/configure_apache_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/configure_apache_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 require "fileutils"
 require 'auth_template_files'
 
-describe MiqConfigSssdLdap::ConfigureApache do
+RSpec.describe MiqConfigSssdLdap::ConfigureApache do
   before do
     @spec_name = File.basename(__FILE__).split(".rb").first.freeze
   end

--- a/spec/tools/miq_config_sssd_ldap/configure_appliance_settings_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/configure_appliance_settings_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools", "miq_config_sssd_ldap").to_s
 
 require "configure_appliance_settings"
 
-describe MiqConfigSssdLdap::ConfigureApplianceSettings do
+RSpec.describe MiqConfigSssdLdap::ConfigureApplianceSettings do
   before do
     stub_const("LOGGER", double)
     allow(LOGGER).to receive(:debug)

--- a/spec/tools/miq_config_sssd_ldap/configure_selinux_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/configure_selinux_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "miq_config_sssd_ldap"
 
-describe MiqConfigSssdLdap::ConfigureSELinux do
+RSpec.describe MiqConfigSssdLdap::ConfigureSELinux do
   describe '#configure' do
     before do
       @initial_settings = {:ldapport => '22'}

--- a/spec/tools/miq_config_sssd_ldap/configure_sssd_rules_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/configure_sssd_rules_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 require "fileutils"
 require 'auth_template_files'
 
-describe MiqConfigSssdLdap::ConfigureSssdRules do
+RSpec.describe MiqConfigSssdLdap::ConfigureSssdRules do
   before do
     @spec_name = File.basename(__FILE__).split(".rb").first.freeze
   end

--- a/spec/tools/miq_config_sssd_ldap/sssd_conf_spec.rb
+++ b/spec/tools/miq_config_sssd_ldap/sssd_conf_spec.rb
@@ -5,7 +5,7 @@ require "tempfile"
 require "fileutils"
 require "auth_template_files"
 
-describe MiqConfigSssdLdap::SssdConf do
+RSpec.describe MiqConfigSssdLdap::SssdConf do
   before do
     @spec_name = File.basename(__FILE__).split(".rb").first.freeze
   end

--- a/spec/tools/pg_inspector/active_connections_to_human_spec.rb
+++ b/spec/tools/pg_inspector/active_connections_to_human_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require 'pg_inspector'
 
-describe PgInspector::ActiveConnectionsHumanYAML do
+RSpec.describe PgInspector::ActiveConnectionsHumanYAML do
   it "#compress_id" do
     subject = described_class.new
     expect(subject.send(:compress_id, 5)).to eq("5")

--- a/spec/tools/server_settings_replicator/server_settings_replicator_spec.rb
+++ b/spec/tools/server_settings_replicator/server_settings_replicator_spec.rb
@@ -2,7 +2,7 @@ $LOAD_PATH << Rails.root.join("tools").to_s
 
 require "server_settings_replicator/server_settings_replicator"
 
-describe ServerSettingsReplicator do
+RSpec.describe ServerSettingsReplicator do
   let(:miq_server) { EvmSpecHelper.local_miq_server }
   let!(:miq_server_remote) { EvmSpecHelper.remote_miq_server }
   let(:settings) { {:k1 => {:k2 => {:k3 => 'v3'}}} }


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/19732, this updates the specs under spec/tools and spec/lib to use `RSpec.describe` on the outer describe block.