### PR TITLE
Include vendor and parent cluster info into C&U collection summary

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -260,7 +260,7 @@ class EmsCluster < ApplicationRecord
     end
 
     hids = cl_hash.values.flat_map { |v| v[:ho_ids] }.compact.uniq
-    hosts_by_id = Host.where(:id => hids).includes(:tags, :taggings).select(:id, :name).index_by(&:id)
+    hosts_by_id = Host.where(:id => hids).includes(:tags, :taggings).select(:id, :name, :vmm_vendor, :ems_cluster_id).index_by(&:id)
 
     cl_hash.each do |_k, v|
       hosts = hosts_by_id.values_at(*v[:ho_ids]).compact


### PR DESCRIPTION
I'm [converting](https://github.com/ManageIQ/manageiq-ui-classic/pull/6790) nodes in the C&U selection from hash to objects, but I need these two additional fields into the output of `EmsCluster.get_perf_collection_object_list` in order to decorate and to make the rendering a little bit faster.

@miq-bot add_label enhancement