### PR TITLE
update parent setting test in vm_or_template to use update!

### DIFF
--- a/spec/models/vm_or_template_spec.rb
+++ b/spec/models/vm_or_template_spec.rb
@@ -106,7 +106,15 @@ RSpec.describe VmOrTemplate do
     let(:vm) { FactoryBot.create(:vm_vmware) }
     let(:parent) { FactoryBot.create(:vm_vmware) }
 
-    it "sets parent" do
+    it "sets parent via update!" do
+      vm.update!(:genealogy_parent => parent)
+
+      reloaded_vm = Vm.find(vm.id)
+      expect(reloaded_vm.parent).to eq(parent)
+      expect(reloaded_vm.genealogy_parent).to eq(parent)
+    end
+
+    it "sets parent via =" do
       vm.genealogy_parent = parent
       vm.save!
 


### PR DESCRIPTION
anywhere — yes all three of them — that set parents via genealogy got updated yesterday to use `update!` and our tests ought to reflect that change. we're leaving the old test in because it's rather likely i will be refactoring this code some more in the future and it might still be utile

extension of https://github.com/ManageIQ/manageiq/pull/20304

@miq-bot add_labels test, jansa/no 
