### PR TITLE
Add a report for vms with alerts

### DIFF
--- a/config/miq_expression.yml
+++ b/config/miq_expression.yml
@@ -44,6 +44,8 @@
 - Host
 - HostAggregate
 - HostPerformance
+- MiqAlert
+- MiqAlertStatus
 - MiqGroup
 - MiqRegion
 - MiqRequest
@@ -127,6 +129,8 @@
 - last_compliances
 - linux_initprocesses
 - miq_actions
+- miq_alerts
+- miq_alert_statuses
 - miq_approval_stamps
 - miq_custom_attributes
 - miq_policy_sets
@@ -225,6 +229,8 @@
   ManageIQ::Providers::ContainerManager: ext_management_system
   ExtManagementSystem: ext_management_system
   Host: host
+  MiqAlert: miq_alert
+  MiqAlertStatus: miq_alert_status
   MiqGroup: miq_group
   MiqTemplate: miq_template
   ResourcePool: resource_pool

--- a/product/reports/100_Configuration Management - Virtual Machines/008_VMs w_Alerts.yaml
+++ b/product/reports/100_Configuration Management - Virtual Machines/008_VMs w_Alerts.yaml
@@ -1,0 +1,45 @@
+---
+dims:
+created_on: 2020-04-15 22:29:55.101908 Z
+title: "Vms with Alerts"
+conditions: !ruby/object:MiqExpression
+  exp:
+    "=":
+      field: MiqAlertStatus-resource_type
+      value: VmOrTemplate
+updated_on: 2020-04-15 22:29:55.101908 Z
+order: Ascending
+graph:
+menu_name: "Vms with Alerts"
+rpt_group: Custom
+priority: 231
+col_order:
+- resource_id
+- miq_alert_id
+- ems_id
+- miq_alert.description
+timeline:
+id: 81
+file_mtime:
+categories:
+rpt_type: Custom
+filename:
+include:
+  miq_alert:
+    columns:
+    - id
+    - description
+db: MiqAlertStatus
+cols:
+- resource_type
+- resource_id
+- ems_id
+template_type: report
+group:
+sortby:
+- resource_id
+headers:
+- Vm Id
+- Alert Id
+- Ems Id
+- Alert Description


### PR DESCRIPTION
Creates a report for vms with alerts. 

Has to go through alert statuses (joins on alerts) to do so and it'd be helpful to get input about what columns should be included here. 

Here's what it looks like right now: 
<img width="792" alt="Screen Shot 2020-04-16 at 2 47 21 PM" src="https://user-images.githubusercontent.com/16326669/79494692-6cf40a00-7ff1-11ea-9072-a347311eed75.png">

it's for https://bugzilla.redhat.com/show_bug.cgi?id=1704200
