### PR TITLE
With rails 5.2, where clauses will no longer cast Class objects as Strings

### DIFF
--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -384,7 +384,7 @@ class MiqReportResult < ApplicationRecord
   end
 
   def self.with_chargeback
-    includes(:miq_report).where(:miq_reports => {:db => Chargeback.subclasses})
+    includes(:miq_report).where(:miq_reports => {:db => Chargeback.subclasses.collect(&:name)})
   end
 
   def self.with_saved_chargeback_reports(report_id = nil)


### PR DESCRIPTION
We need to explicitly pass String objects.

Similar to https://github.com/ManageIQ/manageiq/pull/19016

Fixes errors of this variety on rails 5.2 (in a rails 5.1 backward compatible
way):

```
irb(main):001:0> MiqReportResult.with_chargeback
The version of PostgreSQL being connected to is incompatible with ManageIQ (10 required)
PostgreSQLAdapter#log_after_checkout, connection_pool: size: 5, connections: 1, in use: 1, waiting_in_queue: 0
Traceback (most recent call last):
       16: from activerecord (5.2.4.2) lib/active_record/relation.rb:584:in `skip_query_cache_if_necessary
       ...
        1: from activerecord (5.2.4.2) lib/active_record/connection_adapters/abstract/quoting.rb:34:in `rescue in type_cast'
TypeError (can't cast Class)
```