### PR TITLE
Remove the Refresher#manager_refresh_post_processing method

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -95,18 +95,7 @@ module ManageIQ
 
           Benchmark.realtime_block(:save_inventory) { save_inventory(ems, target, parsed) }
           _log.info "#{log_header} Refreshing target #{target.class} [#{target.name}] id [#{target.id}]...Complete"
-
-          if parsed.kind_of?(ManageIQ::Providers::Inventory::Persister)
-            _log.info("#{log_header} ManagerRefresh Post Processing #{target.class} [#{target.name}] id [#{target.id}]...")
-            # We have array of InventoryCollection, we want to use that data for post refresh
-            Benchmark.realtime_block(:manager_refresh_post_processing) { manager_refresh_post_processing(ems, target, parsed) }
-            _log.info("#{log_header} ManagerRefresh Post Processing #{target.class} [#{target.name}] id [#{target.id}]...Complete")
-          end
         end
-      end
-
-      def manager_refresh_post_processing(_ems, _target, _inventory_collections)
-        # Implement post refresh actions in a specific refresher
       end
 
       def collect_inventory_for_targets(ems, targets)


### PR DESCRIPTION
This method was only used by containers to raise creation events for two
inventory collections.  This can be replaced by custom_save_block ICs
and then we can remove this method thus cleaning up the base manager
refresher.

Depends on: ~~https://github.com/ManageIQ/manageiq/pull/19973~~, ~~https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/356~~