### PR TITLE
Allow overriding ESXi IP address with a custom attribute

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -366,7 +366,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       :vmware_uri           => URI::Generic.build(
         :scheme   => 'esx',
         :userinfo => CGI.escape(source.host.authentication_userid),
-        :host     => source.host.ipaddress,
+        :host     => source.host.miq_custom_get('TransformationIPAddress') || source.host.ipaddress,
         :path     => '/',
         :query    => { :no_verify => 1 }.to_query
       ).to_s,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -596,7 +596,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
             conversion_host.vddk_transport_supported = true
           end
 
-          it "generates conversion options hash" do
+          it "generates conversion options hash with host admin IP address" do
             expect(task_1.conversion_options).to eq(
               :vm_name              => src_vm_1.name,
               :vm_uuid              => src_vm_1.uid_ems,
@@ -604,6 +604,30 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :transport_method     => 'vddk',
               :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "esx://esx_user@10.0.0.1/?no_verify=1",
+              :vmware_password      => 'esx_passwd',
+              :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
+              :rhv_cluster          => redhat_cluster.name,
+              :rhv_storage          => redhat_storages.first.name,
+              :rhv_password         => redhat_ems.authentication_password,
+              :source_disks         => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings     => task_1.network_mappings,
+              :install_drivers      => true,
+              :insecure_connection  => true,
+              :two_phase            => true,
+              :warm                 => true,
+              :daemonize            => false
+            )
+          end
+
+          it "generates conversion options hash with host custom IP address" do
+            src_host.miq_custom_set('TransformationIPAddress', '192.168.254.1')
+            expect(task_1.conversion_options).to eq(
+              :vm_name              => src_vm_1.name,
+              :vm_uuid              => src_vm_1.uid_ems,
+              :conversion_host_uuid => conversion_host.resource.ems_ref,
+              :transport_method     => 'vddk',
+              :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri           => "esx://esx_user@192.168.254.1/?no_verify=1",
               :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,


### PR DESCRIPTION
When ManageIQ builds the input file for virt-v2v-wrapper, it uses `source.host.ipaddress` to build the VMware URL. This IP address is usually the one on management network, which is probably not the most performance network connected to the ESXi host.

It would be great to have a mechanism to specify the IP address to use for VM transformation (V2V), so that the URL build can use it. The user could then provide the IP address on the most performant network. It would be user's responsibility to ensure that the IP address is reachable by conversion hosts.

This pull request implement a solution based on a custom attribute on the VMware host that the backend would use it if it is present, defaulting to `source.host.ipaddress`.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1812685