### PR TITLE
ContainerRoutes belong to the ems not ContainerServices

### DIFF
--- a/app/models/manageiq/providers/container_manager.rb
+++ b/app/models/manageiq/providers/container_manager.rb
@@ -16,6 +16,7 @@ module ManageIQ::Providers
     has_many :containers, -> { active }, :foreign_key => :ems_id
     has_many :container_projects, -> { active }, :foreign_key => :ems_id
     has_many :container_quotas, -> { active }, :foreign_key => :ems_id
+    has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_limits, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_image_registries, :foreign_key => :ems_id, :dependent => :destroy
     has_many :container_images, -> { active }, :foreign_key => :ems_id, :dependent => :destroy
@@ -34,7 +35,6 @@ module ManageIQ::Providers
     has_many :container_env_vars, :through => :containers
     has_many :security_contexts, :through => :containers
     has_many :container_service_port_configs, :through => :container_services
-    has_many :container_routes, :through => :container_services
     has_many :container_quota_scopes, :through => :container_quotas
     has_many :container_quota_items, :through => :container_quotas
     has_many :container_limit_items, :through => :container_limits

--- a/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/container_manager.rb
@@ -179,8 +179,7 @@ module ManageIQ::Providers
 
         def container_routes
           add_properties(
-            :attributes_blacklist         => %i(namespace),
-            :parent_inventory_collections => %i(container_services)
+            :attributes_blacklist => %i(namespace)
           )
           add_common_default_values
         end


### PR DESCRIPTION
ContainerRoutes belong to the ExtManagementSystem but the persister definition has it belonging to the container_project.

This was causing errors when doing targeted refresh of the Openshift provider:

```
[----] I, [2020-05-04T09:11:06.415427 #64690:33c228]  INFO -- : EMS: [CRC], id: [2] Saving EMS Inventory...
[----] E, [2020-05-04T09:11:06.445212 #64690:33c228] ERROR -- : Error when saving InventoryCollection:<ContainerRoute>, blacklist: [namespace], strategy: local_db_find_missing_references with strategy: local_db_find_missing_references, saver_strategy: batch, targeted: true. Message: PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "container_services"
LINE 1: ...tes" WHERE "container_routes"."ems_id" = $1 AND (("container...
                                                             ^
: SELECT "container_routes".* FROM "container_routes" WHERE "container_routes"."ems_id" = $1 AND (("container_services"."ems_ref" = '3195ff72-0df4-4298-bbf0-6a6a70141b01'))
[----] E, [2020-05-04T09:11:06.445288 #64690:33c228] ERROR -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker::Runner#refresh_block) EMS [CRC], id: [2] Refresh failed: PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "container_services"
LINE 1: ...tes" WHERE "container_routes"."ems_id" = $1 AND (("container...
                                                             ^
: SELECT "container_routes".* FROM "container_routes" WHERE "container_routes"."ems_id" = $1 AND (("container_services"."ems_ref" = '3195ff72-0df4-4298-bbf0-6a6a70141b01'))
[----] E, [2020-05-04T09:11:06.445354 #64690:33c228] ERROR -- : [ActiveRecord::StatementInvalid]: PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "container_services"
LINE 1: ...tes" WHERE "container_routes"."ems_id" = $1 AND (("container...
                                                             ^
: SELECT "container_routes".* FROM "container_routes" WHERE "container_routes"."ems_id" = $1 AND (("container_services"."ems_ref" = '3195ff72-0df4-4298-bbf0-6a6a70141b01'))  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2020-05-04T09:11:06.445411 #64690:33c228] ERROR -- : /home/grare/adam/.gems/2.7.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `exec_params'
```

Dependent: https://github.com/ManageIQ/manageiq-providers-openshift/pull/170
Cross Repo Test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/118