### PR TITLE
key_base replaced token, so we shouldn't need this

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,7 +57,6 @@ Vmdb::Application.configure do
   # Do not include all helpers for all views
   config.action_controller.include_all_helpers = false
   config.secret_key_base = SecureRandom.random_bytes(32)
-  config.secret_token = SecureRandom.random_bytes(32)
 end
 
 require "minitest"


### PR DESCRIPTION
We're still getting these deprecation warnings and I think it's cause of this.

`secrets.secret_token` is deprecated in favor of `secret_key_base`

see https://github.com/ManageIQ/manageiq/pull/19514

Sorry Keenan but we have new records to set for the number of one-liners I can ask you to deal with :) 

@miq-bot assign @kbrock 