### PR TITLE
nix the string interpolation on the hardware query in the aggregation mixin

### DIFF
--- a/app/models/container_project.rb
+++ b/app/models/container_project.rb
@@ -73,6 +73,7 @@ class ContainerProject < ApplicationRecord
 
   # required by aggregate_hardware
   alias all_computer_system_ids computer_system_ids
+  alias all_computer_systems    computer_systems
 
   def aggregate_memory(targets = nil)
     aggregate_hardware(:computer_systems, :memory_mb, targets)

--- a/app/models/mixins/aggregation_mixin/methods.rb
+++ b/app/models/mixins/aggregation_mixin/methods.rb
@@ -41,10 +41,8 @@ module AggregationMixin
     def aggregate_hardware(from, field, targets = nil)
       from      = from.to_s.singularize
       select    = field == :aggregate_cpu_speed ? "cpu_total_cores, cpu_speed" : field
-      targets ||= send("all_#{from}_ids")
-      targets   = targets.collect(&:id) unless targets.first.kind_of?(Integer)
-      hdws      = Hardware.where("#{from}_id".to_sym => targets).select(select)
-
+      targets ||= send("all_#{from.pluralize}")
+      hdws      = Hardware.where(from.singularize => targets).select(select)
       hdws.inject(0) { |t, hdw| t + hdw.send(field).to_i }
     end
 

--- a/spec/models/mixins/aggregation_mixin_spec.rb
+++ b/spec/models/mixins/aggregation_mixin_spec.rb
@@ -112,6 +112,13 @@ RSpec.describe AggregationMixin do
     end
   end
 
+  describe "aggregate_hardware" do
+    it "calculates from hosts" do
+      cluster = cluster_2_1_host(hardware_args)
+      expect(cluster.aggregate_hardware("host", :aggregate_cpu_speed)).to eq(cpu_speed * 2)
+    end
+  end
+
   private
 
   def cluster_2_1_host(hardware_args)


### PR DESCRIPTION
It's just a minor cleanup from https://github.com/ManageIQ/manageiq/pull/20132 cause I was silly and didn't catch it the first time. 

Or rather it was. I'm stealing a lot of this now from https://github.com/ManageIQ/manageiq/compare/master...kbrock:virtual_aggregates_ems

thanks Keenan
