### PR TITLE
Explicitly disable systemd support in podified env

### DIFF
--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -16,7 +16,7 @@ module MiqEnvironment
 
     def self.supports_systemd?
       return @supports_systemd unless @supports_systemd.nil?
-      @supports_systemd = is_appliance? && supports_command?('systemctl')
+      @supports_systemd = is_appliance? && !is_container? && supports_command?('systemctl')
     end
 
     def self.supports_nohup_and_backgrounding?

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -115,6 +115,19 @@ RSpec.describe MiqEnvironment do
             assert_same_result_every_time(:is_production_build?, true)
           end
         end
+
+        context ".supports_systemd?" do
+          it "returns false when container conditions are met" do
+            container_conditions
+            assert_same_result_every_time(:supports_systemd?, false)
+          end
+
+          it "returns true when appliance conditions are met" do
+            appliance_conditions
+            expect(MiqEnvironment::Command).to receive(:supports_command?).with("systemctl").and_return(true)
+            assert_same_result_every_time(:supports_systemd?, true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
If we are on a podified environment we should explicitly disable systemd support.

https://github.com/ManageIQ/manageiq-rpm_build/pull/62#issuecomment-644348692