### PR TITLE
[wip] add transaction to save of groups tabs and dialog

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -4,7 +4,7 @@ class Dialog < ApplicationRecord
   # The following gets around a glob symbolic link issue
   YAML_FILES_PATTERN = "{,*/**/}*.{yaml,yml}".freeze
 
-  has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy
+  has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy, autosave: true
   validate :validate_children
 
   include DialogMixin

--- a/app/models/dialog_group.rb
+++ b/app/models/dialog_group.rb
@@ -1,6 +1,6 @@
 class DialogGroup < ApplicationRecord
   include DialogMixin
-  has_many   :dialog_fields, -> { order(:position) }, :dependent => :destroy
+  has_many   :dialog_fields, -> { order(:position) }, :dependent => :destroy, autosave: true
   belongs_to :dialog_tab
   validate :validate_children
 

--- a/app/models/dialog_tab.rb
+++ b/app/models/dialog_tab.rb
@@ -1,6 +1,6 @@
 class DialogTab < ApplicationRecord
   include DialogMixin
-  has_many   :dialog_groups, -> { order(:position) }, :dependent => :destroy
+  has_many   :dialog_groups, -> { order(:position) }, :dependent => :destroy, autosave: true
   belongs_to :dialog
   validate :validate_children
 


### PR DESCRIPTION
Saving dialogs and related things should be in a transaction, and this would fix that. 

@miq-bot assign @bdunne 

I didn't test it but it fixes the open API issue about this, and it'd be good to have anyway