### PR TITLE
[V2V] Unpause disk precopy to run cutover

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -280,6 +280,14 @@ class ConversionHost < ApplicationRecord
     false
   end
 
+  def delete_pause_disks_precopy_file(task_id)
+    command = AwesomeSpawn.build_command_line("rm", ["/var/lib/uci/#{task_id}/pause_operations"])
+    connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
+    true
+  rescue
+    false
+  end
+
   def create_cutover_file(task_id)
     command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/cutover"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -281,7 +281,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def delete_pause_disks_precopy_file(task_id)
-    command = AwesomeSpawn.build_command_line("rm", ["/var/lib/uci/#{task_id}/pause_operations"])
+    command = AwesomeSpawn.build_command_line("rm", {:f =>["/var/lib/uci/#{task_id}/pause_operations"]})
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true
   rescue

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -467,8 +467,12 @@ class InfraConversionJob < Job
 
   def transform_vm
     update_migration_task_progress(:on_entry)
-    migration_task.run_conversion unless migration_task.warm_migration?
-    migration_task.cutover
+    if migration_task.warm_migration?
+      migration_task.cutover
+      migration_task.unpause_disks_precopy
+    else
+      migration_task.run_conversion
+    end
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
   rescue => error

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -309,6 +309,12 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
   end
 
+  def unpause_disks_precopy
+    unless conversion_host.delete_pause_disks_precopy_file(id)
+      raise _("Couldn't delete disks precopy pause file for #{source.name} on #{conversion_host.name}")
+    end
+  end
+
   def cutover
     unless conversion_host.create_cutover_file(id)
       raise _("Couldn't create cutover file for #{source.name} on #{conversion_host.name}")

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1350,7 +1350,6 @@ RSpec.describe InfraConversionJob, :v2v do
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
           expect(job.migration_task).to receive(:run_conversion)
-          expect(job.migration_task).to receive(:cutover)
           expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
           job.signal(:transform_vm)
         end
@@ -1361,6 +1360,7 @@ RSpec.describe InfraConversionJob, :v2v do
         Timecop.freeze(2019, 2, 6) do
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
+          expect(job.migration_task).to receive(:unpause_disks_precopy)
           expect(job.migration_task).to receive(:cutover)
           expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
           job.signal(:transform_vm)


### PR DESCRIPTION
This is a follow-up of https://github.com/ManageIQ/manageiq/pull/19978/ to unpause virt-v2v-wrapper once the cutover file has been created.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1814258