### PR TITLE
MiqAeNamespace should use ancestry instead of acts_as_tree

### DIFF
--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -29,7 +29,7 @@ class MiqAeClass < ApplicationRecord
     name_space = MiqAeNamespace.lookup_by_fqname(name_space)
     return nil if name_space.nil?
 
-    name_space.ae_classes.detect { |c| name.casecmp(c.name).zero? }
+    find_by(:namespace_id => name_space.id).where(arel_table[:name].lower.eq(name.downcase))
   end
 
   singleton_class.send(:alias_method, :find_by_namespace_and_name, :lookup_by_namespace_and_name)

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe MiqAeClass do
 
   before do
     @user = FactoryBot.create(:user_with_group)
+    @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
   end
 
   it "should not create class without namespace" do
@@ -46,20 +47,20 @@ RSpec.describe MiqAeClass do
   end
 
   it "should not create class without name" do
-    expect { MiqAeClass.new(:namespace => "TEST").save! }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { MiqAeClass.new(:namespace_id => @ns.id).save! }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
   it "should set the updated_by field on save" do
-    c1 = MiqAeClass.create(:namespace => "TEST", :name => "oleg")
+    c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "oleg")
     expect(c1.updated_by).to eq('system')
   end
 
   it "should not create classes with the same name in the same namespace" do
-    c1 = MiqAeClass.new(:namespace => "TEST", :name => "oleg")
+    c1 = MiqAeClass.new(:namespace_id => @ns.id, :name => "oleg")
     expect(c1).not_to be_nil
     expect(c1.save!).to be_truthy
-    expect { MiqAeClass.new(:namespace => "TEST", :name => "OLEG").save! }.to raise_error(ActiveRecord::RecordInvalid)
-    c2 = MiqAeClass.new(:namespace => "PROD", :name => "oleg")
+    expect { MiqAeClass.new(:namespace_id => @ns.id, :name => "OLEG").save! }.to raise_error(ActiveRecord::RecordInvalid)
+    c2 = MiqAeClass.new(:namespace_id => FactoryBot.create(:miq_ae_namespace).id, :name => "oleg")
     expect(c2).not_to be_nil
     expect(c2.save!).to be_truthy
   end

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe MiqAeField do
 
   context "legacy tests" do
     before do
-      @c1 = MiqAeClass.create(:namespace => "TEST", :name => "fields_test")
+      @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
+      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "fields_test")
       @user = FactoryBot.create(:user_with_group)
     end
 

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe MiqAeInstance do
   context "legacy tests" do
     before do
       @user = FactoryBot.create(:user_with_group)
-      @c1 = MiqAeClass.create(:namespace => "TEST", :name => "instance_test")
+      @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
+      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "instance_test")
       @fname1 = "field1"
       @f1 = @c1.ae_fields.create(:name => @fname1)
     end
@@ -149,7 +150,7 @@ RSpec.describe MiqAeInstance do
 
     it "should return editable as false if the parent namespace/class is not editable" do
       d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => User.current_tenant)
-      n1 = FactoryBot.create(:miq_ae_namespace, :parent_id => d1.id)
+      n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
       c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
       expect(i1.editable?(@user)).to be_falsey
@@ -158,7 +159,7 @@ RSpec.describe MiqAeInstance do
     it "should return editable as true if the parent namespace/class is editable" do
       User.current_user = @user
       d1 = FactoryBot.create(:miq_ae_domain, :tenant => User.current_tenant)
-      n1 = FactoryBot.create(:miq_ae_namespace, :parent_id => d1.id)
+      n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
       c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
       expect(i1.editable?(@user)).to be_truthy
@@ -204,14 +205,14 @@ RSpec.describe MiqAeInstance do
 
   context "#copy" do
     before do
-      @d1 = FactoryBot.create(:miq_ae_namespace, :name => "domain1", :parent_id => nil, :priority => 1)
-      @ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent_id => @d1.id)
+      @d1 = FactoryBot.create(:miq_ae_namespace, :name => "domain1", :priority => 1)
+      @ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent => @d1)
       @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
       @i1 = FactoryBot.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance1")
       @i2 = FactoryBot.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance2")
 
       @d2 = FactoryBot.create(:miq_ae_domain, :name => "domain2", :priority => 2)
-      @ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent_id => @d2.id)
+      @ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent => @d2)
     end
 
     it "copies instances under specified namespace" do
@@ -261,8 +262,8 @@ RSpec.describe MiqAeInstance do
     let(:u1) { FactoryBot.create(:user_with_group, :name => 'user1') }
     let(:d1) { FactoryBot.create(:miq_ae_domain, :name => 'dom1', :priority => 1) }
     let(:d2) { FactoryBot.create(:miq_ae_domain, :name => 'dom2', :priority => 2) }
-    let(:n1) { FactoryBot.create(:miq_ae_namespace, :parent_id => d1.id, :name => "namespace") }
-    let(:n2) { FactoryBot.create(:miq_ae_namespace, :parent_id => d2.id, :name => "namespace") }
+    let(:n1) { FactoryBot.create(:miq_ae_namespace, :parent => d1, :name => "namespace") }
+    let(:n2) { FactoryBot.create(:miq_ae_namespace, :parent => d2, :name => "namespace") }
     let(:c1) { FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "class") }
     let(:c2) { FactoryBot.create(:miq_ae_class, :namespace_id => n2.id, :name => "class") }
     let!(:i1) { FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "instance") }

--- a/spec/models/miq_ae_namespace_spec.rb
+++ b/spec/models/miq_ae_namespace_spec.rb
@@ -34,17 +34,17 @@ RSpec.describe MiqAeNamespace do
 
     context "with a duplicite names" do
       let(:domain) { FactoryBot.create(:miq_ae_domain) }
-      let(:ns1)    { FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent_id => domain.id) }
+      let(:ns1)    { FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => domain) }
 
       before do
-        FactoryBot.create(:miq_ae_namespace, :name => 'namespace', :parent_id => ns1.id)
+        FactoryBot.create(:miq_ae_namespace, :name => 'namespace', :parent => ns1)
       end
 
       it "with a distinct path is allowed" do
         # domain/ns1/namespace
         # domain/ns2/namespace
-        ns2 = FactoryBot.create(:miq_ae_namespace, :name => 'ns2', :parent_id => domain.id)
-        dup_namespace = FactoryBot.create(:miq_ae_namespace, :name => 'namespace', :parent_id => ns2.id)
+        ns2 = FactoryBot.create(:miq_ae_namespace, :name => 'ns2', :parent => domain)
+        dup_namespace = FactoryBot.create(:miq_ae_namespace, :name => 'namespace', :parent => ns2)
 
         expect(ns2.valid?).to be_truthy
         expect(dup_namespace.valid?).to be_truthy
@@ -54,7 +54,7 @@ RSpec.describe MiqAeNamespace do
         # domain/ns1/namespace
         # domain/ns1/NAMESPACE
         expect do
-          FactoryBot.create(:miq_ae_namespace, :name => 'NAMESPACE', :parent_id => ns1.id)
+          FactoryBot.create(:miq_ae_namespace, :name => 'NAMESPACE', :parent => ns1)
         end.to raise_error("Validation failed: MiqAeNamespace: Name has already been taken")
       end
     end
@@ -92,9 +92,9 @@ RSpec.describe MiqAeNamespace do
     n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
     expect(n1.editable?(@user)).to be_falsey
 
-    n2 = MiqAeNamespace.create!(:name => 'ns2', :parent_id => n1.id)
+    n2 = MiqAeNamespace.create!(:name => 'ns2', :parent => n1)
 
-    n3 = MiqAeNamespace.create!(:name => 'ns3', :parent_id => n2.id)
+    n3 = MiqAeNamespace.create!(:name => 'ns3', :parent => n2)
     expect(n3.editable?(@user)).to be_falsey
   end
 


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-schema/pull/455.
Related to https://github.com/ManageIQ/manageiq-automation_engine/pull/425.
~~Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/6668.~~

Cross Repo Tests: ManageIQ/manageiq-cross_repo-tests#66

https://github.com/ManageIQ/manageiq-automation_engine/issues/409

@miq-bot add_label performance, automate, changelog/yes
