### PR TITLE
[V2V] ConversionHost - Validate resource is not already a conversion host

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -54,8 +54,7 @@ module ConversionHost::Configurations
       params = params.symbolize_keys
       resource = params.delete(:resource)
 
-      conversion_host = ConversionHost.where(:resource => resource)
-      raise "the resource '#{resource.name}' is already configured as a conversion host" unless conversion_host.empty?
+      raise "the resource '#{resource.name}' is already configured as a conversion host" if ConversionHost.exists?(:resource => resource)
 
       params[:resource_id] = resource.id
       params[:resource_type] = resource.class.base_class.name

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -54,6 +54,9 @@ module ConversionHost::Configurations
       params = params.symbolize_keys
       resource = params.delete(:resource)
 
+      conversion_host = ConversionHost.where(:resource => resource)
+      raise "the resource '#{resource.name}' is already configured as a conversion host" unless conversion_host.empty?
+
       params[:resource_id] = resource.id
       params[:resource_type] = resource.class.base_class.name
 

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -117,6 +117,11 @@ RSpec.describe ConversionHost, :v2v do
     context ".enable_queue" do
       let(:op) { 'enable' }
 
+      it "raises an error if the resource is already configured as a conversion host" do
+        FactoryBot.create(:conversion_host, :resource => vm)
+        expect { described_class.enable_queue(:resource => vm) }.to raise_error("the resource '#{vm.name}' is already configured as a conversion host")
+      end
+
       it "to queue with a task" do
         task_id = described_class.enable_queue(params)
         expected_context_data = {:request_params => params.except(:resource)}


### PR DESCRIPTION
When one tries to add a conversion host by REST API while there is an existing conversion host with the same resource, the configuration process is executed, then the ConversionHost object creation fails because the resource is already associated to another conversion host. There are two wrong consequences to that:

. The conversion host resource is configured a second time, breaking potentially the existing configuration and blocking migration.
. There's no error message apart from log/evm.log.

This does not affect users configuring conversion hosts through the UI, as the list of resources is filtered. So, it is limited to API.

This pull request adds a validation at raises an exception if the resource is already used by a conversion host. This fails faster and doesn't queue the configuration task.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1810555