### PR TITLE
[V2V] Don't run Ansible playbook if conversion host resource is absent or archived

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -331,6 +331,7 @@ class ConversionHost < ApplicationRecord
 
   def check_conversion_host_role(miq_task_id = nil)
     return if resource.nil? || resource.ext_management_system.nil?
+
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,
@@ -346,6 +347,7 @@ class ConversionHost < ApplicationRecord
     return if resource.nil? || resource.ext_management_system.nil?
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
+
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,
@@ -361,6 +363,7 @@ class ConversionHost < ApplicationRecord
 
   def disable_conversion_host_role(miq_task_id = nil)
     return if resource.nil? || resource.ext_management_system.nil?
+
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_disable.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -330,6 +330,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def check_conversion_host_role(miq_task_id = nil)
+    return if resource.nil? || resource.ext_management_system.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,
@@ -342,6 +343,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, tls_ca_certs = nil, miq_task_id = nil)
+    return if resource.nil? || resource.ext_management_system.nil?
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml"
@@ -358,6 +360,7 @@ class ConversionHost < ApplicationRecord
   end
 
   def disable_conversion_host_role(miq_task_id = nil)
+    return if resource.nil? || resource.ext_management_system.nil?
     playbook = "/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_disable.yml"
     extra_vars = {
       :v2v_host_type        => resource.ext_management_system.emstype,

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -185,6 +185,18 @@ RSpec.describe ConversionHost, :v2v do
       let(:package_url) { 'http://file.example.com/vddk-stable.tar.gz' }
       let(:enable_playbook) { '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_enable.yml' }
 
+      it "check_conversion_host_role doesn't call ansible_playbook if resource is absent" do
+        allow(conversion_host).to receive(:resource).and_return(nil)
+        expect(conversion_host).not_to receive(:ansible_playbook)
+        conversion_host.check_conversion_host_role(1)
+      end
+
+      it "check_conversion_host_role doesn't call ansible_playbook if resource is archived" do
+        allow(conversion_host.resource).to receive(:ext_management_system).and_return(nil)
+        expect(conversion_host).not_to receive(:ansible_playbook)
+        conversion_host.check_conversion_host_role(1)
+      end
+
       it "check_conversion_host_role calls ansible_playbook with extra_vars" do
         check_playbook = '/usr/share/v2v-conversion-host-ansible/playbooks/conversion_host_check.yml'
         check_extra_vars = {
@@ -193,6 +205,18 @@ RSpec.describe ConversionHost, :v2v do
         }
         expect(conversion_host).to receive(:ansible_playbook).with(check_playbook, check_extra_vars, 1)
         conversion_host.check_conversion_host_role(1)
+      end
+
+      it "disable_conversion_host_role doesn't call ansible_playbook if resource is absent" do
+        allow(conversion_host).to receive(:resource).and_return(nil)
+        expect(conversion_host).not_to receive(:ansible_playbook)
+        conversion_host.disable_conversion_host_role(1)
+      end
+
+      it "disable_conversion_host_role doesn't call ansible_playbook if resource is archived" do
+        allow(conversion_host.resource).to receive(:ext_management_system).and_return(nil)
+        expect(conversion_host).not_to receive(:ansible_playbook)
+        conversion_host.disable_conversion_host_role(1)
       end
 
       it "disable_conversion_host_role calls ansible_playbook with extra_vars" do
@@ -206,6 +230,18 @@ RSpec.describe ConversionHost, :v2v do
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(disable_playbook, disable_extra_vars, 1)
         expect(conversion_host).to receive(:ansible_playbook).once.ordered.with(check_playbook, check_extra_vars, 1)
         conversion_host.disable_conversion_host_role(1)
+      end
+
+      it "enable_conversion_host_role doesn't call ansible_playbook if resource is absent" do
+        allow(conversion_host).to receive(:resource).and_return(nil)
+        expect(conversion_host).not_to receive(:ansible_playbook)
+        conversion_host.enable_conversion_host_role(1)
+      end
+
+      it "enable_conversion_host_role doesn't call ansible_playbook if resource is archived" do
+        allow(conversion_host.resource).to receive(:ext_management_system).and_return(nil)
+        expect(conversion_host).not_to receive(:ansible_playbook)
+        conversion_host.enable_conversion_host_role(1)
       end
 
       it "enable_conversion_host_role raises if vmware_vddk_package_url is nil" do


### PR DESCRIPTION
When the resource associated to a conversion host is nil, running the conversion host playbooks (check, disable, enable) will fail, because the `tag_resource_as_*` method will try to tag a nil object and raise. For the disable method, it has a side effect that the conversion host is not destroyed.

And before trying to tag the resource, it will also try to run the associated Ansible playbook that will also fail and be rescued for nothing.

This pull request checks that the resource is present and returns early if it not, avoiding unneeded load and failure, and allowing conversion host destruction. It also returns if the resource is archived as it means the VM / Host doesn't exist in the provider and the playbook will also fail.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1810406