### PR TITLE
Fixed Settings hierarchy on Global region

### DIFF
--- a/app/models/miq_server.rb
+++ b/app/models/miq_server.rb
@@ -474,7 +474,7 @@ class MiqServer < ApplicationRecord
   end
 
   def miq_region
-    ::MiqRegion.my_region
+    MiqRegion.find_by(:region => region_id)
   end
 
   def self.display_name(number = 1)

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -585,10 +585,6 @@ RSpec.describe Vmdb::Settings do
                                :value         => "value from global region")
       end
 
-      after do
-        SettingsChange.delete_all
-      end
-
       it "applies settings from remote sever if there are specified" do
         SettingsChange.create!(:id            => ApplicationRecord.id_in_region(1, @region_remote.region),
                                :resource_id   => @server_remote.id,

--- a/spec/lib/vmdb/settings_spec.rb
+++ b/spec/lib/vmdb/settings_spec.rb
@@ -575,10 +575,10 @@ RSpec.describe Vmdb::Settings do
       before do
         Zone.seed
         @region_global = MiqRegion.first
-        @region_remote = FactoryBot.create(:miq_region, :id => MiqRegion.id_in_region(1, @region_global.region + 1))
-        @zone_remote   = FactoryBot.create(:zone, :id => Zone.id_in_region(2, @region_remote.region))
-        @server_remote = FactoryBot.create(:miq_server, :zone => @zone_remote, :id => MiqServer.id_in_region(1, @region_remote.region))
-        SettingsChange.create!(:id            => SettingsChange.id_in_region(1, @region_global.region),
+        @region_remote = FactoryBot.create(:miq_region, :id => ApplicationRecord.id_in_region(1, @region_global.region + 1))
+        @zone_remote   = FactoryBot.create(:zone, :id => ApplicationRecord.id_in_region(2, @region_remote.region))
+        @server_remote = FactoryBot.create(:miq_server, :zone => @zone_remote, :id => ApplicationRecord.id_in_region(1, @region_remote.region))
+        SettingsChange.create!(:id            => ApplicationRecord.id_in_region(1, @region_global.region),
                                :resource_id   => @region_global.id,
                                :resource_type => "MiqRegion",
                                :key           => "/#{key}",
@@ -589,8 +589,8 @@ RSpec.describe Vmdb::Settings do
         SettingsChange.delete_all
       end
 
-      it "applies settings from remote sever if there are specifyied" do
-        SettingsChange.create!(:id            => SettingsChange.id_in_region(1, @region_remote.region),
+      it "applies settings from remote sever if there are specified" do
+        SettingsChange.create!(:id            => ApplicationRecord.id_in_region(1, @region_remote.region),
                                :resource_id   => @server_remote.id,
                                :resource_type => "MiqServer",
                                :key           => "/#{key}",
@@ -598,8 +598,8 @@ RSpec.describe Vmdb::Settings do
         expect(Vmdb::Settings.for_resource(@server_remote)[key]).to eq(value_server_remote)
       end
 
-      it "applies settings from remote region if settings on remote server not specifyied" do
-        SettingsChange.create!(:id            => SettingsChange.id_in_region(1, @region_remote.region),
+      it "applies settings from remote region if settings on remote server not specified" do
+        SettingsChange.create!(:id            => ApplicationRecord.id_in_region(1, @region_remote.region),
                                :resource_id   => @region_remote.id,
                                :resource_type => "MiqRegion",
                                :key           => "/#{key}",

--- a/spec/models/miq_server_spec.rb
+++ b/spec/models/miq_server_spec.rb
@@ -442,6 +442,23 @@ RSpec.describe MiqServer do
     end
   end
 
+  describe "#miq_region" do
+    before do
+      Zone.seed
+      @region1 = MiqRegion.first.region
+      @region2 = FactoryBot.create(:miq_region, :id => MiqRegion.id_in_region(1, @region1 + 1)).region
+      zone = FactoryBot.create(:zone, :id => Zone.id_in_region(2, @region2))
+
+      @server1 = FactoryBot.create(:miq_server)
+      @server2 = FactoryBot.create(:miq_server, :zone => zone, :id => MiqServer.id_in_region(1, @region2))
+    end
+
+    it "returns region this server belongs to" do
+      expect(@server1.miq_region.region).to eq(@region1)
+      expect(@server2.miq_region.region).to eq(@region2)
+    end
+  end
+
   describe ".zone_is_modifiable?" do
     it "is true when there are multiple zones in the region" do
       FactoryBot.create(:miq_server)


### PR DESCRIPTION
**ISSUE:**
 On global region settings hierarchy ```MiqRegion```->```Zone```->```MiqServer``` was always using local region (which is global region), even for remote severs

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1836158

@miq-bot add-label bug, core