### PR TITLE
[HAMMER] Lock manageiq-messaging to 0.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "kubeclient",                     "~>4.0",         :require => false # For s
 gem "linux_admin",                    "~>1.2.1",       :require => false
 gem "log_decorator",                  "~>0.1",         :require => false
 gem "manageiq-api-client",            "~>0.3.3",       :require => false
-gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :branch => "master"
+gem "manageiq-messaging",                              :require => false, :git => "https://github.com/ManageIQ/manageiq-messaging", :tag => "v0.1.2"
 gem "manageiq-postgres_ha_admin",     "~>3.0",         :require => false
 gem "memoist",                        "~>0.15.0",      :require => false
 gem "mime-types",                     "~>3.0",         :path => File.expand_path("mime-types-redirector", __dir__)


### PR DESCRIPTION
Travis is failing in hammer branch due to manageiq-messaging now requiring a newer version of activesupport than what's used in hammer branch. Any version < 0.1.6 will work, but locking to what was last used in the downstream hammer build.

```
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    manageiq-messaging was resolved to 0.1.6, which depends on
      activesupport (~> 5.2.4.3)

    rails (~> 5.0.7.2) was resolved to 5.0.7.2, which depends on
      activesupport (= 5.0.7.2)
```