### PR TITLE
Updated vm_reconfigure_task in app/models to add disk Type information.

### DIFF
--- a/app/models/vm_reconfigure_task.rb
+++ b/app/models/vm_reconfigure_task.rb
@@ -39,7 +39,7 @@ class VmReconfigureTask < MiqRequestTask
 
   def self.build_disk_message(options)
     if options[:disk_add].present?
-      disk_sizes = options[:disk_add].collect { |d| d["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) }
+      disk_sizes = options[:disk_add].collect { |d| d["disk_size_in_mb"].to_i.megabytes.to_s(:human_size) + ", Type: " + d["type"].to_s }
       "Add Disks: #{options[:disk_add].length} : #{disk_sizes.join(", ")} "
     end
   end

--- a/spec/models/vm_reconfigure_task_spec.rb
+++ b/spec/models/vm_reconfigure_task_spec.rb
@@ -40,20 +40,24 @@ RSpec.describe VmReconfigureTask do
   end
 
   context "Single Disk add " do
-    let(:request_options) { {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}.with_indifferent_access]} }
-    let(:description_partial) { "Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} " }
+    let(:request_options) { {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true", "type" => "thin"}.with_indifferent_access]} }
+    let(:description_partial) do
+      "Add Disks: 1 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, Type: "\
+    "#{request.options[:disk_add][0]["type"]} "
+    end
 
     it_behaves_like ".get_description"
   end
 
   context "Multiple Disk add " do
     let(:request_options) do
-      {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true"}.with_indifferent_access,
-                     {"disk_size_in_mb" => "44", "persistent" => "true"}.with_indifferent_access]}
+      {:disk_add => [{"disk_size_in_mb" => "33", "persistent" => "true", "type" => "thin"}.with_indifferent_access,
+                     {"disk_size_in_mb" => "44", "persistent" => "true", "type" => "thick"}.with_indifferent_access]}
     end
     let(:description_partial) do
-      "Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, "\
-      "#{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)} "
+      "Add Disks: 2 : #{request.options[:disk_add][0]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, Type: "\
+      "#{request.options[:disk_add][0]["type"]}, #{request.options[:disk_add][1]["disk_size_in_mb"].to_i.megabytes.to_s(:human_size)}, Type: "\
+      "#{request.options[:disk_add][1]["type"]} "
     end
 
     it_behaves_like ".get_description"


### PR DESCRIPTION
Previously we were just showing number of disks added and size of disk. This will add disk type in the description.

Fixes:https://bugzilla.redhat.com/show_bug.cgi?id=1630858

@miq-bot add_label bug
@miq-bot assign @tinaafitz

Sample Request

![Screen Shot 2020-04-17 at 12 38 04 PM](https://user-images.githubusercontent.com/11841651/79593687-d6cfea80-80a9-11ea-876d-6461028cb081.png)
