### PR TITLE
[IVANCHUK] Fix ivanchuk container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,23 +12,11 @@ RUN yum -y install --setopt=tsflags=nodocs \
                    postgresql-server       \
                    repmgr10                \
                    mod_ssl                 \
-                   openssh-clients         \
-                   openssh-server          \
                    &&                      \
     yum clean all
 
 VOLUME [ "/var/lib/pgsql/data" ]
 VOLUME [ ${APP_ROOT} ]
-
-# Initialize SSH
-RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
-    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
-    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done && \
-    echo "root:smartvm" | chpasswd && \
-    chmod 700 /root/.ssh && \
-    chmod 600 /root/.ssh/*
 
 ## Copy/link the appliance files again so that we get ssl
 RUN ${APPLIANCE_ROOT}/setup && \
@@ -38,7 +26,7 @@ RUN ${APPLIANCE_ROOT}/setup && \
 ## Copy appliance-initialize script and service unit file
 COPY docker-assets/appliance-initialize.sh /usr/bin
 
-EXPOSE 443 22
+EXPOSE 443
 
 ## Atomic Labels
 # The UNINSTALL label by DEFAULT will attempt to delete a container (rm) and image (rmi) if the container NAME is the same as the actual IMAGE

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN yum -y install --setopt=tsflags=nodocs \
     yum clean all
 
 VOLUME [ "/var/lib/pgsql/data" ]
+VOLUME [ ${APP_ROOT} ]
 
 # Initialize SSH
 RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@ RUN yum -y install --setopt=tsflags=nodocs \
                    &&                      \
     yum clean all
 
-VOLUME [ "/var/lib/pgsql/data" ]
-VOLUME [ ${APP_ROOT} ]
-
 ## Copy/link the appliance files again so that we get ssl
 RUN ${APPLIANCE_ROOT}/setup && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
@@ -56,3 +53,6 @@ LABEL io.k8s.description="ManageIQ is a management and automation platform for v
       io.k8s.display-name="ManageIQ" \
       io.openshift.expose-services="443:https" \
       io.openshift.tags="ManageIQ,miq,manageiq"
+
+VOLUME [ "/var/lib/pgsql/data" ]
+VOLUME [ ${APP_ROOT} ]

--- a/docker-assets/appliance-initialize.sh
+++ b/docker-assets/appliance-initialize.sh
@@ -27,7 +27,6 @@ if [ $? -eq 0 ]; then
   test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
 
   bundle exec rake db:migrate
-  exit 0
 else
   echo "** DB has not been initialized"
 
@@ -54,5 +53,6 @@ else
   echo "** MIQ database has been initialized"
 
   generate_miq_server_cert.sh
-  exit 0
 fi
+
+rm -f /var/www/miq/vmdb/tmp/pids/evm.pid

--- a/docker-assets/appliance-initialize.sh
+++ b/docker-assets/appliance-initialize.sh
@@ -4,6 +4,10 @@
 [ -f /etc/default/evm ] &&  . /etc/default/evm
 [[ -s ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh ]] && source "${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh"
 
+# Check if memcached is running, if not start it
+pidof memcached
+test $? -ne 0 && /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -d
+
 function create_v2_key() {
   V2_KEY=$(ruby -ropenssl -rbase64 -e 'puts Base64.strict_encode64(Digest::SHA256.digest(OpenSSL::Random.random_bytes(32))[0, 32])')
   write_v2_key
@@ -34,10 +38,6 @@ else
   echo "** Creating MIQ role"
   su postgres -c "psql -c \"CREATE ROLE root SUPERUSER LOGIN PASSWORD 'smartvm'\""
   test $? -ne 0 && echo "!! Failed to inject MIQ root Role" && exit 1
-
-  # Check if memcached is running, if not start it
-  pidof memcached
-  test $? -ne 0 && /usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 -l 127.0.0.1 -d
 
   echo "** Starting DB setup"
   pushd ${APP_ROOT}

--- a/docker-assets/appliance-initialize.sh
+++ b/docker-assets/appliance-initialize.sh
@@ -21,6 +21,12 @@ echo "== Checking MIQ database status =="
 [[ -d /var/lib/pgsql/data/base ]]
 if [ $? -eq 0 ]; then
   echo "** DB already initialized"
+  echo "** Starting postgresql"
+
+  su postgres -c "pg_ctl -D ${APPLIANCE_PG_DATA} start"
+  test $? -ne 0 && echo "!! Failed to start postgresql service" && exit 1
+
+  bundle exec rake db:migrate
   exit 0
 else
   echo "** DB has not been initialized"


### PR DESCRIPTION
This applies the same sort of changes to the ivanchuk branch as https://github.com/ManageIQ/manageiq/pull/19463 and https://github.com/ManageIQ/manageiq/pull/19920

In particular, it starts memcached and the database on container restarts and creates a volume for the application root directory.

Additionally it removes the ssh configuration as we haven't been running sshd in this container since we removed systemd and it moves the volume commands to the end of the file to avoid https://github.com/containers/buildah/issues/2202

Fixes https://github.com/ManageIQ/manageiq/issues/19879 