### PR TITLE
Fix Foreman::ConfigurationManager without a Provider

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -126,7 +126,9 @@ FactoryBot.define do
   factory :configuration_manager,
           :aliases => ["manageiq/providers/configuration_manager"],
           :class   => "ManageIQ::Providers::Foreman::ConfigurationManager",
-          :parent  => :ext_management_system
+          :parent  => :ext_management_system do
+    provider :factory => :provider
+  end
 
   # Automation managers
 
@@ -138,7 +140,9 @@ FactoryBot.define do
   factory :provisioning_manager,
           :aliases => ["manageiq/providers/provisioning_manager"],
           :class   => "ManageIQ::Providers::Foreman::ProvisioningManager",
-          :parent  => :ext_management_system
+          :parent  => :ext_management_system do
+    provider :factory => :provider
+  end
 
   # Leaf classes for ems_infra
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -130,8 +130,10 @@ RSpec.describe ExtManagementSystem do
     expect { ManageIQ::Providers::CloudManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate! }.to raise_error(ActiveRecord::RecordInvalid)
     expect { ManageIQ::Providers::AutomationManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate! }.to raise_error(ActiveRecord::RecordInvalid)
     expect(ManageIQ::Providers::Vmware::InfraManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
-    expect(ManageIQ::Providers::Foreman::ConfigurationManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
-    expect(ManageIQ::Providers::Foreman::ProvisioningManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
+
+    foreman_provider = ManageIQ::Providers::Foreman::Provider.new
+    expect(ManageIQ::Providers::Foreman::ConfigurationManager.new(:provider => foreman_provider, :hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
+    expect(ManageIQ::Providers::Foreman::ProvisioningManager.new(:provider => foreman_provider, :hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
   end
 
   context "#ipaddress / #ipaddress=" do


### PR DESCRIPTION
The Foreman::ConfigurationManager can't be created without a provider

Introduced when https://github.com/ManageIQ/manageiq-providers-foreman/pull/59 added endpoints to the delegate list (which is how it was being used anyway)