### PR TITLE
Do targeted refresh when waiting for IP address

### DIFF
--- a/app/models/infra_conversion_job.rb
+++ b/app/models/infra_conversion_job.rb
@@ -334,6 +334,14 @@ class InfraConversionJob < Job
         # If no playbook is expected to run, we don't need to wait for the IP address.
         service_template = migration_task.send("#{migration_phase}_ansible_playbook_service_template")
         if target_vm.ipaddresses.empty? && service_template.present?
+          if context["retries_#{state}".to_sym] % 10 == 0
+            target = InventoryRefresh::Target.new(
+              :association => :vms,
+              :manager_ref => {:ems_ref => target_vm.ems_ref},
+              :manager     => target_vm.ext_management_system
+            )
+            EmsRefresh.queue_refresh(target)
+          end
           update_migration_task_progress(:on_retry)
           return queue_signal(:wait_for_ip_address)
         end


### PR DESCRIPTION
When a migration is at the state "Waiting for IP address" for the post migration playbook, it can be because the inventory is not refreshed. The inventory is refreshed while waiting for the new VM to appear. But, during that refresh, it is likely that RHV will not report the IP addresses of the VM, because the RHV Guest Agent is not started yet.

Unfortunately, updates to RHV Guest Agent reported data don't trigger any event on RHV side, so CloudForms cannot know a new refresh is needed. The IP addresses will only be found with the next full refresh, increasing the migration time.

This pull request adds a new targeted refresh every 10 retries, as it consumes little resources and will find the IP address faster.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1847410