### PR TITLE
Bump smartstate to v0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -204,7 +204,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.3.4",       :require => false
+  gem "manageiq-smartstate",            "~>0.5.0",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Update manageiq-smartstate to v0.5.0 to use vmware_web_service v1.0

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/56