### PR TITLE
Update sys-proctable to be compatible with 1.2.x.

### DIFF
--- a/app/models/miq_cockpit_ws_worker/runner.rb
+++ b/app/models/miq_cockpit_ws_worker/runner.rb
@@ -126,7 +126,7 @@ class MiqCockpitWsWorker::Runner < MiqWorker::Runner
 
   def process_alive?(pid)
     return false if pid.nil?
-    process_struct = Sys::ProcTable.ps(pid)
+    process_struct = Sys::ProcTable.ps(:pid => pid)
     return false if process_struct.nil?
     return true if process_struct.state != "Z"
 


### PR DESCRIPTION
Version 1.2 of the `sys-proctable` gem has the advantage of not having to deal with bundler and platform-specific installation issues. But, it also had an API change - keyword arguments. So, this PR updates it to use the places I found (one) where we actually pass an argument to `ProcTable.ps`. Without an argument, the API is unchanged.

Depends on https://github.com/ManageIQ/manageiq-gems-pending/pull/458