### PR TITLE
Replace Bundler.environment with Bundler.load.

### DIFF
--- a/lib/terminal_to_html.rb
+++ b/lib/terminal_to_html.rb
@@ -9,7 +9,7 @@ class TerminalToHtml
   end
 
   def self.wrap_html_container(rendered)
-    stylesheet = File.read(File.join(Bundler.environment.specs["terminal"].first.full_gem_path, "/app/assets/stylesheets/terminal.css"))
+    stylesheet = File.read(File.join(Bundler.load.specs["terminal"].first.full_gem_path, "/app/assets/stylesheets/terminal.css"))
     <<~EOHTML
       <div>
       <style scoped>

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -135,7 +135,7 @@ module Vmdb
       # bug where on Ruby 2.5 the full_gem_path is a nonexistent directory for
       # gems that are also default gems.
       # See https://github.com/bundler/bundler/issues/6930.
-      @bundler_specs_by_path ||= Bundler.environment.specs.index_by { |s| File.realpath(s.full_gem_path) rescue nil }.tap { |s| s.delete(nil) }
+      @bundler_specs_by_path ||= Bundler.load.specs.index_by { |s| File.realpath(s.full_gem_path) rescue nil }.tap { |s| s.delete(nil) }
     end
 
     def content_directories(engine, subfolder)

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Vmdb::Plugins do
         expect(source).to receive(:revision).and_return(sha) if type == :git
 
         spec = instance_double(Gem::Specification, :full_gem_path => dir, :source => source)
-        expect(Bundler.environment).to receive(:specs).and_return([spec])
+        expect(Bundler.load).to receive(:specs).and_return([spec])
 
         yield(sha && sha[0, 8])
       end


### PR DESCRIPTION
bundler 2.1.4
OSX (Catalina)

Running the specs locally I starting seeing deprecation notices like this:

`[DEPRECATED] Bundler.environment has been removed in favor of Bundler.load (called at /Users/dberger/Dev/manageiq-djberg96/lib/vmdb/plugins.rb:138)`

This PR just replaces `Bundler.environment` with `Bundler.load`.