### PR TITLE
[WIP] Do not create duplicate retirement request

### DIFF
--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -129,11 +129,20 @@ module RetirementMixin
 
   def retirement_check
     if retirement_queued?
-      _log.warn("Retirement  request already queued for  #{self.class.name} id:<#{id}>, name:<#{name}> ")
+      _log.warn("Retirement  request already queued for  #{self.class.name} id:<#{id}>, name:<#{name}>")
       return
     end
 
-    return if retired? || retiring? || retirement_initialized?
+    if retired?
+      _log.warn("Object already retired.  #{self.class.name} id:<#{id}>, name:<#{name}>")
+      return
+    end
+
+    if retiring? || retirement_initialized?
+      _log.warn("Retirement  request already started #{self.class.name} id:<#{id}>, name:<#{name}>")
+      return
+    end
+
     requester = system_context_requester
 
     if !retirement_warned? && retirement_warning_due?

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -157,8 +157,6 @@ module RetirementMixin
       _log.info("#{retirement_object_title}: [#{name}], Retires On: [#{retires_on.strftime("%x %R %Z")}], was previously retired, but currently #{retired_invalid_reason}")
     elsif retiring?
       _log.info("#{retirement_object_title}: [#{name}] retirement in progress")
-    elsif retirement_queued?
-      _log.warn("Retirement  request already queued for  #{self.class.name} id:<#{id}>, name:<#{name}> ")
     else
       lock do
         reload

--- a/app/models/mixins/retirement_mixin.rb
+++ b/app/models/mixins/retirement_mixin.rb
@@ -161,7 +161,7 @@ module RetirementMixin
       lock do
         reload
         if error_retiring? || retirement_state.blank?
-          update(:retirement_state => "initializing", :retirement_requester => requester)
+          update(:retirement_state => RETIREMENT_INITIALIZING, :retirement_requester => requester)
           event_name = "request_#{retirement_event_prefix}_retire"
           _log.info("calling #{event_name}")
           begin
@@ -189,13 +189,13 @@ module RetirementMixin
 
   def mark_retired
     self[:retires_on] = Time.zone.now
-    update(:retired => true, :retirement_state => "retired")
+    update(:retired => true, :retirement_state => RETIREMENT_RETIRED)
   end
 
   def start_retirement
     return if retired? || retiring?
     $log.info("Starting Retirement for [#{name}]")
-    update(:retirement_state => "retiring")
+    update(:retirement_state => RETIREMENT_RETIRING)
   end
 
   def retired_validated?


### PR DESCRIPTION
**ISSUE:**
If something wrong with retirement check or it takes some time to process retirement queue  than multiple retirement request for the same object can be created.

**AFTER**:
update ```retirement_state``` attribute of object to ```queued``` when retirement request created

This PR does not change how ``` retire now``` works and there is still possibility to create duplicate request using ```retire now``` functionality.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1851087

@miq-bot add-label bug,  ivanchuk/yes,  jansa/yes?
