### PR TITLE
Move messaging options from Settings to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,9 @@ bin/*
 
 # config/
 config/apache
+config/cable.yml
 config/cockpit
 config/database.yml*
-config/cable.yml
 config/vmdb.yml.db
 
 config/initializers/*.local.rb

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ config/apache
 config/cable.yml
 config/cockpit
 config/database.yml*
+config/messaging.yml
 config/vmdb.yml.db
 
 config/initializers/*.local.rb

--- a/config/messaging.artemis.yml
+++ b/config/messaging.artemis.yml
@@ -1,0 +1,15 @@
+---
+base: &base
+  hostname: localhost
+  port: 61616
+  username: admin
+  password: smartvm
+
+development:
+  <<: *base
+
+production:
+  <<: *base
+
+test:
+  <<: *base

--- a/config/messaging.kafka.yml
+++ b/config/messaging.kafka.yml
@@ -1,0 +1,15 @@
+---
+base: &base
+  hostname: localhost
+  port: 9092
+  username: admin
+  password: smartvm
+
+development:
+  <<: *base
+
+production:
+  <<: *base
+
+test:
+  <<: *base

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -933,16 +933,6 @@
   :allow_api_service_ordering: true
 :prototype:
   :messaging_type: miq_queue
-  :artemis:
-    :messaging_hostname: localhost
-    :messaging_port: 61616
-    :messaging_username: admin
-    :messaging_password: smartvm
-  :kafka:
-    :messaging_hostname: localhost
-    :messaging_port: 9092
-    :messaging_username: admin
-    :messaging_password: smartvm
 :recommendations:
   :cpu_minimum: 1
   :mem_minimum: 32.megabytes

--- a/lib/manageiq/environment.rb
+++ b/lib/manageiq/environment.rb
@@ -28,9 +28,10 @@ module ManageIQ
 
     def self.ensure_config_files
       config_files = {
-        "certs/v2_key.dev"        => "certs/v2_key",
-        "config/cable.yml.sample" => "config/cable.yml",
-        "config/database.pg.yml"  => "config/database.yml",
+        "certs/v2_key.dev"           => "certs/v2_key",
+        "config/cable.yml.sample"    => "config/cable.yml",
+        "config/database.pg.yml"     => "config/database.yml",
+        "config/messaging.kafka.yml" => "config/messaging.yml",
       }
 
       config_files.each do |source, dest|


### PR DESCRIPTION
Required for https://github.com/ManageIQ/manageiq/issues/20001

- Ignore config/messaging.yml
- Move example configs for artemis and kafka to files
- Update messaging_client_options to read from files instead of Settings
- Update config file list in ManageIQ::Environment for bin/setup and bin/update
- Add tests for MiqQueue.messaging_client_options

Also fixes a bug that the settings keys being fetched [here](https://github.com/ManageIQ/manageiq/pull/19984/files#diff-d8c450b508868941c2b0c5884e718324R646) were never renamed [here](https://github.com/ManageIQ/manageiq/pull/19984/files#diff-646ad6b10917e4385cbcc8c8524e24a2R942)