### PR TITLE
Add zone delegation to ems_folder

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -19,6 +19,7 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :hosts,             :uses => :all_relationships
 
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
+  delegate :my_zone, :to => :ext_management_system
 
   #
   # Relationship methods


### PR DESCRIPTION
In order to test the queue things on the engine I think `ems_folder` needs a zone, @agrare if this is wrong I'm sure you'll let me know. 

Found when looking at https://github.com/ManageIQ/manageiq-automation_engine/pull/419 because we're missing specs for some of the models, like ems_folder, and I don't think the base_queue ops can be set without this.