### PR TITLE
Load UI dependency gemfile group in MiqWorker

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -49,7 +49,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.bundler_groups
-    %w[manageiq_default]
+    %w[manageiq_default ui_dependencies]
   end
 
   def self.kill_priority


### PR DESCRIPTION
Currently on master we're seeing `uninitialized constant MiqReport::Formatters::Graph::ReportFormatter` because it's trying to use a UI constant before it's loaded.

As per the suggestion from @jrafanie, this adds `ui_dependencies` to the `MiqWorker#bundler_groups`.

Originally brought up here: https://github.com/ManageIQ/manageiq/issues/19674