### PR TITLE
[V2V] Allow job to continue if kill_virtv2v raises an execption

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -629,7 +629,7 @@ class InfraConversionJob < Job
     end
 
     migration_task.kill_virtv2v('TERM') if context["retries_#{state}".to_sym] == 1
-    queue_signal(:abort_virtv2v)
+    queue_signal(:abort_virtv2v, :deliver_on => Time.now.utc + state_retry_interval)
   end
 
   def poll_automate_state_machine

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -280,6 +280,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
     _log.info("Killing conversion pod for task '#{id}'.")
     conversion_host.kill_virtv2v(id, signal)
+  rescue => err
+    _log.error("Couldn't kill conversion pod for task '#{id}': #{err.message}")
+    update_options(:virtv2v_finished_on => Time.now.utc.strftime('%Y-%m-%d %H:%M:%S'))
+    false
   end
 
   def virtv2v_running?

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1628,15 +1628,19 @@ RSpec.describe InfraConversionJob, :v2v do
       end
 
       it 'sends TERM signal and retries to virt-v2v when entering state for the first time' do
-        expect(job.migration_task).to receive(:kill_virtv2v).with('TERM')
-        expect(job).to receive(:queue_signal).with(:abort_virtv2v)
-        job.abort_virtv2v
+        Timecop.freeze(2019, 2, 6) do
+          expect(job.migration_task).to receive(:kill_virtv2v).with('TERM')
+          expect(job).to receive(:queue_signal).with(:abort_virtv2v, :deliver_on => Time.now.utc + job.state_retry_interval)
+          job.abort_virtv2v
+        end
       end
 
       it 'retries if not entering the state for the first time' do
-        job.context[:retries_aborting_virtv2v] = 1
-        expect(job).to receive(:queue_signal).with(:abort_virtv2v)
-        job.abort_virtv2v
+        Timecop.freeze(2019, 2, 6) do
+          job.context[:retries_aborting_virtv2v] = 1
+          expect(job).to receive(:queue_signal).with(:abort_virtv2v, :deliver_on => Time.now.utc + job.state_retry_interval)
+          job.abort_virtv2v
+        end
       end
     end
   end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -240,6 +240,14 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         allow(conversion_host).to receive(:kill_virtv2v).with(task.id, 'KILL').and_return(true)
         expect(task.kill_virtv2v('KILL')).to eq(true)
       end
+
+      it "considers virt-v2v finished or returns false if an exception occurs" do
+        Timecop.freeze(2019, 2, 6) do
+          allow(task).to receive(:get_conversion_state).and_raise('fake error')
+          expect(task.kill_virtv2v('TERM')).to eq(false)
+          expect(task.options[:virtv2v_finished_on]).to eq(Time.now.utc.strftime('%Y-%m-%d %H:%M:%S'))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently, if virt-v2v-wrapper fails before creating its state file, CloudForms will be stuck trying to read the file. More precisely, the `get_conversion_state` method of `ServiceTemplateTransformationPlanTask` will raise an exception when called from `kill_virtv2v`. This will make the `abort_virtv2v` method of `InfraConversionJob` fail and it will never hand over to Automate. So the task will never finish, as well as its parent request.

This pull request catches exceptions in `kill_virtv2v` and make it forcefully mark virt-v2v as finished and return false. This way, `abort_virtv2v` will exit normally and InfraConversionJob will continue the cancellation process.

We also noticed that `abort_virtv2v` didn't use the retry interval when queuing a retry, making it retry to eagerly. The pull request also adds the `deliver_on` argument to `queue_signal(:abort_virtv2v)`.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1809035
