### PR TITLE
Fix targets_archived_from after refactoring to MetricsCapture

### DIFF
--- a/app/models/manageiq/providers/container_manager/metrics_capture.rb
+++ b/app/models/manageiq/providers/container_manager/metrics_capture.rb
@@ -11,7 +11,7 @@ class ManageIQ::Providers::ContainerManager::MetricsCapture < ManageIQ::Provider
 
   def with_archived(scope)
     # We will look also for freshly archived entities, if the entity was short-lived or even sub-hour
-    archived_from = targets_archived_from
+    archived_from = Metric::Targets.targets_archived_from
     scope.where(:deleted_on => nil).or(scope.where(:deleted_on => (archived_from..Time.now.utc)))
   end
 end


### PR DESCRIPTION
When we moved the capture_ems_targets out of Metrics::Capture and into provider subclasses we didn't catch that this method being called is still in Metric::Capture