### PR TITLE
Set a queue_name for Host/Storage smartstate scans

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -154,6 +154,8 @@ class Host < ApplicationRecord
   include DriftStateMixin
   virtual_delegate :last_scan_on, :to => "last_drift_state_timestamp_rec.timestamp", :allow_nil => true, :type => :datetime
 
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
   include UuidMixin
   include MiqPolicyMixin
   include AlertMixin
@@ -1286,6 +1288,8 @@ class Host < ApplicationRecord
       :method_name  => "scan_from_queue",
       :miq_callback => cb,
       :msg_timeout  => timeout,
+      :role         => "ems_operations",
+      :queue_name   => queue_name_for_ems_operations,
       :zone         => my_zone
     )
   end

--- a/app/models/storage.rb
+++ b/app/models/storage.rb
@@ -68,6 +68,8 @@ class Storage < ApplicationRecord
   virtual_column :total_unmanaged_vms,            :type => :integer  # uses is handled via class method that aggregates
   virtual_column :count_of_vmdk_disk_files,       :type => :integer
 
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
   SUPPORTED_STORAGE_TYPES = %w( VMFS NFS NFS41 FCP ISCSI GLUSTERFS )
 
   supports :smartstate_analysis do

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -647,33 +647,35 @@ RSpec.describe Host do
   end
 
   describe "#scan_queue" do
-    let(:ems) { double("ExtManagementSystem") }
+    let(:host) { FactoryBot.create(:host_vmware, :ext_management_system => ems) }
+
     before do
       MiqRegion.seed
       Zone.seed
-
-      @host = FactoryBot.create(:host_vmware)
-      allow(@host).to receive(:ext_management_system).and_return(ems)
     end
 
-    it 'creates task with Error status when EMS paused' do
-      allow(ems).to receive_messages(:name => 'My provider',
-                                     :zone => Zone.maintenance_zone)
-      @host.scan_queue
-      task = MiqTask.first
-      expect(task.status_error?).to eq(true)
-      expect(task.message).to eq("#{ems.name} is paused")
+    context "when the EMS is paused" do
+      let(:ems) { FactoryBot.create(:ems_infra, :name => "My Provider", :zone => Zone.maintenance_zone, :enabled => false) }
+
+      it 'creates task with Error status when EMS paused' do
+        expect(MiqQueue).not_to receive(:put)
+
+        host.scan_queue
+        task = MiqTask.first
+        expect(task.status_error?).to eq(true)
+        expect(task.message).to eq("#{ems.name} is paused")
+      end
     end
 
-    it 'creates task with valid status EMS active' do
-      allow(ems).to receive_messages(:my_zone => Zone.default_zone,
-                                     :name    => 'My provider',
-                                     :zone    => Zone.default_zone)
-      allow(MiqQueue).to receive(:put).and_return(double)
+    context "when the EMS is active" do
+      let(:ems) { FactoryBot.create(:ems_infra, :name => "My Provider", :zone => Zone.default_zone) }
+      it 'creates task with valid status EMS active' do
+        allow(MiqQueue).to receive(:put).and_return(double)
 
-      @host.scan_queue
-      task = MiqTask.first
-      expect(task.status_ok?).to eq(true)
+        host.scan_queue
+        task = MiqTask.first
+        expect(task.status_ok?).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
Host and Storage smartstate scans hit the provider API and thus need to
have the ems_operations role and set a queue_name.

https://github.com/ManageIQ/manageiq/issues/19543