### PR TITLE
[V2V] Fix InfraConversionThrottler.running_conversion_jobs

### DIFF
--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -62,7 +62,7 @@ class InfraConversionThrottler
 
   # @return [Hash] the list of jobs in state 'running', grouped by conversion host
   def self.running_conversion_jobs
-    running = InfraConversionJob.where(:state => 'running')
+    running = InfraConversionJob.where.not(:state => ['waiting_to_start', 'finished'])
     _log.info("Running InfraConversionJob: #{running.count}")
     running.group_by { |job| job.migration_task.conversion_host }
   end

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe InfraConversionThrottler, :v2v do
   let(:task_running_1) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
   let(:task_running_2) { FactoryBot.create(:service_template_transformation_plan_task, :miq_request => request, :request_type => 'transformation_plan', :source => vm) }
   let(:job_waiting) { FactoryBot.create(:infra_conversion_job, :state => 'waiting_to_start') }
-  let(:job_running_1) { FactoryBot.create(:infra_conversion_job, :state => 'running') }
-  let(:job_running_2) { FactoryBot.create(:infra_conversion_job, :state => 'running') }
+  let(:job_running_1) { FactoryBot.create(:infra_conversion_job, :state => 'waiting_for_inventory_refresh') }
+  let(:job_running_2) { FactoryBot.create(:infra_conversion_job, :state => 'aborting_virtv2v') }
 
   before do
     allow(host).to receive(:supports_conversion_host?).and_return(true)


### PR DESCRIPTION
The method always returns 0 because the jobs are never in state 'running'. A running job is a job that is not in state 'waiting_to_start' or 'finished'. This pull request fixes the DB lookup.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1799074