### PR TITLE
[HAMMER] Lock gettext to < 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "default_value_for",              "~>3.0.3"
 gem "docker-api",                     "~>1.33.6",      :require => false
 gem "elif",                           "=0.1.0",        :require => false
 gem "fast_gettext",                   "~>1.2.0"
+gem "gettext",                        "<3.3",          :require => false
 gem "gettext_i18n_rails",             "~>1.7.2"
 gem "gettext_i18n_rails_js",          "~>1.3.0"
 gem "hamlit",                         "~>2.8.5"


### PR DESCRIPTION
hammer branch uses ruby 2.4.x, and gettext 3.3+ requires ruby 2.5.0+

https://travis-ci.org/ManageIQ/manageiq/builds/647097686

```
Installing gettext 3.3.3
Gem::RuntimeRequirementNotMetError: gettext requires Ruby version >= 2.5.0. The
current ruby version is 2.4.6.354.
An error occurred while installing gettext (3.3.3), and Bundler cannot continue.
Make sure that `gem install gettext -v '3.3.3' --source 'https://rubygems.org/'`
succeeds before bundling.
In Gemfile:
  gettext_i18n_rails_js was resolved to 1.3.0, which depends on
    gettext
```