### PR TITLE
metrics capture target

### DIFF
--- a/app/models/manageiq/providers/base_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/base_manager/metrics_capture.rb
@@ -2,6 +2,8 @@ class ManageIQ::Providers::BaseManager::MetricsCapture
   include Vmdb::Logging
 
   attr_reader :target, :ems
+
+  # @param target [Array[Host,Vm],Vm,Host] object(s) that needs perf capture
   def initialize(target, ems = nil)
     @target = target
     @ems = ems

--- a/app/models/metric/capture.rb
+++ b/app/models/metric/capture.rb
@@ -48,8 +48,7 @@ module Metric::Capture
     _log.info("Queueing performance capture...")
 
     ems = ExtManagementSystem.find(ems_id)
-    pco = ems.perf_capture_object
-    pco.perf_capture
+    ems.perf_capture_object.perf_capture_all_queue
 
     _log.info("Queueing performance capture...Complete")
   end

--- a/app/models/metric/ci_mixin/capture.rb
+++ b/app/models/metric/ci_mixin/capture.rb
@@ -1,9 +1,9 @@
 module Metric::CiMixin::Capture
-  def perf_capture_object
+  def perf_capture_object(targets = nil)
     if self.kind_of?(ExtManagementSystem)
-      self.class::MetricsCapture.new(nil, ext_management_system)
+      self.class::MetricsCapture.new(targets, ext_management_system)
     else
-      self.class.parent::MetricsCapture.new(self, ext_management_system)
+      self.class.parent::MetricsCapture.new(targets || self, ext_management_system)
     end
   end
 

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
     let(:vm2) { FactoryBot.create(:vm_perf, :ext_management_system => ems) }
 
     it "should queue up realtime capture for vm" do
-      subject.queue_captures([vm, vm2], {})
+      subject.queue_captures([vm, vm2])
       expect(MiqQueue.count).to eq(2)
 
       expect(subject._log).to receive(:info).with(/2 "realtime" captures on the queue.*oldest:.*recent:/)
@@ -142,7 +142,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
     context "with vmware targets" do
       it "should queue up targets properly" do
         stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3], {})
+        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3])
 
         bod = Time.now.utc.beginning_of_day
 
@@ -168,11 +168,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       end
 
       it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
-        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3], {})
+        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3])
         messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
         messages.each { |m| m.update(:state => "dequeue") }
 
-        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3], {})
+        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3])
         messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
         messages.each { |m| expect(m.lock_version).to eq(1) }
       end
@@ -185,7 +185,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       context "executing perf_capture_timer" do
         it "should queue up enabled targets" do
           stub_settings(:performance => {:history => {:initial_capture_days => 7}})
-          ems.perf_capture_object.queue_captures(vms, {})
+          ems.perf_capture_object.queue_captures(vms)
 
           bod = Time.now.utc.beginning_of_day
 
@@ -200,7 +200,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
   def trigger_capture(interval, last_perf_capture_on = nil, start_time: nil, end_time: nil, rollups: false)
     vm.last_perf_capture_on = last_perf_capture_on if last_perf_capture_on
-    ems.perf_capture_object.queue_captures([vm], vm => {:interval => interval, :start_time => start_time, :end_time => end_time})
+    ems.perf_capture_object.queue_captures([vm], interval, :start_time => start_time, :end_time => end_time, :rollups => rollups)
   end
 
   describe "#queue_items_for_interval" do

--- a/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/metrics_capture_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
   include Spec::Support::MetricHelper
 
-  subject { described_class.new(nil, ems) }
   let(:miq_server) { EvmSpecHelper.local_miq_server }
   let(:ems) { FactoryBot.create(:ems_vmware, :zone => miq_server.zone) }
 
@@ -10,13 +9,15 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
     let(:vm2) { FactoryBot.create(:vm_perf, :ext_management_system => ems) }
 
     it "should queue up realtime capture for vm" do
-      subject.queue_captures([vm, vm2])
+      pco = described_class.new([vm, vm2], ems)
+      pco.perf_capture_queue
+
       expect(MiqQueue.count).to eq(2)
 
-      expect(subject._log).to receive(:info).with(/2 "realtime" captures on the queue.*oldest:.*recent:/)
-      expect(subject._log).to receive(:info).with(/0 "hourly" captures on the queue/)
-      expect(subject._log).to receive(:info).with(/0 "historical" captures on the queue/)
-      subject.send(:perf_capture_health_check)
+      expect(pco._log).to receive(:info).with(/2 "realtime" captures on the queue.*oldest:.*recent:/)
+      expect(pco._log).to receive(:info).with(/0 "hourly" captures on the queue/)
+      expect(pco._log).to receive(:info).with(/0 "historical" captures on the queue/)
+      pco.send(:perf_capture_health_check)
     end
   end
 
@@ -57,6 +58,8 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
   end
 
   describe ".perf_capture_now?" do
+    subject { described_class.new(nil, ems) }
+
     before do
       stub_performance_settings(
         :capture_threshold_with_alerts => {:host => "2.minutes"},
@@ -119,7 +122,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
     end
   end
 
-  describe ".perf_capture_queue" do
+  describe ".perf_capture_all_queue" do
     before do
       MiqRegion.seed
     end
@@ -137,12 +140,12 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
     end
     let(:vm2)     { FactoryBot.create(:vm_vmware, :ext_management_system => ems, :host => host2) }
     let(:host3)   { FactoryBot.create(:host_vmware, :ext_management_system => ems, :perf_capture_enabled => true) }
-    let(:storage) { FactoryBot.create(:storage_vmware, :perf_capture_enabled => true) }
+    let(:storage) { FactoryBot.create(:storage_vmware, :ems_id => ems.id, :perf_capture_enabled => true) }
 
     context "with vmware targets" do
       it "should queue up targets properly" do
         stub_settings_merge(:performance => {:history => {:initial_capture_days => 7}})
-        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3])
+        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue
 
         bod = Time.now.utc.beginning_of_day
 
@@ -168,11 +171,11 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       end
 
       it "calling perf_capture_timer when existing capture messages are on the queue in dequeue state should NOT merge" do
-        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3])
+        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue
         messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
         messages.each { |m| m.update(:state => "dequeue") }
 
-        ems.perf_capture_object.queue_captures([vm, vm2, storage, host, host2, host3])
+        ems.perf_capture_object([vm, vm2, storage, host, host2, host3]).perf_capture_queue
         messages = MiqQueue.where(:class_name => "Host", :method_name => 'capture_metrics_realtime')
         messages.each { |m| expect(m.lock_version).to eq(1) }
       end
@@ -185,7 +188,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
       context "executing perf_capture_timer" do
         it "should queue up enabled targets" do
           stub_settings(:performance => {:history => {:initial_capture_days => 7}})
-          ems.perf_capture_object.queue_captures(vms)
+          ems.perf_capture_object(vms).perf_capture_queue
 
           bod = Time.now.utc.beginning_of_day
 
@@ -200,7 +203,7 @@ RSpec.describe ManageIQ::Providers::BaseManager::MetricsCapture do
 
   def trigger_capture(interval, last_perf_capture_on = nil, start_time: nil, end_time: nil, rollups: false)
     vm.last_perf_capture_on = last_perf_capture_on if last_perf_capture_on
-    ems.perf_capture_object.queue_captures([vm], interval, :start_time => start_time, :end_time => end_time, :rollups => rollups)
+    ems.perf_capture_object([vm]).perf_capture_queue(interval, :start_time => start_time, :end_time => end_time, :rollups => rollups)
   end
 
   describe "#queue_items_for_interval" do

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Metric::CiMixin::Rollup do
                                     :method_name => "perf_capture_realtime")
           expect(messages.size).to eq(1)
           messages.each do |m|
+            expect(m.miq_task_id).to eq(task.id)
             expect(m.miq_callback).not_to be_nil
             expect(m.miq_callback[:method_name]).to eq(:perf_capture_callback)
             expect(m.miq_callback[:args]).to eq([[task.id]])

--- a/spec/models/metric/ci_mixin/rollup_spec.rb
+++ b/spec/models/metric/ci_mixin/rollup_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Metric::CiMixin::Rollup do
       end
 
       it "should create tasks and queue callbacks for perf_capture_timer" do
-        ems.perf_capture_object.perf_capture
+        ems.perf_capture_object.perf_capture_all_queue
 
         cluster = host2.ems_cluster
         expected_hosts = [host2, host4]
@@ -68,8 +68,8 @@ RSpec.describe Metric::CiMixin::Rollup do
       end
 
       it "calling perf_capture_timer when existing capture messages are on the queue should merge messages and append new task id to cb args" do
-        ems.perf_capture_object.perf_capture
-        ems.perf_capture_object.perf_capture
+        ems.perf_capture_object.perf_capture_all_queue
+        ems.perf_capture_object.perf_capture_all_queue
 
         cluster = host2.ems_cluster
         expected_hosts = [host2, host4]
@@ -107,8 +107,8 @@ RSpec.describe Metric::CiMixin::Rollup do
       end
 
       it "calling perf_capture_timer a second time should create another task with the correct time window" do
-        ems.perf_capture_object.perf_capture
-        ems.perf_capture_object.perf_capture
+        ems.perf_capture_object.perf_capture_all_queue
+        ems.perf_capture_object.perf_capture_all_queue
 
         cluster = host2.ems_cluster
 


### PR DESCRIPTION
extracted from #19741 

### Primary Goal

Update `MetricsCapture` to be created with multiple targets (stored in `@targets`). This allows us to capture multiple objects (e.g. VMs) with a single `MetricsCapture` object.

### secondary:

Parameters are now passed as a single set of options applicable to all targets (e.g.: a single `start_time`) instead of tweaked per target. This allows us to submit a single job on the queue without complex (and unneeded) per target parameter options.
