### PR TITLE
Extract ddf_traverse into a module and implement attribute extraction

### DIFF
--- a/app/models/mixins/verify_credentials_mixin.rb
+++ b/app/models/mixins/verify_credentials_mixin.rb
@@ -60,21 +60,11 @@ module VerifyCredentialsMixin
     # Ensure that any passwords are encrypted before putting them onto the queue for any
     # DDF fields which are a password type
     def encrypt_verify_credential_params!(options)
-      ddf_traverse(params_for_create) do |field|
+      DDF.traverse(params_for_create) do |field|
         key_path = field[:name].try(:split, '.')
         if options.key_path?(key_path) && field[:type] == 'password'
           options.store_path(key_path, MiqPassword.try_encrypt(options.fetch_path(key_path)))
         end
-      end
-    end
-
-    def ddf_traverse(structure, &block)
-      recure = ->(item) { ddf_traverse(item, &block) }
-      if structure.kind_of?(Array)
-        structure.each(&recure)
-      elsif structure.kind_of?(Hash)
-        yield(structure)
-        structure.try(:[], :fields).try(:each, &recure)
       end
     end
   end

--- a/lib/ddf.rb
+++ b/lib/ddf.rb
@@ -1,0 +1,21 @@
+module DDF
+  def self.traverse(schema, &block)
+    recurse = ->(item) { traverse(item, &block) }
+
+    if schema.kind_of?(Array)
+      schema.each(&recurse)
+    elsif schema.kind_of?(Hash)
+      yield(schema)
+      schema.try(:[], :fields).try(:each, &recurse)
+    end
+  end
+
+  def self.extract_attributes(schema, attribute)
+    arr = []
+    traverse(schema) do |item|
+      arr.push(item[attribute])
+    end
+
+    arr.compact.uniq
+  end
+end


### PR DESCRIPTION
I moved out the `ddf_traverse` method from `VerifyCredentialsMixin` as it might be used elsewhere. I also implemented an `extract_attributes` method that allows us to extract a specific attribute (e.g. name) from each field in a DDF schema. 

Parent issue: https://github.com/ManageIQ/manageiq/issues/18818

@miq-bot add_label cleanup, enhancement
@miq-bot add_reviewer @agrare 
@miq-bot add_reviewer @Fryguy 