### PR TITLE
Refactor MiqRequestTask::StateMachine and MiqRequestTask::StateMachine specs

### DIFF
--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -12,7 +12,6 @@ module MiqRequestTask::StateMachine
   end
 
   def signal(phase)
-    $log.warn("SIGNAL(#{phase})")
     return signal(:finish) if ![:finish, :provision_error].include?(phase.to_sym) && prematurely_finished?
 
     self.phase = phase.to_s
@@ -20,7 +19,6 @@ module MiqRequestTask::StateMachine
     save
 
     begin
-      $log.warn("SEND(#{phase})")
       send(phase)
     rescue => err
       case phase

--- a/app/models/miq_request_task/state_machine.rb
+++ b/app/models/miq_request_task/state_machine.rb
@@ -21,7 +21,7 @@ module MiqRequestTask::StateMachine
     begin
       send(phase)
     rescue => err
-      case phase
+      case phase.to_sym
       when :finish
         $log.error("[#{err.class}: #{err.message}] encountered during [#{phase}]")
         $log.log_backtrace(err)

--- a/spec/models/miq_request_task/state_machine_spec.rb
+++ b/spec/models/miq_request_task/state_machine_spec.rb
@@ -1,15 +1,19 @@
 RSpec.describe MiqRequestTask do
+  let(:task) { FactoryBot.create(:miq_request_task) }
+
   context "::StateMachine" do
     context "#signal" do
       it "will deal with exceptions" do
-        task = FactoryBot.create(:miq_request_task)
         allow(task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
         exception = String.xxx rescue $!
-        allow(task).to receive(:some_state).and_raise(exception)
+        allow(task).to receive(:send).with(:some_state).and_raise(exception)
 
         expect($log).to receive(:error).with(/#{exception.class.name}/)
         expect($log).to receive(:error).with(exception.backtrace.join("\n"))
-        expect(task).to receive(:finish)
+
+        expect(task).to receive(:signal).with(:some_state)
+        expect(task).to receive(:signal).with(:provision_error)
+        expect(task).to receive(:signal).with(:finish)
 
         task.signal(:some_state)
 

--- a/spec/models/miq_request_task/state_machine_spec.rb
+++ b/spec/models/miq_request_task/state_machine_spec.rb
@@ -5,15 +5,13 @@ RSpec.describe MiqRequestTask do
     context "#signal" do
       it "will deal with exceptions" do
         allow(task).to receive_messages(:miq_request => double("MiqRequest").as_null_object)
-        exception = String.xxx rescue $!
-        allow(task).to receive(:send).with(:some_state).and_raise(exception)
 
-        expect($log).to receive(:error).with(/#{exception.class.name}/)
-        expect($log).to receive(:error).with(exception.backtrace.join("\n"))
+        expect(task).to receive(:signal).with(:some_state).and_call_original
+        expect(task).to receive(:signal).with(:provision_error).and_call_original
+        expect(task).to receive(:signal).with(:finish).and_call_original
 
-        expect(task).to receive(:signal).with(:some_state)
-        expect(task).to receive(:signal).with(:provision_error)
-        expect(task).to receive(:signal).with(:finish)
+        expect($log).to receive(:error).with(/NoMethodError/) # There's no 'some_state' method
+        expect($log).to receive(:log_backtrace)
 
         task.signal(:some_state)
 


### PR DESCRIPTION
Currently the `MiqRequestTask` state machine specs fail with the following error if strict partial double validation is turned on:

```
Failure/Error: allow(task).to receive(:some_state).and_raise(exception)
       #<MiqRequestTask id: 72000000000110, description: nil, state: "pending", request_type: nil, userid: nil, options: {}, created_on: "2020-02-03 19:22:44", updated_on: "2020-02-03 19:22:44", message: nil, status: "Ok", type: nil, miq_request_id: nil, source_id: nil, source_type: nil, destination_id: nil, destination_type: nil, miq_request_task_id: nil, phase: nil, phase_context: {}, tenant_id: nil, cancelation_status: nil, conversion_host_id: nil> does not implement: some_state
```

This initial error can be solved by switching `receive(:some_state)` with `receive(:send).with(:some_state)` which is what it's doing internally.

The overall logic is somewhat confusing. Near as I can tell it follows this workflow:

* `MiqRequestTask#signal(:some_state)` bypasses the initial `if` check since it is not `prematurely_finished?`
* It calls `save`, which triggers `set_tenant`
* A `send(:some_state)` call is made
* Since there is no `some_state` method, this triggers a `NoMethodError`, which is caught and then `signal(:provision_error)` is called
* Now back at the top of the `signal` method, it bypasses the `if` check again since the phase is now `:provision_error`
* The `save` method is called again, which triggers `set_tenant` again
* A `send(:provision_error)` call is made, which calls the `provision_error` method, which in turn calls `update_and_notify_parent`
* The `update_and_notify_parent` method bombs on the `parent.reload` method because the parent is nil
* The above error is inadvertently rescued, and the error and backtrace is logged. The end.
* But, let's assume the parent isn't nil and the `update_and_notify_parent` works as expected, it would then call `signal(:finish)` at the end of the `provision_error` method.
* Now back at the top of the `signal` method AGAIN, it bypasses the `if` check again since the phase is now `:finish`
* Another call to `save` and thus `set_tenant`
* It tries to call `send(:finish)`, which of course fails since there is no `finish` method, which is again rescued, logged, and finally that's the end of it.

You can see this for yourself:

* Insert some debugging statements like so: https://gist.github.com/djberg96/47c743ff42caec71f90cad57b053d6dd
* Also add a debug print inside the `set_tenant` method within the `TenancyMixin` module.
* Fire up rails console.
* Do `t = MiqRequestTask.new` (or `t = FactoryBot.create(:miq_request_task)` if you prefer test mode)
* Call `t.signal(:some_state)`, and watch workflow.

My other problem with this code is that it isn't really a state machine. Not what I would consider one, anyway.