### PR TITLE
Eager load collection constants to avoid constant loading problems.

### DIFF
--- a/app/models/miq_web_service_worker.rb
+++ b/app/models/miq_web_service_worker.rb
@@ -26,4 +26,9 @@ class MiqWebServiceWorker < MiqWorker
   def self.kill_priority
     MiqWorkerType::KILL_PRIORITY_WEB_SERVICE_WORKERS
   end
+
+  def self.preload_for_worker_role
+    super
+    Api::ApiConfig.collections.each { |_k, v| v.klass.try(:constantize).try(:descendants) }
+  end
 end

--- a/spec/models/miq_web_server_worker_spec.rb
+++ b/spec/models/miq_web_server_worker_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe MiqWebServiceWorker do
+  it "preload_for_worker_role autoloads api collection classes and descendants" do
+    allow(EvmDatabase).to receive(:seeded_primordially?).and_return(true)
+    expect(MiqWebServiceWorker).to receive(:configure_secret_token)
+    MiqWebServiceWorker.preload_for_worker_role
+    expect(defined?(ServiceAnsibleTower)).to be_truthy
+  end
+end


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1823849

Allowing threads to autoload code requires us to spend time tracking down bugs
in code loading and insert disgusting rails interlock blocks to "protect"
various places that could load constants in threads.

This solution tries to avoid these workarounds by eager loading all of the
collection classes and their descendants before any requests are made, since
we're likely to need to load them anyway.