### PR TITLE
[V2V] Preflight check: verify if a VM with same name already exists in destination

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -69,6 +69,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       :source_vm_ipaddresses => source.ipaddresses  # This will determine if we need to wait for ip addresses to appear
     )
     destination_cluster
+    preflight_check_vm_exists_in_destination
     virtv2v_disks
     network_mappings
 
@@ -79,6 +80,20 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     { :status => 'Ok', :message => 'Preflight check is successful' }
   rescue StandardError => error
     { :status => 'Error', :message => error.message }
+  end
+
+  def preflight_check_vm_exists_in_destination
+    send("preflight_check_vm_exists_in_destination_#{destination_ems.emstype}")
+  end
+
+  def preflight_check_vm_exists_in_destination_rhevm
+    vms = Vm.where(:name => source.name, :ems_cluster => destination_cluster)
+    raise "A VM named '#{source.name}' already exist in destination provider" unless vms.empty?
+  end
+
+  def preflight_check_vm_exists_in_destination_openstack
+    vms = Vm.where(:name => source.name, :cloud_tenant_id => destination_cluster.id)
+    raise "A VM named '#{source.name}' already exist in destination provider" unless vms.empty?
   end
 
   def source_cluster

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -87,13 +87,15 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   end
 
   def preflight_check_vm_exists_in_destination_rhevm
-    vms = Vm.where(:name => source.name, :ems_cluster => destination_cluster)
-    raise "A VM named '#{source.name}' already exist in destination provider" unless vms.empty?
+    unless destination_ems.vms_and_templates.where(:name => source.name, :ems_cluster => destination_cluster).count.zero?
+      raise "A VM named '#{source.name}' already exist in destination cluster"
+    end
   end
 
   def preflight_check_vm_exists_in_destination_openstack
-    vms = Vm.where(:name => source.name, :cloud_tenant_id => destination_cluster.id)
-    raise "A VM named '#{source.name}' already exist in destination provider" unless vms.empty?
+    unless destination_ems.vms_and_templates.where(:name => source.name, :cloud_tenant => destination_cluster).count.zero?
+      raise "A VM named '#{source.name}' already exist in destination cloud tenant"
+    end
   end
 
   def source_cluster

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -574,7 +574,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           end
 
           it "fails if a VM already exists in destination" do
-            existing_vm = FactoryBot.create(:vm_redhat, :name => src_vm_1.name, :ext_management_system => redhat_ems, :ems_cluster => redhat_cluster)
+            FactoryBot.create(:vm_redhat, :name => src_vm_1.name, :ext_management_system => redhat_ems, :ems_cluster => redhat_cluster)
             expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination provider")
           end
 
@@ -707,7 +707,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           end
 
           it "fails if a VM already exists in destination" do
-            existing_vm = FactoryBot.create(:vm_openstack, :name => src_vm_1.name, :ext_management_system => openstack_ems, :cloud_tenant => openstack_cloud_tenant)
+            FactoryBot.create(:vm_openstack, :name => src_vm_1.name, :ext_management_system => openstack_ems, :cloud_tenant => openstack_cloud_tenant)
             expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination provider")
           end
 

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -708,7 +708,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "fails if a VM already exists in destination" do
             FactoryBot.create(:vm_openstack, :name => src_vm_1.name, :ext_management_system => openstack_ems, :cloud_tenant => openstack_cloud_tenant)
-            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination cloud_tenant")
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination cloud tenant")
           end
 
           it "fails preflight check if host has no credentials" do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -573,6 +573,11 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             expect(task_1.preflight_check).to eq(:status => 'Ok', :message => 'Preflight check is successful')
           end
 
+          it "fails if a VM already exists in destination" do
+            existing_vm = FactoryBot.create(:vm_redhat, :name => src_vm_1.name, :ext_management_system => redhat_ems, :ems_cluster => redhat_cluster)
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination provider")
+          end
+
           it "fails preflight check if host has no credentials" do
             expect(task_1.preflight_check).to eq(:status => 'Error', :message => "No credentials configured for '#{src_host.name}'")
           end
@@ -699,6 +704,11 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             allow(src_host).to receive(:authentication_status_ok?).and_return(true)
             src_vm_1.send(:power_state=, 'off')
             expect(task_1.preflight_check).to eq(:status => 'Error', :message => 'OSP destination and source power_state is off')
+          end
+
+          it "fails if a VM already exists in destination" do
+            existing_vm = FactoryBot.create(:vm_openstack, :name => src_vm_1.name, :ext_management_system => openstack_ems, :cloud_tenant => openstack_cloud_tenant)
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination provider")
           end
 
           it "fails preflight check if host has no credentials" do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -575,7 +575,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "fails if a VM already exists in destination" do
             FactoryBot.create(:vm_redhat, :name => src_vm_1.name, :ext_management_system => redhat_ems, :ems_cluster => redhat_cluster)
-            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination provider")
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination cluster")
           end
 
           it "fails preflight check if host has no credentials" do
@@ -708,7 +708,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "fails if a VM already exists in destination" do
             FactoryBot.create(:vm_openstack, :name => src_vm_1.name, :ext_management_system => openstack_ems, :cloud_tenant => openstack_cloud_tenant)
-            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination provider")
+            expect(task_1.preflight_check).to eq(:status => 'Error', :message => "A VM named '#{src_vm_1.name}' already exist in destination cloud_tenant")
           end
 
           it "fails preflight check if host has no credentials" do


### PR DESCRIPTION
One failure condition for migration is that a virtual machine with the same name already exists in the destination provider. This would cause virt-v2v to fail and is already checked by virt-v2v-wrapper, that exits in error. The problem is that when we call virt-v2v-wrapper, we have already altered the source VM (pre-migration playbook and shutdown) when we could check this condition in ManageIQ.

This pull request adds a check on the existence of a VM with the same name in the destination cluster or cloud tenant. If it already exists, the preflight check fails and the migration job doesn't even start.

Depends on https://github.com/ManageIQ/manageiq/pull/19914
RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1809027