### PR TITLE
[IVANCHUK] Update manageiq-smartstate Gem to 0.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.3.4",       :require => false
+  gem "manageiq-smartstate",            "~>0.3.6",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Per recent fixes in manageiq-smartstate, change the manageiq Gemfile
to refer to the 0.3.6 version of that gem

Addresses the two BZ's (one an RFE, one a bug/enhancement) below.

@roliveri please review.

Links 
----------------

* https://bugzilla.redhat.com/show_bug.cgi?id=1684589
* https://bugzilla.redhat.com/show_bug.cgi?id=1810194
* https://github.com/ManageIQ/manageiq-smartstate/pull/117
* https://github.com/ManageIQ/manageiq-smartstate/pull/114

Also, 0.3.5 includes fix for https://bugzilla.redhat.com/show_bug.cgi?id=1805467.