### PR TITLE
Add ems_uid and ems_type to event payload

### DIFF
--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -130,7 +130,10 @@ RSpec.describe EmsEvent do
             :service => "manageiq.ems-events",
             :sender  => ems.id,
             :event   => event_hash[:event_type],
-            :payload => event_hash,
+            :payload => event_hash.merge(
+              :ems_type => ems.class.ems_type,
+              :ems_uid  => ems.uid_ems
+            )
           }
 
           expect(messaging_client).to receive(:publish_topic).with(expected_queue_payload)
@@ -150,7 +153,10 @@ RSpec.describe EmsEvent do
             :service => "manageiq.ems-events",
             :sender  => ems.id,
             :event   => event_hash[:event_type],
-            :payload => event_hash,
+            :payload => event_hash.merge(
+              :ems_type => ems.class.ems_type,
+              :ems_uid  => ems.uid_ems
+            )
           }
 
           expect(messaging_client).to receive(:publish_topic).with(expected_queue_payload)


### PR DESCRIPTION
The Event payload already containes the ems_id, we can add the ems_type and ems_uid to assist in identifying the source provider without having to hit the MIQ API.

Followup to: https://github.com/ManageIQ/manageiq/pull/19984

Fixes https://github.com/ManageIQ/manageiq/issues/20178