### PR TITLE
[TimeProfile] Fix "Dangerous query method" warning

### DIFF
--- a/app/models/time_profile.rb
+++ b/app/models/time_profile.rb
@@ -171,7 +171,7 @@ class TimeProfile < ApplicationRecord
   end
 
   def self.ordered_by_desc
-    order("lower(description) ASC")
+    order(Arel.sql("lower(description) ASC"))
   end
 
   def self.profiles_for_user(user_id, region_id)


### PR DESCRIPTION
Similar fixes to what was given in https://github.com/ManageIQ/manageiq/pull/20036

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as
raw SQL) called with non-attribute argument(s): "lower(description) ASC".
Non-attribute arguments will be disallowed in Rails 6.0. This method should not
be called with user-provided values, such as request parameters or model
attributes. Known-safe values can be passed by wrapping them in Arel.sql().

(called from ordered_by_desc at app/models/time_profile.rb:174)
```

These deprecation warnings display in rails 5.2
These fixes work in 5.1


Links
-----

* https://github.com/ManageIQ/manageiq/pull/20036