### PR TITLE
Create ServiceOrder sub-classes

### DIFF
--- a/app/models/service_order.rb
+++ b/app/models/service_order.rb
@@ -17,6 +17,12 @@ class ServiceOrder < ApplicationRecord
   before_create :assign_user
   after_create  :create_order_name
 
+  def initialize(*args)
+    raise NotImplementedError, _("must be implemented in a subclass") if self.class == ServiceOrder
+
+    super
+  end
+
   def self.find_for_user(requester, id)
     find_by!(:user => requester, :tenant => requester.current_tenant, :id => id)
   end
@@ -73,9 +79,11 @@ class ServiceOrder < ApplicationRecord
 
   def self.add_to_cart(request, requester)
     _log.info("Service Order add_to_cart for Request: #{request.id} Requester: #{requester.userid}")
-    service_order = ServiceOrder.find_or_create_by(:state  => STATE_CART,
-                                                   :user   => requester,
-                                                   :tenant => requester.current_tenant)
+    service_order = request.class::SERVICE_ORDER_CLASS.find_or_create_by(
+      :state  => STATE_CART,
+      :user   => requester,
+      :tenant => requester.current_tenant
+    )
     service_order.miq_requests << request
     service_order
   end
@@ -90,10 +98,12 @@ class ServiceOrder < ApplicationRecord
   end
 
   def self.order_immediately(request, requester)
-    ServiceOrder.create(:state        => STATE_ORDERED,
-                        :user         => requester,
-                        :miq_requests => [request],
-                        :tenant       => requester.current_tenant).checkout_immediately
+    request.class::SERVICE_ORDER_CLASS.create(
+      :state        => STATE_ORDERED,
+      :user         => requester,
+      :miq_requests => [request],
+      :tenant       => requester.current_tenant
+    ).checkout_immediately
   end
 
   def deep_copy(new_attributes = {})

--- a/app/models/service_order_cart.rb
+++ b/app/models/service_order_cart.rb
@@ -1,0 +1,2 @@
+class ServiceOrderCart < ServiceOrder
+end

--- a/app/models/service_order_v2v.rb
+++ b/app/models/service_order_v2v.rb
@@ -1,0 +1,2 @@
+class ServiceOrderV2V < ServiceOrder
+end

--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -2,6 +2,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
   TASK_DESCRIPTION  = 'Service_Template_Provisioning'
   SOURCE_CLASS_NAME = 'ServiceTemplate'
   ACTIVE_STATES     = %w( migrated ) + base_class::ACTIVE_STATES
+  SERVICE_ORDER_CLASS = ServiceOrderCart
 
   validates_inclusion_of :request_state,  :in => %w( pending finished ) + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"
   validate               :must_have_user

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -1,5 +1,6 @@
 class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   TASK_DESCRIPTION = 'VM Transformations'.freeze
+  SERVICE_ORDER_CLASS = ServiceOrderV2V
 
   delegate :transformation_mapping, :vm_resources, :to => :source
 

--- a/spec/factories/service_order.rb
+++ b/spec/factories/service_order.rb
@@ -7,5 +7,8 @@ FactoryBot.define do
       name { "shopping cart" }
       state { "cart" }
     end
+
+    factory :service_order_cart, :parent => :service_order,
+                                 :class  => "ServiceOrderCart"
   end
 end

--- a/spec/models/service_order_spec.rb
+++ b/spec/models/service_order_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe ServiceOrder do
   let(:request2)      { create_request }
   let(:request3)      { create_request }
   let(:service_order) do
-    FactoryBot.create(:service_order, :state  => ServiceOrder::STATE_CART,
-                                       :user   => user,
-                                       :tenant => tenant)
+    FactoryBot.create(:service_order_cart,
+                      :state  => ServiceOrder::STATE_CART,
+                      :user   => user,
+                      :tenant => tenant)
   end
   let(:tenant) { Tenant.seed }
 
@@ -101,7 +102,7 @@ RSpec.describe ServiceOrder do
   it "only allows one cart per user, tenant" do
     service_order
     expect do
-      ServiceOrder.create!(:state => ServiceOrder::STATE_CART, :user => user, :tenant => tenant)
+      ServiceOrderCart.create!(:state => ServiceOrder::STATE_CART, :user => user, :tenant => tenant)
     end.to raise_error(ActiveRecord::RecordInvalid, /State has already been taken/)
   end
 

--- a/spec/models/service_template_provision_request_spec.rb
+++ b/spec/models/service_template_provision_request_spec.rb
@@ -1,5 +1,10 @@
 RSpec.describe ServiceTemplateProvisionRequest do
   let(:admin) { FactoryBot.create(:user_admin) }
+
+  describe 'SERVICE_ORDER_CLASS' do
+    it { expect(described_class::SERVICE_ORDER_CLASS).to eq(ServiceOrderCart) }
+  end
+
   context "with multiple tasks" do
     before do
       @request  = FactoryBot.create(:service_template_provision_request, :description => 'Service Request', :requester => admin)

--- a/spec/models/service_template_transformation_plan_request_spec.rb
+++ b/spec/models/service_template_transformation_plan_request_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
     end
   end
 
+  describe 'SERVICE_ORDER_CLASS' do
+    it { expect(described_class::SERVICE_ORDER_CLASS).to eq(ServiceOrderV2V) }
+  end
+
   describe '#validate_conversion_hosts' do
     context 'no conversion host exists in EMS' do
       let(:src_ems) { FactoryBot.create(:ems_vmware) }
@@ -169,6 +173,15 @@ RSpec.describe ServiceTemplateTransformationPlanRequest, :v2v do
       expect(request.request_state).to eq('finished')
       expect(request.status).to eq('Error')
       expect(request.message).to eq('Request is canceled by user.')
+    end
+  end
+
+  describe "#process_service_order" do
+    it "creates a V2V Service Order instance" do
+      request.options[:cart_state] = ServiceOrder::STATE_ORDERED
+      request.process_service_order
+
+      expect(request.service_order).to be_kind_of(ServiceOrderV2V)
     end
   end
 end


### PR DESCRIPTION
NEEDS TO BE MERGED ALONG WITH https://github.com/ManageIQ/manageiq-schema/pull/452

Create separate ServiceOrder types for `ServiceTemplateProvisionRequest` and ServiceTemplateProvisionRequest for v2v (`ServiceTemplateTransformationPlanRequest `)

Attempts to solve ManageIQ/manageiq-ui-service#1463

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1565049

cc @himdel 