### PR TITLE
enhance error handle for failing playbook clone

### DIFF
--- a/app/models/manageiq/providers/ansible_runner_workflow.rb
+++ b/app/models/manageiq/providers/ansible_runner_workflow.rb
@@ -181,6 +181,9 @@ class ManageIQ::Providers::AnsibleRunnerWorkflow < Job
     save!
     _log.info("Checking out git repository to #{options[:git_checkout_tempdir].inspect}...")
     css.checkout_git_repository(options[:git_checkout_tempdir])
+  rescue MiqException::MiqUnreachableError => err
+    miq_task.job.timeout!
+    raise "Failed to connect with [#{err.class}: #{err}], job aborted"
   end
 
   def cleanup_git_repository


### PR DESCRIPTION
at the moment a playbook clone does 100 retries instead of exiting gracefully if the clone fails due to connectivity issues 

part of work for https://bugzilla.redhat.com/show_bug.cgi?id=1835226 I guess

here's what happens now:
```
AwesomeSpawn: ansible exit code: 1
AwesomeSpawn: [WARNING]: - playbook-name was NOT installed successfully: Unknown
/opt/rh/cfme-gemset/gems/awesome_spawn-1.5.0/lib/awesome_spawn.rb:108:in `run!'
```
and then I think we have to delete the job to prevent the retries

@miq-bot assign @NickLaMuro 
sorry Nick, but it's your circus 


edit — to be clear, this does not really **fix** anything. but it's a start to this failing "better" for some definition of better.

and i really don't think it's an `enhancement`, but okay. 