### PR TITLE
Change disk options in oVirts provisioning dialog

### DIFF
--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_clone_to_vm.yaml
@@ -502,14 +502,23 @@
       :fields:
         :disk_format:
           :values:
-            preallocated: Preallocated
-            thin: Thin
-            default: Default
+            cow: qcow2
+            raw: raw
+            default: Same as in template
           :description: Disk Format
-          :required: false
           :display: :edit
           :default: default
           :data_type: :string
+        :disk_sparsity:
+          :values:
+            preallocated: Preallocated
+            thin: Thin
+            default: Same as in template
+          :description: Disk Sparsity
+          :display: :edit
+          :default: default
+          :data_type: :string
+          :validation_method: :validate_disks_configuration
         :number_of_sockets:
           :values:
             1: "1"

--- a/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
+++ b/product/dialogs/miq_dialogs/miq_provision_redhat_dialogs_template.yaml
@@ -523,14 +523,23 @@
       :fields:
         :disk_format:
           :values:
-            preallocated: Preallocated
-            thin: Thin
-            default: Default
+            cow: qcow2
+            raw: raw
+            default: Same as in template
           :description: Disk Format
-          :required: false
           :display: :edit
           :default: default
           :data_type: :string
+        :disk_sparsity:
+          :values:
+            preallocated: Preallocated
+            thin: Thin
+            default: Same as in template
+          :description: Disk Sparsity
+          :display: :edit
+          :default: default
+          :data_type: :string
+          :validation_method: :validate_disks_configuration
         :number_of_sockets:
           :values:
             1: "1"


### PR DESCRIPTION
The user will now be able to select a specific disk format and sparsity
for the disks.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1726590
Required for: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/453
Required for: https://github.com/ManageIQ/manageiq-ui-classic/pull/6692
Related to: https://github.com/ManageIQ/manageiq-schema/pull/459