### PR TITLE
Remove the extra env var for systemd configuration

### DIFF
--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -316,7 +316,7 @@ class MiqWorker < ApplicationRecord
   end
 
   def self.systemd_worker?
-    ENV['MIQ_SYSTEMD_WORKERS'] && MiqEnvironment::Command.supports_systemd? && supports_systemd?
+    MiqEnvironment::Command.supports_systemd? && supports_systemd?
   end
 
   def systemd_worker?


### PR DESCRIPTION
We already have a per-worker setting to disable systemd so an extra environment variable isn't necessary.

This will also re-enable systemd on appliances, https://github.com/ManageIQ/manageiq/issues/19581