### PR TITLE
Don't rely on the default value for ImagePullPolicy

### DIFF
--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -14,6 +14,8 @@ class MiqWorker
 
       if container_image_tag.include?("latest")
         container[:imagePullPolicy] = "Always"
+      else
+        container[:imagePullPolicy] = "IfNotPresent"
       end
 
       container[:image] = "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"


### PR DESCRIPTION
Now we will set the pull policy to always if the tag matche .*latest.*
and also explicitly set it to IfNotPresent otherwise.