### PR TITLE
Use DATABASE_URL friendly AR::Base.configurations

### DIFF
--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -93,7 +93,7 @@ class DatabaseBackup < ApplicationRecord
   private
 
   def current_db_opts
-    current = Rails.configuration.database_configuration[Rails.env]
+    current = ActiveRecord::Base.configurations[Rails.env]
     {
       :hostname => current["host"],
       :dbname   => current["database"],

--- a/app/models/miq_region_remote.rb
+++ b/app/models/miq_region_remote.rb
@@ -65,7 +65,7 @@ class MiqRegionRemote < ApplicationRecord
 
   def self.prepare_default_fields(database, adapter)
     if database.nil? || adapter.nil?
-      db_conf = Rails.configuration.database_configuration[Rails.env]
+      db_conf = ActiveRecord::Base.configurations[Rails.env]
       database ||= db_conf["database"]
       adapter  ||= db_conf["adapter"]
     end
@@ -84,7 +84,7 @@ class MiqRegionRemote < ApplicationRecord
     host = host.to_s.strip
     raise ArgumentError, _("host cannot be blank") if host.blank?
     if [nil, "", "localhost", "localhost.localdomain", "127.0.0.1", "0.0.0.0"].include?(host)
-      local_database = Rails.configuration.database_configuration.fetch_path(Rails.env, "database").to_s.strip
+      local_database = ActiveRecord::Base.configurations.fetch_path(Rails.env, "database").to_s.strip
       if database == local_database
         raise ArgumentError, _("host cannot be set to localhost if database matches the local database")
       end

--- a/lib/evm_database_ops.rb
+++ b/lib/evm_database_ops.rb
@@ -221,7 +221,7 @@ class EvmDatabaseOps
   end
 
   def self.database_connections(database = nil, type = :all)
-    database ||= Rails.configuration.database_configuration[Rails.env]["database"]
+    database ||= ActiveRecord::Base.configurations[Rails.env]["database"]
     conn = ActiveRecord::Base.connection
     conn.client_connections.count { |c| c["database"] == database }
   end

--- a/lib/tasks/test_vmdb.rake
+++ b/lib/tasks/test_vmdb.rake
@@ -42,6 +42,8 @@ namespace :test do
   desc "Run RSpec code examples in parallel"
   task :vmdb_parallel => :spec_deps do
     # Check that '<name_of_test_database>2' exists, else you need additional setup
+    # FIXME, parallel_tests via this rake task does not currently support DATABASE_URL configuration.
+    # We should be using ActiveRecord::Base.configurations at some point.
     test_config = Rails.configuration.database_configuration['test'].tap { |config| config['database'].concat('2') }
     begin
       ActiveRecord::Base.establish_connection(test_config)

--- a/spec/models/miq_region_remote_spec.rb
+++ b/spec/models/miq_region_remote_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MiqRegionRemote do
     it "removes the temporary connection pool" do
       original = described_class.connection.raw_connection.conninfo_hash[:dbname]
 
-      config = Rails.configuration.database_configuration[Rails.env]
+      config = ActiveRecord::Base.configurations[Rails.env]
       params = config.values_at("host", "port", "username", "password", "database", "adapter")
       params[0] ||= "localhost"
       params[4]   = "template1"


### PR DESCRIPTION
Rails.configuration.database_configuration has no knowledge of db configuration
found in the DATABASE_URL environment variable.  We need to use
ActiveRecord::Base.configurations.

Related to: https://github.com/ManageIQ/manageiq/pull/15269