### PR TITLE
Monitor multiple servers when we're running in pods

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -414,6 +414,11 @@ class MiqWorker < ApplicationRecord
   end
 
   def kill_process
+    if containerized_worker?
+      delete_container_objects
+      return
+    end
+
     unless pid.nil?
       begin
         _log.info("Killing worker: ID [#{id}], PID [#{pid}], GUID [#{guid}], status [#{status}]")

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -272,7 +272,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.create_worker_record(*params)
-    init_worker_object(*params).tap(&:save)
+    init_worker_object(*params).tap(&:save!)
   end
 
   def self.start_worker(*params)

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -27,7 +27,6 @@ class MiqWorker
     def delete_container_objects
       orch = ContainerOrchestrator.new
       orch.delete_deployment(worker_deployment_name)
-      orch.delete_service(service_name)
     end
 
     def stop_container

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -114,6 +114,16 @@ module Vmdb
       DUMP_LOG_FILE.write(mask_passwords!(settings.to_hash).to_yaml)
     end
 
+    # This is a near copy of Config.load_and_set_settings, but we can't use that
+    # method as it also calls Config.load_files, which enforces specific file
+    # sources and doesn't allow you insert new sources into the middle of the
+    # stack.
+    def self.reset_settings_constant(settings)
+      name = ::Config.const_name
+      Object.send(:remove_const, name) if Object.const_defined?(name)
+      Object.const_set(name, settings)
+    end
+
     def self.build_template
       ::Config::Options.new.tap do |settings|
         template_sources.each { |s| settings.add_source!(s) }
@@ -177,17 +187,6 @@ module Vmdb
       end
     end
     private_class_method :local_sources
-
-    # This is a near copy of Config.load_and_set_settings, but we can't use that
-    # method as it also calls Config.load_files, which enforces specific file
-    # sources and doesn't allow you insert new sources into the middle of the
-    # stack.
-    def self.reset_settings_constant(settings)
-      name = ::Config.const_name
-      Object.send(:remove_const, name) if Object.const_defined?(name)
-      Object.const_set(name, settings)
-    end
-    private_class_method :reset_settings_constant
 
     def self.replace_magic_values!(settings, resource)
       parent_settings = nil

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -285,7 +285,7 @@ class EvmServer
   def impersonate_server(s)
     return if s == @current_server
 
-    # generic log message to say we're switching servers?
+    _log.info("Impersonating server - id: #{s.id}, guid: #{s.guid}")
 
     MiqServer.my_server_clear_cache
     MiqServer.my_guid = s.guid

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -287,16 +287,19 @@ class EvmServer
 
     # generic log message to say we're switching servers?
 
+    MiqServer.my_server_clear_cache
     MiqServer.my_guid = s.guid
+
     # It is important that we continue to use the same server instance here.
     # A lot of "global" state is stored in instance variables on the server.
     @current_server = s
-    Vmdb::Settings.init
+    Vmdb::Settings.reset_settings_constant(s.settings_for_resource)
   end
 
   def clear_server_caches
     MiqServer.my_guid = nil
     MiqServer.my_server_clear_cache
-    Vmdb::Settings.init
+    # Use Vmdb::Settings.for_resource(:my_server) here as MiqServer.my_server might be nil
+    Vmdb::Settings.reset_settings_constant(Vmdb::Settings.for_resource(:my_server))
   end
 end

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -92,7 +92,7 @@ class EvmServer
   end
 
   def servers_from_db
-    MiqEnvironment::Command.is_podified? ? MiqServer.all.to_a : [MiqServer.my_server(true)]
+    MiqEnvironment::Command.is_podified? ? MiqServer.in_my_region.to_a : [MiqServer.my_server(true)]
   end
 
   def set_process_title

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -61,9 +61,13 @@ class EvmServer
   end
 
   def refresh_servers_to_monitor
-    # Add the server object to our list if we're not monitoring it already
+    # Add the server object to our list and start it if we're not monitoring it already
     servers_from_db.each do |db_server|
-      servers_to_monitor << db_server unless monitoring_server?(db_server)
+      unless monitoring_server?(db_server)
+        servers_to_monitor << db_server
+        impersonate_server(db_server)
+        start_server
+      end
     end
 
     # Remove and shutdown a server if we're monitoring it and it is no longer in the database

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -4,8 +4,6 @@ require 'pid_file'
 class EvmServer
   include Vmdb::Logging
 
-  ##
-  # String used as a title for a linux process. Visible in ps, htop, ...
   SERVER_PROCESS_TITLE = 'MIQ Server'.freeze
 
   attr_accessor :servers_to_monitor
@@ -50,13 +48,6 @@ class EvmServer
     end
   end
 
-  ##
-  # Sets the server process' name if it is possible.
-  #
-  def set_process_title
-    Process.setproctitle(SERVER_PROCESS_TITLE) if Process.respond_to?(:setproctitle)
-  end
-
   def stop_servers
     for_each_server { @server.shutdown }
   end
@@ -70,6 +61,12 @@ class EvmServer
 
   def self.start(*args)
     new.start
+  end
+
+  private
+
+  def set_process_title
+    Process.setproctitle(SERVER_PROCESS_TITLE) if Process.respond_to?(:setproctitle)
   end
 
   def start_server
@@ -235,8 +232,6 @@ class EvmServer
     @server.sync_workers
     @server.wait_for_started_workers
   end
-
-  private
 
   ######################################################################
   # Warning:

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -39,23 +39,23 @@ class EvmServer
 
   def start_servers
     refresh_servers_to_monitor
-    for_each_server { start_server }
+    as_each_server { start_server }
   end
 
   def monitor_servers
     loop do
       refresh_servers_to_monitor
-      for_each_server { monitor }
+      as_each_server { monitor }
       sleep ::Settings.server.monitor_poll.to_i_with_method
     end
   end
 
   def stop_servers
-    for_each_server { @current_server.shutdown }
+    as_each_server { @current_server.shutdown }
   end
 
   def kill_servers
-    for_each_server do
+    as_each_server do
       @current_server.kill_all_workers
       @current_server.update(:stopped_on => Time.now.utc, :status => "killed", :is_master => false)
     end
@@ -274,7 +274,7 @@ class EvmServer
   # such as MiqServer.my_server and MiqServer.my_guid, and also the
   # contents of the global ::Settings constant.
   ######################################################################
-  def for_each_server
+  def as_each_server
     initial_server = @current_server
     servers_to_monitor.each do |s|
       impersonate_server(s)

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -275,15 +275,20 @@ class EvmServer
   # contents of the global ::Settings constant.
   ######################################################################
   def for_each_server
+    initial_server = @server
     servers_to_monitor.each do |s|
       impersonate_server(s)
       yield
     end
   ensure
-    clear_server_caches
+    clear_server_caches if @server != initial_server
   end
 
   def impersonate_server(s)
+    return if s == @server
+
+    # generic log message to say we're switching servers?
+
     MiqServer.my_guid = s.guid
     # It is important that we continue to use the same server instance here.
     # A lot of "global" state is stored in instance variables on the server.

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -92,7 +92,7 @@ class EvmServer
   end
 
   def servers_from_db
-    MiqEnvironment::Command.is_podified? ? MiqServer.in_my_region.to_a : [MiqServer.my_server(true)]
+    MiqEnvironment::Command.is_podified? ? MiqServer.in_my_region.to_a : [MiqServer.my_server(true)].compact
   end
 
   def set_process_title

--- a/lib/workers/evm_server.rb
+++ b/lib/workers/evm_server.rb
@@ -38,6 +38,7 @@ class EvmServer
   end
 
   def start_servers
+    refresh_servers_to_monitor
     for_each_server { start_server }
   end
 

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -10,6 +10,10 @@ describe EvmServer do
       expect(servers_to_monitor.first.id).to eq(server.id)
     end
 
+    it "doesn't give a nil server when there is no local server" do
+      expect(subject.servers_to_monitor).to be_empty
+    end
+
     context "when podified" do
       let(:expected_ids) { MiqServer.pluck(:id) }
 

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -90,7 +90,7 @@ describe EvmServer do
       server = EvmSpecHelper.local_miq_server
       subject.send(:for_each_server) do
         expect(MiqServer.my_server.guid).to eq(server.guid)
-        expect(subject.instance_variable_get(:@server).guid).to eq(server.guid)
+        expect(subject.instance_variable_get(:@current_server).guid).to eq(server.guid)
       end
     end
 
@@ -104,7 +104,7 @@ describe EvmServer do
 
       it "sets the server variable to each server" do
         received_guids = []
-        subject.send(:for_each_server) { received_guids << subject.instance_variable_get(:@server).guid }
+        subject.send(:for_each_server) { received_guids << subject.instance_variable_get(:@current_server).guid }
 
         expect(received_guids).to match_array(expected_guids)
       end

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -51,6 +51,8 @@ describe EvmServer do
         expect(subject.servers_to_monitor.first.id).to eq(MiqServer.first.id)
 
         4.times { FactoryBot.create(:miq_server) }
+        expect(subject).to receive(:impersonate_server).exactly(4).times
+        expect(subject).to receive(:start_server).exactly(4).times
         subject.refresh_servers_to_monitor
 
         expect(subject.servers_to_monitor.count).to eq(5)
@@ -65,6 +67,8 @@ describe EvmServer do
         initial_object_id = subject.servers_to_monitor.first.object_id
 
         4.times { FactoryBot.create(:miq_server) }
+        expect(subject).to receive(:impersonate_server).exactly(4).times
+        expect(subject).to receive(:start_server).exactly(4).times
         subject.refresh_servers_to_monitor
 
         new_objects = subject.servers_to_monitor.map(&:object_id)

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -1,0 +1,46 @@
+require "workers/evm_server"
+
+describe EvmServer do
+  describe "#for_each_server (private)" do
+    it "yields the local server when not podified" do
+      server = EvmSpecHelper.local_miq_server
+      subject.send(:for_each_server) do
+        expect(MiqServer.my_server.guid).to eq(server.guid)
+        expect(subject.instance_variable_get(:@server).guid).to eq(server.guid)
+      end
+    end
+
+    context "when podified" do
+      let(:expected_guids) { MiqServer.pluck(:guid) }
+
+      before do
+        4.times { FactoryBot.create(:miq_server) }
+        allow(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+      end
+
+      it "sets the server variable to each server" do
+        received_guids = []
+        subject.send(:for_each_server) { received_guids << subject.instance_variable_get(:@server).guid }
+
+        expect(received_guids).to match_array(expected_guids)
+      end
+
+      it "sets my_server to each server" do
+        received_guids = []
+        subject.send(:for_each_server) { received_guids << MiqServer.my_server.guid }
+
+        expect(received_guids).to match_array(expected_guids)
+      end
+
+      it "resets ::Settings to the correct server" do
+        MiqServer.all.each do |server|
+          server.add_settings_for_resource(:special => {:settings => {:id => server.id}})
+        end
+
+        received_ids = []
+        subject.send(:for_each_server) { received_ids << ::Settings.special.settings[:id] }
+        expect(received_ids).to match_array(MiqServer.pluck(:id))
+      end
+    end
+  end
+end

--- a/spec/lib/workers/evm_server_spec.rb
+++ b/spec/lib/workers/evm_server_spec.rb
@@ -85,10 +85,10 @@ describe EvmServer do
     end
   end
 
-  describe "#for_each_server (private)" do
+  describe "#as_each_server (private)" do
     it "yields the local server when not podified" do
       server = EvmSpecHelper.local_miq_server
-      subject.send(:for_each_server) do
+      subject.send(:as_each_server) do
         expect(MiqServer.my_server.guid).to eq(server.guid)
         expect(subject.instance_variable_get(:@current_server).guid).to eq(server.guid)
       end
@@ -104,14 +104,14 @@ describe EvmServer do
 
       it "sets the server variable to each server" do
         received_guids = []
-        subject.send(:for_each_server) { received_guids << subject.instance_variable_get(:@current_server).guid }
+        subject.send(:as_each_server) { received_guids << subject.instance_variable_get(:@current_server).guid }
 
         expect(received_guids).to match_array(expected_guids)
       end
 
       it "sets my_server to each server" do
         received_guids = []
-        subject.send(:for_each_server) { received_guids << MiqServer.my_server.guid }
+        subject.send(:as_each_server) { received_guids << MiqServer.my_server.guid }
 
         expect(received_guids).to match_array(expected_guids)
       end
@@ -122,7 +122,7 @@ describe EvmServer do
         end
 
         received_ids = []
-        subject.send(:for_each_server) { received_ids << ::Settings.special.settings[:id] }
+        subject.send(:as_each_server) { received_ids << ::Settings.special.settings[:id] }
         expect(received_ids).to match_array(MiqServer.pluck(:id))
       end
     end


### PR DESCRIPTION
This PR allows `EvmServer` to loop through multiple servers as a part of the monitor loop in a single process.

The biggest issue solved here is that the "local" server is defined by a bunch of global state, specifically the guid class variable on `MiqServer`. When changing servers in this patch we set the guid on the class and reset the global settings variable. This allows all the normal monitoring methods to work as they did when the servers were separate processes.

When on an appliance, we will only monitor the actual local server.

This gets us very close to solving https://github.com/ManageIQ/manageiq-pods/issues/353