### PR TITLE
 take out all the rest of inventory_object_refresh

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -846,10 +846,6 @@ class ExtManagementSystem < ApplicationRecord
     n_('Manager', 'Managers', number)
   end
 
-  def inventory_object_refresh?
-    Settings.ems_refresh.fetch_path(emstype, :inventory_object_refresh)
-  end
-
   def allow_targeted_refresh?
     Settings.ems_refresh.fetch_path(emstype, :allow_targeted_refresh)
   end

--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -52,16 +52,14 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
       phase_context[:new_vm_ems_ref] = clone_task_ref
 
       manager = source.ext_management_system
-      if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
-        # Queue new targeted refresh if allowed
-        vm_target = InventoryRefresh::Target.new(:manager     => manager,
-                                                 :association => :vms,
-                                                 :manager_ref => {:ems_ref => clone_task_ref})
-        EmsRefresh.queue_refresh(vm_target)
-      else
-        # Otherwise queue a full refresh
-        EmsRefresh.queue_refresh(manager)
-      end
+      target = if manager.allow_targeted_refresh?
+                 InventoryRefresh::Target.new(:manager => manager, :association => :vms, :manager_ref => {:ems_ref => clone_task_ref})
+               else
+                 # Otherwise queue a full refresh
+                 manager
+               end
+
+      EmsRefresh.queue_refresh(target)
       signal :poll_destination_in_vmdb
     else
       requeue_phase

--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -159,15 +159,14 @@ class OrchestrationStack < ApplicationRecord
       raise _("Provider failed last authentication check")
     end
 
-    if manager.inventory_object_refresh? && manager.allow_targeted_refresh?
-      # Queue new targeted refresh if allowed
-      orchestration_stack_target = InventoryRefresh::Target.new(:manager     => manager,
-                                                                :association => :orchestration_stacks,
-                                                                :manager_ref => {:ems_ref => manager_ref})
-      EmsRefresh.queue_refresh(orchestration_stack_target)
-    else
-      # Otherwise queue a full refresh
-      EmsRefresh.queue_refresh(manager)
-    end
+    target = if manager.allow_targeted_refresh?
+               # Queue new targeted refresh if allowed
+               InventoryRefresh::Target.new(:manager => manager, :association => :orchestration_stacks, :manager_ref => {:ems_ref => manager_ref})
+             else
+               # Otherwise queue a full refresh
+               manager
+             end
+
+    EmsRefresh.queue_refresh(target)
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,7 +106,6 @@
   :debug_trace: false
   :capture_vm_created_on_date: false
   :ansible_tower_automation:
-    :inventory_object_refresh: true
     :allow_targeted_refresh: true
     :refresh_interval: 15.minutes
   :foreman_configuration:


### PR DESCRIPTION
Remove checks for `ems.inventory_object_refresh?` in the `BaseManager::Refresher#refresh` and other locations.

From https://github.com/ManageIQ/manageiq/pull/19948

@miq-bot assign @agrare 
@miq-bot add_label cleanup

Cross-repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/89