### PR TITLE
Syndicate metrics to Kafka

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -26,7 +26,7 @@ class EmsEvent < EventStream
 
   def self.add_queue(meth, ems_id, event)
     unless MiqQueue.messaging_type == "miq_queue"
-      MiqQueue.messaging_client('event_handler').publish_topic(
+      MiqQueue.messaging_client('event_handler')&.publish_topic(
         :service => "manageiq.ems-events",
         :sender  => ems_id,
         :event   => event[:event_type],

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -205,10 +205,12 @@ module Metric::CiMixin::Processing
 
     metrics.each_value do |metric|
       resource = metric.delete(:resource)
+
       metric[:resource_type] = resource.class.base_class.name
       metric[:resource_id]   = resource.id
-      metric[:resource_ref]  = resource.ems_ref if resource.respond_to?(:ems_ref)
-      metric[:resource_uid]  = resource.uid_ems if resource.respond_to?(:uid_ems)
+
+      metric[:resource_manager_ref] = resource.ems_ref if resource.respond_to?(:ems_ref)
+      metric[:resource_manager_uid] = resource.uid_ems if resource.respond_to?(:uid_ems)
 
       MiqQueue.messaging_client("metrics_capture")&.publish_topic(
         :service => "metrics",

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -207,6 +207,8 @@ module Metric::CiMixin::Processing
       resource = metric.delete(:resource)
       metric[:resource_type] = resource.class.base_class.name
       metric[:resource_id]   = resource.id
+      metric[:resource_ref]  = resource.ems_ref if resource.respond_to?(:ems_ref)
+      metric[:resource_uid]  = resource.uid_ems if resource.respond_to?(:uid_ems)
 
       MiqQueue.messaging_client("metrics_capture")&.publish_topic(
         :service => "metrics",

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -213,7 +213,7 @@ module Metric::CiMixin::Processing
       MiqQueue.messaging_client("metrics_capture")&.publish_topic(
         :service => "metrics",
         :sender  => resource.ext_management_system&.id,
-        :event   => "metrics",
+        :event   => "manageiq.metrics",
         :payload => metric
       )
     end

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -208,7 +208,7 @@ module Metric::CiMixin::Processing
       metric[:resource_type] = resource.class.base_class.name
       metric[:resource_id]   = resource.id
 
-      MiqQueue.messaging_client("metrics_capture").publish_topic(
+      MiqQueue.messaging_client("metrics_capture")&.publish_topic(
         :service => "metrics",
         :sender  => resource.ext_management_system&.id,
         :event   => "metrics",

--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -94,6 +94,8 @@ module Metric::CiMixin::Processing
       resources.each do |resource|
         resource.perf_rollup_to_parents(interval_orig, start_time, end_time)
       end
+
+      publish_metrics(rt_rows)
     end
     _log.info("#{log_header} Processing for #{log_specific_targets(resources)}, for range [#{start_time} - #{end_time}]...Complete - Timings: #{t.inspect}")
 
@@ -196,5 +198,22 @@ module Metric::CiMixin::Processing
       value = percent_norm
     end
     return value, message
+  end
+
+  def publish_metrics(metrics)
+    return if MiqQueue.messaging_type == "miq_queue"
+
+    metrics.each_value do |metric|
+      resource = metric.delete(:resource)
+      metric[:resource_type] = resource.class.base_class.name
+      metric[:resource_id]   = resource.id
+
+      MiqQueue.messaging_client("metrics_capture").publish_topic(
+        :service => "metrics",
+        :sender  => resource.ext_management_system&.id,
+        :event   => "metrics",
+        :payload => metric
+      )
+    end
   end
 end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -48,6 +48,9 @@ class MiqQueue < ApplicationRecord
       # internally the client will track the state of the connection and re-open it,
       # once it's available again - at least thats true for a stomp connection
       ManageIQ::Messaging::Client.open(messaging_client_options.merge(:client_ref => client_ref))
+    rescue => err
+      _log.warn("Failed to open messaging client: #{err}")
+      nil
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -934,15 +934,15 @@
 :prototype:
   :messaging_type: miq_queue
   :artemis:
-    :queue_hostname: localhost
-    :queue_port: 61616
-    :queue_username: admin
-    :queue_password: smartvm
+    :messaging_hostname: localhost
+    :messaging_port: 61616
+    :messaging_username: admin
+    :messaging_password: smartvm
   :kafka:
-    :queue_hostname: localhost
-    :queue_port: 9092
-    :queue_username: admin
-    :queue_password: smartvm
+    :messaging_hostname: localhost
+    :messaging_port: 9092
+    :messaging_username: admin
+    :messaging_password: smartvm
 :recommendations:
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes


### PR DESCRIPTION
This change publishes metrics to kafka or artemis if a queue-type other than miq_queue is enabled.

```
$ bin/kafka-console-consumer.sh --bootstrap-server 'localhost:9092' --topic metrics --from-beginning
{"capture_interval_name"=>"realtime",
 "capture_interval"=>"20",
 "resource_name"=>"Joe_20190719_101454",
 "timestamp"=>"2020-04-01T15:33:40Z",
 "mem_swapout_absolute_average"=>0.0,
 "cpu_used_delta_summation"=>1535.0,
 "cpu_usagemhz_rate_average"=>191.0,
 "cpu_system_delta_summation"=>9.0,
 "cpu_ready_delta_summation"=>19.0,
 "cpu_usage_rate_average"=>2.08,
 "mem_swapped_absolute_average"=>0.0,
 "net_usage_rate_average"=>0.0,
 "cpu_wait_delta_summation"=>78631.0,
 "sys_uptime_absolute_latest"=>22209148.0,
 "mem_usage_absolute_average"=>7.99,
 "mem_vmmemctl_absolute_average"=>0.0,
 "mem_swaptarget_absolute_average"=>0.0,
 "mem_vmmemctltarget_absolute_average"=>0.0,
 "mem_swapin_absolute_average"=>0.0,
 "resource_id"=>1,
 "resource_type"=>"VmOrTemplate",
 "derived_cpu_reserved"=>0,
 "derived_host_count_off"=>0,
 "derived_host_count_on"=>0,
 "derived_host_count_total"=>0,
 "derived_memory_available"=>12288,
 "derived_memory_reserved"=>0,
 "derived_memory_used"=>981.8112,
 "derived_host_sockets"=>nil,
 "derived_vm_allocated_disk_storage"=>"70866960384.0",
 "derived_vm_count_off"=>0,
 "derived_vm_count_on"=>0,
 "derived_vm_count_total"=>0,
 "derived_vm_numvcpus"=>4,
 "derived_vm_used_disk_storage"=>"70866960384.0",
 "assoc_ids"=>{"storages"=>{"on"=>[], "off"=>[]}},
 "tag_names"=>"",
 "parent_host_id"=>1,
 "parent_storage_id"=>1,
 "parent_ems_id"=>2,
 "parent_ems_cluster_id"=>1,
 "resource_ref"=>"vm-382",
 "resource_uid"=>"423d26fa-67df-dd86-27a2-ec7a795048dd"}
```

Depends on: https://github.com/ManageIQ/manageiq/pull/19984

https://github.com/ManageIQ/manageiq/issues/19584