### PR TITLE
[V2V] Fix playbook invocation

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -331,11 +331,12 @@ class InfraConversionJob < Job
     update_migration_task_progress(:on_entry)
     service_template = migration_task.send("#{migration_phase}_ansible_playbook_service_template")
     unless service_template.nil?
+      user_id = User.find_by(:userid => migration_task.userid).id
       service_dialog_options = {
-        :credentials => service_template.config_info[:provision][:credential_id],
-        :hosts       => target_vm.ipaddresses.first || service_template.config_info[:provision][:hosts]
+        :credential => service_template.config_info[:provision][:credential_id],
+        :hosts      => target_vm.ipaddresses.first || service_template.config_info[:provision][:hosts]
       }
-      context["#{migration_phase}_migration_playbook_service_request_id".to_sym] = service_template.provision_request(migration_task.userid.to_i, service_dialog_options).id
+      migration_task.update_options("#{migration_phase}_migration_playbook_service_request_id".to_sym => service_template.provision_request(user_id, service_dialog_options).id)
       update_migration_task_progress(:on_exit)
       return queue_signal(:poll_run_migration_playbook_complete, :deliver_on => Time.now.utc + state_retry_interval)
     end
@@ -355,7 +356,7 @@ class InfraConversionJob < Job
     update_migration_task_progress(:on_entry)
     return abort_conversion('Running migration playbook timed out', 'error') if polling_timeout
 
-    service_request = ServiceTemplateProvisionRequest.find(context["#{migration_phase}_migration_playbook_service_request_id".to_sym])
+    service_request = ServiceTemplateProvisionRequest.find(migration_task.options["#{migration_phase}_migration_playbook_service_request_id".to_sym])
     playbooks_status = migration_task.get_option(:playbooks) || {}
     playbooks_status[migration_phase] = { :job_state => service_request.request_state }
     migration_task.update_options(:playbooks => playbooks_status)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe InfraConversionJob, :v2v do
   let(:transformation_plan) { ServiceTemplateTransformationPlan.create_catalog_item(transformation_plan_catalog_item_options) }
 
   let(:request)         { FactoryBot.create(:service_template_transformation_plan_request, :source => transformation_plan) }
-  let(:task)            { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :source => vm_vmware, :userid => user.id) }
+  let(:task)            { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :source => vm_vmware, :userid => user.userid) }
   let(:job_options)     { {:target_class => task.class.name, :target_id => task.id} }
   let(:job)             { described_class.create_job(job_options) }
 
@@ -1060,7 +1060,7 @@ RSpec.describe InfraConversionJob, :v2v do
               expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
               expect(job).to receive(:queue_signal).with(:poll_run_migration_playbook_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
               job.signal(:run_migration_playbook)
-              service_request = ServiceTemplateProvisionRequest.find(job.context[:pre_migration_playbook_service_request_id])
+              service_request = ServiceTemplateProvisionRequest.find(task.reload.options["#{task.options[:migration_phase]}_migration_playbook_service_request_id".to_sym])
               expect(service_request).to have_attributes(
                 :description => "Provisioning Service [#{embedded_ansible_service_template.name}] from [#{embedded_ansible_service_template.name}]",
                 :state       => 'pending',
@@ -1089,14 +1089,13 @@ RSpec.describe InfraConversionJob, :v2v do
       before do
         job.state = 'running_migration_playbook'
         embedded_ansible_service = FactoryBot.create(:service_ansible_playbook)
-        FactoryBot.create(:service_template_provision_task, :miq_request => embedded_ansible_service_request, :destination => embedded_ansible_service, :userid => user.id)
+        FactoryBot.create(:service_template_provision_task, :miq_request => embedded_ansible_service_request, :destination => embedded_ansible_service, :userid => user.userid)
         FactoryBot.create(:service_resource, :resource => FactoryBot.create(:embedded_ansible_job), :service => embedded_ansible_service)
       end
 
       context "migration_phase is 'pre'" do
         before do
-          task.update_options(:migration_phase => 'pre')
-          job.context[:pre_migration_playbook_service_request_id] = embedded_ansible_service_request.id
+          task.update_options(:migration_phase => 'pre', :pre_migration_playbook_service_request_id => embedded_ansible_service_request.id)
         end
 
         it 'abort_conversion when running_migration_playbook times out' do
@@ -1134,8 +1133,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
       context "migration_phase is 'post'" do
         before do
-          task.update_options(:migration_phase => 'post')
-          job.context[:post_migration_playbook_service_request_id] = embedded_ansible_service_request.id
+          task.update_options(:migration_phase => 'post', :post_migration_playbook_service_request_id => embedded_ansible_service_request.id)
         end
 
         it "exits to next state in case of success" do


### PR DESCRIPTION
The current implementation fails for two reasons:

- a typo in `service_dialog_options`: it should be `credential`
- job context is cleared at each state, so we need to store the service id in the task

This pull request implements the fixes.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789433