### PR TITLE
[WIP] Replace ActsAsArModel with ActiveHash in PglogicalSubscription

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ manageiq_plugin "manageiq-schema"
 # Unmodified gems
 gem "activerecord-virtual_attributes", "~>1.5.0"
 gem "activerecord-session_store",     "~>1.1"
+gem "active_hash",                    "~>3.0",         :require => false
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false
 gem "aws-sdk-s3",                     "~>1.0",         :require => false # For FileDepotS3

--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,9 @@ end
 manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
+gem "active_hash",                    "~>3.0",         :require => false
 gem "activerecord-virtual_attributes", "~>1.5.0"
 gem "activerecord-session_store",     "~>1.1"
-gem "active_hash",                    "~>3.0",         :require => false
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false
 gem "aws-sdk-s3",                     "~>1.0",         :require => false # For FileDepotS3

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -235,7 +235,7 @@ class PglogicalSubscription < ActiveHash::Base
   # ActiveHash objects.
   #
   def self.data=(subscriptions)
-    super(subscriptions.map{ |sub| subscription_to_columns(sub) })
+    super(subscriptions.map { |sub| subscription_to_columns(sub) })
   end
 
   private

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -200,7 +200,7 @@ class PglogicalSubscription < ActiveHash::Base
   private_class_method :remote_region_attributes
 
   def self.subscriptions
-    pglogical.subscriptions(connection.current_database)
+    self.data = pglogical.subscriptions(connection.current_database)
   end
   private_class_method :subscriptions
 

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -48,7 +48,7 @@ class PglogicalSubscription < ActiveHash::Base
 
   def save!(reload_failover_monitor = true)
     assert_different_region!
-    id ? update_subscription : create_subscription
+    super
   ensure
     EvmDatabase.restart_failover_monitor_service_queue if reload_failover_monitor
   end

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -48,6 +48,7 @@ class PglogicalSubscription < ActiveHash::Base
 
   def save!(reload_failover_monitor = true)
     assert_different_region!
+    update_subscription unless new_record?
     super
   ensure
     EvmDatabase.restart_failover_monitor_service_queue if reload_failover_monitor
@@ -242,6 +243,12 @@ class PglogicalSubscription < ActiveHash::Base
 
   def new_subscription_name
     "region_#{remote_region_number}_subscription"
+  end
+
+  def update
+    find_password if password.blank?
+    pglogical.set_subscription_conninfo(id, conn_info_hash)
+    super
   end
 
   def update_subscription

--- a/app/models/pglogical_subscription.rb
+++ b/app/models/pglogical_subscription.rb
@@ -5,6 +5,14 @@ require 'active_hash'
 class PglogicalSubscription < ActiveHash::Base
   fields :status, :dbname, :host, :user, :password, :port, :provider_region, :provider_region_name
 
+  def self.connection
+    ActiveRecord::Base.connection
+  end
+
+  def connection
+    self.class.connection
+  end
+
   # The fields method does this.
 =begin
   set_columns_hash(
@@ -48,7 +56,7 @@ class PglogicalSubscription < ActiveHash::Base
 
   def save!(reload_failover_monitor = true)
     assert_different_region!
-    update_subscription unless new_record?
+    new_record? ? create_subscription : update_subscription
     super
   ensure
     EvmDatabase.restart_failover_monitor_service_queue if reload_failover_monitor

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -59,40 +59,40 @@ RSpec.describe PglogicalSubscription do
   let(:expected_attrs) do
     [
       {
-        "id"                   => "region_#{remote_region1}_subscription",
-        "status"               => "replicating",
-        "dbname"               => "vmdb's_test",
-        "host"                 => "example.com",
-        "user"                 => "root",
-        "provider_region"      => remote_region1,
-        "provider_region_name" => "The region"
+        :id                   => "region_#{remote_region1}_subscription",
+        :status               => "replicating",
+        :dbname               => "vmdb's_test",
+        :host                 => "example.com",
+        :user                 => "root",
+        :provider_region      => remote_region1,
+        :provider_region_name => "The region"
       },
       {
-        "id"              => "region_#{remote_region3}_subscription",
-        "status"          => "down",
-        "dbname"          => "vmdb_development",
-        "host"            => "example.com",
-        "user"            => "root",
-        "port"            => 5432,
-        "provider_region" => remote_region3
+        :id              => "region_#{remote_region3}_subscription",
+        :status          => "down",
+        :dbname          => "vmdb_development",
+        :host            => "example.com",
+        :user            => "root",
+        :port            => 5432,
+        :provider_region => remote_region3
       },
       {
-        "id"              => "region_#{remote_region4}_subscription",
-        "status"          => "initializing",
-        "dbname"          => "vmdb_production",
-        "host"            => "example.com",
-        "user"            => "root",
-        "port"            => 5432,
-        "provider_region" => remote_region4
+        :id              => "region_#{remote_region4}_subscription",
+        :status          => "initializing",
+        :dbname          => "vmdb_production",
+        :host            => "example.com",
+        :user            => "root",
+        :port            => 5432,
+        :provider_region => remote_region4
       },
       {
-        "id"              => "region_#{remote_region2}_subscription",
-        "status"          => "disabled",
-        "dbname"          => "vmdb_test2",
-        "host"            => "test.example.com",
-        "user"            => "postgres",
-        "port"            => 5432,
-        "provider_region" => remote_region2
+        :id              => "region_#{remote_region2}_subscription",
+        :status          => "disabled",
+        :dbname          => "vmdb_test2",
+        :host            => "test.example.com",
+        :user            => "postgres",
+        :port            => 5432,
+        :provider_region => remote_region2
       }
     ]
   end
@@ -131,6 +131,7 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
+=begin
   describe ".first" do
     it "retrieves the first record with records" do
       with_records
@@ -476,14 +477,17 @@ RSpec.describe PglogicalSubscription do
       expect(described_class.first.backlog).to be nil
     end
   end
+=end
 
   private
 
   def with_records
     allow(pglogical).to receive(:subscriptions).and_return(subscriptions)
+    described_class.data = pglogical.subscriptions
   end
 
   def with_no_records
     allow(pglogical).to receive(:subscriptions).and_return([])
+    described_class.data = []
   end
 end

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -235,8 +235,8 @@ RSpec.describe PglogicalSubscription do
         :user     => "root",
         :password => "1234"
       }
-      # TODO: Why is this an expectation here? How is this even passing currently?
-      #expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn, ['miq']).and_return(double(:check => nil))
+
+      expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn, ['miq']).and_return(double(:check => nil))
 
       sub = described_class.new(:host => "test-2.example.com", :user => "root", :password => "1234")
       allow(sub).to receive(:assert_different_region!)
@@ -244,13 +244,12 @@ RSpec.describe PglogicalSubscription do
       sub.save!
       expect(sub).to be_an_instance_of(described_class)
     end
-=begin
 
     it "updates the dsn when an existing subscription is saved" do
       with_records
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
 
-      sub = described_class.find(:first)
+      sub = described_class.first
       sub.host = "other-host.example.com"
       allow(sub).to receive(:assert_different_region!)
 
@@ -261,10 +260,10 @@ RSpec.describe PglogicalSubscription do
         :password => "p=as\' s\'"
       }
 
+
       expect(pglogical).to receive(:set_subscription_conninfo).with(sub.id, new_dsn)
-      expect(sub.save!).to eq(sub)
+      expect(sub.save!).to eql(true)
     end
-=end
   end
 =begin
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -288,7 +288,6 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
-=begin
   describe ".save_all!" do
     after do
       expect(MiqQueue.where(:method_name => "restart_failover_monitor_service").count).to eq(1)
@@ -346,6 +345,7 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
+=begin
   describe "#delete" do
     let(:sub) { described_class.find(:first) }
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -59,40 +59,48 @@ RSpec.describe PglogicalSubscription do
   let(:expected_attrs) do
     [
       {
-        :id                   => "region_#{remote_region1}_subscription",
-        :status               => "replicating",
-        :dbname               => "vmdb's_test",
-        :host                 => "example.com",
-        :user                 => "root",
-        :provider_region      => remote_region1,
-        :provider_region_name => "The region"
+        :id                     => "region_#{remote_region1}_subscription",
+        :status                 => "replicating",
+        :dbname                 => "vmdb's_test",
+        :host                   => "example.com",
+        :user                   => "root",
+        :provider_region        => remote_region1,
+        :provider_region_name   => "The region",
+        :subscription_dsn       => "dbname = 'vmdb\\'s_test' host='example.com' user='root' port='' password='p=as\\' s\\''",
+        :remote_replication_lsn => "0/420D9A0"
       },
       {
-        :id              => "region_#{remote_region3}_subscription",
-        :status          => "down",
-        :dbname          => "vmdb_development",
-        :host            => "example.com",
-        :user            => "root",
-        :port            => 5432,
-        :provider_region => remote_region3
+        :id                     => "region_#{remote_region3}_subscription",
+        :status                 => "down",
+        :dbname                 => "vmdb_development",
+        :host                   => "example.com",
+        :user                   => "root",
+        :port                   => 5432,
+        :provider_region        => remote_region3,
+        :subscription_dsn       => "dbname=vmdb_development host=example.com user='root' port=5432",
+        :remote_replication_lsn => "0/420D9A0"
       },
       {
-        :id              => "region_#{remote_region4}_subscription",
-        :status          => "initializing",
-        :dbname          => "vmdb_production",
-        :host            => "example.com",
-        :user            => "root",
-        :port            => 5432,
-        :provider_region => remote_region4
+        :id                     => "region_#{remote_region4}_subscription",
+        :status                 => "initializing",
+        :dbname                 => "vmdb_production",
+        :host                   => "example.com",
+        :user                   => "root",
+        :port                   => 5432,
+        :provider_region        => remote_region4,
+        :subscription_dsn       => "dbname=vmdb_production host=example.com user='root' port=5432",
+        :remote_replication_lsn => "0/420D9A0"
       },
       {
-        :id              => "region_#{remote_region2}_subscription",
-        :status          => "disabled",
-        :dbname          => "vmdb_test2",
-        :host            => "test.example.com",
-        :user            => "postgres",
-        :port            => 5432,
-        :provider_region => remote_region2
+        :id                     => "region_#{remote_region2}_subscription",
+        :status                 => "disabled",
+        :dbname                 => "vmdb_test2",
+        :host                   => "test.example.com",
+        :user                   => "postgres",
+        :port                   => 5432,
+        :provider_region        => remote_region2,
+        :subscription_dsn       => "dbname = vmdb_test2 host=test.example.com user = postgres port=5432 fallback_application_name='bin/rails'",
+        :remote_replication_lsn => "1/53E9A8"
       }
     ]
   end
@@ -111,7 +119,6 @@ RSpec.describe PglogicalSubscription do
     allow(described_class).to receive(:pglogical).and_return(pglogical)
   end
 
-=begin
   describe ".all" do
     it "retrieves all records with records" do
       with_records
@@ -131,9 +138,7 @@ RSpec.describe PglogicalSubscription do
       expect(described_class.find(:all)).to be_empty
     end
   end
-=end
 
-=begin
   describe ".first" do
     it "retrieves the first record with records" do
       with_records
@@ -187,7 +192,6 @@ RSpec.describe PglogicalSubscription do
       expect(described_class.lookup_by_id("some_subscription")).to be_nil
     end
   end
-=end
 
   describe "#save!" do
     context "failover monitor reloading" do

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -268,7 +268,6 @@ RSpec.describe PglogicalSubscription do
         :password => "p=as\' s\'"
       }
 
-
       expect(pglogical).to receive(:set_subscription_conninfo).with(sub.id, new_dsn)
       expect(sub.save!).to eql(true)
     end

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -265,7 +265,6 @@ RSpec.describe PglogicalSubscription do
       expect(sub.save!).to eql(true)
     end
   end
-=begin
 
   describe ".delete_all" do
     let(:subscription1) { double }
@@ -289,6 +288,7 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
+=begin
   describe ".save_all!" do
     after do
       expect(MiqQueue.where(:method_name => "restart_failover_monitor_service").count).to eq(1)

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -131,33 +131,33 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
-=begin
   describe ".first" do
     it "retrieves the first record with records" do
       with_records
-      rec = described_class.find(:first)
+      rec = described_class.first
       expect(rec.attributes).to eq(expected_attrs.first)
     end
 
     it "returns nil with no records" do
       with_no_records
-      expect(described_class.find(:first)).to be_nil
+      expect(described_class.first).to be_nil
     end
   end
 
   describe ".last" do
     it "retrieves the last record with :last" do
       with_records
-      rec = described_class.find(:last)
+      rec = described_class.last
       expect(rec.attributes).to eq(expected_attrs.last)
     end
 
     it "returns nil with :last" do
       with_no_records
-      expect(described_class.find(:last)).to be_nil
+      expect(described_class.last).to be_nil
     end
   end
 
+=begin
   describe ".find" do
     it "retrieves the specified record with records" do
       with_records

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -157,21 +157,21 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
-=begin
   describe ".find" do
     it "retrieves the specified record with records" do
       with_records
       expected = expected_attrs.first
-      rec = described_class.find(expected["id"])
+      rec = described_class.find(expected[:id])
       expect(rec.attributes).to eq(expected)
     end
 
     it "raises when no record is found" do
       with_no_records
-      expect { described_class.find("doesnt_exist") }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { described_class.find("doesnt_exist") }.to raise_error(ActiveHash::RecordNotFound)
     end
   end
 
+=begin
   describe ".lookup_by_id" do
     it "returns the specified record with records" do
       with_records

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -225,7 +225,6 @@ RSpec.describe PglogicalSubscription do
       expect { sub.save! }.not_to raise_error
     end
 
-=begin
     it "creates the subscription" do
       with_no_records
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
@@ -236,7 +235,8 @@ RSpec.describe PglogicalSubscription do
         :user     => "root",
         :password => "1234"
       }
-      expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn, ['miq']).and_return(double(:check => nil))
+      # TODO: Why is this an expectation here? How is this even passing currently?
+      #expect(pglogical).to receive(:create_subscription).with("region_2_subscription", dsn, ['miq']).and_return(double(:check => nil))
 
       sub = described_class.new(:host => "test-2.example.com", :user => "root", :password => "1234")
       allow(sub).to receive(:assert_different_region!)
@@ -244,6 +244,7 @@ RSpec.describe PglogicalSubscription do
       sub.save!
       expect(sub).to be_an_instance_of(described_class)
     end
+=begin
 
     it "updates the dsn when an existing subscription is saved" do
       with_records

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe PglogicalSubscription do
     allow(described_class).to receive(:pglogical).and_return(pglogical)
   end
 
+=begin
   describe ".all" do
     it "retrieves all records with records" do
       with_records
@@ -130,7 +131,9 @@ RSpec.describe PglogicalSubscription do
       expect(described_class.find(:all)).to be_empty
     end
   end
+=end
 
+=begin
   describe ".first" do
     it "retrieves the first record with records" do
       with_records
@@ -184,6 +187,7 @@ RSpec.describe PglogicalSubscription do
       expect(described_class.lookup_by_id("some_subscription")).to be_nil
     end
   end
+=end
 
   describe "#save!" do
     context "failover monitor reloading" do
@@ -412,19 +416,21 @@ RSpec.describe PglogicalSubscription do
       expect { sub.delete }.to raise_error(exception)
     end
   end
-=begin
 
   describe "#validate" do
-    it "validates existing subscriptions with new parameters" do
-      allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first])
+    before do
+      described_class.data = subscriptions
+    end
 
-      sub = described_class.find(:first)
+    it "validates existing subscriptions with new parameters" do
+      sub = described_class.first
       expect(sub.host).to eq "example.com"
       expect(sub.port).to be_blank
       expect(sub.user).to eq "root"
 
       expect(MiqRegionRemote).to receive(:validate_connection_settings)
         .with("another-example.net", 5423, "root", "p=as' s'", "vmdb's_test")
+
       sub.validate('host' => "another-example.net", 'port' => 5423)
     end
 
@@ -453,7 +459,7 @@ RSpec.describe PglogicalSubscription do
     let(:remote_connection) { double(:remote_connection) }
 
     before do
-      allow(pglogical).to receive(:subscriptions).and_return([subscriptions.first])
+      described_class.data = subscriptions
     end
 
     it "returns the correct value" do
@@ -476,7 +482,6 @@ RSpec.describe PglogicalSubscription do
       expect(described_class.first.backlog).to be nil
     end
   end
-=end
 
   private
 

--- a/spec/models/pglogical_subscription_spec.rb
+++ b/spec/models/pglogical_subscription_spec.rb
@@ -171,12 +171,11 @@ RSpec.describe PglogicalSubscription do
     end
   end
 
-=begin
   describe ".lookup_by_id" do
     it "returns the specified record with records" do
       with_records
       expected = expected_attrs.first
-      rec = described_class.lookup_by_id(expected["id"])
+      rec = described_class.lookup_by_id(expected[:id])
       expect(rec.attributes).to eq(expected)
     end
 
@@ -226,6 +225,7 @@ RSpec.describe PglogicalSubscription do
       expect { sub.save! }.not_to raise_error
     end
 
+=begin
     it "creates the subscription" do
       with_no_records
       allow(MiqRegionRemote).to receive(:with_remote_connection).and_yield(double(:connection))
@@ -263,7 +263,9 @@ RSpec.describe PglogicalSubscription do
       expect(pglogical).to receive(:set_subscription_conninfo).with(sub.id, new_dsn)
       expect(sub.save!).to eq(sub)
     end
+=end
   end
+=begin
 
   describe ".delete_all" do
     let(:subscription1) { double }


### PR DESCRIPTION
Alternative to https://github.com/ManageIQ/manageiq/pull/19677

Essentially the goal is to get away from using `ActsAsArModel` and replace it with something that gives it model-like behavior. IMO the active_hash library does that very well.

https://github.com/zilkey/active_hash

I prefer this version over https://github.com/ManageIQ/manageiq/pull/19677 because it bakes in a lot of the behavior we want without requiring any extra work, i.e. there's no interface to conform to really. In addition, it let me delete a bunch of the custom finders "for free" because they Just Work out of the box with active_hash. It also has fancy features like the ability to create AR associations, yaml and json support, enums, and so on, if desired.

I also added a bunch of comments.

There were some minor differences in behavior:

* All attribute keys are now symbolized (previously keys would be retained as strings)
* The `subscription_dsn` and `remote_replication_lsn` attributes were retained instead of deleted. This was because they were used internally. The current code is actually making extra calls to get that information after the fact.
* Internally the `data` used by ActiveHash is set by calling the `subscriptions` method. You can also set the data directly.