### PR TITLE
Extract format options from MiqReport Formatter#format

### DIFF
--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -77,21 +77,26 @@ module MiqReport::Formatting
     return value.to_s if column_formatter == :_none_ # Raw value was requested, do not attempt to format
 
     default_format_attributes = nil
-    # Format name passed in as a symbol or string
-    default_format_attributes = MiqReport::Formats.details(column_formatter) if (column_formatter.kind_of?(Symbol) || column_formatter.kind_of?(String)) && column_formatter != :_default_
 
-    # Look in this report object for column format
-    self.col_formats ||= []
-    if column_formatter.nil? && default_format_attributes.nil?
-      idx = col_order.index(col)
-      default_format_attributes = MiqReport::Formats.details(self.col_formats[idx])
-    end
-
-    # Use default format for column stil nil
-    if (column_formatter.nil? || column_formatter == :_default_) && default_format_attributes.nil?
+    if column_formatter == :_default_
       default_format_attributes = format_from_miq_expression(col, value)
     else
-      default_format_attributes = format_from_miq_expression.deep_clone # Make sure we don't taint the original
+      # Format name passed in as a symbol or string
+      default_format_attributes = MiqReport::Formats.details(column_formatter) if (column_formatter.kind_of?(Symbol) || column_formatter.kind_of?(String))
+
+      # Look in this report object for column format
+      self.col_formats ||= []
+      if column_formatter.nil? && default_format_attributes.nil?
+        idx = col_order.index(col)
+        default_format_attributes = MiqReport::Formats.details(self.col_formats[idx])
+      end
+
+      # Use default format for column stil nil
+      if column_formatter.nil? && default_format_attributes.nil?
+        default_format_attributes = format_from_miq_expression(col, value)
+      else
+        default_format_attributes = format_from_miq_expression.deep_clone # Make sure we don't taint the original
+      end
     end
 
     default_format_attributes.merge!(options) if default_format_attributes # Merge additional options that were passed in as overrides

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -42,7 +42,9 @@ module MiqReport::Formatting
   end
 
   def column_to_format(column)
-    if db.to_s == "VimPerformanceTrend"
+    if is_numeric?(column)
+      col_order[column]
+    elsif db.to_s == "VimPerformanceTrend"
       if col == "limit_col_value"
         db_options[:limit_col]
       elsif col.to_s.ends_with?("_value")
@@ -68,11 +70,8 @@ module MiqReport::Formatting
     # Look in this report object for column format
     self.col_formats ||= []
     if column_formatter.nil? && default_format_attributes.nil?
-      idx = col.kind_of?(String) ? col_order.index(col) : col
-      if idx
-        col = col_order[idx]
-        default_format_attributes = MiqReport::Formats.details(self.col_formats[idx])
-      end
+      idx = col_order.index(col)
+      default_format_attributes = MiqReport::Formats.details(self.col_formats[idx])
     end
 
     # Use default format for column stil nil

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -25,7 +25,7 @@ module MiqReport::Formatting
   end
 
   def format_options_by(column)
-    format_options = {}
+    format_options = {:column => column_to_format(column)}
 
     if db.to_s == "ChargebackContainerProject" # override format: default is mhz but cores needed for containers
       if column == "cpu_used_metric" || column == "cpu_metric"
@@ -38,7 +38,7 @@ module MiqReport::Formatting
       format_options[:unit] = @rates_cache.currency_for_report if @rates_cache.currency_for_report
     end
 
-    format_options || {}
+    format_options
   end
 
   def column_to_format(column)
@@ -56,11 +56,11 @@ module MiqReport::Formatting
   end
 
   def format(col, value, options = {})
-    col = column_to_format(col)
+    return "" if value.nil?
+
     options = options.merge(format_options_by(col))
 
     column_formatter = options.delete(:format)
-    return "" if value.nil?
     return value.to_s if column_formatter == :_none_ # Raw value was requested, do not attempt to format
 
     default_format_attributes = nil
@@ -80,8 +80,6 @@ module MiqReport::Formatting
     else
       default_format_attributes = format_from_miq_expression.deep_clone # Make sure we don't taint the original
     end
-
-    options[:column] = col
 
     default_format_attributes.merge!(options) if default_format_attributes # Merge additional options that were passed in as overrides
     value = apply_format_function(value, default_format_attributes) if default_format_attributes && !default_format_attributes[:function].nil?

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -28,7 +28,7 @@ module MiqReport::Formatting
     formatter = nil
     if Chargeback.db_is_chargeback?(db)
       if db.to_s == "ChargebackContainerProject" # override format: default is mhz but cores needed for containers
-        if column == "cpu_used_metric" || column == "cpu_metric"
+        if %w[cpu_used_metric cpu_metric].include?(column)
           formatter = :cores
         end
       end
@@ -70,8 +70,8 @@ module MiqReport::Formatting
 
   def format_attributes_for(column_formatter, col, value)
     format_attributes = if column_formatter == :_default_
-                           format_from_miq_expression(col, value)
-                        elsif (column_formatter.kind_of?(Symbol) || column_formatter.kind_of?(String))
+                          format_from_miq_expression(col, value)
+                        elsif column_formatter.kind_of?(Symbol) || column_formatter.kind_of?(String)
                           MiqReport::Formats.details(column_formatter)
                         elsif column_formatter
                           column_formatter.deep_clone # Make sure we don't taint the original

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -91,7 +91,7 @@ module MiqReport::Formatting
     options = options.merge(format_options_by(col))
 
     column_formatter = options.delete(:format)
-    return value.to_s if column_formatter == :_none_ # Raw value was requested, do not attempt to format
+    return String.new(value.to_s) if column_formatter == :_none_ # Raw value was requested, do not attempt to format
 
     default_format_attributes = format_attributes_for(column_formatter, col, value)
 

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -41,18 +41,21 @@ module MiqReport::Formatting
     format_options || {}
   end
 
-  def format(col, value, options = {})
+  def column_to_format(column)
     if db.to_s == "VimPerformanceTrend"
       if col == "limit_col_value"
-        col = db_options[:limit_col] || col
+        db_options[:limit_col]
       elsif col.to_s.ends_with?("_value")
-        col = db_options[:trend_col] || col
+        db_options[:trend_col]
       end
-    end
+    elsif Chargeback.db_is_chargeback?(db)
+      Chargeback.default_column_for_format(col.to_s)
+    end || column
+  end
 
+  def format(col, value, options = {})
+    col = column_to_format(col)
     options = options.merge(format_options_by(col))
-
-    col = Chargeback.default_column_for_format(col.to_s) if Chargeback.db_is_chargeback?(db)
 
     column_formatter = options.delete(:format)
     return "" if value.nil?

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -24,6 +24,18 @@ module MiqReport::Formatting
     [function_name, options]
   end
 
+  def format_options_by(column)
+    format_options = {}
+
+    if db.to_s == "ChargebackContainerProject" # override format: default is mhz but cores needed for containers
+      if column == "cpu_used_metric" || column == "cpu_metric"
+        format_options[:format] = :cores
+      end
+    end
+
+    format_options || {}
+  end
+
   def format(col, value, options = {})
     if db.to_s == "VimPerformanceTrend"
       if col == "limit_col_value"
@@ -31,11 +43,9 @@ module MiqReport::Formatting
       elsif col.to_s.ends_with?("_value")
         col = db_options[:trend_col] || col
       end
-    elsif db.to_s == "ChargebackContainerProject" # override format: default is mhz but cores needed for containers
-      if col == "cpu_used_metric" || col == "cpu_metric"
-        options[:format] = :cores
-      end
     end
+
+    options = options.merge(format_options_by(col))
 
     # TODO: remove this and update storing column format to instance of report in UI (this requires migration)
     options[:format] = :_none_ if Chargeback.db_is_chargeback?(db) && Chargeback.rate_column?(col.to_s)

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -95,14 +95,9 @@ module MiqReport::Formatting
 
     default_format_attributes = format_attributes_for(column_formatter, col, value)
 
-    # Use default format for column stil nil
-    if default_format_attributes.nil?
-      default_format_attributes = format_from_miq_expression(col, value)
+    if default_format_attributes && default_format_attributes.merge!(options)[:function]
+      value = apply_format_function(value, default_format_attributes)
     end
-
-    default_format_attributes.merge!(options) if default_format_attributes # Merge additional options that were passed in as overrides
-
-    value = apply_format_function(value, default_format_attributes) if default_format_attributes && !default_format_attributes[:function].nil?
 
     String.new(value.to_s) # Generate value as a string in case it is a SafeBuffer
   end

--- a/app/models/miq_report/formatting.rb
+++ b/app/models/miq_report/formatting.rb
@@ -96,7 +96,7 @@ module MiqReport::Formatting
     default_format_attributes = format_attributes_for(column_formatter, col, value)
 
     if default_format_attributes && default_format_attributes.merge!(options)[:function]
-      value = apply_format_function(value, default_format_attributes)
+      value = apply_format_function(value, default_format_attributes.deep_clone)
     end
 
     String.new(value.to_s) # Generate value as a string in case it is a SafeBuffer


### PR DESCRIPTION
Goal is to extract code which is related to certain report models (and then this code can be moved to models) and clean formatting method.



@miq-bot assign @kbrock 

@miq-bot add_label refactoring