### PR TITLE
Remove invalid partials from presenter helper

### DIFF
--- a/spec/support/presenter_helper.rb
+++ b/spec/support/presenter_helper.rb
@@ -5,8 +5,6 @@ module Spec
 
       def login_as(user)
         User.current_user = user
-        allow_any_instance_of(ActionController::TestSession).to receive(:userid).and_return(user.userid)
-        allow_any_instance_of(ActionController::TestSession).to receive(:group).and_return(user.current_group.try(:id))
       end
     end
   end


### PR DESCRIPTION
With strict partials enabled you will see some spec failures in the ui-classic repo like this since `ActionController::TestSession` doesn't actually implement a `userid` method, nor a `group` method:

```
75) TreeBuilderResourcePools#x_get_tree_roots no ems folders with a single provider returns with a no roots
      Failure/Error: login_as FactoryBot.create(:user_with_group, :role => "operator", :settings => {})
        ActionController::TestSession does not implement #userid
      # /home/dberger/Dev/manageiq-djberg96/spec/support/presenter_helper.rb:8:in `login_as'
      # ./spec/presenters/tree_builder_resource_pools_spec.rb:3:in `block (2 levels) in <top (required)>'
```
The core repo itself doesn't appear to use this helper, but the ui-classic repo does. Running the ui-classic specs again locally with this change did not cause any failures.

Cross repo tests at https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/83