### PR TITLE
[V2V] Use two-phase migration only for warm migration

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -345,7 +345,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :query    => { :no_verify => 1 }.to_query
       ).to_s,
       :vmware_password      => source.host.authentication_password,
-      :two_phase            => true,
+      :two_phase            => warm_migration?,
       :warm                 => warm_migration?,
       :daemonize            => false
     }


### PR DESCRIPTION
Two-phase migration changes the migration flow in virt-v2v-wrapper: the disks are created by virt-v2v-wrapper and attached to the conversion host. Then, the conversion phase writes to _local disks_ instead of using RHV upload API. This converges the processes for RHV and OpenStack, and can involve performance increase.

However, currently virt-v2v-wrapper only allows two-phase for warm migration, so we need to limit it. In a previous PR, we anticipated too much to availability for cold migration, so we introduced a regression with current version of virt-v2v-wrapper (2.0.x). This PR ties two-phase and warm migration.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1807770