### PR TITLE
Update Gemfile to use secondary source block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,10 @@ raise "Ruby versions >= 2.7.0 are unsupported!" if RUBY_VERSION >= "2.7.0"
 source 'https://rubygems.org'
 
 source 'http://rubygems.manageiq.org' do
-  gem "manageiq-gems-pending", ">0", :require => "manageiq-gems-pending", :branch => "master"
-  gem "handsoap", "=0.2.5.5", :require => false
+  gem "manageiq-gems-pending", ">0",        :require => "manageiq-gems-pending"
+  gem "handsoap",              "=0.2.5.5",  :require => false
+  gem "rugged",                "=0.28.2.2", :require => false
+  gem "ruport",                "=1.7.0.3"
 end
 
 plugin "bundler-inject", "~> 1.1"
@@ -75,8 +77,6 @@ gem "sys-filesystem",                 "~>1.3.1"
 gem "terminal",                                        :require => false
 
 # Modified gems (forked on Github)
-gem "rugged",                         "=0.28.2.2", :source => "http://rubygems.manageiq.org", :require => false
-gem "ruport",                         "=1.7.0.3",  :source => "http://rubygems.manageiq.org"
 
 # In 1.9.3: Time.parse uses british version dd/mm/yyyy instead of american version mm/dd/yyyy
 # american_date fixes this to be compatible with 1.8.7 until all callers can be converted to the 1.9.3 format prior to parsing.

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ source 'http://rubygems.manageiq.org' do
   gem "handsoap",              "=0.2.5.5",  :require => false
   gem "rugged",                "=0.28.2.2", :require => false
   gem "ruport",                "=1.7.0.3"
-  gem "manageiq-gems-pending", ">0",        :require => "manageiq-gems-pending"
-  gem "manageiq-schema"
 end
+
+gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
@@ -20,6 +20,8 @@ def manageiq_plugin(plugin_name)
     gem plugin_name, :git => "https://github.com/ManageIQ/#{plugin_name}", :branch => "master"
   end
 end
+
+manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-virtual_attributes", "~>1.5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,17 +3,13 @@ raise "Ruby versions >= 2.7.0 are unsupported!" if RUBY_VERSION >= "2.7.0"
 
 source 'https://rubygems.org'
 
+source 'http://rubygems.manageiq.org' do
+  gem "manageiq-gems-pending", ">0", :require => "manageiq-gems-pending", :branch => "master"
+  gem "handsoap", "=0.2.5.5", :require => false
+end
+
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
-
-#
-# VMDB specific gems
-#
-
-gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-
-# Modified gems for gems-pending.  Setting sources here since they are git references
-gem "handsoap", "=0.2.5.5", :require => false, :source => "http://rubygems.manageiq.org"
 
 # when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
 def manageiq_plugin(plugin_name)

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,13 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 source 'http://rubygems.manageiq.org' do
-  gem "handsoap",              "=0.2.5.5",  :require => false
-  gem "rugged",                "=0.28.2.2", :require => false
-  gem "ruport",                "=1.7.0.3"
+  gem "handsoap", "=0.2.5.5",  :require => false
+  gem "rugged",   "=0.28.2.2", :require => false
+  gem "ruport",   "=1.7.0.3"
+
+  group :ui_dependencies do
+    gem "jquery-rjs", "=0.1.1.1"
+  end
 end
 
 gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
@@ -210,8 +214,6 @@ end
 group :ui_dependencies do # Added to Bundler.require in config/application.rb
   manageiq_plugin "manageiq-decorators"
   manageiq_plugin "manageiq-ui-classic"
-  # Modified gems (forked on Github)
-  gem "jquery-rjs",                     "=0.1.1.1", :source => "http://rubygems.manageiq.org"
 end
 
 group :v2v, :ui_dependencies do

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,11 @@ raise "Ruby versions >= 2.7.0 are unsupported!" if RUBY_VERSION >= "2.7.0"
 source 'https://rubygems.org'
 
 source 'http://rubygems.manageiq.org' do
-  gem "manageiq-gems-pending", ">0",        :require => "manageiq-gems-pending"
   gem "handsoap",              "=0.2.5.5",  :require => false
   gem "rugged",                "=0.28.2.2", :require => false
   gem "ruport",                "=1.7.0.3"
+  gem "manageiq-gems-pending", ">0",        :require => "manageiq-gems-pending"
+  gem "manageiq-schema"
 end
 
 plugin "bundler-inject", "~> 1.1"
@@ -19,8 +20,6 @@ def manageiq_plugin(plugin_name)
     gem plugin_name, :git => "https://github.com/ManageIQ/#{plugin_name}", :branch => "master"
   end
 end
-
-manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
 gem "activerecord-virtual_attributes", "~>1.5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ raise "Ruby versions >= 2.7.0 are unsupported!" if RUBY_VERSION >= "2.7.0"
 
 source 'https://rubygems.org'
 
+plugin "bundler-inject", "~> 1.1"
+require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
+
 source 'http://rubygems.manageiq.org' do
   gem "handsoap",              "=0.2.5.5",  :require => false
   gem "rugged",                "=0.28.2.2", :require => false
@@ -10,9 +13,6 @@ source 'http://rubygems.manageiq.org' do
 end
 
 gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-
-plugin "bundler-inject", "~> 1.1"
-require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 # when using this Gemfile inside a providers Gemfile, the dependency for the provider is already declared
 def manageiq_plugin(plugin_name)


### PR DESCRIPTION
It seems bundler may be getting more strict about gem sources, as I recently saw this warning:

```
[DEPRECATED] Your Gemfile contains multiple primary sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source. To upgrade this warning to an error, run `bundle config set disable_multisource true`
```
The solution is to use a block form of the `source` argument, and specify which gems are using that source. See https://mensfeld.pl/2015/03/bundler-warning-this-gemfile-contains-multiple-primary-sources, for example.

Draft for now while I try to figure out if provider repos are supposed to be on the secondary source.