### PR TITLE
Embedded ansible provider should allow creation in maintenance zone

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/provider.rb
+++ b/app/models/manageiq/providers/embedded_ansible/provider.rb
@@ -14,6 +14,9 @@ class ManageIQ::Providers::EmbeddedAnsible::Provider < ::Provider
   def ensure_managers
     build_automation_manager unless automation_manager
     automation_manager.name    = _("%{name} Automation Manager") % {:name => name}
-    automation_manager.zone_id = zone_id if zone_id_changed?
+    if zone_id_changed?
+      automation_manager.enabled = Zone.maintenance_zone&.id != zone_id
+      automation_manager.zone_id = zone_id
+    end
   end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -70,9 +70,25 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::Provider do
   end
 
   context "ensure_managers callback" do
+    before do
+      EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
+    end
+
     it "automatically creates an automation manager if none is provided" do
       provider = FactoryBot.create(:provider_embedded_ansible)
       expect(provider.automation_manager).to be_kind_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager)
+    end
+
+    it "sets the automation manager to disabled if created in the maintenance zone" do
+      provider = FactoryBot.create(:provider_embedded_ansible, :zone => Zone.maintenance_zone)
+      expect(provider.automation_manager.enabled).to eql(false)
+      expect(provider.automation_manager.zone).to eql(Zone.maintenance_zone)
+    end
+
+    it "sets the automation manager to enabled if not created in the maintenance zone" do
+      provider = FactoryBot.create(:provider_embedded_ansible, :zone => Zone.default_zone)
+      expect(provider.automation_manager.enabled).to eql(true)
+      expect(provider.automation_manager.zone).to eql(Zone.default_zone)
     end
   end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -68,4 +68,11 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::Provider do
       expect(Hardware.count).to              eq(0)
     end
   end
+
+  context "ensure_managers callback" do
+    it "automatically creates an automation manager if none is provided" do
+      provider = FactoryBot.create(:provider_embedded_ansible)
+      expect(provider.automation_manager).to be_kind_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager)
+    end
+  end
 end

--- a/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/provider_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::Provider do
   let(:miq_server) { FactoryBot.create(:miq_server) }
 
   before do
+    MiqRegion.seed
+    Zone.seed
     EvmSpecHelper.assign_embedded_ansible_role(miq_server)
   end
 
@@ -70,10 +72,6 @@ RSpec.describe ManageIQ::Providers::EmbeddedAnsible::Provider do
   end
 
   context "ensure_managers callback" do
-    before do
-      EvmSpecHelper.local_miq_server(:is_master => true, :zone => Zone.seed)
-    end
-
     it "automatically creates an automation manager if none is provided" do
       provider = FactoryBot.create(:provider_embedded_ansible)
       expect(provider.automation_manager).to be_kind_of(ManageIQ::Providers::EmbeddedAnsible::AutomationManager)


### PR DESCRIPTION
Currently you cannot create an embedded Ansible provider in the maintenance zone. Instead, this should be legal, though with the automation manager disabled.

You can see the current behavior here:
```
# RAILS_ENV=test bundle exec rails c
server = FactoryBot.create(:miq_server, :zone => Zone.seed)
provider = FactoryBot.create(:provider_embedded_ansible, :zone => Zone.maintenance_zone)

result: ActiveRecord::RecordInvalid (Validation failed: ManageIQ::Providers::EmbeddedAnsible::Provider: Zone cannot be the maintenance zone when provider is active)
```
This PR alters the `ensure_managers` method to allow it, setting the `enabled` attribute as appropriate.

Based on https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/211