### PR TITLE
Delegate queue_name for refresh to parent manager instead of queue_name arrays

### DIFF
--- a/app/models/ems_refresh.rb
+++ b/app/models/ems_refresh.rb
@@ -115,7 +115,7 @@ module EmsRefresh
 
   def self.queue_merge(targets, ems, create_task = false)
     queue_options = {
-      :queue_name  => ems.queue_name,
+      :queue_name  => ems.queue_name_for_ems_refresh,
       :class_name  => name,
       :method_name => 'refresh',
       :role        => "ems_inventory",

--- a/app/models/ext_management_system.rb
+++ b/app/models/ext_management_system.rb
@@ -693,6 +693,10 @@ class ExtManagementSystem < ApplicationRecord
     'generic'
   end
 
+  def queue_name_for_ems_refresh
+    queue_name
+  end
+
   def enforce_policy(target, event)
     inputs = {:ext_management_system => self}
     inputs[:vm]   = target if target.kind_of?(Vm)

--- a/app/models/manageiq/providers/base_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/base_manager/refresh_worker.rb
@@ -7,17 +7,6 @@ class ManageIQ::Providers::BaseManager::RefreshWorker < MiqQueueWorkerBase
   self.include_stopping_workers_on_synchronize = true
   self.required_roles = %w[ems_inventory]
 
-  def self.queue_name_for_ems(ems)
-    return ems unless ems.kind_of?(ExtManagementSystem)
-    return ems.queue_name unless ems.child_managers.any?
-    combined_managers(ems).map(&:queue_name).sort
-  end
-
-  def self.combined_managers(ems)
-    [ems].concat(ems.child_managers)
-  end
-  private_class_method :combined_managers
-
   def friendly_name
     @friendly_name ||= begin
       ems = ext_management_system

--- a/app/models/manageiq/providers/network_manager.rb
+++ b/app/models/manageiq/providers/network_manager.rb
@@ -39,6 +39,8 @@ module ManageIQ::Providers
                :class_name  => "ManageIQ::Providers::BaseManager",
                :autosave    => true
 
+    delegate :queue_name_for_ems_refresh, :to => :parent_manager
+
     has_many :availability_zones,            -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
     has_many :flavors,                       -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id
     has_many :cloud_tenants,                 -> { where.not(:ems_id => nil) }, :primary_key => :parent_ems_id, :foreign_key => :ems_id

--- a/app/models/manageiq/providers/storage_manager.rb
+++ b/app/models/manageiq/providers/storage_manager.rb
@@ -16,6 +16,8 @@ module ManageIQ::Providers
                :class_name  => "ManageIQ::Providers::BaseManager",
                :autosave    => true
 
+    delegate :queue_name_for_ems_refresh, :to => :parent_manager
+
     def self.display_name(number = 1)
       n_('Storage Manager', 'Storage Managers', number)
     end

--- a/app/models/miq_queue.rb
+++ b/app/models/miq_queue.rb
@@ -208,7 +208,7 @@ class MiqQueue < ApplicationRecord
       # options[:queue_name] = "generic"
       options[:role] = service
     when "ems_inventory"
-      options[:queue_name] = MiqEmsRefreshWorker.queue_name_for_ems(resource)
+      options[:queue_name] = resource.queue_name_for_ems_refresh
       options[:role]       = service
       options[:zone]       = resource.my_zone
     when "ems_operations"

--- a/app/models/miq_worker.rb
+++ b/app/models/miq_worker.rb
@@ -274,18 +274,6 @@ class MiqWorker < ApplicationRecord
     MiqWorker.log_status(level)
   end
 
-  # Overriding queue_name as now some queue names can be
-  # arrays of names for some workers not just a singular name.
-  # We use JSON.parse as the array of names is stored as a string.
-  # This converts it back to a Ruby Array safely.
-  def queue_name
-    begin
-      JSON.parse(self[:queue_name]).sort
-    rescue JSON::ParserError, TypeError
-      self[:queue_name]
-    end
-  end
-
   def self.containerized_worker?
     MiqEnvironment::Command.is_podified?
   end

--- a/app/models/mixins/per_ems_worker_mixin.rb
+++ b/app/models/mixins/per_ems_worker_mixin.rb
@@ -115,7 +115,7 @@ module PerEmsWorkerMixin
     end
 
     def ems_id_from_queue_name(queue_name)
-      queue_name.kind_of?(Array) ? queue_name.collect { |q| parse_ems_id(q) }.flatten : parse_ems_id(queue_name)
+      parse_ems_id(queue_name)
     end
 
     def ems_from_queue_name(queue_name)


### PR DESCRIPTION
Instead of changing the worker queue_name to allow for arrays which has been problematic we could simply delegate the queue_name for refresh to the parent manager if the child managers are targeted and leave the parent manager's RefreshWorker queue_name alone.

Depends on:
- [x] Update standalone network managers (Nuage and NSX-t) to not delegate to parent_manager (https://github.com/ManageIQ/manageiq-providers-nuage/pull/217, https://github.com/ManageIQ/manageiq-providers-nsxt/pull/10)

Dependent:
- [x] Data migration to clear worker records with json queue names (https://github.com/ManageIQ/manageiq-schema/pull/496)

Fixes https://github.com/ManageIQ/manageiq/issues/20307