### PR TITLE
Use the server's zone to determine a node selector when running in pods

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -481,6 +481,10 @@ class MiqServer < ApplicationRecord
     n_('Server', 'Servers', number)
   end
 
+  def self.zone_is_modifiable?
+    Zone.visible.in_my_region.count > 1 && !MiqEnvironment::Command.is_podified?
+  end
+
   private
 
   def zone_unchanged_in_pods

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -38,6 +38,7 @@ class MiqServer < ApplicationRecord
   virtual_delegate :description, :to => :zone, :prefix => true, :allow_nil => true, :type => :string
 
   validate :validate_zone_not_maintenance?
+  validate :zone_unchanged_in_pods, :on => :update
 
   GUID_FILE = Rails.root.join("GUID").freeze
 
@@ -478,5 +479,13 @@ class MiqServer < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Server', 'Servers', number)
+  end
+
+  private
+
+  def zone_unchanged_in_pods
+    return unless MiqEnvironment::Command.is_podified?
+
+    errors.add(:zone, N_('cannot be changed when running in containers')) if zone_id_changed?
   end
 end # class MiqServer

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -482,7 +482,9 @@ class MiqServer < ApplicationRecord
   end
 
   def self.zone_is_modifiable?
-    Zone.visible.in_my_region.count > 1 && !MiqEnvironment::Command.is_podified?
+    return false if MiqEnvironment::Command.is_podified?
+
+    Zone.visible.in_my_region.count > 1
   end
 
   private

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -8,6 +8,10 @@ class MiqWorker
       definition[:spec][:replicas] = replicas
       definition[:spec][:template][:spec][:terminationGracePeriodSeconds] = self.class.worker_settings[:stopping_timeout].seconds
 
+      if MiqServer.my_zone != "default"
+        definition[:spec][:template][:spec][:nodeSelector] = zone_selector
+      end
+
       container = definition[:spec][:template][:spec][:containers].first
       container[:image] = "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
       container[:env] << {:name => "WORKER_CLASS_NAME", :value => self.class.name}
@@ -17,6 +21,10 @@ class MiqWorker
     def scale_deployment
       ContainerOrchestrator.new.scale(worker_deployment_name, self.class.workers)
       delete_container_objects if self.class.workers.zero?
+    end
+
+    def zone_selector
+      {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone" => MiqServer.my_zone}
     end
 
     def container_image_namespace

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -24,7 +24,7 @@ class MiqWorker
     end
 
     def zone_selector
-      {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone" => MiqServer.my_zone}
+      {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone/#{MiqServer.my_zone}" => "true"}
     end
 
     def container_image_namespace

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -24,7 +24,7 @@ class MiqWorker
     end
 
     def zone_selector
-      {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone/#{MiqServer.my_zone}" => "true"}
+      {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone-#{MiqServer.my_zone}" => "true"}
     end
 
     def container_image_namespace

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -243,8 +243,8 @@ class Zone < ApplicationRecord
 
   def message_for_invalid_delete
     return _("cannot delete default zone") if name == "default"
-    return _("cannot delete maintenance zone") if self == miq_region.maintenance_zone
-    return _("zone name '%{name}' is used by a server") % {:name => name} if miq_servers.present?
+    return _("cannot delete maintenance zone") if self == self.class.maintenance_zone
+    return _("zone name '%{name}' is used by a server") % {:name => name} if !MiqEnvironment::Command.is_podified? && miq_servers.present?
     _("zone name '%{name}' is used by a provider") % {:name => name} if ext_management_systems.present?
   end
 

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -420,4 +420,25 @@ RSpec.describe MiqServer do
       expect(s.description).to eq(s.name)
     end
   end
+
+  describe "#zone_unchanged_in_pods" do
+    it "allows zone changes when not in pods" do
+      server = FactoryBot.create(:miq_server)
+      zone = FactoryBot.create(:zone)
+
+      server.zone = zone
+      expect(server.zone_id_changed?).to be_truthy
+      expect(server.save).to be_truthy
+    end
+
+    it "prevents zone changes in pods" do
+      allow(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+      server = FactoryBot.create(:miq_server)
+      zone = FactoryBot.create(:zone)
+
+      server.zone = zone
+      expect(server.zone_id_changed?).to be_truthy
+      expect(server.save).to be_falsey
+    end
+  end
 end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -441,4 +441,27 @@ RSpec.describe MiqServer do
       expect(server.save).to be_falsey
     end
   end
+
+  describe ".zone_is_modifiable?" do
+    it "is true when there are multiple zones in the region" do
+      FactoryBot.create(:miq_server)
+      FactoryBot.create(:zone)
+
+      expect(described_class.zone_is_modifiable?).to be_truthy
+    end
+
+    it "is false when there is only one zone" do
+      FactoryBot.create(:miq_server)
+      expect(Zone.count).to eq(1)
+      expect(described_class.zone_is_modifiable?).to be_falsey
+    end
+
+    it "is false when in pods" do
+      allow(MiqEnvironment::Command).to receive(:is_podified?).and_return(true)
+      FactoryBot.create(:miq_server)
+      FactoryBot.create(:zone)
+
+      expect(described_class.zone_is_modifiable?).to be_falsey
+    end
+  end
 end

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       worker = FactoryBot.create(:miq_generic_worker)
       worker.configure_worker_deployment(test_deployment)
 
-      expect(test_deployment.dig(:spec, :template, :spec, :nodeSelector)).to eq("manageiq/zone" => MiqServer.my_zone)
+      expect(test_deployment.dig(:spec, :template, :spec, :nodeSelector)).to eq("manageiq/zone/#{MiqServer.my_zone}" => "true")
     end
 
     it "doesn't add a node selector for the default zone" do

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       worker = FactoryBot.create(:miq_generic_worker)
       worker.configure_worker_deployment(test_deployment)
 
-      expect(test_deployment.dig(:spec, :template, :spec, :nodeSelector)).to eq("manageiq/zone/#{MiqServer.my_zone}" => "true")
+      expect(test_deployment.dig(:spec, :template, :spec, :nodeSelector)).to eq("manageiq/zone-#{MiqServer.my_zone}" => "true")
     end
 
     it "doesn't add a node selector for the default zone" do

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -6,6 +6,46 @@ RSpec.describe MiqWorker::ContainerCommon do
     "#{compressed_server_id}-#{name}"
   end
 
+  describe "#configure_worker_deplyoment" do
+    let(:test_deployment) do
+      {
+        :metadata => {
+          :name      => "test",
+          :labels    => {:app => "manageiq"},
+          :namespace => "manageiq",
+        },
+        :spec     => {
+          :selector => {:matchLabels => {:name => "test"}},
+          :template => {
+            :metadata => {:name => "test", :labels => {:name => "test", :app => "manageiq"}},
+            :spec     => {
+              :serviceAccountName => "miq-anyuid",
+              :containers         => [{
+                :name => "test",
+                :env  => []
+              }]
+            }
+          }
+        }
+      }
+    end
+
+    it "adds a node selector based on the zone name" do
+      worker = FactoryBot.create(:miq_generic_worker)
+      worker.configure_worker_deployment(test_deployment)
+
+      expect(test_deployment.dig(:spec, :template, :spec, :nodeSelector)).to eq("manageiq/zone" => MiqServer.my_zone)
+    end
+
+    it "doesn't add a node selector for the default zone" do
+      MiqServer.my_server.zone.update(:name => "default")
+      worker = FactoryBot.create(:miq_generic_worker)
+      worker.configure_worker_deployment(test_deployment)
+
+      expect(test_deployment.dig(:spec, :template, :spec).keys).not_to include(:nodeSelector)
+    end
+  end
+
   describe "#worker_deployment_name" do
     let(:test_cases) do
       [


### PR DESCRIPTION
This will allow workers to be target to specific nodes.

~~This works for now, but I haven't looked into what happens if a server changes zones. Leaving this as WIP until I get around to that.~~

As a part of this I added a validation to fail updates to a server's zone in pods. Additionally I created [a UI PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/6652) to disable the zone drop-down for pods and handle validation errors when changing the server zone.

Fixes https://github.com/ManageIQ/manageiq-pods/issues/353