### PR TITLE
Add PhysicalServer to RBAC Filterer

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -50,6 +50,7 @@ module Rbac
       NetworkRouter
       OrchestrationStack
       OrchestrationTemplate
+      PhysicalServer
       PxeImage
       ResourcePool
       SecurityGroup


### PR DESCRIPTION
Allow PhysicalServers to be filtered by RBAC

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1793262