### PR TITLE
[HAMMER] Fix embedded_ansible appliance spec

### DIFF
--- a/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
+++ b/spec/lib/embedded_ansible/appliance_embedded_ansible_spec.rb
@@ -315,7 +315,7 @@ describe ApplianceEmbeddedAnsible do
         miq_database.ansible_secret_key = "supersecretkey"
         expect(subject).to receive(:find_or_create_database_authentication).and_return(double(:userid => "awx", :password => "databasepassword"))
 
-        expect(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new("error", 1))
+        expect(AwesomeSpawn).to receive(:run!).and_raise(AwesomeSpawn::CommandResultError.new("error", AwesomeSpawn::CommandResult.new("systemctl start ansible-tower", "", "Failed", 1)))
         expect { subject.start }.to raise_error(AwesomeSpawn::CommandResultError)
         expect(miq_database.reload.ansible_secret_key).not_to be_present
       end


### PR DESCRIPTION
The AwesomeSpawn::CommandResultError takes an AwesomeSpawn::CommandResult as the second parameter.

This is a hammer only PR because this spec was removed for ivanchuk