### PR TITLE
[WIP] Use create_from_base64 to create service template pictures

### DIFF
--- a/app/models/service_template.rb
+++ b/app/models/service_template.rb
@@ -409,8 +409,9 @@ class ServiceTemplate < ApplicationRecord
   end
 
   def picture=(value)
+    save!
     if value.kind_of?(Hash)
-      super(Picture.new(value))
+      Picture.create_from_base64(value.merge(:resource_type => "ServiceTemplate", :resource_id => self.id))
     else
       super
     end


### PR DESCRIPTION
with `new` the content encoding is wrong from the api call to edit service templates for a picture add because it needs to have the ` Base64.strict_decode64` run on it. we also have the timing issue fixed in https://github.com/ManageIQ/manageiq/pull/19015 which means we have to have saved the template before we can run the picture create. since the picture create can happen either from the options hash or from a straight api call it might just make sense to do this. 

@miq-bot assign @jrafanie 
@miq-bot add_label bug 
(supposed to go back to hammer)
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1770197


also please note there's (I think) still a UI bug where even though we tell people the photo can be either png or jpeg, the latter won't display correctly