### PR TITLE
Destroying a provider doesn't destroy its parent manager

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -65,7 +65,10 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  belongs_to :provider
+  # Typically belongs_to wouldn't dependent destroy but currently all management of
+  # Providers is done via the Manager, so when we delete the Manager we have to
+  # dependent delete the provider.
+  belongs_to :provider, :dependent => :destroy
   has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
 
   belongs_to :tenant

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -678,6 +678,15 @@ RSpec.describe ExtManagementSystem do
       expect(ExtManagementSystem.count).to eq(0)
       expect(worker.class.exists?(worker.id)).to eq(false)
     end
+
+    it "destroys a parent provider if present" do
+      provider = FactoryBot.create(:provider)
+      ems      = FactoryBot.create(:ext_management_system, :provider => provider)
+
+      ems.destroy
+
+      expect(Provider.count).to be_zero
+    end
   end
 
   context ".destroy_queue" do


### PR DESCRIPTION
When destroying a manager that has a parent Provider via the API or UI it will orphan the Provider record.  A dependent destroy on a belongs_to is far from ideal, but the UI/API has no ability to manage the `Provider` since the `/providers` API is really `ExtManagementSystem`

TODO: I need to check how this will interact with the openstack manager/provider relationship since they have their own before_destroy callback from the InfraManager to destroy the provider.

Fixes https://github.com/ManageIQ/manageiq-providers-ansible_tower/issues/225