### PR TITLE
Fixup polymorphic issues with MiqReport + Rbac

### DIFF
--- a/app/models/miq_report/generator.rb
+++ b/app/models/miq_report/generator.rb
@@ -88,6 +88,29 @@ module MiqReport::Generator
     include_as_hash(include.presence || invent_report_includes)
   end
 
+  def polymorphic_includes
+    @polymorphic_includes ||= begin
+      top_level_rels = Array(get_include.try(:keys)) + Array(get_include_for_find.try(:keys))
+
+      top_level_rels.uniq.each_with_object([]) do |assoc, polymorphic_rels|
+        reflection = db_klass.reflect_on_association(assoc)
+        polymorphic_rels << assoc if reflection && reflection.polymorphic?
+      end
+    end
+  end
+
+  def get_include_for_find_rbac
+    polymorphic_includes.each_with_object(get_include_for_find.dup) do |key, includes|
+      includes.delete(key)
+    end
+  end
+
+  def get_include_rbac
+    polymorphic_includes.each_with_object(get_include.dup) do |key, includes|
+      includes.delete(key)
+    end
+  end
+
   def invent_includes
     include_as_hash(invent_report_includes)
   end
@@ -312,8 +335,8 @@ module MiqReport::Generator
     rbac_opts = options.merge(
       :targets          => targets,
       :filter           => conditions,
-      :include_for_find => get_include_for_find,
-      :references       => get_include,
+      :include_for_find => get_include_for_find_rbac,
+      :references       => get_include_rbac,
       :where_clause     => where_clause,
       :skip_counts      => true
     )

--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -1,4 +1,6 @@
 module Rbac
+  class PolymorphicError < ArgumentError; end
+
   class Filterer
     # This list is used to detemine whether RBAC, based on assigned tags, should be applied for a class in a search that is based on the class.
     # Classes should be added to this list ONLY after:
@@ -319,6 +321,8 @@ module Rbac
       attrs[:auth_count] = auth_count unless options[:skip_counts]
 
       return targets, attrs
+    rescue ActiveRecord::EagerLoadPolymorphicError
+      raise Rbac::PolymorphicError
     end
 
     def is_sti?(klass)

--- a/spec/models/miq_report_spec.rb
+++ b/spec/models/miq_report_spec.rb
@@ -755,8 +755,13 @@ RSpec.describe MiqReport do
       end
     end
     context "performance reports" do
-      let(:report) do
-        MiqReport.new(
+      let(:miq_server) { EvmSpecHelper.local_miq_server }
+      let(:ems) { FactoryBot.create(:ems_vmware, :zone => miq_server.zone) }
+      let(:vm) { FactoryBot.create(:vm_vmware, :ext_management_system => ems) }
+      let(:time_profile) { FactoryBot.create(:time_profile_utc) }
+
+      it "runs daily report" do
+        report = MiqReport.new(
           :title   => "vim_perf_daily.yaml",
           :db      => "VimPerformanceDaily",
           :cols    => %w(timestamp cpu_usagemhz_rate_average max_derived_cpu_available),
@@ -765,10 +770,18 @@ RSpec.describe MiqReport do
                             cpu_usagemhz_rate_average_low_over_time_period
                             derived_memory_used_high_over_time_period
                             derived_memory_used_low_over_time_period)}})
+        report.generate_table(:userid => "admin")
       end
-      let(:ems) { FactoryBot.create(:ems_vmware, :zone => @server.zone) }
 
-      it "runs report" do
+      it "runs report with polymorphic references" do
+        FactoryBot.create(:metric_rollup_vm_daily, :resource => vm, :time_profile => time_profile)
+
+        report = MiqReport.new(
+          :title     => "vim_perf_daily.yaml",
+          :db        => "VimPerformanceDaily",
+          :col_order => %w[timestamp cpu_usagemhz_rate_average max_derived_cpu_available
+                           resource.derived_memory_used_low_over_time_period]
+        )
         report.generate_table(:userid => "admin")
       end
     end


### PR DESCRIPTION
Alternative to https://github.com/ManageIQ/manageiq/pull/19778

Takes an "alternative" approach to the above by not trying to fix the issue in Rbac, but instead assume the `Rbac` implementation is as intended, and callers need to work around it.

In this specific case, change the caller of `MiqReport::Generator` so we aren't passing in arguments to `Rbac` that are polymorphic.

Links
-----

* Bug/Issue:  https://github.com/ManageIQ/manageiq/issues/19664
* Alternative PR:  https://github.com/ManageIQ/manageiq/pull/19778