### PR TITLE
Use Host#uid_ems to link host records to ems_events

### DIFF
--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -95,7 +95,7 @@ class EmsEvent < EventStream
 
     if event[:host_id].nil? && uid_ems.present?
       # Attempt to find a host in the current EMS first, then fallback to archived hosts
-      host = Host.find_by(:ems_id => event[:ems_id], :uid_ems => uid_ems) || Host.find_by(:ems_id => nil, :uid_ems => uid_ems)
+      host = Host.where(:uid_ems => uid_ems, :ems_id => [event[:ems_id], nil]).order("ems_id NULLS LAST").first
       unless host.nil?
         event[:host_id]     = host.id
         event[:host_name] ||= host.name

--- a/app/models/ems_event.rb
+++ b/app/models/ems_event.rb
@@ -90,7 +90,17 @@ class EmsEvent < EventStream
   end
 
   def self.process_host_in_event!(event, options = {})
+    uid_ems = event.delete(:host_uid_ems)
     process_object_in_event!(Host, event, options)
+
+    if event[:host_id].nil? && uid_ems.present?
+      # Attempt to find a host in the current EMS first, then fallback to archived hosts
+      host = Host.find_by(:ems_id => event[:ems_id], :uid_ems => uid_ems) || Host.find_by(:ems_id => nil, :uid_ems => uid_ems)
+      unless host.nil?
+        event[:host_id]     = host.id
+        event[:host_name] ||= host.name
+      end
+    end
   end
 
   def self.process_container_entities_in_event!(event, _options = {})

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -275,6 +275,34 @@ RSpec.describe EmsEvent do
         end
       end
     end
+
+    context "with a host" do
+      let(:event) do
+        {
+          :ems_id       => ems.id,
+          :event_type   => "HostAddEvent",
+          :host_uid_ems => host.uid_ems
+        }
+      end
+
+      context "with an active host" do
+        let(:host) { FactoryBot.create(:host, :uid_ems => "6f3fa3f1-bbe0-4aab-9a69-5d652324357f", :ext_management_system => ems) }
+
+        it "should link the event to the host" do
+          ems_event = described_class.add(ems.id, event)
+          expect(ems_event.host).to eq(host)
+        end
+      end
+
+      context "with an archived host" do
+        let(:host) { FactoryBot.create(:host, :uid_ems => "6f3fa3f1-bbe0-4aab-9a69-5d652324357f") }
+
+        it "should link the event to the host" do
+          ems_event = described_class.add(ems.id, event)
+          expect(ems_event.host).to eq(host)
+        end
+      end
+    end
   end
 
   context '.event_groups' do

--- a/spec/models/ems_event_spec.rb
+++ b/spec/models/ems_event_spec.rb
@@ -302,6 +302,16 @@ RSpec.describe EmsEvent do
           expect(ems_event.host).to eq(host)
         end
       end
+
+      context "with active and archived hosts with the same uid_ems" do
+        let!(:archived_host) { FactoryBot.create(:host, :uid_ems => "6f3fa3f1-bbe0-4aab-9a69-5d652324357f") }
+        let!(:host)          { FactoryBot.create(:host, :uid_ems => "6f3fa3f1-bbe0-4aab-9a69-5d652324357f", :ext_management_system => ems) }
+
+        it "should prefer the active host" do
+          ems_event = described_class.add(ems.id, event)
+          expect(ems_event.host).to eq(host)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
If we are unable to find the host by ems_ref attempt to use the host_uid_ems attribute similar to how VMs are looked up.

This allows us to delete a DB query from the OpenStack EventCatcher

Needed for: https://github.com/ManageIQ/manageiq-providers-openstack/pull/617