### PR TITLE
Added support for optional auth debugging

### DIFF
--- a/app/models/authenticator/base.rb
+++ b/app/models/authenticator/base.rb
@@ -52,6 +52,8 @@ module Authenticator
     end
 
     def authenticate(username, password, request = nil, options = {})
+      log_auth_debug("authenticate(username=#{username}, options=#{options})")
+
       options = options.dup
       options[:require_user] ||= false
       options[:authorize_only] ||= false
@@ -323,6 +325,14 @@ module Authenticator
 
     def normalize_username(username)
       username.downcase
+    end
+
+    def debug_auth?
+      !!Settings.authentication.debug
+    end
+
+    def log_auth_debug(msgs)
+      Array(msgs).each { |msg| _log.info(msg) } if debug_auth?
     end
 
     private def audit_success(options)

--- a/app/models/authenticator/httpd.rb
+++ b/app/models/authenticator/httpd.rb
@@ -131,18 +131,13 @@ module Authenticator
 
     def user_details_from_headers(username, request)
       if debug_auth?
-        log_auth_debug(
-          [
-            "External-Auth User Headers:",
-            "  X-REMOTE-USER           = #{username}",
-            "  X-REMOTE-USER-FIRSTNAME = #{request.headers['X-REMOTE-USER-FIRSTNAME']}",
-            "  X-REMOTE-USER-LASTNAME  = #{request.headers['X-REMOTE-USER-LASTNAME']}",
-            "  X-REMOTE-USER-FULLNAME  = #{request.headers['X-REMOTE-USER-FULLNAME']}",
-            "  X-REMOTE-USER-EMAIL     = #{request.headers['X-REMOTE-USER-EMAIL']}",
-            "  X-REMOTE-USER-DOMAIN    = #{request.headers['X-REMOTE-USER-DOMAIN']}",
-            "  X-REMOTE-USER-GROUPS    = #{CGI.unescape(request.headers['X-REMOTE-USER-GROUPS'])}"
-          ]
-        )
+        log_auth_debug("user_details_from_headers(username=#{username})")
+
+        remote_user_headers = %w[X-REMOTE-USER X-REMOTE-USER-FIRSTNAME X-REMOTE-USER-LASTNAME X-REMOTE-USER-FULLNAME X-REMOTE-USER-EMAIL X-REMOTE-USER-DOMAIN X-REMOTE-USER-GROUPS]
+        logged_headers = remote_user_headers.map { |rh| "  %-24{key} = \"%{val}\"" % {:key => rh, :val => request.headers[rh]} }
+
+        log_auth_debug("External-Auth remote user request.headers:")
+        log_auth_debug(logged_headers)
       end
       user_attrs = {:username  => username,
                     :fullname  => request.headers['X-REMOTE-USER-FULLNAME'],

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,11 +4,11 @@
   :bind_dn:
   :bind_pwd:
   :bind_timeout: 30
+  :debug: false
   :follow_referrals: false
   :get_direct_groups: true
   :group_memberships_max_depth: 2
   :group_attribute: memberof
-  :debug: false
   :ldaphost:
   :ldapport: '389'
   :mode: database

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,7 @@
   :get_direct_groups: true
   :group_memberships_max_depth: 2
   :group_attribute: memberof
+  :debug: false
   :ldaphost:
   :ldapport: '389'
   :mode: database


### PR DESCRIPTION
Added support for the **Settings.authentication.debug** boolean, when set to true, User.authenticate method's authenticate
is logged in evm.log including the user details and membership list we fetched with external auth  as well as  request headers
sent to us via X-REMOTE-USER*.

When setting:
```
   Settings.authentication.debug: true
```

The evm.log now includes the following lines shown here below from #log_auth_debug:

```
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug) authenticate(username=jsmith, options={:require_user=>true, :timeout=>30})

[----] I, ...  INFO -- : <AuditSuccess> MIQ(Base.audit_success) userid: [jsmith] - User jsmith successfully validated by External httpd

[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug) authorize_queue(username=jsmith, options={:require_user=>true, :timeout=>30, :authorize_only=>false})
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug) External-Auth User Headers:
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER           = jsmith
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER-FIRSTNAME = John
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER-LASTNAME  = Smith
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER-FULLNAME  = John S. Smith
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER-EMAIL     = john@smith.com
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER-DOMAIN    = smith.com
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   X-REMOTE-USER-GROUPS    = EvmGroup-super_administrator
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug) authorize_queue user details:
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   username     = jsmith
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   fullname     = John S. Smith
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   firstname    = John
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   lastname     = Smith
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   email        = john@smith.com
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   domain       = smith.com
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#log_auth_debug)   groups       = EvmGroup-super_administrator

[----] I, ...  INFO -- : MIQ(MiqTask#update_status) Task: [14] [Active] [Ok] [Authorizing]
[----] I, ...  INFO -- : MIQ(Authenticator::Httpd#authorize) Authorized User: [jsmith@smith.com]
[----] I, ...  INFO -- : MIQ(MiqTask#update_status) Task: [14] [Finished] [Ok] [User authorized successfully]
[----] I, ...  INFO -- : <AuditSuccess> MIQ(Base.audit_success) userid: [jsmith] - Authentication successful for user jsmith
```

Oh how I wish this was in when debugging auth redirects back to an MiQ pod from a keycloak pod within the CRC cluster  /cc @carbonin 
