### PR TITLE
Move the complex logic of remove_snapshot_by_description to vmware repo

### DIFF
--- a/app/models/vm_or_template/operations/snapshot.rb
+++ b/app/models/vm_or_template/operations/snapshot.rb
@@ -115,23 +115,8 @@ module VmOrTemplate::Operations::Snapshot
     raise NotImplementedError, _("must be implemented in a subclass")
   end
 
-  def remove_snapshot_by_description(description, refresh = false, retry_time = nil)
-    if (ext_management_system.kind_of?(ManageIQ::Providers::Vmware::InfraManager) && ManageIQ::Providers::Vmware::InfraManager.use_vim_broker? && MiqVimBrokerWorker.available?) || host.nil? || host.state == "on"
-      raw_remove_snapshot_by_description(description, refresh)
-    else
-      if retry_time.nil?
-        raise _("The VM's Host system is unavailable to remove the snapshot. VM id:[%{id}] Snapshot description:[%{description}]") %
-                {:id => id, :descrption => description}
-      end
-      # If the host is off re-queue the action based on the retry_time
-      MiqQueue.put(:class_name  => self.class.name,
-                   :instance_id => id,
-                   :method_name => 'remove_snapshot_by_description',
-                   :args        => [description, refresh, retry_time],
-                   :deliver_on  => Time.now.utc + retry_time,
-                   :role        => "smartstate",
-                   :zone        => my_zone)
-    end
+  def remove_snapshot_by_description(description, refresh = false, _retry_time = nil)
+    raw_remove_snapshot_by_description(description, refresh)
   end
 
   def raw_remove_all_snapshots


### PR DESCRIPTION
Move the complex logic of remove_snapshot_by_description to the vmware repo, and just call raw_remove_snapshot_by_descrption in core.

- [x] Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/518