### PR TITLE
Bump secure_headers gem to a more recent version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -226,7 +226,7 @@ group :web_server, :manageiq_default do
   gem "puma",                           "~>4.2"
   gem "responders",                     "~>2.0"
   gem "ruby-dbus" # For external auth
-  gem "secure_headers",                 "~>3.0.0"
+  gem "secure_headers",                 "~>3.9"
 end
 
 group :web_socket, :manageiq_default do


### PR DESCRIPTION
Update the secure_headers gem to a more recent version

https://github.com/twitter/secure_headers/security/advisories/GHSA-xq52-rv6w-397c