### PR TITLE
Add a comment to the snapshot factory

### DIFF
--- a/spec/factories/snapshot.rb
+++ b/spec/factories/snapshot.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
+  # Note that in practice you will need to call EvmSpecHelper.local_miq_server
+  # before attempting to create a snapshot factory. This is so that a valid EMS
+  # and zone exist for the on_create callback in the Snapshot model.
   factory :snapshot do
     vm_or_template { create(:vm_vmware) }
     create_time { 1.minute.ago }


### PR DESCRIPTION
A wafer thin change that simply adds a comment to the snapshot factory explaining that you'll need to call `EvmSpecHelper.local_miq_server` before using it.

Followup to https://github.com/ManageIQ/manageiq/issues/19615