### PR TITLE
Serverid not required if all_servers is used

### DIFF
--- a/tools/configure_server_settings.rb
+++ b/tools/configure_server_settings.rb
@@ -14,7 +14,7 @@ opts = Optimist.options(ARGV) do
          "Example (Array):   #{__FILE__} -s 1 -p ntp/server -v 0.pool.ntp.org,1.pool.ntp.org -t array"
 
   opt :dry_run,         "Dry Run",                                  :short => "d"
-  opt :serverid,        "Server Id",                                :short => "s", :type => :integer, :required => true
+  opt :serverid,        "Server Id",                                :short => "s", :type => :integer, :required => false
   opt :path,            "Path within advanced settings hash",       :short => "p", :type => :string,  :required => true
   opt :value,           "New Value for setting",                    :short => "v", :type => :string,  :required => true
   opt :force,           "Force change value regardless of type",    :short => "f", :type => :boolean, :default  => false


### PR DESCRIPTION
Links [Optional]
----------------
* Consolidate existing server setting CLI tools (https://github.com/ManageIQ/manageiq/pull/19848)
* Fix for 19434, replication single value (https://github.com/ManageIQ/manageiq/pull/19441)

Steps for Testing/QA [Optional]
-------------------------------
When testing the new configure server setting tool, using the ''all_servers" option, also a serverid must be supplied.
```
$ tools/configure_server_settings.rb -p server/company -v KPN -a
Error: option --serverid must be specified.
Try --help for help.
```
After this PR
```
$ tools/configure_server_settings.rb -p server/company -v KPN -a
** Using session_store: ActionDispatch::Session::MemCacheStore
** ManageIQ ivanchuk-1, codename: Ivanchuk
Setting [server/company], old value: [KPN], new value: [KPN]
 - replicating to server id=1...
Done
```


