### PR TITLE
refactor with_rel_type genealogy setter

### DIFF
--- a/app/models/ems_refresh/save_inventory.rb
+++ b/app/models/ems_refresh/save_inventory.rb
@@ -164,8 +164,7 @@ module EmsRefresh::SaveInventory
       hashes.each do |h|
         parent = vms[h.fetch_path(:parent_vm, :id)]
         child = vms[h[:id]]
-
-        child.with_relationship_type('genealogy') { child.parent = parent } if parent && child
+        child.update!(:genealogy_parent => parent) if parent && child
       end
     end
 

--- a/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
+++ b/app/models/manageiq/providers/inventory/persister/builder/cloud_manager.rb
@@ -102,8 +102,7 @@ module ManageIQ::Providers
                                                                      .where(:id => vms_genealogy_parents.values).find_each.index_by(&:id)
             vms_inventory_collection.model_class
                                     .where(:id => vms_genealogy_parents.keys).find_each do |vm|
-              parent = parent_miq_templates[vms_genealogy_parents[vm.id]]
-              vm.with_relationship_type('genealogy') { vm.parent = parent }
+              vm.update!(:genealogy_parent => parent_miq_templates[vms_genealogy_parents[vm.id]])
             end
           end
 
@@ -113,8 +112,7 @@ module ManageIQ::Providers
                                                  .where(:id => miq_template_genealogy_parents.values).find_each.index_by(&:id)
             miq_templates_inventory_collection.model_class
                                               .where(:id => miq_template_genealogy_parents.keys).find_each do |miq_template|
-              parent = parent_vms[miq_template_genealogy_parents[miq_template.id]]
-              miq_template.with_relationship_type('genealogy') { miq_template.parent = parent }
+              miq_template.update!(:genealogy_parent => parent_vms[miq_template_genealogy_parents[miq_template.id]])
             end
           end
         end

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -892,12 +892,6 @@ class VmOrTemplate < ApplicationRecord
     true
   end
 
-  def set_genealogy_parent(parent)
-    with_relationship_type('genealogy') do
-      self.parent = parent
-    end
-  end
-
   def add_genealogy_child(child)
     with_relationship_type('genealogy') do
       set_child(child)


### PR DESCRIPTION
I'm just separating the removal of 'set_rel_type' with bio parents out of the black magic binding stuff in https://github.com/ManageIQ/manageiq/pull/20274

@miq_bot assign @kbrock 
@miq-bot add_label refactoring

<sub><sup>although let's just be honest for a minute, shall we? https://github.com/ManageIQ/manageiq/pull/20274 is _awesome_ despite being the PR from hell </sup></sub>