### PR TITLE
Improve automate object looking up performance.

### DIFF
--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -11,7 +11,7 @@ class MiqAeClass < ApplicationRecord
   has_many   :ae_methods,   :class_name => "MiqAeMethod",    :foreign_key => :class_id,
                             :dependent => :destroy, :inverse_of => :ae_class
 
-  validates_presence_of   :name, :namespace_id, :domain_id
+  validates :name, :namespace_id, :domain_id, :presence => true
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :namespace_id
   validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ . - characters")
@@ -180,11 +180,9 @@ class MiqAeClass < ApplicationRecord
   end
 
   def set_relative_path
-    return if ae_namespace.blank?
-
-    self.domain_id ||= domain&.id || ae_namespace.domain_id
-    self.domain_id ||= ae_namespace.id if ae_namespace.root?
-    self.relative_path = [ae_namespace.relative_path, name].compact.join("/") if name_changed? || relative_path.nil?
+    self.domain_id ||= domain&.id || ae_namespace&.domain_id
+    self.domain_id ||= ae_namespace.id if ae_namespace&.root?
+    self.relative_path = [ae_namespace.relative_path, name].compact.join("/") if (name_changed? || relative_path.nil?) && ae_namespace
   end
 
   def set_children_relative_path

--- a/app/models/miq_ae_field.rb
+++ b/app/models/miq_ae_field.rb
@@ -4,7 +4,8 @@ class MiqAeField < ApplicationRecord
 
   belongs_to :ae_class,   :class_name => "MiqAeClass",  :foreign_key => :class_id, :touch => true
   belongs_to :ae_method,  :class_name => "MiqAeMethod", :foreign_key => :method_id, :touch => true
-  has_many   :ae_values,  :class_name => "MiqAeValue",  :foreign_key => :field_id, :dependent => :destroy
+  has_many   :ae_values,  :class_name => "MiqAeValue",  :foreign_key => :field_id, :dependent => :destroy,
+                          :inverse_of => :ae_field
 
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :method_id]
   validates_presence_of   :name

--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -9,7 +9,7 @@ class MiqAeInstance < ApplicationRecord
 
   before_validation :set_relative_path
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :class_id
-  validates_presence_of   :name
+  validates               :name, :domain_id, :class_id, :presence => true
   validates_format_of     :name, :with    => /\A[\w.-]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ . - characters")
 
@@ -168,8 +168,8 @@ class MiqAeInstance < ApplicationRecord
   end
 
   def set_relative_path
-    self.domain_id ||= ae_class.domain_id
-    self.relative_path = "#{ae_class.relative_path}/#{name}" if name_changed? || relative_path_changed?
+    self.domain_id ||= ae_class&.domain_id
+    self.relative_path = "#{ae_class.relative_path}/#{name}" if (name_changed? || relative_path_changed?) && ae_class
   end
 
   private

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -6,7 +6,9 @@ class MiqAeMethod < ApplicationRecord
   default_value_for(:embedded_methods) { [] }
   validates :embedded_methods, :exclusion => { :in => [nil] }
   serialize :options, Hash
+  before_validation :set_relative_path
 
+  belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
   belongs_to :ae_class, :class_name => "MiqAeClass", :foreign_key => :class_id
   has_many   :inputs,   -> { order(:priority) }, :class_name => "MiqAeField", :foreign_key => :method_id,
                         :dependent => :destroy, :autosave => true
@@ -47,10 +49,13 @@ class MiqAeMethod < ApplicationRecord
   end
 
   def fqname
-    "#{ae_class.fqname}/#{name}"
+    ["", domain&.name, relative_path].compact.join("/")
   end
 
-  delegate :domain, :to => :ae_class
+  # my method's fqname is /domain/namespace1/namespace2/class/method
+  def namespace
+    fqname.split("/")[0..-3].join("/")
+  end
 
   def self.default_method_text
     <<-DEFAULT_METHOD_TEXT
@@ -135,5 +140,16 @@ class MiqAeMethod < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Automate Method', 'Automate Methods', number)
+  end
+
+  def self.find_best_match_by(user, relative_path)
+    domain_ids = user.current_tenant.enabled_domains.collect(&:id)
+    joins(:domain).where(:miq_ae_namespaces => {:id => domain_ids}).order("miq_ae_namespaces.priority DESC")
+                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase))
+  end
+
+  def set_relative_path
+    self.domain_id ||= ae_class.domain_id
+    self.relative_path = "#{ae_class.relative_path}/#{name}" if name_changed? || relative_path_changed?
   end
 end

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -13,7 +13,7 @@ class MiqAeMethod < ApplicationRecord
   has_many   :inputs,   -> { order(:priority) }, :class_name => "MiqAeField", :foreign_key => :method_id,
                         :dependent => :destroy, :autosave => true
 
-  validates_presence_of   :name, :scope
+  validates               :name, :scope, :domain_id, :class_id, :presence => true
   validates_uniqueness_of :name, :case_sensitive => false, :scope => [:class_id, :scope]
   validates_format_of     :name, :with    => /\A[\w]+\z/i,
                                  :message => N_("may contain only alphanumeric and _ characters")
@@ -149,7 +149,7 @@ class MiqAeMethod < ApplicationRecord
   end
 
   def set_relative_path
-    self.domain_id ||= ae_class.domain_id
-    self.relative_path = "#{ae_class.relative_path}/#{name}" if name_changed? || relative_path_changed?
+    self.domain_id ||= ae_class&.domain_id
+    self.relative_path = "#{ae_class.relative_path}/#{name}" if (name_changed? || relative_path_changed?) && ae_class
   end
 end

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -11,6 +11,7 @@ class MiqAeNamespace < ApplicationRecord
                          /^commit_time/, /^commit_sha/, /^ref$/, /^ref_type$/,
                          /^last_import_on/, /^source/, /^top_level_namespace/].freeze
 
+  belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
   has_many :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) }, :class_name => "MiqAeClass",
            :foreign_key => :namespace_id, :dependent => :destroy, :inverse_of => :ae_namespace
 
@@ -25,7 +26,6 @@ class MiqAeNamespace < ApplicationRecord
 
   before_validation :set_relative_path
   after_save :set_children_relative_path
-  belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
 
   def parent
     parent_id == domain_id ? domain : super

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -12,26 +12,37 @@ class MiqAeNamespace < ApplicationRecord
                          /^last_import_on/, /^source/, /^top_level_namespace/].freeze
 
   has_many :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) }, :class_name => "MiqAeClass",
-           :foreign_key => :namespace_id, :dependent => :destroy, :inverse_of => false
+           :foreign_key => :namespace_id, :dependent => :destroy, :inverse_of => :ae_namespace
 
   validates :name,
             :format     => {:with => /\A[\w\.\-\$]+\z/i, :message => N_("may contain only alphanumeric and _ . - $ characters")},
             :presence   => true,
             :uniqueness => {:scope => :ancestry, :case_sensitive => false}
 
-  alias ae_namespaces children
+  alias_attribute :fqname_sans_domain, :relative_path
   virtual_has_many :ae_namespaces
+  alias ae_namespaces children
+
+  before_validation :set_relative_path
+  after_save :set_children_relative_path
+  belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
+
+  def parent
+    parent_id == domain_id ? domain : super
+  end
 
   def self.lookup_by_fqname(fqname, include_classes = true)
     return nil if fqname.blank?
 
-    fqname = fqname[0] == '/' ? fqname : "/#{fqname}"
-    fqname = fqname.downcase
-    last = fqname.split('/').last
-    low_name = arel_table[:name].lower
+    fqname = fqname[1..-1] if fqname[0] == '/'
+    dname, *partial = fqname.downcase.split('/')
+
+    domain_query = MiqAeDomain.unscoped.where(MiqAeDomain.arel_table[:name].lower.eq(dname)).where(:domain_id => nil)
+    return domain_query.first if partial.empty?
 
     query = include_classes ? includes(:ae_classes) : all
-    query.where(low_name.eq(last)).detect { |namespace| namespace.fqname.downcase == fqname }
+    query = query.where(arel_table[:relative_path].lower.eq(partial.join("/")))
+    query.find_by(:domain_id => domain_query.select(:id))
   end
 
   singleton_class.send(:alias_method, :find_by_fqname, :lookup_by_fqname)
@@ -61,6 +72,7 @@ class MiqAeNamespace < ApplicationRecord
     found
   end
 
+  # TODO: broken since 2017
   def self.find_tree(find_options = {})
     namespaces = where(find_options)
     ns_lookup = namespaces.inject({}) do |h, ns|
@@ -88,7 +100,9 @@ class MiqAeNamespace < ApplicationRecord
   end
 
   def fqname
-    @fqname ||= "/#{path.pluck(:name).join('/')}"
+    return "/#{name}" if domain_id.blank?
+
+    ["", domain&.name, relative_path].compact.join("/")
   end
 
   def editable?(user = User.current_user)
@@ -103,16 +117,8 @@ class MiqAeNamespace < ApplicationRecord
     fqname.sub(domain_name.to_s, '')
   end
 
-  def fqname_sans_domain
-    fqname.split('/')[2..-1].join("/")
-  end
-
   def domain_name
-    domain.try(:name)
-  end
-
-  def domain
-    root if root.domain?
+    domain&.name
   end
 
   def domain?
@@ -121,5 +127,19 @@ class MiqAeNamespace < ApplicationRecord
 
   def self.display_name(number = 1)
     n_('Automate Namespace', 'Automate Namespaces', number)
+  end
+
+  def set_relative_path
+    return if root?
+
+    self.domain_id ||= parent.domain_id || parent.id
+    self.relative_path = [parent.relative_path, name].compact.join("/") if name_changed? || relative_path.nil?
+  end
+
+  def set_children_relative_path
+    return unless saved_change_to_relative_path?
+
+    ae_namespaces.each { |ns| ns.update!(:parent => self, :relative_path => nil) }
+    ae_classes.each { |klass| klass.update!(:ae_namespace => self, :relative_path => nil) }
   end
 end

--- a/spec/factories/miq_ae_class.rb
+++ b/spec/factories/miq_ae_class.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
 
     trait :with_instances_and_methods do
       transient do
-        ae_fields {}
-        ae_instances {}
-        ae_methods {}
+        ae_fields { {} }
+        ae_instances { {} }
+        ae_methods { {} }
       end
 
       after :create do |aeclass, evaluator|
@@ -15,28 +15,22 @@ FactoryBot.define do
         end
 
         evaluator.ae_instances.each do |name, values|
-          FactoryBot.create(:miq_ae_instance, :with_values,
+          FactoryBot.create(:miq_ae_instance,
                              :class_id => aeclass.id,
                              :name     => name,
                              'values'  => values)
         end
 
         evaluator.ae_methods.each do |name, aemethod|
-          FactoryBot.create(:miq_ae_method, :with_params,
+          FactoryBot.create(:miq_ae_method,
                              {:class_id => aeclass.id,
                               :name     => name}.merge(aemethod))
         end
       end
     end
 
-    trait :of_domain do
-      transient do
-        domain { nil }
-      end
-
-      before(:create) do |ae_class, evaluator|
-        ae_class.namespace_id = FactoryBot.create(:miq_ae_namespace, :parent => evaluator.domain).id
-      end
+    before(:create) do |aeclass|
+      aeclass.ae_namespace ||= FactoryBot.create(:miq_ae_namespace, :parent => aeclass.domain) unless aeclass.namespace_id
     end
   end
 end

--- a/spec/factories/miq_ae_domain.rb
+++ b/spec/factories/miq_ae_domain.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     git_repository { FactoryBot.create(:git_repository) }
   end
 
-  factory :miq_ae_domain, :parent => :miq_ae_namespace, :class => "MiqAeDomain" do
+  factory :miq_ae_domain, :class => "MiqAeDomain" do
     sequence(:name) { |n| "miq_ae_domain#{seq_padded_for_sorting(n)}" }
     tenant { Tenant.seed }
     enabled { true }

--- a/spec/factories/miq_ae_instance.rb
+++ b/spec/factories/miq_ae_instance.rb
@@ -2,12 +2,16 @@ FactoryBot.define do
   factory :miq_ae_instance do
     sequence(:name) { |n| "miq_ae_instance_#{seq_padded_for_sorting(n)}" }
 
-    trait :with_values do
-      transient do
-        values {}
-      end
+    transient do
+      values { {} }
+    end
 
-      after :create do |aeinstance, evaluator|
+    before :create do |aeinstance, evaluator|
+      aeinstance.ae_class ||= FactoryBot.create(:miq_ae_class) unless evaluator.class_id
+    end
+
+    after :create do |aeinstance, evaluator|
+      unless evaluator.values.empty?
         aeinstance.ae_values << aeinstance.ae_class.ae_fields.collect do |field|
           next unless evaluator.values.key?(field.name)
           FactoryBot.build(:miq_ae_value, {:field_id => field.id}.merge(evaluator.values[field.name]))

--- a/spec/factories/miq_ae_method.rb
+++ b/spec/factories/miq_ae_method.rb
@@ -1,21 +1,25 @@
 FactoryBot.define do
   factory :miq_ae_method do
     sequence(:name) { |n| "miq_ae_method#{seq_padded_for_sorting(n)}" }
+    language { "ruby" }
+    location { "inline" }
 
-    trait :with_params do
-      transient do
-        params {}
-      end
+    transient do
+      params { {} }
+    end
 
-      after :create do |aemethod, evaluator|
-        evaluator.params.each do |name, f|
-          FactoryBot.create(:miq_ae_field,
-                             :name          => name,
-                             :datatype      => f['datatype'],
-                             :aetype        => f['aetype'],
-                             :method_id     => aemethod.id,
-                             :default_value => f['default_value'].blank? ? '' : f['default_value'])
-        end
+    before :create do |aemethod, evaluator|
+      aemethod.ae_class ||= FactoryBot.create(:miq_ae_class) unless evaluator.class_id
+    end
+
+    after :create do |aemethod, evaluator|
+      evaluator.params.each do |name, f|
+        FactoryBot.create(:miq_ae_field,
+                          :name          => name,
+                          :datatype      => f['datatype'],
+                          :aetype        => f['aetype'],
+                          :method_id     => aemethod.id,
+                          :default_value => f['default_value'].presence || '')
       end
     end
   end

--- a/spec/factories/miq_ae_namespace.rb
+++ b/spec/factories/miq_ae_namespace.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
   factory :miq_ae_namespace do
     sequence(:name) { |n| "miq_ae_namespace_#{seq_padded_for_sorting(n)}" }
+
+    before(:create) do |ns, evaluator|
+      if evaluator.domain_id
+        ns.parent_id ||= evaluator.domain_id
+      elsif evaluator.domain
+        ns.parent ||= evaluator.domain
+      else
+        ns.parent ||= FactoryBot.create(:miq_ae_domain)
+      end
+    end
   end
 end

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -2,7 +2,8 @@ RSpec.describe MiqAeClass do
   include Spec::Support::AutomationHelper
 
   describe "name attribute validation" do
-    subject { described_class.new }
+    let(:ns) { FactoryBot.create(:miq_ae_namespace) }
+    subject { described_class.new(:ae_namespace => ns) }
 
     example "with no name" do
       subject.name = nil
@@ -51,29 +52,32 @@ RSpec.describe MiqAeClass do
   end
 
   it "should set the updated_by field on save" do
-    c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "oleg")
+    c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "oleg", :domain => @ns.domain)
     expect(c1.updated_by).to eq('system')
   end
 
   it "should not create classes with the same name in the same namespace" do
-    c1 = MiqAeClass.new(:namespace_id => @ns.id, :name => "oleg")
+    c1 = MiqAeClass.new(:namespace_id => @ns.id, :name => "oleg", :domain => @ns.domain)
     expect(c1).not_to be_nil
     expect(c1.save!).to be_truthy
-    expect { MiqAeClass.new(:namespace_id => @ns.id, :name => "OLEG").save! }.to raise_error(ActiveRecord::RecordInvalid)
-    c2 = MiqAeClass.new(:namespace_id => FactoryBot.create(:miq_ae_namespace).id, :name => "oleg")
+    expect { MiqAeClass.new(:namespace_id => @ns.id, :name => "OLEG", :domain => @ns.domain).save! }.to raise_error(ActiveRecord::RecordInvalid)
+    n2 = FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain))
+    c2 = MiqAeClass.new(:namespace_id => n2.id, :domain => n2.domain, :name => "oleg")
     expect(c2).not_to be_nil
     expect(c2.save!).to be_truthy
   end
 
   it "should return editable as false if the parent namespace is not editable" do
-    n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
+    n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
     expect(c1.editable?(@user)).to be_falsey
   end
 
   it "should return editable as true if the parent namespace is editable" do
-    n1 = FactoryBot.create(:miq_ae_domain, :tenant => @user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    d1 = FactoryBot.create(:miq_ae_domain, :tenant => @user.current_tenant)
+    n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
     expect(c1.editable?(@user)).to be_truthy
   end
 
@@ -178,10 +182,10 @@ RSpec.describe MiqAeClass do
 
   context "#copy" do
     before do
-      @d1 = FactoryBot.create(:miq_ae_namespace, :name => "domain1", :parent => nil, :priority => 1)
+      @d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1", :parent => nil, :priority => 1)
       @ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent => @d1)
-      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
-      @cls2 = FactoryBot.create(:miq_ae_class, :name => "cls2", :namespace_id => @ns1.id)
+      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id, :domain => @d1)
+      @cls2 = FactoryBot.create(:miq_ae_class, :name => "cls2", :namespace_id => @ns1.id, :domain => @d1)
 
       @d2 = FactoryBot.create(:miq_ae_domain, :name => "domain2", :priority  => 2)
       @ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent => @d2)
@@ -288,14 +292,16 @@ RSpec.describe MiqAeClass do
   end
 
   it "#domain" do
-    c1 = MiqAeClass.create(:namespace => "TEST/ABC", :name => "oleg")
+    d1 = FactoryBot.create(:miq_ae_system_domain, :name => "TEST")
+    c1 = MiqAeClass.create(:namespace => "TEST/ABC", :name => "oleg", :domain => d1)
     expect(c1.domain.name).to eql('TEST')
   end
 
   context "state_machine_class tests" do
     before do
-      n1 = FactoryBot.create(:miq_ae_system_domain, :name => 'ns1', :priority => 10)
-      @c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+      d1 = FactoryBot.create(:miq_ae_system_domain, :priority => 10)
+      n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => d1)
+      @c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
     end
 
     it "class with only state field" do
@@ -334,9 +340,11 @@ RSpec.describe MiqAeClass do
       create_state_ae_model(:name => 'FRED', :ae_class => 'CLASS1', :ae_namespace  => 'A/B/C')
       create_state_ae_model(:name => 'FREDDY', :ae_class => 'CLASS2', :ae_namespace  => 'C/D/E')
       create_ae_model(:name => 'MARIO', :ae_class => 'CLASS3', :ae_namespace  => 'C/D/E')
-      ns_fqnames = %w(FRED FRED/A FRED/A/B FRED/A/B/C FREDDY FREDDY/C FREDDY/C/D FREDDY/C/D/E)
+      domain_fqnames = %w[FRED FREDDY]
+      ns_fqnames = %w[FRED/A FRED/A/B FRED/A/B/C FREDDY/C FREDDY/C/D FREDDY/C/D/E]
       class_fqnames = %w(/FRED/A/B/C/CLASS1 /FREDDY/C/D/E/CLASS2)
-      ids = ns_fqnames.collect { |ns| "MiqAeNamespace::#{MiqAeNamespace.lookup_by_fqname(ns, false).id}" }
+      ids = domain_fqnames.collect { |ns| "MiqAeDomain::#{MiqAeNamespace.lookup_by_fqname(ns, false).id}" }
+      ids += ns_fqnames.collect { |ns| "MiqAeNamespace::#{MiqAeNamespace.lookup_by_fqname(ns, false).id}" }
       ids += class_fqnames.collect { |cls| "MiqAeClass::#{MiqAeClass.lookup_by_fqname(cls).id}" }
       expect(MiqAeClass.waypoint_ids_for_state_machines).to match_array(ids)
     end

--- a/spec/models/miq_ae_class_spec.rb
+++ b/spec/models/miq_ae_class_spec.rb
@@ -52,17 +52,17 @@ RSpec.describe MiqAeClass do
   end
 
   it "should set the updated_by field on save" do
-    c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "oleg", :domain => @ns.domain)
+    c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "oleg")
     expect(c1.updated_by).to eq('system')
   end
 
   it "should not create classes with the same name in the same namespace" do
-    c1 = MiqAeClass.new(:namespace_id => @ns.id, :name => "oleg", :domain => @ns.domain)
+    c1 = MiqAeClass.new(:namespace_id => @ns.id, :name => "oleg")
     expect(c1).not_to be_nil
     expect(c1.save!).to be_truthy
-    expect { MiqAeClass.new(:namespace_id => @ns.id, :name => "OLEG", :domain => @ns.domain).save! }.to raise_error(ActiveRecord::RecordInvalid)
+    expect { MiqAeClass.new(:namespace_id => @ns.id, :name => "OLEG").save! }.to raise_error(ActiveRecord::RecordInvalid)
     n2 = FactoryBot.create(:miq_ae_namespace, :parent => FactoryBot.create(:miq_ae_domain))
-    c2 = MiqAeClass.new(:namespace_id => n2.id, :domain => n2.domain, :name => "oleg")
+    c2 = MiqAeClass.new(:namespace_id => n2.id, :name => "oleg")
     expect(c2).not_to be_nil
     expect(c2.save!).to be_truthy
   end
@@ -70,14 +70,14 @@ RSpec.describe MiqAeClass do
   it "should return editable as false if the parent namespace is not editable" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => @user.current_tenant)
     n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     expect(c1.editable?(@user)).to be_falsey
   end
 
   it "should return editable as true if the parent namespace is editable" do
     d1 = FactoryBot.create(:miq_ae_domain, :tenant => @user.current_tenant)
     n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     expect(c1.editable?(@user)).to be_truthy
   end
 
@@ -184,8 +184,8 @@ RSpec.describe MiqAeClass do
     before do
       @d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1", :parent => nil, :priority => 1)
       @ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent => @d1)
-      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id, :domain => @d1)
-      @cls2 = FactoryBot.create(:miq_ae_class, :name => "cls2", :namespace_id => @ns1.id, :domain => @d1)
+      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
+      @cls2 = FactoryBot.create(:miq_ae_class, :name => "cls2", :namespace_id => @ns1.id)
 
       @d2 = FactoryBot.create(:miq_ae_domain, :name => "domain2", :priority  => 2)
       @ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent => @d2)
@@ -292,8 +292,7 @@ RSpec.describe MiqAeClass do
   end
 
   it "#domain" do
-    d1 = FactoryBot.create(:miq_ae_system_domain, :name => "TEST")
-    c1 = MiqAeClass.create(:namespace => "TEST/ABC", :name => "oleg", :domain => d1)
+    c1 = MiqAeClass.create(:namespace => "TEST/ABC", :name => "oleg")
     expect(c1.domain.name).to eql('TEST')
   end
 
@@ -301,7 +300,7 @@ RSpec.describe MiqAeClass do
     before do
       d1 = FactoryBot.create(:miq_ae_system_domain, :priority => 10)
       n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => d1)
-      @c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
+      @c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     end
 
     it "class with only state field" do

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MiqAeField do
   context "legacy tests" do
     before do
       @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
-      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "fields_test")
+      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "fields_test", :domain_id => @ns.domain_id)
       @user = FactoryBot.create(:user_with_group)
     end
 
@@ -167,15 +167,17 @@ RSpec.describe MiqAeField do
     end
 
     it "should return editable as false if the parent namespace/class is not editable" do
-      n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => User.current_tenant)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+      d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => User.current_tenant)
+      n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
       f1 = FactoryBot.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
       expect(f1.editable?(@user)).to be_falsey
     end
 
     it "should return editable as true if the parent namespace/class is editable" do
-      n1 = FactoryBot.create(:miq_ae_domain, :tenant => @user.current_tenant)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+      d1 = FactoryBot.create(:miq_ae_domain, :tenant => @user.current_tenant)
+      n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
       f1 = FactoryBot.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
       expect(f1.editable?(@user)).to be_truthy
     end

--- a/spec/models/miq_ae_field_spec.rb
+++ b/spec/models/miq_ae_field_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MiqAeField do
   context "legacy tests" do
     before do
       @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
-      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "fields_test", :domain_id => @ns.domain_id)
+      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "fields_test")
       @user = FactoryBot.create(:user_with_group)
     end
 
@@ -169,7 +169,7 @@ RSpec.describe MiqAeField do
     it "should return editable as false if the parent namespace/class is not editable" do
       d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => User.current_tenant)
       n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       f1 = FactoryBot.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
       expect(f1.editable?(@user)).to be_falsey
     end
@@ -177,7 +177,7 @@ RSpec.describe MiqAeField do
     it "should return editable as true if the parent namespace/class is editable" do
       d1 = FactoryBot.create(:miq_ae_domain, :tenant => @user.current_tenant)
       n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :domain => d1, :name => "foo")
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       f1 = FactoryBot.create(:miq_ae_field, :class_id => c1.id, :name => "foo_field")
       expect(f1.editable?(@user)).to be_truthy
     end

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe MiqAeInstance do
     before do
       @user = FactoryBot.create(:user_with_group)
       @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
-      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "instance_test", :domain_id => @ns.domain_id)
+      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "instance_test")
       @fname1 = "field1"
       @f1 = @c1.ae_fields.create(:name => @fname1)
     end
@@ -81,7 +81,7 @@ RSpec.describe MiqAeInstance do
       expect(i1.get_field_value(@f1)).to eq(value2)
 
       # Set/Get a value of a field from a different class
-      c2 = MiqAeClass.create(:namespace => @ns.name, :name => "instance_test2", :domain => @ns.domain)
+      c2 = MiqAeClass.create(:namespace => @ns.name, :name => "instance_test2")
       fname2 = "field2"
       f2 = c2.ae_fields.create(:name => fname2)
 
@@ -151,7 +151,7 @@ RSpec.describe MiqAeInstance do
     it "should return editable as false if the parent namespace/class is not editable" do
       d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => User.current_tenant)
       n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
       expect(i1.editable?(@user)).to be_falsey
     end
@@ -160,7 +160,7 @@ RSpec.describe MiqAeInstance do
       User.current_user = @user
       d1 = FactoryBot.create(:miq_ae_domain, :tenant => User.current_tenant)
       n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
       i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
       expect(i1.editable?(@user)).to be_truthy
     end
@@ -207,7 +207,7 @@ RSpec.describe MiqAeInstance do
     before do
       @d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1", :priority => 1)
       @ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent => @d1)
-      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id, :domain => @d1)
+      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
       @i1 = FactoryBot.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance1")
       @i2 = FactoryBot.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance2")
 
@@ -253,8 +253,8 @@ RSpec.describe MiqAeInstance do
 
   it "#domain" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1')
-    n1 = FactoryBot.create(:miq_ae_namespace, :name => 'n1', :domain => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
+    n1 = FactoryBot.create(:miq_ae_namespace, :name => 'n1', :parent => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
     expect(i1.domain.name).to eql('dom1')
   end
@@ -265,8 +265,8 @@ RSpec.describe MiqAeInstance do
     let(:d2) { FactoryBot.create(:miq_ae_domain, :name => 'dom2', :priority => 2) }
     let(:n1) { FactoryBot.create(:miq_ae_namespace, :parent => d1, :name => "namespace") }
     let(:n2) { FactoryBot.create(:miq_ae_namespace, :parent => d2, :name => "namespace") }
-    let(:c1) { FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "class", :domain => d1) }
-    let(:c2) { FactoryBot.create(:miq_ae_class, :namespace_id => n2.id, :name => "class", :domain => d2) }
+    let(:c1) { FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "class") }
+    let(:c2) { FactoryBot.create(:miq_ae_class, :namespace_id => n2.id, :name => "class") }
     let!(:i1) { FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "instance") }
     let!(:i2) { FactoryBot.create(:miq_ae_instance, :class_id => c2.id, :name => "instance") }
 

--- a/spec/models/miq_ae_instance_spec.rb
+++ b/spec/models/miq_ae_instance_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe MiqAeInstance do
     before do
       @user = FactoryBot.create(:user_with_group)
       @ns = FactoryBot.create(:miq_ae_namespace, :name => "TEST", :parent => FactoryBot.create(:miq_ae_domain))
-      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "instance_test")
+      @c1 = MiqAeClass.create(:namespace_id => @ns.id, :name => "instance_test", :domain_id => @ns.domain_id)
       @fname1 = "field1"
       @f1 = @c1.ae_fields.create(:name => @fname1)
     end
@@ -81,7 +81,7 @@ RSpec.describe MiqAeInstance do
       expect(i1.get_field_value(@f1)).to eq(value2)
 
       # Set/Get a value of a field from a different class
-      c2 = MiqAeClass.create(:namespace => "TEST", :name => "instance_test2")
+      c2 = MiqAeClass.create(:namespace => @ns.name, :name => "instance_test2", :domain => @ns.domain)
       fname2 = "field2"
       f2 = c2.ae_fields.create(:name => fname2)
 
@@ -151,7 +151,7 @@ RSpec.describe MiqAeInstance do
     it "should return editable as false if the parent namespace/class is not editable" do
       d1 = FactoryBot.create(:miq_ae_system_domain, :tenant => User.current_tenant)
       n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
       i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
       expect(i1.editable?(@user)).to be_falsey
     end
@@ -160,7 +160,7 @@ RSpec.describe MiqAeInstance do
       User.current_user = @user
       d1 = FactoryBot.create(:miq_ae_domain, :tenant => User.current_tenant)
       n1 = FactoryBot.create(:miq_ae_namespace, :parent => d1)
-      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+      c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
       i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
       expect(i1.editable?(@user)).to be_truthy
     end
@@ -205,9 +205,9 @@ RSpec.describe MiqAeInstance do
 
   context "#copy" do
     before do
-      @d1 = FactoryBot.create(:miq_ae_namespace, :name => "domain1", :priority => 1)
+      @d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1", :priority => 1)
       @ns1 = FactoryBot.create(:miq_ae_namespace, :name => "ns1", :parent => @d1)
-      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id)
+      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => @ns1.id, :domain => @d1)
       @i1 = FactoryBot.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance1")
       @i2 = FactoryBot.create(:miq_ae_instance, :class_id => @cls1.id, :name => "foo_instance2")
 
@@ -252,8 +252,9 @@ RSpec.describe MiqAeInstance do
   end
 
   it "#domain" do
-    n1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1')
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1')
+    n1 = FactoryBot.create(:miq_ae_namespace, :name => 'n1', :domain => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
     i1 = FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "foo_instance")
     expect(i1.domain.name).to eql('dom1')
   end
@@ -264,8 +265,8 @@ RSpec.describe MiqAeInstance do
     let(:d2) { FactoryBot.create(:miq_ae_domain, :name => 'dom2', :priority => 2) }
     let(:n1) { FactoryBot.create(:miq_ae_namespace, :parent => d1, :name => "namespace") }
     let(:n2) { FactoryBot.create(:miq_ae_namespace, :parent => d2, :name => "namespace") }
-    let(:c1) { FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "class") }
-    let(:c2) { FactoryBot.create(:miq_ae_class, :namespace_id => n2.id, :name => "class") }
+    let(:c1) { FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "class", :domain => d1) }
+    let(:c2) { FactoryBot.create(:miq_ae_class, :namespace_id => n2.id, :name => "class", :domain => d2) }
     let!(:i1) { FactoryBot.create(:miq_ae_instance, :class_id => c1.id, :name => "instance") }
     let!(:i2) { FactoryBot.create(:miq_ae_instance, :class_id => c2.id, :name => "instance") }
 

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MiqAeMethod do
   let(:user) { FactoryBot.create(:user_with_group) }
   it "should return editable as false if the parent namespace/class is not editable" do
     n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => n1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     f1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",
@@ -14,7 +14,7 @@ RSpec.describe MiqAeMethod do
 
   it "should return editable as true if the parent namespace/class is editable" do
     n1 = FactoryBot.create(:miq_ae_domain, :tenant => user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => n1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     f1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",
@@ -26,7 +26,7 @@ RSpec.describe MiqAeMethod do
 
   it "should lookup method" do
     n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => n1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     f1 = FactoryBot.create(:miq_ae_method,
                            :class_id => c1.id,
                            :name     => "foo_method",
@@ -45,7 +45,7 @@ RSpec.describe MiqAeMethod do
     let(:m2) { FactoryBot.create(:miq_ae_method, :class_id => @cls1.id, :name => "foo_method2", :scope => "instance", :language => "ruby", :location => "inline") }
     before do
       @d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1", :parent => nil, :priority => 1)
-      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id, :domain => @d1)
+      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
       @ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent => d2)
     end
 
@@ -118,7 +118,7 @@ RSpec.describe MiqAeMethod do
   it "#domain" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1', :priority => 10)
     n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     m1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",
@@ -131,7 +131,7 @@ RSpec.describe MiqAeMethod do
   it "#to_export_yaml" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1', :priority => 10)
     n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
     m1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",

--- a/spec/models/miq_ae_method_spec.rb
+++ b/spec/models/miq_ae_method_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe MiqAeMethod do
   let(:user) { FactoryBot.create(:user_with_group) }
   it "should return editable as false if the parent namespace/class is not editable" do
     n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => n1)
     f1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",
@@ -14,7 +14,7 @@ RSpec.describe MiqAeMethod do
 
   it "should return editable as true if the parent namespace/class is editable" do
     n1 = FactoryBot.create(:miq_ae_domain, :tenant => user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => n1)
     f1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",
@@ -26,7 +26,7 @@ RSpec.describe MiqAeMethod do
 
   it "should lookup method" do
     n1 = FactoryBot.create(:miq_ae_system_domain, :tenant => user.current_tenant)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => n1)
     f1 = FactoryBot.create(:miq_ae_method,
                            :class_id => c1.id,
                            :name     => "foo_method",
@@ -44,8 +44,8 @@ RSpec.describe MiqAeMethod do
     let(:m1) { FactoryBot.create(:miq_ae_method, :class_id => @cls1.id, :name => "foo_method1", :scope => "instance", :language => "ruby", :location => "inline") }
     let(:m2) { FactoryBot.create(:miq_ae_method, :class_id => @cls1.id, :name => "foo_method2", :scope => "instance", :language => "ruby", :location => "inline") }
     before do
-      @d1 = FactoryBot.create(:miq_ae_namespace, :name => "domain1", :parent => nil, :priority => 1)
-      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id)
+      @d1 = FactoryBot.create(:miq_ae_domain, :name => "domain1", :parent => nil, :priority => 1)
+      @cls1 = FactoryBot.create(:miq_ae_class, :name => "cls1", :namespace_id => ns1.id, :domain => @d1)
       @ns2 = FactoryBot.create(:miq_ae_namespace, :name => "ns2", :parent => d2)
     end
 
@@ -118,7 +118,7 @@ RSpec.describe MiqAeMethod do
   it "#domain" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1', :priority => 10)
     n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
     m1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",
@@ -131,7 +131,7 @@ RSpec.describe MiqAeMethod do
   it "#to_export_yaml" do
     d1 = FactoryBot.create(:miq_ae_system_domain, :name => 'dom1', :priority => 10)
     n1 = FactoryBot.create(:miq_ae_namespace, :name => 'ns1', :parent => d1)
-    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo")
+    c1 = FactoryBot.create(:miq_ae_class, :namespace_id => n1.id, :name => "foo", :domain => d1)
     m1 = FactoryBot.create(:miq_ae_method,
                             :class_id => c1.id,
                             :name     => "foo_method",


### PR DESCRIPTION
New columns `domain_id`,  and `relative_path` have been added to `MiqAeNamespace/MiqAeClass/MiqAeInstance/MiqAeMethod`.
So these objects can be looked up based on these three columns instead of loop thru the namespace by fqname, then find the class to get the instance/method.

Depends on https://github.com/ManageIQ/manageiq-schema/pull/465.
Blocks https://github.com/ManageIQ/manageiq-automation_engine/pull/439.
Blocks https://github.com/ManageIQ/manageiq-ui-classic/pull/7006.
Blocks https://github.com/ManageIQ/manageiq-api/pull/820.

cross repo tests: ManageIQ/manageiq-cross_repo-tests#112

https://github.com/ManageIQ/manageiq-automation_engine/issues/410

cc @kbrock @mkanoor @tinaafitz 