### PR TITLE
Set ems container alias

### DIFF
--- a/app/models/aliases/ems_container.rb
+++ b/app/models/aliases/ems_container.rb
@@ -1,0 +1,1 @@
+::EmsContainer = ::ManageIQ::Providers::ContainerManager


### PR DESCRIPTION
We don't have an alias for ems container and it'd be cool if we did to match the ems network side. We do use this alias, and the API RBAC check on provider add is cleaner with the alias set.