### PR TITLE
[V2V] Add fixed SSH key file path for virt-v2v-wrapper

### DIFF
--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -425,6 +425,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
       :vmware_password      => source.host.authentication_password,
+      :ssh_key_file         => '/var/lib/uci/ssh_private_key',
       :two_phase            => two_phase?,
       :warm                 => false,
       :daemonize            => false

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -661,6 +661,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password      => 'esx_passwd',
+              :ssh_key_file         => '/var/lib/uci/ssh_private_key',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -685,6 +686,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password      => 'esx_passwd',
+              :ssh_key_file         => '/var/lib/uci/ssh_private_key',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -833,6 +835,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri                 => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password            => 'esx_passwd',
+              :ssh_key_file               => '/var/lib/uci/ssh_private_key',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(
                   :scheme => openstack_ems.security_protocol == 'non-ssl' ? 'http' : 'https',


### PR DESCRIPTION
With UCI, the path for the SSH private key file that virt-v2v-wrapper uses must be provided in the input JSON. Because ManageIQ will mount the private key file as `/var/lib/uci/ssh_private_key`, this pull request adds a hard coded attribute to the generated input.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1825023