### PR TITLE
Move DialogFieldVisibilityService and friends back to core

### DIFF
--- a/lib/services/auto_placement_visibility_service.rb
+++ b/lib/services/auto_placement_visibility_service.rb
@@ -1,0 +1,26 @@
+class AutoPlacementVisibilityService
+  def determine_visibility(auto_placement_enabled)
+    field_names_to_hide = []
+    field_names_to_edit = []
+
+    auto_placement_values = %i[
+      placement_host_name
+      placement_ds_name
+      host_filter
+      ds_filter
+      cluster_filter
+      placement_cluster_name
+      rp_filter
+      placement_rp_name
+      placement_dc_name
+    ]
+
+    if auto_placement_enabled
+      field_names_to_hide += auto_placement_values
+    else
+      field_names_to_edit += auto_placement_values
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+end

--- a/lib/services/customize_fields_visibility_service.rb
+++ b/lib/services/customize_fields_visibility_service.rb
@@ -1,0 +1,60 @@
+class CustomizeFieldsVisibilityService
+  def determine_visibility(platform, supports_customization_template, customize_fields_list)
+    field_names_to_edit = []
+    field_names_to_hide = []
+
+    if supports_customization_template
+      field_names_to_edit += %i[
+        addr_mode
+        customization_template_id
+        customization_template_script
+        dns_servers
+        dns_suffixes
+        gateway
+        hostname
+        ip_addr
+        root_password
+        subnet_mask
+        sysprep_admin_password
+        sysprep_computer_name
+        sysprep_domain_name
+        sysprep_domain_password
+        sysprep_locale_input
+        sysprep_locale_system
+        sysprep_locale_ui
+        sysprep_locale_user
+        sysprep_machine_object_ou
+        sysprep_product_key
+        sysprep_timezone
+        sysprep_domain_admin
+      ]
+    else
+      exclude_list = %i[
+        sysprep_spec_override
+        sysprep_custom_spec
+        sysprep_enabled
+        sysprep_upload_file
+        sysprep_upload_text
+        linux_host_name
+        ip_addr
+        subnet_mask
+        gateway
+        dns_servers
+        dns_suffixes
+      ]
+
+      customize_fields_list.each do |field_name|
+        next if exclude_list.include?(field_name)
+        next unless platform == "linux"
+
+        if field_name == :linux_domain_name
+          field_names_to_edit << field_name
+        else
+          field_names_to_hide << field_name
+        end
+      end
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+end

--- a/lib/services/dialog_field_visibility_service.rb
+++ b/lib/services/dialog_field_visibility_service.rb
@@ -1,0 +1,105 @@
+class DialogFieldVisibilityService
+  attr_accessor :auto_placement_visibility_service
+  attr_accessor :number_of_vms_visibility_service
+  attr_accessor :service_template_fields_visibility_service
+  attr_accessor :network_visibility_service
+  attr_accessor :sysprep_auto_logon_visibility_service
+  attr_accessor :retirement_visibility_service
+  attr_accessor :customize_fields_visibility_service
+  attr_accessor :sysprep_custom_spec_visibility_service
+  attr_accessor :request_type_visibility_service
+  attr_accessor :pxe_iso_visibility_service
+  attr_accessor :linked_clone_visibility_service
+
+  def initialize(
+    auto_placement_visibility_service = AutoPlacementVisibilityService.new,
+    number_of_vms_visibility_service = NumberOfVmsVisibilityService.new,
+    service_template_fields_visibility_service = ServiceTemplateFieldsVisibilityService.new,
+    network_visibility_service = NetworkVisibilityService.new,
+    sysprep_auto_logon_visibility_service = SysprepAutoLogonVisibilityService.new,
+    retirement_visibility_service = RetirementVisibilityService.new,
+    customize_fields_visibility_service = CustomizeFieldsVisibilityService.new,
+    sysprep_custom_spec_visibility_service = SysprepCustomSpecVisibilityService.new,
+    request_type_visibility_service = RequestTypeVisibilityService.new,
+    pxe_iso_visibility_service = PxeIsoVisibilityService.new,
+    linked_clone_visibility_service = LinkedCloneVisibilityService.new
+  )
+    @auto_placement_visibility_service = auto_placement_visibility_service
+    @number_of_vms_visibility_service = number_of_vms_visibility_service
+    @service_template_fields_visibility_service = service_template_fields_visibility_service
+    @network_visibility_service = network_visibility_service
+    @sysprep_auto_logon_visibility_service = sysprep_auto_logon_visibility_service
+    @retirement_visibility_service = retirement_visibility_service
+    @customize_fields_visibility_service = customize_fields_visibility_service
+    @sysprep_custom_spec_visibility_service = sysprep_custom_spec_visibility_service
+    @request_type_visibility_service = request_type_visibility_service
+    @pxe_iso_visibility_service = pxe_iso_visibility_service
+    @linked_clone_visibility_service = linked_clone_visibility_service
+  end
+
+  def set_visibility_for_field(visibility_hash, field_name, field)
+    status = field[:display]
+    status = :show if visibility_hash[:show].include?(field_name)
+    status = :edit if visibility_hash[:edit].include?(field_name)
+    status = :hide if visibility_hash[:hide].include?(field_name)
+
+    field[:display] = field[:display_override].presence || status || :edit
+  end
+
+  def determine_visibility(options)
+    @field_names_to_hide = []
+    @field_names_to_edit = []
+    @field_names_to_show = []
+
+    add_to_visibility_arrays(service_template_fields_visibility_service, options[:service_template_request])
+    add_to_visibility_arrays(auto_placement_visibility_service, options[:auto_placement_enabled])
+    add_to_visibility_arrays(number_of_vms_visibility_service, options[:number_of_vms], options[:platform])
+
+    add_to_visibility_arrays(
+      network_visibility_service,
+      options[:sysprep_enabled],
+      options[:supports_pxe],
+      options[:supports_iso],
+      options[:addr_mode]
+    )
+
+    add_to_visibility_arrays(sysprep_auto_logon_visibility_service, options[:sysprep_auto_logon])
+    add_to_visibility_arrays(retirement_visibility_service, options[:retirement])
+
+    add_to_visibility_arrays(
+      customize_fields_visibility_service,
+      options[:platform],
+      options[:supports_customization_template],
+      options[:customize_fields_list]
+    )
+
+    add_to_visibility_arrays(sysprep_custom_spec_visibility_service, options[:sysprep_custom_spec])
+    add_to_visibility_arrays(request_type_visibility_service, options[:request_type])
+    add_to_visibility_arrays(pxe_iso_visibility_service, options[:supports_iso], options[:supports_pxe])
+    add_to_visibility_arrays(
+      linked_clone_visibility_service,
+      options[:provision_type],
+      options[:linked_clone],
+      options[:snapshot_count]
+    )
+
+    @field_names_to_hide -= @field_names_to_hide & @field_names_to_edit
+    @field_names_to_hide.uniq!
+    @field_names_to_edit.uniq!
+
+    {
+      :hide => @field_names_to_hide.flatten,
+      :edit => @field_names_to_edit.flatten,
+      :show => @field_names_to_show.flatten
+    }
+  end
+
+  private
+
+  def add_to_visibility_arrays(visibility_service, *options)
+    visibility_hash = visibility_service.determine_visibility(*options)
+    @field_names_to_hide += visibility_hash[:hide]
+    @field_names_to_edit += visibility_hash[:edit] if visibility_hash[:edit]
+    @field_names_to_show += visibility_hash[:show] if visibility_hash[:show]
+  end
+end

--- a/lib/services/linked_clone_visibility_service.rb
+++ b/lib/services/linked_clone_visibility_service.rb
@@ -1,0 +1,25 @@
+class LinkedCloneVisibilityService
+  def determine_visibility(provision_type, linked_clone, snapshot_count)
+    field_names_to_show = []
+    field_names_to_edit = []
+    field_names_to_hide = []
+
+    if provision_type.to_s == 'vmware'
+      if snapshot_count.positive?
+        field_names_to_edit += [:linked_clone]
+      else
+        field_names_to_show += [:linked_clone]
+      end
+
+      if linked_clone == true
+        field_names_to_edit += [:snapshot]
+      else
+        field_names_to_hide += [:snapshot]
+      end
+    else
+      field_names_to_hide += %i[linked_clone snapshot]
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit, :show => field_names_to_show}
+  end
+end

--- a/lib/services/network_visibility_service.rb
+++ b/lib/services/network_visibility_service.rb
@@ -1,0 +1,30 @@
+class NetworkVisibilityService
+  def determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)
+    field_names_to_hide = []
+    field_names_to_edit = []
+
+    if show_dns_settings?(sysprep_enabled, supports_pxe, supports_iso)
+      field_names_to_edit += %i[addr_mode dns_suffixes dns_servers]
+
+      if show_ip_settings?(addr_mode, supports_pxe, supports_iso)
+        field_names_to_edit += %i[ip_addr subnet_mask gateway]
+      else
+        field_names_to_hide += %i[ip_addr subnet_mask gateway]
+      end
+    else
+      field_names_to_hide += %i[addr_mode ip_addr subnet_mask gateway dns_servers dns_suffixes]
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+
+  private
+
+  def show_dns_settings?(sysprep_enabled, supports_pxe, supports_iso)
+    sysprep_enabled.in?(%w[fields file]) || supports_pxe || supports_iso
+  end
+
+  def show_ip_settings?(addr_mode, supports_pxe, supports_iso)
+    addr_mode == "static" || supports_pxe || supports_iso
+  end
+end

--- a/lib/services/number_of_vms_visibility_service.rb
+++ b/lib/services/number_of_vms_visibility_service.rb
@@ -1,0 +1,24 @@
+class NumberOfVmsVisibilityService
+  def determine_visibility(number_of_vms, platform)
+    field_names_to_hide = []
+    field_names_to_edit = []
+
+    if number_of_vms > 1
+      field_names_to_hide += %i[sysprep_computer_name linux_host_name floating_ip_address]
+      field_names_to_edit += [:ip_addr]
+    else
+      field_names_to_hide += [:ip_addr]
+      field_names_to_edit += [:floating_ip_address]
+
+      if platform == "linux"
+        field_names_to_edit += [:linux_host_name]
+        field_names_to_hide += [:sysprep_computer_name]
+      else
+        field_names_to_edit += [:sysprep_computer_name]
+        field_names_to_hide += [:linux_host_name]
+      end
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+end

--- a/lib/services/pxe_iso_visibility_service.rb
+++ b/lib/services/pxe_iso_visibility_service.rb
@@ -1,0 +1,20 @@
+class PxeIsoVisibilityService
+  def determine_visibility(supports_iso, supports_pxe)
+    field_names_to_edit = []
+    field_names_to_hide = []
+
+    if supports_pxe
+      field_names_to_edit += %i[pxe_image_id pxe_server_id]
+    else
+      field_names_to_hide += %i[pxe_image_id pxe_server_id]
+    end
+
+    if supports_iso
+      field_names_to_edit += [:iso_image_id]
+    else
+      field_names_to_hide += [:iso_image_id]
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+end

--- a/lib/services/request_type_visibility_service.rb
+++ b/lib/services/request_type_visibility_service.rb
@@ -1,0 +1,14 @@
+class RequestTypeVisibilityService
+  def determine_visibility(request_type)
+    field_names_to_hide = []
+
+    if %i[clone_to_vm clone_to_template].include?(request_type)
+      field_names_to_hide += [:vm_filter]
+      if request_type == :clone_to_template
+        field_names_to_hide += [:vm_auto_start]
+      end
+    end
+
+    {:hide => field_names_to_hide}
+  end
+end

--- a/lib/services/retirement_visibility_service.rb
+++ b/lib/services/retirement_visibility_service.rb
@@ -1,0 +1,14 @@
+class RetirementVisibilityService
+  def determine_visibility(retirement)
+    fields_to_edit = []
+    fields_to_hide = []
+
+    if retirement.positive?
+      fields_to_edit += [:retirement_warn]
+    else
+      fields_to_hide += [:retirement_warn]
+    end
+
+    {:hide => fields_to_hide, :edit => fields_to_edit}
+  end
+end

--- a/lib/services/service_template_fields_visibility_service.rb
+++ b/lib/services/service_template_fields_visibility_service.rb
@@ -1,0 +1,10 @@
+class ServiceTemplateFieldsVisibilityService
+  def determine_visibility(service_template_request)
+    field_names_to_hide = []
+    if service_template_request
+      field_names_to_hide += %i[vm_description schedule_type schedule_time]
+    end
+
+    {:hide => field_names_to_hide}
+  end
+end

--- a/lib/services/sysprep_auto_logon_visibility_service.rb
+++ b/lib/services/sysprep_auto_logon_visibility_service.rb
@@ -1,0 +1,14 @@
+class SysprepAutoLogonVisibilityService
+  def determine_visibility(sysprep_auto_logon)
+    field_names_to_hide = []
+    field_names_to_edit = []
+
+    if sysprep_auto_logon == false
+      field_names_to_hide += [:sysprep_auto_logon_count]
+    else
+      field_names_to_edit += [:sysprep_auto_logon_count]
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+end

--- a/lib/services/sysprep_custom_spec_visibility_service.rb
+++ b/lib/services/sysprep_custom_spec_visibility_service.rb
@@ -1,0 +1,14 @@
+class SysprepCustomSpecVisibilityService
+  def determine_visibility(sysprep_custom_spec)
+    field_names_to_hide = []
+    field_names_to_edit = []
+
+    if sysprep_custom_spec
+      field_names_to_edit += [:sysprep_spec_override]
+    else
+      field_names_to_hide += [:sysprep_spec_override]
+    end
+
+    {:hide => field_names_to_hide, :edit => field_names_to_edit}
+  end
+end

--- a/spec/lib/services/auto_placement_visibility_service_spec.rb
+++ b/spec/lib/services/auto_placement_visibility_service_spec.rb
@@ -1,0 +1,47 @@
+describe AutoPlacementVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when auto placement is enabled" do
+      let(:auto_placement) { true }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(auto_placement)).to eq(
+          :hide => %i(
+            placement_host_name
+            placement_ds_name
+            host_filter
+            ds_filter
+            cluster_filter
+            placement_cluster_name
+            rp_filter
+            placement_rp_name
+            placement_dc_name
+          ),
+          :edit => []
+        )
+      end
+    end
+
+    context "when auto placement is not enabled" do
+      let(:auto_placement) { false }
+
+      it "adds values to the field names to edit" do
+        expect(subject.determine_visibility(auto_placement)).to eq(
+          :hide => [],
+          :edit => %i(
+            placement_host_name
+            placement_ds_name
+            host_filter
+            ds_filter
+            cluster_filter
+            placement_cluster_name
+            rp_filter
+            placement_rp_name
+            placement_dc_name
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/services/customize_fields_visibility_service_spec.rb
+++ b/spec/lib/services/customize_fields_visibility_service_spec.rb
@@ -1,0 +1,102 @@
+describe CustomizeFieldsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the customization template is supported" do
+      let(:supports_customization_template) { true }
+      let(:platform) { "potato" }
+      let(:customize_fields_list) { "potato" }
+
+      it "returns a list of pxe customization fields to edit" do
+        expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq(
+          :hide => [],
+          :edit => %i(
+            addr_mode
+            customization_template_id
+            customization_template_script
+            dns_servers
+            dns_suffixes
+            gateway
+            hostname
+            ip_addr
+            root_password
+            subnet_mask
+            sysprep_admin_password
+            sysprep_computer_name
+            sysprep_domain_name
+            sysprep_domain_password
+            sysprep_locale_input
+            sysprep_locale_system
+            sysprep_locale_ui
+            sysprep_locale_user
+            sysprep_machine_object_ou
+            sysprep_product_key
+            sysprep_timezone
+            sysprep_domain_admin
+          )
+        )
+      end
+    end
+
+    context "when the customization template is not supported" do
+      let(:supports_customization_template) { false }
+
+      context "when the customize_fields_list contains only items from exclude list" do
+        let(:customize_fields_list) do
+          %i(
+            sysprep_spec_override
+            sysprep_custom_spec
+            sysprep_enabled
+            sysprep_upload_file
+            sysprep_upload_text
+            linux_host_name
+            ip_addr
+            subnet_mask
+            gateway
+            dns_servers
+            dns_suffixes
+          )
+        end
+        let(:platform) { "linux" }
+
+        it "returns an empty hide/edit hash" do
+          expect(subject.determine_visibility(platform, supports_customization_template, customize_fields_list)).to eq(
+            :hide => [], :edit => []
+          )
+        end
+      end
+
+      context "when the customize_fields_list contains linux_domain_name" do
+        let(:customize_fields_list) { %i(linux_domain_name potato) }
+
+        context "when the platform is linux" do
+          let(:platform) { "linux" }
+
+          it "returns the correct list of things to edit/hide" do
+            expect(subject.determine_visibility(
+                     platform,
+                     supports_customization_template,
+                     customize_fields_list
+            )).to eq(
+              :hide => [:potato], :edit => [:linux_domain_name]
+            )
+          end
+        end
+
+        context "when the platform is not linux" do
+          let(:platform) { "potato" }
+
+          it "returns an empty hide/edit hash" do
+            expect(subject.determine_visibility(
+                     platform,
+                     supports_customization_template,
+                     customize_fields_list
+            )).to eq(
+              :hide => [], :edit => []
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/services/dialog_field_visibility_service_spec.rb
+++ b/spec/lib/services/dialog_field_visibility_service_spec.rb
@@ -1,0 +1,317 @@
+describe DialogFieldVisibilityService do
+  let(:subject) { described_class.new }
+
+  context "accessors" do
+    it "defines an auto_placement_visibility_service accessor" do
+      expect(subject).to respond_to(:auto_placement_visibility_service)
+      expect(subject).to respond_to(:auto_placement_visibility_service=)
+    end
+
+    it "defines an number_of_vms_visibility_service accessor" do
+      expect(subject).to respond_to(:number_of_vms_visibility_service)
+      expect(subject).to respond_to(:number_of_vms_visibility_service=)
+    end
+
+    it "defines an service_template_fields_visibility_service accessor" do
+      expect(subject).to respond_to(:service_template_fields_visibility_service)
+      expect(subject).to respond_to(:service_template_fields_visibility_service=)
+    end
+
+    it "defines an network_visibility_service accessor" do
+      expect(subject).to respond_to(:network_visibility_service)
+      expect(subject).to respond_to(:network_visibility_service=)
+    end
+
+    it "defines an sysprep_auto_logon_visibility_service accessor" do
+      expect(subject).to respond_to(:sysprep_auto_logon_visibility_service)
+      expect(subject).to respond_to(:sysprep_auto_logon_visibility_service=)
+    end
+
+    it "defines an retirement_visibility_service accessor" do
+      expect(subject).to respond_to(:retirement_visibility_service)
+      expect(subject).to respond_to(:retirement_visibility_service=)
+    end
+
+    it "defines an customize_fields_visibility_service accessor" do
+      expect(subject).to respond_to(:customize_fields_visibility_service)
+      expect(subject).to respond_to(:customize_fields_visibility_service=)
+    end
+
+    it "defines an sysprep_custom_spec_visibility_service accessor" do
+      expect(subject).to respond_to(:sysprep_custom_spec_visibility_service)
+      expect(subject).to respond_to(:sysprep_custom_spec_visibility_service=)
+    end
+
+    it "defines an request_type_visibility_service accessor" do
+      expect(subject).to respond_to(:request_type_visibility_service)
+      expect(subject).to respond_to(:request_type_visibility_service=)
+    end
+
+    it "defines an pxe_iso_visibility_service accessor" do
+      expect(subject).to respond_to(:pxe_iso_visibility_service)
+      expect(subject).to respond_to(:pxe_iso_visibility_service=)
+    end
+
+    it "defines an linked_clone_visibility_service accessor" do
+      expect(subject).to respond_to(:linked_clone_visibility_service)
+      expect(subject).to respond_to(:linked_clone_visibility_service=)
+    end
+  end
+
+  describe "#determine_visibility" do
+    let(:subject) do
+      described_class.new(
+        auto_placement_visibility_service,
+        number_of_vms_visibility_service,
+        service_template_fields_visibility_service,
+        network_visibility_service,
+        sysprep_auto_logon_visibility_service,
+        retirement_visibility_service,
+        customize_fields_visibility_service,
+        sysprep_custom_spec_visibility_service,
+        request_type_visibility_service,
+        pxe_iso_visibility_service,
+        linked_clone_visibility_service
+      )
+    end
+
+    let(:options) do
+      {
+        :addr_mode                       => addr_mode,
+        :auto_placement_enabled          => auto_placement_enabled,
+        :customize_fields_list           => customize_fields_list,
+        :linked_clone                    => linked_clone,
+        :number_of_vms                   => number_of_vms,
+        :platform                        => platform,
+        :provision_type                  => provision_type,
+        :request_type                    => request_type,
+        :retirement                      => retirement,
+        :service_template_request        => service_template_request,
+        :snapshot_count                  => snapshot_count,
+        :supports_customization_template => supports_customization_template,
+        :supports_iso                    => supports_iso,
+        :supports_pxe                    => supports_pxe,
+        :sysprep_auto_logon              => sysprep_auto_logon,
+        :sysprep_custom_spec             => sysprep_custom_spec,
+        :sysprep_enabled                 => sysprep_enabled
+      }
+    end
+
+    let(:service_template_fields_visibility_service) { double("ServiceTemplateFieldsVisibilityService") }
+    let(:service_template_request) { "service_template_request" }
+
+    let(:auto_placement_visibility_service) { double("AutoPlacementVisibilityService") }
+    let(:auto_placement_enabled) { "auto_placement_enabled" }
+
+    let(:number_of_vms_visibility_service) { double("NumberOfVmsVisibilityService") }
+    let(:number_of_vms) { "number_of_vms" }
+    let(:platform) { "platform" }
+
+    let(:network_visibility_service) { double("NetworkVisibilityService") }
+    let(:sysprep_enabled) { "sysprep_enabled" }
+    let(:supports_pxe) { "supports_pxe" }
+    let(:supports_iso) { "supports_iso" }
+    let(:addr_mode) { "addr_mode" }
+
+    let(:sysprep_auto_logon_visibility_service) { double("SysprepAutoLogonVisibilityService") }
+    let(:sysprep_auto_logon) { "sysprep_auto_logon" }
+
+    let(:retirement_visibility_service) { double("RetirementVisibilityService") }
+    let(:retirement) { "retirement" }
+
+    let(:customize_fields_visibility_service) { double("CustomizeFieldsVisibilityService") }
+    let(:supports_customization_template) { "supports_customization_template" }
+    let(:customize_fields_list) { "customize_fields_list" }
+
+    let(:sysprep_custom_spec_visibility_service) { double("SysprepCustomSpecVisibilityService") }
+    let(:sysprep_custom_spec) { "sysprep_custom_spec" }
+
+    let(:request_type_visibility_service) { double("RequestTypeVisibilityService") }
+    let(:request_type) { "request_type" }
+
+    let(:pxe_iso_visibility_service) { double("PxeIsoVisibilityService") }
+
+    let(:linked_clone_visibility_service) { double("LinkedCloneVisibilityService") }
+    let(:provision_type) { "provision_type" }
+    let(:linked_clone) { "linked_clone" }
+    let(:snapshot_count) { "snapshot_count" }
+
+    before do
+      allow(service_template_fields_visibility_service)
+        .to receive(:determine_visibility).with(service_template_request).and_return(
+          :hide => [:service_template_request_hide]
+        )
+
+      allow(auto_placement_visibility_service)
+        .to receive(:determine_visibility).with(auto_placement_enabled).and_return(
+          :hide => [:auto_hide], :edit => [:auto_edit]
+        )
+
+      allow(number_of_vms_visibility_service)
+        .to receive(:determine_visibility).with(number_of_vms, platform).and_return(
+          :hide => [:number_hide], :edit => [:number_edit]
+        )
+
+      allow(network_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_enabled, supports_pxe, supports_iso, addr_mode).and_return(
+          :hide => [:network_hide], :edit => [:network_edit]
+        )
+
+      allow(sysprep_auto_logon_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_auto_logon).and_return(
+          :hide => [:sysprep_auto_logon_hide], :edit => [:sysprep_auto_logon_edit]
+        )
+
+      allow(retirement_visibility_service)
+        .to receive(:determine_visibility).with(retirement).and_return(
+          :hide => [:retirement_hide], :edit => [:retirement_edit]
+        )
+
+      allow(customize_fields_visibility_service)
+        .to receive(:determine_visibility).with(
+          platform, supports_customization_template, customize_fields_list
+        ).and_return(
+          :hide => %i(customize_fields_hide number_hide), # Forces uniq
+          :edit => %i(customize_fields_edit number_edit retirement_hide) # Forces uniq and removal of intersection
+        )
+
+      allow(sysprep_custom_spec_visibility_service)
+        .to receive(:determine_visibility).with(sysprep_custom_spec).and_return(
+          :hide => [:sysprep_custom_spec_hide],
+          :edit => [:sysprep_custom_spec_edit]
+        )
+
+      allow(request_type_visibility_service)
+        .to receive(:determine_visibility).with(request_type).and_return(:hide => [:request_type_hide])
+
+      allow(pxe_iso_visibility_service)
+        .to receive(:determine_visibility).with(supports_iso, supports_pxe).and_return(
+          :hide => [:pxe_iso_hide],
+          :edit => [:pxe_iso_edit]
+        )
+
+      allow(linked_clone_visibility_service)
+        .to receive(:determine_visibility).with(provision_type, linked_clone, snapshot_count).and_return(
+          :hide => [:linked_clone_hide],
+          :edit => [:linked_clone_edit],
+          :show => [:linked_clone_show]
+        )
+    end
+
+    it "adds the values to the field names to hide, edit, and show without duplicates or intersections" do
+      result = subject.determine_visibility(options)
+      expect(result[:hide]).to match_array(%i(
+                                             auto_hide
+                                             customize_fields_hide
+                                             linked_clone_hide
+                                             network_hide
+                                             number_hide
+                                             pxe_iso_hide
+                                             request_type_hide
+                                             service_template_request_hide
+                                             sysprep_auto_logon_hide
+                                             sysprep_custom_spec_hide
+                                           ))
+      expect(result[:edit]).to match_array(%i(
+                                             auto_edit
+                                             customize_fields_edit
+                                             linked_clone_edit
+                                             network_edit
+                                             number_edit
+                                             pxe_iso_edit
+                                             retirement_hide
+                                             retirement_edit
+                                             sysprep_auto_logon_edit
+                                             sysprep_custom_spec_edit
+                                           ))
+      expect(result[:show]).to match_array([:linked_clone_show])
+    end
+  end
+
+  describe "#set_visibility_for_field" do
+    let(:field) { {:display_override => display_override} }
+    let(:visibility_hash) { {:edit => "edit_me", :hide => "hide_me", :show => "show_me"} }
+
+    before do
+      subject.set_visibility_for_field(visibility_hash, field_name, field)
+    end
+
+    shared_examples_for "#set_visibility_for_field with a display override" do
+      context "when the field has a display override" do
+        let(:display_override) { :potato }
+
+        it "sets the display value to the override" do
+          expect(field[:display]).to eq(:potato)
+        end
+      end
+    end
+
+    context "when the field name is contained in the field names to edit" do
+      let(:field_name) { "edit_me" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the display value to edit" do
+          expect(field[:display]).to eq(:edit)
+        end
+      end
+    end
+
+    context "when the field name is contained in the field names to hide" do
+      let(:field_name) { "hide_me" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the display value to hide" do
+          expect(field[:display]).to eq(:hide)
+        end
+      end
+    end
+
+    context "when the field name is contained in the field names to show" do
+      let(:field_name) { "show_me" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        it "sets the display value to show" do
+          expect(field[:display]).to eq(:show)
+        end
+      end
+    end
+
+    context "when the field name is not contained in either the field names to edit or hide or show" do
+      let(:field_name) { "potato" }
+
+      it_behaves_like "#set_visibility_for_field with a display override"
+
+      context "when the field display override is blank" do
+        let(:display_override) { "" }
+
+        context "when the field does not have a display value" do
+          let(:display) { nil }
+
+          it "sets the display value to edit" do
+            expect(field[:display]).to eq(:edit)
+          end
+        end
+
+        context "when the field does have a display value" do
+          let(:field) { {:display_override => display_override, :display => :hide} }
+
+          it "uses the given display value" do
+            expect(field[:display]).to eq(:hide)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/services/linked_clone_visibility_service_spec.rb
+++ b/spec/lib/services/linked_clone_visibility_service_spec.rb
@@ -1,0 +1,64 @@
+describe LinkedCloneVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when provision type is vmware" do
+      let(:provision_type) { "vmware" }
+
+      context "when there are snapshots to show" do
+        let(:snapshot_count) { 1 }
+
+        context "when linked clone is true" do
+          let(:linked_clone) { true }
+
+          it "adds values to the field names to edit" do
+            expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+              :hide => [],
+              :edit => %i(linked_clone snapshot),
+              :show => []
+            )
+          end
+        end
+
+        context "when linked clone is not true" do
+          let(:linked_clone) { false }
+
+          it "adds values to the field names to hide" do
+            expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+              :hide => [:snapshot],
+              :edit => [:linked_clone],
+              :show => []
+            )
+          end
+        end
+      end
+
+      context "when there are no snapshots to show" do
+        let(:snapshot_count) { 0 }
+        let(:linked_clone) { "potato" }
+
+        it "adds values to the field names to hide and show" do
+          expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+            :hide => [:snapshot],
+            :edit => [],
+            :show => [:linked_clone]
+          )
+        end
+      end
+    end
+
+    context "when provision type is not vmware" do
+      let(:provision_type) { nil }
+      let(:linked_clone) { nil }
+      let(:snapshot_count) { "potato" }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(provision_type, linked_clone, snapshot_count)).to eq(
+          :hide => %i(linked_clone snapshot),
+          :edit => [],
+          :show => []
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/services/network_visibility_service_spec.rb
+++ b/spec/lib/services/network_visibility_service_spec.rb
@@ -1,0 +1,130 @@
+describe NetworkVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    let(:supports_pxe) { nil }
+    let(:supports_iso) { nil }
+    let(:addr_mode) { nil }
+
+    shared_examples_for "NetworkVisibilityService#determine_visibility that shows everything" do
+      it "adds the network values to the edit values" do
+        expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
+          :hide => [],
+          :edit => %i(addr_mode dns_suffixes dns_servers ip_addr subnet_mask gateway)
+        )
+      end
+    end
+
+    shared_examples_for "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'" do
+      context "when addr_mode is static" do
+        let(:addr_mode) { "static" }
+
+        it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+      end
+
+      context "when addr_mode is not static" do
+        let(:addr_mode) { "not static" }
+
+        context "when supports_pxe is true" do
+          let(:supports_pxe) { true }
+
+          it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+        end
+
+        context "when supports_pxe is false" do
+          let(:supports_pxe) { false }
+
+          context "when supports_iso is true" do
+            let(:supports_iso) { true }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when supports_iso is false" do
+            let(:supports_iso) { false }
+
+            it "adds the correct values to the edit and hide values" do
+              expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
+                :hide => %i(ip_addr subnet_mask gateway),
+                :edit => %i(addr_mode dns_suffixes dns_servers)
+              )
+            end
+          end
+        end
+      end
+    end
+
+    context "when sysprep_enabled is 'fields'" do
+      let(:sysprep_enabled) { "fields" }
+
+      it_behaves_like "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'"
+    end
+
+    context "when sysprep_enabled is 'file'" do
+      let(:sysprep_enabled) { "file" }
+
+      it_behaves_like "NetworkVisibilityService#determine_visibility sysprep_enabled is 'fields' or 'file'"
+    end
+
+    context "when sysprep_enabled is something else" do
+      let(:sysprep_enabled) { "potato" }
+
+      context "when supports_pxe is true" do
+        let(:supports_pxe) { true }
+
+        context "when addr_mode is static" do
+          let(:addr_mode) { "static" }
+
+          it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+        end
+
+        context "when addr_mode is not static" do
+          let(:addr_mode) { "not static" }
+
+          context "when supports_iso is true" do
+            let(:supports_iso) { true }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when supports_iso is false" do
+            let(:supports_iso) { false }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+        end
+      end
+
+      context "when supports_pxe is false" do
+        let(:supports_pxe) { false }
+
+        context "when supports_iso is true" do
+          let(:supports_iso) { true }
+
+          context "when addr_mode is static" do
+            let(:addr_mode) { "static" }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+
+          context "when addr_mode is not static" do
+            let(:addr_mode) { "not static" }
+
+            it_behaves_like "NetworkVisibilityService#determine_visibility that shows everything"
+          end
+        end
+
+        context "when supports_iso is false" do
+          let(:supports_iso) { false }
+
+          it "adds the correct values to the hide values" do
+            expect(subject.determine_visibility(sysprep_enabled, supports_pxe, supports_iso, addr_mode)).to eq(
+              :hide => %i(addr_mode ip_addr subnet_mask gateway dns_servers dns_suffixes),
+              :edit => []
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/services/number_of_vms_visibility_service_spec.rb
+++ b/spec/lib/services/number_of_vms_visibility_service_spec.rb
@@ -1,0 +1,57 @@
+describe NumberOfVmsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the number of vms is greater than 1" do
+      let(:number_of_vms) { 2 }
+
+      context "when the platform is linux" do
+        let(:platform) { "linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => %i(sysprep_computer_name linux_host_name floating_ip_address),
+            :edit => [:ip_addr]
+          )
+        end
+      end
+
+      context "when the platform is not linux" do
+        let(:platform) { "not linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => %i(sysprep_computer_name linux_host_name floating_ip_address),
+            :edit => [:ip_addr]
+          )
+        end
+      end
+    end
+
+    context "when the number of vms is not greater than 1" do
+      let(:number_of_vms) { 1 }
+
+      context "when the platform is linux" do
+        let(:platform) { "linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => %i(ip_addr sysprep_computer_name),
+            :edit => %i(floating_ip_address linux_host_name)
+          )
+        end
+      end
+
+      context "when the platform is not linux" do
+        let(:platform) { "not linux" }
+
+        it "adds values to field names to hide and edit" do
+          expect(subject.determine_visibility(number_of_vms, platform)).to eq(
+            :hide => %i(ip_addr linux_host_name),
+            :edit => %i(floating_ip_address sysprep_computer_name)
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/services/pxe_iso_visibility_service_spec.rb
+++ b/spec/lib/services/pxe_iso_visibility_service_spec.rb
@@ -1,0 +1,57 @@
+describe PxeIsoVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when pxe is supported" do
+      let(:supports_pxe) { true }
+
+      context "when iso is supported" do
+        let(:supports_iso) { true }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => [],
+            :edit => %i(pxe_image_id pxe_server_id iso_image_id)
+          )
+        end
+      end
+
+      context "when iso is not supported" do
+        let(:supports_iso) { false }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => [:iso_image_id],
+            :edit => %i(pxe_image_id pxe_server_id)
+          )
+        end
+      end
+    end
+
+    context "when pxe is not supported" do
+      let(:supports_pxe) { false }
+
+      context "when iso is supported" do
+        let(:supports_iso) { true }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => %i(pxe_image_id pxe_server_id),
+            :edit => [:iso_image_id]
+          )
+        end
+      end
+
+      context "when iso is not supported" do
+        let(:supports_iso) { false }
+
+        it "returns the values to be edit and hidden" do
+          expect(subject.determine_visibility(supports_iso, supports_pxe)).to eq(
+            :hide => %i(pxe_image_id pxe_server_id iso_image_id),
+            :edit => []
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/services/request_type_visibility_service_spec.rb
+++ b/spec/lib/services/request_type_visibility_service_spec.rb
@@ -1,0 +1,29 @@
+describe RequestTypeVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when the request type is 'clone_to_template'" do
+      let(:request_type) { :clone_to_template }
+
+      it "returns the values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq(:hide => %i(vm_filter vm_auto_start))
+      end
+    end
+
+    context "when the request type is 'clone_to_vm'" do
+      let(:request_type) { :clone_to_vm }
+
+      it "returns the values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [:vm_filter])
+      end
+    end
+
+    context "when the request type is anything else" do
+      let(:request_type) { :potato }
+
+      it "returns an empty list of values to be hidden" do
+        expect(subject.determine_visibility(request_type)).to eq(:hide => [])
+      end
+    end
+  end
+end

--- a/spec/lib/services/retirement_visibility_service_spec.rb
+++ b/spec/lib/services/retirement_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe RetirementVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when retirement to_i is greater than 0" do
+      let(:retirement) { 123 }
+
+      it "adds the retirement warn to the edit fields" do
+        expect(subject.determine_visibility(retirement)).to eq(
+          :hide => [],
+          :edit => [:retirement_warn]
+        )
+      end
+    end
+
+    context "when retirement to_i is not greater than 0" do
+      let(:retirement) { 0 }
+
+      it "adds the retirement warn to the hide fields" do
+        expect(subject.determine_visibility(retirement)).to eq(
+          :hide => [:retirement_warn],
+          :edit => []
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/services/service_template_fields_visibility_service_spec.rb
+++ b/spec/lib/services/service_template_fields_visibility_service_spec.rb
@@ -1,0 +1,25 @@
+describe ServiceTemplateFieldsVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when service_template_request exists" do
+      let(:service_template_request) { "a service template request" }
+
+      it "adds values to field names to hide" do
+        expect(subject.determine_visibility(service_template_request)).to eq(
+          :hide => %i(vm_description schedule_type schedule_time)
+        )
+      end
+    end
+
+    context "when service_template_request does not exist" do
+      let(:service_template_request) { nil }
+
+      it "returns an empty hide/show hash" do
+        expect(subject.determine_visibility(service_template_request)).to eq(
+          :hide => []
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/services/sysprep_auto_logon_visibility_service_spec.rb
+++ b/spec/lib/services/sysprep_auto_logon_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe SysprepAutoLogonVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when sysprep_auto_logon is false" do
+      let(:sysprep_auto_logon) { false }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
+          :hide => [:sysprep_auto_logon_count],
+          :edit => []
+        )
+      end
+    end
+
+    context "when sysprep auto logon is true" do
+      let(:sysprep_auto_logon) { true }
+
+      it "adds values to the field names to edit" do
+        expect(subject.determine_visibility(sysprep_auto_logon)).to eq(
+          :hide => [],
+          :edit => [:sysprep_auto_logon_count]
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/services/sysprep_custom_spec_visibility_service_spec.rb
+++ b/spec/lib/services/sysprep_custom_spec_visibility_service_spec.rb
@@ -1,0 +1,27 @@
+describe SysprepCustomSpecVisibilityService do
+  let(:subject) { described_class.new }
+
+  describe "#determine_visibility" do
+    context "when sysprep custom spec is not blank" do
+      let(:sysprep_custom_spec) { "foo" }
+
+      it "adds values to the field names to edit" do
+        expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
+          :hide => [],
+          :edit => [:sysprep_spec_override]
+        )
+      end
+    end
+
+    context "when sysprep custom spec is blank" do
+      let(:sysprep_custom_spec) { nil }
+
+      it "adds values to the field names to hide" do
+        expect(subject.determine_visibility(sysprep_custom_spec)).to eq(
+          :hide => [:sysprep_spec_override],
+          :edit => []
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Transferred from ManageIQ/manageiq-ui-classic@2845683da3c8652c9376e3f4591cb00c949ca8d7

- [ ] Must be merged with [manageiq-ui-classic PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/6720)
- [x] [Cross repo tests](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/77)

They're referenced from MiqProvisionVirtWorkflow and the latter cannot be run
without manageiq-ui-classic.  Moving it back to core allows the model/backend
code to run without manageiq-ui-classic, while still letting ui-classic autoload
the right module/class.  Note, visibility logic probably shouldn't live in core
but the MiqProvisionVirtWorkflow would need to be able to load these
VisibilityServices somehow, so core is the only place for now.

For #19863