### PR TITLE
Specify what is missing if tag assignment failed

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -99,10 +99,14 @@ class Classification < ApplicationRecord
 
   def self.classify(obj, category_name, entry_name, is_request = true)
     cat = Classification.lookup_by_name(category_name, obj.region_id)
-    unless cat.nil?
-      ent = cat.find_entry_by_name(entry_name, obj.region_id)
-      ent.assign_entry_to(obj, is_request) unless ent.nil? || obj.is_tagged_with?(ent.to_tag, :ns => "none")
-    end
+    raise "Tag category '#{category_name}' not found in region #{obj.region_id}" if cat.nil?
+
+    ent = cat.find_entry_by_name(entry_name, obj.region_id)
+    raise "Tag name '#{entry_name}' not found  in region #{obj.region_id}" if ent.nil?
+
+    raise "Object already tagged with ':ns' set to 'none'" if obj.is_tagged_with?(ent.to_tag, :ns => "none")
+
+    ent.assign_entry_to(obj, is_request)
   end
 
   def self.unclassify(obj, category_name, entry_name, is_request = true)


### PR DESCRIPTION
**ISSUE:**
  if  tag category or tag name misspelled when executing API call to assign tag than return message did not indicate what went wrong

Example: 
```curl --user admin:smartvm -i -X POST -d '{"action":"assign","resources":[{"category":"team","name":"it_pnp"}]}' http://localhost:3000/api/vms/54/tags```
**BEFORE**:
```{"results":[{"success":false,"message":"Assigning Tag: category:'team' name:'it_pnp'",   ...}```
**AFTER:** 
```{"results":[{"success":false,"message":"Tag category 'team' not found in region 0",   ...}```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1792106

