### PR TITLE
Remove Vmdb::Settings last_loaded and simplify server settings reload

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -10,7 +10,12 @@ module MiqServer::ConfigurationManagement
     return if is_remote?
 
     Vmdb::Settings.reload!
+
     activate_settings_for_appliance
+    sync_config
+    sync_assigned_roles
+    reset_queue_messages
+    update_sync_timestamp(Time.now.utc)
   end
 
   # The purpose of this method is to do special activation of things
@@ -51,17 +56,10 @@ module MiqServer::ConfigurationManagement
   end
 
   def sync_config
-    @config_last_loaded = Vmdb::Settings.last_loaded
     sync_log_level
     sync_worker_monitor_settings
     sync_child_worker_settings
     $log.log_hashes(@worker_monitor_settings)
-  end
-
-  def sync_config_changed?
-    stale = @config_last_loaded != Vmdb::Settings.last_loaded
-    @config_last_loaded = Vmdb::Settings.last_loaded if stale
-    stale
   end
 
   def sync_log_level

--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -56,14 +56,8 @@ module MiqServer::ConfigurationManagement
   end
 
   def sync_config
-    sync_log_level
     sync_worker_monitor_settings
     sync_child_worker_settings
     $log.log_hashes(@worker_monitor_settings)
-  end
-
-  def sync_log_level
-    # TODO: Can this be removed since the Vmdb::Settings::Activator will do this anyway?
-    Vmdb::Loggers.apply_config(::Settings.log)
   end
 end

--- a/app/models/miq_worker/runner.rb
+++ b/app/models/miq_worker/runner.rb
@@ -246,7 +246,6 @@ class MiqWorker::Runner
     # Sync settings
     Vmdb::Settings.reload!
     @my_zone ||= MiqServer.my_zone
-    sync_log_level
     sync_worker_settings
     sync_blacklisted_events
     after_sync_config
@@ -257,11 +256,6 @@ class MiqWorker::Runner
     $log.log_hashes(@cfg)
 
     @worker.release_db_connection if @worker.respond_to?(:release_db_connection)
-  end
-
-  def sync_log_level
-    # TODO: Can this be removed since the Vmdb::Settings::Activator will do this anyway?
-    Vmdb::Loggers.apply_config(::Settings.log)
   end
 
   def sync_worker_settings

--- a/lib/patches/config_patch.rb
+++ b/lib/patches/config_patch.rb
@@ -3,7 +3,7 @@ module ConfigDecryptPasswords
     Vmdb::Settings.decrypt_passwords!(super).tap do
       # The following should only be done when loading/reloading the current
       #   process' Settings, as opposed to a remote server's settings.
-      Vmdb::Settings.on_reload if equal?(::Settings)
+      Vmdb::Settings.dump_to_log_directory(::Settings) if equal?(::Settings)
     end
   end
 

--- a/lib/vmdb/settings.rb
+++ b/lib/vmdb/settings.rb
@@ -25,17 +25,10 @@ module Vmdb
     RESET_COMMAND = "<<reset>>".freeze
     RESET_VALUE = HashDiffer::MissingKey
 
-    cattr_accessor :last_loaded
-
     def self.init
       ::Config.overwrite_arrays = true
       ::Config.merge_nil_values = false
       reset_settings_constant(for_resource(:my_server))
-      on_reload
-    end
-
-    def self.on_reload
-      self.last_loaded = Time.now.utc
       dump_to_log_directory(::Settings)
     end
 

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -1,37 +1,25 @@
 RSpec.describe Vmdb::Settings do
-  describe ".on_reload" do
+  describe ".dump_to_log_directory" do
     it "is called on top-level ::Settings.reload!" do
-      expect(described_class).to receive(:on_reload)
+      expect(described_class).to receive(:dump_to_log_directory)
 
       ::Settings.reload!
     end
 
-    it "updates the last_loaded time" do
-      Timecop.freeze(Time.now.utc) do
-        expect(described_class.last_loaded).to_not eq(Time.now.utc)
+    it "writes them" do
+      ::Settings.api.token_ttl = "1.minute"
+      described_class.dump_to_log_directory(::Settings)
 
-        described_class.on_reload
-
-        expect(described_class.last_loaded).to eq(Time.now.utc)
-      end
+      dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
+      expect(dumped_yaml.fetch_path(:api, :token_ttl)).to eq "1.minute"
     end
 
-    context "dumping the settings to the log directory" do
-      it "writes them" do
-        ::Settings.api.token_ttl = "1.minute"
-        described_class.on_reload
+    it "masks passwords" do
+      ::Settings.authentication.bind_pwd = "pa$$w0rd"
+      described_class.dump_to_log_directory(::Settings)
 
-        dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
-        expect(dumped_yaml.fetch_path(:api, :token_ttl)).to eq "1.minute"
-      end
-
-      it "masks passwords" do
-        ::Settings.authentication.bind_pwd = "pa$$w0rd"
-        described_class.on_reload
-
-        dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
-        expect(dumped_yaml.fetch_path(:authentication, :bind_pwd)).to eq "********"
-      end
+      dumped_yaml = YAML.load_file(described_class::DUMP_LOG_FILE)
+      expect(dumped_yaml.fetch_path(:authentication, :bind_pwd)).to eq "********"
     end
   end
 

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MiqServer, "::ConfigurationManagement" do
   end
 
   describe "#reload_settings" do
-    let(:miq_server) { EvmSpecHelper.local_miq_server }
+    let(:miq_server) { EvmSpecHelper.local_miq_server.tap(&:setup_drb_variables) }
 
     it "reloads the new changes into the settings for the resource" do
       Vmdb::Settings.save!(miq_server, :some_test_setting => 2)

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe MiqServer, "::ConfigurationManagement" do
     it "reloads the new changes into the settings for the resource" do
       Vmdb::Settings.save!(miq_server, :some_test_setting => 2)
       expect(Settings.some_test_setting).to be_nil
+      expect(miq_server).to receive(:update_sync_timestamp)
 
       miq_server.reload_settings
 

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -30,8 +30,7 @@ module EvmSpecHelper
 
   # Clear all EVM caches
   def self.clear_caches
-    @settings_loaded = Vmdb::Settings.last_loaded
-
+    settings_digest = Digest::MD5.hexdigest(::Settings.to_json)
     yield if block_given?
   ensure
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
@@ -47,7 +46,7 @@ module EvmSpecHelper
     # Clear the thread local variable to prevent test contamination
     User.current_user = nil if defined?(User) && User.respond_to?(:current_user=)
 
-    ::Settings.reload! if @settings_loaded != Vmdb::Settings.last_loaded
+    ::Settings.reload! if Digest::MD5.hexdigest(::Settings.to_json) != settings_digest
   end
 
   def self.clear_instance_variables(instance)


### PR DESCRIPTION
This PR moves the work done when a server process needs to reload settings from a two phase action to one. Specifically, all of the work that needs to be done when settings change for a server is now done in `reload_settings`.

A call to this method is enqueued by a worker when it changes the
settings for a server. Previously, this method would reload the
server process's settings and this would set the last_changed
attribute on Vmdb::Settings. This attribute would later indicate to
the server to do some more work because its settings had changed
recently. This condition was checked and the work was done in
the #sync_monitor method.

This commit changes this flow so the work that was previously done
in #sync_monitor if the settings had been changed is now just done
directly when the server is told that it should reload its settings.

This simplifies the #sync_monitor method and also allows us to
remove Vmdb::Settings.last_loaded attribute entirely.