### PR TITLE
Update rails to 5.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "pg",                                              :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
 gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.2.5",
-gem "rails-i18n",                     "~>5.x"
+gem "rails-i18n",                     "~>5.x",
 gem "rake",                           ">=12.3.3",      :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false
 gem "ripper_ruby_parser",             "~>1.5.1",       :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem "optimist",                       "~>3.0",         :require => false
 gem "pg",                                              :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
 gem "query_relation",                 "~>0.1.0",       :require => false
-gem "rails",                          "~>5.2.4", ">=5.2.4.3"
+gem "rails",                          "~>5.2.5",
 gem "rails-i18n",                     "~>5.x"
 gem "rake",                           ">=12.3.3",      :require => false
 gem "rest-client",                    "~>2.0.0",       :require => false


### PR DESCRIPTION
This updates the rails gem from 5.2.4 to 5.2.5. This addresses CVE-2020-8165, which apparently suffers from a potential issue with MemCacheStore and RedisCacheStore.

https://groups.google.com/forum/#!topic/rubyonrails-security/bv6fW4S0Y1c