### PR TITLE
Remove extra vm_xen reference from factories

### DIFF
--- a/app/models/template_xen.rb
+++ b/app/models/template_xen.rb
@@ -1,2 +1,0 @@
-class TemplateXen < ManageIQ::Providers::InfraManager::Template
-end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -22,7 +22,6 @@ FactoryBot.define do
   factory(:vm_cloud,       :class => "VmCloud",       :parent => :vm)       { cloud { true } }
   factory(:vm_infra,       :class => "VmInfra",       :parent => :vm)
   factory(:vm_server,      :class => "VmServer",      :parent => :vm)
-  factory(:vm_xen,         :class => "VmXen",         :parent => :vm_infra)
   factory(:template_cloud, :class => "TemplateCloud", :parent => :template) { cloud { true } }
   factory(:template_infra, :class => "TemplateInfra", :parent => :template)
 

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -69,8 +69,6 @@ FactoryBot.define do
     vendor { "vmware" }
   end
 
-  factory(:template_xen, :class => "TemplateXen", :parent => :template_infra)
-
   factory :vm_amazon, :class => "ManageIQ::Providers::Amazon::CloudManager::Vm", :parent => :vm_cloud do
     location { |x| "#{x.name}.us-west-1.compute.amazonaws.com" }
     vendor   { "amazon" }


### PR DESCRIPTION
follow-up to ManageIQ/manageiq#20250

removes a vm_xen factory, related to https://github.com/ManageIQ/manageiq-ui-classic/pull/7132

EDIT: and a template_xen factory + TemplateXen class
