### PR TITLE
fix order warnings

### DIFF
--- a/app/models/custom_button.rb
+++ b/app/models/custom_button.rb
@@ -3,7 +3,7 @@ class CustomButton < ApplicationRecord
 
   scope :with_array_order, lambda { |ids, column = :id, column_type = :bigint|
     order = sanitize_sql_array(["array_position(ARRAY[?]::#{column_type}[], #{table_name}.#{column}::#{column_type})", ids])
-    order(order)
+    order(Arel.sql(order))
   }
 
   serialize :options, Hash

--- a/app/models/miq_report_result.rb
+++ b/app/models/miq_report_result.rb
@@ -388,7 +388,7 @@ class MiqReportResult < ApplicationRecord
   end
 
   def self.with_saved_chargeback_reports(report_id = nil)
-    with_report(report_id).auto_generated.with_current_user_groups.with_chargeback.order('LOWER(miq_reports.name)')
+    with_report(report_id).auto_generated.with_current_user_groups.with_chargeback.order(Arel.sql('LOWER(miq_reports.name)'))
   end
 
   def self.select_distinct_results

--- a/app/models/mixins/process_tasks_mixin.rb
+++ b/app/models/mixins/process_tasks_mixin.rb
@@ -187,7 +187,7 @@ module ProcessTasksMixin
     def validate_tasks(options)
       tasks = []
 
-      instances = base_class.where(:id => options[:ids]).order("lower(name)").to_a
+      instances = base_class.where(:id => options[:ids]).order(Arel.sql("lower(name)")).to_a
       return instances, tasks unless options[:invoke_by] == :task # jobs will be used instead of tasks for feedback
 
       instances.each do |instance|

--- a/db/fixtures/tools/create_customization_templates_fixture.rb
+++ b/db/fixtures/tools/create_customization_templates_fixture.rb
@@ -1,4 +1,4 @@
-recs = CustomizationTemplate.where(:system => true).order("LOWER(name)")
+recs = CustomizationTemplate.where(:system => true).order(Arel.sql("LOWER(name)"))
 recs = recs.collect do |r|
   attrs = r.attributes.except("id", "created_at", "updated_at", "pxe_image_type_id").symbolize_keys
   attrs[:system] = true

--- a/db/fixtures/tools/create_pxe_image_types_fixture.rb
+++ b/db/fixtures/tools/create_pxe_image_types_fixture.rb
@@ -1,4 +1,4 @@
-recs = PxeImageType.order("LOWER(name)").collect { |r| r.attributes.except("id").symbolize_keys }
+recs = PxeImageType.order(Arel.sql("LOWER(name)")).collect { |r| r.attributes.except("id").symbolize_keys }
 File.open(PxeImageType.seed_file_name, "w") do |f|
   f.write(recs.to_yaml)
 end

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -278,8 +278,8 @@ RSpec.describe Classification do
       expect(all_tagged_with(Host.order('name'), ent11.name, ent11.parent.name)).to eq([host1])
       expect(any_tagged_with(Host.order('name'), ent11.name, ent11.parent.name)).to eq([host1])
 
-      expect(all_tagged_with(Host.order('lower(name)'), ent11.name, ent11.parent.name)).to eq([host1])
-      expect(any_tagged_with(Host.order('lower(name)'), ent11.name, ent11.parent.name)).to eq([host1])
+      expect(all_tagged_with(Host.order(Arel.sql('lower(name)')), ent11.name, ent11.parent.name)).to eq([host1])
+      expect(any_tagged_with(Host.order(Arel.sql('lower(name)')), ent11.name, ent11.parent.name)).to eq([host1])
 
       expect(all_tagged_with(Host.order(Host.arel_table[:name].lower), ent11.name, ent11.parent.name)).to eq([host1])
       expect(any_tagged_with(Host.order(Host.arel_table[:name].lower), ent11.name, ent11.parent.name)).to eq([host1])

--- a/tools/db_printers/print_network.rb
+++ b/tools/db_printers/print_network.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../config/environment', __dir__)
 
 def print_switch(indent, switch)
   puts "#{indent}Switch: #{switch.name}"
-  switch.lans.order("lower(name)").each do |lan|
+  switch.lans.order(Arel.sql("lower(name)")).each do |lan|
     puts "#{indent}  Lan: #{lan.name}"
     vms = lan.guest_devices.collect { |gd| [gd.hardware.vm, gd.device_name] if gd.hardware && gd.hardware.vm }.compact
     vms.sort_by { |vm| vm[0].name.downcase }.each { |vm| puts "#{indent}    #{vm[0].class}: #{vm[0].name} (vNIC: #{vm[1]})" }
@@ -15,7 +15,7 @@ Host.all.each do |host|
 
   found_switches = []
   unless host.hardware.nil?
-    pnics = host.hardware.guest_devices.where(:device_type => 'ethernet').order("lower(device_name)")
+    pnics = host.hardware.guest_devices.where(:device_type => 'ethernet').order(Arel.sql("lower(device_name)"))
 
     # Group the pNICs by Switch
     pnics_grouped = []
@@ -40,7 +40,7 @@ Host.all.each do |host|
 
   unless host.switches.length == found_switches.length
     puts "  pNIC: (None)"
-    host.switches.order("lower(name)").each do |switch|
+    host.switches.order(Arel.sql("lower(name)")).each do |switch|
       next if found_switches.include?(switch.name)
       print_switch("    ", switch)
     end

--- a/tools/db_printers/print_scsi.rb
+++ b/tools/db_printers/print_scsi.rb
@@ -4,12 +4,12 @@ require File.expand_path('../../config/environment', __dir__)
 Host.all.each do |host|
   puts "Host: #{host.name} (id: #{host.id})"
 
-  host.hardware.guest_devices.where(:device_type => 'storage').order("lower(device_name)").each do |adapter|
+  host.hardware.guest_devices.where(:device_type => 'storage').order(Arel.sql("lower(device_name)")).each do |adapter|
     sub_name = adapter.iscsi_name.nil? ? "" : " (#{adapter.iscsi_name})"
     puts "  SCSI Adapter: #{adapter.device_name}#{sub_name}"
-    adapter.miq_scsi_targets.order("lower(target)").each do |target|
+    adapter.miq_scsi_targets.order(Arel.sql("lower(target)")).each do |target|
       puts "    Target: #{target.iscsi_name} (#{target.target})"
-      target.miq_scsi_luns.order("lower(lun)").each do |lun|
+      target.miq_scsi_luns.order(Arel.sql("lower(lun)")).each do |lun|
         puts "      Lun: #{lun.canonical_name} (#{lun.lun})"
       end
     end


### PR DESCRIPTION
```
DEPRECATION WARNING: Dangerous query method (method whose arguments are
used as raw SQL) called with non-attribute argument(s): "lower(name)".
Non-attribute arguments will be disallowed in Rails 6.0.
This method should not be called with user-provided values,
such as request parameters or model attributes.
Known-safe values can be passed by wrapping them in Arel.sql().
```

These deprecation warnings display in rails 5.2
These fixes work in 5.1