### PR TITLE
Removed provider_foreman explorer and added new non-explorer style screens under Configuration main tab.

### DIFF
--- a/app/models/aliases/ems_configuration.rb
+++ b/app/models/aliases/ems_configuration.rb
@@ -1,0 +1,1 @@
+::EmsConfiguration = ::ManageIQ::Providers::ConfigurationManager

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -46,6 +46,7 @@ class ConfiguredSystem < ApplicationRecord
   scope :with_manager,                  ->(manager_id) { where(:manager_id => manager_id) }
   scope :with_configuration_profile_id, ->(profile_id) { where(:configuration_profile_id => profile_id) }
   scope :without_configuration_profile_id,          -> { where(:configuration_profile_id => nil) }
+  scope :under_configuration_managers, -> { where(:manager => ManageIQ::Providers::ConfigurationManager.all) }
 
   def configuration_architecture
     tag_hash[ConfigurationArchitecture]

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4612,9 +4612,9 @@
     :feature_type: view
     :identifier: physical_infra_overview_view
 
-# Configuration Managemers
+# Configuration Managers
 - :name: Configuration Managers
-  :description: Everything under Providers
+  :description: Everything under Configuration Manager Providers
   :feature_type: node
   :identifier: ems_configuration
   :children:

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4647,7 +4647,7 @@
     - :name: Refresh Configuration Manager Providers
       :description: Refresh relationships for all items related to Configuration Manager Provider
       :feature_type: control
-      :identifier: ems_configuration_refresh
+      :identifier: ems_configuration_refresh_provider
   - :name: Modify
     :description: Modify Configuration Manager Providers
     :feature_type: admin
@@ -4656,23 +4656,15 @@
     - :name: Remove Configuration Manager Providers
       :description: Remove Configuration Manager Provider
       :feature_type: admin
-      :identifier: ems_configuration_delete
+      :identifier: ems_configuration_delete_provider
     - :name: Edit Configuration Manager Provider
       :description: Edit a Configuration Manager Provider
       :feature_type: admin
-      :identifier: ems_configuration_edit
-    - :name: Pause
-      :description: Pause a Configuration Manager Provider
-      :feature_type: admin
-      :identifier: ems_configuration_pause
-    - :name: Resume
-      :description: Resume a Configuration Manager Provider
-      :feature_type: admin
-      :identifier: ems_configuration_resume
+      :identifier: ems_configuration_edit_provider
     - :name: Add Configuration Manager Provider
       :description: Add a Configuration Manager Provider
       :feature_type: admin
-      :identifier: ems_configuration_add
+      :identifier: ems_configuration_add_provider
 - :name: Configuration Profiles
   :description: Everything under Configuration Profiles
   :feature_type: node

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4612,7 +4612,7 @@
     :feature_type: view
     :identifier: physical_infra_overview_view
 
-# Foreman
+# Configuration Management
 - :name: Configuration Management
   :description: Everything under Configuration Management
   :feature_type: node
@@ -4624,49 +4624,49 @@
     :identifier: providers_accord
     :children:
     - :name: View
-      :description: View Providers, Configuration Profiles, Configured Systems
+      :description: View Configuration Manager Providers, Configuration Profiles, Configured Systems
       :feature_type: view
       :identifier: configuration_manager_view
     - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
+      :description: Perform Operations on Configuration Manager Providers and Configured Systems
       :feature_type: control
       :identifier: configuration_manager_control
       :children:
       - :name: Edit Tags
-        :description: Edit Tags of Foreman Provider
+        :description: Edit Tags of Configuration Manager Provider
         :feature_type: control
         :identifier: configuration_manager_provider_tag
       - :name: Provision Configured Systems
         :description: Provision Configured Systems
         :feature_type: control
         :identifier: configuration_manager_configured_system_provision
-      - :name: Refresh Providers
-        :description: Refresh relationships for all items related of Provider
+      - :name: Refresh Configuration Manager Providers
+        :description: Refresh relationships for all items related to Configuration Manager Provider
         :feature_type: control
         :identifier: configuration_manager_refresh_provider
     - :name: Modify
-      :description: Modify Providers
+      :description: Modify Configuration Manager Providers
       :feature_type: admin
       :identifier: provider_admin
       :children:
-      - :name: Remove Providers
-        :description: Remove Provier
+      - :name: Remove Configuration Manager Providers
+        :description: Remove Configuration Manager Provider
         :feature_type: admin
         :identifier: configuration_manager_delete_provider
-      - :name: Edit Provider
-        :description: Edit a Provider
+      - :name: Edit Configuration Manager Provider
+        :description: Edit a Configuration Manager Provider
         :feature_type: admin
         :identifier: configuration_manager_edit_provider
       - :name: Pause
-        :description: Pause a Provider
+        :description: Pause a Configuration Manager Provider
         :feature_type: admin
         :identifier: configuration_manager_pause
       - :name: Resume
-        :description: Resume a Provider
+        :description: Resume a Configuration Manager Provider
         :feature_type: admin
         :identifier: configuration_manager_resume
-      - :name: Add Provider
-        :description: Add a Provider
+      - :name: Add Configuration Manager Provider
+        :description: Add a Configuration Manager Provider
         :feature_type: admin
         :identifier: configuration_manager_add_provider
   - :name: Configuration Profiles

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4640,10 +4640,6 @@
       :description: Edit Tags of Configuration Manager Provider
       :feature_type: control
       :identifier: ems_configuration_tag
-    - :name: Provision Configured Systems
-      :description: Provision Configured Systems
-      :feature_type: control
-      :identifier: ems_configuration_configured_system_provision
     - :name: Refresh Configuration Manager Providers
       :description: Refresh relationships for all items related to Configuration Manager Provider
       :feature_type: control

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4619,7 +4619,7 @@
   :identifier: configuration_management
   :children:
   - :name: Providers
-    :description: Everything under Providers accordion
+    :description: Everything under Providers
     :feature_type: node
     :identifier: configuration_manager
     :children:
@@ -4679,7 +4679,7 @@
         :feature_type: admin
         :identifier: configuration_manager_add_provider
   - :name: Configuration Profiles
-    :description: Configuration Profiles
+    :description: Everything under Configuration Profiles
     :feature_type: node
     :identifier: configuration_profile
     :children:
@@ -4713,20 +4713,20 @@
     - :name: View
       :description: View Configured Systems
       :feature_type: view
-      :identifier: configured_system_view
+      :identifier: configured_systems_view
       :children:
-       - :name: List
-         :description: Display Lists of Configured Systems
-         :feature_type: view
-         :identifier: configured_system_show_list
-       - :name: Show
-         :description: Display Individual Configured System
-         :feature_type: view
-         :identifier: configured_system_show
+      - :name: List
+       :description: Display Lists of Configured Systems
+       :feature_type: view
+       :identifier: configured_system_show_list
+      - :name: Show
+       :description: Display Individual Configured System
+       :feature_type: view
+       :identifier: configured_system_show
     - :name: Operate
       :description: Perform Operations on Configured Systems
       :feature_type: control
-      :identifier: configured_system_control
+      :identifier: configured_systems_control
       :children:
       - :name: Edit Tags
         :description: Edit Configured Systems Tags

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4700,7 +4700,7 @@
   - :name: View
     :description: View Configured Systems
     :feature_type: view
-    :identifier: configured_systems_view
+    :identifier: configured_system_view
     :children:
     - :name: List
       :description: Display Lists of Configured Systems
@@ -4713,7 +4713,7 @@
   - :name: Operate
     :description: Perform Operations on Configured Systems
     :feature_type: control
-    :identifier: configured_systems_control
+    :identifier: configured_system_control
     :children:
     - :name: Edit Tags
       :description: Edit Configured Systems Tags
@@ -4723,28 +4723,6 @@
       :description: Provision Configured Systems
       :feature_type: control
       :identifier: configured_system_provision
-  - :name: Ansible Tower Job Templates
-    :description: Everything under Ansible Tower Job Templates accordion
-    :feature_type: node
-    :identifier: configuration_scripts_accord
-    :children:
-    - :name: View
-      :description: View Ansible Tower Job Templates
-      :feature_type: view
-      :identifier: configuration_script_view
-    - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
-      :feature_type: control
-      :identifier: configuration_script_control
-      :children:
-      - :name: Create Service Dialog
-        :description: Create Service Dialog
-        :feature_type: admin
-        :identifier: configscript_service_dialog
-      - :name: Edit Tags
-        :description: Edit Job Templates Tags
-        :feature_type: control
-        :identifier: configuration_script_tag
 
 # Embedded Automation Manager
 - :name: Embedded Automation Manager
@@ -4923,17 +4901,17 @@
         :description: Edit Configured Systems Tags
         :feature_type: control
         :identifier: automation_manager_configured_system_tag
-  - :name: Automation Scripts
-    :description: Everything under Automation Scripts accordion
+  - :name: Templates
+    :description: Everything under Templates accordion
     :feature_type: node
     :identifier: automation_manager_configuration_scripts_accord
     :children:
     - :name: View
-      :description: View Automation Scripts
+      :description: View Templates
       :feature_type: view
       :identifier: automation_manager_configuration_script_view
     - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
+      :description: Perform Operations on Templates
       :feature_type: control
       :identifier: automation_manager_configuration_script_control
       :children:
@@ -6321,19 +6299,6 @@
   :feature_type: node
   :identifier: api_exclusive
   :children:
-  - :name: Configured Systems
-    :description: Everything under Configured Systems
-    :feature_type: node
-    :identifier: configured_systems
-    :children:
-    - :name: View
-      :description: View Configured Systems
-      :feature_type: view
-      :identifier: configured_system_view
-    - :name: Operate
-      :description: Perform Operations on Configured Systems
-      :feature_type: control
-      :identifier: configured_system_control
   # Pictures
   - :name: Pictures
     :description: Everything under Pictures

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4656,7 +4656,7 @@
     - :name: Modify
       :description: Modify Configuration Manager Providers
       :feature_type: admin
-      :identifier: provider_admin
+      :identifier: configuration_manager_admin
       :children:
       - :name: Remove Configuration Manager Providers
         :description: Remove Configuration Manager Provider

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4616,17 +4616,26 @@
 - :name: Configuration Management
   :description: Everything under Configuration Management
   :feature_type: node
-  :identifier: configuration_manager_explorer
+  :identifier: configuration_management
   :children:
   - :name: Providers
     :description: Everything under Providers accordion
     :feature_type: node
-    :identifier: providers_accord
+    :identifier: configuration_manager
     :children:
     - :name: View
-      :description: View Configuration Manager Providers, Configuration Profiles, Configured Systems
+      :description: View Configuration Manager Providers
       :feature_type: view
       :identifier: configuration_manager_view
+      :children:
+      - :name: List
+        :description: Display Lists of Configuration Manager Providers
+        :feature_type: view
+        :identifier: configuration_manager_show_list
+      - :name: Show
+        :description: Display Individual Configuration Manager Provider
+        :feature_type: view
+        :identifier: configuration_manager_show
     - :name: Operate
       :description: Perform Operations on Configuration Manager Providers and Configured Systems
       :feature_type: control
@@ -4678,6 +4687,15 @@
       :description: View Configuration Profiles
       :feature_type: view
       :identifier: configuration_profile_view
+      :children:
+      - :name: List
+        :description: Display Lists of Configuration Profiles
+        :feature_type: view
+        :identifier: configuration_profile_show_list
+      - :name: Show
+        :description: Display Individual Configuration Profile
+        :feature_type: view
+        :identifier: configuration_profile_show
     - :name: Operate
       :description: Perform Operations on Configuration Profiles
       :feature_type: control
@@ -4688,18 +4706,27 @@
         :feature_type: control
         :identifier: configuration_profile_tag
   - :name: Configured Systems
-    :description: Everything under Configured Systems accordion
+    :description: Everything under Configured Systems
     :feature_type: node
-    :identifier: configured_systems_filter_accord
+    :identifier: configured_system
     :children:
     - :name: View
       :description: View Configured Systems
       :feature_type: view
-      :identifier: configured_systems_filter_accord_view
+      :identifier: configured_system_view
+      :children:
+       - :name: List
+         :description: Display Lists of Configured Systems
+         :feature_type: view
+         :identifier: configured_system_show_list
+       - :name: Show
+         :description: Display Individual Configured System
+         :feature_type: view
+         :identifier: configured_system_show
     - :name: Operate
       :description: Perform Operations on Configured Systems
       :feature_type: control
-      :identifier: configuredsystem_control
+      :identifier: configured_system_control
       :children:
       - :name: Edit Tags
         :description: Edit Configured Systems Tags

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4616,7 +4616,7 @@
 - :name: Configuration Management
   :description: Everything under Configuration Management
   :feature_type: node
-  :identifier: provider_foreman_explorer
+  :identifier: configuration_manager_explorer
   :children:
   - :name: Providers
     :description: Everything under Providers accordion
@@ -4626,11 +4626,11 @@
     - :name: View
       :description: View Providers, Configuration Profiles, Configured Systems
       :feature_type: view
-      :identifier: provider_foreman_view
+      :identifier: configuration_manager_view
     - :name: Operate
       :description: Perform Operations on Providers and Configured Systems
       :feature_type: control
-      :identifier: provider_foreman_control
+      :identifier: configuration_manager_control
       :children:
       - :name: Edit Tags
         :description: Edit Tags of Foreman Provider
@@ -4639,11 +4639,11 @@
       - :name: Provision Configured Systems
         :description: Provision Configured Systems
         :feature_type: control
-        :identifier: provider_foreman_configured_system_provision
+        :identifier: configuration_manager_configured_system_provision
       - :name: Refresh Providers
         :description: Refresh relationships for all items related of Provider
         :feature_type: control
-        :identifier: provider_foreman_refresh_provider
+        :identifier: configuration_manager_refresh_provider
     - :name: Modify
       :description: Modify Providers
       :feature_type: admin
@@ -4652,23 +4652,23 @@
       - :name: Remove Providers
         :description: Remove Provier
         :feature_type: admin
-        :identifier: provider_foreman_delete_provider
+        :identifier: configuration_manager_delete_provider
       - :name: Edit Provider
         :description: Edit a Provider
         :feature_type: admin
-        :identifier: provider_foreman_edit_provider
+        :identifier: configuration_manager_edit_provider
       - :name: Pause
         :description: Pause a Provider
         :feature_type: admin
-        :identifier: provider_foreman_pause
+        :identifier: configuration_manager_pause
       - :name: Resume
         :description: Resume a Provider
         :feature_type: admin
-        :identifier: provider_foreman_resume
+        :identifier: configuration_manager_resume
       - :name: Add Provider
         :description: Add a Provider
         :feature_type: admin
-        :identifier: provider_foreman_add_provider
+        :identifier: configuration_manager_add_provider
   - :name: Configuration Profiles
     :description: Configuration Profiles
     :feature_type: node

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4716,13 +4716,13 @@
       :identifier: configured_systems_view
       :children:
       - :name: List
-       :description: Display Lists of Configured Systems
-       :feature_type: view
-       :identifier: configured_system_show_list
+        :description: Display Lists of Configured Systems
+        :feature_type: view
+        :identifier: configured_system_show_list
       - :name: Show
-       :description: Display Individual Configured System
-       :feature_type: view
-       :identifier: configured_system_show
+        :description: Display Individual Configured System
+        :feature_type: view
+        :identifier: configured_system_show
     - :name: Operate
       :description: Perform Operations on Configured Systems
       :feature_type: control

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4612,130 +4612,125 @@
     :feature_type: view
     :identifier: physical_infra_overview_view
 
-# Configuration Management
-- :name: Configuration Management
-  :description: Everything under Configuration Management
+# Configuration Managemers
+- :name: Configuration Managers
+  :description: Everything under Providers
   :feature_type: node
-  :identifier: configuration_management
+  :identifier: ems_configuration
   :children:
-  - :name: Providers
-    :description: Everything under Providers
-    :feature_type: node
-    :identifier: configuration_manager
+  - :name: View
+    :description: View Configuration Manager Providers
+    :feature_type: view
+    :identifier: ems_configuration_view
     :children:
-    - :name: View
-      :description: View Configuration Manager Providers
+    - :name: List
+      :description: Display Lists of Configuration Manager Providers
       :feature_type: view
-      :identifier: configuration_manager_view
-      :children:
-      - :name: List
-        :description: Display Lists of Configuration Manager Providers
-        :feature_type: view
-        :identifier: configuration_manager_show_list
-      - :name: Show
-        :description: Display Individual Configuration Manager Provider
-        :feature_type: view
-        :identifier: configuration_manager_show
-    - :name: Operate
-      :description: Perform Operations on Configuration Manager Providers and Configured Systems
+      :identifier: ems_configuration_show_list
+    - :name: Show
+      :description: Display Individual Configuration Manager Provider
+      :feature_type: view
+      :identifier: ems_configuration_show
+  - :name: Operate
+    :description: Perform Operations on Configuration Manager Providers and Configured Systems
+    :feature_type: control
+    :identifier: ems_configuration_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Configuration Manager Provider
       :feature_type: control
-      :identifier: configuration_manager_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Tags of Configuration Manager Provider
-        :feature_type: control
-        :identifier: configuration_manager_provider_tag
-      - :name: Provision Configured Systems
-        :description: Provision Configured Systems
-        :feature_type: control
-        :identifier: configuration_manager_configured_system_provision
-      - :name: Refresh Configuration Manager Providers
-        :description: Refresh relationships for all items related to Configuration Manager Provider
-        :feature_type: control
-        :identifier: configuration_manager_refresh_provider
-    - :name: Modify
-      :description: Modify Configuration Manager Providers
+      :identifier: ems_configuration_tag
+    - :name: Provision Configured Systems
+      :description: Provision Configured Systems
+      :feature_type: control
+      :identifier: ems_configuration_configured_system_provision
+    - :name: Refresh Configuration Manager Providers
+      :description: Refresh relationships for all items related to Configuration Manager Provider
+      :feature_type: control
+      :identifier: ems_configuration_refresh
+  - :name: Modify
+    :description: Modify Configuration Manager Providers
+    :feature_type: admin
+    :identifier: ems_configuration_admin
+    :children:
+    - :name: Remove Configuration Manager Providers
+      :description: Remove Configuration Manager Provider
       :feature_type: admin
-      :identifier: configuration_manager_admin
-      :children:
-      - :name: Remove Configuration Manager Providers
-        :description: Remove Configuration Manager Provider
-        :feature_type: admin
-        :identifier: configuration_manager_delete_provider
-      - :name: Edit Configuration Manager Provider
-        :description: Edit a Configuration Manager Provider
-        :feature_type: admin
-        :identifier: configuration_manager_edit_provider
-      - :name: Pause
-        :description: Pause a Configuration Manager Provider
-        :feature_type: admin
-        :identifier: configuration_manager_pause
-      - :name: Resume
-        :description: Resume a Configuration Manager Provider
-        :feature_type: admin
-        :identifier: configuration_manager_resume
-      - :name: Add Configuration Manager Provider
-        :description: Add a Configuration Manager Provider
-        :feature_type: admin
-        :identifier: configuration_manager_add_provider
-  - :name: Configuration Profiles
-    :description: Everything under Configuration Profiles
-    :feature_type: node
-    :identifier: configuration_profile
+      :identifier: ems_configuration_delete
+    - :name: Edit Configuration Manager Provider
+      :description: Edit a Configuration Manager Provider
+      :feature_type: admin
+      :identifier: ems_configuration_edit
+    - :name: Pause
+      :description: Pause a Configuration Manager Provider
+      :feature_type: admin
+      :identifier: ems_configuration_pause
+    - :name: Resume
+      :description: Resume a Configuration Manager Provider
+      :feature_type: admin
+      :identifier: ems_configuration_resume
+    - :name: Add Configuration Manager Provider
+      :description: Add a Configuration Manager Provider
+      :feature_type: admin
+      :identifier: ems_configuration_add
+- :name: Configuration Profiles
+  :description: Everything under Configuration Profiles
+  :feature_type: node
+  :identifier: configuration_profile
+  :children:
+  - :name: View
+    :description: View Configuration Profiles
+    :feature_type: view
+    :identifier: configuration_profile_view
     :children:
-    - :name: View
-      :description: View Configuration Profiles
+    - :name: List
+      :description: Display Lists of Configuration Profiles
       :feature_type: view
-      :identifier: configuration_profile_view
-      :children:
-      - :name: List
-        :description: Display Lists of Configuration Profiles
-        :feature_type: view
-        :identifier: configuration_profile_show_list
-      - :name: Show
-        :description: Display Individual Configuration Profile
-        :feature_type: view
-        :identifier: configuration_profile_show
-    - :name: Operate
-      :description: Perform Operations on Configuration Profiles
-      :feature_type: control
-      :identifier: configuration_profile_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Configuration Profiles Tags
-        :feature_type: control
-        :identifier: configuration_profile_tag
-  - :name: Configured Systems
-    :description: Everything under Configured Systems
-    :feature_type: node
-    :identifier: configured_system
+      :identifier: configuration_profile_show_list
+    - :name: Show
+      :description: Display Individual Configuration Profile
+      :feature_type: view
+      :identifier: configuration_profile_show
+  - :name: Operate
+    :description: Perform Operations on Configuration Profiles
+    :feature_type: control
+    :identifier: configuration_profile_control
     :children:
-    - :name: View
-      :description: View Configured Systems
-      :feature_type: view
-      :identifier: configured_systems_view
-      :children:
-      - :name: List
-        :description: Display Lists of Configured Systems
-        :feature_type: view
-        :identifier: configured_system_show_list
-      - :name: Show
-        :description: Display Individual Configured System
-        :feature_type: view
-        :identifier: configured_system_show
-    - :name: Operate
-      :description: Perform Operations on Configured Systems
+    - :name: Edit Tags
+      :description: Edit Configuration Profiles Tags
       :feature_type: control
-      :identifier: configured_systems_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Configured Systems Tags
-        :feature_type: control
-        :identifier: configured_system_tag
-      - :name: Provision Configured Systems
-        :description: Provision Configured Systems
-        :feature_type: control
-        :identifier: configured_system_provision
+      :identifier: configuration_profile_tag
+- :name: Configured Systems
+  :description: Everything under Configured Systems
+  :feature_type: node
+  :identifier: configured_system
+  :children:
+  - :name: View
+    :description: View Configured Systems
+    :feature_type: view
+    :identifier: configured_systems_view
+    :children:
+    - :name: List
+      :description: Display Lists of Configured Systems
+      :feature_type: view
+      :identifier: configured_system_show_list
+    - :name: Show
+      :description: Display Individual Configured System
+      :feature_type: view
+      :identifier: configured_system_show
+  - :name: Operate
+    :description: Perform Operations on Configured Systems
+    :feature_type: control
+    :identifier: configured_systems_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Configured Systems Tags
+      :feature_type: control
+      :identifier: configured_system_tag
+    - :name: Provision Configured Systems
+      :description: Provision Configured Systems
+      :feature_type: control
+      :identifier: configured_system_provision
   - :name: Ansible Tower Job Templates
     :description: Everything under Ansible Tower Job Templates accordion
     :feature_type: node

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -294,10 +294,10 @@
   :url: /migration/#settings
   :rbac_feature_name: migration_settings
   :startup: true
-- :name: configuration_manager
+- :name: ems_configuration
   :description: Configuration / Providers
-  :url: configuration_manager/show_list
-  :rbac_feature_name: configuration_manager_show_list
+  :url: ems_configuration/show_list
+  :rbac_feature_name: ems_configuration_show_list
 - :name: configuration_profile
   :description: Configuration / Profiles
   :url: configuration_profile/show_list

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -298,10 +298,12 @@
   :description: Configuration / Providers
   :url: ems_configuration/show_list
   :rbac_feature_name: ems_configuration_show_list
+  :startup: true
 - :name: configuration_profile
   :description: Configuration / Profiles
   :url: configuration_profile/show_list
   :rbac_feature_name: configuration_profile_show_list
+  :startup: true
 - :name: configured_system
   :description: Configured / Systems
   :url: configured_system/show_list

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -294,10 +294,18 @@
   :url: /migration/#settings
   :rbac_feature_name: migration_settings
   :startup: true
-- :name: configuration_management
-  :description: Configuration / Management
-  :url: configuration_manager/explorer
-  :rbac_feature_name: configuration_manager_explorer
+- :name: configuration_manager
+  :description: Configuration / Providers
+  :url: configuration_manager/show_list
+  :rbac_feature_name: configuration_manager_show_list
+- :name: configuration_profile
+  :description: Configuration / Profiles
+  :url: configuration_profile/show_list
+  :rbac_feature_name: configuration_profile_show_list
+- :name: configured_system
+  :description: Configured / Systems
+  :url: configured_system/show_list
+  :rbac_feature_name: configured_system_show_list
   :startup: true
 - :name: ems_networks
   :description: Networks / Providers

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -296,8 +296,8 @@
   :startup: true
 - :name: configuration_management
   :description: Configuration / Management
-  :url: provider_foreman/explorer
-  :rbac_feature_name: provider_foreman_explorer
+  :url: configuration_manager/explorer
+  :rbac_feature_name: configuration_manager_explorer
   :startup: true
 - :name: ems_networks
   :description: Networks / Providers

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -36,7 +36,7 @@
   - container_dashboard
   - ems_container
   - configuration_job
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - container_project
@@ -290,7 +290,7 @@
   - about
   - all_vm_rules
   - automation_manager
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - dashboard
@@ -366,7 +366,7 @@
   - embedded_automation_manager
   - chargeback
   - chargeback_reports
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - dashboard
@@ -891,7 +891,7 @@
   - embedded_automation_manager
   - ems_physical_infra_console
   - catalog_items_view
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - miq_task_my_ui
@@ -950,7 +950,7 @@
   - about
   - all_vm_rules
   - automation_manager
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - embedded_automation_manager
@@ -1027,7 +1027,7 @@
   - chargeback
   - catalog
   - cloud_tenant
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - control_explorer
@@ -1087,7 +1087,7 @@
   - chargeback
   - catalog
   - cloud_tenant
-  - configuration_manager
+  - ems_configuration
   - configuration_profile
   - configured_system
   - control_explorer
@@ -1306,7 +1306,7 @@
   - physical_server_view
   - physical_storage_view
   - policy_log
-  - configuration_manager_view
+  - ems_configuration_view
   - pxe_image_type_view
   - pxe_server_view
   - rbac_group_view

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -75,7 +75,7 @@
   - physical_storage
   - physical_infra_topology
   - policy_import_export
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - pxe
   - resource_pool
   - rss
@@ -316,7 +316,7 @@
   - physical_switch_view
   - physical_server_view
   - physical_storage_view
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - vm_clone
   - vm_compare
   - vm_cloud_explorer
@@ -432,7 +432,7 @@
   - resource_pool_tag
   - rss
   - service_view
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - storage_delete
   - storage_scan
   - storage_show
@@ -900,7 +900,7 @@
   - my_settings_visuals
   - miq_request_admin
   - miq_request_view
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - service_edit
   - service_delete
   - service_reconfigure
@@ -958,7 +958,7 @@
   - miq_template_timeline
   - my_settings_default_views
   - my_settings_visuals
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - vm_check_compliance
   - vm_clone
   - vm_cloud_explorer
@@ -1043,7 +1043,7 @@
   - miq_template
   - orchestration_stack
   - policy_import_export
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - pxe
   - rbac_group
   - rbac_role_view
@@ -1098,7 +1098,7 @@
   - miq_template
   - orchestration_stack
   - policy_import_export
-  - provider_foreman_explorer
+  - configuration_manager_explorer
   - pxe
   - rbac_tenant_view
   - rbac_tenant_manage_quotas
@@ -1292,7 +1292,7 @@
   - physical_server_view
   - physical_storage_view
   - policy_log
-  - provider_foreman_view
+  - configuration_manager_view
   - pxe_image_type_view
   - pxe_server_view
   - rbac_group_view

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -36,6 +36,9 @@
   - container_dashboard
   - ems_container
   - configuration_job
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - container_project
   - container_route
   - container_service
@@ -75,7 +78,6 @@
   - physical_storage
   - physical_infra_topology
   - policy_import_export
-  - configuration_manager_explorer
   - pxe
   - resource_pool
   - rss
@@ -288,6 +290,9 @@
   - about
   - all_vm_rules
   - automation_manager
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - dashboard
   - ems_physical_infra
   - event_streams
@@ -316,7 +321,6 @@
   - physical_switch_view
   - physical_server_view
   - physical_storage_view
-  - configuration_manager_explorer
   - vm_clone
   - vm_compare
   - vm_cloud_explorer
@@ -362,6 +366,9 @@
   - embedded_automation_manager
   - chargeback
   - chargeback_reports
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - dashboard
   - ems_cluster_compare
   - ems_cluster_drift
@@ -432,7 +439,6 @@
   - resource_pool_tag
   - rss
   - service_view
-  - configuration_manager_explorer
   - storage_delete
   - storage_scan
   - storage_show
@@ -885,6 +891,9 @@
   - embedded_automation_manager
   - ems_physical_infra_console
   - catalog_items_view
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - miq_task_my_ui
   - miq_template_clone
   - miq_template_drift
@@ -900,7 +909,6 @@
   - my_settings_visuals
   - miq_request_admin
   - miq_request_view
-  - configuration_manager_explorer
   - service_edit
   - service_delete
   - service_reconfigure
@@ -942,6 +950,9 @@
   - about
   - all_vm_rules
   - automation_manager
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - embedded_automation_manager
   - miq_task_my_ui
   - miq_request_admin
@@ -958,7 +969,6 @@
   - miq_template_timeline
   - my_settings_default_views
   - my_settings_visuals
-  - configuration_manager_explorer
   - vm_check_compliance
   - vm_clone
   - vm_cloud_explorer
@@ -1017,6 +1027,9 @@
   - chargeback
   - catalog
   - cloud_tenant
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - control_explorer
   - dashboard
   - storage
@@ -1043,7 +1056,6 @@
   - miq_template
   - orchestration_stack
   - policy_import_export
-  - configuration_manager_explorer
   - pxe
   - rbac_group
   - rbac_role_view
@@ -1075,6 +1087,9 @@
   - chargeback
   - catalog
   - cloud_tenant
+  - configuration_manager
+  - configuration_profile
+  - configured_system
   - control_explorer
   - dashboard
   - storage
@@ -1098,7 +1113,6 @@
   - miq_template
   - orchestration_stack
   - policy_import_export
-  - configuration_manager_explorer
   - pxe
   - rbac_tenant_view
   - rbac_tenant_manage_quotas

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1009,6 +1009,8 @@ en:
       ems_clouds:                  Cloud Providers
       ems_cluster:                 Cluster
       ems_clusters:                Clusters
+      ems_configuration:           Configuration Manager
+      ems_configurations:          Configuration Managers
       ems_custom_attribute:        VC Custom Attribute
       ems_custom_attributes:       VC Custom Attributes
       ems_event:                   Management Event

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -781,11 +781,9 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript: Job Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow: Workflow Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook: Playbook (Ansible Tower)
-      ManageIQ::Providers::CloudAutomationManager::ConfigurationManager:    Configuration Manager (Cloud Automation Manager)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem: Configured System (Ansible Tower)
-      ManageIQ::Providers::CloudAutomationManager::ConfigurationManager::ConfiguredSystem: Configured System (Cloud Automation Manager)
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Configured System (Foreman)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Job:         Ansible Tower Job
       ManageIQ::Providers::CloudManager:                                    Cloud Provider

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -781,9 +781,11 @@ en:
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript: Job Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationWorkflow: Workflow Template (Ansible Tower)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Playbook: Playbook (Ansible Tower)
+      ManageIQ::Providers::CloudAutomationManager::ConfigurationManager:    Configuration Manager (Cloud Automation Manager)
       ManageIQ::Providers::Foreman::ConfigurationManager:                   Configuration Manager (Foreman)
       ManageIQ::Providers::ConfigurationManager:                            Configuration Manager
       ManageIQ::Providers::AnsibleTower::AutomationManager::ConfiguredSystem: Configured System (Ansible Tower)
+      ManageIQ::Providers::CloudAutomationManager::ConfigurationManager::ConfiguredSystem: Configured System (Cloud Automation Manager)
       ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem: Configured System (Foreman)
       ManageIQ::Providers::AnsibleTower::AutomationManager::Job:         Ansible Tower Job
       ManageIQ::Providers::CloudManager:                                    Cloud Provider


### PR DESCRIPTION
Removed provider_foreman explorer and added new non-explorer style screens under Configuration main tab.

Follow up PR for https://github.com/ManageIQ/manageiq-ui-classic/pull/6730

- [ ] UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/6782
- [ ] Schema PR: https://github.com/ManageIQ/manageiq-schema/pull/464

before
![before](https://user-images.githubusercontent.com/3450808/78901532-722be480-7a46-11ea-85a0-11ce2da5583e.png)

![before_shortcuts](https://user-images.githubusercontent.com/3450808/78911579-7c54df80-7a54-11ea-838e-2de7ff2c078f.png)

after
![Screenshot from 2020-04-09 12-43-04](https://user-images.githubusercontent.com/3450808/78919339-c8f1e800-7a5f-11ea-8a2b-2f19e9d81ffe.png)

![after_shortcuts](https://user-images.githubusercontent.com/3450808/78907649-faae8300-7a4e-11ea-9ae3-a4fa63912956.png)

