### PR TITLE
[Gemfile] Ensure manageiq-smartstate is 0.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.5.0",       :require => false
+  gem "manageiq-smartstate",            "~>0.5.3",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Makes sure some of the manageiq-smartstate gem dependencies match what we require in manageiq-gems-pending.


Links
-----

* https://github.com/ManageIQ/manageiq-gems-pending/pull/465