### PR TITLE
Add back some missing state transitions to VmScan

### DIFF
--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -26,6 +26,8 @@ class VmScan < Job
       :data               => {'scanning'                  => 'scanning',
                               'synchronizing'             => 'synchronizing',
                               'finished'                  => 'finished'},
+      :scan_retry         => {'scanning'                  => 'scanning'},
+      :abort_retry        => {'scanning'                  => 'scanning'},
       :abort_job          => {'*'                         => 'aborting'},
       :cancel             => {'*'                         => 'canceling'},
       :error              => {'*'                         => '*'},


### PR DESCRIPTION
Some of the state transitions on error conditions were removed during the prior VmScan refactoring, specifically scan_retry which is called [here](https://github.com/ManageIQ/manageiq/blob/a987cd9693c2d1ca16d590ff34dbd3443ae57529/app/models/vm_scan.rb#L281) and abort_retry which is called [here](https://github.com/ManageIQ/manageiq/blob/a987cd9693c2d1ca16d590ff34dbd3443ae57529/app/models/vm_scan.rb#L230)