### PR TITLE
Use a single query to get count of active VMs and Hosts

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -143,6 +143,9 @@ class Host < ApplicationRecord
   virtual_total :v_total_vms, :vms
   virtual_total :v_total_miq_templates, :miq_templates
 
+  scope :active,   -> { where.not(:ems_id => nil) }
+  scope :archived, -> { where(:ems_id => nil) }
+
   alias_method :datastores, :storages    # Used by web-services to return datastores as the property name
 
   alias_method :parent_cluster, :ems_cluster

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -488,15 +488,9 @@ class MiqServer < ApplicationRecord
   end
 
   def self.audit_managed_resources
-    total_vms     = 0
-    total_hosts   = 0
+    total_vms   = VmOrTemplate.active.count
+    total_hosts = Host.active.count
 
-    ExtManagementSystem.all.each do |e|
-      vms     = e.all_vms_and_templates.count
-      hosts   = e.all_hosts.count
-      total_vms += vms
-      total_hosts += hosts
-    end
     totals = {"vms" => total_vms, "hosts" => total_hosts}
     $audit_log.info("Under Management: #{totals.to_json}")
   end

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -464,4 +464,19 @@ RSpec.describe MiqServer do
       expect(described_class.zone_is_modifiable?).to be_falsey
     end
   end
+
+  context ".audit_managed_resources" do
+    let(:ems) { FactoryBot.create(:ems_infra) }
+    let!(:active_vm) { FactoryBot.create(:vm_infra, :ext_management_system => ems) }
+    let!(:archived_vm) { FactoryBot.create(:vm_infra) }
+    let!(:active_host) { FactoryBot.create(:host, :ext_management_system => ems) }
+    let!(:archived_host) { FactoryBot.create(:host) }
+
+    it "with active and archived vms and hosts" do
+      expected_message = "Under Management: #{{"vms" => 1, "hosts" => 1}.to_json}"
+
+      expect($audit_log).to receive(:info).with(expected_message)
+      described_class.audit_managed_resources
+    end
+  end
 end


### PR DESCRIPTION
Instead of looping through all ExtManagementSystems and adding up the counts of vms and hosts manually we can get this count in one shot by querying for active VMs and Hosts.