### PR TITLE
Remove unused ems_inv_to_hashes method

### DIFF
--- a/app/models/manageiq/providers/base_manager/refresher.rb
+++ b/app/models/manageiq/providers/base_manager/refresher.rb
@@ -129,21 +129,13 @@ module ManageIQ
         persister
       end
 
-      def parse_legacy_inventory(ems)
-        ems.class::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
-      end
-
       # Saves the inventory to the DB
       #
       # @param ems [ManageIQ::Providers::BaseManager]
       # @param target [ManageIQ::Providers::BaseManager or InventoryRefresh::Target or InventoryRefresh::TargetCollection]
       # @param parsed [Array<Hash> or ManageIQ::Providers::Inventory::Persister]
-      def save_inventory(ems, target, parsed_hashes_or_persister)
-        if parsed_hashes_or_persister.kind_of?(ManageIQ::Providers::Inventory::Persister)
-          parsed_hashes_or_persister.persist!
-        else
-          EmsRefresh.save_ems_inventory(ems, parsed_hashes_or_persister, target)
-        end
+      def save_inventory(ems, _target, persister)
+        InventoryRefresh::SaveInventory.save_inventory(ems, persister.inventory_collections)
       end
 
       def post_refresh_ems_cleanup(_ems, _targets)

--- a/app/models/manageiq/providers/storage_manager/cinder_manager/refresher.rb
+++ b/app/models/manageiq/providers/storage_manager/cinder_manager/refresher.rb
@@ -1,12 +1,5 @@
 #
 module ManageIQ::Providers
   class StorageManager::CinderManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
-    def parse_legacy_inventory(ems)
-      ManageIQ::Providers::StorageManager::CinderManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
-    end
-
-    def post_process_refresh_classes
-      []
-    end
   end
 end


### PR DESCRIPTION
The RefreshParser.ems_inv_to_hashes method was used by legacy refresh
and is no longer needed.  Also cleanup the #save_inventory method which
was still handling the legacy refresh case of not being passed a
persister object.

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/102