### PR TITLE
Remove defunct provider resume/pause

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -501,14 +501,6 @@
       :description: Edit a Cloud Provider
       :feature_type: admin
       :identifier: ems_cloud_edit
-    - :name: Pause
-      :description: Pause Cloud Providers
-      :feature_type: admin
-      :identifier: ems_cloud_pause
-    - :name: Resume
-      :description: Resume Cloud Providers
-      :feature_type: admin
-      :identifier: ems_cloud_resume
     - :name: Add
       :description: Add a Cloud Provider
       :feature_type: admin
@@ -1091,14 +1083,6 @@
       :description: Edit an Infrastructure Provider
       :feature_type: admin
       :identifier: ems_infra_edit
-    - :name: Pause
-      :description: Pause Infrastructure Providers
-      :feature_type: admin
-      :identifier: ems_infra_pause
-    - :name: Resume
-      :description: Resume Infrastructure Providers
-      :feature_type: admin
-      :identifier: ems_infra_resume
     - :name: Add
       :description: Add an Infrastructure Provider
       :feature_type: admin


### PR DESCRIPTION
Provider pause/resume was removed, so we don't need these.

Follow-up to https://github.com/ManageIQ/manageiq-api/pull/740

@miq-bot assign @agrare 
And maybe there's a few more that could be removed from here, Adam? 