### PR TITLE
Productize pods without product name

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -72,7 +72,7 @@ class ContainerOrchestrator
         {:name      => "DATABASE_USER",
          :valueFrom => {:secretKeyRef=>{:name => "postgresql-secrets", :key => "username"}}},
         {:name      => "ENCRYPTION_KEY",
-         :valueFrom => {:secretKeyRef=>{:name => "#{app_name}-secrets", :key => "encryption-key"}}}
+         :valueFrom => {:secretKeyRef=>{:name => "app-secrets", :key => "encryption-key"}}}
       ]
     end
 

--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -14,7 +14,7 @@ class ContainerOrchestrator
           :template => {
             :metadata => {:name => name, :labels => {:name => name, :app => app_name}},
             :spec     => {
-              :serviceAccountName => "miq-anyuid",
+              :serviceAccountName => "#{app_name}-anyuid",
               :containers         => [{
                 :name          => name,
                 :env           => default_environment,
@@ -89,7 +89,7 @@ class ContainerOrchestrator
     end
 
     def app_name
-      Vmdb::Appliance.PRODUCT_NAME.downcase
+      ENV["APP_NAME"]
     end
   end
 end


### PR DESCRIPTION
This PR allows for changing the app name in a pods objects based on an environment variable rather than using the application name from our source.

Requires https://github.com/ManageIQ/manageiq-pods/pull/369