### PR TITLE
Fixed cockpit process starting

### DIFF
--- a/app/models/miq_cockpit_ws_worker/runner.rb
+++ b/app/models/miq_cockpit_ws_worker/runner.rb
@@ -66,9 +66,9 @@ class MiqCockpitWsWorker::Runner < MiqWorker::Runner
 
   def stop_cockpit_ws_process
     return unless @pid
-    Process.kill("TERM", @pid)
     @stdout&.close
     @stderr&.close
+    Process.kill("TERM", @pid)
     wait_on_cockpit_ws
   end
 

--- a/lib/miq_cockpit.rb
+++ b/lib/miq_cockpit.rb
@@ -71,7 +71,7 @@ module MiqCockpit
 
     def initialize(opts = {})
       @opts = opts || {}
-      @config_dir = File.join(__dir__, "..", "config")
+      @config_dir = Rails.root.join("config").to_s
       @cockpit_conf_dir = File.join(@config_dir, "cockpit")
       FileUtils.mkdir_p(@cockpit_conf_dir)
     end


### PR DESCRIPTION
**Issue:**  Cockpit process not starting

There were multiple issues with each preventing successful starting for cockpit process.

**After:**
  Cockpit process successfully started on reproducer environment:
```
[----] I, [2020-04-20T16:23:44.266812 #31345:2b15806da5b8]  INFO -- : MIQ(MiqCockpitWsWorker::Runner#cockpit_ws_run) Starting cockpit-ws process with command: /usr/libexec/cockpit-ws --port 9002 --address 127.0.0.1 --no-tls 
[----] I, [2020-04-20T16:23:44.267070 #31345:2b15806da5b8]  INFO -- : MIQ(MiqCockpitWsWorker::Runner#cockpit_ws_run) Cockpit environment {"XDG_CONFIG_DIRS"=>"/var/www/miq/vmdb/config", "DRB_URI"=>"drbunix:///tmp/cockpit20200420-31345-1w35084"} 
[----] I, [2020-04-20T16:23:44.291255 #31345:2b15806da5b8]  INFO -- : MIQ(MiqCockpitWsWorker::Runner#cockpit_ws_run) MIQ(MiqCockpitWsWorker::Runner) cockpit-ws process started - pid=31363

```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1824355

@miq-bot add-label bug, core, ivanchuk/yes