### PR TITLE
Combine child managers' RefreshWorkers

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -154,7 +154,7 @@ module EmsRefresh
 
   def self.queue_merge(targets, ems, create_task = false)
     queue_options = {
-      :queue_name  => MiqEmsRefreshWorker.queue_name_for_ems(ems),
+      :queue_name  => ems.queue_name,
       :class_name  => name,
       :method_name => 'refresh',
       :role        => "ems_inventory",

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -7,6 +7,17 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
   self.include_stopping_workers_on_synchronize = true
   self.required_roles = %w[ems_inventory]
 
+  def self.queue_name_for_ems(ems)
+    return ems unless ems.kind_of?(ExtManagementSystem)
+    return ems.queue_name unless ems.child_managers.any?
+    combined_managers(ems).map(&:queue_name).sort
+  end
+
+  def self.combined_managers(ems)
+    [ems].concat(ems.child_managers)
+  end
+  private_class_method :combined_managers
+
   def friendly_name
     @friendly_name ||= begin
       ems = ext_management_system


### PR DESCRIPTION
Providers with multiple managers shouldn't be refreshed by different workers.  Most multi-manager providers already do this and the rest should.

This addresses point 1 of https://github.com/ManageIQ/manageiq/issues/19950

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/145
Dependents:
* https://github.com/ManageIQ/manageiq-providers-azure/pull/401
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/608
* https://github.com/ManageIQ/manageiq-providers-amazon/pull/632
* https://github.com/ManageIQ/manageiq-providers-vmware/pull/595