### PR TITLE
keep host and vm_or_template all_* rels in cluster

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -59,6 +59,9 @@ class EmsCluster < ApplicationRecord
   include MiqPolicyMixin
   include AsyncDeleteMixin
 
+  alias all_vm_or_template_ids vm_or_template_ids
+  alias all_host_ids           host_ids
+
   #
   # Provider Object methods - to be overwritten by Provider authors
   #


### PR DESCRIPTION
yeah, my fault. 

I gutted the all_* relations in https://github.com/ManageIQ/manageiq/pull/20149/files on Friday and we were still using `vm_or_template` and `host` 

caught by @himdel, sorry Martin :( 

cross repo test is here: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/130


or um, go with Keenan's solution cause his is tested. 
closing in favor of https://github.com/ManageIQ/manageiq/pull/20206