### PR TITLE
Don't run rake update:ui on travis

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,18 @@ EOS
   exit 1
 end
 
+def skip_ui_update?
+  ENV["CI"]
+end
+
+def skip_database_setup?
+  ENV["SKIP_DATABASE_SETUP"] || ENV["CI"]
+end
+
+def skip_test_reset?
+  ENV["SKIP_TEST_RESET"]
+end
+
 Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.ensure_config_files
 
@@ -21,15 +33,15 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.install_bundler
   ManageIQ::Environment.bundle_update
 
-  ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["CI"]
+  ui_thread = ManageIQ::Environment.update_ui_thread unless skip_ui_update?
 
-  unless ENV["SKIP_DATABASE_SETUP"]
+  unless skip_database_setup?
     ManageIQ::Environment.create_database
     ManageIQ::Environment.migrate_database
     ManageIQ::Environment.seed_database
   end
 
-  ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
+  ManageIQ::Environment.setup_test_environment unless skip_test_reset?
 
   ui_thread&.join
 

--- a/bin/setup
+++ b/bin/setup
@@ -21,15 +21,17 @@ Dir.chdir(ManageIQ::Environment::APP_ROOT) do
   ManageIQ::Environment.install_bundler
   ManageIQ::Environment.bundle_update
 
-  ManageIQ::Environment.while_updating_ui do
-    unless ENV["SKIP_DATABASE_SETUP"]
-      ManageIQ::Environment.create_database
-      ManageIQ::Environment.migrate_database
-      ManageIQ::Environment.seed_database
-    end
+  ui_thread = ManageIQ::Environment.update_ui_thread unless ENV["CI"]
 
-    ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
+  unless ENV["SKIP_DATABASE_SETUP"]
+    ManageIQ::Environment.create_database
+    ManageIQ::Environment.migrate_database
+    ManageIQ::Environment.seed_database
   end
+
+  ManageIQ::Environment.setup_test_environment unless ENV["SKIP_TEST_RESET"]
+
+  ui_thread&.join
 
   ManageIQ::Environment.clear_logs_and_temp
 end

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -44,8 +44,7 @@ module ManageIQ
       Dir.mkdir(logdir) unless Dir.exist?(logdir)
     end
 
-    def self.while_updating_ui
-      # Run update:ui in a thread and continue to do the non-js stuff
+    def self.update_ui_thread
       puts "\n== Updating UI assets (in parallel) =="
 
       ui_thread = Thread.new do
@@ -54,9 +53,13 @@ module ManageIQ
       end
 
       ui_thread.abort_on_exception = true
+      ui_thread
+    end
 
+    def self.while_updating_ui
+      # Run update:ui in a thread and continue to do the non-js stuff
+      ui_thread = update_ui_thread
       yield
-
       ui_thread.join
     end
 


### PR DESCRIPTION
When running from cross_repo-tests bin/setup was running rake update:ui
which was failing due to not having the right version of node installed.

We shouldn't need to update the UI assets for core tests so we can skip
this step when running on travis.