### PR TITLE
Update Service OrchestrationStack reconnection script

### DIFF
--- a/tools/reconnect_service_orchestration_stacks.rb
+++ b/tools/reconnect_service_orchestration_stacks.rb
@@ -39,8 +39,7 @@ ServiceOrchestration.all.each do |service|
           if opts[:dry_run]
             puts "  **** This is a dry-run, nothing updated, skipping. ****"
           else
-            # Create linking object directly
-            ServiceResource.create!(service: service, resource: matching_stack)
+            service.add_resource!(matching_stack)
             reconnected += 1
           end
         else


### PR DESCRIPTION
Hopefully tha last update of reconnection script, introduced in https://github.com/ManageIQ/manageiq/pull/20239

Use recommended Service.add_resource!(<an_orch_stack>) method to reconnect the Service.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1836102
