### PR TITLE
Don't run worker pods as root

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -16,7 +16,6 @@ class ContainerOrchestrator
             :metadata => {:name => name, :labels => {:name => name, :app => app_name}},
             :spec     => {
               :imagePullSecrets   => [{:name => ENV["IMAGE_PULL_SECRET"].to_s}],
-              :serviceAccountName => "#{app_name}-anyuid",
               :containers         => [{
                 :name          => name,
                 :env           => default_environment,

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe MiqWorker::ContainerCommon do
           :template => {
             :metadata => {:name => "test", :labels => {:name => "test", :app => "manageiq"}},
             :spec     => {
-              :serviceAccountName => "miq-anyuid",
               :containers         => [{
                 :name => "test",
                 :env  => []


### PR DESCRIPTION
A bunch of certifications require us not to run as root
in containers. Additionally the vast majority of the application
should run fine without root and the parts that need root are
typically things we can't do in containers anyway.

Related to https://github.com/ManageIQ/manageiq-pods/issues/442

Merge with https://github.com/ManageIQ/manageiq-pods/pull/466