### PR TITLE
rename relationship ancestry method to clarify that it's for relationships

### DIFF
--- a/app/models/miq_filter.rb
+++ b/app/models/miq_filter.rb
@@ -73,7 +73,7 @@ module MiqFilter
       raise _("Folder Root is not a Provider")
     end
 
-    tag = obj.ancestry(
+    tag = obj.relationship_ancestry(
       :field_delimiter  => '|',
       :record_delimiter => '/',
       :include_self     => true,

--- a/app/models/mixins/relationship_mixin.rb
+++ b/app/models/mixins/relationship_mixin.rb
@@ -465,7 +465,7 @@ module RelationshipMixin
   # Returns a String form of the ancestor class/id pairs of the record
   #   Accepts the usual options, plus the options for Relationship.stringify_*,
   #   as well as :include_self which defaults to false.
-  def ancestry(*args)
+  def relationship_ancestry(*args)
     stringify_options = args.extract_options!
     options = stringify_options.slice!(:field_delimiter, :record_delimiter, :exclude_class, :field_method, :include_self)
 


### PR DESCRIPTION
this change is to make it clear that this method is for the relationship side only, not actual hierarchy methods

vms use both

as with https://github.com/ManageIQ/manageiq/pull/20310, is an extension of the cleanup of https://github.com/ManageIQ/manageiq/pull/20274

I'd like https://github.com/ManageIQ/manageiq/pull/20274 to be as minimal as possible. It is complicated enough without the distractions; I'd rather it to be only adding the binding, not compensating for all the other mostly unrelated things I had to do to get it to work. All the aforementioned things are valid, albeit small and sort of insignificant changes (in comparison).

this is one of the last and was a valid change in its own right

🍒 adjacent (you have to know the _why_)
