### PR TITLE
Add additional privilege escalation methods

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/machine_credential.rb
@@ -32,7 +32,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential
       :type       => :choice,
       :label      => N_('Privilege Escalation'),
       :help_text  => N_('Privilege escalation method'),
-      :choices    => ['', 'sudo', 'su', 'pbrun', 'pfexec']
+      :choices    => ['', 'sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'pmrun', 'runas', 'enable', 'ksu', 'sesu', 'machinectl']
     },
     :become_username => {
       :type       => :string,


### PR DESCRIPTION
Changed this list to match the output of `ansible-doc -t become -l` from our latest appliance

![image](https://user-images.githubusercontent.com/12697904/77773237-b1f2d500-701f-11ea-929a-b63563aa5f0f.png)


Fixes https://github.com/ManageIQ/manageiq/issues/18470