### PR TITLE
Configuration of conversion host without IP should fail early

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -428,6 +428,7 @@ class ConversionHost < ApplicationRecord
     task = MiqTask.find(miq_task_id) if miq_task_id.present?
 
     host = hostname || ipaddress
+    raise "#{resource.class.name.demodulize} '#{resource.name}' doesn't have a hostname or IP address in inventory" if host.nil?
 
     params = [
       playbook,

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -212,6 +212,22 @@ RSpec.describe ConversionHost, :v2v do
         expect { conversion_host.enable_conversion_host_role }.to raise_error("vmware_vddk_package_url is mandatory if transformation method is vddk")
       end
 
+      it "enable_conversion_host_role raises if resource has no hostname nor IP address" do
+        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
+        enable_extra_vars = {
+          :v2v_host_type        => 'rhevm',
+          :v2v_transport_method => 'vddk',
+          :v2v_vddk_package_url => package_url
+        }
+        check_extra_vars = {
+          :v2v_host_type        => 'rhevm',
+          :v2v_transport_method => 'vddk'
+        }
+        allow(host).to receive(:hostname).and_return(nil)
+        allow(host).to receive(:ipaddresses).and_return([])
+        expect { conversion_host.enable_conversion_host_role('http://file.example.com/vddk-stable.tar.gz', nil) }.to raise_error("Host '#{host.name}' doesn't have a hostname or IP address in inventory")
+      end
+
       it "enable_conversion_host_role calls ansible_playbook with extra_vars" do
         check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
         enable_extra_vars = {

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -213,16 +213,6 @@ RSpec.describe ConversionHost, :v2v do
       end
 
       it "enable_conversion_host_role raises if resource has no hostname nor IP address" do
-        check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
-        enable_extra_vars = {
-          :v2v_host_type        => 'rhevm',
-          :v2v_transport_method => 'vddk',
-          :v2v_vddk_package_url => package_url
-        }
-        check_extra_vars = {
-          :v2v_host_type        => 'rhevm',
-          :v2v_transport_method => 'vddk'
-        }
         allow(host).to receive(:hostname).and_return(nil)
         allow(host).to receive(:ipaddresses).and_return([])
         expect { conversion_host.enable_conversion_host_role('http://file.example.com/vddk-stable.tar.gz', nil) }.to raise_error("Host '#{host.name}' doesn't have a hostname or IP address in inventory")


### PR DESCRIPTION
We noticed that a conversion host VM that doesn't have a hostname or IP address in ManageIQ inventory will not be configured by the enablement playbook. In log, the hosts list is empty, because with pass `nil` as host in the Ansible inventory. So, the playbook doesn't fail.

This pull request make the `ansible_playbook` method raise an exception if the conversion host resource has neither a hostname or IP address, so it will forcefully fail the configuration task and not even try to run the playbook.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1810135