### PR TITLE
Set the default signal to 'TERM' in ConversionHost#kill_virtv2v

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -283,7 +283,7 @@ class ConversionHost < ApplicationRecord
   # Kill a specific remote process over ssh, sending the specified +signal+, or 'TERM'
   # if no signal is specified.
   #
-  def kill_virtv2v(task_id, signal)
+  def kill_virtv2v(task_id, signal = 'TERM')
     command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :s, signal, "virt-v2v"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -270,7 +270,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
   end
 
-  def kill_virtv2v
+  def kill_virtv2v(signal = 'TERM')
     get_conversion_state
 
     unless virtv2v_running?
@@ -279,7 +279,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
 
     _log.info("Killing conversion pod for task '#{id}'.")
-    conversion_host.kill_virtv2v(id)
+    conversion_host.kill_virtv2v(id, signal)
   end
 
   def virtv2v_running?

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -232,13 +232,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       end
 
       it "returns false if if kill command failed" do
-        allow(conversion_host).to receive(:kill_virtv2v).with(task.id).and_return(false)
-        expect(task.kill_virtv2v).to eq(false)
+        allow(conversion_host).to receive(:kill_virtv2v).with(task.id, 'KILL').and_return(false)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
       end
 
       it "returns true if if kill command succeeded" do
-        allow(conversion_host).to receive(:kill_virtv2v).with(task.id).and_return(true)
-        expect(task.kill_virtv2v).to eq(true)
+        allow(conversion_host).to receive(:kill_virtv2v).with(task.id, 'KILL').and_return(true)
+        expect(task.kill_virtv2v('KILL')).to eq(true)
       end
     end
   end


### PR DESCRIPTION
At some point we added a second argument to `ConversionHost#kill_virtv2v`, but then forgot to update the call to it at https://github.com/ManageIQ/manageiq/blob/master/app/models/service_template_transformation_plan_task.rb#L282.

But, rather than updating all the other model(s) that may be calling it, just set a default `signal` value. It's what the comments already suggested the default was.

Update: turns out we needed to add an argument to the `ServiceTemplateTransformationPlanTask#kill_virt2v2` method as well since `InfraConversionJob#abort_virtv2v` calls it with one.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1806718