### PR TITLE
Skip showback models for full-refresh tests

### DIFF
--- a/spec/support/ems_refresh_helper.rb
+++ b/spec/support/ems_refresh_helper.rb
@@ -3,7 +3,7 @@ module Spec
     module EmsRefreshHelper
       def serialize_inventory
         # These models don't have tables behind them
-        skip_models = [MiqRegionRemote, VmdbDatabaseConnection, VmdbDatabaseLock, VmdbDatabaseSetting]
+        skip_models = [MiqRegionRemote, VmdbDatabaseConnection, VmdbDatabaseLock, VmdbDatabaseSetting, ManageIQ::Showback::DataRollup, ManageIQ::Showback::DataView, ManageIQ::Showback::Rate]
         models = ApplicationRecord.subclasses - skip_models
 
         # Skip attributes that always change between refreshes


### PR DESCRIPTION
I'm not entirely sure what is going on, but this spec is failing on jansa and not master on a model with no data in it with the following error:
```
  1) ManageIQ::Providers::Openshift::ContainerManager::Refresher Targeted refresh doesn't impact unassociated records
     Failure/Error: after_full_refresh = serialize_inventory
     
     ActiveRecord::AttributeMethods::Serialization::ColumnNotSerializableError:
       Column `data` of type ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Jsonb does not support `serialize` feature.
       Usually it means that you are trying to use `serialize`
       on a column that already implements serialization natively.
```

Just calling `ManageIQ::Showback::DataView.all` will raise this error

https://travis-ci.com/github/ManageIQ/manageiq-providers-openshift/jobs/330997162#L1933-L1951