### PR TITLE
metrics: simplify dates on queue

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -228,8 +228,6 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
 
   def queue_items_for_interval(target, interval_name, start_time, end_time)
     if interval_name == 'historical'
-      start_time = Metric::Capture.historical_start_time if start_time.nil?
-      end_time ||= 1.day.from_now.utc.beginning_of_day # Ensure no more than one historical collection is queue up in the same day
       split_capture_intervals(interval_name, start_time, end_time)
     else
       # if last_perf_capture_on is earlier than 4.hour.ago.beginning_of_day,

--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -214,40 +214,43 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
     end
   end
 
+  # split capture interval for historical queue captures (so the fetch is not too big)
+  # an array of ordered pairs from start_time to end_time partitioned by each day. (most recent day first / reverse chronological)
+  #
+  # example:
+  #
+  #  start_time = 2017/01/01 12:00:00, end_time = 2017/01/04 12:00:00
+  #  [[interval_name, 2017-01-03 12:00:00 UTC, 2017-01-04 12:00:00 UTC],
+  #   [interval_name, 2017-01-02 12:00:00 UTC, 2017-01-03 12:00:00 UTC],
+  #   [interval_name, 2017-01-01 12:00:00 UTC, 2017-01-02 12:00:00 UTC]]
   def split_capture_intervals(interval_name, start_time, end_time, threshold = 1.day)
-    # Create an array of ordered pairs from start_time and end_time so that each ordered pair is contained
-    # within the threshold.  Then, reverse it so the newest ordered pair is first:
-    # start_time = 2017/01/01 12:00:00, end_time = 2017/01/04 12:00:00
-    # [[interval_name, 2017-01-03 12:00:00 UTC, 2017-01-04 12:00:00 UTC],
-    #  [interval_name, 2017-01-02 12:00:00 UTC, 2017-01-03 12:00:00 UTC],
-    #  [interval_name, 2017-01-01 12:00:00 UTC, 2017-01-02 12:00:00 UTC]]
     (start_time.utc..end_time.utc).step_value(threshold).each_cons(2).collect do |s_time, e_time|
       [interval_name, s_time, e_time]
     end.reverse
   end
 
+  # Note: default values are also derived in ci_mixin/capture.rb#fix_capture_start_end_time
+  # @return realtime_interval, realtime_date, historical_start, historical_end
   def queue_items_for_interval(target, interval_name, start_time, end_time)
+    # if last_perf_capture_on is nil (initial refresh), also go back historically
+    # if last_perf_capture_on is earlier than 4.hour.ago.beginning_of_day,
+    # then create *one* realtime capture for start_time = 4.hours.ago.beginning_of_day (no end_time)
+    # and create historical captures for each day from last_perf_capture_on until 4.hours.ago.beginning_of_day
+    realtime_cut_off = 4.hours.ago.utc.beginning_of_day
     if interval_name == 'historical'
       split_capture_intervals(interval_name, start_time, end_time)
+    elsif interval_name == "hourly"
+      [[interval_name]]
+    # interval_name == "realtime"
+    elsif target.last_perf_capture_on.nil? && Metric::Capture.historical_days != 0
+      [[interval_name]] +
+        split_capture_intervals("historical", Metric::Capture.historical_start_time, 1.day.from_now.utc.beginning_of_day)
+    elsif target.last_perf_capture_on && target.last_perf_capture_on < realtime_cut_off
+      # TODO: we need to limit the number of historical days captured here
+      [[interval_name]] +
+        split_capture_intervals("historical", target.last_perf_capture_on, realtime_cut_off)
     else
-      # if last_perf_capture_on is earlier than 4.hour.ago.beginning_of_day,
-      # then create *one* realtime capture for start_time = 4.hours.ago.beginning_of_day (no end_time)
-      # and create historical captures for each day from last_perf_capture_on until 4.hours.ago.beginning_of_day
-      realtime_cut_off = 4.hours.ago.utc.beginning_of_day
-      if target.last_perf_capture_on.nil?
-        # for initial refresh of non-Storage objects, also go back historically
-        if !target.kind_of?(Storage) && Metric::Capture.historical_days != 0
-          [[interval_name]] +
-            split_capture_intervals("historical", Metric::Capture.historical_start_time, 1.day.from_now.utc.beginning_of_day)
-        else
-          [[interval_name]]
-        end
-      elsif target.last_perf_capture_on < realtime_cut_off
-        [[interval_name]] +
-          split_capture_intervals("historical", target.last_perf_capture_on, realtime_cut_off)
-      else
-        [[interval_name]]
-      end
+      [[interval_name]]
     end
   end
 

--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -237,16 +237,16 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
       if target.last_perf_capture_on.nil?
         # for initial refresh of non-Storage objects, also go back historically
         if !target.kind_of?(Storage) && Metric::Capture.historical_days != 0
-          [[interval_name, realtime_cut_off]] +
+          [[interval_name]] +
             split_capture_intervals("historical", Metric::Capture.historical_start_time, 1.day.from_now.utc.beginning_of_day)
         else
-          [[interval_name, realtime_cut_off]]
+          [[interval_name]]
         end
       elsif target.last_perf_capture_on < realtime_cut_off
-        [[interval_name, realtime_cut_off]] +
+        [[interval_name]] +
           split_capture_intervals("historical", target.last_perf_capture_on, realtime_cut_off)
       else
-        [interval_name]
+        [[interval_name]]
       end
     end
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -45,14 +45,11 @@ module Metric::CiMixin::Capture
 
     # Determine the start_time for capturing if not provided
     if interval_name == 'historical'
-      start_time = Metric::Capture.historical_start_time if start_time.nil?
-    else
-      start_time = last_perf_capture_on if start_time.nil?
-      if start_time.nil? && interval_name == 'hourly'
-        # For hourly on the first capture, we don't want to get all of the
-        #   historical data, so we shorten the query
-        start_time = 4.hours.ago.utc
-      end
+      start_time ||= Metric::Capture.historical_start_time
+    elsif interval_name == "hourly"
+      start_time ||= last_perf_capture_on || 4.hours.ago.utc
+    else # interval_name == realtime
+      start_time ||= [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].max
     end
     [start_time, end_time]
   end

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
         expect(queue_timings).to eq(
           "realtime"   => {
-            host  => [[4.hours.ago.utc.beginning_of_day]],
-            host2 => [[4.hours.ago.utc.beginning_of_day]],
-            host3 => [[4.hours.ago.utc.beginning_of_day]],
-            vm    => [[4.hours.ago.utc.beginning_of_day]],
-            vm2   => [[4.hours.ago.utc.beginning_of_day]]
+            host  => [[]],
+            host2 => [[]],
+            host3 => [[]],
+            vm    => [[]],
+            vm2   => [[]]
           },
           "historical" => {
             host  => arg_day_range(bod - 7.days, bod + 1.day),
@@ -162,7 +162,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
             vm2   => arg_day_range(bod - 7.days, bod + 1.day)
           },
           "hourly"     => {
-            storage => [[4.hours.ago.utc.beginning_of_day]]
+            storage => [[]]
           }
         )
       end
@@ -190,7 +190,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
           bod = Time.now.utc.beginning_of_day
 
           expect(queue_timings).to eq(
-            "realtime"   => vms.each_with_object({}) { |k, h| h[k] = [[4.hours.ago.utc.beginning_of_day]] },
+            "realtime"   => vms.each_with_object({}) { |k, h| h[k] = [[]] },
             "historical" => vms.each_with_object({}) { |k, h| h[k] = arg_day_range(bod - 7.days, bod + 1.day) }
           )
         end
@@ -244,14 +244,14 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture(nil, :interval => "realtime")
 
         expect(queue_timings).to eq(
-          "realtime" => {vm => [[4.hours.ago.utc.beginning_of_day]]}
+          "realtime" => {vm => [[]]}
         )
 
         Timecop.travel(20.minutes)
         trigger_capture(nil, :interval => "realtime")
 
         expect(queue_timings).to eq(
-          "realtime" => {vm => [[4.hours.ago.utc.beginning_of_day]]}
+          "realtime" => {vm => [[]]}
         )
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture(nil, :interval => "realtime")
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[4.hours.ago.utc.beginning_of_day]]},
+          "realtime"   => {vm => [[]]},
           "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
         )
       end
@@ -276,7 +276,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture(last_perf_capture_on, :interval => "realtime")
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[4.hours.ago.utc.beginning_of_day]]},
+          "realtime"   => {vm => [[]]},
           "historical" => {vm => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
         )
       end
@@ -301,7 +301,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture(last_perf_capture_on, :interval => "realtime")
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[4.hours.ago.utc.beginning_of_day]]},
+          "realtime"   => {vm => [[]]},
           "historical" => {vm => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
         )
 
@@ -309,7 +309,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
         trigger_capture(nil, :interval => "realtime")
 
         expect(queue_timings).to eq(
-          "realtime"   => {vm => [[4.hours.ago.utc.beginning_of_day]]},
+          "realtime"   => {vm => [[]]},
           "historical" => {vm => arg_day_range(last_perf_capture_on, Time.now.utc.beginning_of_day)}
         )
       end

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -269,24 +269,6 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       end
     end
 
-    it "creates historical only when requesting historical and with last_perf_capture_on.nil? (first time) with initial_capture" do
-      stub_performance_settings(:history => {:initial_capture_days => 7})
-      MiqQueue.delete_all
-      Timecop.freeze(Time.now.utc.end_of_day - 6.hours) do
-        trigger_capture(nil, :interval => "historical")
-        expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
-        )
-
-        Timecop.travel(20.minutes)
-        trigger_capture(nil, :interval => "historical")
-
-        expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
-        )
-      end
-    end
-
     it "creates realtime and historical with last_perf_capture_on older than the realtime_cut_off" do
       MiqQueue.delete_all
       Timecop.freeze(Time.now.utc.end_of_day - 6.hours) do
@@ -333,53 +315,19 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       end
     end
 
-    it "creates queue item with task_id (which will set MiqTask#started_on)" do
-      MiqQueue.delete_all
-      task = FactoryBot.create(:miq_task)
-      trigger_capture(nil, :interval => "realtime", :task_id => task.id)
-
-      expect(MiqQueue.first.miq_task_id).to eq task.id
-    end
-
-    it "creates historical only when requesting historical and with old last_perf_capture_on with initial_capture" do
+    it "creates historical with no last_perf_capture_on" do
       stub_performance_settings(:history => {:initial_capture_days => 7})
       MiqQueue.delete_all
       Timecop.freeze(Time.now.utc.end_of_day - 6.hours) do
-        last_perf_capture_on = (10.days + 5.hours + 23.minutes).ago
-        trigger_capture(last_perf_capture_on, :interval => "historical")
-        expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
-        )
-
-        Timecop.travel(20.minutes)
-        trigger_capture(last_perf_capture_on, :interval => "historical")
+        trigger_capture(nil, :interval => "historical", :start_time => 4.days.ago.utc, :end_time => 2.days.ago.utc)
 
         expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
+          "historical" => {vm => arg_day_range(4.days.ago.utc, 2.days.ago.utc)}
         )
       end
     end
 
-    it "creates historical only when requesting historical and recent last_perf_capture_on with initial_capture" do
-      stub_performance_settings(:history => {:initial_capture_days => 7})
-      MiqQueue.delete_all
-      Timecop.freeze(Time.now.utc.end_of_day - 6.hours) do
-        last_perf_capture_on = (2.days + 5.hours + 23.minutes).ago
-        trigger_capture(last_perf_capture_on, :interval => "historical")
-        expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
-        )
-
-        Timecop.travel(20.minutes)
-        trigger_capture(last_perf_capture_on, :interval => "historical")
-
-        expect(queue_timings).to eq(
-          "historical" => {vm => arg_day_range(7.days.ago.utc.beginning_of_day, 1.day.from_now.utc.beginning_of_day)}
-        )
-      end
-    end
-
-    it "creates historical only when requesting historical with dates with recent last_perf_capture_on" do
+    it "creates historical even with recent last_perf_capture_on" do
       MiqQueue.delete_all
       Timecop.freeze(Time.now.utc.end_of_day - 6.hours) do
         last_perf_capture_on = (2.days + 5.hours + 23.minutes).ago


### PR DESCRIPTION
Joe: This is the work for cap&u batching that has been going on for a while
extracted from #19741

### Summary

For batches, we will queue realtime separate from historical. So these changes makes it easier to deal with one or the other.

### Details

1. Since we only run historical with dates, remove tests that test historical without dates (invalid)
2. For realtime, the default date was what we want. So this logic was moved to capture's fixup route which is called when the entries are pulled off the queue.
3. Move the logic dealing with realtime dates (that limit the start time) to the fixup routine.

@agrare I think we want to revisit the realtime / historical cut offs. A few years ago they got changed to reduce duplicates on the queue. I feel like it should be `4.hours.ago` rather than `4.hours.ago.beginning_of_day`. This PR will allow us to fix this logic more easily if we choose to do that.