### PR TITLE
Bump sys-filesystem version to 1.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem "snmp",                           "~>1.2.0",       :require => false
 gem "sprockets",                      "~>3.7.2",       :require => false
 gem "sqlite3",                        "~>1.3.0",       :require => false
 gem "sync",                           "~>0.5",         :require => false
-gem "sys-filesystem",                 "~>1.3.1"
+gem "sys-filesystem",                 "~>1.3.4"
 gem "terminal",                                        :require => false
 
 # Modified gems (forked on Github)


### PR DESCRIPTION
This bumps the sys-filesystem gem to 1.3.4. This includes a potential 32/64 bit issue on Linux, as well as including the Apache-2.0 LICENSE file properly.

https://github.com/djberg96/sys-filesystem/blob/ffi/CHANGES.rdoc

Note that the license did NOT change. It's just that previously it did not contain a copy of the license file.