### PR TITLE
Added virtual column `has_policies` to be used by Host list view

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -136,6 +136,7 @@ class Host < ApplicationRecord
   virtual_column :vmm_vendor_display,           :type => :string
   virtual_column :ipmi_enabled,                 :type => :boolean
   virtual_column :archived, :type => :boolean
+  virtual_column :has_policies, :type => :boolean
 
   virtual_has_many   :resource_pools,                               :uses => :all_relationships
   virtual_has_many   :miq_scsi_luns,                                :uses => {:hardware => {:storage_adapters => {:miq_scsi_targets => :miq_scsi_luns}}}

--- a/app/models/mixins/miq_policy_mixin.rb
+++ b/app/models/mixins/miq_policy_mixin.rb
@@ -36,6 +36,7 @@ module MiqPolicyMixin
   def has_policies?
     get_policies.length > 0
   end
+  alias has_policies has_policies?
 
   def resolve_policies(list, event = nil)
     MiqPolicy.resolve(self, list, event)

--- a/app/models/vm_or_template.rb
+++ b/app/models/vm_or_template.rb
@@ -157,6 +157,7 @@ class VmOrTemplate < ApplicationRecord
   virtual_column :memory_exceeds_current_host_headroom, :type => :string,     :uses => [:mem_cpu, {:host => [:hardware, :ext_management_system]}]
   virtual_column :has_rdm_disk,                         :type => :boolean,    :uses => {:hardware => :disks}
   virtual_column :disks_aligned,                        :type => :string,     :uses => {:hardware => {:hard_disks => :partitions_aligned}}
+  virtual_column :has_policies,                         :type => :boolean
 
   virtual_has_many   :processes,              :class_name => "OsProcess",    :uses => {:operating_system => :processes}
   virtual_has_many   :event_logs,                                            :uses => {:operating_system => :event_logs}


### PR DESCRIPTION
For changes in https://github.com/ManageIQ/manageiq-ui-classic/pull/7189

Added a virtual column to show Policy icon in the Host list view.