### PR TITLE
Skip models that do not respond to :display_name

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -309,7 +309,7 @@ namespace :locale do
   task "model_display_names" => :environment do
     f = File.open(Rails.root.join("config/model_display_names.rb"), "w+")
     Rails.application.eager_load!
-    ApplicationRecord.descendants.sort_by(&:display_name).collect do |model|
+    ApplicationRecord.descendants.select { |ar| ar.respond_to?(:display_name) }.sort_by(&:display_name).collect do |model|
       next if model.model_name.singular.titleize != model.display_name || model.display_name.start_with?('ManageIQ')
 
       f.puts "n_('#{model.display_name}', '#{model.display_name 2}', n)"


### PR DESCRIPTION
It seems that some models (VmReconfigureTask) use `display_name` as a private method for their own thing, so we need to skip these models and perhaps rename the method to something non-conflicting.

Otherwise we'd be getting a `NoMethodError` when doing `ApplicationRecord.descendants.sort_by(&:display_name)`

@miq-bot add_label jansa/yes, internationalization