### PR TITLE
[WIP] Use STI with ServiceOrder model

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -1,4 +1,6 @@
 class ServiceOrder < ApplicationRecord
+  include NewWithStiMixin
+
   STATE_CART    = 'cart'.freeze
   STATE_WISH    = 'wish'.freeze
   STATE_ORDERED = 'ordered'.freeze

--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -1,5 +1,5 @@
 class ServiceOrder < ApplicationRecord
-  include NewWithStiMixin
+  include NewWithTypeStiMixin
 
   STATE_CART    = 'cart'.freeze
   STATE_WISH    = 'wish'.freeze

--- a/app/models/service_order_cart.rb
+++ b/app/models/service_order_cart.rb
@@ -1,0 +1,2 @@
+class ServiceOrderCart < ServiceOrder
+end

--- a/app/models/service_order_v2v.rb
+++ b/app/models/service_order_v2v.rb
@@ -1,0 +1,2 @@
+class ServiceOrderV2V < ServiceOrder
+end


### PR DESCRIPTION
This PR mixes in the `NewWithTypeStiMixin` module so that we can distinguish between different types of service orders. For now that means "v2v" and "everything else".

Required for https://github.com/ManageIQ/manageiq-schema/pull/328

Attempts to solve ManageIQ/manageiq-ui-service#1463

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1565049