### PR TITLE
Double the initial delay and timeout for worker container liveness probes

### DIFF
--- a/lib/container_orchestrator/object_definition.rb
+++ b/lib/container_orchestrator/object_definition.rb
@@ -97,8 +97,9 @@ class ContainerOrchestrator
     def liveness_probe
       {
         :exec                => {:command => ["/usr/local/bin/manageiq_liveness_check"]},
-        :initialDelaySeconds => 120,
-        :timeoutSeconds      => 5
+        :initialDelaySeconds => 240,
+        :timeoutSeconds      => 10,
+        :periodSeconds       => 15
       }
     end
 


### PR DESCRIPTION
Some environments we deploy to need quite a bit of extra time for
the worker pods to come up.

This required adding a value for `periodSeconds`. The default is to check every 10 seconds, but if we also have the timeout at 10 seconds, we really want to leave some room in between the checks.