### PR TITLE
initialize_type_map now expects 1 argument

### DIFF
--- a/lib/extensions/ar_types.rb
+++ b/lib/extensions/ar_types.rb
@@ -1,7 +1,7 @@
 require 'active_record/connection_adapters/postgresql_adapter'
 ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
   prepend Module.new {
-    def initialize_type_map(m)
+    def initialize_type_map(m = type_map)
       super
       m.alias_type('xid', 'varchar')
     end


### PR DESCRIPTION
Fixes:

```
4: from activerecord (5.2.3) lib/active_record/connection_adapters/postgresql_adapter.rb:48:in `new'
        3: from config/initializers/postgres_required_versions.rb:3:in `initialize'
        2: from activerecord (5.2.3) lib/active_record/connection_adapters/postgresql_adapter.rb:235:in `initialize'
        1: from lib/extensions/ar_types.rb:4:in `initialize_type_map'
ArgumentError (wrong number of arguments (given 0, expected 1))
```

The interface changed in rails 5.2.  This change is backward compatible with rails 5.1.