### PR TITLE
fix report formatter deprecation warning

### DIFF
--- a/app/models/miq_report/formatters/text.rb
+++ b/app/models/miq_report/formatters/text.rb
@@ -1,6 +1,6 @@
 module MiqReport::Formatters::Text
   def to_text
-    ReportFormatter::ReportRenderer.render(:text) do |e|
+    ManageIQ::Reporting::Formatter::ReportRenderer.render(:text) do |e|
       e.options.mri = (self) # set the MIQ_Report instance in the formatter
       e.options.ignore_table_width = true
     end


### PR DESCRIPTION
```
DEPRECATION WARNING: ReportFormatter::ReportRenderer is deprecated!
Use ManageIQ::Reporting::Formatter::ReportRenderer instead.
```

I don't understand the implications of this change.
I'll tag as ui because they probably know more about this