### PR TITLE
Map server to zone in pods

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -331,6 +331,8 @@ class MiqServer < ApplicationRecord
   end
 
   def is_deleteable?
+    return true if MiqEnvironment::Command.is_podified?
+
     if self.is_local?
       message = N_("Cannot delete currently used %{log_message}") % {:log_message => format_short_log_msg}
       @errors ||= ActiveModel::Errors.new(self)

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -29,7 +29,9 @@ class Zone < ApplicationRecord
   has_many :containers,            :through => :container_managers
   virtual_has_many :active_miq_servers, :class_name => "MiqServer"
 
+  before_destroy :remove_servers_if_podified
   before_destroy :check_zone_in_use_on_destroy
+  after_create :create_server_if_podified
 
   include AuthenticationMixin
 
@@ -240,6 +242,19 @@ class Zone < ApplicationRecord
   end
 
   protected
+
+  def remove_servers_if_podified
+    return unless MiqEnvironment::Command.is_podified?
+
+    miq_servers.destroy_all
+  end
+
+  def create_server_if_podified
+    return unless MiqEnvironment::Command.is_podified?
+    return if name == "default" || !visible
+
+    miq_servers.create!(:name => name)
+  end
 
   def check_zone_in_use_on_destroy
     raise _("cannot delete default zone") if name == "default"

--- a/spec/models/miq_server/queue_management_spec.rb
+++ b/spec/models/miq_server/queue_management_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe "Queue Management" do
 
   describe "#ntp_reload_queue" do
     it "enqueues a message if the server is an appliance, but not a container" do
-      expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
-      expect(MiqEnvironment::Command).to receive(:is_container?).and_return(false)
+      allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
+      allow(MiqEnvironment::Command).to receive(:is_container?).and_return(false)
 
       server.ntp_reload_queue
 
@@ -12,7 +12,7 @@ RSpec.describe "Queue Management" do
     end
 
     it "doesn't enqueue a message if the server is not an appliance" do
-      expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)
+      allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(false)
 
       server.ntp_reload_queue
 
@@ -20,8 +20,8 @@ RSpec.describe "Queue Management" do
     end
 
     it "doesn't enqueue a message if the server is a container" do
-      expect(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
-      expect(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
+      allow(MiqEnvironment::Command).to receive(:is_appliance?).and_return(true)
+      allow(MiqEnvironment::Command).to receive(:is_container?).and_return(true)
 
       server.ntp_reload_queue
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -172,6 +172,13 @@ RSpec.describe MiqServer do
 
         expect(@miq_server.errors.full_messages.first).to match(/recently/)
       end
+
+      it "doesn't enforce when podified" do
+        allow(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+        allow(@miq_server).to receive(:is_local?).and_return(true)
+        @miq_server.last_heartbeat = 2.minutes.ago.utc
+        @miq_server.destroy!
+      end
     end
 
     context "#ntp_reload_queue" do


### PR DESCRIPTION
This PR makes some changes to zones and servers to make them easier to manage in pods.

Automatically create a server when a zone is created and delete the servers in a zone when a zone is deleted. This also requires toning down the restrictions on deleting servers and zones.

While testing this change I found that the UI has separate logic to determine when a zone is able to be deleted. This PR also consolidates that logic with the most important change that we're allowing a zone to be deleted if it has schedules associated with it. Previously the UI prevented the delete if schedules were present, but the model didn't check for that and, in fact, has a `:dependent_destroy` on the relation.

Applies to https://github.com/ManageIQ/manageiq-pods/issues/353