### PR TITLE
[V2V] Do not wait for IP address if no playbook is expected

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -321,15 +321,20 @@ class InfraConversionJob < Job
     update_migration_task_progress(:on_entry)
     return abort_conversion('Waiting for IP address timed out', 'error') if polling_timeout
 
-    # If the target VM is powered off, we won't get an IP address, so no need to wait.
-    # We don't block powered off VMs, because the playbook could still be relevant.
-    if target_vm.power_state == 'on'
-      # If the source VM didn't report IP addresses during pre-flight check, there's no need to wait.
-      # We don't block VMsi with no IP address, because the playbook could still be relevant.
-      unless migration_task.options[:source_vm_ipaddresses].empty?
-        if target_vm.ipaddresses.empty?
-          update_migration_task_progress(:on_retry)
-          return queue_signal(:wait_for_ip_address)
+    # The IP address is used only for pre and post-migration playbooks.
+    # If no playbook is expected to run, we don't need to wait for the IP address.
+    service_template = migration_task.send("#{migration_phase}_ansible_playbook_service_template")
+    unless service_template.nil?
+      # If the target VM is powered off, we won't get an IP address, so no need to wait.
+      # We don't block powered off VMs, because the playbook could still be relevant.
+      if target_vm.power_state == 'on'
+        # If the source VM didn't report IP addresses during pre-flight check, there's no need to wait.
+        # We don't block VMsi with no IP address, because the playbook could still be relevant.
+        unless migration_task.options[:source_vm_ipaddresses].empty?
+          if target_vm.ipaddresses.empty?
+            update_migration_task_progress(:on_retry)
+            return queue_signal(:wait_for_ip_address)
+          end
         end
       end
     end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1003,6 +1003,14 @@ RSpec.describe InfraConversionJob, :v2v do
         job.signal(:wait_for_ip_address)
       end
 
+      it 'exits if no playbook is expected to run' do
+        allow(job.migration_task).to receive(:pre_ansible_playbook_service_template).and_return(nil)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+        expect(job).to receive(:queue_signal).with(:run_migration_playbook)
+        job.signal(:wait_for_ip_address)
+      end
+
       it 'exits if VM is powered off' do
         vm_vmware.update!(:raw_power_state => 'poweredOff')
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)


### PR DESCRIPTION
In the migration workflow, it's possible to run a pre or post-migration playbook. In the current implementation, we wait for the VM to report its IP address in CloudForms inventory before moving on. But if the VM is on but doesn't have VMware tools, it won't be reported and the migration will fail even if no playbook is expected to run.

This pull request skips waiting for the IP address if no playbook is expected to run.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1814876