### PR TITLE
Add evm:plugins:list rake task

### DIFF
--- a/lib/tasks/evm_plugins.rake
+++ b/lib/tasks/evm_plugins.rake
@@ -1,0 +1,25 @@
+namespace :evm do
+  namespace :plugins do
+    desc "List the available plugins in the specified format ('human' or 'json')"
+    task :list, :format do |_, args|
+      format = args.fetch(:format, "human")
+
+      require "vmdb/plugins"
+      details = Vmdb::Plugins.details
+
+      case format
+      when "json"
+        puts JSON.pretty_generate(details.values)
+      when "human"
+        details.each_value do |detail|
+          puts "#{detail[:name]}:"
+          puts detail
+            .except(:name)
+            .map { |k, v| "  #{k}: #{v}" }
+        end
+      else
+        raise "Invalid format #{format.inspect}"
+      end
+    end
+  end
+end

--- a/lib/vmdb/plugins.rb
+++ b/lib/vmdb/plugins.rb
@@ -28,10 +28,18 @@ module Vmdb
       register_models
     end
 
-    def versions
+    def details
       each_with_object({}) do |engine, hash|
-        hash[engine] = version(engine)
+        hash[engine] = {
+          :name    => engine.name,
+          :version => version(engine),
+          :path    => engine.root.to_s
+        }
       end
+    end
+
+    def versions
+      details.transform_values { |v| v[:version] }
     end
 
     def ansible_content

--- a/spec/lib/vmdb/plugins_spec.rb
+++ b/spec/lib/vmdb/plugins_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe Vmdb::Plugins do
     )
   end
 
+  it ".details" do
+    details = described_class.details
+
+    expect(details).to be_kind_of(Hash)
+    expect(details.keys).to match_array described_class.all
+
+    detail = details.values.first
+    expect(detail).to be_kind_of(Hash)
+    expect(detail.keys).to match_array([:name, :version, :path])
+  end
+
   it ".versions" do
     versions = described_class.versions
 


### PR DESCRIPTION
This adds a rake task for listing the plugins and some details about them.  It has 2 formats:

human format:

```text
$ bundle exec rake evm:plugins:list
# or bundle exec rake evm:plugins:list[human]
ManageIQ::Api::Engine:
  version: master@fdc94421
  path: /Users/jfrey/.gem/ruby/2.6.5/bundler/gems/manageiq-api-fdc94421077e
ManageIQ::AutomationEngine::Engine:
  version: master@42a7b75a
  path: /Users/jfrey/.gem/ruby/2.6.5/bundler/gems/manageiq-automation_engine-42a7b75ac940
...
```

json format:

```json
$ bundle exec rake evm:plugins:list[json]
[
  {
    "name": "ManageIQ::Api::Engine",
    "version": "master@fdc94421",
    "path": "/Users/jfrey/.gem/ruby/2.6.5/bundler/gems/manageiq-api-fdc94421077e"
  },
  {
    "name": "ManageIQ::AutomationEngine::Engine",
    "version": "master@42a7b75a",
    "path": "/Users/jfrey/.gem/ruby/2.6.5/bundler/gems/manageiq-automation_engine-42a7b75ac940"
  },
  ...
]
```

The latter will be useful in the RPM build where we might have to manipulate files from the plugins, and need to get the list.  As a rake task, it doesn't have to load the Rails env, and thus is useful in cases where there is no DB (like the build).

cc @simaishi 