### PR TITLE
[JANSA] Renamed provider_foreman to configuration_manager

### DIFF
--- a/app/models/aliases/ems_configuration.rb
+++ b/app/models/aliases/ems_configuration.rb
@@ -1,0 +1,1 @@
+::EmsConfiguration = ::ManageIQ::Providers::ConfigurationManager

--- a/app/models/configured_system.rb
+++ b/app/models/configured_system.rb
@@ -46,6 +46,7 @@ class ConfiguredSystem < ApplicationRecord
   scope :with_manager,                  ->(manager_id) { where(:manager_id => manager_id) }
   scope :with_configuration_profile_id, ->(profile_id) { where(:configuration_profile_id => profile_id) }
   scope :without_configuration_profile_id,          -> { where(:configuration_profile_id => nil) }
+  scope :under_configuration_managers, -> { where(:manager => ManageIQ::Providers::ConfigurationManager.all) }
 
   def configuration_architecture
     tag_hash[ConfigurationArchitecture]

--- a/db/fixtures/miq_product_features.yml
+++ b/db/fixtures/miq_product_features.yml
@@ -4628,107 +4628,94 @@
     :feature_type: view
     :identifier: physical_infra_overview_view
 
-# Foreman
-- :name: Configuration Management
-  :description: Everything under Configuration Management
+# Configuration Managers
+- :name: Configuration Managers
+  :description: Everything under Configuration Manager Providers
   :feature_type: node
-  :identifier: provider_foreman_explorer
+  :identifier: ems_configuration
   :children:
-  - :name: Providers
-    :description: Everything under Providers accordion
-    :feature_type: node
-    :identifier: providers_accord
+  - :name: View
+    :description: View Configuration Manager Providers
+    :feature_type: view
+    :identifier: ems_configuration_view
     :children:
-    - :name: View
-      :description: View Providers, Configuration Profiles, Configured Systems
+    - :name: List
+      :description: Display Lists of Configuration Manager Providers
       :feature_type: view
-      :identifier: provider_foreman_view
-    - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
+      :identifier: ems_configuration_show_list
+    - :name: Show
+      :description: Display Individual Configuration Manager Provider
+      :feature_type: view
+      :identifier: ems_configuration_show
+  - :name: Operate
+    :description: Perform Operations on Configuration Manager Providers and Configured Systems
+    :feature_type: control
+    :identifier: ems_configuration_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Tags of Configuration Manager Provider
       :feature_type: control
-      :identifier: provider_foreman_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Tags of Foreman Provider
-        :feature_type: control
-        :identifier: configuration_manager_provider_tag
-      - :name: Provision Configured Systems
-        :description: Provision Configured Systems
-        :feature_type: control
-        :identifier: provider_foreman_configured_system_provision
-      - :name: Refresh Providers
-        :description: Refresh relationships for all items related of Provider
-        :feature_type: control
-        :identifier: provider_foreman_refresh_provider
-    - :name: Modify
-      :description: Modify Providers
+      :identifier: ems_configuration_tag
+    - :name: Refresh Configuration Manager Providers
+      :description: Refresh relationships for all items related to Configuration Manager Provider
+      :feature_type: control
+      :identifier: ems_configuration_refresh_provider
+  - :name: Modify
+    :description: Modify Configuration Manager Providers
+    :feature_type: admin
+    :identifier: ems_configuration_admin
+    :children:
+    - :name: Remove Configuration Manager Providers
+      :description: Remove Configuration Manager Provider
       :feature_type: admin
-      :identifier: provider_admin
+      :identifier: configuration_manager_admin
       :children:
-      - :name: Remove Providers
-        :description: Remove Provier
+      - :name: Remove Configuration Manager Providers
+        :description: Remove Configuration Manager Provider
         :feature_type: admin
-        :identifier: provider_foreman_delete_provider
-      - :name: Edit Provider
-        :description: Edit a Provider
+        :identifier: configuration_manager_delete_provider
+      - :name: Edit Configuration Manager Provider
+        :description: Edit a Configuration Manager Provider
         :feature_type: admin
-        :identifier: provider_foreman_edit_provider
+        :identifier: configuration_manager_edit_provider
       - :name: Pause
-        :description: Pause a Provider
+        :description: Pause a Configuration Manager Provider
         :feature_type: admin
-        :identifier: provider_foreman_pause
+        :identifier: configuration_manager_pause
       - :name: Resume
-        :description: Resume a Provider
+        :description: Resume a Configuration Manager Provider
         :feature_type: admin
-        :identifier: provider_foreman_resume
-      - :name: Add Provider
-        :description: Add a Provider
+        :identifier: configuration_manager_resume
+      - :name: Add Configuration Manager Provider
+        :description: Add a Configuration Manager Provider
         :feature_type: admin
-        :identifier: provider_foreman_add_provider
+        :identifier: configuration_manager_add_provider
   - :name: Configured Systems
-    :description: Everything under Configured Systems accordion
+    :description: Everything under Configured Systems
     :feature_type: node
-    :identifier: configured_systems_filter_accord
+    :identifier: configured_system
     :children:
     - :name: View
       :description: View Configured Systems
       :feature_type: view
-      :identifier: configured_systems_filter_accord_view
-    - :name: Operate
-      :description: Perform Operations on Configured Systems
-      :feature_type: control
-      :identifier: configuredsystem_control
-      :children:
-      - :name: Edit Tags
-        :description: Edit Configured Systems Tags
-        :feature_type: control
-        :identifier: configured_system_tag
-      - :name: Provision Configured Systems
-        :description: Provision Configured Systems
-        :feature_type: control
-        :identifier: configured_system_provision
-  - :name: Ansible Tower Job Templates
-    :description: Everything under Ansible Tower Job Templates accordion
-    :feature_type: node
-    :identifier: configuration_scripts_accord
-    :children:
-    - :name: View
-      :description: View Ansible Tower Job Templates
+      :identifier: configured_system_show_list
+    - :name: Show
+      :description: Display Individual Configured System
       :feature_type: view
-      :identifier: configuration_script_view
-    - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
+      :identifier: configured_system_show
+  - :name: Operate
+    :description: Perform Operations on Configured Systems
+    :feature_type: control
+    :identifier: configured_system_control
+    :children:
+    - :name: Edit Tags
+      :description: Edit Configured Systems Tags
       :feature_type: control
-      :identifier: configuration_script_control
-      :children:
-      - :name: Create Service Dialog
-        :description: Create Service Dialog
-        :feature_type: admin
-        :identifier: configscript_service_dialog
-      - :name: Edit Tags
-        :description: Edit Job Templates Tags
-        :feature_type: control
-        :identifier: configuration_script_tag
+      :identifier: configured_system_tag
+    - :name: Provision Configured Systems
+      :description: Provision Configured Systems
+      :feature_type: control
+      :identifier: configured_system_provision
 
 # Embedded Automation Manager
 - :name: Embedded Automation Manager
@@ -4894,8 +4881,8 @@
     :feature_type: node
     :identifier: automation_manager_configured_system
     :children:
-    - :name: View
-      :description: View Configured Systems
+    - :name: List
+      :description: Display Lists of Configured Systems
       :feature_type: view
       :identifier: automation_manager_configured_system_view
     - :name: Operate
@@ -4907,17 +4894,17 @@
         :description: Edit Configured Systems Tags
         :feature_type: control
         :identifier: automation_manager_configured_system_tag
-  - :name: Automation Scripts
-    :description: Everything under Automation Scripts accordion
+  - :name: Templates
+    :description: Everything under Templates accordion
     :feature_type: node
     :identifier: automation_manager_configuration_scripts_accord
     :children:
     - :name: View
-      :description: View Automation Scripts
+      :description: View Templates
       :feature_type: view
       :identifier: automation_manager_configuration_script_view
     - :name: Operate
-      :description: Perform Operations on Providers and Configured Systems
+      :description: Perform Operations on Templates
       :feature_type: control
       :identifier: automation_manager_configuration_script_control
       :children:
@@ -6305,19 +6292,6 @@
   :feature_type: node
   :identifier: api_exclusive
   :children:
-  - :name: Configured Systems
-    :description: Everything under Configured Systems
-    :feature_type: node
-    :identifier: configured_systems
-    :children:
-    - :name: View
-      :description: View Configured Systems
-      :feature_type: view
-      :identifier: configured_system_view
-    - :name: Operate
-      :description: Perform Operations on Configured Systems
-      :feature_type: control
-      :identifier: configured_system_control
   # Pictures
   - :name: Pictures
     :description: Everything under Pictures

--- a/db/fixtures/miq_shortcuts.yml
+++ b/db/fixtures/miq_shortcuts.yml
@@ -294,10 +294,20 @@
   :url: /migration/#settings
   :rbac_feature_name: migration_settings
   :startup: true
-- :name: configuration_management
-  :description: Configuration / Management
-  :url: provider_foreman/explorer
-  :rbac_feature_name: provider_foreman_explorer
+- :name: ems_configuration
+  :description: Configuration / Providers
+  :url: ems_configuration/show_list
+  :rbac_feature_name: ems_configuration_show_list
+  :startup: true
+- :name: configuration_profile
+  :description: Configuration / Profiles
+  :url: configuration_profile/show_list
+  :rbac_feature_name: configuration_profile_show_list
+  :startup: true
+- :name: configured_system
+  :description: Configured / Systems
+  :url: configured_system/show_list
+  :rbac_feature_name: configured_system_show_list
   :startup: true
 - :name: ems_networks
   :description: Networks / Providers

--- a/db/fixtures/miq_user_roles.yml
+++ b/db/fixtures/miq_user_roles.yml
@@ -35,6 +35,9 @@
   - container_dashboard
   - ems_container
   - configuration_job
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - container_project
   - container_route
   - container_service
@@ -74,7 +77,6 @@
   - physical_storage
   - physical_infra_topology
   - policy_import_export
-  - provider_foreman_explorer
   - pxe
   - resource_pool
   - rss
@@ -287,6 +289,9 @@
   - about
   - all_vm_rules
   - automation_manager
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - dashboard
   - ems_physical_infra
   - event_streams
@@ -315,7 +320,6 @@
   - physical_switch_view
   - physical_server_view
   - physical_storage_view
-  - provider_foreman_explorer
   - vm_clone
   - vm_compare
   - vm_cloud_explorer
@@ -361,6 +365,9 @@
   - embedded_automation_manager
   - chargeback
   - chargeback_reports
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - dashboard
   - ems_cluster_compare
   - ems_cluster_drift
@@ -431,7 +438,6 @@
   - resource_pool_tag
   - rss
   - service_view
-  - provider_foreman_explorer
   - storage_delete
   - storage_scan
   - storage_show
@@ -884,6 +890,9 @@
   - embedded_automation_manager
   - ems_physical_infra_console
   - catalog_items_view
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - miq_task_my_ui
   - miq_template_clone
   - miq_template_drift
@@ -899,7 +908,6 @@
   - my_settings_visuals
   - miq_request_admin
   - miq_request_view
-  - provider_foreman_explorer
   - service_edit
   - service_delete
   - service_reconfigure
@@ -941,6 +949,9 @@
   - about
   - all_vm_rules
   - automation_manager
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - embedded_automation_manager
   - miq_task_my_ui
   - miq_request_admin
@@ -957,7 +968,6 @@
   - miq_template_timeline
   - my_settings_default_views
   - my_settings_visuals
-  - provider_foreman_explorer
   - vm_check_compliance
   - vm_clone
   - vm_cloud_explorer
@@ -1016,6 +1026,9 @@
   - chargeback
   - catalog
   - cloud_tenant
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - control_explorer
   - dashboard
   - storage
@@ -1042,7 +1055,6 @@
   - miq_template
   - orchestration_stack
   - policy_import_export
-  - provider_foreman_explorer
   - pxe
   - rbac_group
   - rbac_role_view
@@ -1074,6 +1086,9 @@
   - chargeback
   - catalog
   - cloud_tenant
+  - ems_configuration
+  - configuration_profile
+  - configured_system
   - control_explorer
   - dashboard
   - storage
@@ -1097,7 +1112,6 @@
   - miq_template
   - orchestration_stack
   - policy_import_export
-  - provider_foreman_explorer
   - pxe
   - rbac_tenant_view
   - rbac_tenant_manage_quotas
@@ -1291,7 +1305,7 @@
   - physical_server_view
   - physical_storage_view
   - policy_log
-  - provider_foreman_view
+  - ems_configuration_view
   - pxe_image_type_view
   - pxe_server_view
   - rbac_group_view

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1007,6 +1007,8 @@ en:
       ems_clouds:                  Cloud Providers
       ems_cluster:                 Cluster
       ems_clusters:                Clusters
+      ems_configuration:           Configuration Manager
+      ems_configurations:          Configuration Managers
       ems_custom_attribute:        VC Custom Attribute
       ems_custom_attributes:       VC Custom Attributes
       ems_event:                   Management Event


### PR DESCRIPTION
Renamed provider_foreman specific features, links etc to configuration_manager
Jansa specific PR for backport of https://github.com/ManageIQ/manageiq/pull/19949
