### PR TITLE
Add associations for networks and nics on Vms

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -76,6 +76,8 @@ class VmOrTemplate < ApplicationRecord
   has_many                  :users, -> { where(:accttype => 'user') }, :class_name => "Account"
   has_many                  :groups, -> { where(:accttype => 'group') }, :class_name => "Account"
   has_many                  :disks, :through => :hardware
+  has_many                  :networks, :through => :hardware
+  has_many                  :nics, :through => :hardware
   has_many                  :miq_provisions_from_template, :class_name => "MiqProvision", :as => :source, :dependent => :nullify
   has_many                  :miq_provision_vms, :through => :miq_provisions_from_template, :source => :destination, :source_type => "VmOrTemplate"
   has_many                  :miq_provision_requests, :as => :source


### PR DESCRIPTION
There is an association to get disks through hardware which is a nice
convenience to not have to go to the hardware.

This makes it easier to do e.g.:
`GET /api/vms?expand=resources&attributes=name,networks,nics,lans,disks`

in a single API call