### PR TITLE
Remove the deprecation warning on validate_credentials_task

### DIFF
--- a/app/models/mixins/verify_credentials_mixin.rb
+++ b/app/models/mixins/verify_credentials_mixin.rb
@@ -1,12 +1,6 @@
 module VerifyCredentialsMixin
   extend ActiveSupport::Concern
 
-  included do
-    class << self
-      Vmdb::Deprecation.deprecate_methods self, :validate_credentials_task => :verify_credentials_task
-    end
-  end
-
   module ClassMethods
     def validate_credentials_task(args, user_id, zone)
       task_opts = {


### PR DESCRIPTION
The old validate_credentials_task method is still actively being used and the warnings are causing people to try to remove it too quickly.

https://github.com/ManageIQ/manageiq-ui-classic/pull/6664#issuecomment-584225751