### PR TITLE
Make External-facing networks available to all tenants

### DIFF
--- a/app/models/cloud_network.rb
+++ b/app/models/cloud_network.rb
@@ -52,7 +52,7 @@ class CloudNetwork < ApplicationRecord
   end
 
   def self.tenant_id_clause_format(tenant_ids)
-    ["((tenants.id IN (?) OR cloud_networks.shared IS TRUE) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE OR ext_management_systems.tenant_mapping_enabled IS NULL", tenant_ids]
+    ["((tenants.id IN (?) OR cloud_networks.shared IS TRUE OR cloud_networks.external_facing IS TRUE) AND ext_management_systems.tenant_mapping_enabled IS TRUE) OR ext_management_systems.tenant_mapping_enabled IS FALSE OR ext_management_systems.tenant_mapping_enabled IS NULL", tenant_ids]
   end
 
   private


### PR DESCRIPTION
External-facing networks, at least in Openstack, are supposed to be scoped to all tenants. This updates the tenant_id clause for CloudNetworks to consider whether external_facing is true when deciding whether to allow a tenant to see a network.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1779536

@agrare I don't know if there are other providers using the CloudNetwork model that don't treat external_facing networks this way, so if necessary I can probably move this into the Openstack provider repo.

@aufi please give this a look when you have a chance, make sure I'm not missing anything :)

Links
----------------

* https://www.redhat.com/en/blog/four-types-neutron-networks-you-must-understand
* https://bugzilla.redhat.com/show_bug.cgi?id=1779536

Steps for Testing/QA
-------------------------------

Scenario 1:
1. Create an external-facing network in tenant A.
2. Log in with user in a group assigned to tenant B.
3. See that the network is available on the Network -> Networks list view, and when creating a network router.

Scenario 2:
1. Create an internal-facing network in tenant A.
2. Log in with user in a group assigned to tenant B.
3. See that the network is not visible on the Network -> Networks list view, or when creating a network router.
