### PR TITLE
add dialog system value

### DIFF
--- a/app/models/dialog.rb
+++ b/app/models/dialog.rb
@@ -4,6 +4,7 @@ class Dialog < ApplicationRecord
   # The following gets around a glob symbolic link issue
   YAML_FILES_PATTERN = "{,*/**/}*.{yaml,yml}".freeze
 
+  default_value_for :system, false
   has_many :dialog_tabs, -> { order(:position) }, :dependent => :destroy
   validate :validate_children
 

--- a/spec/lib/task_helpers/exports/service_dialogs_spec.rb
+++ b/spec/lib/task_helpers/exports/service_dialogs_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe TaskHelpers::Exports::ServiceDialogs do
       "description" => description1,
       "buttons"     => buttons,
       "label"       => label1,
-      "dialog_tabs" => []
+      "dialog_tabs" => [],
+      "system"      => false
     }]
   end
 
@@ -20,6 +21,7 @@ RSpec.describe TaskHelpers::Exports::ServiceDialogs do
       "buttons"     => buttons,
       "label"       => label2,
       "dialog_tabs" => [],
+      "system"      => false
     }]
   end
 

--- a/spec/models/dialog_serializer_spec.rb
+++ b/spec/models/dialog_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe DialogSerializer do
         "description"    => description,
         "buttons"        => buttons,
         "label"          => label,
+        "system"         => false,
         "dialog_tabs"    => %w[serialized_dialog1 serialized_dialog2],
         "export_version" => DialogImportService::CURRENT_DIALOG_VERSION,
       }

--- a/spec/models/dialog_yaml_serializer_spec.rb
+++ b/spec/models/dialog_yaml_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe DialogYamlSerializer do
         "description"    => description,
         "buttons"        => buttons,
         "label"          => label,
+        "system"         => false,
         "dialog_tabs"    => %w[serialized_dialog1 serialized_dialog2],
         "export_version" => DialogImportService::CURRENT_DIALOG_VERSION,
       }


### PR DESCRIPTION
dialogs have a system value now 

https://github.com/ManageIQ/manageiq-schema/pull/471#issuecomment-632167899

add default value for dialog system col
update the export spec

@miq-bot assign @bdunne 
And, Brandon, what seeding logic? 
@miq-bot add_label dialogs, enhancement 

also i expect without this, people are about to start seeing core prs fail. 