### PR TITLE
Use CONTAINER_IMAGE_TAG for worker deployment tag

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -34,7 +34,7 @@ class MiqWorker
     end
 
     def container_image_tag
-      "latest"
+      ENV["CONTAINER_IMAGE_TAG"] || "latest"
     end
 
     def deployment_prefix


### PR DESCRIPTION
This will start the worker containers with the same tag as the orchestrator

https://github.com/ManageIQ/manageiq-pods/issues/464