### PR TITLE
Fix Service assignment in ServiceOrchestration reconnection script

### DIFF
--- a/tools/reconnect_service_orchestration_stacks.rb
+++ b/tools/reconnect_service_orchestration_stacks.rb
@@ -39,8 +39,8 @@ ServiceOrchestration.all.each do |service|
           if opts[:dry_run]
             puts "  **** This is a dry-run, nothing updated, skipping. ****"
           else
-            matching_stack.service = service
-            matching_stack.save!
+            # Create linking object directly
+            ServiceResource.create!(service: service, resource: matching_stack)
             reconnected += 1
           end
         else


### PR DESCRIPTION
Using orchestration_stack.service is a virtual column, its assignment fails.

Updated to go via direct_services association.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1836102 and https://github.com/ManageIQ/manageiq/pull/20239
