### PR TITLE
Kill workers before destroying child managers when destroying an EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -578,11 +578,11 @@ class ExtManagementSystem < ApplicationRecord
   def destroy(task_id = nil)
     disable!(:validate => false) if enabled?
 
-    _log.info("Destroying #{child_managers.count} child_managers")
-    child_managers.destroy_all
-
     # kill workers
     MiqWorker.find_alive.where(:queue_name => queue_name).each(&:kill)
+
+    _log.info("Destroying #{child_managers.count} child_managers")
+    child_managers.destroy_all
 
     super().tap do
       if task_id


### PR DESCRIPTION
When destroying an EMS we should kill the workers before destroying the child managers to prevent orphan records from being created e.g. by a RefreshWorker after the child NetworkManager has been destroyed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1798047