### PR TITLE
Change seeding specs to look for a specific plugin path

### DIFF
--- a/spec/models/miq_dialog/seeding_spec.rb
+++ b/spec/models/miq_dialog/seeding_spec.rb
@@ -76,9 +76,12 @@ RSpec.describe MiqDialog do
       )
     end
 
-    it "will include files from plugins" do
+    it "will include files from a plugin" do
+      plugin = Vmdb::Plugins.detect { |p| p.root.join("content/miq_dialogs").exist? }
+      skip "no plugin with content exists" unless plugin
+
       expect(described_class.send(:seed_files)).to include(
-        a_string_matching(%r{#{Bundler.install_path}/.+/content/miq_dialogs/})
+        a_string_starting_with(plugin.root.join("content/miq_dialogs").to_s)
       )
     end
   end

--- a/spec/models/scan_item/seeding_spec.rb
+++ b/spec/models/scan_item/seeding_spec.rb
@@ -78,9 +78,11 @@ RSpec.describe ScanItem do
     end
 
     it "will include files from plugins" do
-      skip "Until a plugin brings a scan item"
+      plugin = Vmdb::Plugins.detect { |p| p.root.join("content/scan_items").exist? }
+      skip "no plugin with content exists" unless plugin
+
       expect(described_class.send(:seed_files)).to include(
-        a_string_matching(%r{#{Bundler.install_path}/.+/content/scan_items/})
+        a_string_starting_with(plugin.root.join("content/scan_items").to_s)
       )
     end
   end


### PR DESCRIPTION
It's possible, with repo path overrides, to cause these tests to fail
since they won't be in the Bundler.install_path. This scenario might
happen in cross-repo tests. Instead, we can detect a plugin with the
expected content and ensure its path is in the expected list.

@agrare Please review.