### PR TITLE
[V2V] Forces a targeted refresh of the created VM

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -458,7 +458,8 @@ class InfraConversionJob < Job
   def inventory_refresh
     update_migration_task_progress(:on_entry)
     if migration_task.options[:destination_vm_uuid].present?
-      EmsRefresh.refresh(migration_task.destination_ems, :vms, migration_task.options[:destination_vm_uuid])
+      target_collection = InventoryRefresh::TargetCollection.new(:manager => migration_task.destination_ems)
+      target_collection.add_target(:association => :vms, :manager_ref => {:ems_ref => migration_task.options[:destination_vm_uuid]})
     end
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + state_retry_interval)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -470,11 +470,12 @@ class InfraConversionJob < Job
   def inventory_refresh
     update_migration_task_progress(:on_entry)
     if migration_task.options[:destination_vm_uuid].present?
-      InventoryRefresh::Target.new(
+      target = InventoryRefresh::Target.new(
         :association => :vms,
         :manager_ref => {:ems_ref => destination_vm_ems_ref(migration_task.options[:destination_vm_uuid])},
         :manager     => migration_task.destination_ems
       )
+      EmsRefresh.queue_refresh_task(target)
     end
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + state_retry_interval)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -473,7 +473,7 @@ class InfraConversionJob < Job
       InventoryRefresh::Target.new(
         :association => :vms,
         :manager_ref => {:ems_ref => destination_vm_ems_ref(migration_task.options[:destination_vm_uuid])},
-        :manager => migration_task.destination_ems
+        :manager     => migration_task.destination_ems
       )
     end
     update_migration_task_progress(:on_exit)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -475,7 +475,7 @@ class InfraConversionJob < Job
         :manager_ref => {:ems_ref => destination_vm_ems_ref(migration_task.options[:destination_vm_uuid])},
         :manager     => migration_task.destination_ems
       )
-      EmsRefresh.queue_refresh_task(target)
+      EmsRefresh.queue_refresh(target)
     end
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + state_retry_interval)

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -462,7 +462,7 @@ class InfraConversionJob < Job
     end
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + state_retry_interval)
-  rescue StandardError => error
+  rescue
     update_migration_task_progress(:on_error)
     queue_signal(:poll_inventory_refresh_complete)
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -242,6 +242,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         updates[:virtv2v_status] = 'failed'
       elsif !canceling?
         updates[:virtv2v_status] = 'succeeded'
+        updates[:destination_vm_uuid] = virtv2v_state['vm_id']
         updated_disks.each { |d| d[:percent] = 100 }
       end
     end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1351,7 +1351,6 @@ RSpec.describe InfraConversionJob, :v2v do
         job.signal(:inventory_refresh)
       end
     end
- 
   end
 
   context '#poll_inventory_refresh_complete' do

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1353,7 +1353,7 @@ RSpec.describe InfraConversionJob, :v2v do
           :manager     => ems_redhat,
           :manager_ref => {:ems_ref => '/api/vms/01234567-89ab-cdef-0123-456789ab-cdef'}
         ).and_return(target)
-        expect(EmsRefresh).to receive(:queue_refresh_task).with(target)
+        expect(EmsRefresh).to receive(:queue_refresh).with(target)
         expect(job).to receive(:queue_signal).with(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
         job.signal(:inventory_refresh)
       end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1348,8 +1348,11 @@ RSpec.describe InfraConversionJob, :v2v do
       Timecop.freeze(2019, 2, 6) do
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit).and_call_original
-        expect(InventoryRefresh::TargetCollection).to receive(:new).with(:manager => ems_redhat).and_return(target_collection)
-        expect(target_collection).to receive(:add_target).with(:association => :vms, :manager_ref => {:ems_ref => '01234567-89ab-cdef-0123-456789ab-cdef'})
+        expect(InventoryRefresh::Target).to receive(:new).with(
+          :association => :vms,
+          :manager     => ems_redhat,
+          :manager_ref => {:ems_ref => '/api/vms/01234567-89ab-cdef-0123-456789ab-cdef'}
+        )
         expect(job).to receive(:queue_signal).with(:poll_inventory_refresh_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
         job.signal(:inventory_refresh)
       end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -465,7 +465,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             ],
             "pid"         => 5855,
             "return_code" => 0,
-            "disk_count"  => 1
+            "disk_count"  => 1,
+            "vm_id"       => "01234567-89ab-cdef-0123-456789ab-cdef"
           )
           task_1.get_conversion_state
           expect(task_1.options[:virtv2v_disks]).to eq(


### PR DESCRIPTION
Over time, we had issues with the destination provider refresh, making the whole migration fail just because the newly created VM doesn't appear in the inventory.  For some time already, virt-v2v-wrapper provides the UUID of the VM created during the conversion.

This pull request makes the migration workflow trigger a targeted refresh, that will ensure that the VM will appear in the VMDB.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1794005