### PR TITLE
Don't send VMware specific types from Core

### DIFF
--- a/app/models/vm_migrate_task.rb
+++ b/app/models/vm_migrate_task.rb
@@ -53,10 +53,7 @@ class VmMigrateTask < MiqRequestTask
     datastore_id = get_option(:placement_ds_name)
     datastore = Storage.find_by(:id => datastore_id)
 
-    disk_transform = case get_option(:disk_format)
-                     when 'thin'  then VimString.new('sparse', "VirtualMachineRelocateTransformation")
-                     when 'thick' then VimString.new('flat', "VirtualMachineRelocateTransformation")
-                     end
+    disk_transform = get_option(:disk_format)
 
     # Determine if we call migrate for relocate
     vc_method = if datastore || disk_transform


### PR DESCRIPTION
The disk_transform argument here was a specific VMware class (VirtualMachineRelocateTransformation) which isn't portable across other providers that might implement VmMigrateTask.  Simply send thin or thick as the disk_transform.

Depends on: https://github.com/ManageIQ/manageiq-providers-vmware/pull/527