### PR TITLE
fix all_host_ids reference

### DIFF
--- a/app/models/ems_cluster.rb
+++ b/app/models/ems_cluster.rb
@@ -190,13 +190,13 @@ class EmsCluster < ApplicationRecord
     cond = ["ems_cluster_id = ?"]
     cond_params = [id]
 
-    ids = all_host_ids
+    ids = host_ids
     unless ids.empty?
       cond << "host_id IN (?) OR dest_host_id IN (?)"
       cond_params += [ids, ids]
     end
 
-    ids = all_vm_or_template_ids
+    ids = vm_or_template_ids
     unless ids.empty?
       cond << "vm_or_template_id IN (?) OR dest_vm_or_template_id IN (?)"
       cond_params += [ids, ids]


### PR DESCRIPTION
introduced in:
ManageIQ/manageiq#20149

```
  1) EmsClusterController#show render listnav partial correctly for timeline page
     Failure/Error: sdate, edate = @tl_record.first_and_last_event(@tl_options.evt_type)

     NameError:
       undefined local variable or method `all_host_ids' for #<EmsCluster:0x000055e3fd7fb930>
       Did you mean?  all_relationship_ids
```

https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/131