### PR TITLE
[V2V] Add VMware host credentials check to migration preflight check

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -71,7 +71,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     destination_cluster
     virtv2v_disks
     network_mappings
-    raise "Invalid authentication for '#{source.host.name}'" unless source.host.authentication_status_ok?
+
+    host = source.host
+    raise "No credentials configured for '#{host.name}'" if host.missing_credentials?
+    raise "Invalid authentication for '#{host.name}': #{host.default_authentication.status_details}" unless host.authentication_status_ok?
 
     { :status => 'Ok', :message => 'Preflight check is successful' }
   rescue StandardError => error

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -71,6 +71,15 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     destination_cluster
     virtv2v_disks
     network_mappings
+
+    begin
+      raise unless source.host.verify_credentials?
+    rescue => err
+      msg = "Invalid credentials for '#{source.host.name}'"
+      msg += ": #{err.message}" unless err.message.empty?
+      raise msg
+    end
+
     { :status => 'Ok', :message => 'Preflight check is successful' }
   rescue StandardError => error
     { :status => 'Error', :message => error.message }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -71,14 +71,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     destination_cluster
     virtv2v_disks
     network_mappings
-
-    begin
-      raise unless source.host.verify_credentials?
-    rescue => err
-      msg = "Invalid credentials for '#{source.host.name}'"
-      msg += ": #{err.message}" unless err.message.empty?
-      raise msg
-    end
+    raise "Invalid authentication for '#{source.host.name}'" unless source.host.authentication_status_ok?
 
     { :status => 'Ok', :message => 'Preflight check is successful' }
   rescue StandardError => error

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -556,7 +556,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           end
         end
 
-        context "#prelight_check" do 
+        context "#prelight_check" do
           it "passes preflight check regardless of power_state" do
             allow(src_host).to receive(:verify_credentials?).and_return(true)
             src_vm_1.send(:power_state=, 'anything')

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -558,14 +558,14 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         context "#prelight_check" do
           it "passes preflight check regardless of power_state" do
-            allow(src_host).to receive(:verify_credentials?).and_return(true)
+            allow(src_host).to receive(:authentication_status_ok?).and_return(true)
             src_vm_1.send(:power_state=, 'anything')
             expect(task_1.preflight_check).to eq(:status => 'Ok', :message => 'Preflight check is successful')
           end
 
           it "fails preflight check if we can't verify host credentials" do
-            allow(src_host).to receive(:verify_credentials?).and_return(false)
-            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "Invalid credentials for '#{src_host.name}'")
+            allow(src_host).to receive(:authentication_status_ok?).and_return(false)
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "Invalid authentication for '#{src_host.name}'")
           end
         end
 
@@ -680,14 +680,14 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         context "preflight_check" do
           it "fails preflight check if src is power off" do
-            allow(src_host).to receive(:verify_credentials?).and_return(true)
+            allow(src_host).to receive(:authentication_status_ok?).and_return(true)
             src_vm_1.send(:power_state=, 'off')
             expect(task_1.preflight_check).to eq(:status => 'Error', :message => 'OSP destination and source power_state is off')
           end
 
           it "fails preflight check if we can't verify host credentials" do
-            allow(src_host).to receive(:verify_credentials?).and_raise("fake error")
-            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "Invalid credentials for '#{src_host.name}': fake error")
+            allow(src_host).to receive(:authentication_status_ok?).and_return(false)
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "Invalid authentication for '#{src_host.name}'")
           end
         end
 


### PR DESCRIPTION
It appears that despite the documentation, many users forget to configure the credentials for the VMware hosts before running migrations. This leads to a failure at the virt-v2v level, which is after the execution of the pre-migration playbook and the VM shutdown.

The goal of this pull request is to make the migration fail as early as possible to limit the impact of missing credentials on the source VM. It also allows for a better error message in the UI.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1719266