### PR TITLE
Bump virtual_attributes gem to 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 manageiq_plugin "manageiq-schema"
 
 # Unmodified gems
-gem "activerecord-virtual_attributes", "~>1.6.0"
+gem "activerecord-virtual_attributes", "~>2.0.0"
 gem "activerecord-session_store",     "~>1.1"
 gem "acts_as_tree",                   "~>2.7" # acts_as_tree needs to be required so that it loads before ancestry
 gem "ancestry",                       "~>3.0.7",       :require => false


### PR DESCRIPTION
Pull in fixes for ruby 2.7 deprecation warnings

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/138
