### PR TITLE
Validate according to cols for MiqReportResult#result_set_for_reporting

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -288,7 +288,7 @@ class MiqReport < ApplicationRecord
 
   def validate_columns(sorting_columns)
     Array(sorting_columns).collect do |attr|
-      if col_order&.include?(attr)
+      if cols_for_report.include?(attr)
         attr
       else
         raise ArgumentError, N_("%{attribute} is not a valid attribute for %{name}") % {:attribute => attr, :name => name}

--- a/app/models/miq_report_result/result_set_operations.rb
+++ b/app/models/miq_report_result/result_set_operations.rb
@@ -41,10 +41,10 @@ module MiqReportResult::ResultSetOperations
       if result_set.present? && report
         if filtering_enabled?(options)
           result_set, count_of_full_result_set = report.filter_result_set(result_set, filter_options(options))
-          allowed_columns_to_format = report.col_order - filter_options(options).keys
+          allowed_columns_to_format = report.cols_for_report - filter_options(options).keys
         end
 
-        result_set.map! { |x| x.slice(*report.col_order) }
+        result_set.map! { |x| x.slice(*report.cols_for_report) }
         result_set = result_set.tabular_sort(sorting_columns, options[:sort_order])
         result_set = apply_limit_and_offset(result_set, options)
       end

--- a/spec/models/miq_report_result/result_set_operations_spec.rb
+++ b/spec/models/miq_report_result/result_set_operations_spec.rb
@@ -71,5 +71,36 @@ RSpec.describe MiqReportResult::ResultSetOperations do
         expect { subject }.to raise_error(ArgumentError, "Value for column type (filter_column_2 parameter) is missing, please specify filter_string_2 parameter")
       end
     end
+
+    context 'ChargebackVm' do
+      let(:result_set_options) { result_set_options_base }
+
+      let(:expected_result_set) do
+        [{'start_date' => '11/01/18 00:00:00 +00:00', 'date_range' => 'Nov 2018', 'storage_allocated_cost' => '$494.00'},
+         {'start_date' => '11/02/18 00:00:00 +00:00', 'date_range' => 'Nov 2018', 'storage_allocated_cost' => '$301.00'}]
+      end
+
+      let(:result_set) do
+        [{'start_date' => Date.parse('2018-11-01 00:00:00 UTC'), 'date_range' => 'Nov 2018', 'storage_allocated_cost' => 494.0},
+         {'start_date' => Date.parse('2018-11-02 00:00:00 UTC'), 'date_range' => 'Nov 2018', 'storage_allocated_cost' => 301.0}]
+      end
+
+      let(:columns)   { %w[start_date date_range storage_allocated_cost vm_name] }
+      let(:col_order) { %w[date_range storage_allocated_cost] }
+      let(:sort_by)   { %w[vm_name start_date] }
+
+      let!(:report) do
+        FactoryBot.create(:miq_report_chargeback, :miq_group          => user.current_group,
+                                                  :miq_report_results => [report_result],
+                                                  :cols               => columns,
+                                                  :col_formats        => col_formats,
+                                                  :col_order          => col_order,
+                                                  :sortby             => sort_by)
+      end
+
+      it 'returns default chargeback columns' do
+        expect(subject[:result_set]).to match_array(expected_result_set)
+      end
+    end
   end
 end


### PR DESCRIPTION
It looks like that array `MiqReport#cols` and `MiqReport#col_order` should have same length.

This is not true for chargeback reports because  `MiqReport#col_order` [doesn't have default chargeback column 'start_date' ](https://github.com/ManageIQ/manageiq/blob/200596a8bf63e227224a760fe0727d6f1a13f103/app/models/chargeback.rb#L243)

(and I think `MiqReport#col_order` should have also `start_date` and should be fixed by migration as well)

**Current Issue**

[as we added `hash_attribute=result_set` especially for filtering and sorting ](https://github.com/ManageIQ/manageiq-api/pull/547)- it allows us to fetch formatted report results (when we are not using sorting by `sort_by` parameter )

when `sort_by` parameter is not present in request then it uses default sorting columns
from `MiqReport#sortby`  (for chargeback `vm_name, start_date`)
and validation is done against  `MiqReport#col_order` and thanks to that the validation will fail:


```
./api/results/23039?hash_attribute=result_set
```

```ruby
{
    "error": {
        "kind": "internal_server_error",
        "message": "start_date is not a valid attribute for Chargeback - Blue Demo",
        "klass": "ArgumentError"
    }
}
```
@miq-bot assign @kbrock 
@miq-bot add_label bug

