### PR TITLE
Remove no-longer used line from forever ago

### DIFF
--- a/tools/classify_vms_by_folder
+++ b/tools/classify_vms_by_folder
@@ -1,1 +1,0 @@
-Vm.all.each { |vm| vm.classify_with_parent_folder_path }


### PR DESCRIPTION
Originally from https://bugzilla.redhat.com/show_bug.cgi?id=935776 which is CF 2.2. Jason looked at the history[1] and said I could ✂️ this as well.


[1]: Automatically classify VMs with parent blue and yellow folder paths as management tags during refresh. Refresh is now triggered when MoveIntoFolder_Task event is received. This way new folder assignments and classifications are done as soon as a VM is moved to a folder.

@miq-bot assign @gtanzillo 
@miq-bot add_label technical debt

