### PR TITLE
remove extra selects from the persister builder cloud manager queries

### DIFF
--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -99,10 +99,8 @@ module ManageIQ::Providers
           ActiveRecord::Base.transaction do
             # associate parent templates to child instances
             parent_miq_templates = miq_templates_inventory_collection.model_class
-                                                                     .select([:id])
                                                                      .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
             vms_inventory_collection.model_class
-                                    .select([:id])
                                     .where(:id => vms_genealogy_parents.keys).find_each do |vm|
               parent = parent_miq_templates[vms_genealogy_parents[vm.id]]
               vm.with_relationship_type('genealogy') { vm.parent = parent }
@@ -112,10 +110,8 @@ module ManageIQ::Providers
           ActiveRecord::Base.transaction do
             # associate parent instances to child templates
             parent_vms = vms_inventory_collection.model_class
-                                                 .select([:id])
                                                  .where(:id => miq_template_genealogy_parents.values).find_each.index_by(&:id)
             miq_templates_inventory_collection.model_class
-                                              .select([:id])
                                               .where(:id => miq_template_genealogy_parents.keys).find_each do |miq_template|
               parent = parent_vms[miq_template_genealogy_parents[miq_template.id]]
               miq_template.with_relationship_type('genealogy') { miq_template.parent = parent }


### PR DESCRIPTION
we shouldn't need these at all, i think

we want objects, not the ids

@miq-bot assign @kbrock 
sorry Keenan, maybe you're willing to look at this for me please? 
it ought to be 🍒 

it was found as part of https://github.com/ManageIQ/manageiq/pull/20274, this fixes one of the remaining five failures on that PR[1] but is an unrelated bug

[1]:
```
ManageIQ::Providers::Inventory::Persister tests we can serialize inventory object with nested lazy references

     Failure/Error: self.tenant_id = miq_group.tenant_id if miq_group

     ActiveModel::MissingAttributeError:missing attribute: miq_group_id
     # ./app/models/mixins/ownership_mixin.rb:113:in `set_tenant_from_group'
     # ./app/models/mixins/relationship_mixin.rb:624:in `block in parent='
     # ./app/models/mixins/relationship_mixin.rb:89:in `with_relationship_type'
     # ./app/models/mixins/relationship_mixin.rb:622:in `parent='
     # ./app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb:107:in `block (4 levels) in vm_and_miq_template_ancestry_save_block'
     # ./app/models/mixins/relationship_mixin.rb:89:in `with_relationship_type'
     # ./app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb:107:in `block (3 levels) in vm_and_miq_template_ancestry_save_block'
     # ./app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb:106:in `block (2 levels) in vm_and_miq_template_ancestry_save_block'
     # ./app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb:99:in `block in vm_and_miq_template_ancestry_save_block'
     # ./app/models/manageiq/providers/inventory/persister.rb:23:in `persist!'
     # ./spec/models/manageiq/providers/inventory/persister/serializing_spec.rb:21:in `block (2 levels) in <top (required)>'
```