### PR TITLE
[V2V] Filter out jobs.migration_task.conversion_host.nil? in InfraConversionThrottler.running_conversions

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -217,8 +217,12 @@ class InfraConversionJob < Job
     state_hash
   end
 
+  def task_progress
+    migration_task.options[:progress] || {:current_state => state, :status => "ok", :percent => 0.0, :states => {}}
+  end
+
   def update_migration_task_progress(state_phase, state_progress = nil)
-    progress = migration_task.options[:progress] || {:current_state => state, :status => "ok", :percent => 0.0, :states => {}}
+    progress = task_progress
     state_hash = send(state_phase, progress[:states][state.to_sym], state_progress)
     progress[:states][state.to_sym] = state_hash
     if state_phase == :on_entry
@@ -243,7 +247,7 @@ class InfraConversionJob < Job
 
   def abort_conversion(message, status)
     migration_task.canceling
-    progress = migration_task.options[:progress]
+    progress = task_progress
     progress[:current_description] = "Migration failed: #{message}. Cancelling"
     progress[:status] = "error"
     migration_task.update_options(:progress => progress)

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -62,7 +62,7 @@ class InfraConversionThrottler
 
   # @return [Hash] the list of jobs in state 'running', grouped by conversion host
   def self.running_conversion_jobs
-    running = InfraConversionJob.where.not(:state => ['waiting_to_start', 'finished'])
+    running = InfraConversionJob.where.not(:state => ['waiting_to_start', 'finished']).reject { |job| job.migration_task&.conversion_host.nil? }
     _log.info("Running InfraConversionJob: #{running.count}")
     running.group_by { |job| job.migration_task.conversion_host }
   end

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -62,7 +62,7 @@ class InfraConversionThrottler
 
   # @return [Hash] the list of jobs in state 'running', grouped by conversion host
   def self.running_conversion_jobs
-    running = InfraConversionJob.where.not(:state => ['waiting_to_start', 'finished']).reject { |job| job.migration_task&.conversion_host.nil? }
+    running = InfraConversionJob.where.not(:state => ['waiting_to_start', 'finished'])
     _log.info("Running InfraConversionJob: #{running.count}")
     running.group_by { |job| job.migration_task.conversion_host }
   end
@@ -80,6 +80,8 @@ class InfraConversionThrottler
   # Applying the limits is done via the conversion_host which handles the writing.
   def self.apply_limits
     running_conversion_jobs.each do |ch, jobs|
+      next if ch.nil?
+
       number_of_jobs = jobs.size
 
       cpu_limit = ch.cpu_limit || Settings.transformation.limits.cpu_limit_per_host

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -81,7 +81,7 @@ class InfraConversionThrottler
   def self.apply_limits
     running_conversion_jobs.each do |ch, jobs|
       if ch.nil?
-        bad_tasks = jobs.collect { |j| j.migration_task.source.name }.join(', ')
+        bad_tasks = jobs.map { |j| j.migration_task&.source&.name }.compact.join(', ')
         _log.error("The following migrating VMs don't have a conversion host: #{bad_tasks}.")
         next
       end

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -81,7 +81,8 @@ class InfraConversionThrottler
   def self.apply_limits
     running_conversion_jobs.each do |ch, jobs|
       if ch.nil?
-        _log.error("Migration task for '#{migration_task.source.name}' is running but has no conversion host")
+        bad_tasks = jobs.collect { |j| j.migration_task.source.name }.join(', ')
+        _log.error("The following migrating VMs don't have a conversion host: #{bad_tasks}.")
         next
       end
 

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -80,7 +80,10 @@ class InfraConversionThrottler
   # Applying the limits is done via the conversion_host which handles the writing.
   def self.apply_limits
     running_conversion_jobs.each do |ch, jobs|
-      next if ch.nil?
+      if ch.nil?
+        _log.error("Migration task for '#{migration_task.source.name}' is running but has no conversion host")
+        next
+      end
 
       number_of_jobs = jobs.size
 

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
       }
       task_running_1.update_options(
         :virtv2v_started_on => Time.now.utc,
-        :virtv2v_wrapper => {'state_file' => "/var/lib/uci/#{task_running_1.id}/state.json"}
+        :virtv2v_wrapper    => {'state_file' => "/var/lib/uci/#{task_running_1.id}/state.json"}
       )
       task_running_2.options[:virtv2v_started_on] = Time.now.utc
       task_running_2.options[:virtv2v_wrapper] = {'state_file' => "/var/lib/uci/#{task_running_2.id}/state.json"}


### PR DESCRIPTION
From field feedback, it seems that it can happen that a migration task which is running doesn't have a conversion host (mostly because it has been deleted). The consequence is that the InfraConversionThrottler cannot enforce the limits, as an exception is raised when trying to connect to a nullified conversion host. The symptoms are this kind of log message:

```
[----] I, [2020-02-26T03:06:07.440488 #4518:2b12ad6985bc]  INFO -- : Q-task_id([job_dispatcher]) Exception in realtime_block :total_time - Timings: {:v2v_dispatching=>0.0015590190887451172, :v2v_limits=>0.019486188888549805, :total_time=>0.02106475830078125}
[----] E, [2020-02-26T03:06:07.444027 #4518:2b12ad6985bc] ERROR -- : Q-task_id([job_dispatcher]) MIQ(MiqQueue#deliver) Message id: [1000000918612], Error: [undefined method `cpu_limit' for nil:NilClass]
[----] E, [2020-02-26T03:06:07.444194 #4518:2b12ad6985bc] ERROR -- : Q-task_id([job_dispatcher]) [NoMethodError]: undefined method `cpu_limit' for nil:NilClass  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2020-02-26T03:06:07.444247 #4518:2b12ad6985bc] ERROR -- : Q-task_id([job_dispatcher]) /var/www/miq/vmdb/lib/infra_conversion_throttler.rb:83:in `block in apply_limits'
/var/www/miq/vmdb/lib/infra_conversion_throttler.rb:80:in `each'
/var/www/miq/vmdb/lib/infra_conversion_throttler.rb:80:in `apply_limits'
/var/www/miq/vmdb/app/models/job_proxy_dispatcher.rb:108:in `apply_v2v_limits'
```

This pull request rejects the running jobs that have a migration task without a conversion host from the list of running jobs. It also logs an error message.