### PR TITLE
Fix REGEX for virtual custom attributes in MiqExpression::Field

### DIFF
--- a/lib/miq_expression/field.rb
+++ b/lib/miq_expression/field.rb
@@ -5,7 +5,7 @@ class MiqExpression::Field < MiqExpression::Target
 \.?(?<associations>[a-z][0-9a-z_\.]+)?
 -
 (?:
-  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z]+[:_\-.\/[:alnum:]]*)|
+  (?<virtual_custom_column>#{CustomAttributeMixin::CUSTOM_ATTRIBUTES_PREFIX}[a-z0-9A-Z]+[:_\-.\/[:alnum:]]*)|
   (?<column>[a-z]+(_[[:alnum:]]+)*)
 )
 /x
@@ -13,6 +13,7 @@ class MiqExpression::Field < MiqExpression::Target
   def self.parse(field)
     parsed_params = parse_params(field) || return
     return unless parsed_params[:model_name]
+
     new(parsed_params[:model_name], parsed_params[:associations], parsed_params[:column] ||
         parsed_params[:virtual_custom_column])
   end

--- a/spec/lib/miq_expression/field_spec.rb
+++ b/spec/lib/miq_expression/field_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe MiqExpression::Field do
       expect(described_class.parse(field).column).to eq("name")
     end
 
+    it "can parse the virtual custom attribute" do
+      field = "ChargebackVm-virtual_custom_attribute_Application"
+      expect(described_class.parse(field).column).to eq("virtual_custom_attribute_Application")
+    end
+
+    it "can parse the virtual custom attribute which represents label" do
+      field = "ChargebackVm-virtual_custom_attribute_Application:SECTION:labels"
+      expect(described_class.parse(field).column).to eq("virtual_custom_attribute_Application:SECTION:labels")
+    end
+
     it "can parse the column name with associations present" do
       field = "Vm.host-name"
       expect(described_class.parse(field).column).to eq("name")


### PR DESCRIPTION
Fixes CP4MCM#10061

According to https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/labels.md container label can start with `[a-z0-9A-Z]` so this change updates REGEX for parsing virtual custom attribute in MiqExpression::Field.



Issue has occurred in [report editor ](https://github.com/ManageIQ/manageiq-ui-classic/blob/8bcc1e0dfcdb39891217a7383dce30422d7c03bd/app/controllers/report_controller/reports/editor.rb#L1121) and caused that virtual custom attribute for example:

`virtual_custom_attribute_Application:SECTION:labels`

was parsed

to 

`virtual_custom_attribute_Application`

thanks to the capital first letter. 

and then it appeared as "regular" custom attribute (and not as custom attribute representing container label ) in list of Selected Fields. (see the issue for more details how to reproduce it)



**Before**
<img width="863" alt="Screenshot 2020-06-19 at 16 53 29" src="https://user-images.githubusercontent.com/14937244/85145813-6da55880-b24d-11ea-8b94-484f879daf8c.png">

**After**
<img width="867" alt="Screenshot 2020-06-19 at 16 55 29" src="https://user-images.githubusercontent.com/14937244/85146023-b8bf6b80-b24d-11ea-8680-fecd1fb75fbf.png">



@miq-bot add_label bug, chargeback, jansa/yes
@miq-bot assign @gtanzillo 