### PR TITLE
Force test:initialize to set RAILS_ENV=test

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -3,9 +3,13 @@ require_relative './evm_test_helper'
 if defined?(RSpec)
 namespace :test do
   task :initialize do
-    ENV['RAILS_ENV'] ||= "test"
-    Rails.env = ENV['RAILS_ENV'] if defined?(Rails)
-    ENV['VERBOSE']   ||= "false"
+    if ENV['RAILS_ENV'] && ENV["RAILS_ENV"] != "test"
+      warn "Warning: RAILS_ENV is currently set to '#{ENV["RAILS_ENV"]}'. Forcing to 'test' for this run."
+    end
+    ENV['RAILS_ENV'] = "test"
+    Rails.env = 'test' if defined?(Rails)
+
+    ENV['VERBOSE'] ||= "false"
   end
 
   task :verify_no_db_access_loading_rails_environment do


### PR DESCRIPTION
Tasks that end up using this task as a prereq make assumption that the
test database is being accessed.  In particualr test:vmdb:setup destroys
the test database, so if this value is non-test, it will destroy that
non-test database.


@NickLaMuro Please review.

Cross repo tests at https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/101

Fixes #20020