### PR TITLE
Since the base class is no longer valid, create records of a subclass

### DIFF
--- a/spec/factories/service_order.rb
+++ b/spec/factories/service_order.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory(:service_order) do
+  factory(:service_order, :class => :ServiceOrderCart) do
     name { "service order" }
     state { "ordered" }
 


### PR DESCRIPTION
Since https://github.com/ManageIQ/manageiq/pull/19795/files#diff-f5aafc4dc4e7284f971559aef2bb6a64R21 it is no longer valid to create records of the base class, picking a subclass as a default