### PR TITLE
Autosave the EMS's provider to allow delegates

### DIFF
--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -68,7 +68,7 @@ class ExtManagementSystem < ApplicationRecord
     end
   end
 
-  belongs_to :provider
+  belongs_to :provider, :autosave => true
   has_many :child_managers, :class_name => 'ExtManagementSystem', :foreign_key => 'parent_ems_id'
 
   belongs_to :tenant


### PR DESCRIPTION
Delegating things like endpoints, name, and zone to the provider only works when the base relation has autosave => true

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/148