### PR TITLE
Remove MiqSockUtil and just use Socket

### DIFF
--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -44,7 +44,7 @@ module MiqServer::EnvironmentManagement
           mac_address = eth0.mac_address
         else
           require 'socket'
-          ipaddr      = Socket.ip_address_list.detect{ |addr| addr.ipv4? && !addr.ipv4_private? }&.ip_address
+          ipaddr      = Socket.ip_address_list.detect { |addr| addr.ipv4? && !addr.ipv4_private? }&.ip_address
           hostname    = Socket.gethostbyname(Socket.gethostname).first
           mac_address = UUIDTools::UUID.mac_address.dup
         end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -43,9 +43,9 @@ module MiqServer::EnvironmentManagement
           hostname    = LinuxAdmin::Hosts.new.hostname
           mac_address = eth0.mac_address
         else
-          require 'MiqSockUtil'
-          ipaddr      = MiqSockUtil.getIpAddr
-          hostname    = MiqSockUtil.getFullyQualifiedDomainName
+          require 'socket'
+          ipaddr      = Socket.ip_address_list.select{ |addr| addr.ipv4? && !addr.ipv4_private? }.first&.ip_address
+          hostname    = Socket.gethostbyname(Socket.gethostname).first
           mac_address = UUIDTools::UUID.mac_address.dup
         end
       rescue

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -43,7 +43,6 @@ module MiqServer::EnvironmentManagement
           hostname    = LinuxAdmin::Hosts.new.hostname
           mac_address = eth0.mac_address
         else
-          require 'socket'
           ipaddr      = MiqEnvironment.local_ip_address
           hostname    = MiqEnvironment.fully_qualified_domain_name
           mac_address = UUIDTools::UUID.mac_address.dup

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -44,7 +44,7 @@ module MiqServer::EnvironmentManagement
           mac_address = eth0.mac_address
         else
           require 'socket'
-          ipaddr      = Socket.ip_address_list.select{ |addr| addr.ipv4? && !addr.ipv4_private? }.first&.ip_address
+          ipaddr      = Socket.ip_address_list.detect{ |addr| addr.ipv4? && !addr.ipv4_private? }&.ip_address
           hostname    = Socket.gethostbyname(Socket.gethostname).first
           mac_address = UUIDTools::UUID.mac_address.dup
         end

--- a/app/models/miq_server/environment_management.rb
+++ b/app/models/miq_server/environment_management.rb
@@ -44,8 +44,8 @@ module MiqServer::EnvironmentManagement
           mac_address = eth0.mac_address
         else
           require 'socket'
-          ipaddr      = Socket.ip_address_list.detect { |addr| addr.ipv4? && !addr.ipv4_private? }&.ip_address
-          hostname    = Socket.gethostbyname(Socket.gethostname).first
+          ipaddr      = MiqEnvironment.local_ip_address
+          hostname    = MiqEnvironment.fully_qualified_domain_name
           mac_address = UUIDTools::UUID.mac_address.dup
         end
       rescue

--- a/lib/miq_environment.rb
+++ b/lib/miq_environment.rb
@@ -1,6 +1,19 @@
 require 'sys-uname'
+require 'socket'
 
 module MiqEnvironment
+  # Return the fully qualified hostname for the local host.
+  #
+  def self.fully_qualified_domain_name
+    Socket.gethostbyname(Socket.gethostname).first
+  end
+
+  # Return the local IP v4 address of the local host, ignoring private addresses.
+  #
+  def self.local_ip_address
+    Socket.ip_address_list.detect { |addr| addr.ipv4? && !addr.ipv4_private? }&.ip_address
+  end
+
   class Command
     EVM_KNOWN_COMMANDS = %w[apachectl memcached memcached-tool nohup service systemctl].freeze
 

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe MiqEnvironment do
       silence_warnings { Sys::Platform::IMPL = @old_impl } if @old_impl
     end
 
+    context "Host Info" do
+      example "fully_qualified_domain_name" do
+        expect(described_class.fully_qualified_domain_name).to eq(`hostname -f`.chomp)
+      end
+
+      example "local_ip_address" do
+        expect(described_class.local_ip_address).to eq(`hostname -i`.chomp)
+      end
+    end
+
     context "Command" do
       context ".supports_memcached?" do
         it "should run once and cache the result" do

--- a/spec/lib/miq_environment_spec.rb
+++ b/spec/lib/miq_environment_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MiqEnvironment do
       end
 
       example "local_ip_address" do
-        expect(described_class.local_ip_address).to eq(`hostname -i`.chomp)
+        expect(described_class.local_ip_address).to eq(`hostname -i`.chomp.split.first)
       end
     end
 

--- a/spec/models/miq_server/environment_manager_spec.rb
+++ b/spec/models/miq_server/environment_manager_spec.rb
@@ -1,4 +1,17 @@
+require 'socket'
+
 RSpec.describe "Server Environment Management" do
+  let(:mac_address) { 'a:1:b:2:c:3:d:4' }
+  let(:hostname) { Socket.gethostname }
+  let(:loopback) { '127.0.0.1' }
+
+  context ".get_network_information" do
+    it "when in non-production mode" do
+      allow(UUIDTools::UUID).to receive(:mac_address).and_return(mac_address)
+      expect(MiqServer.get_network_information).to eq([loopback, hostname, mac_address])
+    end
+  end
+
   context ".spartan_mode" do
     before { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }
     after { MiqServer.class_eval { instance_variable_set :@spartan_mode, nil } }

--- a/tools/show_host_file_entries_for_vnc.rb
+++ b/tools/show_host_file_entries_for_vnc.rb
@@ -17,7 +17,7 @@ ManageIQ::Providers::Vmware::Host.all.each do |host|
   else
     require 'socket'
     begin
-      ipaddress = TCPSocket.gethostbyname(hostname.split(',').first).last
+      ipaddress = TCPSocket.gethostbyname(host.ipaddress.split(',').first).last
     rescue SocketError => err
       STDERR.puts "Cannot resolve hostname(#{host.ipaddress}) for Host ID=#{host.id.inspect}, Name=#{host.name.inspect} because #{err.message}"
       next

--- a/tools/show_host_file_entries_for_vnc.rb
+++ b/tools/show_host_file_entries_for_vnc.rb
@@ -15,8 +15,9 @@ ManageIQ::Providers::Vmware::Host.all.each do |host|
   if host.ipaddress.ipaddress?
     ipaddress = host.ipaddress
   else
+    require 'socket'
     begin
-      ipaddress = MiqSockUtil.resolve_hostname(host.ipaddress)
+      ipaddress = TCPSocket.gethostbyname(hostname.split(',').first).last
     rescue SocketError => err
       STDERR.puts "Cannot resolve hostname(#{host.ipaddress}) for Host ID=#{host.id.inspect}, Name=#{host.name.inspect} because #{err.message}"
       next


### PR DESCRIPTION
Let's replace `MiqSockUtil` with plain `Socket` calls, since it's a pretty thin wrapper already and not used in a lot of places. This will then let us yank it from gems-pending.

Part of the continuing cleanup effort layed out in https://github.com/ManageIQ/manageiq-gems-pending/issues/231.