### PR TITLE
Skip empty Volumes in VM provisioning

### DIFF
--- a/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/cloud_manager/provision/state_machine.rb
@@ -10,7 +10,7 @@ module ManageIQ::Providers::CloudManager::Provision::StateMachine
   end
 
   def prepare_volumes
-    if options[:volumes]
+    if options[:volumes].present?
       phase_context[:requested_volumes] = create_requested_volumes(options[:volumes])
       signal :poll_volumes_complete
     else


### PR DESCRIPTION
VM provisioning can contain Volumes which should be provisiing along with the VM.
Extending condition by any? check on volumes to not call provider specific methods if volumes array is defined, but empty (case of OpenStack when no volumes were entered into provisioning form).

Moved to main repo from https://github.com/ManageIQ/manageiq-providers-openstack/pull/575

Links
----------------

* original openstack provider PR https://github.com/ManageIQ/manageiq-providers-openstack/pull/575

Steps for Testing
-------------------------------

The only difference is that Openstack provider does not connect to the Cinder (Volume) service when no volumes were specified in the provisioning form.