### PR TITLE
Check compliance policy for only specified profile.

### DIFF
--- a/app/models/compliance.rb
+++ b/app/models/compliance.rb
@@ -74,7 +74,7 @@ class Compliance < ApplicationRecord
     end
     check_event = "#{target_class}_compliance_check"
     _log.info("Checking compliance...")
-    results = MiqPolicy.enforce_policy(target, check_event)
+    results = MiqPolicy.enforce_policy(target, check_event, inputs)
 
     if results[:details].empty?
       _log.info("No compliance policies were assigned or in scope, compliance status will not be set")

--- a/app/models/miq_policy.rb
+++ b/app/models/miq_policy.rb
@@ -371,12 +371,20 @@ class MiqPolicy < ApplicationRecord
     [first_event, last_event].compact
   end
 
+  #
+  # Only check the policies in the profile if :only_this_profile is specified. Built-in policies are skipped.
+  #
   def self.get_policies_for_target(target, mode, event, inputs = {})
     event = find_event_def(event) if event.kind_of?(String)
 
-    # collect policies expand profiles (sets)
-    profiles, plist = get_expanded_profiles_and_policies(target)
-    plist = built_in_policies.concat(plist).uniq
+    if inputs[:only_this_profile].present?
+      profiles = %w[inputs[:only_this_profile]]
+      plist = inputs[:only_this_profile].get_policies
+    else
+      # collect policies expand profiles (sets)
+      profiles, plist = get_expanded_profiles_and_policies(target)
+      plist = built_in_policies.concat(plist).uniq
+    end
 
     towhat = target.class.base_model.name
     towhat = "Vm" if towhat.downcase.match("template")

--- a/app/models/mixins/compliance_mixin.rb
+++ b/app/models/mixins/compliance_mixin.rb
@@ -20,8 +20,8 @@ module ComplianceMixin
                      :prefix    => true
   end
 
-  def check_compliance
-    Compliance.check_compliance(self)
+  def check_compliance(inputs = {})
+    Compliance.check_compliance(self, inputs)
   end
 
   def check_compliance_queue

--- a/spec/models/miq_policy_spec.rb
+++ b/spec/models/miq_policy_spec.rb
@@ -198,10 +198,18 @@ RSpec.describe MiqPolicy do
     end
 
     describe ".get_policies_for_target" do
+      before { allow(target).to receive(:get_policies).and_return(profiles) }
+
       it 'gets profiles and policies for a target' do
-        allow(target).to receive(:get_policies).and_return(profiles)
         prof_list, pol_list = described_class.get_policies_for_target(target, 'control', events[0].name)
         expect(prof_list.size).to eq(2)
+        expect(pol_list.size).to  eq(1)
+        expect(pol_list[0]).to    eq(policies[0])
+      end
+
+      it 'gets policies only from this profile' do
+        prof_list, pol_list = described_class.get_policies_for_target(target, 'control', events[0].name, :only_this_profile => profiles[0])
+        expect(prof_list.size).to eq(1)
         expect(pol_list.size).to  eq(1)
         expect(pol_list[0]).to    eq(policies[0])
       end


### PR DESCRIPTION
Check compliance policy for only specified profile. 
All built-in policies and other assigned policies not from the specified profile would be skipped if `:only_this_profile` is specified.

Blocks https://github.com/ManageIQ/manageiq-api/pull/848.

@miq-bot add_label enhancement, core/policy

cc @gtanzillo 