### PR TITLE
[WIP] Set the queue_name for the smartstate role

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -616,6 +616,10 @@ class ExtManagementSystem < ApplicationRecord
     'generic'
   end
 
+  def queue_name_for_smartstate
+    'generic'
+  end
+
   def enforce_policy(target, event)
     inputs = {:ext_management_system => self}
     inputs[:vm]   = target if target.kind_of?(Vm)

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -228,6 +228,7 @@ class MiqQueue < ApplicationRecord
     when "smartstate"
       options[:role] = service
       options[:zone] = resource.try(:my_zone) || MiqServer.my_zone
+      options[:queue_name] = resource.try(:queue_name_for_smartstate) || "generic"
     end
 
     # Note, options[:zone] is set in 'put' via 'determine_queue_zone' and handles setting

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -180,6 +180,7 @@ class VmOrTemplate < ApplicationRecord
 
   delegate :connect_lans, :disconnect_lans, :to => :hardware, :allow_nil => true
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+  delegate :queue_name_for_smartstate, :to => :ext_management_system, :allow_nil => true
 
   after_save :save_genealogy_information
 

--- a/app/models/vm_or_template/scanning.rb
+++ b/app/models/vm_or_template/scanning.rb
@@ -12,7 +12,11 @@ module VmOrTemplate::Scanning
       return nil
     end
 
-    check_policy_prevent(:request_vm_scan, :raw_scan, userid, options)
+    check_policy_prevent(:request_vm_scan, :scan_queue, userid, options)
+  end
+
+  def scan_queue(userid = "system", options = {})
+    run_command_via_queue("raw_scan", :queue_name => queue_name_for_smartstate, :role => "smartstate", :args => [userid, options])
   end
 
   def scan_job_class

--- a/app/models/vm_scan.rb
+++ b/app/models/vm_scan.rb
@@ -81,7 +81,8 @@ class VmScan < Job
       :method_name => "signal",
       :args        => [:before_scan],
       :zone        => from_zone,
-      :role        => "smartstate"
+      :role        => "smartstate",
+      :queue_name  => vm.queue_name_for_smartstate
     )
   end
 


### PR DESCRIPTION
Allow SmartState scans to be run on specialized workers like the VMware
OperationsWorker

https://github.com/ManageIQ/manageiq/issues/19543