### PR TITLE
Metrics - perf_capture_queue_targets

### DIFF
--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
     it "should queue up realtime capture for vm" do
       pco = described_class.new([vm, vm2], ems)
-      pco.perf_capture_queue
+      pco.perf_capture_queue("realtime")
 
       expect(MiqQueue.count).to eq(2)
 
@@ -145,7 +145,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
     context "with vmware targets" do
       it "should queue up targets properly" do
         stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue
+        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue("realtime")
 
         bod = Time.now.utc.beginning_of_day
 
@@ -171,11 +171,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       end
 
       it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
-        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue
+        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue("realtime")
         messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
         messages.each { |m| m.update(:state => "dequeue") }
 
-        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue
+        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue("realtime")
         messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
         messages.each { |m| expect(m.lock_version).to eq(1) }
       end
@@ -188,7 +188,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       context "executing perf_capture_timer" do
         it "should queue up enabled targets" do
           stub_settings(:performance => {:history => {:initial_capture_days => 7}})
-          ems.perf_capture_object(vms).perf_capture_queue
+          ems.perf_capture_object(vms).perf_capture_queue("realtime")
 
           bod = Time.now.utc.beginning_of_day
 


### PR DESCRIPTION
#### Summary:

metrics queuing for the work that I'm revamping the way we queue c&U messages

cross repo:  🍏https://github.com/ManageIQ/manageiq-cross_repo/pull/60

#### Details

Separately send different classes on the queue.
This separates storages, that are not handled by the actual ems metrics_capture, and it separates out the hosts, which have a rollup record (by ems_cluster)

In order to better group historical messages together, putting a message on the queue (`perf_capture_queue_target`) now only puts a single message onto the queue. Larger ranges of targets are now put on.

Note: the tests have not be significantly altered besides a few parameters passed around. This changes the order and the grouping of the messages, but all the same messages go onto the queue.

(stay tuned for next PR for when I pull the table cloth out from under the messages)