### PR TITLE
Remove the journald logger to resolve segfaults

### DIFF
--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -49,7 +49,8 @@ module Vmdb
 
       $audit_log          = AuditLogger.new(path_dir.join("audit.log"))
       $container_log      = ContainerLogger.new
-      $journald_log       = create_journald_logger
+      # TODO: The journald logger can occasionally segfault the worker process
+      # $journald_log       = create_journald_logger
       $log                = create_multicast_logger(path_dir.join("evm.log"))
       $rails_log          = create_multicast_logger(path_dir.join("#{Rails.env}.log"))
       $api_log            = create_multicast_logger(path_dir.join("api.log"))


### PR DESCRIPTION
Sometimes the journald logger segfaults, remove it until this can be further investigated:
`/usr/local/lib/ruby/gems/2.6.0/gems/systemd-journal-1.4.1/lib/systemd/journal/writable.rb:69: [BUG] Segmentation fault at 0x0000000000000c91`