### PR TITLE
Add a connection timeout for remote region connections

### DIFF
--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -78,7 +78,7 @@ class MiqRegionRemote < ApplicationRecord
     return host, port, username, password, database, adapter
   end
 
-  def self.with_remote_connection(host, port, username, password, database, adapter)
+  def self.with_remote_connection(host, port, username, password, database, adapter, connect_timeout = 0)
     # Don't allow accidental connections to localhost.  A blank host will
     # connect to localhost, so don't allow that at all.
     host = host.to_s.strip
@@ -92,12 +92,13 @@ class MiqRegionRemote < ApplicationRecord
 
     begin
       pool = establish_connection({
-        :adapter  => adapter,
-        :host     => host,
-        :port     => port,
-        :username => username,
-        :password => password,
-        :database => database
+        :adapter         => adapter,
+        :host            => host,
+        :port            => port,
+        :username        => username,
+        :password        => password,
+        :database        => database,
+        :connect_timeout => connect_timeout
       }.delete_blanks)
       conn = pool.connection
       yield conn

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -261,12 +261,12 @@ class PglogicalSubscription < ActsAsArModel
   end
 
   def remote_region_lsn
-    with_remote_connection(&:xlog_location)
+    with_remote_connection(5.seconds) { |conn| conn.xlog_location }
   end
 
-  def with_remote_connection
+  def with_remote_connection(connect_timeout = 0)
     find_password
-    MiqRegionRemote.with_remote_connection(host, port || 5432, user, decrypted_password, dbname, "postgresql") do |conn|
+    MiqRegionRemote.with_remote_connection(host, port || 5432, user, decrypted_password, dbname, "postgresql", connect_timeout) do |conn|
       yield conn
     end
   end


### PR DESCRIPTION
This will prevent a non-responsive remote region from hanging
the UI when trying to query for the replication backlog.

Regular ruby Timeout won't work here because the PG connection code
doesn't respond to the exception until after it has exhausted the
underlying libpq timeout logic.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1796681