### PR TITLE
[GitWorktree/GitRepository] Handle submodules

### DIFF
--- a/app/models/git_repository.rb
+++ b/app/models/git_repository.rb
@@ -63,7 +63,7 @@ class GitRepository < ApplicationRecord
       message = "Checking out #{url}@#{ref} to #{path}..."
       _log.info(message)
       worktree.ref = ref
-      worktree.checkout(path)
+      worktree.checkout_at(path)
       _log.info("#{message}...Complete")
     end
     path

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -235,7 +235,15 @@ class GitWorktree
     current_index.remove_dir(old_dir)
   end
 
+  def checkout_to(target_directory)
+    tree = lookup_commit_tree
+    @repo.checkout_tree(tree, :target_directory => target_directory, :strategy => :force)
+  end
+
   def checkout_at(target_directory)
+    checkout_to(target_directory)
+  rescue Rugged::SubmoduleError
+    FileUtils.rm_rf(target_directory) # cleanup from failed checkout above
     GitWorktree.checkout_at(@path, target_directory)
   end
 

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -32,6 +32,8 @@ class GitWorktree
     @proxy_url            = options[:proxy_url]
     @certificate_check_cb = options[:certificate_check]
 
+    @options              = options
+
     @remote_name = 'origin'
     @base_name   = File.basename(@path)
 
@@ -244,7 +246,7 @@ class GitWorktree
     checkout_to(target_directory)
   rescue Rugged::SubmoduleError
     FileUtils.rm_rf(target_directory) # cleanup from failed checkout above
-    GitWorktree.checkout_at(@path, target_directory)
+    GitWorktree.checkout_at(@path, target_directory, @options)
   end
 
   def checkout
@@ -252,7 +254,7 @@ class GitWorktree
     @repo.submodules.each do |submodule|
       submodule.init
       module_path = File.expand_path(submodule.path, @path)
-      GitWorktree.checkout_at(submodule.url, module_path, :commit_sha => submodule.head_oid)
+      GitWorktree.checkout_at(submodule.url, module_path, @options.merge(:commit_sha => submodule.head_oid))
     end
   end
 


### PR DESCRIPTION
Do to some limitations with `rugged`/`libgit2`, this seems to be the best option available for dealing with submodules:

- Do a clone of the existing bare repo as a normal clone to target dir
- Checkout using `.checkout` to ensure the working tree/index is correct
- Iterate through the submodules
- init submodule and call `.checkout_at` recursively

This seems to be the simplest way I could find to determine if the submodule (and any nested submodules) needed submodules initialized.  Sadly, this can be a pretty expensive operation depending on how many submodules there are in a given project and how deep the histories are for each of the repos.


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1807928


Testing
-------

So I mostly tested this manually using the following scripts for a few of my public repos, running from the root of the `ManageIQ/manageiq` dir:

```ruby
lib_dir = File.expand_path "lib", Dir.pwd
$: << lib_dir unless $:.include? lib_dir

require "active_support/core_ext/object/blank"

require 'fileutils'
require 'io/console'
require 'securerandom'
require 'tempfile'

require 'git_worktree'

# Must be run from `/var/www/miq/vmdb`
ask_pass        = Tempfile.new
repos_dir       = File.join Dir.pwd, 'data', 'git_repos'
git_dir         = File.join(repos_dir, "repo-#{SecureRandom.uuid}")
checkout_dir    = File.join(repos_dir, "repo-checkout-#{SecureRandom.uuid}")
inline_config   = nil
worktree_params = {
  :path              => git_dir,
  # :certificate_check => lambda { true },
  :username          => "NickLaMuro",  # for https user/pass auth
  :password          => ENV["GIT_PASS"],
  # :username          => "git",
  # :ssh_private_key   => File.read(File.join(Dir.home, ".ssh", "id_rsa"))
}

if worktree_params.has_key?(:password)
  if worktree_params[:password].nil?
    print "password for '#{worktree_params[:username]}': "
    worktree_params[:password] = STDIN.noecho(&:gets).chomp.tap { puts }
  end

  # Setup one-time configuration for auto-input of user/pass via +ask_pass+
  # script, and the options configured above (if using user/pass)
  #
  # - The `inline_config` passes the `-c` option to replace the https URL with
  #   a username included from the hash above
  # - Set +ENV['GIT_PASS']+ if it hasn't been already
  # - Define the +ENV['GIT_ASKPASS']+ so +git+ knows where to find the script
  # - write a simple ask_pass script that just echos the `$GIT_PASS` env var
  # - make said script executable
  #
  # See the following link for more info:
  #
  #   https://coolaj86.com/articles/vanilla-devops-git-credentials-cheatsheet/
  #
  inline_config      = %Q(-c 'url."https://#{worktree_params[:username]}@github.com/".insteadOf="https://github.com/"')
  ENV["GIT_PASS"]  ||= worktree_params[:password]
  ENV["GIT_ASKPASS"] = ask_pass.path

  ask_pass.puts("echo $GIT_PASS")
  ask_pass.close
  FileUtils.chmod "+x", ask_pass.path
end

clone_params = worktree_params.merge(
  ##### NO SUBMODULES #####
  # :url   => "https://github.com/NickLaMuro/ansible-tower-samples.git",
  # :url   => "git@github.com:NickLaMuro/ansible-tower-samples.git",

  ##### HAS SUBMODULES #####
  :url   => "https://github.com/NickLaMuro/dotfiles.git",
  # :url   => "git@github.com:NickLaMuro/dotfiles.git",
  :clone => true
)

FileUtils.mkdir_p repos_dir

begin
  worktree = GitWorktree.new(clone_params)

  puts "Cloned to #{git_dir}..."
  # puts "Repo entries..."
  # puts

  # puts worktree.entries("").map { |e| "  #{e}" }
  # puts
  # puts "press any key to continue..."

  # STDIN.noecho(&:getch)

  puts
  puts "update_repo..."
  worktree = GitWorktree.new(worktree_params)
  worktree.send(:pull)

  puts
  puts "Checking out #{clone_params[:url]}@master to #{checkout_dir}..."
  worktree = GitWorktree.new(worktree_params)
  worktree.ref = 'master'
  rugged_repo = worktree.checkout_at(checkout_dir)

  puts
  puts "Checkout entries..."
  puts
  puts Dir.glob("#{checkout_dir}/*", File::FNM_DOTMATCH)
  puts
  puts "press any key to continue..."

  STDIN.noecho(&:getch)
ensure
  FileUtils.rm_rf git_dir
  FileUtils.rm_rf checkout_dir
end
```

The `NickLaMuro/dotfiles` repo has a pretty substantial amount of submodules that proved to be a good reproducer of the bug (and example of how slow submodules and this new approach is over all), and validator that this worked with the new changes.

That said, it doesn't test any of the `EmbeddedAnsible` based code, but to be fair, that should be functionally the same as far as it is concerned.