### PR TITLE
[IVANCHUK] Do targeted refresh when waiting for IP address

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -348,6 +348,14 @@ class InfraConversionJob < Job
         # If no playbook is expected to run, we don't need to wait for the IP address.
         service_template = migration_task.send("#{migration_phase}_ansible_playbook_service_template")
         if target_vm.ipaddresses.empty? && service_template.present?
+          if context["retries_#{state}".to_sym] % 10 == 0
+            target = InventoryRefresh::Target.new(
+              :association => :vms,
+              :manager_ref => {:id => target_vm.id},
+              :manager     => target_vm.ext_management_system
+            )
+            EmsRefresh.queue_refresh(target)
+          end
           update_migration_task_progress(:on_retry)
           return queue_signal(:wait_for_ip_address)
         end

--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -351,7 +351,7 @@ class InfraConversionJob < Job
           if context["retries_#{state}".to_sym] % 10 == 0
             target = InventoryRefresh::Target.new(
               :association => :vms,
-              :manager_ref => {:id => target_vm.id},
+              :manager_ref => {:ems_ref => target_vm.ems_ref},
               :manager     => target_vm.ext_management_system
             )
             EmsRefresh.queue_refresh(target)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1159,7 +1159,7 @@ RSpec.describe InfraConversionJob, :v2v do
         allow(InventoryRefresh::Target).to receive(:new).with(
           :association => :vms,
           :manager     => ems_vmware,
-          :manager_ref => {:id => vm_vmware.id}
+          :manager_ref => {:ems_ref => vm_vmware.ems_ref}
         ).and_return(target)
         expect(EmsRefresh).to receive(:queue_refresh).with(target)
         expect(job).to receive(:queue_signal).with(:wait_for_ip_address)

--- a/spec/models/infra_conversion_job_spec.rb
+++ b/spec/models/infra_conversion_job_spec.rb
@@ -1104,9 +1104,11 @@ RSpec.describe InfraConversionJob, :v2v do
     end
 
     context '#wait_for_ip_address' do
+      let(:target) { double(InventoryRefresh::TargetCollection) }
+
       before do
         task.update_options(:migration_phase => 'pre', :source_vm_ipaddresses => ['10.0.0.1'])
-        job.state = 'started'
+        job.state = 'waiting_for_ip_address'
       end
 
       it 'abort_conversion when waiting_on_ip_address times out' do
@@ -1140,10 +1142,26 @@ RSpec.describe InfraConversionJob, :v2v do
         job.signal(:wait_for_ip_address)
       end
 
-      it 'retries if VM is powered on and does not have an IP address' do
+      it 'retries without refresh if VM is powered on, does not have an IP address and number of retries is not a multiple of 10' do
         vm_vmware.update!(:raw_power_state => 'poweredOn')
+        job.context[:retries_waiting_for_ip_address] = 14
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
         expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+        expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
+        job.signal(:wait_for_ip_address)
+      end
+
+      it 'retries with refresh if VM is powered on, does not have an IP address and number of retries is a multiple of 10' do
+        vm_vmware.update!(:raw_power_state => 'poweredOn')
+        job.context[:retries_waiting_for_ip_address] = 19
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_entry)
+        expect(job).to receive(:update_migration_task_progress).once.ordered.with(:on_retry)
+        allow(InventoryRefresh::Target).to receive(:new).with(
+          :association => :vms,
+          :manager     => ems_vmware,
+          :manager_ref => {:id => vm_vmware.id}
+        ).and_return(target)
+        expect(EmsRefresh).to receive(:queue_refresh).with(target)
         expect(job).to receive(:queue_signal).with(:wait_for_ip_address)
         job.signal(:wait_for_ip_address)
       end


### PR DESCRIPTION
When a migration is at the state "Waiting for IP address" for the post migration playbook, it can be because the inventory is not refreshed. The inventory is refreshed while waiting for the new VM to appear. But, during that refresh, it is likely that RHV will not report the IP addresses of the VM, because the RHV Guest Agent is not started yet.

Unfortunately, updates to RHV Guest Agent reported data don't trigger any event on RHV side, so CloudForms cannot know a new refresh is needed. The IP addresses will only be found with the next full refresh, increasing the migration time.

This pull request adds a new targeted refresh every 10 retries, as it consumes little resources and will find the IP address faster.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1847410