### PR TITLE
Add an `InfraManager#host_virtual_lans` collection

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -39,10 +39,13 @@ class Host < ApplicationRecord
   has_many                  :storages, :through => :host_storages
   has_many                  :writable_accessible_host_storages, -> { writable_accessible }, :class_name => "HostStorage"
   has_many                  :writable_accessible_storages, :through => :writable_accessible_host_storages, :source => :storage
+
   has_many                  :host_virtual_switches, :class_name => "Switch", :dependent => :destroy, :inverse_of => :host
   has_many                  :host_switches, :dependent => :destroy
   has_many                  :switches, :through => :host_switches
   has_many                  :lans,     :through => :switches
+  has_many                  :host_virtual_lans, :through => :host_virtual_switches, :source => :lans
+
   has_many                  :subnets,  :through => :lans
   has_many                  :networks, :through => :hardware
   has_many                  :patches, :dependent => :destroy

--- a/app/models/manageiq/providers/infra_manager.rb
+++ b/app/models/manageiq/providers/infra_manager.rb
@@ -17,6 +17,7 @@ module ManageIQ::Providers
     has_many :distributed_virtual_switches, :dependent => :destroy, :foreign_key => :ems_id, :inverse_of => :ext_management_system
     has_many :distributed_virtual_lans, -> { distinct }, :through => :distributed_virtual_switches, :source => :lans
     has_many :host_virtual_switches, -> { distinct }, :through => :hosts
+    has_many :host_virtual_lans, -> { distinct }, :through => :hosts
 
     has_many :host_hardwares,             :through => :hosts, :source => :hardware
     has_many :host_operating_systems,     :through => :hosts, :source => :operating_system

--- a/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/infra_manager.rb
@@ -200,8 +200,17 @@ module ManageIQ::Providers
 
         def distributed_virtual_lans
           add_properties(
+            :model_class                  => Lan,
             :manager_ref                  => %i(switch uid_ems),
             :parent_inventory_collections => %i(distributed_virtual_switches),
+          )
+        end
+
+        def host_virtual_lans
+          add_properties(
+            :model_class                  => Lan,
+            :manager_ref                  => %i[switch uid_ems],
+            :parent_inventory_collections => %i[hosts]
           )
         end
 


### PR DESCRIPTION
Add a collection of host_virtual_lans through hosts at the infra_manager level.  This allows us to do targeted refreshes of hosts and switches without too much caching.

E.g.:
Full refresh: `ems.host_virtual_lans` goes through all `ems.hosts` and `ems.distributed_virtual_lans` goes through all `ems.distributed_virtual_switches`
Targeted host refresh: `host.host_virtual_lans` doesn't delete any unrelated distributed virtual lans
Targeted swich refresh: `dvs.distributed_virtual_lans` doesn't delete any unrelated host virtual lans.