### PR TITLE
Fix Full Pathname Stored in DB

### DIFF
--- a/app/models/filesystem.rb
+++ b/app/models/filesystem.rb
@@ -46,11 +46,7 @@ class Filesystem < ApplicationRecord
         nh = e.attributes.to_h
 
         nh[:base_name] = nh[:name]
-        if nh[:fqname]
-          nh[:name] = nh[:fqname]
-        else
-          nh[:name] = File.join(path, nh[:name])
-        end
+        nh[:name] = nh[:fqname] || File.join(path, nh[:name])
         nh[:rsc_type] = e.name
         nh.delete(:fqname)
         nh[:mtime] = Time.parse(nh[:mtime])

--- a/app/models/filesystem.rb
+++ b/app/models/filesystem.rb
@@ -46,7 +46,7 @@ class Filesystem < ApplicationRecord
         nh = e.attributes.to_h
 
         nh[:base_name] = nh[:name]
-        nh[:name] = nh[:fqname] || File.join(path, nh[:name])
+        nh[:name] = nh[:fqname]
         nh[:rsc_type] = e.name
         nh.delete(:fqname)
         nh[:mtime] = Time.parse(nh[:mtime])

--- a/app/models/filesystem.rb
+++ b/app/models/filesystem.rb
@@ -46,7 +46,11 @@ class Filesystem < ApplicationRecord
         nh = e.attributes.to_h
 
         nh[:base_name] = nh[:name]
-        nh[:name] = File.join(path, nh[:name])
+        if nh[:fqname]
+          nh[:name] = nh[:fqname]
+        else
+          nh[:name] = File.join(path, nh[:name])
+        end
         nh[:rsc_type] = e.name
         nh.delete(:fqname)
         nh[:mtime] = Time.parse(nh[:mtime])


### PR DESCRIPTION
The filesystem attribute in the XML produced by SSA currently contains the
search path specified by the user in the scan profile.  Since we can now add
glob characters to directory names with the addition of
https://github.com/ManageIQ/manageiq-smartstate/pull/114,
an issue arises in that the Filesystem class which parses the XML will use the
search path plus the basename of the discovered file to build the full pathname,
and store it in the DB.  This pathname can now sometimes contain a glob character,
which does not provide a full path.

Conveniently, the XML already contained an fqname element which already contained the
*real* fully qualified, expanded pathname.  If the fqname element exists in the XML,
we'll use that for the DB element.

The RFE in https://bugzilla.redhat.com/show_bug.cgi?id=1684589
requests allowing multiple glob files in the SSA profile paths.
PR https://github.com/ManageIQ/manageiq-smartstate/pull/114
was submitted to allow this.  This current PR fixes an issue caused
by the use of the specified profile path in the XML, which now may contain
glob characters.

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1684589
* https://github.com/ManageIQ/manageiq-smartstate/pull/114

Steps for Testing/QA 
-------------------------------

Create an analysis profile with glob character(s) in the pathname (not just in the basename).
Run SSA using the profile.
Check that the pathname contained in the UI (or Database) does not contain glob characters.
