### PR TITLE
Implemented account lockout policy backend

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -44,7 +44,6 @@ module Authenticator
       options = options.dup
       options[:require_user] ||= false
       options[:authorize_only] ||= false
-      fail_message = _("Authentication failed")
 
       user_or_taskid = nil
 
@@ -52,7 +51,10 @@ module Authenticator
         username = normalize_username(username)
         audit = {:event => audit_event, :userid => username}
 
-        authenticated = options[:authorize_only] || _authenticate(username, password, request)
+        # The fail_message might or might not come from the _authenticate method
+        authenticated, fail_message = options[:authorize_only] || _authenticate(username, password, request)
+        fail_message ||= _("Authentication failed") # Fall back to the default fail_message
+
         if authenticated
           audit_success(audit.merge(:message => "User #{username} successfully validated by #{self.class.proper_name}"))
 

--- a/app/models/authenticator/database.rb
+++ b/app/models/authenticator/database.rb
@@ -13,7 +13,15 @@ module Authenticator
     def _authenticate(username, password, _request)
       user = case_insensitive_find_by_userid(username)
 
-      user && user.authenticate_bcrypt(password)
+      return [false, _('Your account has been locked due to too many failed login attempts, please contact the administrator.')] if user&.locked?
+
+      if user&.authenticate_bcrypt(password) # Authenticate if the username matches
+        user.unlock! # Reset the number of failed logins
+        return true
+      end
+
+      user&.fail_login! # Increase the number of failed login attempts
+      [false, _("The username or password you entered is incorrect.")]
     end
 
     def authorize?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,6 +11,8 @@
   :ldaphost:
   :ldapport: '389'
   :mode: database
+  :max_failed_login_attempts: 3
+  :locked_account_timeout: 2.minutes
   :search_timeout: 30
   :user_suffix:
   :user_type: userprincipalname

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,6 +145,21 @@ RSpec.describe User do
     end
   end
 
+  describe '#fail_login!' do
+    let(:user) { FactoryBot.create(:user, :password => "smartvm", :failed_login_attempts => 0) }
+
+    it 'increases the number of failed login attempts' do
+      user.fail_login!
+      expect(user.reload.failed_login_attempts).to eq(1)
+    end
+
+    it 'queues an unlock task if the account is locked' do
+      allow(user).to receive(:locked?).and_return(true)
+      expect(user).to receive(:unlock_queue)
+      user.fail_login!
+    end
+  end
+
   context "#authorize_ldap" do
     before do
       @fq_user = "thin1@manageiq.com"


### PR DESCRIPTION
So according to the [parent issue](https://github.com/ManageIQ/manageiq/issues/20043) I added a [new column](https://github.com/ManageIQ/manageiq-schema/pull/467) to the users table for counting failed login attempts. I introduced two new parametres under `Settings.authentication` for setting the maximum number of failed login attempts before a lockout and the timeout after the account gets unlocked by a background job. 

I did some changes in the `Authenticator::Base` class for having a way to retrieve the actual reason of a login failure. If there's no failure provider, it would fall back to the original `Authentication failed` message. This message is further [consumed](https://github.com/ManageIQ/manageiq-ui-classic/pull/6989) by the UI and also to the API.

I have this feeling that @abellotti might not like the idea of returning with two things from the `_authenticate` method instead of one, but I tried to limit the scope of my changes to just the DB authentication as we discussed. If you have a better idea of how do to it, I am willing to change my second commit.

@miq-bot add_reviewer @abellotti 
@miq-bot add_reviewer @Fryguy 
@miq-bot add_reviewer @jvlcek 
@miq-bot add_label enhancement, question