### PR TITLE
MiqExpression#contains improvement

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -335,8 +335,8 @@ class MiqExpression
     operator = exp.keys.first
     case operator.downcase
     when "contains"
-      if exp[operator].keys.include?("tag") && exp[operator]["tag"].split(".").length == 2 # Only support for tags of the main model
-        return true
+      if exp[operator].key?("tag")
+        Tag.parse(exp[operator]["tag"]).reflection_supported_by_sql?
       elsif exp[operator].key?("field")
         Field.parse(exp[operator]["field"]).attribute_supported_by_sql?
       else
@@ -1367,8 +1367,8 @@ class MiqExpression
       # Only support for tags of the main model
       if exp[operator].key?("tag")
         tag = Tag.parse(exp[operator]["tag"])
-        ids = tag.model.find_tagged_with(:any => parsed_value, :ns => tag.namespace).pluck(:id)
-        tag.model.arel_attribute(:id).in(ids)
+        ids = tag.target.find_tagged_with(:any => parsed_value, :ns => tag.namespace).pluck(:id)
+        subquery_for_contains(tag, tag.arel_attribute.in(ids))
       else
         subquery_for_contains(field, arel_attribute.eq(parsed_value))
       end

--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -337,14 +337,8 @@ class MiqExpression
     when "contains"
       if exp[operator].keys.include?("tag") && exp[operator]["tag"].split(".").length == 2 # Only support for tags of the main model
         return true
-      elsif exp[operator].keys.include?("field") && exp[operator]["field"].split(".").length == 2
-        db, field = exp[operator]["field"].split(".")
-        assoc, _column = field.split("-")
-        ref = db.constantize.reflect_on_association(assoc.to_sym)
-        return false unless ref
-        return false unless ref.macro == :has_many || ref.macro == :has_one
-        return false if ref.options && ref.options.key?(:as)
-        return field_in_sql?(exp[operator]["field"])
+      elsif exp[operator].key?("field")
+        Field.parse(exp[operator]["field"]).attribute_supported_by_sql?
       else
         return false
       end

--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -64,30 +64,6 @@ class MiqExpression::Field < MiqExpression::Target
     (associations + [column]).join('.')
   end
 
-  # this should only be accessed in MiqExpression
-  # please avoid using it
-  def arel_table
-    if associations.none?
-      model.arel_table
-    else
-      # if the target attribute is in the same table as the model (the base table),
-      # alias the table to avoid conflicting table from clauses
-      # seems AR should do this for us...
-      ref = reflections.last
-      if ref.klass.table_name == model.table_name
-        ref.klass.arel_table.alias(ref.alias_candidate(model.table_name))
-      else
-        ref.klass.arel_table
-      end
-    end
-  end
-
-  # this should only be accessed in MiqExpression
-  # please avoid using it
-  def arel_attribute
-    target.arel_attribute(column, arel_table) if target
-  end
-
   private
 
   def custom_attribute_column_name

--- a/lib/miq_expression/tag.rb
+++ b/lib/miq_expression/tag.rb
@@ -48,6 +48,13 @@ class MiqExpression::Tag < MiqExpression::Target
     "#{@base_namespace}.#{column}"
   end
 
+  # this should only be accessed in MiqExpression
+  # please avoid using it
+  # for tags, the tag tables are joined to the table's id
+  def arel_attribute
+    target&.arel_attribute("id", arel_table)
+  end
+
   private
 
   def tag_path

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -59,6 +59,8 @@ class MiqExpression::Target
 
   def reflection_supported_by_sql?
     model&.follow_associations(associations).present?
+  rescue ArgumentError
+    false
   end
 
   # AR or virtual reflections

--- a/lib/miq_expression/target.rb
+++ b/lib/miq_expression/target.rb
@@ -104,6 +104,30 @@ class MiqExpression::Target
     end
   end
 
+  # this should only be accessed in MiqExpression
+  # please avoid using it
+  def arel_table
+    if associations.none?
+      model.arel_table
+    else
+      # if the target attribute is in the same table as the model (the base table),
+      # alias the table to avoid conflicting table from clauses
+      # seems AR should do this for us...
+      ref = reflections.last
+      if ref.klass.table_name == model.table_name
+        ref.klass.arel_table.alias(ref.alias_candidate(model.table_name))
+      else
+        ref.klass.arel_table
+      end
+    end
+  end
+
+  # this should only be accessed in MiqExpression
+  # please avoid using it
+  def arel_attribute
+    target&.arel_attribute(column, arel_table)
+  end
+
   private
 
   def tag_path

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -142,6 +142,11 @@ RSpec.describe MiqExpression::Field do
       field = described_class.new(Vm, [], "destroy")
       expect(field).not_to be_valid
     end
+
+    it "returns false for non-valid associations" do
+      field = described_class.new(Vm, %w[bogus association], "foo")
+      expect(field).not_to be_valid
+    end
   end
 
   describe "#reflections" do
@@ -299,6 +304,10 @@ RSpec.describe MiqExpression::Field do
 
     it "detects if column is supported by sql through virtual association" do
       expect(MiqExpression::Field.parse("Vm.service-name").attribute_supported_by_sql?).to be_falsey
+    end
+
+    it "returns false if the associations are bogus" do
+      expect(MiqExpression::Field.parse("Vm.bogus.service-name").attribute_supported_by_sql?).to be_falsey
     end
   end
 

--- a/spec/lib/miq_expression/tag_spec.rb
+++ b/spec/lib/miq_expression/tag_spec.rb
@@ -140,25 +140,25 @@ RSpec.describe MiqExpression::Tag do
 
   describe "#column_type" do
     it "is always a string" do
-      expect(described_class.new(Vm, [], "/host").column_type).to eq(:string)
+      expect(described_class.new(Vm, [], "host").column_type).to eq(:string)
     end
   end
 
   describe "#numeric?" do
     it "is never numeric" do
-      expect(described_class.new(Vm, [], "/host")).not_to be_numeric
+      expect(described_class.new(Vm, [], "host")).not_to be_numeric
     end
   end
 
   describe "#sub_type" do
     it "is always a string" do
-      expect(described_class.new(Vm, [], "/host").sub_type).to eq(:string)
+      expect(described_class.new(Vm, [], "host").sub_type).to eq(:string)
     end
   end
 
   describe "#attribute_supported_by_sql?" do
     it "is always false" do
-      expect(described_class.new(Vm, [], "/host")).not_to be_attribute_supported_by_sql
+      expect(described_class.new(Vm, [], "host")).not_to be_attribute_supported_by_sql
     end
   end
 end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -495,24 +495,34 @@ RSpec.describe MiqExpression do
       expect(sql).to eq(expected)
     end
 
-    it "can't generate the SQL for a CONTAINS expression with association.association-field" do
+    it "generates the SQL for a CONTAINS expression with association.association-field" do
       sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.guest_applications.host-name", "value" => "foo"}).to_sql
-      expect(sql).to be_nil
+      rslt = "\"vms\".\"id\" IN (SELECT \"vms\".\"id\" FROM \"vms\" INNER JOIN \"guest_applications\" ON \"guest_applications\".\"vm_or_template_id\" = \"vms\".\"id\" INNER JOIN \"hosts\" ON \"hosts\".\"id\" = \"guest_applications\".\"host_id\" WHERE \"hosts\".\"name\" = 'foo')"
+      expect(sql).to eq(rslt)
     end
 
-    it "can't generate the SQL for a CONTAINS expression with belongs_to field" do
+    it "generates the SQL for a CONTAINS expression with belongs_to field" do
       sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm.host-name", "value" => "foo"}).to_sql
-      expect(sql).to be_nil
+      rslt = "\"vms\".\"id\" IN (SELECT \"vms\".\"id\" FROM \"vms\" INNER JOIN \"hosts\" ON \"hosts\".\"id\" = \"vms\".\"host_id\" WHERE \"hosts\".\"name\" = 'foo')"
+      expect(sql).to eq(rslt)
     end
 
-    it "can't generate the SQL for multi level contains with a scope" do
+    it "generates the SQL for multi level contains with a scope" do
       sql, _ = MiqExpression.new("CONTAINS" => {"field" => "ExtManagementSystem.clustered_hosts.operating_system-name", "value" => "RHEL"}).to_sql
-      expect(sql).to be_nil
+      rslt = "\"ext_management_systems\".\"id\" IN (SELECT \"ext_management_systems\".\"id\" FROM \"ext_management_systems\" " \
+             "INNER JOIN \"hosts\" ON \"hosts\".\"ems_id\" = \"ext_management_systems\".\"id\" AND \"hosts\".\"ems_cluster_id\" IS NOT NULL " \
+             "INNER JOIN \"operating_systems\" ON \"operating_systems\".\"host_id\" = \"hosts\".\"id\" " \
+             "WHERE \"operating_systems\".\"name\" = 'RHEL')"
+      expect(sql).to eq(rslt)
     end
 
-    it "can't generate the SQL for field belongs to 'has_and_belongs_to_many' association" do
+    it "generates the SQL for field belongs to 'has_and_belongs_to_many' association" do
       sql, _ = MiqExpression.new("CONTAINS" => {"field" => "ManageIQ::Providers::InfraManager::Vm.storages-name", "value" => "abc"}).to_sql
-      expect(sql).to be_nil
+      rslt = "\"vms\".\"id\" IN (SELECT \"vms\".\"id\" FROM \"vms\" " \
+             "INNER JOIN \"storages_vms_and_templates\" ON \"storages_vms_and_templates\".\"vm_or_template_id\" = \"vms\".\"id\" " \
+             "INNER JOIN \"storages\" ON \"storages\".\"id\" = \"storages_vms_and_templates\".\"storage_id\" " \
+             "WHERE \"storages\".\"name\" = 'abc')"
+      expect(sql).to eq(rslt)
     end
 
     it "can't generate the SQL for a CONTAINS expression virtualassociation" do
@@ -537,9 +547,9 @@ RSpec.describe MiqExpression do
       expect(sql).to eq(expected)
     end
 
-    it "can't generate the SQL for a CONTAINS in the main table" do
+    it "generates the SQL for a CONTAINS in the main table" do
       sql, * = MiqExpression.new("CONTAINS" => {"field" => "Vm-name", "value" => "foo"}).to_sql
-      expect(sql).to be_nil
+      expect(sql).to eq("\"vms\".\"name\" = 'foo'")
     end
 
     it "generates the SQL for a CONTAINS expression with tag" do
@@ -2979,12 +2989,6 @@ RSpec.describe MiqExpression do
 
         it "returns false if field belongs to virtual_has_many association" do
           field = "ManageIQ::Providers::InfraManager::Vm.processes-type"
-          expression = {"CONTAINS" => {"field" => field, "value" => "abc"}}
-          expect(described_class.new(nil).sql_supports_atom?(expression)).to eq(false)
-        end
-
-        it "returns false if field belongs to 'has_and_belongs_to_many' association" do
-          field = "ManageIQ::Providers::InfraManager::Vm.storages-name"
           expression = {"CONTAINS" => {"field" => field, "value" => "abc"}}
           expect(described_class.new(nil).sql_supports_atom?(expression)).to eq(false)
         end


### PR DESCRIPTION
## Before

- MiqExpression only supports contains value and tags for limited models.
- MiqExpression has a lot of code around determining what contains is supported.

## After

- MiqExpression supports contains values and tags for any models reachable by non-virtual associations.
- MiqExpression now uses `MiqExpression::Target#*_supports_sql?` instead of rewriting that logic.

added 36 lines of tests and 10 lines of comments - so feature for nothing and the code for free :)