### PR TITLE
Re-enable journald logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ end
 
 group :systemd, :optional => true do
   gem "dbus-systemd",    "~>1.1.0", :require => false
-  gem "systemd-journal", "~>1.4.0", :require => false
+  gem "systemd-journal", "~>1.4.2", :require => false
 end
 
 group :openshift, :manageiq_default do

--- a/lib/vmdb/loggers.rb
+++ b/lib/vmdb/loggers.rb
@@ -50,8 +50,7 @@ module Vmdb
       path_dir = ManageIQ.root.join("log")
 
       $container_log      = ContainerLogger.new
-      # TODO: The journald logger can occasionally segfault the worker process
-      # $journald_log       = create_journald_logger
+      $journald_log       = create_journald_logger
       $log                = create_multicast_logger(path_dir.join("evm.log"))
       $rails_log          = create_multicast_logger(path_dir.join("#{Rails.env}.log"))
       $audit_log          = create_multicast_logger(path_dir.join("audit.log"), AuditLogger)


### PR DESCRIPTION
There were some instances where logging to journald was segfaulting.  It appears to be if a printf-style format specifier was printed.

See https://github.com/ledbettj/systemd-journal/issues/89 for more details

https://github.com/ledbettj/systemd-journal/pull/90 and v1.4.2 should resolve this issue.  Thanks to @djberg96 for finding and reporting this!