### PR TITLE
Conditionally add the messaging environment vars to worker containers

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -64,8 +64,6 @@ class ContainerOrchestrator
         {:name => "GUID",                    :value => MiqServer.my_guid},
         {:name => "MEMCACHED_SERVER",        :value => ENV["MEMCACHED_SERVER"]},
         {:name => "MEMCACHED_SERVICE_NAME",  :value => ENV["MEMCACHED_SERVICE_NAME"]},
-        {:name => "MESSAGING_PORT",          :value => ENV["MESSAGING_PORT"]},
-        {:name => "MESSAGING_TYPE",          :value => ENV["MESSAGING_TYPE"]},
         {:name => "WORKER_HEARTBEAT_FILE",   :value => Rails.root.join("tmp", "worker.hb").to_s},
         {:name => "WORKER_HEARTBEAT_METHOD", :value => "file"},
         {:name      => "DATABASE_HOSTNAME",
@@ -77,7 +75,16 @@ class ContainerOrchestrator
         {:name      => "DATABASE_USER",
          :valueFrom => {:secretKeyRef=>{:name => "postgresql-secrets", :key => "username"}}},
         {:name      => "ENCRYPTION_KEY",
-         :valueFrom => {:secretKeyRef=>{:name => "app-secrets", :key => "encryption-key"}}},
+         :valueFrom => {:secretKeyRef=>{:name => "app-secrets", :key => "encryption-key"}}}
+      ] + messaging_environment
+    end
+
+    def messaging_environment
+      return [] unless ENV["MESSAGING_TYPE"].present?
+
+      [
+        {:name => "MESSAGING_PORT", :value => ENV["MESSAGING_PORT"]},
+        {:name => "MESSAGING_TYPE", :value => ENV["MESSAGING_TYPE"]},
         {:name      => "MESSAGING_HOSTNAME",
          :valueFrom => {:secretKeyRef=>{:name => "kafka-secrets", :key => "hostname"}}},
         {:name      => "MESSAGING_PASSWORD",


### PR DESCRIPTION
If we don't provide a value for MESSAGING_TYPE we shouldn't assume
that the kafka secret is present. If we try to deploy a container
with env vars referencing the secret the container won't be created.

https://github.com/ManageIQ/manageiq-pods/issues/541