### PR TITLE
[wip] remove save_networks_inventory

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -288,23 +288,6 @@ module EmsRefresh::SaveInventory
     end
   end
 
-  def save_networks_inventory(hardware, hashes, mode = :refresh)
-    return if hashes.nil?
-
-    case mode
-    when :refresh
-      deletes = hardware.networks.reload.to_a
-
-      # Remove networks that were already saved via guest devices
-      saved_hashes, new_hashes = hashes.partition { |h| h[:id] }
-      saved_hashes.each { |h| deletes.delete_if { |d| d.id == h[:id] } } unless deletes.empty? || saved_hashes.empty?
-
-      save_inventory_multi(hardware.networks, new_hashes, deletes, [:ipaddress, :ipv6address], nil, :guest_device)
-    when :scan
-      save_inventory_multi(hardware.networks, hashes, :use_association, [:description, :guid])
-    end
-  end
-
   def save_firmwares_inventory(hardware, hashes)
     return if hashes.nil?
 

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -15,8 +15,6 @@ class Network < ApplicationRecord
     if parent.respond_to?(:hardware)
       # it's possible that the hardware for this vm does not exist, so create it
       parent.hardware = Hardware.new if parent.hardware.nil?
-
-      EmsRefresh.save_networks_inventory(parent.hardware, hashes, :scan)
     end
   end
 


### PR DESCRIPTION
this is one of the save_inventory methods that we can delete, I think. 


I don't know anything but I'm not afraid to be wrong so...
what is this missing, Adam?

@miq-bot assign @agrare 