### PR TITLE
[IVANCHUK] Fix VM Retirement Error Message

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -361,7 +361,7 @@ class VmOrTemplate < ApplicationRecord
     vms = where(:id => src_ids)
 
     missing_ids = src_ids - vms.pluck(:id)
-    _log.error("Retirement of [Vm] IDs: [#{missing_ids.join(', ')}] skipped - target(s) does not exist")
+    _log.error("Retirement of [Vm] IDs: [#{missing_ids.join(', ')}] skipped - target(s) does not exist") if missing_ids.present?
 
     vms.each do |target|
       target.check_policy_prevent('request_vm_retire', "retire_request_after_policy_check", requester.userid, :initiated_by => initiated_by)

--- a/spec/models/vm/retirement_management_spec.rb
+++ b/spec/models/vm/retirement_management_spec.rb
@@ -156,6 +156,18 @@ describe "VM Retirement Management" do
       Vm.make_retire_request(@vm.id, vm2.id, user)
     end
 
+    it "with user as initiated_by" do
+      expect(Vm).not_to receive(:_log)
+      Vm.make_retire_request(@vm.id, user, :initiated_by => user)
+    end
+
+    it "with user as initiated_by, with unknown vm.id" do
+      log_stub = instance_double("_log")
+      expect(Vm).to receive(:_log).and_return(log_stub).at_least(:once)
+      expect(log_stub).to receive(:error).with("Retirement of [Vm] IDs: [123] skipped - target(s) does not exist")
+      Vm.make_retire_request(@vm.id, 123, user, :initiated_by => user)
+    end
+
     it "policy prevents" do
       expect(VmRetireRequest).not_to receive(:make_request)
 


### PR DESCRIPTION
Manual backport https://github.com/ManageIQ/manageiq/pull/19710 to Ivanchuk.

Fix  https://bugzilla.redhat.com/show_bug.cgi?id=1794733.

@miq-bot add_label bug, changelog/yes, lifecycle/retirement

cc @simaishi 