### PR TITLE
Fix Vm#supports_terminate? checking EMS#vm_destroy

### DIFF
--- a/app/models/vm_or_template/operations.rb
+++ b/app/models/vm_or_template/operations.rb
@@ -139,12 +139,6 @@ module VmOrTemplate::Operations
             end
       unsupported_reason_add(:control, msg) if msg
     end
-
-    supports :terminate do
-      msg = unsupported_reason(:control) unless supports_control?
-      msg ||= _("Provider doesn't support vm_destroy") unless ext_management_system.respond_to?(:vm_destroy)
-      unsupported_reason_add(:terminate, msg) if msg
-    end
   end
 
   def validate_vm_control_powered_on


### PR DESCRIPTION
We removed the redundant EMS#vm_destroy methods which just called VM#raw_destroy for all providers except VMware.  The supports_feature block however was still checking if the EMS respond_to?(:vm_destroy) so no vm was supporting terminate.

Related to: https://github.com/ManageIQ/manageiq/pull/19452

Depends:

- [x] https://github.com/ManageIQ/manageiq-providers-amazon/pull/626

- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/397

- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/137

- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/164

- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/598

- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/497

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/584

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/135