### PR TITLE
 Move git_based_domain_import to core

### DIFF
--- a/lib/services/git_based_domain_import_service.rb
+++ b/lib/services/git_based_domain_import_service.rb
@@ -1,0 +1,140 @@
+class GitBasedDomainImportService
+  def queue_import(git_repo_id, branch_or_tag, tenant_id)
+    git_repo = GitRepository.find_by(:id => git_repo_id)
+
+    ref_type = if git_repo.git_branches.any? { |git_branch| git_branch.name == branch_or_tag }
+                 "branch"
+               else
+                 "tag"
+               end
+
+    import_options = {
+      "git_repository_id" => git_repo.id,
+      "ref"               => branch_or_tag,
+      "ref_type"          => ref_type,
+      "tenant_id"         => tenant_id,
+      "overwrite"         => true
+    }
+
+    task_options = {
+      :action => "Import git repository",
+      :userid => User.current_user.userid
+    }
+
+    queue_options = {
+      :class_name  => "MiqAeDomain",
+      :method_name => "import_git_repo",
+      :role        => "git_owner",
+      :user_id     => User.current_user.id,
+      :args        => [import_options]
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  def queue_refresh(git_repo_id)
+    task_options = {
+      :action => "Refresh git repository",
+      :userid => User.current_user.userid
+    }
+
+    queue_options = {
+      :class_name  => "GitRepository",
+      :method_name => "refresh",
+      :instance_id => git_repo_id,
+      :role        => "git_owner",
+      :user_id     => User.current_user.id,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  def queue_refresh_and_import(git_url, ref, ref_type, tenant_id, auth_args = {})
+    import_options = {
+      "git_url"   => git_url,
+      "ref"       => ref,
+      "ref_type"  => ref_type,
+      "tenant_id" => tenant_id,
+      "overwrite" => true
+    }.merge(prepare_auth_options(auth_args))
+
+    task_options = {
+      :action => "Refresh and import git repository",
+      :userid => User.current_user.userid
+    }
+
+    queue_options = {
+      :class_name  => "MiqAeDomain",
+      :method_name => "import_git_url",
+      :role        => "git_owner",
+      :user_id     => User.current_user.id,
+      :args        => [import_options]
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  def queue_destroy_domain(domain_id)
+    task_options = {
+      :action => "Destroy domain",
+      :userid => User.current_user.userid
+    }
+
+    queue_options = {
+      :class_name  => "MiqAeDomain",
+      :method_name => "destroy",
+      :instance_id => domain_id,
+      :role        => "git_owner",
+      :user_id     => User.current_user.id,
+      :args        => []
+    }
+
+    MiqTask.generic_action_with_callback(task_options, queue_options)
+  end
+
+  def import(git_repo_id, branch_or_tag, tenant_id)
+    task_id = queue_import(git_repo_id, branch_or_tag, tenant_id)
+    task = MiqTask.wait_for_taskid(task_id)
+
+    domain = task.task_results
+    raise MiqException::Error, task.message unless domain.kind_of?(MiqAeDomain)
+
+    domain.update(:enabled => true)
+  end
+
+  def refresh(git_repo_id)
+    task_id = queue_refresh(git_repo_id)
+    task = MiqTask.wait_for_taskid(task_id)
+
+    raise MiqException::Error, task.message unless task.status == "Ok"
+
+    task.task_results
+  end
+
+  def destroy_domain(domain_id)
+    task_id = queue_destroy_domain(domain_id)
+    task = MiqTask.wait_for_taskid(task_id)
+
+    raise MiqException::Error, task.message unless task.status == "Ok"
+
+    task.task_results
+  end
+
+  def self.available?
+    MiqRegion.my_region.role_active?("git_owner")
+  end
+
+  private
+
+  def prepare_auth_options(auth_args)
+    auth_args.stringify_keys!
+
+    auth_options = {}
+    auth_options["password"] = ManageIQ::Password.try_encrypt(auth_args["password"]) unless auth_args["password"].nil?
+    auth_options["userid"] = auth_args["userid"] unless auth_args["userid"].nil?
+    auth_options["verify_ssl"] = auth_args["verify_ssl"] unless auth_args["verify_ssl"].nil?
+
+    auth_options
+  end
+end

--- a/spec/lib/services/git_based_domain_import_service_spec.rb
+++ b/spec/lib/services/git_based_domain_import_service_spec.rb
@@ -1,0 +1,303 @@
+describe GitBasedDomainImportService do
+  shared_context "import setup" do
+    let(:git_repo) do
+      double("GitRepository", :git_branches => git_branches,
+                              :id           => 123,
+                              :url          => 'http://www.example.com')
+    end
+    let(:user) { double("User", :userid => userid, :id => 123) }
+    let(:domain) { FactoryBot.build(:miq_ae_git_domain, :id => 999) }
+    let(:userid) { "fred" }
+    let(:task) { double("MiqTask", :id => 123) }
+    let(:ref_name) { 'the_branch_name' }
+    let(:ref_type) { 'branch' }
+    let(:method_name) { 'import_git_repo' }
+    let(:action) { 'Import git repository' }
+    let(:task_options) { {:action => action, :userid => userid} }
+    let(:queue_options) do
+      {
+        :class_name  => "MiqAeDomain",
+        :method_name => method_name,
+        :role        => "git_owner",
+        :user_id     => 123,
+        :args        => [import_options]
+      }
+    end
+    let(:import_options) do
+      {
+        "git_repository_id" => git_repo.id,
+        "ref"               => ref_name,
+        "ref_type"          => ref_type,
+        "tenant_id"         => 321,
+        "overwrite"         => true
+      }
+    end
+    let(:status) { "Ok" }
+    let(:message) { "Success" }
+  end
+
+  shared_context "repository setup" do
+    let(:git_branches) { [] }
+    let(:queue_options) do
+      {
+        :class_name  => "GitRepository",
+        :instance_id => git_repo.id,
+        :method_name => method_name,
+        :role        => "git_owner",
+        :user_id     => 123,
+        :args        => []
+      }
+    end
+  end
+
+  shared_context "domain setup" do
+    let(:git_branches) { [] }
+    let(:queue_options) do
+      {
+        :class_name  => "MiqAeDomain",
+        :instance_id => domain.id,
+        :method_name => method_name,
+        :role        => "git_owner",
+        :user_id     => 123,
+        :args        => []
+      }
+    end
+  end
+
+  describe "#import" do
+    include_context "import setup"
+    before do
+      allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
+      allow(domain).to receive(:update_attribute).with(:enabled, true)
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:message).and_return(nil)
+    end
+
+    context "when git branches that match the given name exist" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "calls 'import' with the correct options" do
+        allow(task).to receive(:task_results).and_return(domain)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain).to receive(:update).with(:enabled => true)
+
+        subject.import(git_repo.id, ref_name, 321)
+      end
+    end
+
+    context "when git branches that match the given name do not exist" do
+      let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
+
+      it "calls 'import' with the correct options" do
+        allow(task).to receive(:task_results).and_return(domain)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, queue_options).and_return(task.id)
+        expect(domain).to receive(:update).with(:enabled => true)
+        subject.import(git_repo.id, ref_name, 321)
+      end
+    end
+
+    context "when import fails and the task result is nil" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "raises an exception with a message about invalid domain" do
+        allow(task).to receive(:task_results).and_return(nil)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
+          MiqException::Error, "MiqException::Error"
+        )
+      end
+
+      it "raises an exception with a message about multiple domains" do
+        allow(task).to receive(:task_results).and_return(nil)
+        allow(task).to receive(:message).and_return('multiple domains')
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect { subject.import(git_repo.id, ref_name, 321) }.to raise_exception(
+          MiqException::Error, 'multiple domains'
+        )
+      end
+    end
+  end
+
+  describe "#queue_import" do
+    include_context "import setup"
+    before do
+      allow(GitRepository).to receive(:find_by).with(:id => git_repo.id).and_return(git_repo)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:message).and_return(nil)
+    end
+
+    context "when git branches that match the given name exist" do
+      let(:git_branches) { [double("GitBranch", :name => ref_name)] }
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
+      end
+    end
+
+    context "when git branches that match the given name do not exist" do
+      let(:git_branches) { [] }
+      let(:ref_name) { "the_tag_name" }
+      let(:ref_type) { "tag" }
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect(subject.queue_import(git_repo.id, ref_name, 321)).to eq(task.id)
+      end
+    end
+  end
+
+  describe "#queue_refresh_and_import" do
+    include_context "import setup"
+    before do
+      allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:message).and_return(nil)
+    end
+
+    let(:git_branches) { [] }
+    let(:ref_name) { "the_tag_name" }
+    let(:ref_type) { "tag" }
+    let(:method_name) { 'import_git_url' }
+    let(:action) { 'Refresh and import git repository' }
+
+    context "when git branches that match the given name do not exist" do
+      let(:import_options) do
+        {
+          "git_url"   => git_repo.url,
+          "ref"       => ref_name,
+          "ref_type"  => ref_type,
+          "tenant_id" => 321,
+          "overwrite" => true
+        }
+      end
+
+      it "calls 'queue_import' with the correct options" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321)).to eq(task.id)
+      end
+    end
+
+    context "when auth args are provided" do
+      let(:import_options) do
+        {
+          "git_url"    => git_repo.url,
+          "ref"        => ref_name,
+          "ref_type"   => ref_type,
+          "tenant_id"  => 321,
+          "overwrite"  => true,
+          "userid"     => "bob",
+          "verify_ssl" => false
+        }
+      end
+
+      it "calls 'queue_import' with additional auth args using stringified keys" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321, "userid" => "bob", :verify_ssl => false)).to eq(task.id)
+      end
+    end
+
+    context "when a password is provided" do
+      let(:import_options) do
+        {
+          "git_url"   => git_repo.url,
+          "ref"       => ref_name,
+          "ref_type"  => ref_type,
+          "tenant_id" => 321,
+          "overwrite" => true,
+          "userid"    => "bob",
+          "password"  => ManageIQ::Password.try_encrypt("secret")
+        }
+      end
+
+      it "calls 'queue_import' with an encrypted password" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect(subject.queue_refresh_and_import(git_repo.url, ref_name, ref_type, 321, "userid" => "bob", :password => "secret")).to eq(task.id)
+      end
+    end
+  end
+
+  describe "#queue_refresh" do
+    include_context "import setup"
+    include_context "repository setup"
+    let(:action) { 'Refresh git repository' }
+    let(:method_name) { 'refresh' }
+    before do
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    it "calls 'queue_refresh' with the correct options" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+      expect(subject.queue_refresh(git_repo.id)).to eq(task.id)
+    end
+  end
+
+  describe "#refresh" do
+    include_context "import setup"
+    include_context "repository setup"
+    let(:action) { 'Refresh git repository' }
+    let(:method_name) { 'refresh' }
+    let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
+
+    before do
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(MiqTask).to receive(:find).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+    end
+
+    context "success" do
+      it "calls 'refresh' with the correct options and succeeds" do
+        allow(task).to receive(:task_results).and_return(true)
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect(subject.refresh(git_repo.id)).to be_truthy
+      end
+    end
+
+    context "failure" do
+      let(:status) { "Failed" }
+      let(:message) { "My Error Message" }
+      it "calls 'refresh' with the correct options and fails" do
+        expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+        expect { subject.refresh(git_repo.id) }.to raise_exception(MiqException::Error, message)
+      end
+    end
+  end
+
+  describe "destroy domain" do
+    include_context "import setup"
+    include_context "domain setup"
+    let(:action) { 'Destroy domain' }
+    let(:method_name) { 'destroy' }
+    let(:task) { double("MiqTask", :id => 123, :status => status, :message => message) }
+
+    before do
+      allow(MiqTask).to receive(:wait_for_taskid).with(task.id).and_return(task)
+      allow(User).to receive(:current_user).and_return(user)
+      allow(task).to receive(:task_results).and_return(true)
+    end
+
+    it "#destroy_domain" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+      expect(subject.destroy_domain(domain.id)).to be_truthy
+    end
+
+    it "#queue_destroy_domain" do
+      expect(MiqTask).to receive(:generic_action_with_callback).with(task_options, hash_including(queue_options)).and_return(task.id)
+
+      expect(subject.queue_destroy_domain(domain.id)).to eq(task.id)
+    end
+  end
+end


### PR DESCRIPTION
used in ui-classic and api so it should live in core anyway

LJ's got that moving code that lives in UI-classic that could be called from non-puma workers thing happening and this one is valid and shouldn't run afoul of Jason's comment at the bottom of that open issue

## NEEDS CONCURRENT MERGE WITH https://github.com/ManageIQ/manageiq-ui-classic/pull/6763

it's wip cause it requires https://github.com/ManageIQ/manageiq-ui-classic/pull/6763 and LJ's approval

transferred from https://github.com/ManageIQ/manageiq-ui-classic/commit/5ed6abfea3090fbf6c33e860101bd69059c6d3bf