### PR TITLE
[V2V] Prevent removing active conversion host

### DIFF
--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -54,6 +54,7 @@ module ConversionHost::Configurations
       params = params.symbolize_keys
       resource = params.delete(:resource)
 
+      raise "#{resource.class.name.demodulize} '#{resource.name}' doesn't have a hostname or IP address in inventory" if resource.hostname.nil? && resource.ipaddresses.empty?
       raise "the resource '#{resource.name}' is already configured as a conversion host" if ConversionHost.exists?(:resource => resource)
 
       params[:resource_id] = resource.id
@@ -108,6 +109,8 @@ module ConversionHost::Configurations
   end
 
   def disable_queue(auth_user = nil)
+    raise "There are active migration tasks running on this conversion host" if active_tasks.present?
+
     self.class.queue_configuration('disable', id, resource, {}, auth_user)
   end
 

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -109,19 +109,18 @@ module ConversionHost::Configurations
   end
 
   def disable_queue(auth_user = nil)
-    raise "There are active migration tasks running on this conversion host" if active_tasks.present?
-
     self.class.queue_configuration('disable', id, resource, {}, auth_user)
   end
 
   def disable(_params = nil, _auth_user = nil)
     resource_info = "type=#{resource.class.name} id=#{resource.id}"
-    _log.debug("Disabling a conversion_host #{resource_info}")
+    raise "There are active migration tasks running on this conversion host" if active_tasks.present?
 
+    _log.debug("Disabling a conversion_host #{resource_info}")
     disable_conversion_host_role
     destroy!
   rescue StandardError => error
-    raise
+    raise error
   ensure
     self.class.notify_configuration_result('disable', error.nil?, resource_info)
   end

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -117,12 +117,20 @@ RSpec.describe ConversionHost, :v2v do
     context ".enable_queue" do
       let(:op) { 'enable' }
 
+      it "raises if resource has no hostname nor IP address" do
+        allow(vm).to receive(:hostname).and_return(nil)
+        allow(vm).to receive(:ipaddresses).and_return([])
+        expect { described_class.enable_queue(:resource => vm) }.to raise_error("Vm '#{vm.name}' doesn't have a hostname or IP address in inventory")
+      end
+
       it "raises an error if the resource is already configured as a conversion host" do
+        allow(vm).to receive(:ipaddresses).and_return(['10.0.0.1'])
         FactoryBot.create(:conversion_host, :resource => vm)
         expect { described_class.enable_queue(:resource => vm) }.to raise_error("the resource '#{vm.name}' is already configured as a conversion host")
       end
 
       it "to queue with a task" do
+        allow(vm).to receive(:ipaddresses).and_return(['10.0.0.1'])
         task_id = described_class.enable_queue(params)
         expected_context_data = {:request_params => params.except(:resource)}
 
@@ -138,6 +146,7 @@ RSpec.describe ConversionHost, :v2v do
       end
 
       it "rejects ssh key information as context data" do
+        allow(vm).to receive(:ipaddresses).and_return(['10.0.0.1'])
         task_id = described_class.enable_queue(params.merge(:conversion_host_ssh_private_key => 'xxx', :vmware_ssh_private_key => 'yyy'))
         expected_context_data = {:request_params => params.except(:resource)}
 
@@ -156,6 +165,12 @@ RSpec.describe ConversionHost, :v2v do
             :op_arg  => "type=#{vm.class.name} id=#{vm.id}"
           }
         }
+      end
+
+      it "to raise if active tasks exist" do
+        allow(vm).to receive(:ipaddresses).and_return(['10.0.0.1'])
+        FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host, :state => 'migrate')
+        expect { conversion_host.disable_queue }.to raise_error("There are active migration tasks running on this conversion host")
       end
 
       it "to queue with a task" do

--- a/spec/models/conversion_host/configurations_spec.rb
+++ b/spec/models/conversion_host/configurations_spec.rb
@@ -90,11 +90,11 @@ RSpec.describe ConversionHost, :v2v do
         conversion_host.disable
       end
 
-      it "to fail and send notification" do
+      it "to raise if active tasks exist" do
         expected_notify[:type] = :conversion_host_config_failure
-        allow(conversion_host).to receive(:disable_conversion_host_role).and_raise
+        FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host, :state => 'migrate')
         expect(Notification).to receive(:create).with(expected_notify)
-        expect { conversion_host.disable }.to raise_error(StandardError)
+        expect { conversion_host.disable }.to raise_error(StandardError, "There are active migration tasks running on this conversion host")
       end
 
       it "tags the associated resource as expected" do
@@ -165,12 +165,6 @@ RSpec.describe ConversionHost, :v2v do
             :op_arg  => "type=#{vm.class.name} id=#{vm.id}"
           }
         }
-      end
-
-      it "to raise if active tasks exist" do
-        allow(vm).to receive(:ipaddresses).and_return(['10.0.0.1'])
-        FactoryBot.create(:service_template_transformation_plan_task, :conversion_host => conversion_host, :state => 'migrate')
-        expect { conversion_host.disable_queue }.to raise_error("There are active migration tasks running on this conversion host")
       end
 
       it "to queue with a task" do


### PR DESCRIPTION
It is currently possible to remove a conversion host, while it is used by an active migration task. This will fail the migration task, so this should be blocked with a clear message.

While looking at how to implement that check, we noticed that most tests happen after the async configuration task has been created, which makes it difficult for an API user to understand why it failed.

This pull request adds a check in the `disable_queue` method for existing active tasks associated to the conversion host. And it also adds a check in `enable_queue` for the presence of an IP address for the resource.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1718846