### PR TITLE
Update MiqProvisionVirtWorkflow specs

### DIFF
--- a/spec/factories/miq_request_workflow.rb
+++ b/spec/factories/miq_request_workflow.rb
@@ -18,4 +18,8 @@ FactoryBot.define do
   end
 
   factory :miq_provision_virt_workflow, :class => "MiqProvisionVirtWorkflow", :parent => :miq_provision_workflow
+
+  factory :miq_provision_virt_workflow_vmware,
+    :class  => "ManageIQ::Providers::Vmware::InfraManager::ProvisionWorkflow",
+    :parent => :miq_provision_virt_workflow
 end

--- a/spec/models/miq_provision_virt_workflow_spec.rb
+++ b/spec/models/miq_provision_virt_workflow_spec.rb
@@ -231,8 +231,9 @@ RSpec.describe MiqProvisionVirtWorkflow do
 
     it "with a provider model defined" do
       ems = FactoryBot.create(:ems_vmware)
-      expect(workflow.class).to receive(:provider_model).once.and_return(ems.class)
+      workflow = FactoryBot.create(:miq_provision_virt_workflow_vmware)
 
+      expect(workflow.class).to receive(:provider_model).once.and_return(ems.class)
       expect(workflow.allowed_template_condition).to eq(["vms.template = ? AND vms.ems_id in (?)", true, [ems.id]])
     end
   end


### PR DESCRIPTION
With strict partial validation turned on, the current specs for `MiqProvisionVirtWorkflow` will fail because the `provider_model` method isn't defined on the base class.

This PR adds a vmware-specific factory (to accompany the already-present vmware-specific ems) and uses it for the one spec that currently fails.