### PR TITLE
cloud manager needs all_vm_or_template alias set

### DIFF
--- a/app/models/manageiq/providers/cloud_manager.rb
+++ b/app/models/manageiq/providers/cloud_manager.rb
@@ -34,6 +34,8 @@ module ManageIQ::Providers
     # Only taggings mapped from labels, excluding user-assigned tags.
     has_many :vm_and_template_taggings,      -> { joins(:tag).merge(Tag.controlled_by_mapping) },
                                              :through     => :vms_and_templates, :source => :taggings
+    alias_method :all_vms_and_templates,  :vms_and_templates
+    alias_method :all_vm_or_template_ids, :vm_or_template_ids
 
     virtual_has_many :volume_availability_zones, :class_name => "AvailabilityZone", :uses => :availability_zones
 


### PR DESCRIPTION

fixes `ManageIQ::Providers::Google::CloudManager Inst Including Associations (0.1ms - 1rows)
[----] F, [2020-06-17T13:58:28.726000 #394303:ae790] FATAL -- : Error caught: [NoMethodError] undefined method 'all_vms_and_templates'` from https://github.com/ManageIQ/manageiq/issues/20284

thanks Adam
@miq-bot assign @agrare 
@miq-bot add_label bug

broken in https://github.com/ManageIQ/manageiq/pull/20149

