### PR TITLE
[JANSA] Move the systemd env var check into the systemd_worker? method

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -316,7 +316,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.systemd_worker?
-    MiqEnvironment::Command.supports_systemd? && supports_systemd?
+    ENV['MIQ_SYSTEMD_WORKERS'] && MiqEnvironment::Command.supports_systemd? && supports_systemd?
   end
 
   def systemd_worker?
@@ -324,7 +324,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def start_runner
-    if ENV['MIQ_SYSTEMD_WORKERS'] && systemd_worker?
+    if systemd_worker?
       start_systemd_worker
     elsif containerized_worker?
       start_runner_via_container

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1099,7 +1099,7 @@
       :poll_method: :normal
       :starting_timeout: 10.minutes
       :stopping_timeout: 10.minutes
-      :systemd_enabled: true
+      :systemd_enabled: false
     :agent_coordinator_worker:
       :heartbeat_timeout: 30.minutes
       :poll: 30.seconds


### PR DESCRIPTION
Jansa backport of https://github.com/ManageIQ/manageiq/pull/20321 plus disabling systemd on jansa