### PR TITLE
Create env vars to override the full worker image ref

### DIFF
--- a/app/models/miq_ui_worker.rb
+++ b/app/models/miq_ui_worker.rb
@@ -41,4 +41,8 @@ class MiqUiWorker < MiqWorker
   def container_image_name
     "manageiq-ui-worker"
   end
+
+  def container_image
+    ENV["UI_WORKER_IMAGE"] || default_image
+  end
 end

--- a/app/models/miq_worker/container_common.rb
+++ b/app/models/miq_worker/container_common.rb
@@ -18,7 +18,7 @@ class MiqWorker
         container[:imagePullPolicy] = "IfNotPresent"
       end
 
-      container[:image] = "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
+      container[:image] = container_image
       container[:env] << {:name => "WORKER_CLASS_NAME", :value => self.class.name}
       container[:env] << {:name => "BUNDLER_GROUPS", :value => self.class.bundler_groups.join(",")}
     end
@@ -30,6 +30,14 @@ class MiqWorker
 
     def zone_selector
       {"#{Vmdb::Appliance.PRODUCT_NAME.downcase}/zone-#{MiqServer.my_zone}" => "true"}
+    end
+
+    def container_image
+      ENV["BASE_WORKER_IMAGE"] || default_image
+    end
+
+    def default_image
+      "#{container_image_namespace}/#{container_image_name}:#{container_image_tag}"
     end
 
     def container_image_namespace

--- a/app/models/miq_worker/service_worker.rb
+++ b/app/models/miq_worker/service_worker.rb
@@ -52,5 +52,9 @@ class MiqWorker
     def container_image_name
       "manageiq-webserver-worker"
     end
+
+    def container_image
+      ENV["WEBSERVER_WORKER_IMAGE"] || default_image
+    end
   end
 end


### PR DESCRIPTION
This will allow advanced users more flexability in how
the worker images are specified. Specifically this allows
changing the image name itself and also allows for digest-based
identifiers (rather than using only tags)

Applies to https://github.com/ManageIQ/manageiq-pods/issues/557