### PR TITLE
Add an ExtManagementSystem#refresh instance method

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -540,6 +540,9 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
+  # Queue an EMS refresh using +opts+. Credentials must exist, and the
+  # authentication status must be ok, otherwise an error is raised.
+  #
   def refresh_ems(opts = {})
     if missing_credentials?
       raise _("no Provider credentials defined")
@@ -548,6 +551,17 @@ class ExtManagementSystem < ApplicationRecord
       raise _("Provider failed last authentication check")
     end
     EmsRefresh.queue_refresh(self, nil, opts)
+  end
+
+  alias queue_refresh refresh_ems
+
+  # Execute an EMS refresh immediately. Credentials must exist, and the
+  # authentication status must be ok, otherwise an error is raised.
+  #
+  def refresh
+    raise _("no Provider credentials defined") if missing_credentials?
+    raise _("Provider failed last authentication check") unless authentication_status_ok?
+    EmsRefresh.refresh(self)
   end
 
   def self.ems_infra_discovery_types

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -561,6 +561,7 @@ class ExtManagementSystem < ApplicationRecord
   def refresh
     raise _("no Provider credentials defined") if missing_credentials?
     raise _("Provider failed last authentication check") unless authentication_status_ok?
+
     EmsRefresh.refresh(self)
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -338,10 +338,6 @@ RSpec.describe ExtManagementSystem do
 
       expect(EmsRefresh).to have_received(:refresh)
     end
-
-    it "defines a queue_refresh alias for refresh_ems" do
-      expect(ems.method(:refresh_ems)).to eql(ems.method(:queue_refresh))
-    end
   end
 
   context "with virtual totals" do

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -312,37 +312,35 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
-  context "refresh" do
-    before do
-      @ems = FactoryBot.create(:ext_management_system)
-    end
+  describe "refresh" do
+    let(:ems) { FactoryBot.create(:ext_management_system) }
 
     it "raises an error if the authentication check fails" do
-      allow(@ems).to receive(:missing_credentials?).and_return(false)
-      allow(@ems).to receive(:authentication_status_ok?).and_return(false)
+      allow(ems).to receive(:missing_credentials?).and_return(false)
+      allow(ems).to receive(:authentication_status_ok?).and_return(false)
 
-      expect { @ems.refresh }.to raise_error(RuntimeError, "Provider failed last authentication check")
+      expect { ems.refresh }.to raise_error(RuntimeError, "Provider failed last authentication check")
     end
 
     it "raises an error if no provider credentials are defined" do
-      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
-      allow(@ems).to receive(:missing_credentials?).and_return(true)
+      allow(ems).to receive(:authentication_status_ok?).and_return(true)
+      allow(ems).to receive(:missing_credentials?).and_return(true)
 
-      expect { @ems.refresh }.to raise_error(RuntimeError, "no Provider credentials defined")
+      expect { ems.refresh }.to raise_error(RuntimeError, "no Provider credentials defined")
     end
 
     it "calls the EmsRefresh.refresh method internally" do
-      allow(@ems).to receive(:missing_credentials?).and_return(false)
-      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+      allow(ems).to receive(:missing_credentials?).and_return(false)
+      allow(ems).to receive(:authentication_status_ok?).and_return(true)
       allow(EmsRefresh).to receive(:refresh)
 
-      @ems.refresh
+      ems.refresh
 
       expect(EmsRefresh).to have_received(:refresh)
     end
 
     it "defines a queue_refresh alias for refresh_ems" do
-      expect(@ems.method(:refresh_ems)).to eql(@ems.method(:queue_refresh))
+      expect(ems.method(:refresh_ems)).to eql(ems.method(:queue_refresh))
     end
   end
 

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -312,6 +312,30 @@ RSpec.describe ExtManagementSystem do
     end
   end
 
+  context "refresh" do
+    before do
+      @ems = FactoryBot.create(:ext_management_system)
+    end
+
+    it "raises an error if the authentication check fails" do
+      allow(@ems).to receive(:missing_credentials?).and_return(false)
+      allow(@ems).to receive(:authentication_check_ok?).and_return(false)
+
+      expect { @ems.refresh }.to raise_error(RuntimeError, "Provider failed last authentication check")
+    end
+
+    it "raises an error if no provider credentials are defined" do
+      allow(@ems).to receive(:authentication_check_ok?).and_return(true)
+      allow(@ems).to receive(:missing_credentials?).and_return(true)
+
+      expect { @ems.refresh }.to raise_error(RuntimeError, "no Provider credentials defined")
+    end
+
+    it "defines a queue_refresh alias for refresh_ems" do
+      expect(@ems.method(:refresh_ems)).to eql(@ems.method(:queue_refresh))
+    end
+  end
+
   context "with virtual totals" do
     before do
       @ems = FactoryBot.create(:ems_vmware)

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -319,16 +319,26 @@ RSpec.describe ExtManagementSystem do
 
     it "raises an error if the authentication check fails" do
       allow(@ems).to receive(:missing_credentials?).and_return(false)
-      allow(@ems).to receive(:authentication_check_ok?).and_return(false)
+      allow(@ems).to receive(:authentication_status_ok?).and_return(false)
 
       expect { @ems.refresh }.to raise_error(RuntimeError, "Provider failed last authentication check")
     end
 
     it "raises an error if no provider credentials are defined" do
-      allow(@ems).to receive(:authentication_check_ok?).and_return(true)
+      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
       allow(@ems).to receive(:missing_credentials?).and_return(true)
 
       expect { @ems.refresh }.to raise_error(RuntimeError, "no Provider credentials defined")
+    end
+
+    it "calls the EmsRefresh.refresh method internally" do
+      allow(@ems).to receive(:missing_credentials?).and_return(false)
+      allow(@ems).to receive(:authentication_status_ok?).and_return(true)
+      allow(EmsRefresh).to receive(:refresh)
+
+      @ems.refresh
+
+      expect(EmsRefresh).to have_received(:refresh)
     end
 
     it "defines a queue_refresh alias for refresh_ems" do


### PR DESCRIPTION
This PR adds the `ExtManagementSystem#refresh` instance method. Unlike `refresh_ems`, this would not be queued.

I've also added a `queue_refresh` alias for the `refresh_ems` method to help avoid confusion because IMHO that method name does not make it obvious that the operation  is queued.

I also added some comments and specs.