### PR TITLE
Allow plugins to bring I18n yaml files

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -4,8 +4,12 @@
 # temporarily force it off while we load stuff.
 old_debug, $DEBUG = $DEBUG, nil
 begin
-  # consistently sort en_foo.yml *after* en.yml; to_s because pathnames
-  I18n.load_path += Dir[Rails.root.join('locale', '*.yml')].sort_by(&:to_s)
+  load_paths = Vmdb::Plugins.to_a.unshift(Rails).flat_map do |engine|
+    Dir.glob(engine.root.join('locale', '*.yml'))
+  end
+  load_paths.sort_by! { |p| File.basename(p) } # consistently sort en_foo.yml *after* en.yml
+  I18n.load_path += load_paths
+
   Vmdb::FastGettextHelper.register_locales
   Vmdb::FastGettextHelper.register_human_localenames
   gettext_options = %w(--sort-by-msgid --location --no-wrap)


### PR DESCRIPTION
@chessbyte @mzazrivec Please review.

This modifies the i18n initializer to allow plugins to bring i18n files (which can be used for productization to avoid symlinking)
