### PR TITLE
Schedule a daily count of managed VMs and print result to audit log.

### DIFF
--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -16,6 +16,10 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
+  def miq_audit_vm_total
+    queue_work(:class_name  => "MiqServer", :method_name => "audit_vm_totals", :task_id => "audit_vm_total", :server_guid => MiqServer.my_guid)
+  end
+
   def vmdb_database_connection_log_statistics
     queue_work(:class_name  => "VmdbDatabaseConnection", :method_name => "log_statistics", :server_guid => MiqServer.my_guid)
   end

--- a/app/models/miq_schedule_worker/jobs.rb
+++ b/app/models/miq_schedule_worker/jobs.rb
@@ -16,8 +16,8 @@ class MiqScheduleWorker::Jobs
     queue_work(:class_name  => "MiqWorker", :method_name => "log_status_all", :task_id => "log_status", :server_guid => MiqServer.my_guid, :priority => MiqQueue::HIGH_PRIORITY)
   end
 
-  def miq_audit_vm_total
-    queue_work(:class_name  => "MiqServer", :method_name => "audit_vm_totals", :task_id => "audit_vm_total", :server_guid => MiqServer.my_guid)
+  def miq_server_audit_managed_resources
+    queue_work(:class_name  => "MiqServer", :method_name => "audit_managed_resources", :task_id => "audit_managed_resources", :server_guid => MiqServer.my_guid)
   end
 
   def vmdb_database_connection_log_statistics

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -110,6 +110,12 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
       ) { enqueue(:miq_server_queue_update_registration_status) }
     end
 
+    # Schedule - Add audit log entry for total number of vms managed by system.
+    scheduler.schedule_every(
+      worker_settings[:audit_vm_total],
+      :tags          =>[:miq_audit_vm_total, schedule_category]
+    ) { enqueue(:miq_audit_vm_total)}
+
     @schedules[:all]
   end
 

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -112,9 +112,9 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
 
     # Schedule - Add audit log entry for total number of vms managed by system.
     scheduler.schedule_every(
-      worker_settings[:audit_vm_total],
-      :tags =>[:miq_audit_vm_total, schedule_category]
-    ) { enqueue(:miq_audit_vm_total) }
+      worker_settings[:audit_managed_resources],
+      :tags =>[:miq_server_audit_managed_resources, schedule_category]
+    ) { enqueue(:miq_server_audit_managed_resources) }
     @schedules[:all]
   end
 

--- a/app/models/miq_schedule_worker/runner.rb
+++ b/app/models/miq_schedule_worker/runner.rb
@@ -113,9 +113,8 @@ class MiqScheduleWorker::Runner < MiqWorker::Runner
     # Schedule - Add audit log entry for total number of vms managed by system.
     scheduler.schedule_every(
       worker_settings[:audit_vm_total],
-      :tags          =>[:miq_audit_vm_total, schedule_category]
-    ) { enqueue(:miq_audit_vm_total)}
-
+      :tags =>[:miq_audit_vm_total, schedule_category]
+    ) { enqueue(:miq_audit_vm_total) }
     @schedules[:all]
   end
 

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -490,14 +490,14 @@ class MiqServer < ApplicationRecord
   def self.audit_vm_totals
     total_vms     = 0
     total_hosts   = 0
-  
+
     ExtManagementSystem.all.each do |e|
       vms     = e.all_vms_and_templates.count
       hosts   = e.all_hosts.count
       total_vms += vms
       total_hosts += hosts
     end
-    $audit_log.info("Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}]")  
+    $audit_log.info("Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}]")
   end
 
   private

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -487,6 +487,19 @@ class MiqServer < ApplicationRecord
     Zone.visible.in_my_region.count > 1
   end
 
+  def self.audit_vm_totals
+    total_vms     = 0
+    total_hosts   = 0
+  
+    ExtManagementSystem.all.each do |e|
+      vms     = e.all_vms_and_templates.count
+      hosts   = e.all_hosts.count
+      total_vms += vms
+      total_hosts += hosts
+    end
+    $audit_log.info("Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}]")  
+  end
+
   private
 
   def zone_unchanged_in_pods

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -487,7 +487,7 @@ class MiqServer < ApplicationRecord
     Zone.visible.in_my_region.count > 1
   end
 
-  def self.audit_vm_totals
+  def self.audit_managed_resources
     total_vms     = 0
     total_hosts   = 0
 
@@ -497,7 +497,8 @@ class MiqServer < ApplicationRecord
       total_vms += vms
       total_hosts += hosts
     end
-    $audit_log.info("Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}]")
+    totals = {"vms" => total_vms, "hosts" => total_hosts}
+    $audit_log.info("Under Management: #{totals.to_json}")
   end
 
   private

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1211,6 +1211,7 @@
       :vim_performance_states_purge_interval: 1.day
       :vm_retired_interval: 10.minutes
       :yum_update_check: 12.hours
+      :audit_vm_total: 1.days
     :ui_worker:
       :connection_pool_size: 8
       :memory_threshold: 1.gigabytes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1169,6 +1169,7 @@
         :queue_timeout: 20.minutes
         :heartbeat_thread_shutdown_timeout: 10.seconds
     :schedule_worker:
+      :audit_managed_resources: 1.days
       :container_entities_purge_interval: 1.day
       :binary_blob_purge_interval: 1.hour
       :authentication_check_interval: 1.hour
@@ -1211,7 +1212,6 @@
       :vim_performance_states_purge_interval: 1.day
       :vm_retired_interval: 10.minutes
       :yum_update_check: 12.hours
-      :audit_managed_resources: 1.days
     :ui_worker:
       :connection_pool_size: 8
       :memory_threshold: 1.gigabytes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1211,7 +1211,7 @@
       :vim_performance_states_purge_interval: 1.day
       :vm_retired_interval: 10.minutes
       :yum_update_check: 12.hours
-      :audit_vm_total: 1.days
+      :audit_managed_resources: 1.days
     :ui_worker:
       :connection_pool_size: 8
       :memory_threshold: 1.gigabytes


### PR DESCRIPTION
To implement license management, we need to get a daily count of managed VMs. This work adds a scheduled task controlled. The frequency is controlled by :audit_vm_total key.  A new method was added to miq_server which performs the count and logging.

The more specific license management is not part of this PR. We decided to add this feature here to avoid requiring credentials in the client script.
