### PR TITLE
Automate RelativePath mixin

### DIFF
--- a/app/models/miq_ae_class.rb
+++ b/app/models/miq_ae_class.rb
@@ -1,6 +1,7 @@
 class MiqAeClass < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
+  include RelativePathMixin
 
   belongs_to :ae_namespace, :class_name => "MiqAeNamespace", :foreign_key => :namespace_id
   belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
@@ -21,34 +22,32 @@ class MiqAeClass < ApplicationRecord
   virtual_attribute :fqname, :string
 
   def self.lookup_by_fqname(fqname, _args = {})
-    fqname = fqname[1..-1] if fqname[0] == '/'
-    dname, *partial = fqname.downcase.split('/')
-    domain_id = MiqAeDomain.unscoped.where(MiqAeDomain.arel_table[:name].lower.eq(dname)).where(:domain_id => nil).select(:id)
-    where(arel_table[:relative_path].lower.eq(partial.join("/"))).find_by(:domain_id => domain_id)
+    return if fqname.blank?
+
+    dname, *partial = split_fqname(fqname)
+    domain_id = MiqAeDomain.unscoped.where(MiqAeDomain.arel_table[:name].lower.eq(dname.downcase)).where(:domain_id => nil).select(:id)
+    find_by(:lower_relative_path => partial.join("/").downcase, :domain_id => domain_id)
   end
 
   singleton_class.send(:alias_method, :find_by_fqname, :lookup_by_fqname)
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_fqname => :lookup_by_fqname)
 
   def self.lookup_by_namespace_and_name(name_space, name, _args = {})
-    name_space = MiqAeNamespace.lookup_by_fqname(name_space)
-    return nil if name_space.nil?
-
-    where(:namespace_id => name_space.id).find_by(arel_table[:name].lower.eq(name.downcase))
+    lookup_by_fqname(name_space + "/" + name)
   end
 
   singleton_class.send(:alias_method, :find_by_namespace_and_name, :lookup_by_namespace_and_name)
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_namespace_and_name => :lookup_by_namespace_and_name)
 
   def self.lookup_by_namespace_id_and_name(ns_id, name)
-    where(:namespace_id => ns_id).where(["lower(name) = ?", name.downcase]).first
+    where(:namespace_id => ns_id).find_by(:lower_name => name.downcase)
   end
 
   singleton_class.send(:alias_method, :find_by_namespace_id_and_name, :lookup_by_namespace_id_and_name)
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_namespace_id_and_name => :lookup_by_namespace_id_and_name)
 
   def self.lookup_by_name(name)
-    where(["lower(name) = ?", name.downcase]).includes([:ae_methods, :ae_fields]).first
+    find_by(:lower_name => name.downcase)
   end
 
   singleton_class.send(:alias_method, :find_by_name, :lookup_by_name)
@@ -94,9 +93,6 @@ class MiqAeClass < ApplicationRecord
     end
   end
 
-  def fqname
-    ["", domain&.name, relative_path].compact.join("/")
-  end
 
   # my class's fqname is /domain/namespace1/namespace2/class
   def namespace

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -129,7 +129,7 @@ class MiqAeMethod < ApplicationRecord
   end
 
   def self.lookup_by_class_id_and_name(class_id, name)
-    ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(name)
+    ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(name.downcase, nil, true)
     ::MiqAeMethod.where(ae_method_filter).where(:class_id => class_id).first
   end
 
@@ -144,7 +144,7 @@ class MiqAeMethod < ApplicationRecord
     domain_ids = user.current_tenant.enabled_domains
     joins(:domain).where(:miq_ae_namespaces => {:id => domain_ids})
                   .order("miq_ae_namespaces.priority DESC")
-                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase))
+                  .find_by(arel_table[:relative_path].lower.matches(relative_path.downcase, nil, true))
   end
 
   private

--- a/app/models/miq_ae_method.rb
+++ b/app/models/miq_ae_method.rb
@@ -3,6 +3,8 @@ require 'manageiq/automation_engine/syntax_checker'
 class MiqAeMethod < ApplicationRecord
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
+  include RelativePathMixin
+
   default_value_for(:embedded_methods) { [] }
   validates :embedded_methods, :exclusion => { :in => [nil] }
   serialize :options, Hash
@@ -46,10 +48,6 @@ class MiqAeMethod < ApplicationRecord
     result = ManageIQ::AutomationEngine::SyntaxChecker.check(code_text)
     return nil if result.valid?
     [[result.error_line, result.error_text]] # Array of arrays for future multi-line support
-  end
-
-  def fqname
-    ["", domain&.name, relative_path].compact.join("/")
   end
 
   # my method's fqname is /domain/namespace1/namespace2/class/method

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -64,7 +64,7 @@ class MiqAeNamespace < ApplicationRecord
     end
 
     new_parts.each do |p|
-      found = found ? create(:name => p, :parent => found) : create(:name => p)
+      found = found ? create(:name => p, :parent => found) : MiqAeDomain.create(:name => p)
     end
 
     found

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -5,6 +5,7 @@ class MiqAeNamespace < ApplicationRecord
   has_ancestry
   include MiqAeSetUserInfoMixin
   include MiqAeYamlImportExportMixin
+  include RelativePathMixin
 
   EXPORT_EXCLUDE_KEYS = [/^id$/, /_id$/, /^created_on/, /^updated_on/,
                          /^updated_by/, /^reserved$/, /^commit_message/,
@@ -35,30 +36,24 @@ class MiqAeNamespace < ApplicationRecord
     return nil if fqname.blank?
 
     dname, *partial = split_fqname(fqname)
-    domain_query = MiqAeDomain.unscoped.where(MiqAeDomain.arel_table[:name].lower.eq(dname)).where(:domain_id => nil)
+    domain_query = MiqAeDomain.unscoped.where(MiqAeDomain.arel_table[:name].lower.eq(dname.downcase)).where(:domain_id => nil)
     return domain_query.first if partial.empty?
 
+    domain_id = domain_query.select(:id)
     query = include_classes ? includes(:ae_classes) : all
-    query = query.where(arel_table[:relative_path].lower.eq(partial.join("/")))
-    query.find_by(:domain_id => domain_query.select(:id))
+    query.find_by(:domain_id => domain_id, :lower_relative_path => partial.join("/").downcase)
   end
 
   singleton_class.send(:alias_method, :find_by_fqname, :lookup_by_fqname)
   Vmdb::Deprecation.deprecate_methods(singleton_class, :find_by_fqname => :lookup_by_fqname)
 
-  def self.split_fqname(fqname)
-    fqname = fqname[1..-1] if fqname[0] == '/'
-    fqname.downcase.split('/')
-  end
-
   def self.find_or_create_by_fqname(fqname, include_classes = true)
     return nil if fqname.blank?
 
-    fqname = fqname[1..-1] if fqname[0] == '/'
     found = lookup_by_fqname(fqname, include_classes)
     return found unless found.nil?
 
-    parts = fqname.split('/')
+    parts = split_fqname(fqname)
     new_parts = [parts.pop]
     loop do
       break if parts.empty?
@@ -102,12 +97,6 @@ class MiqAeNamespace < ApplicationRecord
     roots
   end
 
-  def fqname
-    return "/#{name}" if domain_id.blank?
-
-    ["", domain&.name, relative_path].compact.join("/")
-  end
-
   def editable?(user = User.current_user)
     raise ArgumentError, "User not provided to editable?" unless user
     return false if domain? && user.current_tenant.id != tenant_id
@@ -118,10 +107,6 @@ class MiqAeNamespace < ApplicationRecord
   def ns_fqname
     return nil if fqname == domain_name
     fqname.sub(domain_name.to_s, '')
-  end
-
-  def domain_name
-    domain&.name
   end
 
   def domain?

--- a/app/models/miq_ae_namespace.rb
+++ b/app/models/miq_ae_namespace.rb
@@ -13,7 +13,7 @@ class MiqAeNamespace < ApplicationRecord
                          /^last_import_on/, /^source/, /^top_level_namespace/].freeze
 
   belongs_to :domain, :class_name => "MiqAeDomain", :inverse_of => false
-  has_many :ae_classes, -> { includes([:ae_methods, :ae_fields, :ae_instances]) }, :class_name => "MiqAeClass",
+  has_many :ae_classes, :class_name => "MiqAeClass",
            :foreign_key => :namespace_id, :dependent => :destroy, :inverse_of => :ae_namespace
 
   validates :name,

--- a/app/models/mixins/relative_path_mixin.rb
+++ b/app/models/mixins/relative_path_mixin.rb
@@ -1,0 +1,31 @@
+module RelativePathMixin
+  extend ActiveSupport::Concern
+
+  included do
+    virtual_attribute :lower_name, :string, :arel => ->(t) { t.grouping(t[:name].lower) }
+    virtual_attribute :lower_relative_path, :string, :arel => ->(t) { t.grouping(t[:relative_path].lower) }
+  end
+
+  def fqname
+    ["", domain_name, relative_path].compact.join("/")
+  end
+
+  def lower_name
+    name&.downcase
+  end
+
+  def lower_relative_path
+    rel_path&.downcase
+  end
+
+  def domain_name
+    domain&.name
+  end
+
+  module ClassMethods
+    def split_fqname(fqname)
+      fqname = fqname[1..-1] if fqname[0] == '/'
+      fqname.split('/')
+    end
+  end
+end


### PR DESCRIPTION
The various automate models define many of the same methods:

- splitting a fully qualified domain into many
- a way to search the relative path case insensitively
- getting the domain name
- getting the fqname (i.e.: fully qualified name = domain.name + "/" + relative path)

This PR pulls them into their own module.

`MiqAeDomain` (in automation-engine repo) will use this mixin after this is merged