### PR TITLE
Fix foreman provider missing url in specs

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -127,7 +127,7 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/configuration_manager"],
           :class   => "ManageIQ::Providers::Foreman::ConfigurationManager",
           :parent  => :ext_management_system do
-    provider :factory => :provider
+    provider :factory => :provider_foreman
   end
 
   # Automation managers
@@ -141,7 +141,7 @@ FactoryBot.define do
           :aliases => ["manageiq/providers/provisioning_manager"],
           :class   => "ManageIQ::Providers::Foreman::ProvisioningManager",
           :parent  => :ext_management_system do
-    provider :factory => :provider
+    provider :factory => :provider_foreman
   end
 
   # Leaf classes for ems_infra

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -140,9 +140,10 @@ RSpec.describe ExtManagementSystem do
     expect { ManageIQ::Providers::AutomationManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate! }.to raise_error(ActiveRecord::RecordInvalid)
     expect(ManageIQ::Providers::Vmware::InfraManager.new(:hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
 
-    foreman_provider = ManageIQ::Providers::Foreman::Provider.new
-    expect(ManageIQ::Providers::Foreman::ConfigurationManager.new(:provider => foreman_provider, :hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
-    expect(ManageIQ::Providers::Foreman::ProvisioningManager.new(:provider => foreman_provider, :hostname => "abc", :name => "abc", :zone => FactoryBot.build(:zone)).validate!).to eq(true)
+    zone = FactoryBot.create(:zone)
+    foreman_provider = ManageIQ::Providers::Foreman::Provider.new(:name => "abc", :zone => zone, :url => "https://abc")
+    expect(ManageIQ::Providers::Foreman::ConfigurationManager.new(:provider => foreman_provider, :name => "abc", :zone => zone).validate!).to eq(true)
+    expect(ManageIQ::Providers::Foreman::ProvisioningManager.new(:provider => foreman_provider, :name => "abc", :zone => zone).validate!).to eq(true)
   end
 
   context "#ipaddress / #ipaddress=" do


### PR DESCRIPTION
Fix EMS specs now that the foreman configuration_manager auto-creates a provider

Followup to https://github.com/ManageIQ/manageiq-providers-foreman/pull/62