### PR TITLE
[V2V] Renaming openstack_tls_ca_cert variable

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -238,7 +238,7 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, openstack_tls_ca_certs = nil, miq_task_id = nil)
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, tls_ca_certs = nil, miq_task_id = nil)
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
@@ -247,7 +247,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
-      :v2v_ca_bundle        => openstack_tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars, miq_task_id)
   ensure

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -75,7 +75,7 @@ module ConversionHost::Configurations
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
-      openstack_tls_ca_certs = params.delete(:openstack_tls_ca_certs)
+      tls_ca_certs = params.delete(:tls_ca_certs)
 
       new(params).tap do |conversion_host|
         if ssh_key
@@ -87,7 +87,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, openstack_tls_ca_certs, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, tls_ca_certs, miq_task_id)
         conversion_host.save!
 
         if miq_task_id


### PR DESCRIPTION
In order to have a consistent wizard for oVirt and OpenStack conversion hosts, we ask for the provider endpoint TLS CA certificate for both. This means that the specific variable `openstack_tls_ca_cert` should be renamed to something more generic. We decided that it would be `tls_ca_cert`. This pull request renames the variable.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1789479