### PR TITLE
Fixed Vmdb::FastGettextHelper.supported_locales

### DIFF
--- a/lib/vmdb/fast_gettext_helper.rb
+++ b/lib/vmdb/fast_gettext_helper.rb
@@ -1,4 +1,5 @@
 require 'vmdb/gettext/domains'
+require 'vmdb/plugins'
 
 module Vmdb
   module FastGettextHelper
@@ -30,10 +31,10 @@ module Vmdb
       # - it
       # - nl
       #
-      @supported_locales ||= supported_locales_files.flat_map { |file| YAML.load_file(file) }
+      @supported_locales ||= supported_locale_files.flat_map { |file| YAML.load_file(file) }
     end
 
-    private_class_method def self.supported_locales_files
+    private_class_method def self.supported_locale_files
       Vmdb::Plugins.to_a.unshift(Rails)
         .map { |source| source.root.join("config", "supported_locales.yml") }
         .select(&:exist?)


### PR DESCRIPTION
Now that Vmdb::Plugins is called, need to add a require
Changed method name from supported_locales_files to supported_locale_files

This issue was introduced in https://github.com/ManageIQ/manageiq/pull/20054