### PR TITLE
update rest-client to 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.2.4"
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=12.3.3",      :require => false
-gem "rest-client",                    "~>2.0.0",       :require => false
+gem "rest-client",                    "~>2.1.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false
 gem "ruby-progressbar",               "~>1.7.0",       :require => false
 gem "rubyzip",                        "~>2.0.0",       :require => false


### PR DESCRIPTION
azure-armrest new cut needs this, and https://github.com/ManageIQ/manageiq-api-client/pull/90/files needs azure-armrest with 2.1, you can see all the failures on https://github.com/ManageIQ/manageiq-api-client/pull/90/files

@agrare this one's for you 