### PR TITLE
Revert v2v warm migration and UCI changes

### DIFF
--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -283,7 +283,7 @@ class ConversionHost < ApplicationRecord
   # Kill a specific remote process over ssh, sending the specified +signal+, or 'TERM'
   # if no signal is specified.
   #
-  def kill_virtv2v(task_id, signal = 'TERM')
+  def kill_virtv2v(task_id, signal)
     command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :s, signal, "virt-v2v"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -159,50 +159,14 @@ class ConversionHost < ApplicationRecord
   # @raise [Net::SSH::HostKeyMismatch] if conversion host key has changed
   # @raise [JSON::GeneratorError] if limits hash can't be converted to JSON
   # @raise [StandardError] if any other problem happens
-  def apply_task_limits(task_id, limits = {})
-    connect_ssh do |ssu|
-      ssu.put_file("/tmp/#{task_id}-limits.json", limits.to_json)
-      command = AwesomeSpawn.build_command_line("mv", ["/tmp/#{task_id}-limits.json", "/var/lib/uci/#{task_id}/limits.json"])
-      ssu.shell_exec(command, nil, nil, nil)
-    end
+  def apply_task_limits(path, limits = {})
+    connect_ssh { |ssu| ssu.put_file(path, limits.to_json) }
   rescue Net::SSH::AuthenticationFailed, Net::SSH::HostKeyMismatch => err
-    raise "Failed to connect and apply limits for task '#{task_id}' with [#{err.class}: #{err}]"
+    raise "Failed to connect and apply limits in file '#{path}' with [#{err.class}: #{err}]"
   rescue JSON::GeneratorError => err
     raise "Could not generate JSON from limits '#{limits}' with [#{err.class}: #{err}]"
   rescue => err
-    raise "Could not apply the limits for task '#{task_id}' on '#{resource.name}' with [#{err.class}: #{err}]"
-  end
-
-  # Prepare the conversion assets for a specific task.
-  #
-  # @param [Integer] id of the task that needs the preparation
-  # @param [Hash] conversion options to write on the conversion host
-  #
-  # @return [Integer] length of data written to conversion options file
-  #
-  # @raise [Net::SSH::AuthenticationFailed] if conversion host credentials are invalid
-  # @raise [Net::SSH::HostKeyMismatch] if conversion host key has changed
-  # @raise [JSON::GeneratorError] if limits hash can't be converted to JSON
-  # @raise [StandardError] if any other problem happens
-  def prepare_conversion(task_id, conversion_options)
-    filtered_options = filter_options(conversion_options)
-
-    connect_ssh do |ssu|
-      # Prepare the conversion folders
-      command = AwesomeSpawn.build_command_line("mkdir", [:p, "/var/lib/uci/#{task_id}", "/var/log/uci/#{task_id}"])
-      ssu.shell_exec(command, nil, nil, nil)
-
-      # Write the conversion options file
-      ssu.put_file("/tmp/#{task_id}-input.json", conversion_options.to_json)
-      command = AwesomeSpawn.build_command_line("mv", ["/tmp/#{task_id}-input.json", "/var/lib/uci/#{task_id}/input.json"])
-      ssu.shell_exec(command, nil, nil, nil)
-    end
-  rescue Net::SSH::AuthenticationFailed, Net::SSH::HostKeyMismatch => err
-    raise "Failed to connect and prepare conversion for task '#{task_id}' with [#{err.class}: #{err}]"
-  rescue JSON::GeneratorError => err
-    raise "Could not generate JSON for task '#{task_id}' from options '#{filtered_options}' with [#{err.class}: #{err}]"
-  rescue => err
-    raise "Preparation of conversion for task '#{task_id}' failed on '#{resource.name}' with [#{err.class}: #{err}]"
+    raise "Could not apply the limits in file '#{path}' on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
   # Checks that LUKS keys vault exists and is valid JSON
@@ -225,36 +189,6 @@ class ConversionHost < ApplicationRecord
     false
   end
 
-  # Build the podman command to execute conversion
-  #
-  # @param [Integer] id of the task that conversion applies to
-  #
-  # @return [String] podman command to be executed on conversion host
-  def build_podman_command(task_id, conversion_options)
-    uci_settings = Settings.transformation.uci.container
-    uci_image = uci_settings.image
-    uci_image = "#{uci_settings.registry}/#{image}" if uci_settings.registry.present?
-
-    params = [
-      "run",
-      :detach,
-      :privileged,
-      [:name,    "conversion-#{task_id}"],
-      [:network, "host"],
-      [:volume,  "/dev:/dev"],
-      [:volume,  "/etc/pki/ca-trust:/etc/pki/ca-trust"],
-      [:volume,  "/var/tmp:/var/tmp"],
-      [:volume,  "/var/lib/uci/#{task_id}:/var/lib/uci"],
-      [:volume,  "/var/log/uci/#{task_id}:/var/log/uci"],
-      [:volume,  "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"]
-    ]
-    params << [:volume, "/root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"] if conversion_options[:transport_method] == 'ssh'
-    params << [:volume, "/root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"] if luks_keys_vault_valid?
-    params << uci_image
-
-    AwesomeSpawn.build_command_line("/usr/bin/podman", params)
-  end
-
   # Run the virt-v2v-wrapper script on the remote host and return a hash
   # result from the parsed JSON output.
   #
@@ -262,18 +196,21 @@ class ConversionHost < ApplicationRecord
   # that information from showing up in the UI or logs.
   #
   # @param [Integer] id of the task that conversion applies to
-  def run_conversion(task_id, conversion_options)
+  def run_conversion(conversion_options)
     filtered_options = filter_options(conversion_options)
-    prepare_conversion(task_id, conversion_options)
-    connect_ssh { |ssu| ssu.shell_exec(build_podman_command(task_id, conversion_options), nil, nil, nil) }
+    command = AwesomeSpawn.build_command_line("/usr/bin/virt-v2v-wrapper")
+    result = connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, conversion_options.to_json) }
+    JSON.parse(result)
   rescue Net::SSH::AuthenticationFailed, Net::SSH::HostKeyMismatch => err
     raise "Failed to connect and run conversion using options #{filtered_options} with [#{err.class}: #{err}]"
+  rescue JSON::ParserError
+    raise "Could not parse result data after running virt-v2v-wrapper using options: #{filtered_options}. Result was: #{result}"
   rescue => err
-    raise "Starting conversion for task '#{task_id}' failed on '#{resource.name}' with [#{err.class}: #{err}]"
+    raise "Starting conversion failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
-  def create_cutover_file(task_id)
-    command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/cutover"])
+  def create_cutover_file(path)
+    command = AwesomeSpawn.build_command_line("touch", [path])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true
   rescue
@@ -283,8 +220,8 @@ class ConversionHost < ApplicationRecord
   # Kill a specific remote process over ssh, sending the specified +signal+, or 'TERM'
   # if no signal is specified.
   #
-  def kill_virtv2v(task_id, signal)
-    command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :s, signal, "virt-v2v"])
+  def kill_virtv2v(pid, signal = 'TERM')
+    command = AwesomeSpawn.build_command_line("/bin/kill", [:s, signal, pid])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true
   rescue
@@ -294,15 +231,15 @@ class ConversionHost < ApplicationRecord
   # Retrieve the conversion state information from a remote file as a stream.
   # Then parse and return the stream data as a hash using JSON.parse.
   #
-  def get_conversion_state(task_id)
-    json_state = connect_ssh { |ssu| ssu.get_file("/var/lib/uci/#{task_id}/state.json", nil) }
+  def get_conversion_state(path)
+    json_state = connect_ssh { |ssu| ssu.get_file(path, nil) }
     JSON.parse(json_state)
   rescue Net::SSH::AuthenticationFailed, Net::SSH::HostKeyMismatch => err
-    raise "Failed to connect and retrieve conversion state data from file '/var/lib/uci/#{task_id}/state.json' with [#{err.class}: #{err}]"
+    raise "Failed to connect and retrieve conversion state data from file '#{path}' with [#{err.class}: #{err}]"
   rescue JSON::ParserError
-    raise "Could not parse conversion state data from file '/var/lib/uci/#{task_id}/state.json': #{json_state}"
+    raise "Could not parse conversion state data from file '#{path}': #{json_state}"
   rescue => err
-    raise "Error retrieving and parsing conversion state file '/var/lib/uci/#{task_id}/state.json' from '#{resource.name}' with [#{err.class}: #{err}"
+    raise "Error retrieving and parsing conversion state file '#{path}' from '#{resource.name}' with [#{err.class}: #{err}"
   end
 
   # Get and return the contents of the remote conversion log at +path+.

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -233,7 +233,7 @@ class ConversionHost < ApplicationRecord
   def build_podman_command(task_id, conversion_options)
     uci_settings = Settings.transformation.uci.container
     uci_image = uci_settings.image
-    uci_image = "#{uci_settings.registry}/#{uci_image}" if uci_settings.registry.present?
+    uci_image = "#{uci_settings.registry}/#{image}" if uci_settings.registry.present?
 
     params = [
       "run",

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -246,8 +246,8 @@ class ConversionHost < ApplicationRecord
       [:volume,  "/var/tmp:/var/tmp"],
       [:volume,  "/var/lib/uci/#{task_id}:/var/lib/uci"],
       [:volume,  "/var/log/uci/#{task_id}:/var/log/uci"],
+      [:volume,  "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"]
     ]
-    params << [:volume, "/opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"] unless conversion_options[:transport_method] == 'ssh'
     params << [:volume, "/root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"] if conversion_options[:transport_method] == 'ssh'
     params << [:volume, "/root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"] if luks_keys_vault_valid?
     params << uci_image

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -280,14 +280,6 @@ class ConversionHost < ApplicationRecord
     false
   end
 
-  def delete_pause_disks_precopy_file(task_id)
-    command = AwesomeSpawn.build_command_line("rm", {:f =>["/var/lib/uci/#{task_id}/pause_operations"]})
-    connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
-    true
-  rescue
-    false
-  end
-
   def create_cutover_file(task_id)
     command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/cutover"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -300,7 +300,7 @@ class ConversionHost < ApplicationRecord
   # if no signal is specified.
   #
   def kill_virtv2v(task_id, signal = 'TERM')
-    command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :signal, signal, "virt-v2v"])
+    command = AwesomeSpawn.build_command_line("/usr/bin/podman", ["exec", "conversion-#{task_id}", "/usr/bin/killall", :s, signal, "virt-v2v"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
     true
   rescue

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -272,14 +272,6 @@ class ConversionHost < ApplicationRecord
     raise "Starting conversion for task '#{task_id}' failed on '#{resource.name}' with [#{err.class}: #{err}]"
   end
 
-  def create_pause_disks_precopy_file(task_id)
-    command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/pause_operations"])
-    connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }
-    true
-  rescue
-    false
-  end
-
   def create_cutover_file(task_id)
     command = AwesomeSpawn.build_command_line("touch", ["/var/lib/uci/#{task_id}/cutover"])
     connect_ssh { |ssu| ssu.shell_exec(command, nil, nil, nil) }

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -461,7 +461,7 @@ class ConversionHost < ApplicationRecord
       raise MiqException::MiqInvalidCredentialsError, _("Unknown auth type: %{auth_type}") % {:auth_type => auth.authtype}
     end
 
-    extra_vars.each { |k, v| params << {:extra_vars= => "#{k}='#{v}'"} }
+    params << {:extra_vars => "'#{extra_vars.to_json}'"}
 
     command = AwesomeSpawn.build_command_line("ansible-playbook", params)
     result = AwesomeSpawn.run(command)

--- a/app/models/conversion_host.rb
+++ b/app/models/conversion_host.rb
@@ -264,7 +264,7 @@ class ConversionHost < ApplicationRecord
     tag_resource_as('disabled')
   end
 
-  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, tls_ca_certs = nil, miq_task_id = nil)
+  def enable_conversion_host_role(vmware_vddk_package_url = nil, vmware_ssh_private_key = nil, openstack_tls_ca_certs = nil, miq_task_id = nil)
     return if resource.nil? || resource.ext_management_system.nil?
     raise "vmware_vddk_package_url is mandatory if transformation method is vddk" if vddk_transport_supported && vmware_vddk_package_url.nil?
     raise "vmware_ssh_private_key is mandatory if transformation_method is ssh" if ssh_transport_supported && vmware_ssh_private_key.nil?
@@ -275,7 +275,7 @@ class ConversionHost < ApplicationRecord
       :v2v_transport_method => source_transport_method,
       :v2v_vddk_package_url => vmware_vddk_package_url,
       :v2v_ssh_private_key  => vmware_ssh_private_key,
-      :v2v_ca_bundle        => tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
+      :v2v_ca_bundle        => openstack_tls_ca_certs || resource.ext_management_system.connection_configurations['default'].certificate_authority
     }.compact
     ansible_playbook(playbook, extra_vars, miq_task_id)
   ensure

--- a/app/models/conversion_host/configurations.rb
+++ b/app/models/conversion_host/configurations.rb
@@ -78,7 +78,7 @@ module ConversionHost::Configurations
 
       ssh_key = params.delete(:conversion_host_ssh_private_key)
 
-      tls_ca_certs = params.delete(:tls_ca_certs)
+      openstack_tls_ca_certs = params.delete(:openstack_tls_ca_certs)
 
       new(params).tap do |conversion_host|
         if ssh_key
@@ -90,7 +90,7 @@ module ConversionHost::Configurations
           )
         end
 
-        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, tls_ca_certs, miq_task_id)
+        conversion_host.enable_conversion_host_role(vmware_vddk_package_url, vmware_ssh_private_key, openstack_tls_ca_certs, miq_task_id)
         conversion_host.save!
 
         if miq_task_id

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -502,10 +502,8 @@ class InfraConversionJob < Job
           message = "Converting disk #{converted_disks.length} / #{virtv2v_disks.length} [#{percent.round(2)}%]."
         end
         update_migration_task_progress(:on_retry, :message => message, :percent => percent)
-      else
-        update_migration_task_progress(:on_retry, :message => 'Warm migration in progress')
+        queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
       end
-      queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
     when 'failed'
       raise migration_task.options[:virtv2v_message]
     when 'succeeded'

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -470,12 +470,8 @@ class InfraConversionJob < Job
 
   def transform_vm
     update_migration_task_progress(:on_entry)
-    if migration_task.warm_migration?
-      migration_task.cutover
-      migration_task.unpause_disks_precopy
-    else
-      migration_task.run_conversion
-    end
+    migration_task.run_conversion unless migration_task.warm_migration?
+    migration_task.cutover
     update_migration_task_progress(:on_exit)
     queue_signal(:poll_transform_vm_complete, :deliver_on => Time.now.utc + state_retry_interval)
   rescue => error

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -425,7 +425,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
       :vmware_password      => source.host.authentication_password,
-      :ssh_key_file         => '/var/lib/uci/ssh_private_key',
       :two_phase            => two_phase?,
       :warm                 => false,
       :daemonize            => false

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -66,8 +66,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     raise 'OSP destination and source power_state is off' if destination_ems.emstype == 'openstack' && source.power_state == 'off'
     update_options(
       :source_vm_power_state => source.power_state, # This will determine power_state of destination_vm
-      :source_vm_ipaddresses => source.ipaddresses, # This will determine if we need to wait for ip addresses to appear
-      :two_phase             => two_phase?          # This will help the UI to know how to display the data
+      :source_vm_ipaddresses => source.ipaddresses  # This will determine if we need to wait for ip addresses to appear
     )
     destination_cluster
     preflight_check_vm_exists_in_destination
@@ -97,10 +96,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     unless destination_ems.vms_and_templates.where(:name => source.name, :cloud_tenant => destination_cluster).count.zero?
       raise "A VM named '#{source.name}' already exist in destination cloud tenant"
     end
-  end
-
-  def two_phase?
-    source.snapshots.empty?
   end
 
   def source_cluster
@@ -276,7 +271,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     updates[:virtv2v_message] = virtv2v_state['last_message']['message'] if virtv2v_state['last_message'].present?
     if virtv2v_state['finished'].nil?
       updates[:virtv2v_status] = virtv2v_state['status'] == 'Paused' ? 'paused' : 'active'
-      if two_phase?
+      if warm_migration?
         updated_disks = virtv2v_state['disks']
       else
         updated_disks.each do |disk|
@@ -302,7 +297,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
   rescue
     failures = options[:get_conversion_state_failures] || 0
     update_options(:get_conversion_state_failures => failures + 1)
-    raise "Failed to get conversion state 20 times in a row" if options[:get_conversion_state_failures] > 20
+    raise "Failed to get conversion state 5 times in a row" if options[:get_conversion_state_failures] > 5
   ensure
     _log.info("InfraConversionJob get_conversion_state to update_options: #{updates}")
     update_options(updates)
@@ -405,7 +400,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :query    => { :no_verify => 1 }.to_query
       ).to_s,
       :vmware_password      => source.host.authentication_password,
-      :two_phase            => two_phase?,
+      :two_phase            => warm_migration?,
       :warm                 => warm_migration?,
       :daemonize            => false
     }
@@ -413,20 +408,15 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
 
   def conversion_options_source_provider_vmwarews_ssh(storage)
     {
-      :vm_name              => source.name,
-      :vm_uuid              => source.uid_ems,
-      :conversion_host_uuid => conversion_host_resource_ref(conversion_host.resource),
-      :transport_method     => 'ssh',
-      :vmware_fingerprint   => source.host.thumbprint_sha1,
-      :vmware_uri           => URI::Generic.build(
+      :vm_name              => URI::Generic.build(
         :scheme   => 'ssh',
         :userinfo => 'root',
         :host     => source.host.miq_custom_get('TransformationIPAddress') || source.host.ipaddress,
         :path     => "/vmfs/volumes/#{Addressable::URI.escape(storage.name)}/#{Addressable::URI.escape(source.location)}"
       ).to_s,
-      :vmware_password      => source.host.authentication_password,
-      :two_phase            => two_phase?,
-      :warm                 => false,
+      :vm_uuid              => source.uid_ems,
+      :conversion_host_uuid => conversion_host_resource_ref(conversion_host.resource),
+      :transport_method     => 'ssh',
       :daemonize            => false
     }
   end

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -371,7 +371,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
         :query    => { :no_verify => 1 }.to_query
       ).to_s,
       :vmware_password      => source.host.authentication_password,
-      :two_phase            => warm_migration?,
+      :two_phase            => true,
       :warm                 => warm_migration?,
       :daemonize            => false
     }

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -292,7 +292,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
   end
 
-  def kill_virtv2v(signal = 'TERM')
+  def kill_virtv2v
     get_conversion_state
 
     unless virtv2v_running?
@@ -301,7 +301,7 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
 
     _log.info("Killing conversion pod for task '#{id}'.")
-    conversion_host.kill_virtv2v(id, signal)
+    conversion_host.kill_virtv2v(id)
   rescue => err
     _log.error("Couldn't kill conversion pod for task '#{id}': #{err.message}")
     update_options(:virtv2v_finished_on => Time.now.utc.strftime('%Y-%m-%d %H:%M:%S'))

--- a/app/models/service_template_transformation_plan_task.rb
+++ b/app/models/service_template_transformation_plan_task.rb
@@ -309,12 +309,6 @@ class ServiceTemplateTransformationPlanTask < ServiceTemplateProvisionTask
     end
   end
 
-  def unpause_disks_precopy
-    unless conversion_host.delete_pause_disks_precopy_file(id)
-      raise _("Couldn't delete disks precopy pause file for #{source.name} on #{conversion_host.name}")
-    end
-  end
-
   def cutover
     unless conversion_host.create_cutover_file(id)
       raise _("Couldn't create cutover file for #{source.name} on #{conversion_host.name}")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1047,10 +1047,6 @@
     :max_concurrent_tasks_per_conversion_host: 10
     :cpu_limit_per_host: unlimited
     :network_limit_per_host: unlimited
-  :uci:
-    :container:
-      :registry:
-      :image: manageiq/v2v-conversion-host:latest
 :ui:
   :mark_translated_strings: false
   :url:

--- a/lib/infra_conversion_throttler.rb
+++ b/lib/infra_conversion_throttler.rb
@@ -97,13 +97,14 @@ class InfraConversionThrottler
       jobs.each do |job|
         migration_task = job.migration_task
         next unless migration_task.virtv2v_running?
+        next unless migration_task.options.fetch_path(:virtv2v_wrapper, 'throttling_file')
 
         limits = {
           :cpu     => cpu_limit,
           :network => network_limit
         }
         unless migration_task.options[:virtv2v_limits] == limits
-          ch.apply_task_limits(migration_task.id, limits)
+          ch.apply_task_limits(migration_task.options.fetch_path(:virtv2v_wrapper, 'throttling_file'), limits)
           migration_task.update_options(:virtv2v_limits => limits)
         end
       end

--- a/spec/lib/infra_conversion_throttler_spec.rb
+++ b/spec/lib/infra_conversion_throttler_spec.rb
@@ -120,12 +120,18 @@ RSpec.describe InfraConversionThrottler, :v2v do
       }
       task_running_1.update_options(
         :virtv2v_started_on => Time.now.utc,
-        :virtv2v_wrapper    => {'state_file' => "/var/lib/uci/#{task_running_1.id}/state.json"}
+        :virtv2v_wrapper    => {
+          'state_file'      => "/tmp/state_1.json",
+          'throttling_file' => '/tmp/throttling_1.json'
+        }
       )
-      task_running_2.options[:virtv2v_started_on] = Time.now.utc
-      task_running_2.options[:virtv2v_wrapper] = {'state_file' => "/var/lib/uci/#{task_running_2.id}/state.json"}
-      expect(conversion_host).to receive(:apply_task_limits).with(task_running_1.id, limits)
-      expect(conversion_host).not_to receive(:apply_task_limits).with(task_running_2.id, limits)
+      task_running_2.update_options(
+        :virtv2v_started_on => Time.now.utc,
+        :virtv2v_wrapper    => {
+          'state_file'      => "/tmp/state_2.json"
+        }
+      )
+      expect(conversion_host).to receive(:apply_task_limits).with('/tmp/throttling_1.json', limits)
       described_class.apply_limits
       expect(task_running_1.reload.options[:virtv2v_limits]).to eq(limits)
       expect(task_running_2.reload.options[:virtv2v_limits]).to be_nil

--- a/spec/models/conversion_host_spec.rb
+++ b/spec/models/conversion_host_spec.rb
@@ -602,6 +602,7 @@ RSpec.describe ConversionHost, :v2v do
         " --volume /var/tmp:/var/tmp"\
         " --volume /var/lib/uci/#{task.id}:/var/lib/uci"\
         " --volume /var/log/uci/#{task.id}:/var/log/uci"\
+        " --volume /opt/vmware-vix-disklib-distrib:/opt/vmware-vix-disklib-distrib"\
         " --volume /root/.ssh/id_rsa:/var/lib/uci/ssh_private_key"\
         " --volume /root/.v2v_luks_keys_vault.json:/var/lib/uci/luks_keys_vault.json"\
         " manageiq/v2v-conversion-host:latest"

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -581,7 +581,7 @@ RSpec.describe InfraConversionJob, :v2v do
   end
 
   context 'state transitions' do
-    %w[start start_precopying_disks poll_precopying_disks pause_disks_precopy poll_pause_disks_precopy_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine finish abort_job cancel error].each do |signal|
+    %w[start start_precopying_disks poll_precopying_disks wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine finish abort_job cancel error].each do |signal|
       shared_examples_for "allows #{signal} signal" do
         it signal.to_s do
           expect(job).to receive(signal.to_sym)
@@ -590,7 +590,7 @@ RSpec.describe InfraConversionJob, :v2v do
       end
     end
 
-    %w[start start_precopying_disks poll_precopying_disks pause_disks_precopy poll_pause_disks_precopy_complete wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine].each do |signal|
+    %w[start start_precopying_disks poll_precopying_disks wait_for_ip_address run_migration_playbook poll_run_migration_playbook_complete shutdown_vm poll_shutdown_vm_complete transform_vm poll_transform_vm_complete inventory_refresh poll_inventory_refresh_complete apply_right_sizing restore_vm_attributes power_on_vm poll_power_on_vm_complete mark_vm_migrated abort_virtv2v poll_automate_state_machine].each do |signal|
       shared_examples_for "doesn't allow #{signal} signal" do
         it signal.to_s do
           expect { job.signal(signal.to_sym) }.to raise_error(RuntimeError, /#{signal} is not permitted at state #{job.state}/)
@@ -641,8 +641,6 @@ RSpec.describe InfraConversionJob, :v2v do
 
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -664,37 +662,6 @@ RSpec.describe InfraConversionJob, :v2v do
       end
 
       it_behaves_like 'allows poll_precopying_disks signal'
-      it_behaves_like 'allows pause_disks_precopy signal'
-      it_behaves_like 'allows finish signal'
-      it_behaves_like 'allows abort_job signal'
-      it_behaves_like 'allows cancel signal'
-      it_behaves_like 'allows error signal'
-
-      it_behaves_like 'doesn\'t allow start signal'
-      it_behaves_like 'doesn\'t allow start_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
-      it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
-      it_behaves_like 'doesn\'t allow run_migration_playbook signal'
-      it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
-      it_behaves_like 'doesn\'t allow shutdown_vm signal'
-      it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
-      it_behaves_like 'doesn\'t allow transform_vm signal'
-      it_behaves_like 'doesn\'t allow poll_transform_vm_complete signal'
-      it_behaves_like 'doesn\'t allow poll_inventory_refresh_complete signal'
-      it_behaves_like 'doesn\'t allow apply_right_sizing signal'
-      it_behaves_like 'doesn\'t allow restore_vm_attributes signal'
-      it_behaves_like 'doesn\'t allow power_on_vm signal'
-      it_behaves_like 'doesn\'t allow poll_power_on_vm_complete signal'
-      it_behaves_like 'doesn\'t allow mark_vm_migrated signal'
-      it_behaves_like 'doesn\'t allow poll_automate_state_machine signal'
-    end
-
-    context 'pausing_disks_precopy' do
-      before do
-        job.state = 'pausing_disks_precopy'
-      end
-
-      it_behaves_like 'allows poll_pause_disks_precopy_complete signal'
       it_behaves_like 'allows wait_for_ip_address signal'
       it_behaves_like 'allows finish signal'
       it_behaves_like 'allows abort_job signal'
@@ -703,8 +670,6 @@ RSpec.describe InfraConversionJob, :v2v do
 
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -735,8 +700,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
@@ -767,8 +730,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_shutdown_vm_complete signal'
@@ -796,8 +757,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -827,8 +786,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -859,8 +816,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -890,8 +845,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -921,8 +874,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -955,8 +906,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
       it_behaves_like 'doesn\'t allow shutdown_vm signal'
@@ -983,8 +932,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -1014,8 +961,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -1047,8 +992,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -1078,8 +1021,6 @@ RSpec.describe InfraConversionJob, :v2v do
       it_behaves_like 'doesn\'t allow start signal'
       it_behaves_like 'doesn\'t allow start_precopying_disks signal'
       it_behaves_like 'doesn\'t allow poll_precopying_disks signal'
-      it_behaves_like 'doesn\'t allow pause_disks_precopy signal'
-      it_behaves_like 'doesn\'t allow poll_pause_disks_precopy_complete signal'
       it_behaves_like 'doesn\'t allow wait_for_ip_address signal'
       it_behaves_like 'doesn\'t allow run_migration_playbook signal'
       it_behaves_like 'doesn\'t allow poll_run_migration_playbook_complete signal'
@@ -1155,55 +1096,8 @@ RSpec.describe InfraConversionJob, :v2v do
           request.save!
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-          expect(job).to receive(:queue_signal).with(:pause_disks_precopy)
-          job.signal(:poll_precopying_disks)
-        end
-      end
-    end
-
-    context '#pause_disks_precopy' do
-      before do
-        job.state = 'precopying_disks'
-      end
-
-      it 'pause disks precopy' do
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-          expect(job.migration_task).to receive(:pause_disks_precopy)
-          expect(job).to receive(:queue_signal).with(:poll_pause_disks_precopy_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
-          job.signal(:pause_disks_precopy)
-        end
-      end
-    end
-
-    context '#poll_pause_disks_precopy_complete' do
-      before do
-        job.state = 'pausing_disks_precopy'
-        allow(job.migration_task).to receive(:get_conversion_state)
-      end
-
-      it 'abort_conversion when pausing_disks_precopy times out' do
-        job.context[:retries_pausing_disks_precopy] = 8640
-        expect(job).to receive(:abort_conversion).with('Pausing disks precopy timed out', 'error')
-        job.signal(:poll_pause_disks_precopy_complete)
-      end
-
-      it 'retries if disks precopy is not paused' do
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
-          expect(job).to receive(:queue_signal).with(:poll_pause_disks_precopy_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
-          job.signal(:poll_pause_disks_precopy_complete)
-        end
-      end
-
-      it 'exits if disks precopy is paused' do
-        job.migration_task.update_options(:virtv2v_status => 'paused')
-        Timecop.freeze(2019, 2, 6) do
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
-          expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
           expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
-          job.signal(:poll_pause_disks_precopy_complete)
+          job.signal(:poll_precopying_disks)
         end
       end
     end

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1461,6 +1461,7 @@ RSpec.describe InfraConversionJob, :v2v do
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
           expect(job.migration_task).to receive(:run_conversion)
+          expect(job.migration_task).to receive(:cutover)
           expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
           job.signal(:transform_vm)
         end
@@ -1471,7 +1472,6 @@ RSpec.describe InfraConversionJob, :v2v do
         Timecop.freeze(2019, 2, 6) do
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
           expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_exit)
-          expect(job.migration_task).to receive(:unpause_disks_precopy)
           expect(job.migration_task).to receive(:cutover)
           expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
           job.signal(:transform_vm)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1501,7 +1501,6 @@ RSpec.describe InfraConversionJob, :v2v do
 
         it 'returns a message stating conversion has not started' do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
-          allow(job.migration_task).to receive(:two_phase?).and_return(false)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Disk transformation is initializing.', :percent => 1).and_call_original
@@ -1523,9 +1522,9 @@ RSpec.describe InfraConversionJob, :v2v do
           ]
         end
 
-        it "updates message and percentage, and retries if conversion is one-phase and not finished" do
+        it "updates message and percentage, and retries if conversion is cold and not finished" do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
-          allow(job.migration_task).to receive(:two_phase?).and_return(false)
+          allow(job.migration_task).to receive(:warm_migration?).and_return(false)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Converting disk 2 / 2 [43.75%].', :percent => 43.75).and_call_original
@@ -1538,12 +1537,12 @@ RSpec.describe InfraConversionJob, :v2v do
           end
         end
 
-        it "retries if conversion is two-phase and not finished" do
+        it "retries if conversion is warm and not finished" do
           task.update_options(:virtv2v_status => 'active', :virtv2v_disks => virtv2v_disks)
           allow(job.migration_task).to receive(:warm_migration?).and_return(true)
           Timecop.freeze(2019, 2, 6) do
             expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry).and_call_original
-            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Converting disks')
+            expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry, :message => 'Warm migration in progress')
             expect(job).to receive(:queue_signal).with(:poll_transform_vm_complete, :deliver_on => Time.now.utc + job.state_retry_interval)
             job.signal(:poll_transform_vm_complete)
           end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -399,18 +399,18 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           )
         end
 
-        it "rescues when conversion_host.get_conversion_state fails less than 20 times" do
+        it "rescues when conversion_host.get_conversion_state fails less than 5 times" do
           task_1.update_options(:get_conversion_state_failures => 2)
           allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
           task_1.get_conversion_state
           expect(task_1.options[:get_conversion_state_failures]).to eq(3)
         end
 
-        it "rescues when conversion_host.get_conversion_state fails more than 20 times" do
-          task_1.update_options(:get_conversion_state_failures => 20)
+        it "rescues when conversion_host.get_conversion_state fails more than 5 times" do
+          task_1.update_options(:get_conversion_state_failures => 5)
           allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
-          expect { task_1.get_conversion_state }.to raise_error("Failed to get conversion state 20 times in a row")
-          expect(task_1.options[:get_conversion_state_failures]).to eq(21)
+          expect { task_1.get_conversion_state }.to raise_error("Failed to get conversion state 5 times in a row")
+          expect(task_1.options[:get_conversion_state_failures]).to eq(6)
         end
 
         it "updates progress when conversion is failed" do
@@ -654,13 +654,10 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name              => src_vm_1.name,
+              :vm_name              => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
-              :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
-              :vmware_uri           => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -669,8 +666,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :network_mappings     => task_1.network_mappings,
               :install_drivers      => true,
               :insecure_connection  => true,
-              :two_phase            => true,
-              :warm                 => false,
               :daemonize            => false
             )
           end
@@ -678,13 +673,10 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           it "generates conversion options hash with host custom IP address" do
             src_host.miq_custom_set('TransformationIPAddress', '192.168.254.1')
             expect(task_1.conversion_options).to eq(
-              :vm_name              => src_vm_1.name,
+              :vm_name              => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vm_uuid              => src_vm_1.uid_ems,
               :conversion_host_uuid => conversion_host.resource.ems_ref,
               :transport_method     => 'ssh',
-              :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
-              :vmware_uri           => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :vmware_password      => 'esx_passwd',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -693,8 +685,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :network_mappings     => task_1.network_mappings,
               :install_drivers      => true,
               :insecure_connection  => true,
-              :two_phase            => true,
-              :warm                 => false,
               :daemonize            => false
             )
           end
@@ -826,13 +816,10 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
           it "generates conversion options hash" do
             expect(task_1.conversion_options).to eq(
-              :vm_name                    => src_vm_1.name,
+              :vm_name                    => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vm_uuid                    => src_vm_1.uid_ems,
               :conversion_host_uuid       => conversion_host.ems_ref,
               :transport_method           => 'ssh',
-              :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
-              :vmware_uri                 => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
-              :vmware_password            => 'esx_passwd',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(
                   :scheme => openstack_ems.security_protocol == 'non-ssl' ? 'http' : 'https',
@@ -853,8 +840,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :osp_security_groups_ids    => [openstack_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings           => task_1.network_mappings,
-              :two_phase                  => true,
-              :warm                       => false,
               :daemonize                  => false
             )
           end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -232,13 +232,13 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       end
 
       it "returns false if if kill command failed" do
-        allow(conversion_host).to receive(:kill_virtv2v).with(task.id, 'KILL').and_return(false)
-        expect(task.kill_virtv2v('KILL')).to eq(false)
+        allow(conversion_host).to receive(:kill_virtv2v).with(task.id).and_return(false)
+        expect(task.kill_virtv2v).to eq(false)
       end
 
       it "returns true if if kill command succeeded" do
-        allow(conversion_host).to receive(:kill_virtv2v).with(task.id, 'KILL').and_return(true)
-        expect(task.kill_virtv2v('KILL')).to eq(true)
+        allow(conversion_host).to receive(:kill_virtv2v).with(task.id).and_return(true)
+        expect(task.kill_virtv2v).to eq(true)
       end
 
       it "considers virt-v2v finished or returns false if an exception occurs" do

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -449,8 +449,8 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
           task_1.get_conversion_state
           expect(task_1.options[:virtv2v_disks]).to eq(
             [
-              {"path" => src_disk_1.filename, "progress" => 100},
-              {"path" => src_disk_2.filename, "progress" => 50}
+              { :path => src_disk_1.filename, :size => src_disk_1.size, :percent => 100, :weight => 50 },
+              { :path => src_disk_2.filename, :size => src_disk_2.size, :percent => 50, :weight => 50 }
             ]
           )
           expect(task_1.options[:virtv2v_status]).to eq('active')

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -231,14 +231,20 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         expect(task.kill_virtv2v).to eq(false)
       end
 
-      it "returns false if if kill command failed" do
-        allow(conversion_host).to receive(:kill_virtv2v).with(task.id).and_return(false)
+      it "returns false if virtv2v_pid is absent" do
+        task.options[:virtv2v_pid] = nil
+        expect(conversion_host).not_to receive(:kill_virtv2v)
         expect(task.kill_virtv2v).to eq(false)
       end
 
+      it "returns false if if kill command failed" do
+        expect(conversion_host).to receive(:kill_virtv2v).with('1234', 'KILL').and_return(false)
+        expect(task.kill_virtv2v('KILL')).to eq(false)
+      end
+
       it "returns true if if kill command succeeded" do
-        allow(conversion_host).to receive(:kill_virtv2v).with(task.id).and_return(true)
-        expect(task.kill_virtv2v).to eq(true)
+        expect(conversion_host).to receive(:kill_virtv2v).with('1234', 'KILL').and_return(true)
+        expect(task.kill_virtv2v('KILL')).to eq(true)
       end
 
       it "considers virt-v2v finished or returns false if an exception occurs" do
@@ -319,17 +325,19 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
       let(:time_now) { Time.now.utc }
       before do
         allow(Time).to receive(:now).and_return(time_now)
-        allow(conversion_host).to receive(:run_conversion).with(task_1.id, task_1.conversion_options)
+        allow(conversion_host).to receive(:run_conversion).with(task_1.conversion_options).and_return(
+          "wrapper_log" => "/tmp/wrapper.log",
+          "v2v_log"     => "/tmp/v2v.log",
+          "state_file"  => "/tmp/v2v.state"
+        )
       end
 
       it "collects the wrapper state hash" do
         task_1.run_conversion
         expect(task_1.options[:virtv2v_wrapper]).to eq(
-          "state_file"      => "/var/lib/uci/#{task_1.id}/state.json",
-          "throttling_file" => "/var/lib/uci/#{task_1.id}/limits.json",
-          "cutover_file"    => "/var/lib/uci/#{task_1.id}/cutover",
-          "v2v_log"         => "/var/log/uci/#{task_1.id}/virt-v2v.log",
-          "wrapper_log"     => "/var/log/uci/#{task_1.id}/virt-v2v-wrapper.log"
+          "wrapper_log" => "/tmp/wrapper.log",
+          "v2v_log"     => "/tmp/v2v.log",
+          "state_file"  => "/tmp/v2v.state"
         )
         expect(task_1.options[:virtv2v_started_on]).to eq(time_now.strftime('%Y-%m-%d %H:%M:%S'))
         expect(task_1.options[:virtv2v_status]).to eq('active')
@@ -401,20 +409,20 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "rescues when conversion_host.get_conversion_state fails less than 5 times" do
           task_1.update_options(:get_conversion_state_failures => 2)
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
+          allow(conversion_host).to receive(:get_conversion_state).with('fake_state').and_raise("Fake error")
           task_1.get_conversion_state
           expect(task_1.options[:get_conversion_state_failures]).to eq(3)
         end
 
         it "rescues when conversion_host.get_conversion_state fails more than 5 times" do
           task_1.update_options(:get_conversion_state_failures => 5)
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_raise("Fake error")
+          allow(conversion_host).to receive(:get_conversion_state).with('fake_state').and_raise("Fake error")
           expect { task_1.get_conversion_state }.to raise_error("Failed to get conversion state 5 times in a row")
           expect(task_1.options[:get_conversion_state_failures]).to eq(6)
         end
 
         it "updates progress when conversion is failed" do
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with('fake_state').and_return(
             "failed"       => true,
             "finished"     => true,
             "started"      => true,
@@ -437,7 +445,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         end
 
         it "updates disks progress" do
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with('fake_state').and_return(
             "started"    => true,
             "disks"      => [
               { "path" => src_disk_1.filename, "progress" => 100.0 },
@@ -457,7 +465,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
         end
 
         it "sets disks progress to 100% when conversion is finished and successful" do
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with('fake_state').and_return(
             "finished"    => true,
             "started"     => true,
             "disks"       => [
@@ -483,7 +491,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
 
         it "sets disks progress to 100% when conversion is finished and successful unless canceling" do
           task_1.canceling
-          allow(conversion_host).to receive(:get_conversion_state).with(task_1.id).and_return(
+          allow(conversion_host).to receive(:get_conversion_state).with('fake_state').and_return(
             "finished"    => true,
             "started"     => true,
             "disks"       => [
@@ -614,8 +622,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :install_drivers      => true,
               :insecure_connection  => true,
               :two_phase            => true,
-              :warm                 => true,
-              :daemonize            => false
+              :warm                 => true
             )
           end
 
@@ -638,8 +645,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :install_drivers      => true,
               :insecure_connection  => true,
               :two_phase            => true,
-              :warm                 => true,
-              :daemonize            => false
+              :warm                 => true
             )
           end
 
@@ -665,8 +671,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :source_disks         => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings     => task_1.network_mappings,
               :install_drivers      => true,
-              :insecure_connection  => true,
-              :daemonize            => false
+              :insecure_connection  => true
             )
           end
 
@@ -684,8 +689,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :source_disks         => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings     => task_1.network_mappings,
               :install_drivers      => true,
-              :insecure_connection  => true,
-              :daemonize            => false
+              :insecure_connection  => true
             )
           end
         end
@@ -802,8 +806,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
               :network_mappings           => task_1.network_mappings,
               :two_phase                  => true,
-              :warm                       => true,
-              :daemonize                  => false
+              :warm                       => true
             )
           end
         end
@@ -839,8 +842,7 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :osp_flavor_id              => openstack_flavor.ems_ref,
               :osp_security_groups_ids    => [openstack_security_group.ems_ref],
               :source_disks               => [src_disk_1.filename, src_disk_2.filename],
-              :network_mappings           => task_1.network_mappings,
-              :daemonize                  => false
+              :network_mappings           => task_1.network_mappings
             )
           end
         end

--- a/spec/models/service_template_transformation_plan_task_spec.rb
+++ b/spec/models/service_template_transformation_plan_task_spec.rb
@@ -661,7 +661,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password      => 'esx_passwd',
-              :ssh_key_file         => '/var/lib/uci/ssh_private_key',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -686,7 +685,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_fingerprint   => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri           => "ssh://root@192.168.254.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password      => 'esx_passwd',
-              :ssh_key_file         => '/var/lib/uci/ssh_private_key',
               :rhv_url              => "https://#{redhat_ems.hostname}/ovirt-engine/api",
               :rhv_cluster          => redhat_cluster.name,
               :rhv_storage          => redhat_storages.first.name,
@@ -835,7 +833,6 @@ RSpec.describe ServiceTemplateTransformationPlanTask, :v2v do
               :vmware_fingerprint         => '01:23:45:67:89:ab:cd:ef:01:23:45:67:89:ab:cd:ef:01:23:45:67',
               :vmware_uri                 => "ssh://root@10.0.0.1/vmfs/volumes/stockage%20r%C3%A9cent/#{src_vm_1.location}",
               :vmware_password            => 'esx_passwd',
-              :ssh_key_file               => '/var/lib/uci/ssh_private_key',
               :osp_environment            => {
                 :os_auth_url             => URI::Generic.build(
                   :scheme => openstack_ems.security_protocol == 'non-ssl' ? 'http' : 'https',


### PR DESCRIPTION
Going through BZs and reverting PRs for warm migration and UCI image support for v2v as discussed with @Fryguy and @fdupont-redhat.

Will un-WIP when all PRs are added to this PR, confirmed by @fdupont-redhat and Travis is green.

Related PR:
https://github.com/ManageIQ/manageiq-v2v/pull/1133
https://github.com/ManageIQ/manageiq-appliance-build/pull/418