### PR TITLE
Allow EmsFolder#folder_path to be called from the API

### DIFF
--- a/app/models/ems_folder.rb
+++ b/app/models/ems_folder.rb
@@ -18,6 +18,8 @@ class EmsFolder < ApplicationRecord
   virtual_has_many :miq_templates,     :uses => :all_relationships
   virtual_has_many :hosts,             :uses => :all_relationships
 
+  virtual_attribute :folder_path, :string, :uses => :all_relationships
+
   delegate :queue_name_for_ems_operations, :to => :ext_management_system, :allow_nil => true
   delegate :my_zone, :to => :ext_management_system
 


### PR DESCRIPTION
It isn't possible to get the "folder_path" attribute for an EmsFolder from the API.

This will allow you to do: `/api/providers/:id/folders/:id?attributes=folder_path` which will return e.g. `    "folder_path": "Datacenters/dev-vc67-DC/vm/agrare"`

https://github.com/ManageIQ/manageiq/issues/20204