### PR TITLE
Fixing issues with field properties from tower templates

### DIFF
--- a/app/models/dialog/ansible_tower_job_template_dialog_service.rb
+++ b/app/models/dialog/ansible_tower_job_template_dialog_service.rb
@@ -48,11 +48,13 @@ class Dialog
         :data_type      => "string",
         :display        => "edit",
         :required       => false,
+        :dynamic        => false,
         :options        => {:protected => false},
         :label          => options[:label],
         :position       => position,
-        :reconfigurable => true,
-        :dialog_group   => group
+        :reconfigurable => false,
+        :dialog_group   => group,
+        :read_only      => false
       )
     end
 
@@ -106,14 +108,17 @@ class Dialog
         :name           => "param_#{parameter['variable']}",
         :display        => "edit",
         :required       => parameter['required'],
+        :dynamic        => false,
         :options        => {:force_multi_value => parameter["type"] == "multiselect"},
         :values         => dropdown_list,
         :default_value  => default_value || dropdown_list.first,
         :label          => parameter['question_name'],
         :description    => parameter['question_description'],
-        :reconfigurable => true,
+        :reconfigurable => false,
+        :data_type      => "string",
         :position       => position,
-        :dialog_group   => group
+        :dialog_group   => group,
+        :read_only      => false
       )
     end
 
@@ -124,13 +129,15 @@ class Dialog
         :data_type      => parameter['type'] == 'integer' ? 'integer' : 'string',
         :display        => "edit",
         :required       => parameter['required'],
+        :dynamic        => false,
         :default_value  => parameter['default'],
         :options        => {:protected => parameter['type'] == 'password'},
         :label          => parameter['question_name'],
         :description    => parameter['question_description'],
-        :reconfigurable => true,
+        :reconfigurable => false,
         :position       => position,
-        :dialog_group   => group
+        :dialog_group   => group,
+        :read_only      => false
       )
     end
 
@@ -154,10 +161,11 @@ class Dialog
         :data_type      => "string",
         :display        => "edit",
         :required       => false,
+        :dynamic        => false,
         :default_value  => value,
         :label          => key,
         :description    => key,
-        :reconfigurable => true,
+        :reconfigurable => false,
         :position       => position,
         :dialog_group   => group,
         :read_only      => true

--- a/spec/models/dialog/ansible_tower_job_template_dialog_service_spec.rb
+++ b/spec/models/dialog/ansible_tower_job_template_dialog_service_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Dialog::AnsibleTowerJobTemplateDialogService do
     expect(group).to have_attributes(:label => "Options", :display => "edit")
     fields = group.dialog_fields
     expect(fields.size).to eq(2)
-    expect(fields[0]).to have_attributes(:label => "Service Name", :name => "service_name", :required => false, :data_type => 'string')
-    expect(fields[1]).to have_attributes(:label => "Limit", :name => "limit", :required => false, :data_type => 'string')
+    expect(fields[0]).to have_attributes(:required => false, :data_type => 'string', :dynamic => false, :reconfigurable => false, :read_only => false, :label => "Service Name", :name => "service_name")
+    expect(fields[1]).to have_attributes(:required => false, :data_type => 'string', :dynamic => false, :reconfigurable => false, :read_only => false, :label => "Limit",        :name => "limit")
   end
 
   def assert_field(field, clss, attributes)
@@ -83,13 +83,13 @@ RSpec.describe Dialog::AnsibleTowerJobTemplateDialogService do
     fields = group.dialog_fields
     expect(fields.size).to eq(7)
 
-    assert_field(fields[0], DialogFieldTextBox,      :name => 'param_param1', :data_type => 'integer',   :default_value => "19")
-    assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',    :default_value => "as")
-    assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',    :default_value => "no\nhello")
-    assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',    :default_value => "mypassword", :options => {:protected => true})
-    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :default_value => "Peach", :values => [%w[Apple Apple], %w[Banana Banana], %w[Peach Peach]], :options => {:force_multi_value => false})
-    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :default_value => "[\"opt1\", \"222\"]",  :values => [%w[222 222], %w[opt1 opt1], %w[opt3 opt3]], :options => {:force_multi_value => true})
-    assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string', :default_value => "14.5")
+    assert_field(fields[0], DialogFieldTextBox,      :name => 'param_param1', :data_type => 'integer', :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "19")
+    assert_field(fields[1], DialogFieldTextBox,      :name => 'param_param2', :data_type => 'string',  :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "as")
+    assert_field(fields[2], DialogFieldTextAreaBox,  :name => 'param_param3', :data_type => 'string',  :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "no\nhello")
+    assert_field(fields[3], DialogFieldTextBox,      :name => 'param_param4', :data_type => 'string',  :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "mypassword", :options => {:protected => true})
+    assert_field(fields[4], DialogFieldDropDownList, :name => "param_param5", :data_type => 'string',  :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "Peach", :values => [%w[Apple Apple], %w[Banana Banana], %w[Peach Peach]], :options => {:force_multi_value => false})
+    assert_field(fields[5], DialogFieldDropDownList, :name => "param_param6", :data_type => 'string',  :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "[\"opt1\", \"222\"]", :values => [%w[222 222], %w[opt1 opt1], %w[opt3 opt3]], :options => {:force_multi_value => true})
+    assert_field(fields[6], DialogFieldTextBox,      :name => 'param_param7', :data_type => 'string',  :reconfigurable => false, :dynamic => false, :read_only => false, :default_value => "14.5")
   end
 
   def assert_variables_group(group)
@@ -98,8 +98,8 @@ RSpec.describe Dialog::AnsibleTowerJobTemplateDialogService do
     fields = group.dialog_fields
     expect(fields.size).to eq(3)
 
-    assert_field(fields[0], DialogFieldTextBox, :name => 'param_some_extra_var', :default_value => 'blah', :data_type => 'string', :read_only => true)
-    assert_field(fields[1], DialogFieldTextBox, :name => 'param_other_extra_var', :default_value => '{"name":"some_value"}', :data_type => 'string', :read_only => true)
-    assert_field(fields[2], DialogFieldTextBox, :name => 'param_array_extra_var', :default_value => '[{"name":"some_value"}]', :data_type => 'string', :read_only => true)
+    assert_field(fields[0], DialogFieldTextBox, :name => 'param_some_extra_var',  :data_type => 'string', :dynamic => false, :read_only => true, :reconfigurable => false, :default_value => 'blah')
+    assert_field(fields[1], DialogFieldTextBox, :name => 'param_other_extra_var', :data_type => 'string', :dynamic => false, :read_only => true, :reconfigurable => false, :default_value => '{"name":"some_value"}')
+    assert_field(fields[2], DialogFieldTextBox, :name => 'param_array_extra_var', :data_type => 'string', :dynamic => false, :read_only => true, :reconfigurable => false, :default_value => '[{"name":"some_value"}]')
   end
 end


### PR DESCRIPTION
Creating service dialogs from tower templates is missing some necessary field properties as described in https://github.com/ManageIQ/manageiq/pull/18932#issuecomment-580237952. 

Caught in https://bugzilla.redhat.com/show_bug.cgi?id=1794872. It's the service dialog creation itself is that's borked though, not service ordering or passing vars.

I expect that it also needs some pretty serious tire kicking since none of this code seems to have gotten any yet. I dunno if it's borked for things other than dropdowns. This needs test coverage.

@miq-bot add_label bug, dialogs