### PR TITLE
Relax qpid_proton requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ group :redfish, :manageiq_default do
 end
 
 group :qpid_proton, :optional => true do
-  gem "qpid_proton",                    "~>0.26.0",      :require => false
+  gem "qpid_proton",                    "~>0.30.0",      :require => false
 end
 
 group :systemd, :optional => true do


### PR DESCRIPTION
Relax the qpid_proton version requirement.

Fixes https://github.com/ManageIQ/manageiq/issues/19942