### PR TITLE
MiqRegion#migrations_ran column is no longer necessary

### DIFF
--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -111,16 +111,10 @@ class MiqRegion < ApplicationRecord
     my_region_id = my_region_number
     db_region_id = MiqDatabase.first.try(:region_id)
     if db_region_id && db_region_id != my_region_id
-      raise Exception,
-            _("Region [%{region_id}] does not match the database's region [%{db_id}]") % {:region_id => my_region_id,
-                                                                                          :db_id     => db_region_id}
+      raise Exception, _("Region [%{region_id}] does not match the database's region [%{db_id}]") % {:region_id => my_region_id, :db_id => db_region_id}
     end
-    create_params = {
-      :description    => "Region #{my_region_id}",
-      :migrations_ran => ActiveRecord::SchemaMigration.normalized_versions
-    }
 
-    create_with(create_params).find_or_create_by!(:region => my_region_id) do
+    create_with(:description => "Region #{my_region_id}").find_or_create_by!(:region => my_region_id) do
       _log.info("Creating Region [#{my_region_id}]")
     end
   end

--- a/spec/models/miq_region_spec.rb
+++ b/spec/models/miq_region_spec.rb
@@ -67,10 +67,6 @@ RSpec.describe MiqRegion do
       allow(MiqRegion).to receive_messages(:my_region_number => @region_number + 1)
       expect { MiqRegion.seed }.to raise_error(Exception)
     end
-
-    it "sets the migrations_ran column" do
-      expect(MiqRegion.first.migrations_ran).to match_array(ActiveRecord::SchemaMigration.normalized_versions)
-    end
   end
 
   describe ".replication_type" do


### PR DESCRIPTION
We now track this in the schema_migrations_ran table

Followup to https://github.com/ManageIQ/manageiq/pull/18393