### PR TITLE
Replace old MiqSshUtil with manageiq-ssh-util

### DIFF
--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -1,4 +1,4 @@
-require "MiqSshUtil"
+require 'manageiq-ssh-util'
 
 RSpec.describe ConversionHost, :v2v do
   let(:apst) { FactoryBot.create(:service_template_ansible_playbook) }


### PR DESCRIPTION
Minor fix. This should have been updated as part of https://github.com/ManageIQ/manageiq/pull/19843.