### PR TITLE
Reference ServiceOrder subclasses as root classes

### DIFF
--- a/app/models/service_template_provision_request.rb
+++ b/app/models/service_template_provision_request.rb
@@ -2,7 +2,7 @@ class ServiceTemplateProvisionRequest < MiqRequest
   TASK_DESCRIPTION  = 'Service_Template_Provisioning'
   SOURCE_CLASS_NAME = 'ServiceTemplate'
   ACTIVE_STATES     = %w( migrated ) + base_class::ACTIVE_STATES
-  SERVICE_ORDER_CLASS = ServiceOrderCart
+  SERVICE_ORDER_CLASS = ::ServiceOrderCart
 
   validates_inclusion_of :request_state,  :in => %w( pending finished ) + ACTIVE_STATES, :message => "should be pending, #{ACTIVE_STATES.join(", ")} or finished"
   validate               :must_have_user

--- a/app/models/service_template_transformation_plan_request.rb
+++ b/app/models/service_template_transformation_plan_request.rb
@@ -1,6 +1,6 @@
 class ServiceTemplateTransformationPlanRequest < ServiceTemplateProvisionRequest
   TASK_DESCRIPTION = 'VM Transformations'.freeze
-  SERVICE_ORDER_CLASS = ServiceOrderV2V
+  SERVICE_ORDER_CLASS = ::ServiceOrderV2V
 
   delegate :transformation_mapping, :vm_resources, :to => :source
 


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq/pull/19795

Reference ServiceOrder subclasses as root level classes.