### PR TITLE
[V2V] Allow OpenStack public networks in transformation mappings

### DIFF
--- a/app/models/transformation_mapping_item.rb
+++ b/app/models/transformation_mapping_item.rb
@@ -80,6 +80,7 @@ class TransformationMappingItem < ApplicationRecord
     elsif destination.kind_of?(CloudNetwork) # Openstack, lans are of 'CloudNetwork' type
       tmin             = tm.transformation_mapping_items.where(:destination_type => "CloudTenant")
       dst_cluster_lans = tmin.collect(&:destination).flat_map(&:cloud_networks)
+      dst_cluster_lans |= tmin.map(&:destination).map(&:ext_management_system).flat_map(&:public_networks).uniq
     end
 
     unless dst_cluster_lans.include?(destination_lan)


### PR DESCRIPTION
When creating an Infrastructure Mapping, we do validate that the destination networks belong to the selected destination tenants. The UI enforces that, as well as the model. A while ago, the UI relaxed the filter to also expose the public networks, as they are available across tenants. This pull request also relaxes the validation in the model, because it's not aligned with UI filter and generates errors.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1804263