### PR TITLE
[WIP] [IVANCHUK] Add a configuration directory containing playbooks to quickly configure a CFME Appliance for Migration Analytics use

### DIFF
--- a/tools/configure_for_migration_analytics/configure
+++ b/tools/configure_for_migration_analytics/configure
@@ -1,0 +1,4 @@
+#!/bin/bash
+read -e -p "Path for VMware VDDK file: " vddk_path
+echo "vddk_path:     \"$vddk_path\"" >> vars/miq_vars.yml
+ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i hosts main.yml

--- a/tools/configure_for_migration_analytics/hosts
+++ b/tools/configure_for_migration_analytics/hosts
@@ -1,0 +1,1 @@
+localhost ansible_connection=local

--- a/tools/configure_for_migration_analytics/main.yml
+++ b/tools/configure_for_migration_analytics/main.yml
@@ -2,20 +2,20 @@
 - name: Setup SmartState Analysis
   hosts: localhost
   vars_files:
-    - vars/miq_vars.yml
+  - vars/miq_vars.yml
 
   tasks:
-    - import_tasks: tasks/configure-server-settings.yml
+  - import_tasks: tasks/configure-server-settings.yml
 
-    - import_tasks: tasks/set-control-policy.yml
+  - import_tasks: tasks/set-control-policy.yml
 
-    - import_tasks: tasks/copy-sample-profile-to-default.yml
+  - import_tasks: tasks/copy-sample-profile-to-default.yml
 
-    - name: CFME | SmartState Analysis | Check that the VDDK file {{ vddk_path }} exists
-      stat:
-        path: "{{ vddk_path }}"
-      register: stat_result
+  - name: CFME | SmartState Analysis | Check that the VDDK file {{ vddk_path }} exists
+    stat:
+      path: "{{ vddk_path }}"
+    register: stat_result
 
-    - name: CFME | SmartState Analysis | Install VDDK
-      include_tasks: tasks/install-vddk.yml
-      when: stat_result.stat.exists
+  - name: CFME | SmartState Analysis | Install VDDK
+    include_tasks: tasks/install-vddk.yml
+    when: stat_result.stat.exists

--- a/tools/configure_for_migration_analytics/main.yml
+++ b/tools/configure_for_migration_analytics/main.yml
@@ -1,21 +1,21 @@
 ---
-- name:  Setup SmartState Analysis
+- name: Setup SmartState Analysis
   hosts: localhost
   vars_files:
     - vars/miq_vars.yml
-    
+
   tasks:
     - import_tasks: tasks/configure-server-settings.yml
-    
+
     - import_tasks: tasks/set-control-policy.yml
-    
+
     - import_tasks: tasks/copy-sample-profile-to-default.yml
-    
+
     - name: CFME | SmartState Analysis | Check that the VDDK file {{ vddk_path }} exists
       stat:
         path: "{{ vddk_path }}"
       register: stat_result
-    
+
     - name: CFME | SmartState Analysis | Install VDDK
       include_tasks: tasks/install-vddk.yml
       when: stat_result.stat.exists

--- a/tools/configure_for_migration_analytics/main.yml
+++ b/tools/configure_for_migration_analytics/main.yml
@@ -1,0 +1,21 @@
+---
+- name:  Setup SmartState Analysis
+  hosts: localhost
+  vars_files:
+    - vars/miq_vars.yml
+    
+  tasks:
+    - import_tasks: tasks/configure-server-settings.yml
+    
+    - import_tasks: tasks/set-control-policy.yml
+    
+    - import_tasks: tasks/copy-sample-profile-to-default.yml
+    
+    - name: CFME | SmartState Analysis | Check that the VDDK file {{ vddk_path }} exists
+      stat:
+        path: "{{ vddk_path }}"
+      register: stat_result
+    
+    - name: CFME | SmartState Analysis | Install VDDK
+      include_tasks: tasks/install-vddk.yml
+      when: stat_result.stat.exists

--- a/tools/configure_for_migration_analytics/tasks/configure-server-settings.yml
+++ b/tools/configure_for_migration_analytics/tasks/configure-server-settings.yml
@@ -5,17 +5,17 @@
     source {{ miq_profile }} &&              \
     {{ miq_home_dir }}/bin/rails r "puts MiqServer.my_server.id"
   register: shell_output
-  
+
 - set_fact:
     server_id: "{{ shell_output.stdout }}"
-    
+
 - name: CFME | SmartState Analysis | Enable the server roles
   shell: |
     {{ miq_tools_dir }}/configure_server_settings.rb \
     -s {{ server_id }}                               \
     -p server/role                                   \
     -v automate,database_operations,ems_inventory,ems_operations,event,notifier,reporting,scheduler,smartproxy,smartstate,user_interface,web_services
-    
+
 - name: CFME | SmartState Analysis | Set the number of SmartProxy workers to 5
   shell: |
     {{ miq_tools_dir }}/configure_server_settings.rb                  \
@@ -23,7 +23,7 @@
     -p workers/worker_base/queue_worker_base/smart_proxy_worker/count \
     -v 5                                                              \
     -t integer
-    
+
 - name: CFME | SmartState Analysis | Set scan_via_host to false
   shell: |
     {{ miq_tools_dir }}/configure_server_settings.rb \
@@ -31,7 +31,7 @@
     -p coresident_miqproxy/scan_via_host             \
     -v false                                         \
     -t boolean
-    
+
 - name: CFME | SmartState Analysis | Set concurrent_per_ems to 5
   shell: |
     {{ miq_tools_dir }}/configure_server_settings.rb \

--- a/tools/configure_for_migration_analytics/tasks/configure-server-settings.yml
+++ b/tools/configure_for_migration_analytics/tasks/configure-server-settings.yml
@@ -1,0 +1,41 @@
+---
+- name: CFME | SmartState Analysis | Get the current server ID
+  shell: |
+    set -o pipefail                          \
+    source {{ miq_profile }} &&              \
+    {{ miq_home_dir }}/bin/rails r "puts MiqServer.my_server.id"
+  register: shell_output
+  
+- set_fact:
+    server_id: "{{ shell_output.stdout }}"
+    
+- name: CFME | SmartState Analysis | Enable the server roles
+  shell: |
+    {{ miq_tools_dir }}/configure_server_settings.rb \
+    -s {{ server_id }}                               \
+    -p server/role                                   \
+    -v automate,database_operations,ems_inventory,ems_operations,event,notifier,reporting,scheduler,smartproxy,smartstate,user_interface,web_services
+    
+- name: CFME | SmartState Analysis | Set the number of SmartProxy workers to 5
+  shell: |
+    {{ miq_tools_dir }}/configure_server_settings.rb                  \
+    -s {{ server_id }}                                                \
+    -p workers/worker_base/queue_worker_base/smart_proxy_worker/count \
+    -v 5                                                              \
+    -t integer
+    
+- name: CFME | SmartState Analysis | Set scan_via_host to false
+  shell: |
+    {{ miq_tools_dir }}/configure_server_settings.rb \
+    -s {{ server_id }}                               \
+    -p coresident_miqproxy/scan_via_host             \
+    -v false                                         \
+    -t boolean
+    
+- name: CFME | SmartState Analysis | Set concurrent_per_ems to 5
+  shell: |
+    {{ miq_tools_dir }}/configure_server_settings.rb \
+    -s {{ server_id }}                               \
+    -p coresident_miqproxy/concurrent_per_ems        \
+    -v 5                                             \
+    -t integer

--- a/tools/configure_for_migration_analytics/tasks/copy-sample-profile-to-default.yml
+++ b/tools/configure_for_migration_analytics/tasks/copy-sample-profile-to-default.yml
@@ -7,10 +7,10 @@
       default_si = ScanItemSet.find_by(:name => 'default')
       puts default_si.id unless default_si.nil?"
   register: shell_output
-      
+
 - set_fact:
     default_profile_id: "{{ shell_output.stdout }}"
-  
+
 - name: CFME | Set the default SmartState profile | Copy the sample profile to default
   shell: |
     set -o pipefail                   \

--- a/tools/configure_for_migration_analytics/tasks/copy-sample-profile-to-default.yml
+++ b/tools/configure_for_migration_analytics/tasks/copy-sample-profile-to-default.yml
@@ -1,0 +1,35 @@
+---
+- name: CFME | Set the default SmartState profile | Check if the default profile exists
+  shell: |
+    set -o pipefail                   \
+    source {{ miq_profile }} &&       \
+    {{ miq_home_dir }}/bin/rails r "  \
+      default_si = ScanItemSet.find_by(:name => 'default')
+      puts default_si.id unless default_si.nil?"
+  register: shell_output
+      
+- set_fact:
+    default_profile_id: "{{ shell_output.stdout }}"
+  
+- name: CFME | Set the default SmartState profile | Copy the sample profile to default
+  shell: |
+    set -o pipefail                   \
+    source {{ miq_profile }} &&       \
+    {{ miq_home_dir }}/bin/rails r "  \
+      sample_sis = ScanItemSet.find_by(:name => 'sample')
+      new_sis = ScanItemSet.new
+      new_sis.name = \"default\"
+      new_sis.description = \"VM Default\"
+      new_sis.mode = sample_sis.mode
+      new_sis.read_only = nil
+      new_sis.save!
+      scanitems = sample_sis.members     # Get the member sets
+      scanitems.each do |scanitem|
+        new_si = scanitem.dup
+        new_si.name = \"default_\" + scanitem.name
+        new_si.description = \"default_\" + scanitem.description
+        new_si.save!
+        new_sis.add_member(new_si)
+      end
+    "
+  when: default_profile_id == ""

--- a/tools/configure_for_migration_analytics/tasks/install-vddk.yml
+++ b/tools/configure_for_migration_analytics/tasks/install-vddk.yml
@@ -1,0 +1,39 @@
+---
+- name: CFME | Install VDDK | Create Temp Directory
+  tempfile:
+    state: directory
+    prefix: vmware
+  register: tmp_dir
+
+- name: CFME | Install VDDK | Extract VDDK
+  unarchive:
+    src: "{{ vddk_path }}"
+    dest: "{{ tmp_dir['path'] }}"
+
+- name: CFME | Install VDDK | Sync Folder to /usr/lib
+  copy:
+    src:  "{{ tmp_dir['path'] }}/vmware-vix-disklib-distrib/"
+    dest: /usr/lib/vmware-vix-disklib
+
+- name: CFME | Install VDDK | Link libvixDiskLib.so
+  file:
+    src: /usr/lib/vmware-vix-disklib/lib64/libvixDiskLib.so
+    dest: /usr/lib/libvixDiskLib.so
+    state: link
+  register: link_result_one
+
+- name: CFME | Install VDDK | Link libvixDiskLib.so.6
+  file:
+    src: /usr/lib/vmware-vix-disklib/lib64/libvixDiskLib.so.6
+    dest: /usr/lib/libvixDiskLib.so.6
+    state: link
+  register: link_result_two
+
+- name: CFME | Install VDDK | Clean Up /tmp
+  file:
+    path: "{{ tmp_dir['path'] }}"
+    state: absent
+
+- name: CFME | Install VDDK | Run ldconfig
+  command: 'ldconfig'
+  when: link_result_one is changed or link_result_two is changed

--- a/tools/configure_for_migration_analytics/tasks/install-vddk.yml
+++ b/tools/configure_for_migration_analytics/tasks/install-vddk.yml
@@ -12,7 +12,7 @@
 
 - name: CFME | Install VDDK | Sync Folder to /usr/lib
   copy:
-    src:  "{{ tmp_dir['path'] }}/vmware-vix-disklib-distrib/"
+    src: "{{ tmp_dir['path'] }}/vmware-vix-disklib-distrib/"
     dest: /usr/lib/vmware-vix-disklib
 
 - name: CFME | Install VDDK | Link libvixDiskLib.so

--- a/tools/configure_for_migration_analytics/tasks/set-control-policy.yml
+++ b/tools/configure_for_migration_analytics/tasks/set-control-policy.yml
@@ -1,0 +1,62 @@
+---
+- set_fact:
+    vmware_provider_ids: []
+    provider_type: 'ManageIQ::Providers::Vmware::InfraManager'
+ 
+- name: Generate an API token  
+  shell: |
+    set -o pipefail                    \
+    source {{ miq_profile }} &&        \
+    {{ miq_home_dir }}/bin/rails r "   \
+      puts Api::UserTokenService.new.generate_token('admin', 'api')"
+  register: shell_output
+  
+- set_fact:
+    api_token: "{{ shell_output.stdout }}"
+
+- name: CFME | Add Control Profile | Get the profile ID
+  uri:
+    url: https://localhost/api/policy_profiles?filter[]=name=VM+SmartState+Analysis+profile
+    method: GET
+    headers:
+      X-Auth-Token: "{{ api_token }}"
+    validate_certs: no
+    body_format: json
+  register: rest_return
+  
+- set_fact:
+    control_profile_href: "{{ rest_return.json.resources[0].href }}"
+       
+- name: CFME | Add Control Profile | Get the VMware provider IDs
+  uri:
+    url: https://localhost/api/providers?filter[]=type={{ provider_type }}&expand=resources&attributes=name,id
+    method: GET
+    headers:
+      X-Auth-Token: "{{ api_token }}"
+    validate_certs: no
+    body_format: json
+  register: rest_return
+    
+- set_fact:
+    vmware_provider_ids: "{{ vmware_provider_ids + [ item ] }}"
+  with_items: "{{ rest_return|json_query('json.resources[*].id') }}"
+    
+- debug:
+    var: vmware_provider_ids  
+
+- name: CFME | Add Control Profile | Assign the profile to the VMware provider IDs
+  uri:
+    url: https://localhost/api/providers/{{ item }}/policy_profiles
+    method: POST
+    headers:
+      X-Auth-Token: "{{ api_token }}"
+    validate_certs: no
+    body_format: json
+    body:
+      action: assign
+      resource:
+        href: "{{ control_profile_href }}"
+  with_items: "{{ vmware_provider_ids }}"
+  register: rest_return
+  
+

--- a/tools/configure_for_migration_analytics/tasks/set-control-policy.yml
+++ b/tools/configure_for_migration_analytics/tasks/set-control-policy.yml
@@ -2,15 +2,15 @@
 - set_fact:
     vmware_provider_ids: []
     provider_type: 'ManageIQ::Providers::Vmware::InfraManager'
- 
-- name: Generate an API token  
+
+- name: Generate an API token
   shell: |
     set -o pipefail                    \
     source {{ miq_profile }} &&        \
     {{ miq_home_dir }}/bin/rails r "   \
       puts Api::UserTokenService.new.generate_token('admin', 'api')"
   register: shell_output
-  
+
 - set_fact:
     api_token: "{{ shell_output.stdout }}"
 
@@ -23,10 +23,10 @@
     validate_certs: no
     body_format: json
   register: rest_return
-  
+
 - set_fact:
     control_profile_href: "{{ rest_return.json.resources[0].href }}"
-       
+
 - name: CFME | Add Control Profile | Get the VMware provider IDs
   uri:
     url: https://localhost/api/providers?filter[]=type={{ provider_type }}&expand=resources&attributes=name,id
@@ -36,13 +36,13 @@
     validate_certs: no
     body_format: json
   register: rest_return
-    
+
 - set_fact:
     vmware_provider_ids: "{{ vmware_provider_ids + [ item ] }}"
   with_items: "{{ rest_return|json_query('json.resources[*].id') }}"
-    
+
 - debug:
-    var: vmware_provider_ids  
+    var: vmware_provider_ids
 
 - name: CFME | Add Control Profile | Assign the profile to the VMware provider IDs
   uri:
@@ -58,5 +58,3 @@
         href: "{{ control_profile_href }}"
   with_items: "{{ vmware_provider_ids }}"
   register: rest_return
-  
-

--- a/tools/configure_for_migration_analytics/vars/miq_vars.yml
+++ b/tools/configure_for_migration_analytics/vars/miq_vars.yml
@@ -1,4 +1,4 @@
 ---
-miq_home_dir:  "/var/www/miq/vmdb"
+miq_home_dir: "/var/www/miq/vmdb"
 miq_tools_dir: "{{ miq_home_dir }}/tools"
-miq_profile:   "/etc/profile.d/evm.sh"
+miq_profile: "/etc/profile.d/evm.sh"

--- a/tools/configure_for_migration_analytics/vars/miq_vars.yml
+++ b/tools/configure_for_migration_analytics/vars/miq_vars.yml
@@ -1,0 +1,4 @@
+---
+miq_home_dir:  "/var/www/miq/vmdb"
+miq_tools_dir: "{{ miq_home_dir }}/tools"
+miq_profile:   "/etc/profile.d/evm.sh"


### PR DESCRIPTION
This PR adds a configure_for_migration_analytics directory under $(VMDBs)/tools, containing some playbooks to quickly configure a single CFME Appliance for migration analytics use. Specifically it sets the number of SmartProxy workers, copies the VDDK files, adds the control policy to the provider, renames the 'sample' SmartState profile to 'default', and sets some advanced server settings.

The PR is being made against the Ivanchuk branch as it should be included in CFME 5.11