### PR TITLE
Add a find interface method to ActsAsArModel

### DIFF
--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -145,6 +145,9 @@ class ActsAsArModel
   #
   # Find routines
   #
+  def self.find(*args)
+    raise NotImplementedError, _("find must be implemented in a subclass")
+  end
 
   # This method is called by QueryRelation upon executing the query.
   #   Since it will receive non-legacy search options, we need to convert

--- a/lib/acts_as_ar_model.rb
+++ b/lib/acts_as_ar_model.rb
@@ -145,7 +145,7 @@ class ActsAsArModel
   #
   # Find routines
   #
-  def self.find(*args)
+  def self.find(*_args)
     raise NotImplementedError, _("find must be implemented in a subclass")
   end
 


### PR DESCRIPTION
Currently the specs for ActsAsArModel will fail with strict partial validation enabled because it does not implement a `find` method:

```
1) ActsAsArModel.count chains through active query
     Failure/Error: expect(base_class).to receive(:find).with(:all, {}).and_return([])
       #<Class:0x000000002616e6c8> does not implement: find
     # ./spec/lib/acts_as_ar_model_spec.rb:85:in `block (3 levels) in <top (required)>'
  2) ActsAsArModel.last chains through active query
     Failure/Error: expect(base_class).to receive(:find).with(:last).and_return(nil)
       #<Class:0x0000000026c4aec0> does not implement: find
     # ./spec/lib/acts_as_ar_model_spec.rb:78:in `block (3 levels) in <top (required)>'
  3) ActsAsArModel.first chains through active query
     Failure/Error: expect(base_class).to receive(:find).with(:first).and_return(nil)
       #<Class:0x000000003371dc38> does not implement: find
     # ./spec/lib/acts_as_ar_model_spec.rb:71:in `block (3 levels) in <top (required)>'
  4) ActsAsArModel.all supports where (as an example)
     Failure/Error: expect(base_class).to receive(:find).with(:all, :conditions => {:id => 5}).and_return([])
       #<Class:0x0000000028efeb10> does not implement: find
     # ./spec/lib/acts_as_ar_model_spec.rb:64:in `block (3 levels) in <top (required)>'
  5) ActsAsArModel.all chains through active query
     Failure/Error: expect(base_class).to receive(:find).with(:all, {}).and_return([])
       #<Class:0x000000003b3c8c88> does not implement: find
     # ./spec/lib/acts_as_ar_model_spec.rb:59:in `block (3 levels) in <top (required)>'
```

As with some other models, this one is currently expecting a subclass to implement a `find` method, but does not implement the method itself. So this adds an interface method that raises a `NotImplementedError`.

Currently this potentially affects the following models/classes:

* `PglogicalSubscription` - already implements a `find` method.
* `LiveMetric` - already implements a `find` method.
* `Chargeback` - does not appear to use a find method internally (it calls `ChargebackRateDetail.find`, but that's it)
* `VimPerformanceTrend` - does not appear to use a find method internally.
*  `ManageIQ::Providers::InfraManager::VmOrTemplate` - does not appear to use a find method internally.
* `ActsAsArScope` - subclass of ActsAsArModel, so implements the same behavior.