### PR TITLE
Provide message when tag assignment failed

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -98,11 +98,16 @@ class Classification < ApplicationRecord
   # rubocop:disable Style/NumericPredicate
 
   def self.classify(obj, category_name, entry_name, is_request = true)
-    cat = Classification.lookup_by_name(category_name, obj.region_id)
-    unless cat.nil?
-      ent = cat.find_entry_by_name(entry_name, obj.region_id)
-      ent.assign_entry_to(obj, is_request) unless ent.nil? || obj.is_tagged_with?(ent.to_tag, :ns => "none")
-    end
+    cat = Classification.find_by_name(category_name, obj.region_id)
+    return " - FAILED. Tag category '#{category_name}' not found in region #{obj.region_id}" if cat.nil?
+
+    ent = cat.find_entry_by_name(entry_name, obj.region_id)
+    return " - FAILED. Tag name '#{entry_name}' not found  in region #{obj.region_id}" if ent.nil?
+
+    return " - FAILED. Object already tagged with tag namespace set to 'none'" if obj.is_tagged_with?(ent.to_tag, :ns => "none")
+
+    ent.assign_entry_to(obj, is_request)
+    " - SUCCESS."
   end
 
   def self.unclassify(obj, category_name, entry_name, is_request = true)

--- a/spec/models/classification_spec.rb
+++ b/spec/models/classification_spec.rb
@@ -61,6 +61,35 @@ RSpec.describe Classification do
       FactoryBot.create(:classification_tag,      :name => "multi_entry_2", :parent => parent)
     end
 
+    describe ".classify" do
+      let(:entry) { "test_entry" }
+      let(:category) { "test_category" }
+      before { @vm = FactoryBot.create(:vm) }
+
+      it "returns detailed message if tag category not found" do
+        category = "Hello, World"
+        msg = Classification.classify(@vm, category, entry)
+        expect(msg).to include("Tag category '#{category}' not found in region #{@vm.region_id}")
+      end
+
+      it "returns detailed message message if tag entry not found" do
+        entry = "Hello, World"
+        msg = Classification.classify(@vm, category, entry)
+        expect(msg).to include("Tag name '#{entry}' not found  in region #{@vm.region_id}")
+      end
+
+      it "returns detailed message message if object already tagged with tag namespace set to 'none'" do
+        allow(@vm).to receive(:is_tagged_with?)
+        allow(@vm).to receive(:is_tagged_with?).with("/managed/test_category/test_entry", :ns => "none").and_return(true)
+        msg = Classification.classify(@vm, category, entry)
+        expect(msg).to include("Object already tagged with tag namespace set to 'none'")
+      end
+
+      it "assign tag entry to object if tag category and tag name exist and returns 'SUCCESS'" do
+        expect(Classification.classify(@vm, category, entry)).to include("SUCCESS")
+      end
+    end
+
     context "#destroy" do
       it "a category deletes all entries" do
         cat = Classification.lookup_by_name("test_category")


### PR DESCRIPTION
**ISSUE:**
if tag category or tag name misspelled when executing API call to assign tag than return message did not indicate what went wrong.

with https://github.com/ManageIQ/manageiq-api/pull/843 fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1792106

**Example**:
curl --user admin:smartvm -i -X POST -d '{"action":"assign","resources":[{"category":"team","name":"it_pnp"}]}' http://localhost:3000/api/vms/54/tags
**BEFORE**:
{"results":[{"success":false,"message":"Assigning Tag: category:'team' name:'it_pnp'", ...}
**AFTER**:
{"results":[{"success":false,"message":"Assigning Tag: category:'team' name:'it_pnp' - FAILED. Tag category 'team' not found in region 0", ...}


cross-repo:  https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/133