### PR TITLE
[V2V] Add error message in log when preflight check fails

### DIFF
--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -15,7 +15,7 @@ class InfraConversionThrottler
 
         preflight_check = job.migration_task.preflight_check
         if preflight_check[:status] == 'Error'
-          _log.error("Preflight check for #{vm_name} has failed. Discarding.")
+          _log.error("Preflight check for #{vm_name} has failed: #{preflight_check[:message]}. Discarding.")
           job.abort_conversion(preflight_check[:message], 'error')
           next
         end

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
     it 'will abort conversion job if task fails preflight check' do
       allow(task_waiting).to receive(:preflight_check).and_return(:status => 'Error', :message => 'Fake error message')
       expect(job_waiting).to receive(:abort_conversion).with("Fake error message", 'error')
-      expect(described_class._log).to receive(:error).with("Preflight check for #{vm_name} has failed: Fake error message. Discarding.")
+      expect(described_class._log).to receive(:error).with("Preflight check for #{task_waiting.source.name} has failed: Fake error message. Discarding.")
       described_class.start_conversions
     end
 

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe InfraConversionThrottler, :v2v do
     it 'will abort conversion job if task fails preflight check' do
       allow(task_waiting).to receive(:preflight_check).and_return(:status => 'Error', :message => 'Fake error message')
       expect(job_waiting).to receive(:abort_conversion).with("Fake error message", 'error')
+      expect(described_class._log).to receive(:error).with("Preflight check for #{vm_name} has failed: Fake error message. Discarding.")
       described_class.start_conversions
     end
 


### PR DESCRIPTION
Currently, when a migration task preflight check fails, the log message simply states that it fails and that the task is discarded. When troubleshooting, the only way to get the failure reason is to look run the `preflight_check` method on task object in Rails console. Not very user friendly.

This pull request extends the log message to add the failure reason.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1821842