### PR TITLE
Use a Kubernetes-specific factory for ServiceContainerTemplate specs

### DIFF
--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -14,4 +14,8 @@ class ContainerTemplate < ApplicationRecord
   serialize :object_labels, Hash
 
   acts_as_miq_taggable
+
+  def instantiate(_params, _project_name)
+    raise NotImplementedError, _("instantiate must be implemented in a subclass")
+  end
 end


### PR DESCRIPTION
With strict partials enabled we discover that the specs for `instantiate` are invalid:

```
#<ContainerTemplate id: 91000000000005, ems_ref: nil, name: nil, ems_created_on: nil, resource_version: nil, ems_id: 91000000000020, container_project_id: nil, objects: [], created_at: "2020-01-20 20:03:09", updated_at: "2020-01-20 20:03:09", object_labels: {}, type: nil> does not implement: instantiate
```

Some investigation by @himdel reveals that only the Kubernetes provider actually implements the `instantiate` method in its `ContainerTemplate` subclass (Edit: ok openshift does do, but uses the kubernetes module). So, I've updated the specs to use a Kubernetes-specific container template (and corresponding EMS), with the assistance of a helper factory.

Update: instead, we'll just define an interface method on the core `ContainerTemplate` model.