### PR TITLE
Add queue_name_for_ems_operations delegates for Automate

### DIFF
--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -19,6 +19,8 @@ class CloudVolume < ApplicationRecord
   has_many   :hardwares, :through => :attachments
   has_many   :vms, :through => :hardwares, :foreign_key => :vm_or_template_id
 
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
   acts_as_miq_taggable
 
   def self.volume_types

--- a/app/models/cloud_volume.rb
+++ b/app/models/cloud_volume.rb
@@ -37,6 +37,15 @@ class CloudVolume < ApplicationRecord
     ext_management_system && ext_management_system.class::CloudVolume
   end
 
+  def self.my_zone(ems)
+    # TODO(pblaho): find unified way how to do that
+    ems ? ems.my_zone : MiqServer.my_zone
+  end
+
+  def my_zone
+    self.class.my_zone(ext_management_system)
+  end
+
   # Create a cloud volume as a queued task and return the task id. The queue
   # name and the queue zone are derived from the provided EMS instance. The EMS
   # instance and a userid are mandatory. Any +options+ are forwarded as

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -38,6 +38,8 @@ class EmsCluster < ApplicationRecord
 
   has_many :failover_hosts, -> { failover }, :class_name => "Host"
 
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
   include ProviderObjectMixin
 
   include FilterableMixin

--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -18,6 +18,8 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :miq_templates,     :uses => :all_relationships
   virtual_has_many :hosts,             :uses => :all_relationships
 
+  delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+
   #
   # Relationship methods
   #


### PR DESCRIPTION
Automate has a nice common mixin for queueing ems_operations methods,
make sure there is a queue_name_for_ems_operations delegate on each
class that this mixin is included in.

Required for: https://github.com/ManageIQ/manageiq-automation_engine/pull/419