### PR TITLE
Simplify metrics queuing logic

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -33,6 +33,10 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
     queue_captures(targets, target_options)
   end
 
+  def perf_capture_realtime_queue
+    queue_captures(Array(target), target => {:interval => 'realtime'})
+  end
+
   # @param targets [Array<Object>] list of the targets for capture (from `capture_ems_targets`)
   # @param target_options [ Hash{Object => Hash{Symbol => Object}}] list of options indexed by target
   def queue_captures(targets, target_options)

--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -161,7 +161,6 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
     # for gap, interval_name = historical, start and end time present.
     start_time = options[:start_time]
     end_time   = options[:end_time]
-    priority   = options[:priority] || Metric::Capture.interval_priority(interval_name)
     task_id    = options[:task_id]
 
     # cb is the task used to group cluster realtime metrics
@@ -183,26 +182,23 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
       # Should both interval name and args (dates) be part of uniqueness query?
       queue_item_options = queue_item.merge(:method_name => "perf_capture_#{item_interval}")
       queue_item_options[:args] = start_and_end_time if start_and_end_time.present?
-      next if item_interval != 'realtime' && messages[start_and_end_time].try(:priority) == priority
+      next if item_interval != 'realtime' && messages[start_and_end_time]
 
       MiqQueue.put_or_update(queue_item_options) do |msg, qi|
         # reason for setting MiqQueue#miq_task_id is to initializes MiqTask.started_on column when message delivered.
         qi[:miq_task_id] = task_id if task_id && item_interval == "realtime"
         if msg.nil?
-          qi[:priority] = priority
+          qi[:priority] = Metric::Capture.interval_priority(item_interval)
           qi.delete(:state)
           if cb && item_interval == "realtime"
             qi[:miq_callback] = cb
           end
           qi
-        elsif msg.state == "ready" && (task_id || MiqQueue.higher_priority?(priority, msg.priority))
-          qi[:priority] = priority
-          # rerun the job (either with new task or higher priority)
+        elsif msg.state == "ready" && task_id && item_interval == "realtime"
+          # rerun the job
           qi.delete(:state)
-          if task_id && item_interval == "realtime"
-            existing_tasks = ((msg.miq_callback || {})[:args] || []).first || []
-            qi[:miq_callback] = cb.merge(:args => [existing_tasks + [task_id]])
-          end
+          existing_tasks = ((msg.miq_callback || {})[:args] || []).first || []
+          qi[:miq_callback] = cb.merge(:args => [existing_tasks + [task_id]])
           qi
         else
           interval = qi[:method_name].sub("perf_capture_", "")

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -170,6 +170,6 @@ module Metric::CiMixin::Capture
     # For UI to enable refresh of realtime charts on demand
     _log.info("Realtime capture requested for #{log_target}")
 
-    perf_capture_object.queue_captures([self], self => {:interval => 'realtime'})
+    perf_capture_object.perf_capture_realtime_queue
   end
 end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -170,6 +170,6 @@ module Metric::CiMixin::Capture
     # For UI to enable refresh of realtime charts on demand
     _log.info("Realtime capture requested for #{log_target}")
 
-    perf_capture_object.queue_captures([self], self => {:interval => 'realtime', :priority => MiqQueue::HIGH_PRIORITY})
+    perf_capture_object.queue_captures([self], self => {:interval => 'realtime'})
   end
 end

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -196,36 +196,6 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         end
       end
     end
-
-    context "for queue prioritization" do
-      it "should queue up realtime capture for vm" do
-        vm.perf_capture_realtime_now
-        expect(MiqQueue.count).to eq(1)
-
-        msg = MiqQueue.first
-        expect(msg.priority).to eq(MiqQueue::HIGH_PRIORITY)
-        expect(msg.instance_id).to eq(vm.id)
-        expect(msg.class_name).to eq("ManageIQ::Providers::Vmware::InfraManager::Vm")
-      end
-
-      it "should raise the priority of the existing queue item" do
-        vm.perf_capture_realtime_now
-        MiqQueue.first.update_attribute(:priority, MiqQueue::NORMAL_PRIORITY)
-        vm.perf_capture_realtime_now
-
-        expect(MiqQueue.count).to eq(1)
-        expect(MiqQueue.first.priority).to eq(MiqQueue::HIGH_PRIORITY)
-      end
-
-      it "should not lower the priority of the existing queue item" do
-        vm.perf_capture_realtime_now
-        MiqQueue.first.update_attribute(:priority, MiqQueue::MAX_PRIORITY)
-        vm.perf_capture_realtime_now
-
-        expect(MiqQueue.count).to eq(1)
-        expect(MiqQueue.first.priority).to eq(MiqQueue::MAX_PRIORITY)
-      end
-    end
   end
 
   def trigger_capture(last_perf_capture_on = nil, options = {:interval => "realtime"})


### PR DESCRIPTION
Joe: This is the work for cap&u batching that has been going on for a while
extracted from https://github.com/ManageIQ/manageiq/pull/19741

### before:

We had a lot of logic around background cap&u and whether it was requested in the front end.

### after:

Now it still uses MiqQueue priorities, but the priorities are based upon whether it is realtime or historical values. (the default values)