### PR TITLE
The MiqEventHandler still needs VimTypes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,6 +166,7 @@ end
 
 group :vmware, :manageiq_default do
   manageiq_plugin "manageiq-providers-vmware"
+  gem "vmware_web_service", "~>1.0"
 end
 
 ### shared dependencies

--- a/app/models/miq_event_handler/runner.rb
+++ b/app/models/miq_event_handler/runner.rb
@@ -1,3 +1,5 @@
+require "VMwareWebService/VimTypes"
+
 class MiqEventHandler::Runner < MiqQueueWorkerBase::Runner
   def artemis?
     Settings.prototype.queue_type == 'artemis'


### PR DESCRIPTION
EmsEvents still have vim_types in the full_data property, add back the
require pending a data migration to remove these.