### PR TITLE
Enhanced system token authorization to work with OIDC and SAML

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -44,6 +44,12 @@ module Authenticator
       authenticate(userid, "", {}, {:require_user => true, :authorize_only => true})
     end
 
+    def authorize_user_with_system_token(userid, user_metadata = {})
+      return unless user_authorizable_without_authentication? && user_authorizable_with_system_token?
+
+      authenticate(userid, "", {}, {:require_user => true, :authorize_only => true, :authorize_with_system_token => user_metadata})
+    end
+
     def authenticate(username, password, request = nil, options = {})
       options = options.dup
       options[:require_user] ||= false

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -46,6 +46,7 @@ module Authenticator
 
     def authorize_user_with_system_token(userid, user_metadata = {})
       return unless user_authorizable_without_authentication? && user_authorizable_with_system_token?
+      return if userid != user_metadata[:userid]
 
       authenticate(userid, "", {}, {:require_user => true, :authorize_only => true, :authorize_with_system_token => user_metadata})
     end

--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -35,6 +35,10 @@ module Authenticator
       false
     end
 
+    def user_authorizable_with_system_token?
+      false
+    end
+
     def authorize_user(userid)
       return unless user_authorizable_without_authentication?
       authenticate(userid, "", {}, {:require_user => true, :authorize_only => true})

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -132,7 +132,7 @@ module Authenticator
     end
 
     def user_details_from_system_token(username, user_metadata)
-      return if username != user_metadata[:userid]
+      return [{}, []] if username != user_metadata[:userid]
 
       user_attrs = {:username  => user_metadata[:userid],
                     :fullname  => user_metadata[:name],

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -25,6 +25,10 @@ module Authenticator
       true
     end
 
+    def user_authorizable_with_system_token?
+      ext_auth_is_oidc? || ext_auth_is_saml?
+    end
+
     def _authenticate(_username, _password, request)
       request.present? &&
         request.headers['X-REMOTE-USER'].present?
@@ -156,6 +160,16 @@ module Authenticator
       require_dependency "httpd_dbus_api"
 
       HttpdDBusApi.new.user_attrs(username, ATTRS_NEEDED)
+    end
+
+    def ext_auth_is_oidc?
+      auth_config = Settings.authentication
+      auth_config.mode == "httpd" && auth_config.oidc_enabled && auth_config.provider_type == "oidc"
+    end
+
+    def ext_auth_is_saml?
+      auth_config = Settings.authentication
+      auth_config.mode == "httpd" && auth_config.saml_enabled && auth_config.provider_type == "saml"
     end
   end
 end

--- a/app/models/miq_region.rb
+++ b/app/models/miq_region.rb
@@ -256,9 +256,10 @@ class MiqRegion < ApplicationRecord
 
   def api_system_auth_token(userid)
     token_hash = {
-      :server_guid => remote_ws_miq_server.guid,
-      :userid      => userid,
-      :timestamp   => Time.now.utc
+      :server_guid   => remote_ws_miq_server.guid,
+      :userid        => userid,
+      :timestamp     => Time.now.utc,
+      :user_metadata => User.metadata_for_system_token(userid)
     }
     ManageIQ::Password.encrypt(token_hash.to_yaml)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,10 +223,9 @@ class User < ApplicationRecord
   end
 
   def self.authorize_user_with_system_token(userid, user_metadata = {})
-    auth = authenticator(userid)
-    return authorize_user(userid) if user_metadata.blank? || auth.user_authorizable_with_system_token? == false
+    return if userid.blank? || user_metadata.blank? || admin?(userid)
 
-    auth.authorize_user_with_system_token(userid, user_metadata)
+    authenticator(userid).authorize_user_with_system_token(userid, user_metadata)
   end
 
   def logoff

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -365,7 +365,7 @@ class User < ApplicationRecord
   def self.metadata_for_system_token(userid)
     return unless authenticator(userid).user_authorizable_with_system_token?
 
-    user = in_my_region.find_by_userid(userid)
+    user = in_my_region.find_by(:userid => userid)
     return if user.blank?
 
     {

--- a/spec/models/authenticator/httpd_spec.rb
+++ b/spec/models/authenticator/httpd_spec.rb
@@ -46,6 +46,44 @@ RSpec.describe Authenticator::Httpd do
     end
   end
 
+  describe '.user_authorizable_with_system_token?' do
+    let(:auth_oidc_settings) do
+      {
+        :mode          => "httpd",
+        :httpd_role    => true,
+        :oidc_enabled  => true,
+        :saml_enabled  => false,
+        :provider_type => "oidc"
+      }
+    end
+
+    let(:auth_saml_settings) do
+      {
+        :mode          => "httpd",
+        :httpd_role    => true,
+        :oidc_enabled  => false,
+        :saml_enabled  => true,
+        :provider_type => "saml"
+      }
+    end
+
+    it "is false" do
+      expect(subject.user_authorizable_with_system_token?).to be_falsey
+    end
+
+    it "is true for OIDC" do
+      stub_settings_merge(:authentication => auth_oidc_settings)
+
+      expect(subject.user_authorizable_with_system_token?).to be_truthy
+    end
+
+    it "is true for SAML" do
+      stub_settings_merge(:authentication => auth_saml_settings)
+
+      expect(subject.user_authorizable_with_system_token?).to be_truthy
+    end
+  end
+
   describe '#lookup_by_identity' do
     let(:dn) { 'cn=towmater,ou=people,ou=prod,dc=example,dc=com' }
     let!(:towmater_dn) { FactoryBot.create(:user, :userid => dn) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -636,7 +636,7 @@ RSpec.describe User do
         expect(User.authorize_user_with_system_token("jdoe@acme.com", :userid => "jdoe@acme.com")).to be_nil
       end
 
-      it "returns nil with valid invalid request" do
+      it "returns nil with an invalid request" do
         expect(User.authorize_user_with_system_token("bob@acme.com", :userid => "jdoe@acme.com")).to be_nil
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -629,15 +629,15 @@ RSpec.describe User do
       end
 
       it "returns nil with admin userid" do
-        expect(User.authorize_user_with_system_token("admin", {:userid => "admin"})).to be_nil
+        expect(User.authorize_user_with_system_token("admin", :userid => "admin")).to be_nil
       end
 
       it "returns nil with valid request" do
-        expect(User.authorize_user_with_system_token("jdoe@acme.com", {:userid => "jdoe@acme.com"})).to be_nil
+        expect(User.authorize_user_with_system_token("jdoe@acme.com", :userid => "jdoe@acme.com")).to be_nil
       end
 
       it "returns nil with valid invalid request" do
-        expect(User.authorize_user_with_system_token("bob@acme.com", {:userid => "jdoe@acme.com"})).to be_nil
+        expect(User.authorize_user_with_system_token("bob@acme.com", :userid => "jdoe@acme.com")).to be_nil
       end
     end
 


### PR DESCRIPTION
Enhanced system token authentication to allow user authorization authentication is OpenID-Connect or SAML.

User metadata gets stashed into the system token and then leveraged on the receiving side of the API for creating/updating the user accordingly.

