### PR TITLE
[V2V] Fix UCI name building method

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -233,7 +233,7 @@ class ConversionHost < ApplicationRecord
   def build_podman_command(task_id, conversion_options)
     uci_settings = Settings.transformation.uci.container
     uci_image = uci_settings.image
-    uci_image = "#{uci_settings.registry}/#{image}" if uci_settings.registry.present?
+    uci_image = "#{uci_settings.registry}/#{uci_image}" if uci_settings.registry.present?
 
     params = [
       "run",


### PR DESCRIPTION
When registry in defined in CloudForms settings, the code that build the container image path for UCI fails due to an invalid variable name. This pull request fixes the variable name.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1808360