### PR TITLE
Turn off gpg signing in git command

### DIFF
--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe Vmdb::Plugins do
         Dir.chdir(dir) do
           `
           git init &&
-          touch foo  && git add -A && git commit -m "Added foo" &&
-          touch foo2 && git add -A && git commit -m "Added foo2"
+          touch foo  && git add -A && git commit -m "Added foo" --no-gpg-sign &&
+          touch foo2 && git add -A && git commit -m "Added foo2" --no-gpg-sign
           `
 
           if options[:branch] == "master"


### PR DESCRIPTION
For those of us who sign our git commits, the current vmdb plugin specs will trigger a gpg signing request if credentials aren't already cached.

This just modifies the git command with `--no-gpg-sign` so that doesn't happen.