### PR TITLE
 Call instance method for vm retire queuing

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -347,6 +347,10 @@ class VmOrTemplate < ApplicationRecord
     MiqQueue.put(command_queue_options(queue_options))
   end
 
+  def make_retire_request(requester_id)
+    self.class.make_retire_request(id, User.find(requester_id))
+  end
+
   # keep the same method signature as others in retirement mixin
   def self.make_retire_request(*src_ids, requester, initiated_by: 'user')
     vms = where(:id => src_ids)


### PR DESCRIPTION
I'm sorry about this change, it's bad, I know it's bad. I don't know what else to do to fix this. 
Because of the fact that the entire retirement mechanism is built around a class method (we can't https://github.com/ManageIQ/manageiq-api/blob/a8d26232f54853206f502889fa871a7c91716637/app/controllers/api/base_controller/action.rb#L16 on `make_retire_request` as it's not on the instance), when we introduced vm retirement queuing we should've also included an instance call to the class method. I checked with Libor, he thinks this is the way to go. 

@miq-bot assign @lpichler  

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1805119

Introduced in https://github.com/ManageIQ/manageiq-api/pull/662

## Related: 
https://github.com/ManageIQ/manageiq-api/pull/743