### PR TITLE
Fixed: parameter type for  Sys::ProcTable.ps() when checking if cockpit process alive

### DIFF
--- a/app/models/miq_cockpit_ws_worker/runner.rb
+++ b/app/models/miq_cockpit_ws_worker/runner.rb
@@ -128,7 +128,8 @@ class MiqCockpitWsWorker::Runner < MiqWorker::Runner
 
   def process_alive?(pid)
     return false if pid.nil?
-    process_struct = Sys::ProcTable.ps(:pid => pid)
+    process_struct = Sys::ProcTable.ps(pid)
+    _log.info("#{log_prefix} process_struct:  #{process_struct}")
     return false if process_struct.nil?
     return true if process_struct.state != "Z"
 


### PR DESCRIPTION
Fixed parameter type in  ```Sys::ProcTable.ps``` invocation from named to "regular"

**BEFORE:**
```
[----] E, [2020-05-08T11:26:32.277801 #12161:2b14f456a5c0] ERROR -- : MIQ(MiqCockpitWsWorker::Runner) ID [1000000000241] PID [12161] GUID [c613f92d-aada-498a-8e39-058cc7393a56] An error has occurred during work processing: TypeError
/opt/rh/cfme-gemset/gems/sys-proctable-1.1.5-universal-linux/lib/linux/sys/proctable.rb:112:in `ps'
/var/www/miq/vmdb/app/models/miq_cockpit_ws_worker/runner.rb:131:in `process_alive?'
/var/www/miq/vmdb/app/models/miq_cockpit_ws_worker/runner.rb:121:in `cockpit_ws_alive?'

```

**AFTER:**
```
[----] I, [2020-05-11T13:00:03.810130 #2495:2ab0b00d65c0]  INFO -- : MIQ(MiqCockpitWsWorker::Runner#process_alive?) MIQ(MiqCockpitWsWorker::Runner) process_struct:  #<struct Struct::ProcTableStruct cmdline="/usr/libexec/cockpit-ws --port 9002 --address 127.0.0.1 --no-tls", cwd="/var/www/miq/vmdb", environ={"XDG_CONFIG_DIRS"=>"/var/www/miq/vmdb/config", "DRB_URI"=>"drbunix:///tmp/cockpit20200511-2495-yng7qc"}, exe="/usr/libexec/cockpit-ws", fd={"0"=>"pipe:[1509646]", "1"=>"pipe:[1509648]", "2"=>"pipe:[1509648]", "3"=>"pipe:[1509647]", "4"=>"anon_inode:[eventfd]", "5"=>"socket:[1509658]", "6"=>"anon_inode:[eventfd]"}, root="/", pid=2558, comm="cockpit-ws", state=“S”…
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1834288

@miq-bot add-label bug