### PR TITLE
Revert dependent destroy of provider from EMS

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -65,10 +65,7 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  # Typically belongs_to wouldn't dependent destroy but currently all management of
-  # Providers is done via the Manager, so when we delete the Manager we have to
-  # dependent delete the provider.
-  belongs_to :provider, :dependent => :destroy
+  belongs_to :provider
   has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
 
   belongs_to :tenant

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -678,15 +678,6 @@ RSpec.describe ExtManagementSystem do
       expect(ExtManagementSystem.count).to eq(0)
       expect(worker.class.exists?(worker.id)).to eq(false)
     end
-
-    it "destroys a parent provider if present" do
-      provider = FactoryBot.create(:provider)
-      ems      = FactoryBot.create(:ext_management_system, :provider => provider)
-
-      ems.destroy
-
-      expect(Provider.count).to be_zero
-    end
   end
 
   context ".destroy_queue" do


### PR DESCRIPTION
Dependent destroy of the provider from the EMS breaks the OpenStack CloudManager

Introduced by #20313