### PR TITLE
Remove unused conditional from class_for_platform in MiqProvisionWorkflow

### DIFF
--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -3,17 +3,17 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
     MiqProvisionWorkflow
   end
 
+  # Find the appropriate workflow class for the given +platform+ string. For
+  # example, the argument "openstack" would become:
+  #
+  #  "ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow"
+  #
   def self.class_for_platform(platform)
     classy = platform.classify
 
-    if classy =~ /(.*)Infra/
-      find_matching_constant("MiqProvision#{classy}Workflow") ||
-        find_matching_constant("ManageIQ::Providers::#{$1}::InfraManager::ProvisionWorkflow")
-    else
-      find_matching_constant("MiqProvision#{classy}Workflow") ||
-        find_matching_constant("ManageIQ::Providers::#{classy}::CloudManager::ProvisionWorkflow") ||
-        find_matching_constant("ManageIQ::Providers::#{classy}::InfraManager::ProvisionWorkflow")
-    end
+    find_matching_constant("MiqProvision#{classy}Workflow") ||
+      find_matching_constant("ManageIQ::Providers::#{classy}::CloudManager::ProvisionWorkflow") ||
+      find_matching_constant("ManageIQ::Providers::#{classy}::InfraManager::ProvisionWorkflow")
   end
 
   def self.find_matching_constant(string)

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -3,10 +3,16 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
     MiqProvisionWorkflow
   end
 
-  # Find the appropriate workflow class for the given +platform+ string. For
-  # example, the argument "openstack" would become:
+  # Find the appropriate workflow class for the given 'platform' string.
   #
-  #  "ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow"
+  # @example openstack
+  #   "ManageIQ::Providers::Openstack::CloudManager::ProvisionWorkflow"
+  #
+  # @param platform [String]
+  #   A string of the one of the ManageIQ providers. The case of this
+  #   string is ignored.
+  #
+  # @return [String] A scoped provider constant name.
   #
   def self.class_for_platform(platform)
     classy = platform.classify

--- a/app/models/miq_provision_workflow.rb
+++ b/app/models/miq_provision_workflow.rb
@@ -12,7 +12,7 @@ class MiqProvisionWorkflow < MiqRequestWorkflow
   #   A string of the one of the ManageIQ providers. The case of this
   #   string is ignored.
   #
-  # @return [String] A scoped provider constant name.
+  # @return [Constant] A scoped provider constant name.
   #
   def self.class_for_platform(platform)
     classy = platform.classify


### PR DESCRIPTION
This PR removes what appears to be a legacy conditional that will never actually be triggered. I also added some comments.

Followup to https://github.com/ManageIQ/manageiq/pull/19713