### PR TITLE
Use manageiq-style for both rubocop dependency and config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,9 @@
----
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -28,7 +27,7 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: 'rubocop-0-69'
+    channel: rubocop-0-82
 exclude_patterns:
 - config/dictionary_strings.rb
 - config/model_attributes.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+inherit_gem:
+  manageiq-style: ".rubocop_base.yml"
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
-- .rubocop_local.yml
+- ".rubocop_local.yml"

--- a/.rubocop_cc.yml
+++ b/.rubocop_cc.yml
@@ -1,4 +1,4 @@
 inherit_from:
-- .rubocop_base.yml
-- .rubocop_cc_base.yml
-- .rubocop_local.yml
+- ".rubocop_base.yml"
+- ".rubocop_cc_base.yml"
+- ".rubocop_local.yml"

--- a/Gemfile
+++ b/Gemfile
@@ -250,7 +250,7 @@ unless ENV["APPLIANCE"]
   group :development do
     gem "foreman"
     gem "PoParser"
-    gem "rubocop-performance", "~>1.3",    :require => false
+    gem "manageiq-style",               :require => false
     # ruby_parser is required for i18n string extraction
     gem "ruby_parser",                     :require => false
     gem "yard"

--- a/lib/generators/manageiq/plugin/templates/%plugin_name%.gemspec
+++ b/lib/generators/manageiq/plugin/templates/%plugin_name%.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"
 end

--- a/lib/generators/manageiq/plugin/templates/.codeclimate.yml
+++ b/lib/generators/manageiq/plugin/templates/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/ManageIQ/manageiq-style/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:
@@ -28,7 +28,7 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: 'rubocop-0-69'
+    channel: rubocop-0-82
 exclude_patterns:
 - node_modules/
 - spec/

--- a/lib/generators/manageiq/plugin/templates/.rubocop.yml
+++ b/lib/generators/manageiq/plugin/templates/.rubocop.yml
@@ -1,3 +1,4 @@
+inherit_gem:
+  manageiq-style: ".rubocop_base.yml"
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
-- .rubocop_local.yml
+- ".rubocop_local.yml"

--- a/lib/generators/manageiq/plugin/templates/.rubocop_cc.yml
+++ b/lib/generators/manageiq/plugin/templates/.rubocop_cc.yml
@@ -1,4 +1,4 @@
 inherit_from:
-- .rubocop_base.yml
-- .rubocop_cc_base.yml
-- .rubocop_local.yml
+- ".rubocop_base.yml"
+- ".rubocop_cc_base.yml"
+- ".rubocop_local.yml"


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/miq_bot/pull/506

Keeping these files in sync across several repos is a lot of work.  This should make upgrading much easier since the config and the dependency can be updated in the same PR.

WIP because I'd like to:
- [x] Transfer repo ownership
- [x] Push v1.0.0 to rubygems.org