### PR TITLE
Add {created,updated}_at to global skip attributes

### DIFF
--- a/spec/support/ems_refresh_helper.rb
+++ b/spec/support/ems_refresh_helper.rb
@@ -7,7 +7,7 @@ module Spec
         models = ApplicationRecord.subclasses - skip_models
 
         # Skip attributes that always change between refreshes
-        skip_attrs_global   = ["created_on", "updated_on"]
+        skip_attrs_global   = ["created_on", "created_at", "updated_on", "updated_at"]
         skip_attrs_by_model = {
           "ExtManagementSystem" => ["last_refresh_date", "last_inventory_date"],
         }


### PR DESCRIPTION
A lot of tables have created_at and updated_at so we should add these to the list of global skip attributes when doing full database comparisons.

Required for: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/366