### PR TITLE
Use --signal instead of -s to kill pods

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -300,7 +300,7 @@ class ConversionHost < ApplicationRecord
   # if no signal is specified.
   #
   def kill_virtv2v(task_id, signal = 'TERM')
-    command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :s, signal, "virt-v2v"])
+    command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :signal, signal, "virt-v2v"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true
   rescue


### PR DESCRIPTION
According the `podman kill` man page, the signal is passed with `--signal` option and `-s` doesn't exist. 
This means that we always pass the default signal. This pull request fixes that.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1817151