### PR TITLE
Cleanup some server methods

### DIFF
--- a/app/models/miq_server/configuration_management.rb
+++ b/app/models/miq_server/configuration_management.rb
@@ -12,10 +12,8 @@ module MiqServer::ConfigurationManagement
     Vmdb::Settings.reload!
 
     activate_settings_for_appliance
-    sync_config
-    sync_assigned_roles
-    reset_queue_messages
-    update_sync_timestamp(Time.now.utc)
+    reset_server_caches
+    notify_workers_of_config_change(Time.now.utc)
   end
 
   # The purpose of this method is to do special activation of things
@@ -59,5 +57,11 @@ module MiqServer::ConfigurationManagement
     sync_worker_monitor_settings
     sync_child_worker_settings
     $log.log_hashes(@worker_monitor_settings)
+  end
+
+  def reset_server_caches
+    sync_config
+    sync_assigned_roles
+    reset_queue_messages
   end
 end

--- a/app/models/miq_server/worker_management/monitor.rb
+++ b/app/models/miq_server/worker_management/monitor.rb
@@ -141,12 +141,8 @@ module MiqServer::WorkerManagement::Monitor
       reset_queue_messages       if roles_changed
 
       @last_sync = Time.now.utc
-      update_sync_timestamp(@last_sync)
+      notify_workers_of_config_change(@last_sync)
     end
-  end
-
-  def set_last_change(key, value)
-    key_store.set(key, value)
   end
 
   def key_store
@@ -154,7 +150,7 @@ module MiqServer::WorkerManagement::Monitor
     @key_store ||= Dalli::Client.new(MiqMemcached.server_address, :namespace => "server_monitor")
   end
 
-  def update_sync_timestamp(last_sync)
-    set_last_change("last_config_change", last_sync)
+  def notify_workers_of_config_change(last_sync)
+    key_store.set("last_config_change", last_sync)
   end
 end

--- a/spec/models/miq_server/configuration_management_spec.rb
+++ b/spec/models/miq_server/configuration_management_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MiqServer, "::ConfigurationManagement" do
     it "reloads the new changes into the settings for the resource" do
       Vmdb::Settings.save!(miq_server, :some_test_setting => 2)
       expect(Settings.some_test_setting).to be_nil
-      expect(miq_server).to receive(:update_sync_timestamp)
+      expect(miq_server).to receive(:notify_workers_of_config_change)
 
       miq_server.reload_settings
 

--- a/spec/models/miq_server/worker_monitor_spec.rb
+++ b/spec/models/miq_server/worker_monitor_spec.rb
@@ -252,14 +252,15 @@ RSpec.describe "MiqWorker Monitor" do
         end
 
         context "for messaging through a key store" do
+          let(:key_store) { double("KeyStore") }
           before do
-            allow(@miq_server).to receive(:key_store).and_return(@key_store)
+            allow(@miq_server).to receive(:key_store).and_return(key_store)
             @ts = Time.now.utc
           end
 
           it "should update timestamp with config or role changes" do
-            expect(@miq_server).to receive(:set_last_change).with("last_config_change", @ts)
-            @miq_server.update_sync_timestamp(@ts)
+            expect(key_store).to receive(:set).with("last_config_change", @ts)
+            @miq_server.notify_workers_of_config_change(@ts)
           end
         end
       end


### PR DESCRIPTION
This moves some related calls in `MiqServer::ConfigurationManagement` to a better named method and gives a more useful name to the method used to update the last settings update timestamp in memcached.