### PR TITLE
Define singleton method on MiqServer before attempting to stub it

### DIFF
--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe MiqQueue do
   context "#deliver" do
     before do
       _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
+      MiqServer.define_singleton_method(:setup_data_directory) {}
     end
 
     it "requires class_name" do

--- a/spec/models/miq_queue_spec.rb
+++ b/spec/models/miq_queue_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe MiqQueue do
   context "#deliver" do
     before do
       _, @miq_server, @zone = EvmSpecHelper.create_guid_miq_server_zone
-      MiqServer.define_singleton_method(:setup_data_directory) {}
     end
 
     it "requires class_name" do
@@ -133,8 +132,8 @@ RSpec.describe MiqQueue do
 
     it "sets last_exception on raised Exception" do
       ex = StandardError.new("something blewup")
-      allow(MiqServer).to receive(:setup_data_directory).and_raise(ex)
-      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'setup_data_directory')
+      allow(MiqServer).to receive(:pidfile).and_raise(ex)
+      msg = FactoryBot.build(:miq_queue, :state => MiqQueue::STATE_DEQUEUE, :handler => @miq_server, :class_name => 'MiqServer', :method_name => 'pidfile')
       expect(msg._log).to receive(:error).with(/Error:/)
       expect(msg._log).to receive(:log_backtrace)
       status, message, _result = msg.deliver


### PR DESCRIPTION
With strict partial validation enabled you will see the following error when running the MiqQueue specs:

```
Failure/Error: allow(MiqServer).to receive(:setup_data_directory).and_raise(ex)
       MiqServer(id: integer, guid: string, status: string, started_on: datetime, stopped_on: datetime, pid: integer, build: string, percent_memory: float, percent_cpu: float, cpu_time: float, name: string, last_heartbeat: datetime, os_priority: integer, is_master: boolean, logo: binary, version: string, zone_id: integer, upgrade_status: string, upgrade_message: string, memory_usage: decimal, memory_size: decimal, hostname: string, ipaddress: string, drb_uri: string, mac_address: string, vm_id: integer, has_active_userinterface: boolean, has_active_webservices: boolean, sql_spid: integer, rh_registered: boolean, rh_subscribed: boolean, last_update_check: string, updates_available: boolean, log_file_depot_id: integer, proportional_set_size: decimal, has_active_remote_console: boolean, system_memory_free: decimal, system_memory_used: decimal, system_swap_free: decimal, system_swap_used: decimal, has_active_cockpit_ws: boolean, unique_set_size: decimal, has_vix_disk_lib: boolean, href_slug: string, region_number: integer, region_description: string, zone_description: string) does not implement: setup_data_directory
```
The problem is that there is no `MiqServer.setup_data_directory` method, so I created an empty definition. With this in place the specs pass.