### PR TITLE
update to bundler 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be require
 gem "ancestry",                       "~>3.0.7",       :require => false
 gem "aws-sdk-s3",                     "~>1.0",         :require => false # For FileDepotS3
 gem "bcrypt",                         "~> 3.1.10",     :require => false
-gem "bundler",                        ">=1.15",        :require => false
+gem "bundler",                        "~> 2.1.4",      :require => false
 gem "byebug",                                          :require => false
 gem "color",                          "~>1.8"
 gem "config",                         "~>2.2", ">=2.2.1", :require => false


### PR DESCRIPTION
2.0 includes a deprecation that is relevant to automate and for the purposes of testing I wanted to see what fails with this update.

https://github.com/rubygems/rubygems/commit/71b8454307e636f28b514d4553268c8f9b0d14e2 is the commit that includes the deprecation 

- [ ] To be merged with https://github.com/ManageIQ/manageiq-automation_engine/pull/421