### PR TITLE
Fix smartproxy worker heartbeat thread

### DIFF
--- a/app/models/miq_queue_worker_base/runner.rb
+++ b/app/models/miq_queue_worker_base/runner.rb
@@ -78,7 +78,6 @@ class MiqQueueWorkerBase::Runner < MiqWorker::Runner
         :priority   => @worker.class.queue_priority
       )
       return msg unless msg == :stale
-      heartbeat
     end
   end
 

--- a/app/models/miq_smart_proxy_worker/runner.rb
+++ b/app/models/miq_smart_proxy_worker/runner.rb
@@ -1,8 +1,4 @@
 class MiqSmartProxyWorker::Runner < MiqQueueWorkerBase::Runner
-  def do_before_work_loop
-    @tid = start_heartbeat_thread
-  end
-
   def before_exit(message, _exit_code)
     @exit_requested = true
     #

--- a/spec/models/miq_smart_proxy_worker/runner_spec.rb
+++ b/spec/models/miq_smart_proxy_worker/runner_spec.rb
@@ -1,0 +1,50 @@
+describe MiqSmartProxyWorker::Runner do
+  subject { described_class.allocate }
+
+  describe "#ensure_heartbeat_thread_started" do
+    let(:thread) { double(Thread) }
+
+    it "starts the heartbeat thread if it has never been started" do
+      expect(subject).to receive(:start_heartbeat_thread).and_return(thread)
+      subject.ensure_heartbeat_thread_started
+      expect(subject.instance_variable_get(:@tid)).to eq(thread)
+    end
+
+    it "restarts the heartbeat thread if it has exited" do
+      subject.instance_variable_set(:@tid, thread)
+      expect(thread).to receive(:alive?).and_return(false)
+      expect(thread).to receive(:status).and_return(false)
+
+      new_thread = double(Thread)
+      expect(subject).to receive(:start_heartbeat_thread).and_return(new_thread)
+
+      subject.ensure_heartbeat_thread_started
+      expect(subject.instance_variable_get(:@tid)).to eq(new_thread)
+    end
+
+    it "restarts the heartbeat thread if it has failed" do
+      subject.instance_variable_set(:@tid, thread)
+      expect(thread).to receive(:alive?).and_return(false)
+      expect(thread).to receive(:status).and_return(nil)
+
+      new_thread = double(Thread)
+      expect(subject).to receive(:start_heartbeat_thread).and_return(new_thread)
+
+      subject.ensure_heartbeat_thread_started
+      expect(subject.instance_variable_get(:@tid)).to eq(new_thread)
+    end
+
+    it "kills the heartbeat thread if it is aborting and restarts it" do
+      subject.instance_variable_set(:@tid, thread)
+      expect(thread).to receive(:alive?).and_return(false)
+      expect(thread).to receive(:status).and_return("aborting")
+      expect(thread).to receive(:kill)
+
+      new_thread = double(Thread)
+      expect(subject).to receive(:start_heartbeat_thread).and_return(new_thread)
+
+      subject.ensure_heartbeat_thread_started
+      expect(subject.instance_variable_get(:@tid)).to eq(new_thread)
+    end
+  end
+end


### PR DESCRIPTION
The heartbeat worker thread and the main thread were competing
to define the `Workers::MiqDefaults` constant.

The main thread calls heartbeat from `do_work_loop` which is
unavoidable. So to solve the problem we just wait until the first
call to `do_work` to start the heartbeat worker.

This allows the main thread to resolve the constant without contention
and the heartbeat worker still gets started before we process the
first queue message

Fixes #19813