### PR TITLE
Do not mount VDDK folder if transport method is SSH

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -246,8 +246,8 @@ class ConversionHost < ApplicationRecord
       [:volume,  "/var/tmp:/var/tmp"],
       [:volume,  "/var/lib/uci/#{task_id}:/var/lib/uci"],
       [:volume,  "/var/log/uci/#{task_id}:/var/log/uci"],
-      [:volume,  "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"]
     ]
+    params << [:volume,  "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"] unless conversion_options[:transport_method] == 'ssh'
     params << [:volume, "/root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"] if conversion_options[:transport_method] == 'ssh'
     params << [:volume, "/root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"] if luks_keys_vault_valid?
     params << uci_image

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -247,7 +247,7 @@ class ConversionHost < ApplicationRecord
       [:volume,  "/var/lib/uci/#{task_id}:/var/lib/uci"],
       [:volume,  "/var/log/uci/#{task_id}:/var/log/uci"],
     ]
-    params << [:volume,  "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"] unless conversion_options[:transport_method] == 'ssh'
+    params << [:volume, "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"] unless conversion_options[:transport_method] == 'ssh'
     params << [:volume, "/root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"] if conversion_options[:transport_method] == 'ssh'
     params << [:volume, "/root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"] if luks_keys_vault_valid?
     params << uci_image

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -566,7 +566,6 @@ RSpec.describe ConversionHost, :v2v do
         " --volume /var/tmp:/var/tmp"\
         " --volume /var/lib/uci/#{task.id}:/var/lib/uci"\
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\
-        " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
         " --volume /root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"\
         " --volume /root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"\
         " manageiq/v2v-conversion-host:latest"


### PR DESCRIPTION
When running a migration with SSH transport method and UCI, the migration fails with the following error message:

```
ERROR -- : Q-task_id([job_dispatcher]) MIQ(ConversionHost#connect_ssh) SSH connection failed for [10.1.40.213] with [RuntimeError: MiqSshUtil::exec - Command 'sudo /usr/bin/podman run --detach --privileged --name conversion-26 --network host --volume /dev:/dev --volume /etc/pki/ca-trust:/etc/pki/ca-trust --volume /var/tmp:/var/tmp --volume /var/lib/uci/26:/var/lib/uci --volume /var/log/uci/26:/var/log/uci --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib --volume /root/.ssh/id_rsa:/var/lib/uci/ssh_private_key registry.redhat.io/cloudforms50/v2v-conversion-host-rhel8' failed: Error: error checking path "/opt/vmware-vix-disklib-distrib": stat /opt/vmware-vix-disklib-distrib: no such file or directory, status: 125]
```

This is due to trying to mount `/opt/vmware-vix-disklib-distrib` in the pod, while it doesn't exist on a conversion host configured for SSH.

This pull request removes this volume from list of volumes to mount when transport is SSH.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1815046