### PR TITLE
[V2V] Allow get_conversion_state to fail

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -239,13 +239,17 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       updates[:virtv2v_finished_on] = Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')
       if virtv2v_state['failed']
         updates[:virtv2v_status] = 'failed'
-        raise "Disks transformation failed."
       else
         updates[:virtv2v_status] = 'succeeded'
         updated_disks.each { |d| d[:percent] = 100 }
       end
     end
     updates[:virtv2v_disks] = updated_disks
+    update_options(:get_conversion_state_failures => 0)
+  rescue
+    failures = options[:get_conversion_state_failures] || 0
+    update_options(:get_conversion_state_failures => failures + 1)
+    raise "Failed to get conversion state 5 times in a row" if options[:get_conversion_state_failures] > 5
   ensure
     _log.info("InfraConversionJob get_conversion_state to update_options: #{updates}")
     update_options(updates)


### PR DESCRIPTION
When `ConversionHost.get_conversion_state` method fails it raises an exception, which makes `ServiceTemplateTransformationPlanTask.get_conversion_state` method fail.  This pull request allows up to 6 failures, i.e. 1.5 minute, in a row. This allows `virt-v2v-wrapper` to initialize its state file and with recent changes it might take up to 40 seconds. This gives some extra time.

This pull request also removes the exception raise when conversion is failed (`virtv2v_state['failed'] == true`) because `InfraConversionJob` also raises on the same condition, triggering the cancellation.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789433