### PR TITLE
VimHash and VimArray are VMware specific and shouldn't be in core specs

### DIFF
--- a/spec/models/miq_request_task/dumping_spec.rb
+++ b/spec/models/miq_request_task/dumping_spec.rb
@@ -24,32 +24,6 @@ RSpec.describe MiqRequestTask do
         expect($log).to receive(:info).with(/<PROTECTED>/)
         task.dump_obj({:my_password => "secret"}, "my choices: ", $log, :info, :protected => {:path => /[Pp]assword/})
       end
-
-      it 'with a VimHash' do
-        data = VimHash.new('VirtualDisk') do |vh|
-          vh.backing = {'diskMode' => 'persistent', 'datastore' => 'datastore-001'}
-          vh.capacityInKB = 100
-        end
-        expect(MiqRequestTask).to receive(:dump_hash)
-        expect(STDOUT).to receive(:puts).with(" (VimHash) xsiType: <VirtualDisk>  vimType: <>")
-        task.dump_obj(data)
-      end
-
-      it 'with a VimArray' do
-        array = VimArray.new("ArrayOfHostInternetScsiHbaStaticTarget") do |ta|
-          ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
-            st.address    = "10.1.1.210"
-            st.iScsiName  = "iqn.1992-08.com.netapp:sn.135107242"
-          end
-          ta << VimHash.new("HostInternetScsiHbaStaticTarget") do |st|
-            st.address    = "10.1.1.100"
-            st.iScsiName  = "iqn.2008-08.com.starwindsoftware:starwindm1-starm1-test1"
-          end
-        end
-        expect(MiqRequestTask).to receive(:dump_array)
-        expect(STDOUT).to receive(:puts).with(" (VimArray) xsiType: <ArrayOfHostInternetScsiHbaStaticTarget>  vimType: <>")
-        task.dump_obj(array)
-      end
     end
   end
 end


### PR DESCRIPTION
These types are specific to the VMware plugin and we're trying to remove the vmware_web_service gem from core which is where these types are defined.