### PR TITLE
Fix perf_capture_realtime without a start_time

### DIFF
--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -50,7 +50,6 @@ module Metric::CiMixin::Capture
       start_time ||= last_perf_capture_on || 4.hours.ago.utc
     else # interval_name == realtime
       start_time ||= [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].compact.max
-      end
     end
     [start_time, end_time]
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -49,7 +49,8 @@ module Metric::CiMixin::Capture
     elsif interval_name == "hourly"
       start_time ||= last_perf_capture_on || 4.hours.ago.utc
     else # interval_name == realtime
-      start_time ||= [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].max
+      start_time ||= [last_perf_capture_on, 4.hours.ago.utc.beginning_of_day].compact.max
+      end
     end
     [start_time, end_time]
   end


### PR DESCRIPTION
A number of specs test perf_capture_realtime without a start time and
without a last_perf_capture_on.  This leads to a comparison of nil and
Time failure.