### PR TITLE
Ensure ems workers are killed by their server/orchestrator pod

### DIFF
--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -666,8 +666,15 @@ RSpec.describe ExtManagementSystem do
 
     it "destroys an ems with active workers" do
       ems = FactoryBot.create(:ext_management_system)
-      worker = FactoryBot.create(:miq_ems_refresh_worker, :queue_name => ems.queue_name, :status => "started")
+      worker = FactoryBot.create(:miq_ems_refresh_worker, :queue_name => ems.queue_name, :status => "started", :miq_server => EvmSpecHelper.local_miq_server)
+
       ems.destroy
+
+      # Simulate another process delivering the worker kill message
+      queue_message = MiqQueue.order(:id).first
+      status, message, result = queue_message.deliver
+      queue_message.delivered(status, message, result)
+
       expect(ExtManagementSystem.count).to eq(0)
       expect(worker.class.exists?(worker.id)).to eq(false)
     end
@@ -719,8 +726,8 @@ RSpec.describe ExtManagementSystem do
       ems.destroy_queue
 
       expect(MiqQueue.count).to eq(1)
-
-      deliver_queue_message
+      deliver_queue_message #  ems destroy message
+      deliver_queue_message #  worker kill message
 
       expect(MiqQueue.count).to eq(0)
       expect(ExtManagementSystem.count).to eq(0)

--- a/spec/models/miq_worker_spec.rb
+++ b/spec/models/miq_worker_spec.rb
@@ -392,6 +392,33 @@ RSpec.describe MiqWorker do
       end
     end
 
+    describe "#kill_async" do
+      let!(:remote_server) { EvmSpecHelper.remote_guid_miq_server_zone[1] }
+      let!(:local_server)  { EvmSpecHelper.local_guid_miq_server_zone[1] }
+
+      it "queues local worker to local server" do
+        worker = FactoryBot.create(:miq_worker, :miq_server => local_server)
+        worker.kill_async
+        msg = MiqQueue.where(:method_name => 'kill', :class_name => worker.class.name).first
+        expect(msg).to have_attributes(
+          :queue_name  => 'miq_server',
+          :server_guid => local_server.guid,
+          :zone        => local_server.my_zone
+        )
+      end
+
+      it "queues remote worker to remote server" do
+        worker = FactoryBot.create(:miq_worker, :miq_server => remote_server)
+        worker.kill_async
+        msg = MiqQueue.where(:method_name => 'kill', :class_name => worker.class.name).first
+        expect(msg).to have_attributes(
+          :queue_name  => 'miq_server',
+          :server_guid => remote_server.guid,
+          :zone        => remote_server.my_zone
+        )
+      end
+    end
+
     describe "#stopping_for_too_long?" do
       subject { @worker.stopping_for_too_long? }
 


### PR DESCRIPTION
Fixes #20288

Previously, direct calls to ems#destroy would assume you're calling it local
to each of the ems's workers and would fail to find the pid if not local.  Additionally,
in pods, only the orchestrator pod of the worker has permissions to kill the pod
so this would fail with permission errors such as:

deployments.apps "1-xyz-event-catcher-1" is forbidden: User "abc" cannot patch resource "deployments" in API group "apps" in the namespace "123" for PATCH https:...]

The ems.destroy_queue method calls _queue_task from the AsyncDeleteMixin, which doesn't specify the server_guid or queue_name so a UI request to delete the ems COULD be initiated in a UI appliance and picked up by the same appliance, which isn't where the ems's worker processes are running, and would ultimately call kill on each workers that don't exist locally.

Now, we queue the worker's kill method for the queue_name 'miq_server' so it's handled by the server "process" in appliances or orchestrator in pods and server_guid of the worker's server as an ems's workers can be on different servers.