### PR TITLE
Add a memory and cpu limits on deployments

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -42,14 +42,15 @@ class MiqWorker
     end
 
     def resource_constraints
-      mem_threshold = worker_settings[:memory_threshold]
-      cpu_threshold = worker_settings[:cpu_threshold]
-      {
-        :limits => {
-          :memory => "#{mem_threshold / 1.megabyte}Mi",
-          :cpu    => "#{cpu_threshold}m"
-        }
-      }
+      mem_threshold = self.class.worker_settings[:memory_threshold]
+      cpu_threshold = self.class.worker_settings[:cpu_threshold]
+
+      return {} if mem_threshold.nil? && cpu_threshold.nil?
+
+      {:limits => {}}.tap do |h|
+        h[:limits][:memory] = "#{mem_threshold / 1.megabyte}Mi" if mem_threshold
+        h[:limits][:cpu]    = "#{cpu_threshold}m" if cpu_threshold
+      end
     end
 
     def container_image_namespace

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -21,6 +21,7 @@ class MiqWorker
       container[:image] = container_image
       container[:env] << {:name => "WORKER_CLASS_NAME", :value => self.class.name}
       container[:env] << {:name => "BUNDLER_GROUPS", :value => self.class.bundler_groups.join(",")}
+      container[:resources] = resource_constraints
     end
 
     def scale_deployment
@@ -38,6 +39,15 @@ class MiqWorker
 
     def default_image
       "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
+    end
+
+    def resource_constraints
+      mem_threshold = worker_settings[:memory_threshold]
+      {
+        :limits => {
+          :memory => "#{mem_threshold / 1.megabyte}Mi",
+        }
+      }
     end
 
     def container_image_namespace

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -45,7 +45,7 @@ class MiqWorker
       mem_threshold = self.class.worker_settings[:memory_threshold]
       cpu_threshold = self.class.worker_settings[:cpu_threshold]
 
-      return {} if mem_threshold.nil? && cpu_threshold.nil?
+      return {} if !Settings.server.worker_monitor.enforce_resource_constraints || (mem_threshold.nil? && cpu_threshold.nil?)
 
       {:limits => {}}.tap do |h|
         h[:limits][:memory] = "#{mem_threshold / 1.megabyte}Mi" if mem_threshold

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -43,9 +43,11 @@ class MiqWorker
 
     def resource_constraints
       mem_threshold = worker_settings[:memory_threshold]
+      cpu_threshold = worker_settings[:cpu_threshold]
       {
         :limits => {
           :memory => "#{mem_threshold / 1.megabyte}Mi",
+          :cpu    => "#{cpu_threshold}m"
         }
       }
     end

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -43,13 +43,16 @@ class MiqWorker
 
     def resource_constraints
       mem_threshold = self.class.worker_settings[:memory_threshold]
-      cpu_threshold = self.class.worker_settings[:cpu_threshold]
+      cpu_threshold = self.class.worker_settings[:cpu_threshold_percent]
 
       return {} if !Settings.server.worker_monitor.enforce_resource_constraints || (mem_threshold.nil? && cpu_threshold.nil?)
 
       {:limits => {}}.tap do |h|
         h[:limits][:memory] = "#{mem_threshold / 1.megabyte}Mi" if mem_threshold
-        h[:limits][:cpu]    = "#{cpu_threshold}m" if cpu_threshold
+        if cpu_threshold
+          millicores = ((cpu_threshold / 100.0) * 1000).to_i
+          h[:limits][:cpu] = "#{millicores}m"
+        end
       end
     end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1079,6 +1079,7 @@
   :worker_base:
     :defaults:
       :count: 1
+      :cpu_threshold: 500
       :gc_interval: 15.minutes
       :heartbeat_freq: 10.seconds
       :heartbeat_timeout: 2.minutes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1080,7 +1080,7 @@
   :worker_base:
     :defaults:
       :count: 1
-      :cpu_threshold: 500
+      :cpu_threshold_percent: 50
       :gc_interval: 15.minutes
       :heartbeat_freq: 10.seconds
       :heartbeat_timeout: 2.minutes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -988,6 +988,7 @@
   :worker_messaging_frequency: 5.seconds
   :worker_monitor_frequency: 15.seconds
   :worker_monitor:
+    :enforce_resource_constraints: false
     :kill_algorithm:
       :name: :used_swap_percent_gt_value
       :value: 80

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1117,7 +1117,6 @@
         :poll: 10.seconds
     :queue_worker_base:
       :defaults:
-        :cpu_usage_threshold: 100.percent
         :dequeue_method: :drb
         :memory_threshold: 500.megabytes
         :poll_method: :normal
@@ -1151,7 +1150,6 @@
         :ems_refresh_worker_microsoft: {}
         :ems_refresh_worker_nuage_network: {}
       :event_handler:
-        :cpu_usage_threshold: 0.percent
         :nice_delta: 7
       :generic_worker:
         :count: 2

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       end
 
       it "returns the correct hash when both values are set" do
-        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes, :cpu_threshold => 500)
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes, :cpu_threshold_percent => 50)
         constraints = {
           :limits => {
             :memory => "500Mi",
@@ -165,10 +165,10 @@ RSpec.describe MiqWorker::ContainerCommon do
       end
 
       it "returns only cpu when cpu is set" do
-        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:cpu_threshold => 500)
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:cpu_threshold_percent => 80)
         constraints = {
           :limits => {
-            :cpu => "500m"
+            :cpu => "800m"
           }
         }
         expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
@@ -179,7 +179,7 @@ RSpec.describe MiqWorker::ContainerCommon do
       before { stub_settings(:server => {:worker_monitor => {:enforce_resource_constraints => false}}) }
 
       it "always returns an empty hash" do
-        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes, :cpu_threshold => 500)
+        allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes, :cpu_threshold => 50)
         expect(MiqGenericWorker.new.resource_constraints).to eq({})
       end
     end

--- a/spec/models/miq_worker/container_common_spec.rb
+++ b/spec/models/miq_worker/container_common_spec.rb
@@ -133,4 +133,42 @@ RSpec.describe MiqWorker::ContainerCommon do
       end
     end
   end
+
+  describe "#resource_constraints" do
+    it "returns an empty hash when no thresholds are set" do
+      allow(MiqGenericWorker).to receive(:worker_settings).and_return({})
+      expect(MiqGenericWorker.new.resource_constraints).to eq({})
+    end
+
+    it "returns the correct hash when both values are set" do
+      allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes, :cpu_threshold => 500)
+      constraints = {
+        :limits => {
+          :memory => "500Mi",
+          :cpu    => "500m"
+        }
+      }
+      expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
+    end
+
+    it "returns only memory when memory is set" do
+      allow(MiqGenericWorker).to receive(:worker_settings).and_return(:memory_threshold => 500.megabytes)
+      constraints = {
+        :limits => {
+          :memory => "500Mi",
+        }
+      }
+      expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
+    end
+
+    it "returns only cpu when cpu is set" do
+      allow(MiqGenericWorker).to receive(:worker_settings).and_return(:cpu_threshold => 500)
+      constraints = {
+        :limits => {
+          :cpu => "500m"
+        }
+      }
+      expect(MiqGenericWorker.new.resource_constraints).to eq(constraints)
+    end
+  end
 end


### PR DESCRIPTION
This is based on the worker's memory_threshold setting

Fixes #20163

This really needs to be added to, but I'm not sure where to get the other settings from.
We have something that looks like CPU settings already, but they look either broken or unused as the only values we have are [0](https://github.com/ManageIQ/manageiq/blob/786b234f6040aaac56486ad80b26ef60bf9a8661/config/settings.yml#L1148) or [100](https://github.com/ManageIQ/manageiq/blob/786b234f6040aaac56486ad80b26ef60bf9a8661/config/settings.yml#L1114) percent.

I'm also not sure how to handle requests, these are used for scheduling pods on kubernetes nodes. For the rest of the components in github.com/manageiq/manageiq-pods I don't set a request by default so that the containers will be schedule-able out of the box even on small environments like minikube.

In this repo we would need to expose settings for the requests which would be 0 (or some other flavor of "unset") by default to have similar behavior.