### PR TITLE
Add scopes for VMs from Cloud/Infra Managers

### DIFF
--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -199,6 +199,14 @@ class VmOrTemplate < ApplicationRecord
   scope :from_cloud_managers, -> { where(:ext_management_system => ManageIQ::Providers::CloudManager.all) }
   scope :from_infra_managers, -> { where(:ext_management_system => ManageIQ::Providers::InfraManager.all) }
 
+  def from_cloud_manager?
+    ext_management_system&.kind_of?(ManageIQ::Providers::CloudManager)
+  end
+
+  def from_infra_manager?
+    ext_management_system&.kind_of?(ManageIQ::Providers::InfraManager)
+  end
+
   # The SQL form of `#registered?`, with it's inverse as well.
   # TODO: Vmware Specific (copied (old) TODO from #registered?)
   scope :registered, (lambda do

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -196,6 +196,9 @@ class VmOrTemplate < ApplicationRecord
   scope :not_orphaned, ->       { where.not(:ems_id => nil).or(where(:storage_id => nil)) }
   scope :not_retired,  ->       { where(:retired => false).or(where(:retired => nil)) }
 
+  scope :from_cloud_managers, -> { where(:ext_management_system => ManageIQ::Providers::CloudManager.all) }
+  scope :from_infra_managers, -> { where(:ext_management_system => ManageIQ::Providers::InfraManager.all) }
+
   # The SQL form of `#registered?`, with it's inverse as well.
   # TODO: Vmware Specific (copied (old) TODO from #registered?)
   scope :registered, (lambda do

--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -126,6 +126,88 @@ RSpec.describe VmOrTemplate do
     end
   end
 
+  context ".from_cloud_managers" do
+    context "with cloud and infra vms" do
+      let!(:cloud_vm) { FactoryBot.create(:vm_cloud, :ext_management_system => FactoryBot.create(:ems_cloud)) }
+      let!(:infra_vm) { FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra)) }
+
+      it "returns a cloud vm" do
+        expect(described_class.from_cloud_managers).to include(cloud_vm)
+      end
+
+      it "doesn't return an infra vm" do
+        expect(described_class.from_cloud_managers).not_to include(infra_vm)
+      end
+    end
+
+    context "with archived vms" do
+      let!(:archived_vm) { FactoryBot.create(:vm_cloud, :ext_management_system => nil) }
+
+      it "doesn't return an archived vm" do
+        expect(described_class.from_cloud_managers).not_to include(archived_vm)
+      end
+    end
+  end
+
+  context ".from_infra_managers" do
+    context "with cloud and infra vms" do
+      let!(:cloud_vm) { FactoryBot.create(:vm_cloud, :ext_management_system => FactoryBot.create(:ems_cloud)) }
+      let!(:infra_vm) { FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra)) }
+
+      it "returns an infra vm" do
+        expect(described_class.from_infra_managers).to include(infra_vm)
+      end
+
+      it "doesn't return a cloud vm" do
+        expect(described_class.from_infra_managers).not_to include(cloud_vm)
+      end
+    end
+
+    context "with archived vms" do
+      let!(:archived_vm) { FactoryBot.create(:vm_infra, :ext_management_system => nil) }
+
+      it "doesn't return an archived vm" do
+        expect(described_class.from_infra_managers).not_to include(archived_vm)
+      end
+    end
+  end
+
+  context "#from_cloud_manager?" do
+    let(:cloud_vm)    { FactoryBot.create(:vm_cloud, :ext_management_system => FactoryBot.create(:ems_cloud)) }
+    let(:infra_vm)    { FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra)) }
+    let(:archived_vm) { FactoryBot.create(:vm_infra, :ext_management_system => nil) }
+
+    it "returns true for a cloud vm" do
+      expect(cloud_vm.from_cloud_manager?).to be_truthy
+    end
+
+    it "returns false for an infra vm" do
+      expect(infra_vm.from_cloud_manager?).to be_falsey
+    end
+
+    it "returns false for an archived vm" do
+      expect(archived_vm.from_cloud_manager?).to be_falsey
+    end
+  end
+
+  context "#from_infra_manager?" do
+    let(:cloud_vm)    { FactoryBot.create(:vm_cloud, :ext_management_system => FactoryBot.create(:ems_cloud)) }
+    let(:infra_vm)    { FactoryBot.create(:vm_infra, :ext_management_system => FactoryBot.create(:ems_infra)) }
+    let(:archived_vm) { FactoryBot.create(:vm_infra, :ext_management_system => nil) }
+
+    it "returns false for a cloud vm" do
+      expect(cloud_vm.from_infra_manager?).to be_falsey
+    end
+
+    it "returns true for an infra vm" do
+      expect(infra_vm.from_infra_manager?).to be_truthy
+    end
+
+    it "returns false for an archived vm" do
+      expect(archived_vm.from_infra_manager?).to be_falsey
+    end
+  end
+
   context ".event_by_property" do
     context "should add an EMS event" do
       before do


### PR DESCRIPTION
Add a scope to the VmOrTemplate model to allow for grouping VMs that
come from CloudManagers and InfraManagers without using the :cloud
column