### PR TITLE
Fixing unknown unknowns 

### DIFF
--- a/spec/models/miq_server/log_management_spec.rb
+++ b/spec/models/miq_server/log_management_spec.rb
@@ -149,21 +149,37 @@ RSpec.describe MiqServer do
         it "##{method}" do
           @miq_server.send(method, task.id, log_depot)
           logfile = @miq_server.reload.log_files.first
-          expected_name = [name, "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, "20180511_113312 20180511_153416"].join(" ")
-          expect(logfile).to have_attributes(
-            :file_depot         => log_depot,
-            :local_file         => daily_log,
-            :logging_started_on => log_start,
-            :logging_ended_on   => log_end,
-            :name               => expected_name,
-            :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
-            :miq_task_id        => task.id
-          )
 
-          expected_filename = "#{name}_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
-          expected_filename.gsub!(/\s+/, "_")
-          expect(logfile.destination_file_name).to eq(expected_filename)
-
+          if %w[Current Archive].include?(name)
+            expected_name = [name, "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, "20180511_113312 20180511_153416"].join(" ")
+            expect(logfile).to have_attributes(
+              :file_depot         => log_depot,
+              :local_file         => daily_log,
+              :logging_started_on => log_start,
+              :logging_ended_on   => log_end,
+              :name               => expected_name,
+              :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} 20180511_113312 20180511_153416",
+              :miq_task_id        => task.id
+            )
+            expected_filename = "#{name}_region_#{region.region}_#{zone.name}_#{zone.id}_#{@miq_server.name}_#{@miq_server.id}_20180511_113312_20180511_153416.zip"
+            expected_filename.gsub!(/\s+/, "_")
+            expect(logfile.destination_file_name).to eq(expected_filename)
+          else
+            now = Time.zone.now
+            Timecop.freeze(now) do
+              formatted_now = now.strftime("%Y%m%d_%H%M%S")
+              expected_name = [name, "region", region.region, zone.name, zone.id, @miq_server.name, @miq_server.id, formatted_now, formatted_now].join(" ")
+              expect(logfile).to have_attributes(
+                :file_depot         => log_depot,
+                :local_file         => daily_log,
+                :logging_started_on => be_within(1).of(now),
+                :logging_ended_on   => be_within(1).of(now),
+                :name               => expected_name,
+                :description        => "Logs for Zone #{@miq_server.zone.name} Server #{@miq_server.name} #{formatted_now} #{formatted_now}",
+                :miq_task_id        => task.id
+              )
+            end
+          end
           expect(task.reload).to have_attributes(
             :message => "#{name} log files from #{@miq_server.name} #{@miq_server.zone.name} MiqServer #{@miq_server.id} are posted",
             :state   => "Active",


### PR DESCRIPTION
The automate model and dialog collection logfile thingy doesn't have the timestamp set and so the names look like `Dialogs_region_0_default_2_EVM_1_unknown_unknown.zip`. 

If we did `post_current_logs` before we collected the automate things we could set it to now and not have 🎉 **unknown unknowns** 🎉 .

Something like this could fix https://bugzilla.redhat.com/show_bug.cgi?id=1706989 maybe possibly, I dunno. 

@miq-bot assign @jrafanie 
@miq-bot add_label bug 

<sub><sup>I am almost too young to be making that reference anyway I was barely alive for that </sup></sub>