### PR TITLE
Add 'unassign' support for chargeback (label) rate assignments 

### DIFF
--- a/app/models/chargeback_rate.rb
+++ b/app/models/chargeback_rate.rb
@@ -65,6 +65,16 @@ class ChargebackRate < ApplicationRecord
     result
   end
 
+  def self.unassign_rate_assignments(type, cb_rates)
+    validate_rate_type(type)
+
+    cb_rates.each do |rate|
+      rate[:cb_rate].unassign_objects(rate[:object]) if rate.key?(:object)
+      rate[:cb_rate].unassign_tags(*rate[:tag])      if rate.key?(:tag)
+      rate[:cb_rate].unassign_labels(*rate[:label])  if rate.key?(:label)
+    end
+  end
+
   def self.set_assignments(type, cb_rates)
     validate_rate_type(type)
     ChargebackRate.where(:rate_type => type.to_s.capitalize).each(&:remove_all_assigned_tos)

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -77,9 +77,7 @@ module AssignmentMixin
           next
         end
       end
-      name = AssignmentMixin.escape(obj.name)
-      value = AssignmentMixin.escape(obj.value)
-      tag = "#{klass.underscore}/label/managed/#{name}/#{value}"
+      tag = build_label_tag_path(obj, klass)
       tag_add(tag, :ns => namespace)
     end
     reload
@@ -229,6 +227,12 @@ module AssignmentMixin
   end # module ClassMethods
 
   private
+
+  def build_label_tag_path(obj, klass)
+    name = AssignmentMixin.escape(obj.name)
+    value = AssignmentMixin.escape(obj.value)
+    "#{klass.underscore}/label/managed/#{name}/#{value}"
+  end
 
   def build_object_tag_path(obj, klass = nil)
     if obj.kind_of?(ActiveRecord::Base) # obj is a CI

--- a/app/models/mixins/assignment_mixin.rb
+++ b/app/models/mixins/assignment_mixin.rb
@@ -83,6 +83,16 @@ module AssignmentMixin
     reload
   end
 
+  def unassign_labels(objects, klass)
+    objects.to_miq_a.each do |obj|
+      tag = build_label_tag_path(obj, klass)
+      next if tag.nil?
+
+      tag_remove(tag, :ns => namespace)
+    end
+    reload
+  end
+
   def get_assigned_tos
     # Returns: {:objects => [obj, obj, ...], :tags => [[Classification.entry_object, klass], ...]}
     result = {:objects => [], :tags => [], :labels => []}

--- a/spec/models/mixins/assignment_mixin_spec.rb
+++ b/spec/models/mixins/assignment_mixin_spec.rb
@@ -2,6 +2,26 @@ RSpec.describe AssignmentMixin do
   # too ingrained in AR - has many, acts_as_miq_taggable, ...
   let(:test_class) { MiqAlertSet }
 
+  describe "#unassign_rate_assignments" do
+    let(:chargeback_rate) { FactoryBot.create(:chargeback_rate, :rate_type => 'Compute') }
+
+    let(:label_1) { FactoryBot.create(:custom_attribute, :name => "version/1.2/_label-1", :value => "test/1.0.0  rc_2", :section => 'docker_labels') }
+    let(:label_2) { FactoryBot.create(:custom_attribute, :name => "version/1.2/_label-2", :value => "test/1.0.0  rc_3", :section => 'docker_labels') }
+
+    let(:rate_assignment_2) { {:cb_rate => chargeback_rate, :label => [label_1, "container_image"]} }
+    let(:rate_assignment_1) { {:cb_rate => chargeback_rate, :label => [label_2, "container_image"]} }
+
+    it "unassigns labels from chargeback assignments" do
+      ChargebackRate.set_assignments(:compute, [rate_assignment_1, rate_assignment_2])
+
+      expect(chargeback_rate.assigned_to.map { |x| x[:label][0].id }).to match_array([label_1.id, label_2.id])
+
+      ChargebackRate.unassign_rate_assignments(:compute, [rate_assignment_1])
+
+      expect(chargeback_rate.assigned_to.map { |x| x[:label][0].id }).to match_array([label_1.id])
+    end
+  end
+
   describe '#get_assigned_for_target' do
     context 'searching for ChargebackRate' do
       let(:test_class) { ChargebackRate }


### PR DESCRIPTION
require:
- [x] https://github.com/ManageIQ/manageiq/pull/20136 

It is needed for https://github.com/ManageIQ/manageiq-api/pull/824

PR adds support unassing label from rate assignments
and method common  rate assignments.

@miq-bot add_label jansa/yes?, chargeback
@miq-bot assign @gtanzillo 

