### PR TITLE
Force coveralls 0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -252,7 +252,7 @@ unless ENV["APPLIANCE"]
   group :test do
     gem "brakeman",         "~>3.3",    :require => false
     gem "capybara",         "~>2.5.0",  :require => false
-    gem "coveralls",                    :require => false
+    gem "coveralls",        "~>0.8.23", :require => false
     gem "factory_bot",      "~>5.1",    :require => false
 
     # TODO: faker is used for url generation in git repository factory and the lenovo


### PR DESCRIPTION
running bundle update in ui-classic, I'm seeing `Using coveralls 0.7.1 (was 0.8.23)`.

That seems to lead to a coveralls failure on (non-failing) travis:


https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/645991960#L2415
```
Coveralls encountered an exception:
NoMethodError
undefined method `coverage' for #<SimpleCov::SourceFile:0x000000004bd2fb40>
manageiq-ui-classic/vendor/bundle/gems/coveralls-0.7.1/lib/coveralls/simplecov.rb:50:in `block in format'
ruby-2.5.7/lib/ruby/2.5.0/forwardable.rb:229:in `each'
ruby-2.5.7/lib/ruby/2.5.0/forwardable.rb:229:in `each'
coveralls-0.7.1/lib/coveralls/simplecov.rb:40:in `format'
simplecov-0.18.1/lib/simplecov/result.rb:49:in `format!'
simplecov-0.18.1/lib/simplecov/configuration.rb:196:in `block in at_exit'
simplecov-0.18.1/lib/simplecov.rb:201:in `run_exit_tasks!'
simplecov-0.18.1/lib/simplecov/defaults.rb:31:in `block in <top (required)>'
```

Forcing 0.8...  tested in https://github.com/ManageIQ/manageiq-ui-classic/pull/6651, forcing 0.8 works, but the fix belongs here :).
(The core repo already defaults to 0.8, not sure why the difference.)

Cc @Fryguy 