### PR TITLE
Update manageiq-smartstate Gem to 0.3.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -203,7 +203,7 @@ group :seed, :manageiq_default do
 end
 
 group :smartstate, :manageiq_default do
-  gem "manageiq-smartstate",            "~>0.3.7",       :require => false
+  gem "manageiq-smartstate",            "~>0.3.8",       :require => false
 end
 
 group :consumption, :manageiq_default do


### PR DESCRIPTION
Upgrade manageiq-smartstate gem to 0.3.8 for Ivanchuk.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1824259
and https://bugzilla.redhat.com/show_bug.cgi?id=1824920

@roliveri @Fryguy @simaishi please review and merge for the next build. Thanks.

Links
https://bugzilla.redhat.com/show_bug.cgi?id=1824920
https://bugzilla.redhat.com/show_bug.cgi?id=1824259
ManageIQ/manageiq-smartstate#122
ManageIQ/manageiq-smartstate#121