### PR TITLE
Fix the state of the correct subclass in the service order factory

### DIFF
--- a/spec/factories/service_order.rb
+++ b/spec/factories/service_order.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
     end
 
     factory :service_order_cart, :parent => :service_order,
-                                 :class  => "ServiceOrderCart"
+                                 :class  => "ServiceOrderCart" do
+                                   state { "cart" }
+                                 end
   end
 end


### PR DESCRIPTION
This needs the API PR that I just closed (https://github.com/ManageIQ/manageiq-api/pull/771) to work but I think it's a better fix than Brandon's factory change that just got merged because Brandon's doesn't address the state issue and even if he did change it to do so it changes the behavior of that factory which I don't think was right. 


[the api says `the default state for a service order is 'cart'`](https://github.com/ManageIQ/manageiq-api/blob/ce6ad2837d61acf9bcbc75792f7796611fc74def/spec/requests/service_orders_spec.rb#L100) so we shouldn't be using the [factory with the default set to ordered for the API tests](https://github.com/ManageIQ/manageiq/blob/ec56ab47c4baa27b12cd00d67e49e8f2a1109321/spec/factories/service_order.rb#L11) 

this and the API would bring our total failing tests down to five rather than the 11 that are failing on master right now with Brandon's factory change

and in general the idea of picking the factory that the api is using to be the service order that has already been ordered feels weird? 
