### PR TITLE
Move the systemd env var check into the systemd_worker? method

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -316,7 +316,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.systemd_worker?
-    MiqEnvironment::Command.supports_systemd? && supports_systemd?
+    ENV['MIQ_SYSTEMD_WORKERS'] && MiqEnvironment::Command.supports_systemd? && supports_systemd?
   end
 
   def systemd_worker?
@@ -324,7 +324,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def start_runner
-    if ENV['MIQ_SYSTEMD_WORKERS'] && systemd_worker?
+    if systemd_worker?
       start_systemd_worker
     elsif containerized_worker?
       start_runner_via_container


### PR DESCRIPTION
When starting a worker we were checking an env var and settings, when stopping a worker we were just checking settings.  This meant that if the env var wasn't set we would start the worker with spawn and try to stop it with systemd which will fail because the unit doesn't exist.