### PR TITLE
Enhance acts_as_miq_set to add the corresponding has_many for set members based on the table name of the model

### DIFF
--- a/lib/extensions/ar_miq_set.rb
+++ b/lib/extensions/ar_miq_set.rb
@@ -67,6 +67,8 @@ module ActsAsMiqSet
     alias_with_relationship_type :add_members,        :add_children
 
     alias_method model_table_name.to_sym, :children
+
+    virtual_has_many model_table_name.to_sym, :uses => :all_relationships
   end
 
   module ClassMethods

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -207,6 +207,15 @@ RSpec.describe MiqPolicy do
       end
     end
 
+    describe "#miq_policies (virtual_has_many)" do
+      before { profiles }
+
+      it "gets the policies under a profile" do
+        expect(MiqPolicySet.find_by(:name => "ps3").miq_policies).to match_array([policies[0]])
+        expect(MiqPolicySet.find_by(:name => "ps4").miq_policies).to match_array([policies[1]])
+      end
+    end
+
     describe ".enforce_policy" do
       it 'executes policies for a target' do
         allow(target).to receive(:get_policies).and_return(profiles)


### PR DESCRIPTION
This change is necessary for https://github.com/ManageIQ/manageiq-api/issues/745 in order to expose the `has_many` relationship for set members and generate this construct - 
```ruby
class MiqPolicySet
  has_many miq_policies
```
Ultimately enabling an API request like this -
http://localhost:3000/api/vms/10000000000229/policy_profiles?expand=resources&attributes=miq_policies

Tests are in https://github.com/ManageIQ/manageiq-api/pull/766
Cross repo test - https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/88