### PR TITLE
Moved API specific Chargeback features under API section.

### DIFF
--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -1761,14 +1761,6 @@
     :description: Assignments Accordion
     :feature_type: node
     :identifier: chargeback_assignments
-  - :name: Currencies
-    :description: Chargeback Rate currencies Accordion
-    :feature_type: node
-    :identifier: currency
-  - :name: Measures
-    :description: Chargeback Rate measures Accordion
-    :feature_type: node
-    :identifier: measure
 
 # Timelines
 - :name: Timelines
@@ -6574,6 +6566,14 @@
       :description: View Service Parameters Sets
       :feature_type: view
       :identifier: service_parameters_sets_view
+  - :name: Chargeback Currencies
+    :description: Chargeback Rate currencies Accordion
+    :feature_type: node
+    :identifier: currency
+  - :name: Chargeback Measures
+    :description: Chargeback Rate measures Accordion
+    :feature_type: node
+    :identifier: measure    
 
 # SUI
 - :name: Service UI


### PR DESCRIPTION
While splitting chargeback explorer, noticed these API specific features that should live under API section, it is confusing to have them in UI section as there are no screens to go with these features.

Partially fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6996

before
![before](https://user-images.githubusercontent.com/3450808/81196344-eb0e5580-8f8c-11ea-8e08-a4e3115bb64b.png)

after
![after](https://user-images.githubusercontent.com/3450808/81196418-02e5d980-8f8d-11ea-9880-9bc225177bb2.png)

