### PR TITLE
Use .tabular_sort instead of .stable_sort_by

### DIFF
--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -45,7 +45,7 @@ module MiqReportResult::ResultSetOperations
         end
 
         result_set.map! { |x| x.slice(*report.col_order) }
-        result_set = result_set.stable_sort_by(sorting_columns, options[:sort_order])
+        result_set = result_set.tabular_sort(sorting_columns, options[:sort_order])
         result_set = apply_limit_and_offset(result_set, options)
       end
 

--- a/lib/patches/ruport_patch.rb
+++ b/lib/patches/ruport_patch.rb
@@ -6,7 +6,7 @@ require 'ruport'
 module Ruport::Data
   class Table
     def sort_rows_by(col_names = nil, options = {}, &block)
-      self.class.new(:data         => stable_sort_by(col_names, options[:order], &block),
+      self.class.new(:data         => to_a.tabular_sort(col_names, options[:order], &block),
                      :column_names => @column_names,
                      :record_class => record_class)
     end


### PR DESCRIPTION
`.stable_sort_by` was deprecated here (and now is causing deprecation warnings in specs):

https://github.com/ManageIQ/more_core_extensions/pull/76

And will be removed in `more_core_extensions` v4.0, so this is getting out ahead of that.

Note:  The change to add `.to_a` is ahead of `.tabular_sort` is because `Ruport::Data::Table` inherits from `Enumerable` and not `Array`, but `.tabular_sort` was implemented only on `Array`.  Should still work the same, though.


Links
-----

* Weird timeline of PRs for `more_core_extensions`...
  - add `.stable_sort_by` to `MCE::Enumerable`: https://github.com/ManageIQ/more_core_extensions/pull/67
  - rename/move to `Array#tabular_sort`: https://github.com/ManageIQ/more_core_extensions/pull/68
  - add deprecation of `Enumerable#stable_sort_by`: https://github.com/ManageIQ/more_core_extensions/pull/74
  - Release `v3.8.0`: https://github.com/ManageIQ/more_core_extensions/commit/179bf407de9b41b55eb9990605ffbade76c3741d
  - remove deprecation from above: https://github.com/ManageIQ/more_core_extensions/pull/76 ()
  - Release `v4.0.0`: https://github.com/ManageIQ/more_core_extensions/commit/304bb89f47a0ad4fc76507cf3b27b0b0a01acb0d
* Extraction of `.stable_sort_by` in `ManageIQ/manageiq`: https://github.com/ManageIQ/manageiq/pull/18389
* Some proof that I am not lying about this failing in the test suite:
  - Despite being `"~> 3.7"` in the [Gemfile](https://github.com/ManageIQ/manageiq/blob/46dea6c8d62d6caa48a355fdcd72e78cd51523b2/Gemfile#L59) ...
  - We get `v3.8.0` when bundling https://travis-ci.org/ManageIQ/manageiq/jobs/645606961#L489
    - (Note: this is expected behavior of the `~>`... probably should use `"~> 3.7.0"`
  - ... and some deprecation warnings https://travis-ci.org/ManageIQ/manageiq/jobs/645606961#L646-L650