### PR TITLE
Fix `rake locale:extract_locale_names` by providing environment

### DIFF
--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -102,9 +102,8 @@ namespace :locale do
   end
 
   desc "Extract human locale names from translation catalogs and store them in a yaml file"
-  task :extract_locale_names do
+  task :extract_locale_names => :environment do
     require 'yaml/store'
-    require Rails.root.join("lib/vmdb/fast_gettext_helper")
 
     Vmdb::FastGettextHelper.register_locales
 


### PR DESCRIPTION
Without this, the rake task would error with `NameError: uninitialized constant Vmdb::Plugins`
