### PR TITLE
Remove the miq_workers table from the reindex list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,7 +55,6 @@
     :reindex_tables:
     - Metric
     - MiqQueue
-    - MiqWorker
     :vacuum_schedule: "0 2 * * 6"
     :vacuum_tables:
     - BinaryBlob


### PR DESCRIPTION
This was causing nearly constant deadlocks in an environment with
lots of updates on the workers table. Based on
https://www.postgresql.org/docs/10/sql-reindex.html it sounds like
reindexes will definitely interfere with updates and that the situations
where we actually need a reindex are rather rare.

https://bugzilla.redhat.com/show_bug.cgi?id=1846281
Fixes #20281

I'm actually okay with leaving this without a migration. My thought was that
if a user has changed the tables for a reindex then they would probably be
aware of this deadlock issue if they were hitting it.