### PR TITLE
Don't create a data directory outside of the source tree in containers

### DIFF
--- a/lib/vmdb_helper.rb
+++ b/lib/vmdb_helper.rb
@@ -23,7 +23,7 @@ $:.push("#{File.dirname(__FILE__)}/patches")
 require 'rest_client_patch'
 require 'ruport_patch'
 
-APPLIANCE_DATA_VOL = File.directory?("/var/www/miq/vmdb") ? "/var/lib/data" : Rails.root.join("tmp")
+APPLIANCE_DATA_VOL = File.directory?("/var/www/miq/vmdb") && !MiqEnvironment::Command.is_container? ? "/var/lib/data" : Rails.root.join("tmp")
 MIQ_TEMP           = File.join(APPLIANCE_DATA_VOL, "miq_temp")
 FileUtils.mkdir_p(MIQ_TEMP)
 


### PR DESCRIPTION
For pods, we don't have write permissions to anything outside
of vmdb, so even if this was created correctly, we wouldn't be able
to write into it later.

Required for https://github.com/ManageIQ/manageiq-pods/pull/485

cc @simaishi 