### PR TITLE
[WIP] Expose conditions and expressions in compliance checks at the resource level

### DIFF
--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -8,6 +8,7 @@ module ComplianceMixin
              :as         => :resource,
              :inverse_of => :resource,
              :class_name => "Compliance"
+    virtual_has_many :last_compliance_conditions, :uses => { :last_compliance => :condition }
 
     virtual_delegate :last_compliance_status,
                      :to        => "last_compliance.compliant",
@@ -18,6 +19,8 @@ module ComplianceMixin
                      :allow_nil => true,
                      :type      => :datetime,
                      :prefix    => true
+
+    virtual_column :last_compliance_condition_expressions, :type => :string_set, :uses => { :last_compliance => :condition }
   end
 
   def check_compliance
@@ -36,5 +39,15 @@ module ComplianceMixin
     target_class = self.class.base_model.name.downcase
     _, plist = MiqPolicy.get_policies_for_target(self, "compliance", "#{target_class}_compliance_check")
     plist
+  end
+
+  def last_compliance_conditions
+    return [] unless last_compliance
+
+    last_compliance.compliance_details.map(&:condition)
+  end
+
+  def last_compliance_condition_expressions
+    last_compliance_conditions.map {|c| c.expression.to_human}
   end
 end

--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -8,7 +8,7 @@ module ComplianceMixin
              :as         => :resource,
              :inverse_of => :resource,
              :class_name => "Compliance"
-    virtual_has_many :last_compliance_conditions, :uses => { :last_compliance => :condition }
+    virtual_has_many :last_compliance_conditions, :uses => { :last_compliance => {:compliance_details => :condition }}
 
     virtual_delegate :last_compliance_status,
                      :to        => "last_compliance.compliant",
@@ -20,7 +20,7 @@ module ComplianceMixin
                      :type      => :datetime,
                      :prefix    => true
 
-    virtual_column :last_compliance_condition_expressions, :type => :string_set, :uses => { :last_compliance => :condition }
+    virtual_column :last_compliance_condition_expressions, :type => :string_set, :uses => { :last_compliance => {:compliance_details => :condition }}
   end
 
   def check_compliance

--- a/spec/factories/compliance.rb
+++ b/spec/factories/compliance.rb
@@ -8,5 +8,19 @@ FactoryBot.define do
     updated_on             { DateTime.current }
     event_type             { 'string' }
     compliance_details     { [] }
+
+    trait :with_details_and_conditions do
+      after(:create) do |x|
+        FactoryBot.create(:compliance_detail,
+                          :condition => FactoryBot.create(:condition),
+                          :compliance => x
+        )
+        FactoryBot.create(:compliance_detail,
+                          :condition => FactoryBot.create(:condition),
+                          :compliance => x
+        )
+      end
+    end
+
   end
 end

--- a/spec/models/mixins/compliance_mixin_spec.rb
+++ b/spec/models/mixins/compliance_mixin_spec.rb
@@ -47,4 +47,46 @@ RSpec.describe ComplianceMixin do
       end
     end
   end
+
+  describe "#last_compliance_conditions" do
+    context "with no compliances" do
+      it "returns an empty list" do
+        expect(host.last_compliance_conditions).to be_empty
+      end
+    end
+
+    context "with compliances" do
+      let(:last_compliance) { FactoryBot.create(:compliance, :with_details_and_conditions, :resource => host, :timestamp => Time.now, :compliant => false) }
+
+      before do
+        compliances
+        last_compliance
+      end
+
+      it "returns an array of condition objects" do
+        expect(host.last_compliance_conditions.length).to eq(2)
+      end
+    end
+  end
+
+  describe "#last_compliance_condition_expressions" do
+    context "with no compliances" do
+      it "returns an empty list" do
+        expect(host.last_compliance_condition_expressions).to be_empty
+      end
+    end
+
+    context "with compliances" do
+      let(:last_compliance) { FactoryBot.create(:compliance, :with_details_and_conditions, :resource => host, :timestamp => Time.now, :compliant => false) }
+
+      before do
+        compliances
+        last_compliance
+      end
+
+      it "returns an array of condition expressions" do
+        expect(host.last_compliance_condition_expressions).to eq(["VM and Instance : Number of CPUs >= 2", "VM and Instance : Number of CPUs >= 2"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding support for including the conditions and expressions that were evaluated in the last compliance check at the resources level so that they can be returned with the response of an API resource at the resource level 

`api/vms/10000000000775?attributes=last_compliance_conditions,last_compliance_condition_expressions`

- [x] Tests

/cc @abellotti 

Solves: https://github.com/ManageIQ/manageiq-api/issues/838
