### PR TITLE
Bump to psych 3.1.0 to fix invalid yaml parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem "openscap",                       "~>0.4.8",       :require => false
 gem "optimist",                       "~>3.0",         :require => false
 gem "pg",                                              :require => false
 gem "pg-dsn_parser",                  "~>0.1.0",       :require => false
+gem "psych",                          "~>3.1",         :require => false # This can be dropped once we drop ruby 2.5
 gem "query_relation",                 "~>0.1.0",       :require => false
 gem "rails",                          "~>5.2.4", ">=5.2.4.3"
 gem "rails-i18n",                     "~>5.x"


### PR DESCRIPTION
Alternate fix for https://bugzilla.redhat.com/show_bug.cgi?id=1819310

On psych 3.0.1 parsing `"---\nmy_test: \"test\\/test\\\\test\""` fails with a Psych::SyntaxError, but on 3.1.0 it successfully parses it to `{"my_test"=>"test/test\\test"}`.

Related to: https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/218