### PR TITLE
Commit the data directory rather than creating it when the server starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .ruby-version
 .sass-cache/
 .tags
-/data/
+/data/*
 /productization
 /plugins
 /vmdb/

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -91,12 +91,6 @@ class MiqServer < ApplicationRecord
     EventStream.where(:target_id => server_id, :target_type => "MiqServer").destroy_all
   end
 
-  def self.setup_data_directory
-    # create root data directory
-    data_dir = File.join(File.expand_path(Rails.root), "data")
-    Dir.mkdir(data_dir) unless File.exist?(data_dir)
-  end
-
   def self.pidfile
     @pidfile ||= "#{Rails.root}/tmp/pids/evm.pid"
   end
@@ -176,7 +170,6 @@ class MiqServer < ApplicationRecord
 
     EvmDatabase.seed_primordial
 
-    setup_data_directory
     check_migrations_up_to_date
     Vmdb::Settings.activate
 


### PR DESCRIPTION
If we are not running a server on worker containers it feels like this
directory won't exist. I don't see why we shouldn't just have it exist
in the source tree.

Specifically I think this is important for embedded ansible in pods.

Extracted from https://github.com/ManageIQ/manageiq/pull/19734