### PR TITLE
The api calls exec_api_call directly from Api::Mixins::CentralAdmin

### DIFF
--- a/app/models/mixins/inter_region_api_method_relay.rb
+++ b/app/models/mixins/inter_region_api_method_relay.rb
@@ -69,6 +69,7 @@ module InterRegionApiMethodRelay
   end
 
   def self.exec_api_call(region, collection_name, action, api_args = nil, id = nil)
+    require 'manageiq-api-client'
     api_args ||= {}
     collection = api_client_connection_for_region(region).public_send(collection_name)
     collection_or_instance = id ? collection.find(id) : collection


### PR DESCRIPTION
Fixes broken master on ManageIQ/api

Cross-repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/79