### PR TITLE
Fix issue where the square brackets are being created as directories in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,10 @@
 .git
+/data/*
+/public/assets
+/public/doc
+/public/packs
+/public/pictures
+/public/ui
+/public/upload
+/public/webmks
+/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ EXPOSE 443
 
 LABEL name="manageiq"
 
-VOLUME [ "/var/lib/pgsql/data" ]
-VOLUME [ ${APP_ROOT} ]
+VOLUME "/var/lib/pgsql/data"
+VOLUME ${APP_ROOT}


### PR DESCRIPTION
@carbonin Please review.

This also contains changes to the .dockerignore, because on my machine it was sending almost 500MB to the docker daemon on every local build.