### PR TITLE
[V2V] Add a state to pause disks precopy

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -272,6 +272,14 @@ class ConversionHost < ApplicationRecord
     raise "Starting conversion for task '#{task_id}' failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
+  def create_pause_disks_precopy_file(task_id)
+    command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/pause_operations"])
+    connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
+    true
+  rescue
+    false
+  end
+
   def create_cutover_file(task_id)
     command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/cutover"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -144,6 +144,18 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     network.ems_ref
   end
 
+  def conversion_host_resource_ref(resource)
+    send("conversion_host_resource_ref_#{destination_ems.emstype}", resource)
+  end
+
+  def conversion_host_resource_ref_rhevm(resource)
+    resource.ems_ref.split('/').last
+  end
+
+  def conversion_host_resource_ref_openstack(resource)
+    resource.ems_ref
+  end
+
   def destination_flavor
     Flavor.find_by(:id => vm_resource.options["osp_flavor_id"])
   end
@@ -258,12 +270,16 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     updates[:virtv2v_pid] = virtv2v_state['pid'] if virtv2v_state['pid'].present?
     updates[:virtv2v_message] = virtv2v_state['last_message']['message'] if virtv2v_state['last_message'].present?
     if virtv2v_state['finished'].nil?
-      updates[:virtv2v_status] = 'active'
-      updated_disks.each do |disk|
-        matching_disks = virtv2v_state['disks'].select { |d| d['path'] == disk[:path] }
-        raise "No disk matches '#{disk[:path]}'. Aborting." if matching_disks.length.zero?
-        raise "More than one disk matches '#{disk[:path]}'. Aborting." if matching_disks.length > 1
-        disk[:percent] = matching_disks.first['progress']
+      updates[:virtv2v_status] = virtv2v_state['status'] == 'Paused' ? 'paused' : 'active'
+      if warm_migration?
+        updated_disks = virtv2v_state['disks']
+      else
+        updated_disks.each do |disk|
+          matching_disks = virtv2v_state['disks'].select { |d| d['path'] == disk[:path] }
+          raise "No disk matches '#{disk[:path]}'. Aborting." if matching_disks.length.zero?
+          raise "More than one disk matches '#{disk[:path]}'. Aborting." if matching_disks.length > 1
+          disk[:percent] = matching_disks.first['progress']
+        end
       end
     else
       updates[:virtv2v_finished_on] = Time.now.utc.strftime('%Y-%m-%d %H:%M:%S')
@@ -284,6 +300,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   ensure
     _log.info("InfraConversionJob get_conversion_state to update_options: #{updates}")
     update_options(updates)
+  end
+
+  def pause_disks_precopy
+    unless conversion_host.create_pause_disks_precopy_file(id)
+      raise _("Couldn't create disks precopy pause file for #{source.name} on #{conversion_host.name}")
+    end
   end
 
   def cutover
@@ -360,7 +382,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     {
       :vm_name              => source.name,
       :vm_uuid              => source.uid_ems,
-      :conversion_host_uuid => conversion_host.resource.ems_ref,
+      :conversion_host_uuid => conversion_host_resource_ref(conversion_host.resource),
       :transport_method     => 'vddk',
       :vmware_fingerprint   => source.host.thumbprint_sha1,
       :vmware_uri           => URI::Generic.build(
@@ -386,7 +408,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
       :vm_uuid              => source.uid_ems,
-      :conversion_host_uuid => conversion_host.resource.ems_ref,
+      :conversion_host_uuid => conversion_host_resource_ref(conversion_host.resource),
       :transport_method     => 'ssh',
       :daemonize            => false
     }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -278,6 +278,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
           matching_disks = virtv2v_state['disks'].select { |d| d['path'] == disk[:path] }
           raise "No disk matches '#{disk[:path]}'. Aborting." if matching_disks.length.zero?
           raise "More than one disk matches '#{disk[:path]}'. Aborting." if matching_disks.length > 1
+
           disk[:percent] = matching_disks.first['progress']
         end
       end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -470,7 +470,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w[start start_precopying_disks poll_precopying_disks wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine finish abort_job cancel error].each do |signal|
+    %w[start start_precopying_disks poll_precopying_disks pause_disks_precopy poll_pause_disks_precopy_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -479,7 +479,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w[start start_precopying_disks poll_precopying_disks wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine].each do |signal|
+    %w[start start_precopying_disks poll_precopying_disks pause_disks_precopy poll_pause_disks_precopy_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -530,6 +530,8 @@ RSpec.describe InfraConversionJob, :v2v do
 
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -551,6 +553,37 @@ RSpec.describe InfraConversionJob, :v2v do
       end
 
       it_behaves_like 'allows poll_precopying_disks signal'
+      it_behaves_like 'allows pause_disks_precopy signal'
+      it_behaves_like 'allows finish signal'
+      it_behaves_like 'allows abort_job signal'
+      it_behaves_like 'allows cancel signal'
+      it_behaves_like 'allows error signal'
+
+      it_behaves_like 'doesn\'t allow start signal'
+      it_behaves_like 'doesn\'t allow start_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
+      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
+      it_behaves_like 'doesn\'t allow run_migration_playbook signal'
+      it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
+      it_behaves_like 'doesn\'t allow shutdown_vm signal'
+      it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
+      it_behaves_like 'doesn\'t allow transform_vm signal'
+      it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
+      it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
+      it_behaves_like 'doesn\'t allow apply_right_sizing signal'
+      it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
+      it_behaves_like 'doesn\'t allow power_on_vm signal'
+      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
+      it_behaves_like 'doesn\'t allow mark_vm_migrated signal'
+      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
+    end
+
+    context 'pausing_disks_precopy' do
+      before do
+        job.state = 'pausing_disks_precopy'
+      end
+
+      it_behaves_like 'allows poll_pause_disks_precopy_complete signal'
       it_behaves_like 'allows wait_for_ip_address signal'
       it_behaves_like 'allows finish signal'
       it_behaves_like 'allows abort_job signal'
@@ -559,6 +592,8 @@ RSpec.describe InfraConversionJob, :v2v do
 
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -589,6 +624,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
@@ -619,6 +656,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
@@ -646,6 +685,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -675,6 +716,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -705,6 +748,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -734,6 +779,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -763,6 +810,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -795,6 +844,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -821,6 +872,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -850,6 +903,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -881,6 +936,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -910,6 +967,8 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
+      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
+      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -985,8 +1044,55 @@ RSpec.describe InfraConversionJob, :v2v do
           request.save!
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-          expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
+          expect(job).to receive(:queue_signal).with(:pause_disks_precopy)
           job.signal(:poll_precopying_disks)
+        end
+      end
+    end
+
+    context '#pause_disks_precopy' do
+      before do
+        job.state = 'precopying_disks'
+      end
+
+      it 'pause disks precopy' do
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+          expect(job.migration_task).to receive(:pause_disks_precopy)
+          expect(job).to receive(:queue_signal).with(:poll_pause_disks_precopy_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+          job.signal(:pause_disks_precopy)
+        end
+      end
+    end
+
+    context '#poll_pause_disks_precopy_complete' do
+      before do
+        job.state = 'pausing_disks_precopy'
+        allow(job.migration_task).to receive(:get_conversion_state)
+      end
+
+      it 'abort_conversion when pausing_disks_precopy times out' do
+        job.context[:retries_pausing_disks_precopy] = 8640
+        expect(job).to receive(:abort_conversion).with('Pausing disks precopy timed out', 'error')
+        job.signal(:poll_pause_disks_precopy_complete)
+      end
+
+      it 'retries if disks precopy is not paused' do
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+          expect(job).to receive(:queue_signal).with(:poll_pause_disks_precopy_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+          job.signal(:poll_pause_disks_precopy_complete)
+        end
+      end
+
+      it 'exits if disks precopy is paused' do
+        job.migration_task.update_options(:virtv2v_status => 'paused')
+        Timecop.freeze(2019, 2, 6) do
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+          expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
+          job.signal(:poll_pause_disks_precopy_complete)
         end
       end
     end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -449,8 +449,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           task_1.get_conversion_state
           expect(task_1.options[:virtv2v_disks]).to eq(
             [
-              { :path => src_disk_1.filename, :size => src_disk_1.size, :percent => 100, :weight => 50 },
-              { :path => src_disk_2.filename, :size => src_disk_2.size, :percent => 50, :weight => 50 }
+              { "path" => src_disk_1.filename, "progress" => 100 },
+              { "path" => src_disk_2.filename, "progress" => 50 }
             ]
           )
           expect(task_1.options[:virtv2v_status]).to eq('active')

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -449,8 +449,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           task_1.get_conversion_state
           expect(task_1.options[:virtv2v_disks]).to eq(
             [
-              { "path" => src_disk_1.filename, "progress" => 100 },
-              { "path" => src_disk_2.filename, "progress" => 50 }
+              {"path" => src_disk_1.filename, "progress" => 100},
+              {"path" => src_disk_2.filename, "progress" => 50}
             ]
           )
           expect(task_1.options[:virtv2v_status]).to eq('active')


### PR DESCRIPTION
We have identified a potential race condition when CloudForms tries to perform operations while the wrapper runs its own operations, such as shutting down the VM while wrapper is creating a snapshot. That generates a conflict and either CloudForms or wrapper fails...

The solution is two-fold:

. Allow virt-v2v-wrapper to watch `pause_operations` file to start pausing the disks precopy.
. Extended status in virt-v2v-wrapper to validate that the precopy is in progress or paused.
. Allow virt-v2v-wrapper to be more resilient to `vim.fault.TaskInProgress` exception.

This pull request adds a state in InfraConversionJob to create the `pause_operations` file and wait for virt-v2v-wrapper to be paused.

It also fixes the `conversion_host_uuid` value virt-v2v-wrapper input, as well as skip any calculation of disks for warm migration, as the UI does the maths.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1814258