### PR TITLE
[WIP] Remove checks for ems.inventory_object_refresh? in `Refresher#refresh`

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -846,10 +846,6 @@ class ExtManagementSystem < ApplicationRecord
     n_('Manager', 'Managers', number)
   end
 
-  def inventory_object_refresh?
-    Settings.ems_refresh.fetch_path(emstype, :inventory_object_refresh)
-  end
-
   def allow_targeted_refresh?
     Settings.ems_refresh.fetch_path(emstype, :allow_targeted_refresh)
   end

--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -118,9 +118,6 @@ module ManageIQ
         #
         # override this method and return an array of:
         #   [[target1, inventory_for_target1], [target2, inventory_for_target2]]
-
-        return [[ems, nil]] unless ems.inventory_object_refresh?
-
         targets.map do |target|
           inventory = inventory_class_for(ems.class).build(ems, target)
           inventory.collect!
@@ -136,16 +133,11 @@ module ManageIQ
         log_header = format_ems_for_logging(ems)
         _log.debug("#{log_header} Parsing inventory...")
 
-        hashes_or_persister =
-          if ems.inventory_object_refresh?
-            inventory.parse
-          else
-            parse_legacy_inventory(ems)
-          end
+        parsed_inventory = inventory.parse
 
         _log.debug("#{log_header} Parsing inventory...Complete")
 
-        hashes_or_persister
+        parsed_inventory
       end
 
       def parse_legacy_inventory(ems)
@@ -229,7 +221,6 @@ module ManageIQ
       def preprocess_targets_manager_refresh
         @targets_by_ems_id.each do |ems_id, targets|
           ems = @ems_by_ems_id[ems_id]
-          next unless ems.inventory_object_refresh?
 
           # We want all targets of class EmsEvent to be merged into one target, so they can be refreshed together, otherwise
           # we could be missing some crosslinks in the refreshed data

--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -52,16 +52,16 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
       phase_context[:new_vm_ems_ref] = clone_task_ref
 
       manager = source.ext_management_system
-      if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
+      target = if manager.allow_targeted_refresh?
         # Queue new targeted refresh if allowed
-        vm_target = InventoryRefresh::Target.new(:manager     => manager,
-                                                 :association => :vms,
-                                                 :manager_ref => {:ems_ref => clone_task_ref})
-        EmsRefresh.queue_refresh(vm_target)
+        InventoryRefresh::Target.new(:manager => manager, :association => :vms, :manager_ref => {:ems_ref => clone_task_ref})
       else
         # Otherwise queue a full refresh
-        EmsRefresh.queue_refresh(manager)
+        manager
       end
+
+      EmsRefresh.queue_refresh(target)
+
       signal :poll_destination_in_vmdb
     else
       requeue_phase

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -159,15 +159,14 @@ class OrchestrationStack < ApplicationRecord
       raise _("Provider failed last authentication check")
     end
 
-    if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
+    target = if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
       # Queue new targeted refresh if allowed
-      orchestration_stack_target = InventoryRefresh::Target.new(:manager     => manager,
-                                                                :association => :orchestration_stacks,
-                                                                :manager_ref => {:ems_ref => manager_ref})
-      EmsRefresh.queue_refresh(orchestration_stack_target)
+      InventoryRefresh::Target.new(:manager => manager, :association => :orchestration_stacks, :manager_ref => {:ems_ref => manager_ref})
     else
       # Otherwise queue a full refresh
-      EmsRefresh.queue_refresh(manager)
+      manager
     end
+
+    EmsRefresh.queue_refresh(target)
   end
 end


### PR DESCRIPTION
Remove checks for `ems.inventory_object_refresh?` in the `BaseManager::Refresher#refresh` and other locations.