### PR TITLE
 change hardware memory_mb to a bigint so we can remove the cast

### DIFF
--- a/spec/models/hardware_spec.rb
+++ b/spec/models/hardware_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Hardware do
   end
 
   # this is disks + ram_size_in_bytes
-  # so we end up with 4 different senarios
+  # so we end up with 4 different scenarios
   describe "#provisioned_storage" do
     let(:hardware) { FactoryBot.create(:hardware) }
 

--- a/spec/models/service/aggregation_spec.rb
+++ b/spec/models/service/aggregation_spec.rb
@@ -1,7 +1,41 @@
 RSpec.describe Service do
+  let(:service) { FactoryBot.create(:service) }
+  let(:hardware) { FactoryBot.create(:hardware, :cpu2x2, :memory_mb => 2048) }
+
+  before do
+    service << FactoryBot.create(:vm_vmware, :hardware => hardware)
+    service.save
+  end
+
   it "#aggregate_all_vm_memory_on_disk will not raise when the attribute is nil" do
-    service = FactoryBot.create(:service)
     expect(service).to receive(:has_attribute?).with("aggregate_all_vm_memory_on_disk").and_return(true)
     expect { service.aggregate_all_vm_memory_on_disk }.not_to raise_error
+  end
+
+  it "#aggregate_all_vm_memory" do
+    expect(service.aggregate_all_vm_memory).to eq(2048)
+  end
+
+  it "#aggregate_all_vm_cpus" do
+    expect(service.aggregate_all_vm_cpus).to eq(4)
+  end
+
+  it "#aggregate_all_vm_disk_count" do
+    FactoryBot.create_list(:disk, 2, :hardware => hardware, :device_type => 'disk')
+
+    expect(service.aggregate_all_vm_disk_count).to eq(2)
+  end
+
+  it "#aggregate_all_vm_disk_space_allocated" do
+    FactoryBot.create(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
+    FactoryBot.create(:disk, :size => 1024, :hardware => hardware)
+
+    expect(service.aggregate_all_vm_disk_space_allocated).to eq(11_264)
+  end
+
+  it "#aggregate_all_vm_memory_on_disk" do
+    FactoryBot.build(:disk, :size_on_disk => 1024, :size => 10_240, :hardware => hardware)
+
+    expect(service.aggregate_all_vm_memory_on_disk).to eq(2_147_483_648)
   end
 end


### PR DESCRIPTION
at the moment memory_mb is an int which is problematic with aggregation and the byte conversion.

i'd like to get rid of the cast

cross repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/132/checks?check_run_id=714286746

##
required for https://github.com/ManageIQ/manageiq-schema/pull/485 (the migration that renames the column and adjusts the type)

@miq-bot assign @kbrock 
