### PR TITLE
Move supports :create out of base Flavor model

### DIFF
--- a/app/models/flavor.rb
+++ b/app/models/flavor.rb
@@ -3,9 +3,6 @@ class Flavor < ApplicationRecord
   include CloudTenancyMixin
   include SupportsFeatureMixin
 
-  supports :create
-  supports :delete
-
   acts_as_miq_taggable
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::CloudManager"


### PR DESCRIPTION
Currently the supports :create/:delete features are enabled at the base Flavor model, however only Openstack implements these operations

This was added by https://github.com/ManageIQ/manageiq/pull/15552 along with `validate_create_flavor` and `validate_delete_flavor` methods, however the UI doesn't appear to use these and instead just checks [`ems.class::Flavor.supports?(:create)`](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/application_helper/button/new_flavor.rb#L4)

The result of this is that you can add a flavor on other Cloud providers such as Amazon and Azure but nothing actually happens when you do so.

Cross Repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/149

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-openstack/pull/613

Before: Able to get to the Add a Flavor screen with an AWS provider
![Screenshot from 2020-07-06 12-53-16](https://user-images.githubusercontent.com/12851112/86618962-c4b66780-bf87-11ea-945e-dbc2804af9e7.png)

After: Configuration dropdown is disabled
![Screenshot from 2020-07-06 12-55-05](https://user-images.githubusercontent.com/12851112/86619128-ff200480-bf87-11ea-94c1-88affeba8e16.png)
