### PR TITLE
Remove inventory_obj_refresher

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -107,8 +107,6 @@ module ManageIQ
         #
         # override this method and return an array of:
         #   [[target1, inventory_for_target1], [target2, inventory_for_target2]]
-        return [[ems, nil]] unless ems.inventory_object_refresh?
-
         targets.map do |target|
           inventory = inventory_class_for(ems.class).build(ems, target)
           inventory.collect!
@@ -124,16 +122,11 @@ module ManageIQ
         log_header = format_ems_for_logging(ems)
         _log.debug("#{log_header} Parsing inventory...")
 
-        hashes_or_persister =
-          if ems.inventory_object_refresh?
-            inventory.parse
-          else
-            parse_legacy_inventory(ems)
-          end
+        persister = inventory.parse
 
         _log.debug("#{log_header} Parsing inventory...Complete")
 
-        hashes_or_persister
+        persister
       end
 
       def parse_legacy_inventory(ems)
@@ -217,7 +210,6 @@ module ManageIQ
       def preprocess_targets_manager_refresh
         @targets_by_ems_id.each do |ems_id, targets|
           ems = @ems_by_ems_id[ems_id]
-          next unless ems.inventory_object_refresh?
 
           # We want all targets of class EmsEvent to be merged into one target, so they can be refreshed together, otherwise
           # we could be missing some crosslinks in the refreshed data

--- a/spec/models/manageiq/providers/base_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/base_manager/refresher_spec.rb
@@ -11,20 +11,66 @@ RSpec.describe ManageIQ::Providers::BaseManager::Refresher do
     end
   end
 
-  context "#refresh" do
-    context "#preprocess_targets" do
-      let(:ems) { FactoryBot.create(:ext_management_system) }
-      let(:vm)  { FactoryBot.create(:vm, :ext_management_system => ems) }
-      let(:lots_of_vms) do
-        num_targets = Settings.ems_refresh.full_refresh_threshold + 1
-        Array.new(num_targets) { FactoryBot.create(:vm, :ext_management_system => ems) }
+  context "#preprocess_targets" do
+    let(:ems) { FactoryBot.create(:ext_management_system) }
+    let(:vm)  { FactoryBot.create(:vm, :ext_management_system => ems) }
+    let(:stack) { FactoryBot.create(:orchestration_stack, :ext_management_system => ems) }
+    let(:lots_of_vms) do
+      num_targets = Settings.ems_refresh.full_refresh_threshold + 1
+      Array.new(num_targets) { FactoryBot.create(:vm, :ext_management_system => ems) }
+    end
+
+    context "allow_targeted_refresh true" do
+      before { allow(ems).to receive(:allow_targeted_refresh?).and_return(true) }
+      it "does full refresh on any event" do
+        refresher = described_class.new([vm])
+        refresher.preprocess_targets
+
+        targets_by_ems = refresher.targets_by_ems_id[vm.ext_management_system.id].first
+        expect(targets_by_ems).to be_a(InventoryRefresh::TargetCollection)
+        expect(targets_by_ems.targets.first).to eq(vm)
       end
 
+      it "does a refresh with a stack" do
+        refresher = described_class.new([stack])
+        refresher.preprocess_targets
+
+        targets_by_ems = refresher.targets_by_ems_id[stack.ext_management_system.id].first
+        expect(targets_by_ems).to be_a(InventoryRefresh::TargetCollection)
+        expect(targets_by_ems.targets.first).to eq(stack)
+      end
+
+      it "does a full refresh with an EMS and a VM" do
+        refresher = described_class.new([vm, ems])
+        refresher.preprocess_targets
+
+        expect(refresher.targets_by_ems_id[vm.ext_management_system.id]).to eq([ems])
+      end
+
+      it "does a full refresh with a lot of targets" do
+        refresher = described_class.new(lots_of_vms)
+        refresher.preprocess_targets
+
+        targets_by_ems = refresher.targets_by_ems_id[vm.ext_management_system.id].first
+        expect(targets_by_ems).to be_a(InventoryRefresh::TargetCollection)
+        expect(targets_by_ems.targets.count).to eq(101)
+      end
+    end
+
+    context "allow_targeted_refresh false" do
+      before { allow(ems).to receive(:allow_targeted_refresh?).and_return(false) }
       it "keeps a single vm target" do
         refresher = described_class.new([vm])
         refresher.preprocess_targets
 
-        expect(refresher.targets_by_ems_id[vm.ext_management_system.id]).to eq([vm])
+        expect(refresher.targets_by_ems_id[vm.ext_management_system.id]).to eq([ems])
+      end
+
+      it "does a refresh with a stack" do
+        refresher = described_class.new([stack])
+        refresher.preprocess_targets
+
+        expect(refresher.targets_by_ems_id[stack.ext_management_system.id].first).to eq(ems)
       end
 
       it "does a full refresh with an EMS and a VM" do


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/19990, the  Swift Storage Manager graph refresh implementation got merged so now we can try the removal:
https://github.com/ManageIQ/manageiq/pull/19972#issuecomment-601926020

specs are https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/90
but it's Friday and ... it's Friday so ... um. 

@miq-bot assign @agrare 


<sub><sup>also that was _fast_, I mean, about 19990</sup></sub>
