### PR TITLE
[ansible/runner.rb] Add additional python3 module path for Centos8 support

### DIFF
--- a/lib/ansible/runner.rb
+++ b/lib/ansible/runner.rb
@@ -366,6 +366,7 @@ module Ansible
       PYTHON3_MODULE_PATHS = %w[
         /usr/lib64/python3.6/site-packages
         /var/lib/awx/venv/ansible/lib/python3.6/site-packages
+        /var/lib/manageiq/venv/lib/python3.6/site-packages
       ].freeze
       def python3_modules_path
         @python3_modules_path ||= begin


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq/issues/20309

Adds the mentioned module path to the list.  The list is verified for which ones are valid at runtime, so it isn't required that all of the ones listed exist.


Links
-----

* https://github.com/ManageIQ/manageiq/issues/20309