### PR TITLE
Remove openstack Node / Deployment role logic from Host & EmsCluster

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -288,30 +288,6 @@ class EmsCluster < ApplicationRecord
     hosts(:include => [:taggings, :tags]).select(&:perf_capture_enabled?)
   end
 
-  cache_with_timeout(:node_types) do
-    if !openstack_clusters_exists?
-      :non_openstack
-    elsif non_openstack_clusters_exists?
-      :mixed_clusters
-    else
-      :openstack
-    end
-  end
-
-  def self.openstack_clusters_exists?
-    ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    ems.empty? ? false : EmsCluster.where(:ems_id => ems).exists?
-  end
-
-  def self.non_openstack_clusters_exists?
-    ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    EmsCluster.where.not(:ems_id => ems).exists?
-  end
-
-  def openstack_cluster?
-    ext_management_system.class == ManageIQ::Providers::Openstack::InfraManager
-  end
-
   def self.display_name(number = 1)
     n_('Cluster / Deployment Role', 'Clusters / Deployment Roles', number)
   end

--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -289,6 +289,6 @@ class EmsCluster < ApplicationRecord
   end
 
   def self.display_name(number = 1)
-    n_('Cluster / Deployment Role', 'Clusters / Deployment Roles', number)
+    n_('Cluster', 'Clusters', number)
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1785,6 +1785,6 @@ class Host < ApplicationRecord
   end
 
   def self.display_name(number = 1)
-    n_('Host / Node', 'Hosts / Nodes', number)
+    n_('Host', 'Hosts', number)
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1753,30 +1753,6 @@ class Host < ApplicationRecord
     !plist.blank?
   end
 
-  cache_with_timeout(:node_types) do # TODO: This doesn't belong here
-    if !openstack_hosts_exists?
-      :non_openstack
-    elsif non_openstack_hosts_exists?
-      :mixed_hosts
-    else
-      :openstack
-    end
-  end
-
-  def self.openstack_hosts_exists? # TODO: This doesn't belong here
-    ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    ems.empty? ? false : Host.where(:ems_id => ems).exists?
-  end
-
-  def self.non_openstack_hosts_exists? # TODO: This doesn't belong here
-    ems = ManageIQ::Providers::Openstack::InfraManager.pluck(:id)
-    Host.where.not(:ems_id => ems).exists?
-  end
-
-  def openstack_host? # TODO: This doesn't belong here
-    ext_management_system.class == ManageIQ::Providers::Openstack::InfraManager
-  end
-
   def writable_storages
     if host_storages.loaded? && host_storages.all? { |hs| hs.association(:storage).loaded? }
       host_storages.reject(&:read_only).map(&:storage)

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1120,166 +1120,166 @@
       :feature_type: view
       :identifier: datacenter_show
 
-# Clusters / Deployment Roles
-- :name: Clusters / Deployment Roles
-  :description: Everything under Clusters / Deployment Roles
+# Clusters
+- :name: Clusters
+  :description: Everything under Clusters
   :feature_type: node
   :identifier: ems_cluster
   :children:
   - :name: View
-    :description: View Clusters / Deployment Roles
+    :description: View Clusters
     :feature_type: view
     :identifier: ems_cluster_view
     :children:
     - :name: Compare
-      :description: Compare List of Clusters / Deployment Roles
+      :description: Compare List of Clusters
       :feature_type: view
       :identifier: ems_cluster_compare
     - :name: Drift
-      :description: Display Clusters / Deployment Roles Drift
+      :description: Display Clusters Drift
       :feature_type: view
       :identifier: ems_cluster_drift
     - :name: List
-      :description: Display Lists of Clusters / Deployment Roles
+      :description: Display Lists of Clusters
       :feature_type: view
       :identifier: ems_cluster_show_list
     - :name: Show
-      :description: Display Individual Clusters / Deployment Roles
+      :description: Display Individual Clusters
       :feature_type: view
       :identifier: ems_cluster_show
     - :name: Utilization
-      :description: Show Capacity & Utilization data of Clusters / Deployment Roles
+      :description: Show Capacity & Utilization data of Clusters
       :feature_type: view
       :identifier: ems_cluster_perf
     - :name: Timelines
-      :description: Display Timelines for Clusters / Deployment Roles
+      :description: Display Timelines for Clusters
       :feature_type: view
       :identifier: ems_cluster_timeline
   - :name: Operate
-    :description: Perform Operations on Clusters / Deployment Roles
+    :description: Perform Operations on Clusters
     :feature_type: control
     :identifier: ems_cluster_control
     :children:
     - :name: Analysis
-      :description: Perform SmartState Analysis on Clusters / Deployment Roles
+      :description: Perform SmartState Analysis on Clusters
       :feature_type: control
       :identifier: ems_cluster_scan
     - :name: Manage Policies
-      :description: Manage Policies on Clusters / Deployment Roles
+      :description: Manage Policies on Clusters
       :feature_type: control
       :identifier: ems_cluster_protect
     - :name: Tag
-      :description: Edit Tags for Clusters / Deployment Roles
+      :description: Edit Tags for Clusters
       :feature_type: control
       :identifier: ems_cluster_tag
   - :name: Modify
-    :description: Modify Clusters / Deployment Roles
+    :description: Modify Clusters
     :feature_type: admin
     :identifier: ems_cluster_admin
     :children:
     - :name: Remove
-      :description: Remove Clusters / Deployment Roles
+      :description: Remove Clusters
       :feature_type: admin
       :identifier: ems_cluster_delete
 
-# Hosts / Nodes
-- :name: Hosts / Nodes
-  :description: Everything under Hosts / Nodes
+# Hosts
+- :name: Hosts
+  :description: Everything under Hosts
   :feature_type: node
   :identifier: host
   :children:
   - :name: View
-    :description: View Hosts / Nodes
+    :description: View Hosts
     :feature_type: view
     :identifier: host_view
     :children:
     - :name: Compare
-      :description: Compare List of Hosts / Nodes
+      :description: Compare List of Hosts
       :feature_type: view
       :identifier: host_compare
     - :name: List
-      :description: Display Lists of Hosts / Nodes
+      :description: Display Lists of Hosts
       :feature_type: view
       :identifier: host_show_list
     - :name: Show
-      :description: Display Individual Hosts / Nodes
+      :description: Display Individual Hosts
       :feature_type: view
       :identifier: host_show
     - :name: Drift
-      :description: Display Hosts / Nodes Drift
+      :description: Display Hosts Drift
       :feature_type: view
       :identifier: host_drift
     - :name: Utilization
-      :description: Show Capacity & Utilization data of Hosts / Nodes
+      :description: Show Capacity & Utilization data of Hosts
       :feature_type: view
       :identifier: host_perf
     - :name: Timelines
-      :description: Display Timelines for Hosts / Nodes
+      :description: Display Timelines for Hosts
       :feature_type: view
       :identifier: host_timeline
   - :name: Operate
-    :description: Perform Operations on Hosts / Nodes
+    :description: Perform Operations on Hosts
     :feature_type: control
     :identifier: host_control
     :children:
     - :name: Analysis
-      :description: Perform SmartState Analysis for Hosts / Nodes
+      :description: Perform SmartState Analysis for Hosts
       :feature_type: control
       :identifier: host_scan
     - :name: Analyze then Check Compliance
-      :description: Analyze then Check Compliance for Hosts / Nodes
+      :description: Analyze then Check Compliance for Hosts
       :feature_type: control
       :identifier: host_analyze_check_compliance
     - :name: Check Compliance
-      :description: Check Compliance of Last Known Configuration for Hosts / Nodes
+      :description: Check Compliance of Last Known Configuration for Hosts
       :feature_type: control
       :identifier: host_check_compliance
     - :name: Manage Policies
-      :description: Manage Policies for Hosts / Nodes
+      :description: Manage Policies for Hosts
       :feature_type: control
       :identifier: host_protect
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Hosts / Nodes
+      :description: Refresh relationships and power states for all items related to Hosts
       :feature_type: control
       :identifier: host_refresh
     - :name: Edit Tags
-      :description: Edit Host / Node Tags
+      :description: Edit Host Tags
       :feature_type: control
       :identifier: host_tag
     - :name: Power On
-      :description: Power On a Host / Node
+      :description: Power On a Host
       :feature_type: control
       :identifier: host_start
     - :name: Power Off
-      :description: Power Off a Host / Node
+      :description: Power Off a Host
       :feature_type: control
       :identifier: host_stop
     - :name: Reset
-      :description: Reset a Host / Node
+      :description: Reset a Host
       :feature_type: control
       :identifier: host_reset
     - :name: Toggle Maintenance Mode
-      :description: Toggle a Host / Node into Maintenance Mode
+      :description: Toggle a Host into Maintenance Mode
       :feature_type: control
       :identifier: host_toggle_maintenance
     - :name: Enter Maintenance Mode
-      :description: Put a Host / Node into Maintenance Mode
+      :description: Put a Host into Maintenance Mode
       :feature_type: control
       :identifier: host_enter_maint_mode
     - :name: Exit Maintenance Mode
-      :description: Take a Host / Node out of Maintenance Mode
+      :description: Take a Host out of Maintenance Mode
       :feature_type: control
       :identifier: host_exit_maint_mode
     - :name: Shutdown Host to Standby
-      :description: Shutdown a Host / Node to Standby Mode
+      :description: Shutdown a Host to Standby Mode
       :feature_type: control
       :identifier: host_standby
     - :name: Shutdown Host
-      :description: Shutdown a Host / Node
+      :description: Shutdown a Host
       :feature_type: control
       :identifier: host_shutdown
     - :name: Restart Host
-      :description: Restart a Host / Node
+      :description: Restart a Host
       :feature_type: control
       :identifier: host_reboot
     - :name: Cloud Service Scheduling toggle
@@ -1287,32 +1287,32 @@
       :feature_type: control
       :identifier: host_cloud_service_scheduling_toggle
   - :name: Modify
-    :description: Modify Hosts / Nodes
+    :description: Modify Hosts
     :feature_type: admin
     :identifier: host_admin
     :children:
     - :name: Remove
-      :description: Remove Hosts / Nodes
+      :description: Remove Hosts
       :feature_type: admin
       :identifier: host_delete
     - :name: Edit
-      :description: Edit a Host / Node
+      :description: Edit a Host
       :feature_type: admin
       :identifier: host_edit
-    - :name: Register Hosts / Nodes
-      :description: Register new Hosts / Nodes
+    - :name: Register Hosts
+      :description: Register new Hosts
       :feature_type: admin
       :identifier: host_register_nodes
-    - :name: Set Hosts / Nodes to Manageable State
-      :description: Set Hosts / Nodes to Manageable State
+    - :name: Set Hosts to Manageable State
+      :description: Set Hosts to Manageable State
       :feature_type: admin
       :identifier: host_manageable
-    - :name: Introspect Hosts / Nodes
-      :description: Introspect Hosts / Nodes
+    - :name: Introspect Hosts
+      :description: Introspect Hosts
       :feature_type: admin
       :identifier: host_introspect
-    - :name: Provide Hosts / Nodes
-      :description: Provide Hosts / Nodes
+    - :name: Provide Hosts
+      :description: Provide Hosts
       :feature_type: admin
       :identifier: host_provide
 
@@ -6031,7 +6031,7 @@
     :identifier: physical_switch_control
     :children:
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Physical Switches / Nodes
+      :description: Refresh relationships and power states for all items related to Physical Switches
       :feature_type: control
       :identifier: physical_switch_refresh
     - :name: Restart
@@ -6150,7 +6150,7 @@
       :feature_type: control
       :identifier: physical_server_turn_off_loc_led
     - :name: Refresh
-      :description: Refresh relationships and power states for all items related to Physical Servers / Nodes
+      :description: Refresh relationships and power states for all items related to Physical Servers
       :feature_type: control
       :identifier: physical_server_refresh
     - :name: Manage Policies

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -721,7 +721,7 @@ en:
       ContainerReplicator:      Container Replicator
       ContainerService:         Container Service
       ContainerTemplate:        Container Template
-      EmsCluster:               Cluster / Deployment Role
+      EmsCluster:               Cluster
       EmsClusterPerformance:    Performance - Cluster
       EmsEvent:                 Management Event
       EmsFolder:                Folder
@@ -740,7 +740,7 @@ en:
       GenericObjectDefinition:  Generic Object Class
       GuestApplication:         Guest Application
       GuestDevice:              Guest Device
-      Host:                     Host / Node
+      Host:                     Host
       HostPerformance:          Performance - Host
       IsoDatastore:             ISO Datastore
       IsoImage:                 ISO Image
@@ -1005,8 +1005,8 @@ en:
       ems_block_storages:          Block Storage Managers
       ems_cloud:                   Cloud Provider
       ems_clouds:                  Cloud Providers
-      ems_cluster:                 Cluster / Deployment Role
-      ems_clusters:                Clusters / Deployment Roles
+      ems_cluster:                 Cluster
+      ems_clusters:                Clusters
       ems_custom_attribute:        VC Custom Attribute
       ems_custom_attributes:       VC Custom Attributes
       ems_event:                   Management Event
@@ -1038,8 +1038,8 @@ en:
       floating_ip:                 Floating IP
       floppies:                    Floppy Drives
       guest_devices:               Devices
-      host:                        Host / Node
-      hosts:                       Hosts / Nodes
+      host:                        Host
+      hosts:                       Hosts
       host_services:               Services
       iso_datastore:               ISO Datastore
       iso_image:                   ISO Image

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2181,8 +2181,8 @@ RSpec.describe MiqExpression do
       relats  = MiqExpression.get_relats(Vm)
       details = MiqExpression._model_details(relats, {})
       cluster_sorted = details.select { |d| d.first.starts_with?("Cluster") }.sort
-      expect(cluster_sorted.map(&:first)).to include("Cluster / Deployment Role : Total Number of Physical CPUs")
-      expect(cluster_sorted.map(&:first)).to include("Cluster / Deployment Role : Total Number of Logical CPUs")
+      expect(cluster_sorted.map(&:first)).to include("Cluster : Total Number of Physical CPUs")
+      expect(cluster_sorted.map(&:first)).to include("Cluster : Total Number of Logical CPUs")
       hardware_sorted = details.select { |d| d.first.starts_with?("Hardware") }.sort
       expect(hardware_sorted.map(&:first)).not_to include("Hardware : Logical Cpus")
     end
@@ -2285,7 +2285,7 @@ RSpec.describe MiqExpression do
 
       it "generates a human readable string for a TAG expression" do
         exp = MiqExpression.new("CONTAINS" => {"tag" => "Host.managed-environment", "value" => "prod"})
-        expect(exp.to_human).to eq("Host / Node.My Company Tags : Environment CONTAINS 'Production'")
+        expect(exp.to_human).to eq("Host.My Company Tags : Environment CONTAINS 'Production'")
       end
 
       it "generates a human readable string for a TAG expression with alias" do

--- a/spec/models/ems_cluster_spec.rb
+++ b/spec/models/ems_cluster_spec.rb
@@ -176,50 +176,6 @@ RSpec.describe EmsCluster do
     end
   end
 
-  context "#node_types" do
-    before do
-      @ems1 = FactoryBot.create(:ems_vmware)
-      @ems2 = FactoryBot.create(:ems_openstack_infra)
-    end
-
-    it "returns :mixed_clusters when there are both openstack & non-openstack clusters in db" do
-      FactoryBot.create(:ems_cluster, :ems_id => @ems1.id)
-      FactoryBot.create(:ems_cluster, :ems_id => @ems2.id)
-
-      result = EmsCluster.node_types
-      expect(result).to eq(:mixed_clusters)
-    end
-
-    it "returns :openstack when there are only openstack clusters in db" do
-      FactoryBot.create(:ems_cluster, :ems_id => @ems2.id)
-      result = EmsCluster.node_types
-      expect(result).to eq(:openstack)
-    end
-
-    it "returns :non_openstack when there are non-openstack clusters in db" do
-      FactoryBot.create(:ems_cluster, :ems_id => @ems1.id)
-      result = EmsCluster.node_types
-      expect(result).to eq(:non_openstack)
-    end
-  end
-
-  context "#openstack_cluster?" do
-    it "returns true for openstack cluster" do
-      ems = FactoryBot.create(:ems_openstack_infra)
-      cluster = FactoryBot.create(:ems_cluster, :ems_id => ems.id)
-
-      result = cluster.openstack_cluster?
-      expect(result).to be_truthy
-    end
-
-    it "returns false for non-openstack cluster" do
-      ems = FactoryBot.create(:ems_vmware)
-      cluster = FactoryBot.create(:ems_cluster, :ems_id => ems.id)
-      result = cluster.openstack_cluster?
-      expect(result).to be_falsey
-    end
-  end
-
   context "#tenant_identity" do
     let(:admin)    { FactoryBot.create(:user_with_group, :userid => "admin") }
     let(:tenant)   { FactoryBot.create(:tenant) }

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -294,34 +294,6 @@ RSpec.describe Host do
     it("#enabled_inbound_ports")      { expect(subject.enabled_inbound_ports).to      match_array([1003, 1001]) }
   end
 
-  context ".node_types" do
-    it "returns :mixed_hosts when there are both openstack & non-openstack hosts in db" do
-      FactoryBot.create(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))
-      FactoryBot.create(:host_vmware_esx,      :ext_management_system => FactoryBot.create(:ems_vmware))
-
-      expect(Host.node_types).to eq(:mixed_hosts)
-    end
-
-    it "returns :openstack when there are only openstack hosts in db" do
-      FactoryBot.create(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))
-
-      expect(Host.node_types).to eq(:openstack)
-    end
-
-    it "returns :non_openstack when there are non-openstack hosts in db" do
-      FactoryBot.create(:host_vmware_esx, :ext_management_system => FactoryBot.create(:ems_vmware))
-
-      expect(Host.node_types).to eq(:non_openstack)
-    end
-  end
-
-  context "#openstack_host?" do
-    it("false") { expect(FactoryBot.build(:host).openstack_host?).to be false }
-
-    it "true" do
-      expect(FactoryBot.build(:host_openstack_infra, :ext_management_system => FactoryBot.create(:ems_openstack_infra))).to be_openstack_host
-    end
-  end
 
   def assert_default_credentials_validated
     allow(@host).to receive(:verify_credentials_with_ws)


### PR DESCRIPTION
Depends on:

* UI: https://github.com/ManageIQ/manageiq-ui-classic/pull/6761
* ~~API: https://github.com/ManageIQ/manageiq-api/pull/775~~
* ~~Service UI: https://github.com/ManageIQ/manageiq-ui-service/pull/1630 (not a dependency)~~
* Provider VMware: https://github.com/ManageIQ/manageiq-providers-vmware/pull/555 (spec fix)

This removes..

    EmsCluster#openstack_cluster?
    EmsCluster.node_types
    EmsCluster.non_openstack_clusters_exists?
    EmsCluster.openstack_clusters_exists?

    Host#openstack_host?
    Host.node_types
    Host.non_openstack_hosts_exists?
    Host.openstack_hosts_exists?

and changes `display_name`, `locale/en.yml` and feature names & descriptions to only use "Host" or "Cluster".
