### PR TITLE
Add the Resource's EMS uid_ems to the metrics payload

### DIFF
--- a/app/models/metric/ci_mixin/processing.rb
+++ b/app/models/metric/ci_mixin/processing.rb
@@ -207,6 +207,7 @@ module Metric::CiMixin::Processing
       resource = metric.delete(:resource)
 
       metric[:parent_ems_type] = resource.ext_management_system&.class&.ems_type
+      metric[:parent_ems_uid]  = resource.ext_management_system&.uid_ems
 
       metric[:resource_type] = resource.class.base_class.name
       metric[:resource_id]   = resource.id


### PR DESCRIPTION
To allow for unique identification of managed resources without using VMDB IDs we should include the resource's ext_management_system.uid_ems which is a unique reference of the provider (if available), this combined with the resource_uid (resource.ems_ref) allows for truly global uniqueness.