### PR TITLE
Added new section in product features to handle common UI features

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -6629,3 +6629,24 @@
         :description: Order cart
         :feature_type: control
         :identifier: sui_cart_order
+
+# Common UI related features that are available thru several places in UI
+- :name: Common Features in UI
+  :description: Common Features in UI
+  :feature_type: node
+  :hidden: false
+  :identifier: common_features
+  :children:
+  # Advanced search thru out UI
+  - :name: Search
+    :description: Advanced Search
+    :feature_type: node
+    :hidden: false
+    :identifier: advanced_search
+    :children:
+    # Ability to add global search filter
+    - :name: Add Global Filters
+      :description: Ability to add global filter
+      :feature_type: control
+      :hidden: false
+      :identifier: add_global_filter

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -9,6 +9,7 @@
   :read_only: true
   :miq_product_feature_identifiers:
   - about
+  - add_global_filter
   - all_vm_rules
   - automation_manager
   - embedded_automation_manager


### PR DESCRIPTION
- Any features that are common thru out the UI, are accessible from multiple screens in UI can live in this section. Example of such feature is Advanced search that is available thru out the UI and cannot be added as an individual feature under any one section.
- New feature added in this PR addresses an issue where in the past only Super Admin user and Admin user could add Global filters for everyone to see, but now as we have different types of Admin users it is better to have this as a product feature. Without this fix currently anyone can add global filters in UI.

This PR addresses issues mention in https://github.com/ManageIQ/manageiq-ui-classic/pull/6253

before
![before](https://user-images.githubusercontent.com/3450808/75788455-42e2d300-5d36-11ea-9a1f-314be3b3cfd4.png)

after
![after](https://user-images.githubusercontent.com/3450808/75788466-46765a00-5d36-11ea-9e57-a27d2bad4886.png)

UI changes are in https://github.com/ManageIQ/manageiq-ui-classic/pull/6723