### PR TITLE
Make monolithic image work when built with buildah

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,11 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
       memcached               \
       postgresql-server       \
       mod_ssl                 \
-      openssh-clients         \
-      openssh-server          \
       &&                      \
     dnf clean all
 
 VOLUME [ "/var/lib/pgsql/data" ]
 VOLUME [ ${APP_ROOT} ]
-
-# Initialize SSH
-RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
-    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
-    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done && \
-    echo "root:smartvm" | chpasswd && \
-    chmod 700 /root/.ssh && \
-    chmod 600 /root/.ssh/*
 
 ## Copy/link the appliance files again so that we get ssl
 RUN ${APPLIANCE_ROOT}/setup && \
@@ -34,6 +22,6 @@ RUN ${APPLIANCE_ROOT}/setup && \
 ## Overwrite entrypoint from pods repo
 COPY docker-assets/entrypoint /usr/local/bin
 
-EXPOSE 443 22
+EXPOSE 443
 
 LABEL name="manageiq"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install 
       &&                      \
     dnf clean all
 
-VOLUME [ "/var/lib/pgsql/data" ]
-VOLUME [ ${APP_ROOT} ]
-
 ## Copy/link the appliance files again so that we get ssl
 RUN ${APPLIANCE_ROOT}/setup && \
     mv /etc/httpd/conf.d/ssl.conf{,.orig} && \
@@ -25,3 +22,6 @@ COPY docker-assets/entrypoint /usr/local/bin
 EXPOSE 443
 
 LABEL name="manageiq"
+
+VOLUME [ "/var/lib/pgsql/data" ]
+VOLUME [ ${APP_ROOT} ]


### PR DESCRIPTION
This moves the volume commands down to avoid running into https://github.com/containers/buildah/issues/2202 when using podman or buildah to create the image.

Additionally it removes some unnecessary ssh configuration as we haven't been running sshd since we removed systemd from this image.