### PR TITLE
Add the VMware NSX-t Provider plugin to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,6 +130,10 @@ group :lenovo, :manageiq_default do
   manageiq_plugin "manageiq-providers-lenovo"
 end
 
+group :nsxt, :manageiq_default do
+  manageiq_plugin "manageiq-providers-nsxt"
+end
+
 group :nuage, :manageiq_default do
   manageiq_plugin "manageiq-providers-nuage"
 end

--- a/spec/models/ext_management_system_spec.rb
+++ b/spec/models/ext_management_system_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe ExtManagementSystem do
       "openstack_infra"             => "OpenStack Platform Director",
       "openstack_network"           => "OpenStack Network",
       "lenovo_ph_infra"             => "Lenovo XClarity",
+      "nsxt"                        => "VMware NSX-T Network Manager",
       "nuage_network"               => "Nuage Network Manager",
       "redfish_ph_infra"            => "Redfish",
       "redhat_network"              => "Redhat Network",


### PR DESCRIPTION
This adds the VMware NSX-t provider plugin to the main Gemfile

NSX-t is a network manager that brings network functions virtualization
and software defined networking to the datacenter and cloud-native
resources.

Closes https://github.com/ManageIQ/manageiq/issues/20194