### PR TITLE
[Ansible::Runner] Fix --ask-become-method for machine credentials

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -202,7 +202,6 @@ module Ansible
         command_line_hash = tags.present? ? {:tags => tags} : {}
         if become_enabled
           command_line_hash[:become] = nil
-          command_line_hash[:ask_become_pass] = nil
         end
         command_line_hash.merge!(cred_command_line)
 

--- a/lib/ansible/runner/credential/machine_credential.rb
+++ b/lib/ansible/runner/credential/machine_credential.rb
@@ -7,8 +7,10 @@ module Ansible
 
       def command_line
         {:user => auth.userid}.delete_blanks.merge(become_args).tap do |args|
-          # Add `--ask-pass` flag to ansible_playbook if we have a password to provide
+          # Add `--ask-pass` or `--ask-become-pass` flags to ansible_playbook
+          # if we have a password to provide
           args[:ask_pass] = nil if auth.password.present?
+          args[:ask_become_pass] = nil if auth.become_password.present?
         end
       end
 

--- a/spec/lib/ansible/runner/credential/machine_credential_spec.rb
+++ b/spec/lib/ansible/runner/credential/machine_credential_spec.rb
@@ -32,10 +32,11 @@ RSpec.describe Ansible::Runner::MachineCredential do
     describe "#command_line" do
       it "is correct with all attributes" do
         expected = {
-          :ask_pass      => nil,
-          :become_user   => "root",
-          :become_method => "su",
-          :user          => "manageiq"
+          :ask_pass        => nil,
+          :ask_become_pass => nil,
+          :become_user     => "root",
+          :become_method   => "su",
+          :user            => "manageiq"
         }
         expect(cred.command_line).to eq(expected)
       end
@@ -44,9 +45,22 @@ RSpec.describe Ansible::Runner::MachineCredential do
         auth.update!(:userid => nil)
 
         expected = {
+          :ask_pass        => nil,
+          :ask_become_pass => nil,
+          :become_user     => "root",
+          :become_method   => "su"
+        }
+        expect(cred.command_line).to eq(expected)
+      end
+
+      it "doesn't set :ask_become_pass if become_password is blank" do
+        auth.update!(:become_password => "")
+
+        expected = {
           :ask_pass      => nil,
           :become_user   => "root",
-          :become_method => "su"
+          :become_method => "su",
+          :user          => "manageiq"
         }
         expect(cred.command_line).to eq(expected)
       end

--- a/spec/lib/ansible/runner_spec.rb
+++ b/spec/lib/ansible/runner_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Ansible::Runner do
         _method, dir, _json, _args = options[:params]
         cmdline = File.read(File.join(dir, "env", "cmdline"))
 
-        expect(cmdline).to eq("--become --ask-become-pass")
+        expect(cmdline).to eq("--become")
       end.and_return(result)
 
       described_class.run(env_vars, extra_vars, playbook, :become_enabled => true)


### PR DESCRIPTION
The `ansible-playbook` command has an option to ask for the password that will when escalating privileges on the target host, which is `--ask-become-method`.

`ansible-runner` uses the `env/passwords` file as a collection of STDOUT regexps to match against (keys), in which then should send the corresponding password (values) to STDIN as input.

The problem exists when a machine credential exists that doesn't have a password, so `env/passwords` isn't populated with a match for the prompt "BECOME Password: ", and hangs until a timeout is processed.

This fixes moves the logic for determining if `--ask-become-password` should be included in the `ansible-playbook` commandline ops to the `lib/ansible/runner/credential/machine_credential.rb` and makes it conditional on the presence of a `become_password` in the auth record.


Links
-----

* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1846621


Steps for Testing/QA
--------------------

TODO