### PR TITLE
Fix the RegistrationSystem spec

### DIFF
--- a/spec/models/registration_system_spec.rb
+++ b/spec/models/registration_system_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RegistrationSystem do
     end
 
     it "with invalid credentials" do
-      expect_any_instance_of(LinuxAdmin::SubscriptionManager).to receive(:organizations).once.and_raise(LinuxAdmin::CredentialError, "Invalid username or password")
+      expect_any_instance_of(LinuxAdmin::SubscriptionManager).to receive(:organizations).once.and_raise(LinuxAdmin::CredentialError, AwesomeSpawn::CommandResult.new("command_line", "Invalid username or password", "Invalid username or password", 1))
       expect { RegistrationSystem.available_organizations(creds) }.to raise_error(LinuxAdmin::CredentialError)
     end
 
@@ -86,7 +86,7 @@ RSpec.describe RegistrationSystem do
     end
 
     it "with invalid credentials" do
-      expect(LinuxAdmin::RegistrationSystem).to receive(:validate_credentials).once.and_raise(LinuxAdmin::CredentialError, "Invalid username or password")
+      expect(LinuxAdmin::RegistrationSystem).to receive(:validate_credentials).once.and_raise(LinuxAdmin::CredentialError, AwesomeSpawn::CommandResult.new("command_line", "Invalid username or password", "Invalid username or password", 1))
       expect(RegistrationSystem.verify_credentials(creds)).to be_falsey
     end
 


### PR DESCRIPTION
AwesomeSpawn::CommandResultError expects an AwesomeSpawn::CommandResult
argument to `#initailize` not a string.

LinuxAdmin correctly passes the result to the exception: https://github.com/ManageIQ/linux_admin/blob/master/lib/linux_admin/registration_system/subscription_manager.rb#L8

This spec was stubbing the
`LinuxAdmin::SubscriptionManager#organizations` method and raising an
exception with a string instead of a CommandResult.

This was changed by https://github.com/ManageIQ/awesome_spawn/pull/39 which was committed a while ago but only recently released.