### PR TITLE
Refactor log_under_management and audit_managed_resources

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -489,7 +489,7 @@ class MiqServer < ApplicationRecord
 
   def self.managed_resources
     {
-      :vms                     => VmOrTemplate.active.count,
+      :vms                     => Vm.active.count,
       :hosts                   => Host.active.count,
       :aggregate_physical_cpus => MiqRegion.my_region.aggregate_physical_cpus(Host.active),
     }
@@ -497,7 +497,7 @@ class MiqServer < ApplicationRecord
 
   def self.unmanaged_resources
     {
-      :vms                     => VmOrTemplate.not_active.count,
+      :vms                     => Vm.not_active.count,
       :hosts                   => Host.archived.count,
       :aggregate_physical_cpus => MiqRegion.my_region.aggregate_physical_cpus(Host.archived),
     }

--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -487,11 +487,24 @@ class MiqServer < ApplicationRecord
     Zone.visible.in_my_region.count > 1
   end
 
-  def self.audit_managed_resources
-    total_vms   = VmOrTemplate.active.count
-    total_hosts = Host.active.count
+  def self.managed_resources
+    {
+      :vms                     => VmOrTemplate.active.count,
+      :hosts                   => Host.active.count,
+      :aggregate_physical_cpus => MiqRegion.my_region.aggregate_physical_cpus(Host.active),
+    }
+  end
 
-    totals = {"vms" => total_vms, "hosts" => total_hosts}
+  def self.unmanaged_resources
+    {
+      :vms                     => VmOrTemplate.not_active.count,
+      :hosts                   => Host.archived.count,
+      :aggregate_physical_cpus => MiqRegion.my_region.aggregate_physical_cpus(Host.archived),
+    }
+  end
+
+  def self.audit_managed_resources
+    totals = managed_resources.slice(:vms, :hosts)
     $audit_log.info("Under Management: #{totals.to_json}")
   end
 

--- a/app/models/miq_server/at_startup.rb
+++ b/app/models/miq_server/at_startup.rb
@@ -50,28 +50,12 @@ module MiqServer::AtStartup
     private
 
     def log_under_management(prefix)
-      total_vms     = 0
-      total_hosts   = 0
-      total_sockets = 0
-
-      ExtManagementSystem.all.each do |e|
-        vms     = e.all_vms_and_templates.count
-        hosts   = e.all_hosts.count
-        sockets = e.aggregate_physical_cpus
-        $log.info("#{prefix}, EMS: [#{e.id}], Name: [#{e.name}], IP Address: [#{e.ipaddress}], Hostname: [#{e.hostname}], VMs: [#{vms}], Hosts: [#{hosts}], Sockets: [#{sockets}]")
-
-        total_vms += vms
-        total_hosts += hosts
-        total_sockets += sockets
-      end
+      total_vms, total_hosts, total_sockets = managed_resources.values_at(:vms, :hosts, :aggregate_physical_cpus)
       $log.info("#{prefix}, Under Management: VMs: [#{total_vms}], Hosts: [#{total_hosts}], Sockets: [#{total_sockets}]")
     end
 
     def log_not_under_management(prefix)
-      hosts_objs = Host.where(:ems_id => nil)
-      hosts      = hosts_objs.count
-      vms        = VmOrTemplate.where(:ems_id => nil).count
-      sockets    = MiqRegion.my_region.aggregate_physical_cpus(hosts_objs)
+      vms, hosts, sockets = unmanaged_resources.values_at(:vms, :hosts, :aggregate_physical_cpus)
       $log.info("#{prefix}, Not Under Management: VMs: [#{vms}], Hosts: [#{hosts}], Sockets: [#{sockets}]")
     end
   end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -188,6 +188,7 @@ class VmOrTemplate < ApplicationRecord
   scope :archived,     ->       { where(:ems_id => nil, :storage_id => nil) }
   scope :orphaned,     ->       { where(:ems_id => nil).where.not(:storage_id => nil) }
   scope :retired,      ->       { where(:retired => true) }
+  scope :not_active,   ->       { where(:ems_id => nil) }
   scope :not_archived, ->       { where.not(:ems_id => nil).or(where.not(:storage_id => nil)) }
   scope :not_orphaned, ->       { where.not(:ems_id => nil).or(where(:storage_id => nil)) }
   scope :not_retired,  ->       { where(:retired => false).or(where(:retired => nil)) }

--- a/spec/models/miq_server/at_startup_spec.rb
+++ b/spec/models/miq_server/at_startup_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe MiqServer, "::AtStartup" do
     end
   end
 
+  it ".log_under_management (private)" do
+    MiqRegion.seed
+    ems = FactoryBot.create(:ems_infra)
+    FactoryBot.create(:host_vmware, :ext_management_system => ems)
+    FactoryBot.create(:vm_vmware, :ext_management_system => ems)
+    expect($log).to receive(:info).with(/VMs: \[1\], Hosts: \[1\]/)
+    described_class.send(:log_under_management, "")
+  end
+
   it ".log_not_under_management (private)" do
     MiqRegion.seed
     FactoryBot.create(:host_vmware)

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -465,7 +465,9 @@ RSpec.describe MiqServer do
     end
   end
 
-  context ".audit_managed_resources" do
+  context ".managed_resources" do
+    before { MiqRegion.seed }
+
     let(:ems) { FactoryBot.create(:ems_infra) }
     let!(:active_vm) { FactoryBot.create(:vm_infra, :ext_management_system => ems) }
     let!(:archived_vm) { FactoryBot.create(:vm_infra) }
@@ -473,10 +475,7 @@ RSpec.describe MiqServer do
     let!(:archived_host) { FactoryBot.create(:host) }
 
     it "with active and archived vms and hosts" do
-      expected_message = "Under Management: #{{"vms" => 1, "hosts" => 1}.to_json}"
-
-      expect($audit_log).to receive(:info).with(expected_message)
-      described_class.audit_managed_resources
+      expect(described_class.managed_resources).to include(:vms => 1, :hosts => 1)
     end
   end
 end


### PR DESCRIPTION
Extract the core managed/unmanaged_resources methods out of the various
log methods (log_under_management, log_not_under_management, and
audit_managed_resources).