### PR TITLE
MiqReport: add skip_references attribute back

### DIFF
--- a/app/models/miq_report.rb
+++ b/app/models/miq_report.rb
@@ -50,7 +50,7 @@ class MiqReport < ApplicationRecord
                            :extras, :record_id, :tl_times, :user_categories, :trend_data, :performance, :include_for_find,
                            :report_run_time, :chart
 
-  attr_accessor_that_yamls :reserved # For legacy imports
+  attr_accessor_that_yamls :reserved, :skip_references # For legacy imports
 
   GROUPINGS = [[:min, "Minimum"], [:avg, "Average"], [:max, "Maximum"], [:total, "Total"]]
   PIVOTS    = [[:min, "Minimum"], [:avg, "Average"], [:max, "Maximum"], [:total, "Total"]]


### PR DESCRIPTION
Fixes a bug where serialized reports were reporting an error.

skip_references won't do anything, since the functionality has been
removed.

But this attribute is available so customer reports that have that
option don't blow up.

Fixes #20106

Steps for Testing/QA
-------------------------------

create a report with
```
db_options:
  skip_references
```

It should break before this change
It should work after this change