### PR TITLE
add a request template subclass post-create in miq_request_workflow

### DIFF
--- a/app/models/miq_provision_request_template.rb
+++ b/app/models/miq_provision_request_template.rb
@@ -21,6 +21,11 @@ class MiqProvisionRequestTemplate < MiqProvisionRequest
     MiqProvision
   end
 
+  def post_create(_auto_approve)
+    update(:description => "Miq Provision Request Template for #{source.name}")
+    self
+  end
+
   def service_template_resource_copy
     dup.tap(&:save!)
   end

--- a/spec/models/miq_provision_request_template_spec.rb
+++ b/spec/models/miq_provision_request_template_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe MiqProvisionRequestTemplate do
     end
   end
 
+  describe "post_create" do
+    it 'sets description' do
+      expect(MiqAeEngine).not_to receive(:resolve_automation_object)
+
+      provision_request_template.post_create(true)
+
+      expect(provision_request_template.description).to eq("Miq Provision Request Template for #{provision_request_template.source.name}")
+    end
+  end
+
   it 'exists after source template is deleted' do
     provision_request_template
     template.destroy


### PR DESCRIPTION
request templates shouldn't be calling automate or needing unique vm names
since at that point nothing has been provisioned

should resolve two errors:
`Could not create Service Template - Service Model not found` and
`Could not create Service Template - Unable to launch Automate Method because currently in SQL transaction`

the api call shouldn't run either vm_naming or anything to do with approval, i think. 

tested by creating a bare bones rhev service template via the ui, getting its config info hash from console, running stringify_keys on that hash, converting to json, and using it as the payload for a post service_template call. 

it's important to note that some of the args necessary for this to work are not found in the service_template spec in the api, i.e. i think `"service_template_request": true,` is necessary (otherwise it'll fail in validation with a `Could not create Service Template - undefined method 'base_class' for FalseClass:Class`) even though the api spec doesn't mention it. and as part of later, unrelated work, the validation that's running really should be more helpful than what it is currently. 

this was found in that recent hangouts chat that's been ongoing for a little while

and I guess my concern with adding this is that if you get the API call wrong with this change and the request doesn't get created, it will be a terrible experience because the only way you will know that something is wrong is that the UI will tell you if you know where to look, at the best case scenario. at the worst, the UI will simply break, without an error that I've managed to find.

@miq-bot assign @tinaafitz 
@miq-bot add_label bug

it's broken on probably everything, at least back to 5.11

https://github.com/ManageIQ/manageiq-api/pull/860 is related