### PR TITLE
Add my_queue_name for ems_operations miq_requests

### DIFF
--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -28,7 +28,7 @@ class ConfiguredSystem < ApplicationRecord
   delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
   delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
   delegate :name, :to => :provider,                      :prefix => true, :allow_nil => true
-  delegate :my_zone, :provider, :zone, :to => :manager
+  delegate :my_zone, :provider, :queue_name_for_ems_operations, :zone, :to => :manager
 
   virtual_column  :my_zone,                            :type => :string
   virtual_column  :configuration_architecture_name,    :type => :string

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -28,7 +28,8 @@ class ConfiguredSystem < ApplicationRecord
   delegate :name, :to => :customization_script_ptable,   :prefix => true, :allow_nil => true
   delegate :name, :to => :operating_system_flavor,       :prefix => true, :allow_nil => true
   delegate :name, :to => :provider,                      :prefix => true, :allow_nil => true
-  delegate :my_zone, :provider, :queue_name_for_ems_operations, :zone, :to => :manager
+  delegate :my_zone, :provider, :zone, :to => :manager
+  delegate :queue_name_for_ems_operations, :to => :manager, :allow_nil => true
 
   virtual_column  :my_zone,                            :type => :string
   virtual_column  :configuration_architecture_name,    :type => :string

--- a/app/models/miq_provision_configured_system_request.rb
+++ b/app/models/miq_provision_configured_system_request.rb
@@ -25,6 +25,10 @@ class MiqProvisionConfiguredSystemRequest < MiqRequest
     'ems_operations'
   end
 
+  def my_queue_name
+    src_configured_systems.first&.manager&.queue_name_for_ems_operations
+  end
+
   def self.request_task_class_from(_attribs)
     ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionTask
   end

--- a/app/models/miq_provision_configured_system_request.rb
+++ b/app/models/miq_provision_configured_system_request.rb
@@ -26,7 +26,7 @@ class MiqProvisionConfiguredSystemRequest < MiqRequest
   end
 
   def my_queue_name
-    src_configured_systems.first&.manager&.queue_name_for_ems_operations
+    src_configured_systems.first.nil? ? super : src_configured_systems.first&.queue_name_for_ems_operations
   end
 
   def self.request_task_class_from(_attribs)

--- a/app/models/physical_server.rb
+++ b/app/models/physical_server.rb
@@ -36,6 +36,8 @@ class PhysicalServer < ApplicationRecord
   virtual_column :v_host_os, :type => :string, :uses => :host
   virtual_delegate :emstype, :to => "ext_management_system", :allow_nil => true
 
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
   has_many :physical_switches, :through => :computer_system, :source => :connected_physical_switches
 
   supports :refresh_ems

--- a/app/models/physical_server_firmware_update_request.rb
+++ b/app/models/physical_server_firmware_update_request.rb
@@ -10,6 +10,10 @@ class PhysicalServerFirmwareUpdateRequest < MiqRequest
     'ems_operations'
   end
 
+  def my_queue_name
+    affected_ems.queue_name_for_ems_operations
+  end
+
   def self.request_task_class
     PhysicalServerFirmwareUpdateTask
   end

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -10,6 +10,14 @@ class PhysicalServerProvisionRequest < MiqRequest
     'ems_operations'
   end
 
+  def my_queue_name
+    source.nil? ? super : source.queue_name_for_ems_operations
+  end
+
+  def source
+    @source ||= self.class.source_physical_server(source_id)
+  end
+
   def self.request_task_class
     PhysicalServerProvisionTask
   end

--- a/app/models/physical_server_provision_request.rb
+++ b/app/models/physical_server_provision_request.rb
@@ -15,7 +15,7 @@ class PhysicalServerProvisionRequest < MiqRequest
   end
 
   def source
-    @source ||= self.class.source_physical_server(source_id)
+    @source ||= PhysicalServer.find_by(:id => source_id)
   end
 
   def self.request_task_class

--- a/app/models/vm_cloud_reconfigure_request.rb
+++ b/app/models/vm_cloud_reconfigure_request.rb
@@ -20,12 +20,19 @@ class VmCloudReconfigureRequest < MiqRequest
     end
   end
 
+  def vm
+    @vm ||= Vm.find_by(:id => options[:src_ids])
+  end
+
   def my_zone
-    vm = Vm.find_by(:id => options[:src_ids])
     vm.nil? ? super : vm.my_zone
   end
 
   def my_role(_action = nil)
     'ems_operations'
+  end
+
+  def my_queue_name
+    vm.nil? ? super : vm.queue_name_for_ems_operations
   end
 end

--- a/app/models/vm_migrate_request.rb
+++ b/app/models/vm_migrate_request.rb
@@ -7,12 +7,19 @@ class VmMigrateRequest < MiqRequest
   validate               :must_have_user
   include MiqProvisionQuotaMixin
 
+  def vm
+    @vm ||= Vm.find_by(:id => options[:src_ids])
+  end
+
   def my_zone
-    vm = Vm.find_by(:id => options[:src_ids])
     vm.nil? ? super : vm.my_zone
   end
 
   def my_role(_action = nil)
     'ems_operations'
+  end
+
+  def my_queue_name
+    vm.nil? ? super : vm.queue_name_for_ems_operations
   end
 end

--- a/spec/models/configured_system_spec.rb
+++ b/spec/models/configured_system_spec.rb
@@ -7,4 +7,23 @@ RSpec.describe ConfiguredSystem do
 
     expect(cs1.counterparts).to match_array([vm, cs2, cs3])
   end
+
+  describe "#queue_name_for_ems_operations" do
+    context "with an active configured_system" do
+      let(:manager)           { FactoryBot.create(:configuration_manager) }
+      let(:configured_system) { FactoryBot.create(:configured_system, :manager => manager) }
+
+      it "uses the manager's queue_name_for_ems_operations" do
+        expect(configured_system.queue_name_for_ems_operations).to eq(manager.queue_name_for_ems_operations)
+      end
+    end
+
+    context "with an archived configured_system" do
+      let(:configured_system) { FactoryBot.create(:configured_system) }
+
+      it "uses the manager's queue_name_for_ems_operations" do
+        expect(configured_system.queue_name_for_ems_operations).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/physical_server_firmware_update_request_spec.rb
+++ b/spec/models/physical_server_firmware_update_request_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe PhysicalServerFirmwareUpdateRequest do
     expect(subject.my_role).to eq('ems_operations')
   end
 
+  describe '#my_queue_name' do
+    let(:ems)             { FactoryBot.create(:ems_physical_infra) }
+    let(:physical_server) { FactoryBot.create(:physical_server, :ext_management_system => ems) }
+
+    it "returns the ems's queue_name_for_ems_operations" do
+      expect(physical_server.queue_name_for_ems_operations).to eq(ems.queue_name_for_ems_operations)
+    end
+  end
+
   it '#requested_task_idx' do
     expect(subject.requested_task_idx).to eq([-1])
   end

--- a/spec/models/physical_server_provision_request_spec.rb
+++ b/spec/models/physical_server_provision_request_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe PhysicalServerProvisionRequest do
     expect(subject.my_role).to eq('ems_operations')
   end
 
+  it "#my_queue_name" do
+    expect(subject.my_queue_name).to be_nil
+  end
+
   describe '.new_request_task' do
     before do
       allow(ems.class).to receive(:provision_class).and_return(task)

--- a/spec/models/physical_server_spec.rb
+++ b/spec/models/physical_server_spec.rb
@@ -28,4 +28,23 @@ RSpec.describe PhysicalServer do
       expect(subject.firmware_compatible?(binary2)).to eq(false)
     end
   end
+
+  describe "#queue_name_for_ems_operations" do
+    context "with an active configured_system" do
+      let(:manager)         { FactoryBot.create(:physical_infra) }
+      let(:physical_server) { FactoryBot.create(:physical_server, :with_asset_detail, :ext_management_system => manager) }
+
+      it "uses the manager's queue_name_for_ems_operations" do
+        expect(physical_server.queue_name_for_ems_operations).to eq(manager.queue_name_for_ems_operations)
+      end
+    end
+
+    context "with an archived configured_system" do
+      let(:physical_server) { FactoryBot.create(:physical_server, :with_asset_detail) }
+
+      it "uses the manager's queue_name_for_ems_operations" do
+        expect(physical_server.queue_name_for_ems_operations).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a queue name for all of the ems_operations MiqRequest classes

https://github.com/ManageIQ/manageiq/issues/19543