### PR TITLE
fix brakeman warning about possible command injection

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "14cf1baf5a62a0f109a2deb71920db195735f3054b031e50513d433f1566a670",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "lib/miq_apache/control.rb",
-      "line": 55,
-      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "system(\"kill -WINCH #{`pgrep -P 1 httpd`.chomp.to_i}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "MiqApache::Control",
-        "method": "s(:self).stop"
-      },
-      "user_input": "`pgrep -P 1 httpd`.chomp.to_i",
-      "confidence": "Medium",
-      "note": "The chomp.to_i ensures we get a number and we protect against 0 with a conditional.  The only other possible avenue for attack is if the attacker could replace pgrep, but then they already have root access, so it's a moot point."
-    },
-    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "4e1918c2d5ff2beacc21db09f696af724d62f1a2a6a101e8e3cb564d0e8a94cd",

--- a/lib/miq_apache/control.rb
+++ b/lib/miq_apache/control.rb
@@ -52,7 +52,7 @@ module MiqApache
     def self.stop
       if ENV["CONTAINER"]
         pid = `pgrep -P 1 httpd`.chomp.to_i
-        system("kill -WINCH #{pid}") if pid > 0
+        Process.kill("WINCH", pid) if pid > 0
       else
         run_apache_cmd('stop')
       end


### PR DESCRIPTION
This line's in our brakeman ignore right now because we were supposed to get back to it later. 

```
Confidence: Medium
Category: Command Injection
Check: Execute
Message: Possible command injection
Code: system("kill -WINCH #{`pgrep -P 1 httpd`.chomp.to_i}")
File: lib/miq_apache/control.rb
Line: 55
```