### PR TITLE
[WIP] Cache Domain names for automate

### DIFF
--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -1,6 +1,7 @@
 class MiqAeClass < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
+  include RelativePathMixin
 
   belongs_to :ae_namespace, :class_name => "MiqAeNamespace", :foreign_key => :namespace_id
   belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
@@ -94,9 +95,6 @@ class MiqAeClass < ApplicationRecord
     end
   end
 
-  def fqname
-    ["", domain&.name, relative_path].compact.join("/")
-  end
 
   # my class's fqname is /domain/namespace1/namespace2/class
   def namespace

--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -47,7 +47,7 @@ class MiqAeClass < ApplicationRecord
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_namespace_id_and_name => :lookup_by_namespace_id_and_name)
 
   def self.lookup_by_name(name)
-    where(["lower(name) = ?", name.downcase]).includes([:ae_methods, :ae_fields]).first
+    find_by(:lower_name => name.downcase)
   end
 
   singleton_class.send(:alias_method, :find_by_name, :lookup_by_name)

--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -40,7 +40,7 @@ class MiqAeClass < ApplicationRecord
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_namespace_and_name => :lookup_by_namespace_and_name)
 
   def self.lookup_by_namespace_id_and_name(ns_id, name)
-    where(:namespace_id => ns_id).where(["lower(name) = ?", name.downcase]).first
+    where(:namespace_id => ns_id).find_by(:lower_name => name.downcase)
   end
 
   singleton_class.send(:alias_method, :find_by_namespace_id_and_name, :lookup_by_namespace_id_and_name)

--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -80,7 +80,7 @@ class MiqAeInstance < ApplicationRecord
 
     query = where(arel_table[:relative_path].lower.matches(str.downcase, nil, true)) # This uses 'like'.
 
-    domain_id = query.joins(:domain).order("miq_ae_namespaces.priority DESC").limit(1).pluck(:domain_id)
+    domain_id = query.joins(:domain).order("miq_ae_namespaces.priority DESC").limit(1).pluck(:domain_id) ### fix?
     query.where(:domain_id => domain_id)
   end
 
@@ -145,11 +145,10 @@ class MiqAeInstance < ApplicationRecord
     n_('Automate Instance', 'Automate Instances', number)
   end
 
-  def self.find_best_match_by(user, relative_path)
-    domain_ids = user.current_tenant.enabled_domains
+  def self.find_best_match_by(domain_ids, relative_path)
     joins(:domain).where(:miq_ae_namespaces => {:id => domain_ids})
                   .order("miq_ae_namespaces.priority DESC")
-                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase))
+                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase, nil, true))
   end
 
   def self.get_homonymic_across_domains(user, fqname, enabled = nil, prefix: true)

--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -15,7 +15,7 @@ class MiqAeInstance < ApplicationRecord
                                  :message => N_("may contain only alphanumeric and _ . - characters")
 
   def self.lookup_by_name(name)
-    where("lower(name) = ?", name.downcase).first
+    find_by(:lower_name => name.downcase)
   end
 
   singleton_class.send(:alias_method, :find_by_name, :lookup_by_name)

--- a/app/models/miq_ae_instance.rb
+++ b/app/models/miq_ae_instance.rb
@@ -1,6 +1,7 @@
 class MiqAeInstance < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
+  include RelativePathMixin
 
   belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
   belongs_to :ae_class,  -> { includes(:ae_fields) }, :class_name => "MiqAeClass", :foreign_key => :class_id
@@ -62,10 +63,6 @@ class MiqAeInstance < ApplicationRecord
       result[f.name] = get_field_value(f, false)
     end
     result
-  end
-
-  def fqname
-    ["", domain&.name, relative_path].compact.join("/")
   end
 
   # my instance's fqname is /domain/namespace1/namespace2/class/instance

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -3,6 +3,8 @@ require 'manageiq/automation_engine/syntax_checker'
 class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
+  include RelativePathMixin
+
   default_value_for(:embedded_methods) { [] }
   validates :embedded_methods, :exclusion => { :in => [nil] }
   serialize :options, Hash
@@ -46,10 +48,6 @@ class MiqAeMethod < ApplicationRecord
     result = ManageIQ::AutomationEngine::SyntaxChecker.check(code_text)
     return nil if result.valid?
     [[result.error_line, result.error_text]] # Array of arrays for future multi-line support
-  end
-
-  def fqname
-    ["", domain&.name, relative_path].compact.join("/")
   end
 
   # my method's fqname is /domain/namespace1/namespace2/class/method

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -129,7 +129,7 @@ class MiqAeMethod < ApplicationRecord
   end
 
   def self.lookup_by_class_id_and_name(class_id, name)
-    ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(name)
+    ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(name.downcase, nil, true)
     ::MiqAeMethod.where(ae_method_filter).where(:class_id => class_id).first
   end
 
@@ -140,11 +140,10 @@ class MiqAeMethod < ApplicationRecord
     n_('Automate Method', 'Automate Methods', number)
   end
 
-  def self.find_best_match_by(user, relative_path)
-    domain_ids = user.current_tenant.enabled_domains
+  def self.find_best_match_by(domain_ids, relative_path)
     joins(:domain).where(:miq_ae_namespaces => {:id => domain_ids})
                   .order("miq_ae_namespaces.priority DESC")
-                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase))
+                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase, nil, true))
   end
 
   private

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -63,7 +63,7 @@ class MiqAeNamespace < ApplicationRecord
     end
 
     new_parts.each do |p|
-      found = found ? create(:name => p, :parent => found) : create(:name => p)
+      found = found ? create(:name => p, :parent => found) : MiqAeDomain.create(:name => p)
     end
 
     found

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -13,7 +13,7 @@ class MiqAeNamespace < ApplicationRecord
                          /^last_import_on/, /^source/, /^top_level_namespace/].freeze
 
   belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
-  has_many :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) }, :class_name => "MiqAeClass",
+  has_many :ae_classes, :class_name => "MiqAeClass",
            :foreign_key => :namespace_id, :dependent => :destroy, :inverse_of => :ae_namespace
 
   validates :name,

--- a/app/models/mixins/relative_path_mixin.rb
+++ b/app/models/mixins/relative_path_mixin.rb
@@ -1,0 +1,33 @@
+module RelativePathMixin
+  extend ActiveSupport::Concern
+
+  included do
+    virtual_attribute :lower_name, :string, :arel => ->(t) { t.grouping(t[:name].lower) }
+    virtual_attribute :lower_relative_path, :string, :arel => ->(t) { t.grouping(t[:relative_path].lower) }
+  end
+
+  def fqname
+    ["", domain_name, relative_path].compact.join("/")
+  end
+
+  def lower_name
+    name&.downcase
+  end
+
+  def lower_relative_path
+    rel_path&.downcase
+  end
+
+  def domain_name
+    MiqAeDomain.id_to_name(domain_id)
+  end
+
+  # TODO: after save?
+
+  module ClassMethods
+    def split_fqname(fqname)
+      fqname = fqname[1..-1] if fqname[0] == '/'
+      fqname.split('/')
+    end
+  end
+end

--- a/spec/support/evm_spec_helper.rb
+++ b/spec/support/evm_spec_helper.rb
@@ -40,6 +40,7 @@ module EvmSpecHelper
     clear_instance_variable(MiqProductFeature, :@obj_cache) if defined?(MiqProductFeature)
     clear_instance_variable(BottleneckEvent, :@event_definitions) if defined?(BottleneckEvent)
     clear_instance_variable(Tenant, :@root_tenant) if defined?(Tenant)
+    MiqAeDomain.clear_domain_cache if defined?(MiqAeDomain)
 
     MiqWorker.my_guid = nil
 


### PR DESCRIPTION
Reduce the domain lookups.

Automate has reduced the number of namespace lookups, but it has greatly increased the number of domain name lookups.

- introduces domain name cache
- simplifies lower name/path lookups (performance is the same)

https://github.com/ManageIQ/manageiq-automation_engine/pull/444
https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/127