### PR TITLE
Add supports feature mixin to container templates

### DIFF
--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -1,6 +1,7 @@
 class ContainerTemplate < ApplicationRecord
   include CustomAttributeMixin
   include CustomActionsMixin
+  include SupportsFeatureMixin
 
   belongs_to :ext_management_system, :foreign_key => "ems_id"
   belongs_to :container_project

--- a/app/models/mixins/supports_feature_mixin.rb
+++ b/app/models/mixins/supports_feature_mixin.rb
@@ -150,6 +150,7 @@ module SupportsFeatureMixin
     :change_password                     => 'Change Password',
     :volume_availability_zones           => 'Volume Availability Zones',
     :assume_role                         => 'Assume Role',
+    :instantiate                         => 'Instantiate',
   }.freeze
 
   # Whenever this mixin is included we define all features as unsupported by default.


### PR DESCRIPTION
Add the supports feature mixin to the container template model and add the "Instantiate" feature

Needed for: https://github.com/ManageIQ/manageiq-providers-openshift/pull/185