### PR TITLE
remaining pieces of skip_references

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -47,7 +47,7 @@ class MiqReport < ApplicationRecord
   attr_accessor :ext_options
   attr_accessor_that_yamls :table, :sub_table, :filter_summary, :extras, :ids, :scoped_association, :html_title, :file_name,
                            :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
-                           :report_run_time, :chart, :skip_references
+                           :report_run_time, :chart
 
   attr_accessor_that_yamls :reserved # For legacy imports
 

--- a/app/models/miq_report/search.rb
+++ b/app/models/miq_report/search.rb
@@ -93,8 +93,7 @@ module MiqReport::Search
     search_options = options.merge(:class            => db,
                                    :conditions       => conditions,
                                    :include_for_find => includes,
-                                   :references       => get_include,
-                                   :skip_references  => skip_references
+                                   :references       => get_include
                                   )
     search_options.merge!(:limit => limit, :offset => offset, :order => order) if order
     search_options[:extra_cols] = va_sql_cols if va_sql_cols.present?


### PR DESCRIPTION
skip_references was removed by 8cc2277b #19127
But 2 remaining variables were left behind.
