### PR TITLE
Remove the vmware_web_service gem from the core Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -166,7 +166,6 @@ end
 
 group :vmware, :manageiq_default do
   manageiq_plugin "manageiq-providers-vmware"
-  gem "vmware_web_service", "~>1.0"
 end
 
 ### shared dependencies

--- a/app/models/miq_event_handler/runner.rb
+++ b/app/models/miq_event_handler/runner.rb
@@ -1,5 +1,3 @@
-require "VMwareWebService/VimTypes"
-
 class MiqEventHandler::Runner < MiqQueueWorkerBase::Runner
   def artemis?
     Settings.prototype.queue_type == 'artemis'


### PR DESCRIPTION
Now that EmsEvents no longer have VimTypes in the serialized full_data column (https://github.com/ManageIQ/manageiq-schema/pull/451) we no longer need this gem in the core Gemfile.  We tried this before in https://github.com/ManageIQ/manageiq/pull/19704 but later found that the EmsEvents had serialized VimHash and VimArrays in the full_data column.