### PR TITLE
[WIP] Store manager class name in persister builder

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder.rb
@@ -33,9 +33,9 @@ module ManageIQ::Providers
       #        (optional) method with this name also used for concrete inventory collection specific properties
       # @param persister_class [Class] used for "guessing" model_class
       # @param options [Hash]
-      def self.prepare_data(name, persister_class, options = {})
+      def self.prepare_data(name, manager_class, persister_class, options = {})
         options = default_options.merge(options)
-        builder = new(name, persister_class, options)
+        builder = new(name, manager_class, persister_class, options)
         builder.construct_data
 
         yield(builder) if block_given?
@@ -43,9 +43,12 @@ module ManageIQ::Providers
         builder
       end
 
+      attr_reader :manager_class, :persister_class
+
       # @see prepare_data()
-      def initialize(name, persister_class, options = self.class.default_options)
+      def initialize(name, manager_class, persister_class, options = self.class.default_options)
         @name = name
+        @manager_class   = manager_class
         @persister_class = persister_class
 
         @properties = {}

--- a/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/persister_helper.rb
@@ -22,15 +22,10 @@ module ManageIQ::Providers::Inventory::Persister::Builder::PersisterHelper
   # @see documentation https://github.com/ManageIQ/guides/tree/master/providers/persister/inventory_collections.md
   #
   def add_collection(builder_class, collection_name, extra_properties = {}, settings = {}, &block)
-    builder = builder_class.prepare_data(collection_name,
-                                         self.class,
-                                         make_builder_settings(settings),
-                                         &block)
+    builder = builder_class.prepare_data(collection_name, manager.class, self.class, make_builder_settings(settings), &block)
 
     builder.add_properties(extra_properties) if extra_properties.present?
-
     builder.add_properties({:manager_uuids => references(collection_name)}, :if_missing) if targeted?
-
     builder.evaluate_lambdas!(self)
 
     collections[collection_name] = builder.to_inventory_collection

--- a/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
+++ b/spec/models/manageiq/providers/inventory/persister/builder_spec.rb
@@ -14,15 +14,14 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   let(:adv_settings) { {:strategy => :local_db_find_missing_references, :saver_strategy => :concurrent_safe_batch} }
 
   let(:cloud) { ::ManageIQ::Providers::Inventory::Persister::Builder::CloudManager }
-
   let(:network) { ::ManageIQ::Providers::Inventory::Persister::Builder::NetworkManager }
-
+  let(:manager_class) { @ems.class }
   let(:persister_class) { ::ManageIQ::Providers::Inventory::Persister }
 
   # --- association ---
 
   it 'assigns association automatically to InventoryCollection' do
-    ic = cloud.prepare_data(:vms, persister_class).to_inventory_collection
+    ic = cloud.prepare_data(:vms, manager_class, persister_class).to_inventory_collection
 
     expect(ic.association).to eq :vms
   end
@@ -34,13 +33,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "derives existing model_class without persister's class" do
-    data = cloud.prepare_data(:vms, persister_class).to_hash
+    data = cloud.prepare_data(:vms, manager_class, persister_class).to_hash
 
     expect(data[:model_class]).to eq ::Vm
   end
 
   it "replaces derived model_class if model_class defined manually" do
-    data = cloud.prepare_data(:vms, persister_class) do |builder|
+    data = cloud.prepare_data(:vms, manager_class, persister_class) do |builder|
       builder.add_properties(:model_class => ::MiqTemplate)
     end.to_hash
 
@@ -48,13 +47,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't try to derive model_class when disabled" do
-    data = cloud.prepare_data(:vms, persister_class, :without_model_class => true).to_hash
+    data = cloud.prepare_data(:vms, manager_class, persister_class, :without_model_class => true).to_hash
 
     expect(data[:model_class]).to be_nil
   end
 
   it 'throws exception if model_class not specified' do
-    builder = cloud.prepare_data(:non_existing_ic, persister_class)
+    builder = cloud.prepare_data(:non_existing_ic, manager_class, persister_class)
 
     expect { builder.to_inventory_collection }.to raise_error(::ManageIQ::Providers::Inventory::Persister::Builder::MissingModelClassError, /NonExistingIc/)
   end
@@ -62,7 +61,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- adv. settings (TODO: link to gui)---
 
   it 'assigns Advanced settings' do
-    builder = cloud.prepare_data(:tmp, persister_class, :adv_settings => adv_settings)
+    builder = cloud.prepare_data(:tmp, manager_class, persister_class, :adv_settings => adv_settings)
     data = builder.to_hash
 
     expect(data[:strategy]).to eq :local_db_find_missing_references
@@ -70,7 +69,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't overwrite defined properties by Advanced settings" do
-    data = cloud.prepare_data(:vms, persister_class, :adv_settings => adv_settings) do |builder|
+    data = cloud.prepare_data(:vms, manager_class, persister_class, :adv_settings => adv_settings) do |builder|
       builder.add_properties(:strategy => :custom)
     end.to_hash
 
@@ -81,13 +80,13 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- shared properties ---
 
   it 'applies shared properties' do
-    data = cloud.prepare_data(:tmp, persister_class, :shared_properties => {:uuid => 1}).to_hash
+    data = cloud.prepare_data(:tmp, manager_class, persister_class, :shared_properties => {:uuid => 1}).to_hash
 
     expect(data[:uuid]).to eq 1
   end
 
   it "doesn't overwrite defined properties by shared properties" do
-    data = cloud.prepare_data(:tmp, persister_class, :shared_properties => {:uuid => 1}) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class, :shared_properties => {:uuid => 1}) do |builder|
       builder.add_properties(:uuid => 2)
     end.to_hash
 
@@ -97,7 +96,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- properties ---
 
   it 'adds properties with add_properties repeatedly' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_properties(:first => 1, :second => 2)
       builder.add_properties(:third => 3)
     end.to_hash
@@ -108,7 +107,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'overrides properties in :overwrite mode' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_properties(:param => 1)
       builder.add_properties({:param => 2}, :overwrite)
     end.to_hash
@@ -117,7 +116,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it "doesn't override properties in :if_missing mode" do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_properties(:param => 1)
       builder.add_properties({:param => 2}, :if_missing)
     end.to_hash
@@ -126,7 +125,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'adds property by method_missing' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_some_tmp_param(:some_value)
     end.to_hash
 
@@ -136,7 +135,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- default values ---
 
   it 'adds default_values repeatedly' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_default_values(:ems_id => 10)
       builder.add_default_values(:ems_id => 20)
       builder.add_default_values(:tmp_id => 30)
@@ -147,7 +146,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'transforms lambdas in default_values' do
-    bldr = cloud.prepare_data(:tmp, persister_class) do |builder|
+    bldr = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_default_values(:ems_id => ->(persister) { persister.manager.id })
     end
     bldr.evaluate_lambdas!(@persister)
@@ -160,19 +159,19 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   # --- inventory object attributes ---
 
   it 'derives inventory object attributes automatically' do
-    data = cloud.prepare_data(:vms, persister_class).to_hash
+    data = cloud.prepare_data(:vms, manager_class, persister_class).to_hash
 
     expect(data[:inventory_object_attributes]).not_to be_empty
   end
 
   it "doesn't derive inventory_object_attributes automatically when disabled" do
-    data = cloud.prepare_data(:vms, persister_class, :auto_inventory_attributes => false).to_hash
+    data = cloud.prepare_data(:vms, manager_class, persister_class, :auto_inventory_attributes => false).to_hash
 
     expect(data[:inventory_object_attributes]).to be_empty
   end
 
   it 'can add inventory_object_attributes manually' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
     end.to_hash
 
@@ -180,7 +179,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'can remove inventory_object_attributes' do
-    data = cloud.prepare_data(:tmp, persister_class) do |builder|
+    data = cloud.prepare_data(:tmp, manager_class, persister_class) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
       builder.remove_inventory_attributes(%i(attr2))
     end.to_hash
@@ -189,7 +188,7 @@ RSpec.describe ManageIQ::Providers::Inventory::Persister::Builder do
   end
 
   it 'can clear all inventory_object_attributes' do
-    data = cloud.prepare_data(:vms, persister_class) do |builder|
+    data = cloud.prepare_data(:vms, manager_class, persister_class) do |builder|
       builder.add_inventory_attributes(%i(attr1 attr2 attr3))
       builder.clear_inventory_attributes!
     end.to_hash


### PR DESCRIPTION
Instead of trying to guess the manager class name from the persister class we can just store the manager's class when we instantiate the builder.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/92