### PR TITLE
fix sql injection brakeman warning in the aggregation mixin query

### DIFF
--- a/app/models/mixins/aggregation_mixin/methods.rb
+++ b/app/models/mixins/aggregation_mixin/methods.rb
@@ -43,7 +43,7 @@ module AggregationMixin
       select    = field == :aggregate_cpu_speed ? "cpu_total_cores, cpu_speed" : field
       targets ||= send("all_#{from}_ids")
       targets   = targets.collect(&:id) unless targets.first.kind_of?(Integer)
-      hdws      = Hardware.where("#{from}_id" => targets).select(select)
+      hdws      = Hardware.where("#{from}_id".to_sym => targets).select(select)
 
       hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
     end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -59,26 +59,6 @@
       "user_input": "remote_address",
       "confidence": "Medium",
       "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "cb757feae151275a993fe7d7e3d0a5fabd22a09220580c25fc4d80359adb7cc0",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/mixins/aggregation_mixin/methods.rb",
-      "line": 46,
-      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Hardware.where(\"#{from.to_s.singularize}_id\" => send(\"all_#{from.to_s.singularize}_ids\").collect(&:id))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "AggregationMixin::Methods",
-        "method": "aggregate_hardware"
-      },
-      "user_input": "from.to_s.singularize",
-      "confidence": "Medium",
-      "note": "Temporarily skipped, found in new brakeman version"
     }
   ],
   "updated": "2017-11-01 11:16:49 -0400",


### PR DESCRIPTION
`Hardware.where("#{from}_id" => targets)` isn't injection proof but I think this is better?
