### PR TITLE
Remove storage references to multiple emses

### DIFF
--- a/spec/models/ems_refresh_spec.rb
+++ b/spec/models/ems_refresh_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe EmsRefresh do
     end
 
     it "with Storage" do
-      allow_any_instance_of(Storage).to receive_messages(:ext_management_systems => [@ems])
-      target = FactoryBot.create(:storage_vmware)
+      target = FactoryBot.create(:storage_vmware, :ext_management_system => @ems)
       queue_refresh_and_assert_queue_item(target, [target])
     end
 


### PR DESCRIPTION
`Storage` now uses `ems_id` instead of `host_storages` for ems references.
https://github.com/ManageIQ/manageiq/pull/19617

This further makes that change
