### PR TITLE
Fix a bug when running Rbac on VimPerformanceDaily

### DIFF
--- a/lib/rbac/filterer.rb
+++ b/lib/rbac/filterer.rb
@@ -414,7 +414,7 @@ module Rbac
     # the associated application model.  See #rbac_class method
     #
     def apply_rbac_through_association?(klass)
-      klass != VimPerformanceDaily && (klass < MetricRollup || klass < Metric)
+      klass != VimPerformanceDaily && klass != VimPerformanceTag && (klass < MetricRollup || klass < Metric)
     end
 
     def rbac_base_class(klass)

--- a/spec/lib/rbac/filterer_spec.rb
+++ b/spec/lib/rbac/filterer_spec.rb
@@ -2622,6 +2622,7 @@ RSpec.describe Rbac::Filterer do
   it ".apply_rbac_through_association?" do
     expect(described_class.new.send(:apply_rbac_through_association?, HostMetric)).to be_truthy
     expect(described_class.new.send(:apply_rbac_through_association?, Vm)).not_to be
+    expect(described_class.new.send(:apply_rbac_through_association?, VimPerformanceTag)).not_to be
   end
 
   describe "find_targets_with_direct_rbac" do


### PR DESCRIPTION
`Rbac.filtered(VimPerformanceDaily)` rendered the following:

```
     Failure/Error: return klass.name[0..-12].constantize.base_class
     
     NameError:
       uninitialized constant VimPer
```

The problem was that it was saying that `VimPerformanceTag`
runs the security off of an associated class.

`VmPerformance` and `HostPerformance` have associated classes: `Vm` and `Host` respectively.

The code actually derives the associated code from the class name by
removing `"performance"` (11 letters) from the end.

But `VimPerformanceTag` is not associated with a model, and the name
does not end in `Performance`. Unsurprisingly stripping off the last
11 letters result in an error.