### PR TITLE
[WIP] Extract NetworkManager parent_manager to a mixin

### DIFF
--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -2,14 +2,11 @@ module ManageIQ::Providers
   class NetworkManager < BaseManager
     include SupportsFeatureMixin
 
-    PROVIDER_NAME = "Network Manager".freeze
-
     class << model_name
       define_method(:route_key) { "ems_networks" }
       define_method(:singular_route_key) { "ems_network" }
     end
 
-    supports_not :ems_network_new
     # cloud_subnets are defined on base class, because of virtual_total performance
     has_many :floating_ips,                       :foreign_key => :ems_id, :dependent => :destroy
     has_many :security_groups,                    :foreign_key => :ems_id, :dependent => :destroy
@@ -34,61 +31,8 @@ module ManageIQ::Providers
 
     alias all_cloud_networks cloud_networks
 
-    belongs_to :parent_manager,
-               :foreign_key => :parent_ems_id,
-               :class_name  => "ManageIQ::Providers::BaseManager",
-               :autosave    => true
-
-    has_many :availability_zones,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :flavors,                       -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_database_flavors,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_resource_quotas,         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volumes,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volume_types,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volume_backups,          -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_volume_snapshots,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_object_store_containers, -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_object_store_objects,    -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_services,                -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :cloud_databases,               -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :hosts,                         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :vms,                           -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :miq_templates,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-    has_many :vms_and_templates,             -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
-
-    virtual_total :total_vms, :vms
-    virtual_total :total_miq_templates, :miq_templates
-    virtual_total :total_vms_and_templates, :vms_and_templates
-
-    # Relationships delegated to parent manager
-    virtual_delegate :orchestration_stacks,
-                     :orchestration_stacks_resources,
-                     :direct_orchestration_stacks,
-                     :resource_groups,
-                     :key_pairs,
-                     :to        => :parent_manager,
-                     :allow_nil => true,
-                     :default   => []
-
     def self.display_name(number = 1)
       n_('Network Manager', 'Network Managers', number)
-    end
-
-    def self.supported_types_and_descriptions_hash
-      supported_subclasses.select(&:supports_ems_network_new?).each_with_object({}) do |klass, hash|
-        hash[klass.ems_type] = klass.description
-      end
-    end
-
-    def name
-      "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
-    end
-
-    def self.find_object_for_belongs_to_filter(name)
-      name.gsub!(" #{self::PROVIDER_NAME}", "")
-      includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
     end
   end
 end

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -34,5 +34,10 @@ module ManageIQ::Providers
     def self.display_name(number = 1)
       n_('Network Manager', 'Network Managers', number)
     end
+
+    def self.find_object_for_belongs_to_filter(name)
+      ems = self.find_by(:name => name)
+      ems&.parent_manager_id&.present? ? self.find(ems.parent_manager_id) : ems
+    end
   end
 end

--- a/app/models/mixins/belongs_to_parent_manager_mixin.rb
+++ b/app/models/mixins/belongs_to_parent_manager_mixin.rb
@@ -45,10 +45,5 @@ module BelongsToParentManagerMixin
     def name
       "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
     end
-
-    def self.find_object_for_belongs_to_filter(name)
-      name.gsub!(" #{self::PROVIDER_NAME}", "")
-      includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
-    end
   end
 end

--- a/app/models/mixins/belongs_to_parent_manager_mixin.rb
+++ b/app/models/mixins/belongs_to_parent_manager_mixin.rb
@@ -1,0 +1,54 @@
+module BelongsToParentManagerMixin
+  extend ActiveSupport::Concern
+
+  PROVIDER_NAME = "Network Manager".freeze
+
+  included do
+    belongs_to :parent_manager,
+               :foreign_key => :parent_ems_id,
+               :class_name  => "ManageIQ::Providers::BaseManager",
+               :autosave    => true
+
+    has_many :availability_zones,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :flavors,                       -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_database_flavors,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_resource_quotas,         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volumes,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volume_types,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volume_backups,          -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_volume_snapshots,        -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_object_store_containers, -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_object_store_objects,    -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_services,                -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :cloud_databases,               -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :hosts,                         -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :vms,                           -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :miq_templates,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+    has_many :vms_and_templates,             -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
+
+    virtual_total :total_vms, :vms
+    virtual_total :total_miq_templates, :miq_templates
+    virtual_total :total_vms_and_templates, :vms_and_templates
+
+    # Relationships delegated to parent manager
+    virtual_delegate :orchestration_stacks,
+                     :orchestration_stacks_resources,
+                     :direct_orchestration_stacks,
+                     :resource_groups,
+                     :key_pairs,
+                     :to        => :parent_manager,
+                     :allow_nil => true,
+                     :default   => []
+
+    def name
+      "#{parent_manager.try(:name)} #{PROVIDER_NAME}"
+    end
+
+    def self.find_object_for_belongs_to_filter(name)
+      name.gsub!(" #{self::PROVIDER_NAME}", "")
+      includes(:parent_manager).find_by(:parent_managers_ext_management_systems => {:name => name})
+    end
+  end
+end

--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -93,9 +93,7 @@ FactoryBot.define do
   factory :ems_network,
           :aliases => ["manageiq/providers/network_manager"],
           :class   => "ManageIQ::Providers::Openstack::NetworkManager",
-          :parent  => :ext_management_system do
-    parent_manager { FactoryBot.create(:ext_management_system) }
-  end
+          :parent  => :ext_management_system
 
   factory :ems_storage,
           :aliases => ["manageiq/providers/storage_manager"],
@@ -239,7 +237,7 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/vmware/network_manager"],
           :class   => "ManageIQ::Providers::Vmware::NetworkManager",
           :parent  => :ems_cloud do
-    parent_manager { FactoryBot.create(:ext_management_system) }
+    parent_manager { FactoryBot.create(:ems_vmware_cloud) }
   end
 
   # Leaf classes for ems_cloud
@@ -256,6 +254,7 @@ FactoryBot.define do
           :class   => "ManageIQ::Providers::Amazon::NetworkManager",
           :parent  => :ems_network do
     provider_region { "us-east-1" }
+    parent_manager { FactoryBot.create(:ems_amazon) }
   end
 
   factory :ems_amazon_with_authentication,
@@ -282,6 +281,7 @@ FactoryBot.define do
           :class   => "ManageIQ::Providers::Azure::NetworkManager",
           :parent  => :ems_network do
     provider_region { "eastus" }
+    parent_manager { FactoryBot.create(:ems_azure) }
   end
 
   factory :ems_azure_with_authentication,
@@ -304,7 +304,9 @@ FactoryBot.define do
   factory :ems_openstack_network,
           :aliases => ["manageiq/providers/openstack/network_manager"],
           :class   => "ManageIQ::Providers::Openstack::NetworkManager",
-          :parent  => :ems_network
+          :parent  => :ems_network do
+    parent_manager { FactoryBot.create(:ems_openstack) }
+  end
 
   factory :ems_nuage_network,
           :aliases => ["manageiq/providers/nuage/network_manager"],
@@ -324,7 +326,9 @@ FactoryBot.define do
   factory :ems_google_network,
           :aliases => ["manageiq/providers/google/network_manager"],
           :class   => "ManageIQ::Providers::Google::NetworkManager",
-          :parent  => :ems_network
+          :parent  => :ems_network do
+    parent_manager { FactoryBot.create(:ems_google) }
+  end
 
   # Leaf classes for ems_container
 

--- a/spec/models/miq_filter_spec.rb
+++ b/spec/models/miq_filter_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe MiqFilter do
       let(:network_manager_folder_path) { "/belongsto/ExtManagementSystem|#{ems_openstack.name} Network Manager" }
 
       it "converts path with network manager" do
-        ems_openstack.update(:name => "XXX")
         expect(belongsto2object_list(network_manager_folder_path)).to match_array([ems_openstack.network_manager])
       end
     end


### PR DESCRIPTION
Extract the logic for a NetworkManager belonging to a CloudManager parent out of the base NetworkManager class and move it to a mixin.  This allows for the standard logic for deciding if a manager can be created directly to be used (aka does it have a belongs_to :parent_manager reflection) for the standalone network providers like Nuage and NSX-t.

Dependents:
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/627
* https://github.com/ManageIQ/manageiq-providers-azure/pull/398
* https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/33
* https://github.com/ManageIQ/manageiq-providers-google/pull/138
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/603
* https://github.com/ManageIQ/manageiq-providers-ovirt/pull/498
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/585

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/136