### PR TITLE
GitRepository/GitWorktree Fix checkout to work with branches + submodules

### DIFF
--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -246,7 +246,7 @@ class GitWorktree
     checkout_to(target_directory)
   rescue Rugged::SubmoduleError
     FileUtils.rm_rf(target_directory) # cleanup from failed checkout above
-    GitWorktree.checkout_at(@path, target_directory, @options)
+    GitWorktree.checkout_at(@path, target_directory, @options.merge(:commit_sha => @commit_sha))
   end
 
   def checkout

--- a/lib/git_worktree.rb
+++ b/lib/git_worktree.rb
@@ -32,7 +32,7 @@ class GitWorktree
     @proxy_url            = options[:proxy_url]
     @certificate_check_cb = options[:certificate_check]
 
-    @options              = options
+    @options              = options.dup
 
     @remote_name = 'origin'
     @base_name   = File.basename(@path)


### PR DESCRIPTION
The fix in https://github.com/ManageIQ/manageiq/pull/19939 missed a use case where if a user specified a branch with a repo with submodules, it would not be respected.

This fix ensures that we are checking out the proper commit sha when doing a "re-checkout" of the repo as a non-bare clone, and checking out the proper sha prior to cloning submodules.


Links
-----

* Previous fix:  https://github.com/ManageIQ/manageiq/pull/19939
* BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=1807928


Testing
-------

I am currently testing on an appliance, but the script from the previous PR can be used as a sanity check.