### PR TITLE
Ensure signal is queued in poll_transform_vm_complete also for warm migration

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -499,8 +499,10 @@ class InfraConversionJob < Job
           message = "Converting disk #{converted_disks.length} / #{virtv2v_disks.length} [#{percent.round(2)}%]."
         end
         update_migration_task_progress(:on_retry, :message => message, :percent => percent)
-        queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
+      else
+        update_migration_task_progress(:on_retry, :message => 'Warm migration in progress')
       end
+      queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
     when 'failed'
       raise migration_task.options[:virtv2v_message]
     when 'succeeded'

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1411,8 +1411,9 @@ RSpec.describe InfraConversionJob, :v2v do
           ]
         end
 
-        it "updates message and percentage, and retries if conversion is not finished" do
+        it "updates message and percentage, and retries if conversion is cold and not finished" do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
+          allow(job.migration_task).to receive(:warm_migration?).and_return(false)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Converting disk 2 / 2 [43.75%].', :percent => 43.75).and_call_original
@@ -1422,6 +1423,17 @@ RSpec.describe InfraConversionJob, :v2v do
               :message => 'Converting disk 2 / 2 [43.75%].',
               :percent => 43.75
             )
+          end
+        end
+
+        it "retries if conversion is warm and not finished" do
+          task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
+          allow(job.migration_task).to receive(:warm_migration?).and_return(true)
+          Timecop.freeze(2019, 2, 6) do
+            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
+            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Warm migration in progress')
+            expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
+            job.signal(:poll_transform_vm_complete)
           end
         end
 


### PR DESCRIPTION
When we run a warm migration, the current code doesn't queue the `poll_transform_vm_complete` signal. This blocks the InfraConversionJob state machine in `transforming_vm` state, even though the conversion is complete on the conversion host.

This pull request adds a specific message for warm migration and ensure that we queue the signal in any case. It also adds a spec for that.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1817096