### PR TITLE
Add inventory_collections for container raise_creation_events

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -228,6 +228,40 @@ module ManageIQ::Providers
           add_common_default_values
         end
 
+        def container_project_creation_events
+          skip_auto_inventory_attributes
+          skip_model_class
+          add_properties(:custom_save_block => raise_creation_events_block)
+          add_dependency_attributes(:container_projects => ->(p) { [p.collections[:container_projects]] })
+        end
+
+        def container_images_creation_events
+          skip_auto_inventory_attributes
+          skip_model_class
+          add_properties(:custom_save_block => raise_creation_events_block)
+          add_dependency_attributes(:container_images => ->(p) { [p.collections[:container_images]] })
+        end
+
+        def raise_creation_events_block
+          lambda do |_manager, inventory_collection|
+            saved_collections = inventory_collection.dependency_attributes.values.map(&:first)
+            saved_collections.each do |saved_collection|
+              next unless saved_collection.saver_strategy == :batch
+
+              batch_size = 100
+              saved_collection.created_records.each_slice(batch_size) do |batch|
+                collection_ids = batch.collect { |x| x[:id] }
+                MiqQueue.submit_job(
+                  :class_name  => saved_collection.model_class.to_s,
+                  :method_name => 'raise_creation_events',
+                  :args        => [collection_ids],
+                  :priority    => MiqQueue::HIGH_PRIORITY
+                )
+              end
+            end
+          end
+        end
+
         protected
 
         def custom_reconnect_block


### PR DESCRIPTION
Add some inventory collections to replace the kubernetes
manager_refresh_post_processing method which raises creation events in
batches after these are saved.  

Needed for: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/356