### PR TITLE
[GitWorktree] Add instructions for ssh support

### DIFF
--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -25,6 +25,19 @@ class GitWorktree
     @remote_name = 'origin'
     @base_name   = File.basename(@path)
 
+    # The libssh2 library must already be installed at gem installation time
+    # for the 'ssh' feature to be available.
+    #
+    # For Fedora/Centos, the presence of libssh2 seems to be enough to get it
+    # to build properly.
+    #
+    # For OSX:
+    #
+    #     $ brew install libssh2
+    #     $ gem uninstall rugged  # if required
+    #     $ export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig"
+    #     $ bin/bundle
+    #
     if @ssh_private_key && !Rugged.features.include?(:ssh)
       raise GitWorktreeException::InvalidCredentialType, "ssh credentials are not enabled for use. Recompile the rugged/libgit2 gem with ssh support to enable it."
     end


### PR DESCRIPTION
Ran into this error:

```
ssh credentials are not enabled for use. Recompile the rugged/libgit2 gem with ssh support to enable it. (GitWorktreeException::InvalidCredentialType)
```

And had to do some digging to determine how to proceed.  This PR puts the instructions somewhere where it is hard to miss.

These instructions where ripped from this PR comment:

https://github.com/ManageIQ/manageiq/pull/19108/commits/51faaf44f0ca1206f3e2ccdbbff546e99098929f#r311280903


Links
-----

* https://github.com/ManageIQ/manageiq/pull/19108