### PR TITLE
Add CloudTenant relationship in VM class

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/cloud_manager/vm.rb
@@ -2,7 +2,6 @@ class ManageIQ::Providers::CloudManager::Vm < ::Vm
   belongs_to :availability_zone
   belongs_to :flavor
   belongs_to :orchestration_stack
-  belongs_to :cloud_tenant
 
   has_many :network_ports, :as => :device
   has_many :cloud_subnets, -> { distinct }, :through => :network_ports

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -63,6 +63,7 @@ class VmOrTemplate < ApplicationRecord
 
   belongs_to                :host
   belongs_to                :ems_cluster
+  belongs_to                :cloud_tenant
   belongs_to                :flavor
 
   belongs_to                :storage


### PR DESCRIPTION
When trying to get search for a VM by CloudTenant, we have the following PostgreSQL error:

```
irb> my_tenant = CloudTenant.find_by(name: 'my_tenant')
irb> my_vms = Vm.where(:name => 'my_vm', :cloud_tenant => my_tenant)
Traceback (most recent call last):
       16: from activerecord (5.1.7) lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
       15: from activerecord (5.1.7) lib/active_record/connection_adapters/abstract/database_statements.rb:371:in `select'
       14: from activerecord (5.1.7) lib/active_record/connection_adapters/postgresql/database_statements.rb:79:in `exec_query'
       13: from activerecord (5.1.7) lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `execute_and_clear'
       12: from activerecord (5.1.7) lib/active_record/connection_adapters/postgresql_adapter.rb:622:in `exec_no_cache'
       11: from activerecord (5.1.7) lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
       10: from activesupport (5.1.7) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
        9: from activerecord (5.1.7) lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
        8: from /usr/share/ruby/monitor.rb:226:in `mon_synchronize'
        7: from activerecord (5.1.7) lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block (2 levels) in log'
        6: from activerecord (5.1.7) lib/active_record/connection_adapters/postgresql_adapter.rb:623:in `block in exec_no_cache'
        5: from activesupport (5.1.7) lib/active_support/dependencies/interlock.rb:45:in `permit_concurrent_loads'
        4: from activesupport (5.1.7) lib/active_support/concurrency/share_lock.rb:185:in `yield_shares'
        3: from activesupport (5.1.7) lib/active_support/dependencies/interlock.rb:46:in `block in permit_concurrent_loads'
        2: from activerecord (5.1.7) lib/active_record/connection_adapters/postgresql_adapter.rb:624:in `block (2 levels) in exec_no_cache'
        1: from activerecord (5.1.7) lib/active_record/connection_adapters/postgresql_adapter.rb:624:in `exec_params'
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column vms.cloud_tenant does not exist)
LINE 1: ...D "vms"."template" = $1 AND "vms"."name" = $2 AND "vms"."clo...
                                                             ^
HINT:  Perhaps you meant to reference the column "vms.cloud_tenant_id".
: SELECT  "vms".* FROM "vms" WHERE "vms"."type" IN ('Vm', 'ManageIQ::Providers::InfraManager::Vm', 'ManageIQ::Providers::CloudManager::Vm', 'VmServer', 'ManageIQ::Providers::Vmware::InfraManager::Vm', 'ManageIQ::Providers::Kubevirt::InfraManager::Vm', 'ManageIQ::Providers::Redhat::InfraManager::Vm', 'ManageIQ::Providers::Microsoft::InfraManager::Vm', 'VmXen', 'ManageIQ::Providers::Amazon::CloudManager::Vm', 'ManageIQ::Providers::Azure::CloudManager::Vm', 'ManageIQ::Providers::AzureStack::CloudManager::Vm', 'ManageIQ::Providers::Google::CloudManager::Vm', 'ManageIQ::Providers::Openstack::CloudManager::Vm', 'ManageIQ::Providers::Vmware::CloudManager::Vm') AND "vms"."template" = $1 AND "vms"."name" = $2 AND "vms"."cloud_tenant" = 9 LIMIT $3
```

This pull request adds the `belongs_to :cloud_tenant` relationship in `VmOrTemplate` class.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1809580