### PR TITLE
Use chargeback model in columns for report editor

### DIFF
--- a/lib/miq_expression.rb
+++ b/lib/miq_expression.rb
@@ -803,7 +803,7 @@ class MiqExpression
     custom_attributes_details = []
 
     klass.custom_keys.each do |custom_key|
-      custom_detail_column = [model, CustomAttributeMixin.column_name(custom_key)].join("-")
+      custom_detail_column = [options[:model_for_column] || model, CustomAttributeMixin.column_name(custom_key)].join("-")
       custom_detail_name = CustomAttributeMixin.to_human(custom_key)
 
       if options[:include_model]
@@ -893,7 +893,7 @@ class MiqExpression
            else
              []
            end
-      md + td + _custom_details_for(cb_model, {})
+      md + td + _custom_details_for(cb_model, :model_for_column => model)
     else
       model_details(model, :include_model => false, :include_tags => true)
     end

--- a/spec/lib/miq_expression_spec.rb
+++ b/spec/lib/miq_expression_spec.rb
@@ -2279,6 +2279,20 @@ RSpec.describe MiqExpression do
 
       expect(MiqExpression._custom_details_for("ContainerImage", {})).to match_array(expected_result)
     end
+
+    context "model is ChargebackVm" do
+      let(:vm) { FactoryBot.create(:vm) }
+      let!(:custom_attribute_for_vm) { FactoryBot.create(:custom_attribute, :name => 'Application', :section => 'labels', :resource => vm) }
+
+      it "returns human names of custom attributes with sections" do
+        expected_result = [
+          ['Labels: Application', 'ChargebackVm-virtual_custom_attribute_Application:SECTION:labels'],
+          ['Custom Attribute: CATTR_1', 'ChargebackVm-virtual_custom_attribute_CATTR_1']
+        ]
+
+        expect(MiqExpression._custom_details_for("Vm", :model_for_column => "ChargebackVm")).to match_array(expected_result)
+      end
+    end
   end
 
   describe "#to_human" do


### PR DESCRIPTION
it was causing that label was still available in report editor available field even when the column was already selected.

- When creating chargeback report, select fields starting with Labels. 
- Save the report and edit it again.
- Check back again Available Fields. 
- Fields starting with Labels are again available to add to the report. 

![932dd880-b70b-11ea-9bf1-83343ed4e01e](https://user-images.githubusercontent.com/14937244/86822368-d5500600-c08b-11ea-85c2-aad41a29a85d.png)

![9f199a80-b70b-11ea-9a50-c1fc7b3ce8a7](https://user-images.githubusercontent.com/14937244/86822374-d719c980-c08b-11ea-83c6-237a14951036.png)

@miq-bot add_label jansa/yes
@miq-bot assign @gtanzillo 