### PR TITLE
Fixed seeding order for Chargeback Rates

### DIFF
--- a/lib/evm_database.rb
+++ b/lib/evm_database.rb
@@ -28,8 +28,8 @@ class EvmDatabase
     MiqPolicySet
     ChargebackRateDetailMeasure
     ChargeableField
-    ChargebackRate
     Currency
+    ChargebackRate
 
     BlacklistedEvent
     Classification


### PR DESCRIPTION
Currencies need to be seeded prior to rates because they are looked up and assigned to chargeback_reate_details during seeding of Chargeback Rates

The order was inadvertently changed in https://github.com/ManageIQ/manageiq/pull/19538

Fixes: https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/9070

/cc @lpichler 