### PR TITLE
Allow string in name of method for allocated_metrics in ChargebackReport

### DIFF
--- a/app/models/chargeback/report_options.rb
+++ b/app/models/chargeback/report_options.rb
@@ -42,7 +42,7 @@ class Chargeback
     ALLOCATED_METHODS_WHITELIST = %i(max avg current_value).freeze
 
     def method_for_allocated_metrics
-      method = self[:method_for_allocated_metrics] || :max
+      method = (self[:method_for_allocated_metrics] || :max).to_sym
 
       unless ALLOCATED_METHODS_WHITELIST.include?(method)
         raise "Invalid method for allocated calculations #{method}"

--- a/spec/models/chargeback_vm_spec.rb
+++ b/spec/models/chargeback_vm_spec.rb
@@ -454,7 +454,7 @@ RSpec.describe ChargebackVm do
           :interval_size                => 12,
           :end_interval_offset          => 1,
           :tenant_id                    => tenant_1.id,
-          :method_for_allocated_metrics => :max,
+          :method_for_allocated_metrics => 'max',
           :include_metrics              => true,
           :groupby                      => "tenant",
         }


### PR DESCRIPTION
`MiqReport#db_options` is hash with settings for report.

This PR allows to have name of method for allocated_metrics(MiqReport#db_options[:method_for_allocated_metrics]`) as string(not just symbol) - this can happen when chargeback report is created by api.

@miq-bot assign @gtanzillo 

@miq-bot add_label chargeback, bug, jansa/yes
