### PR TITLE
Only show catalog types for supported EMSs

### DIFF
--- a/app/models/manageiq/providers/base_manager.rb
+++ b/app/models/manageiq/providers/base_manager.rb
@@ -16,9 +16,10 @@ module ManageIQ::Providers
       self
     end
 
-    def supported_catalog_types
-      []
+    def self.catalog_types
+      {}
     end
+    delegate :catalog_types, :to => :class
 
     def refresher
       self.class::Refresher

--- a/app/models/manageiq/providers/embedded_automation_manager.rb
+++ b/app/models/manageiq/providers/embedded_automation_manager.rb
@@ -10,7 +10,7 @@ class ManageIQ::Providers::EmbeddedAutomationManager < ManageIQ::Providers::Auto
     false
   end
 
-  def supported_catalog_types
-    %w(generic_ansible_playbook)
+  def self.catalog_types
+    {"generic_ansible_playbook" => N_("Ansible Playbook")}
   end
 end

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -70,9 +70,7 @@ module ManageIQ::Providers
 
     def self.supported_types_and_descriptions_hash
       supported_subclasses.select(&:supports_ems_network_new?).each_with_object({}) do |klass, hash|
-        if Vmdb::PermissionStores.instance.supported_ems_type?(klass.ems_type)
-          hash[klass.ems_type] = klass.description
-        end
+        hash[klass.ems_type] = klass.description
       end
     end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -86,8 +86,16 @@ RSpec.describe ExtManagementSystem do
     expect(described_class.types).to match_array(all_types_and_descriptions.keys)
   end
 
-  it ".supported_types" do
-    expect(described_class.supported_types).to match_array(all_types_and_descriptions.keys)
+  describe ".supported_types" do
+    it "with default permissions" do
+      expect(described_class.supported_types).to match_array(all_types_and_descriptions.keys)
+    end
+
+    it "with removed permissions" do
+      stub_vmdb_permission_store_with_types(["ems-type:vmwarews"]) do
+        expect(described_class.supported_types).not_to include("vmwarews")
+      end
+    end
   end
 
   describe ".supported_types_and_descriptions_hash" do

--- a/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/embedded_ansible/automation_manager_spec.rb
@@ -1,9 +1,15 @@
 RSpec.describe ManageIQ::Providers::EmbeddedAnsible::AutomationManager do
-  context 'catalog types' do
+  describe ".catalog_types" do
+    it "includes generic_ansible_playbook" do
+      expect(described_class.catalog_types).to include("generic_ansible_playbook")
+    end
+  end
+
+  describe '#catalog_types' do
     let(:ems) { FactoryBot.create(:embedded_automation_manager_ansible) }
 
-    it "#supported_catalog_types" do
-      expect(ems.supported_catalog_types).to eq(%w(generic_ansible_playbook))
+    it "includes generic_ansible_playbook" do
+      expect(ems.catalog_types).to include("generic_ansible_playbook")
     end
   end
 end


### PR DESCRIPTION
If an EMS isn't supported by disabling it in the Vmdb::PermissionStore we shouldn't show it as an available catalog type

Follow-up to: https://github.com/ManageIQ/manageiq/pull/19214
Pluggability: https://github.com/ManageIQ/manageiq/issues/19440
Cross-Repo-Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/106

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/616
- [ ] https://github.com/ManageIQ/manageiq-providers-azure/pull/389
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/217
- [ ] https://github.com/ManageIQ/manageiq-providers-google/pull/128
- [ ] https://github.com/ManageIQ/manageiq-providers-openshift/pull/163
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/577
- [ ] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/492
- [ ] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/156
- [ ] https://github.com/ManageIQ/manageiq-providers-vmware/pull/568
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/6822

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746084