### PR TITLE
Delay load manageiq-api-client until needed

### DIFF
--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -1,5 +1,3 @@
-require 'manageiq-api-client'
-
 module InterRegionApiMethodRelay
   class InterRegionApiMethodRelayError < RuntimeError; end
 
@@ -54,6 +52,7 @@ module InterRegionApiMethodRelay
   end
 
   def self.api_client_connection_for_region(region_number, user = User.current_userid)
+    require 'manageiq-api-client'
     region = MiqRegion.find_by(:region => region_number)
 
     url = region.remote_ws_url

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -1,5 +1,3 @@
-require 'manageiq-api-client'
-
 module ProcessTasksMixin
   extend ActiveSupport::Concern
   include RetirementMixin
@@ -128,6 +126,7 @@ module ProcessTasksMixin
     end
 
     def send_action(action, collection_name, collection, remote_options, id = nil)
+      require 'manageiq-api-client'
       post_args = remote_options[:args] || {}
       begin
         if id.present?

--- a/spec/models/mixins/inter_region_api_method_relay_spec.rb
+++ b/spec/models/mixins/inter_region_api_method_relay_spec.rb
@@ -1,3 +1,5 @@
+require 'manageiq-api-client'
+
 RSpec.describe InterRegionApiMethodRelay do
   let(:collection_name) { :test_class_collection }
   let(:api_config)      { double("Api::CollectionConfig") }

--- a/spec/models/mixins/process_tasks_mixin_spec.rb
+++ b/spec/models/mixins/process_tasks_mixin_spec.rb
@@ -1,3 +1,5 @@
+require 'manageiq-api-client'
+
 RSpec.describe ProcessTasksMixin do
   let(:test_class) do
     Class.new(ApplicationRecord) do


### PR DESCRIPTION
We can require this when needed instead of eager loading it when Vm or other
models load it.