### PR TITLE
Make systemd the default for worker management

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1094,7 +1094,7 @@
       :poll_method: :normal
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
-      :systemd_enabled: false
+      :systemd_enabled: true
     :agent_coordinator_worker:
       :heartbeat_timeout: 30.minutes
       :poll: 30.seconds


### PR DESCRIPTION
Using Systemd for worker management has been an option for a number of
months, now we are going to make it the default so that we can continue
to stabalize it and find bugs.