### PR TITLE
Handle user create race condition

### DIFF
--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -272,6 +272,18 @@ RSpec.describe Authenticator::Httpd do
                       'X-Remote-User-Email'     => 'Sally@example.com')
       end
 
+      context "with a race condition on create user" do
+        before do
+          authenticate
+        end
+
+        it "update the exiting user" do
+          allow(User).to receive(:lookup_by_userid).and_return(nil)
+          allow(User).to receive(:in_my_region).and_return(User.none, User.all)
+          expect { authenticate }.not_to(change { User.where(:userid => 'sally@example.com').count }.from(1))
+        end
+      end
+
       context "when user record with userid in upn format already exists" do
         let!(:sally_username) { FactoryBot.create(:user, :userid => 'sAlly') }
         let!(:sally_dn) { FactoryBot.create(:user, :userid => dn) }


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/20041

When a user's credentials are used to access ManageIQ for the first time, if properly configured, the user record will be created in the ManageIQ database.

It is possible when multiple simultaneous attempts to access ManageIQ for the first time with a single user name that a race condition could result in multiple user records being created for the same user.

This PR addresses this race condition by placing a lock on the User table when attempting
to create a new user. If a duplicate user record is found at this time it means a different simultaneous login attempt has been completed before the current one. To avoid raising a duplicate userid error this condition is rescued and handled by attempting to **update**, the existing user record instead of creating a new on.

Steps for Testing/QA [Optional]
-------------------------------

Configure ManageIQ for external auth, with get user groups from Identity Provider selected.
Perform multiple simultaneous attempts to access the ManageIQ API with a username and password for a user that is not yet in the database.

This can be done with a shell script that issues multiple simultaneous curl commands to query ManageIQ.

e.g.: Repeat the below line multiple times in a shell script and run the shell script simultaneously from multiple shell windows

```bash
curl --user test_user:<PW> -k -X GET -H "Accept: application/json" https:/my_miq.example.com:443/api &
```