### PR TITLE
Remove the Hardware#m_bios method

### DIFF
--- a/app/models/hardware.rb
+++ b/app/models/hardware.rb
@@ -210,14 +210,6 @@ class Hardware < ApplicationRecord
     self.memory_mb = xmlNode.attributes["memsize"]
   end
 
-  def m_bios(_parent, xmlNode, _deletes)
-    new_bios = MiqUUID.clean_guid(xmlNode.attributes["bios"])
-    self.bios = new_bios.nil? ? xmlNode.attributes["bios"] : new_bios
-
-    new_bios = MiqUUID.clean_guid(xmlNode.attributes["location"])
-    self.bios_location = new_bios.nil? ? xmlNode.attributes["location"] : new_bios
-  end
-
   def m_vm(parent, xmlNode, _deletes)
     xmlNode.each_element do |e|
       self.guest_os = e.attributes["guestos"] if e.name == "guestos"

--- a/lib/vmdb_helper.rb
+++ b/lib/vmdb_helper.rb
@@ -1,5 +1,4 @@
 require 'miq-extensions'
-require 'miq-uuid'
 
 require 'ostruct'
 require 'fileutils'


### PR DESCRIPTION
This is part of the https://github.com/ManageIQ/manageiq-gems-pending/issues/231 effort to remove miq-uuid as a dependency anywhere except vmware.

Since this method doesn't appear to be used, let's remove it.

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/140