### PR TITLE
Fix a missing permission stub in a spec

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -92,9 +92,9 @@ RSpec.describe ExtManagementSystem do
     end
 
     it "with removed permissions" do
-      stub_vmdb_permission_store_with_types(["ems-type:vmwarews"]) do
-        expect(described_class.supported_types).not_to include("vmwarews")
-      end
+      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).and_return(true)
+      allow(Vmdb::PermissionStores.instance).to receive(:supported_ems_type?).with("vmwarews").and_return(false)
+      expect(described_class.supported_types).not_to include("vmwarews")
     end
   end
 


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/20053 removed the `stub_vmdb_permission_store_with_types` method but a new spec that used that method was added by https://github.com/ManageIQ/manageiq/pull/20039

Failure: https://travis-ci.com/github/ManageIQ/manageiq/jobs/318274533#L667-L675
```
Failures:
  1) ExtManagementSystem.supported_types with removed permissions
     Failure/Error:
       stub_vmdb_permission_store_with_types(["ems-type:vmwarews"]) do
         expect(described_class.supported_types).not_to include("vmwarews")
       end
     NoMethodError:
       undefined method `stub_vmdb_permission_store_with_types' for #<RSpec::ExampleGroups::ExtManagementSystem::SupportedTypes:0x00000000300cddb8>
     # ./spec/models/ext_management_system_spec.rb:95:in `block (3 levels) in <top (required)>'
```