### PR TITLE
Allow overriding ESXi IP address with a custom attribute - Part 2

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -411,7 +411,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       :vm_name              => URI::Generic.build(
         :scheme   => 'ssh',
         :userinfo => 'root',
-        :host     => source.host.ipaddress,
+        :host     => source.host.miq_custom_get('TransformationIPAddress') || source.host.ipaddress,
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
       :vm_uuid              => source.uid_ems,

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -669,6 +669,25 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :daemonize            => false
             )
           end
+
+          it "generates conversion options hash with host custom IP address" do
+            src_host.miq_custom_set('TransformationIPAddress', '192.168.254.1')
+            expect(task_1.conversion_options).to eq(
+              :vm_name              => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vm_uuid              => src_vm_1.uid_ems,
+              :conversion_host_uuid => conversion_host.resource.ems_ref,
+              :transport_method     => 'ssh',
+              :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
+              :rhv_cluster          => redhat_cluster.name,
+              :rhv_storage          => redhat_storages.first.name,
+              :rhv_password         => redhat_ems.authentication_password,
+              :source_disks         => [src_disk_1.filename, src_disk_2.filename],
+              :network_mappings     => task_1.network_mappings,
+              :install_drivers      => true,
+              :insecure_connection  => true,
+              :daemonize            => false
+            )
+          end
         end
       end
 


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/ManageIQ/manageiq/pull/19954 to account for the custom attributes when using SSH transport method.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1812685