### PR TITLE
Allow two-phase migration for SSH transport method

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -487,7 +487,9 @@ class InfraConversionJob < Job
     migration_task.get_conversion_state
     case migration_task.options[:virtv2v_status]
     when 'active'
-      unless migration_task.two_phase?
+      if migration_task.two_phase?
+        update_migration_task_progress(:on_retry, :message => 'Converting disks')
+      else
         virtv2v_disks = migration_task.options[:virtv2v_disks]
         converted_disks = virtv2v_disks.reject { |disk| disk[:percent].zero? }
         if converted_disks.empty?
@@ -499,8 +501,6 @@ class InfraConversionJob < Job
           message = "Converting disk #{converted_disks.length} / #{virtv2v_disks.length} [#{percent.round(2)}%]."
         end
         update_migration_task_progress(:on_retry, :message => message, :percent => percent)
-      else
-        update_migration_task_progress(:on_retry, :message => 'Converting disks')
       end
       queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
     when 'failed'

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -498,8 +498,9 @@ class InfraConversionJob < Job
           converted_disks.each { |disk| percent += (disk[:percent].to_f * disk[:weight].to_f / 100.0) }
           message = "Converting disk #{converted_disks.length} / #{virtv2v_disks.length} [#{percent.round(2)}%]."
         end
+        update_migration_task_progress(:on_retry, :message => message, :percent => percent)
       else
-        update_migration_task_progress(:on_retry, :message => 'Warm migration in progress')
+        update_migration_task_progress(:on_retry, :message => 'Converting disks')
       end
       queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
     when 'failed'

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -487,7 +487,7 @@ class InfraConversionJob < Job
     migration_task.get_conversion_state
     case migration_task.options[:virtv2v_status]
     when 'active'
-      unless migration_task.warm_migration?
+      unless migration_task.two_phase?
         virtv2v_disks = migration_task.options[:virtv2v_disks]
         converted_disks = virtv2v_disks.reject { |disk| disk[:percent].zero? }
         if converted_disks.empty?

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -498,7 +498,6 @@ class InfraConversionJob < Job
           converted_disks.each { |disk| percent += (disk[:percent].to_f * disk[:weight].to_f / 100.0) }
           message = "Converting disk #{converted_disks.length} / #{virtv2v_disks.length} [#{percent.round(2)}%]."
         end
-        update_migration_task_progress(:on_retry, :message => message, :percent => percent)
       else
         update_migration_task_progress(:on_retry, :message => 'Warm migration in progress')
       end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -66,7 +66,8 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     raise 'OSP destination and source power_state is off' if destination_ems.emstype == 'openstack' && source.power_state == 'off'
     update_options(
       :source_vm_power_state => source.power_state, # This will determine power_state of destination_vm
-      :source_vm_ipaddresses => source.ipaddresses  # This will determine if we need to wait for ip addresses to appear
+      :source_vm_ipaddresses => source.ipaddresses, # This will determine if we need to wait for ip addresses to appear
+      :two_phase             => two_phase?          # This will help the UI to know how to display the data
     )
     destination_cluster
     preflight_check_vm_exists_in_destination
@@ -96,6 +97,10 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     unless destination_ems.vms_and_templates.where(:name => source.name, :cloud_tenant => destination_cluster).count.zero?
       raise "A VM named '#{source.name}' already exist in destination cloud tenant"
     end
+  end
+
+  def two_phase?
+    source.snapshots.empty?
   end
 
   def source_cluster
@@ -271,7 +276,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     updates[:virtv2v_message] = virtv2v_state['last_message']['message'] if virtv2v_state['last_message'].present?
     if virtv2v_state['finished'].nil?
       updates[:virtv2v_status] = virtv2v_state['status'] == 'Paused' ? 'paused' : 'active'
-      if warm_migration?
+      if two_phase?
         updated_disks = virtv2v_state['disks']
       else
         updated_disks.each do |disk|
@@ -400,7 +405,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :query    => { :no_verify => 1 }.to_query
       ).to_s,
       :vmware_password      => source.host.authentication_password,
-      :two_phase            => source.snapshots.empty?,
+      :two_phase            => two_phase?,
       :warm                 => warm_migration?,
       :daemonize            => false
     }
@@ -420,7 +425,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
       :vmware_password      => source.host.authentication_password,
-      :two_phase            => source.snapshots.empty?,
+      :two_phase            => two_phase?,
       :warm                 => false,
       :daemonize            => false
     }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -413,7 +413,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
       :conversion_host_uuid => conversion_host_resource_ref(conversion_host.resource),
       :transport_method     => 'ssh',
       :vmware_fingerprint   => source.host.thumbprint_sha1,
-      :vmware_uri => URI::Generic.build(
+      :vmware_uri           => URI::Generic.build(
         :scheme   => 'ssh',
         :userinfo => 'root',
         :host     => source.host.miq_custom_get('TransformationIPAddress') || source.host.ipaddress,

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1412,7 +1412,7 @@ RSpec.describe InfraConversionJob, :v2v do
           ]
         end
 
-        it "updates message and percentage, and retries if conversion is cold and not finished" do
+        it "updates message and percentage, and retries if conversion is one-phase and not finished" do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
           allow(job.migration_task).to receive(:two_phase?).and_return(false)
           Timecop.freeze(2019, 2, 6) do
@@ -1427,12 +1427,12 @@ RSpec.describe InfraConversionJob, :v2v do
           end
         end
 
-        it "retries if conversion is warm and not finished" do
+        it "retries if conversion is two-phase and not finished" do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
           allow(job.migration_task).to receive(:warm_migration?).and_return(true)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
-            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Warm migration in progress')
+            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Converting disks')
             expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
             job.signal(:poll_transform_vm_complete)
           end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1390,6 +1390,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
         it 'returns a message stating conversion has not started' do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
+          allow(job.migration_task).to receive(:two_phase?).and_return(false)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Disk transformation is initializing.', :percent => 1).and_call_original
@@ -1413,7 +1414,7 @@ RSpec.describe InfraConversionJob, :v2v do
 
         it "updates message and percentage, and retries if conversion is cold and not finished" do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
-          allow(job.migration_task).to receive(:warm_migration?).and_return(false)
+          allow(job.migration_task).to receive(:two_phase?).and_return(false)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Converting disk 2 / 2 [43.75%].', :percent => 43.75).and_call_original

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -658,7 +658,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
-              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
@@ -682,7 +682,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
-              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
@@ -832,7 +832,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :transport_method           => 'ssh',
               :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri                 => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :vmware_password      => 'esx_passwd',
+              :vmware_password            => 'esx_passwd',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(
                   :scheme => openstack_ems.security_protocol == 'non-ssl' ? 'http' : 'https',

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -399,18 +399,18 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           )
         end
 
-        it "rescues when conversion_host.get_conversion_state fails less than 5 times" do
+        it "rescues when conversion_host.get_conversion_state fails less than 20 times" do
           task_1.update_options(:get_conversion_state_failures => 2)
           allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
           task_1.get_conversion_state
           expect(task_1.options[:get_conversion_state_failures]).to eq(3)
         end
 
-        it "rescues when conversion_host.get_conversion_state fails more than 5 times" do
-          task_1.update_options(:get_conversion_state_failures => 5)
+        it "rescues when conversion_host.get_conversion_state fails more than 20 times" do
+          task_1.update_options(:get_conversion_state_failures => 20)
           allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
-          expect { task_1.get_conversion_state }.to raise_error("Failed to get conversion state 5 times in a row")
-          expect(task_1.options[:get_conversion_state_failures]).to eq(6)
+          expect { task_1.get_conversion_state }.to raise_error("Failed to get conversion state 20 times in a row")
+          expect(task_1.options[:get_conversion_state_failures]).to eq(21)
         end
 
         it "updates progress when conversion is failed" do
@@ -654,10 +654,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name              => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vm_name              => src_vm_1.name,
               :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
+              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri           => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -666,6 +669,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :network_mappings     => task_1.network_mappings,
               :install_drivers      => true,
               :insecure_connection  => true,
+              :two_phase            => true,
+              :warm                 => false,
               :daemonize            => false
             )
           end
@@ -673,10 +678,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash with host custom IP address" do
             src_host.miq_custom_set('TransformationIPAddress', '192.168.254.1')
             expect(task_1.conversion_options).to eq(
-              :vm_name              => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vm_name              => src_vm_1.name,
               :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
+              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri           => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -685,6 +693,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :network_mappings     => task_1.network_mappings,
               :install_drivers      => true,
               :insecure_connection  => true,
+              :two_phase            => true,
+              :warm                 => false,
               :daemonize            => false
             )
           end
@@ -816,10 +826,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vm_name                    => src_vm_1.name,
               :vm_uuid                    => src_vm_1.uid_ems,
               :conversion_host_uuid       => conversion_host.ems_ref,
               :transport_method           => 'ssh',
+              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
+              :vmware_uri                 => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
+              :vmware_password      => 'esx_passwd',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(
                   :scheme => openstack_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
@@ -840,6 +853,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :osp_security_groups_ids    => [openstack_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings           => task_1.network_mappings,
+              :two_phase                  => true,
+              :warm                       => false,
               :daemonize                  => false
             )
           end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-v2v-conversion_host/pull/39 adds the ability to use two-phase migration for SSH transport method. The only condition is that the source VM must not have snapshots, as two-phase uses CBT. So, this is only enabled for VMs without snapshot.

This also requires more information in virt-v2v-wrapper input file, so the `conversion_options_source_provider_vmwarews_ssh` method is updated to provide it.

A side effect of two-phase migration is that the virt-v2v-wrapper state file takes longer to be created. The pull request extends the number of retries to get it.

Depends on https://github.com/ManageIQ/manageiq-v2v-conversion_host/pull/39
Depends on https://github.com/ManageIQ/manageiq-v2v/pull/1123

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1817096